### PR TITLE
sprite renderer should not change sprite via initWithSpriteFrame

### DIFF
--- a/cocos2d/core/components/CCSpriteRenderer.js
+++ b/cocos2d/core/components/CCSpriteRenderer.js
@@ -477,8 +477,9 @@ var SpriteRenderer = cc.Class({
         if (oldSprite && oldSprite.off) {
             oldSprite.off('load', this._applyCapInset, this);
         }
-        if (!this._sprite) { return; }
-        sgNode.initWithSpriteFrame(this._sprite, cc.rect(0, 0, 0, 0));
+        if (!this._sprite) return;
+
+        sgNode.setSpriteFrame(this._sprite);
         var locLoaded = this._sprite.textureLoaded();
         if (!locLoaded) {
             if ( !this._useOriginalSize ) {
@@ -493,6 +494,7 @@ var SpriteRenderer = cc.Class({
             this._applyCapInset(sgNode);
             this._applySpriteSize(sgNode);
         }
+
         if (CC_EDITOR) {
             // Set atlas
             this._applyAtlas(this._sprite);

--- a/cocos2d/core/sprites/CCSpriteFrame.js
+++ b/cocos2d/core/sprites/CCSpriteFrame.js
@@ -219,8 +219,7 @@ cc.SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
      * @return {Rect}
      */
     getRect:function () {
-        var locRect = this._rect;
-        return cc.rect(locRect.x, locRect.y, locRect.width, locRect.height);
+        return this._rect.clone();
     },
 
     /**


### PR DESCRIPTION
这个 PR 用于修复切换 Sprite 后渲染不出来的问题。
重现步骤：在 Assets 文件夹下复制两张完全一样的图片，A 和 B，然后在场景里设置 Sprite 为 A，再设置为 B，就会发现 B 没渲染不出来。
经查，发现是 SpriteRenderer 使用 applySprite 来初始化和修改 Sprite，因此 UIScale9Sprite 的initWithSpriteFrame 会多次调用导致的，改为统一使用 setSpriteFrame 初始化和修改 Sprite 就好了。

@knoxHuang @dabingnn 
