### PR TITLE
基于 Entity/EventTarget 支持新的事件注册方式

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -154,6 +154,7 @@ var _mouseUpHandler = function (event) {
 var Node = cc.Class({
     name: 'cc.Node',
     extends: require('./utils/base-node'),
+    mixins: [EventTarget],
 
     properties: {
         /**
@@ -249,8 +250,6 @@ var Node = cc.Class({
 
         // Mouse event listener
         this._mouseListener = null;
-
-        EventTarget.call(this);
 
         /**
          * Register all related EventTargets,
@@ -839,8 +838,6 @@ var Node = cc.Class({
 });
 
 Node.EventType = EventType;
-
-cc.js.addon(Node.prototype, EventTarget.prototype);
 
 /**
  * @event position-changed

--- a/cocos2d/core/base-nodes/CCSGNode.js
+++ b/cocos2d/core/base-nodes/CCSGNode.js
@@ -1782,9 +1782,16 @@ _ccsg.Node = cc.Class({
      */
     getNodeToWorldTransform: function () {
         //TODO renderCmd has a WorldTransform
-        var t = this.getNodeToParentTransform();
-        for (var p = this._parent; p !== null; p = p.parent)
-            t = cc.affineTransformConcat(t, p.getNodeToParentTransform());
+        var t;
+        if (this._renderCmd && cc._renderType === cc.game.RENDER_TYPE_CANVAS) {
+            t = this._renderCmd._worldTransform;
+        }
+        else {
+            t = this.getNodeToParentTransform();
+            for (var p = this._parent; p !== null; p = p.parent) {
+                t = cc.affineTransformConcat(t, p.getNodeToParentTransform());
+            }
+        }
         return t;
     },
 
@@ -2035,7 +2042,7 @@ _ccsg.Node = cc.Class({
     getBoundingBoxToWorld: function () {
         var rect = cc.rect(0, 0, this._contentSize.width, this._contentSize.height);
         var trans = this.getNodeToWorldTransform();
-        rect = cc.rectApplyAffineTransform(rect, trans);
+        cc._rectApplyAffineTransformIn(rect, trans);
 
         //query child's BoundingBox
         if (!this._children)
@@ -2056,7 +2063,7 @@ _ccsg.Node = cc.Class({
     _getBoundingBoxToCurrentNode: function (parentTransform) {
         var rect = cc.rect(0, 0, this._contentSize.width, this._contentSize.height);
         var trans = (parentTransform === undefined) ? this.getNodeToParentTransform() : cc.affineTransformConcat(this.getNodeToParentTransform(), parentTransform);
-        rect = cc.rectApplyAffineTransform(rect, trans);
+        cc._rectApplyAffineTransformIn(rect, trans);
 
         //query child's BoundingBox
         if (!this._children)

--- a/cocos2d/core/event-manager/CCEventListener.js
+++ b/cocos2d/core/event-manager/CCEventListener.js
@@ -271,30 +271,23 @@ cc.EventListener.KEYBOARD = 3;
  */
 cc.EventListener.MOUSE = 4;
 /**
- * The type code of acceleration event listener.
- * @constant
- * @type {Number}
- */
-cc.EventListener.ACCELERATION = 5;
-/**
  * The type code of focus event listener.
  * @constant
- * @type {Number}
+ * @type {number}
  */
 cc.EventListener.ACCELERATION = 6;
 /**
- * The type code of custom event listener.
- * @constant
- * @type {Number}
- */
-cc.EventListener.CUSTOM = 8;
-
-/**
  * The type code of Focus change event listener.
  * @constant
- * @type {Number}
+ * @type {number}
  */
 cc.EventListener.FOCUS = 7;
+/**
+ * The type code of custom event listener.
+ * @constant
+ * @type {number}
+ */
+cc.EventListener.CUSTOM = 8;
 
 cc._EventListenerCustom = cc.EventListener.extend({
     _onCustomEvent: null,

--- a/cocos2d/core/event-manager/CCEventListener.js
+++ b/cocos2d/core/event-manager/CCEventListener.js
@@ -273,19 +273,19 @@ cc.EventListener.MOUSE = 4;
 /**
  * The type code of focus event listener.
  * @constant
- * @type {number}
+ * @type {Number}
  */
 cc.EventListener.ACCELERATION = 6;
 /**
  * The type code of Focus change event listener.
  * @constant
- * @type {number}
+ * @type {Number}
  */
 cc.EventListener.FOCUS = 7;
 /**
  * The type code of custom event listener.
  * @constant
- * @type {number}
+ * @type {Number}
  */
 cc.EventListener.CUSTOM = 8;
 

--- a/cocos2d/core/event/event-target.js
+++ b/cocos2d/core/event/event-target.js
@@ -122,7 +122,11 @@ JS.mixin(EventTarget.prototype, {
      * @param {Boolean} A value of true if a callback of the specified type is registered; false otherwise.
      */
     hasEventListener: function (type) {
-        return this._bubblingListeners.has(type) || this._capturingListeners.has(type);
+        if (this._bubblingListeners && this._bubblingListeners.has(type))
+            return true;
+        if (this._capturingListeners && this._capturingListeners.has(type))
+            return true;
+        return false;
     },
 
     /**

--- a/cocos2d/core/sprites/CCSGSpriteWebGLRenderCmd.js
+++ b/cocos2d/core/sprites/CCSGSpriteWebGLRenderCmd.js
@@ -429,7 +429,7 @@
         if ((locTexture &&!locTexture._textureLoaded) || this._displayedOpacity === 0)
             return;
 
-        var gl = ctx || cc._renderContext ;
+        var gl = ctx || cc._renderContext;
         //cc.assert(!_t._batchNode, "If _ccsg.Sprite is being rendered by cc.SpriteBatchNode, _ccsg.Sprite#draw SHOULD NOT be called");
 
         if (locTexture) {

--- a/test/visual-tests/main.js
+++ b/test/visual-tests/main.js
@@ -167,7 +167,9 @@ cc.game.run({
         "src/NativeTest/NativeTest.js",
         "src/NativeTest/FileUtils/FileUtilsTest.js",
         "src/NativeTest/JSBExtendTest.js",
-        "src/NativeTest/AudioEngineTest.js"
+        "src/NativeTest/AudioEngineTest.js",
+
+        "src/NodeEventTest/NodeEventTest.js"
     ]
 }, function(){
     cc.view.enableRetina(false);

--- a/test/visual-tests/src/NodeEventTest/NodeEventTest.js
+++ b/test/visual-tests/src/NodeEventTest/NodeEventTest.js
@@ -1,0 +1,247 @@
+/****************************************************************************
+ Copyright (c) 2015 Chukong Technologies Inc.
+
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+'use strict';
+
+(function (window, BaseTestLayer) {
+
+var backHandler = function () {
+    var scene = new _ccsg.Scene();
+    var layer = new TestController();
+    scene.addChild(layer);
+    cc.director.runScene(scene);
+};
+
+var createEntity = function (file, x, y) {
+    var node = new cc.Node(file);
+    if (file) {
+        var tex = cc.textureCache.getTextureForKey(file);
+        var spriteFrame = new cc.SpriteFrame(tex, cc.rect(0, 0, tex.getPixelWidth(), tex.getPixelHeight()));
+        var spriteRenderer = node.addComponent(cc.Sprite);
+        spriteRenderer.spriteFrame = spriteFrame;
+        spriteRenderer._createSgNode();
+    }
+    node.x = x;
+    node.y = y;
+    return node;
+};
+
+var TouchEventTest = ECSTestLayer.extend({
+    _title: 'Node Event Test',
+    _subtitle: 'Grossini can be touched',
+
+    ctor:function() {
+        this._super(cc.color(0,0,0,255), cc.color(98,99,117,255), backHandler, NodeEventTestFlow);
+
+        this._label = new cc.LabelTTF('', 'Arial', 20);
+        this._label.x = cc.winSize.width/2;
+        this._label.y = 150;
+        this.addChild(this._label);
+
+        this._node = null;
+    },
+
+    onEnter: function () {
+        this._super();
+
+        cc.eventManager.addListener({
+            event: cc.EventListener.TOUCH_ONE_BY_ONE,
+            owner: this,
+            onTouchBegan: function () {
+                var layer = this.owner;
+                layer._label.string = 'Touch outside';
+                return true;
+            }
+        }, this);
+
+        this._node = createEntity(s_pathGrossini, cc.winSize.width/2, cc.winSize.height/2);
+        cc.director.getScene().addChild(this._node);
+
+        this._node.on(cc.Node.EventType.TOUCH_BEGAN, function () {
+            this._label.string = 'Touch began - Grossini';
+        }, this);
+        this._node.on(cc.Node.EventType.TOUCH_MOVED, function () {
+            this._label.string = 'Touch moved - Grossini';
+        }, this);
+        this._node.on(cc.Node.EventType.TOUCH_ENDED, function () {
+            this._label.string = 'Touch ended - Grossini';
+        }, this);
+    }
+});
+
+var MouseEventTest = ECSTestLayer.extend({
+    _title: 'Node Event Test',
+    _subtitle: 'Grossini can interact with mouse',
+
+    ctor: function() {
+        this._super(cc.color(0,0,0,255), cc.color(98,99,117,255), backHandler, NodeEventTestFlow);
+        this._label = new cc.LabelTTF('', 'Arial', 20);
+        this._label.x = cc.winSize.width/2;
+        this._label.y = 150;
+        this.addChild(this._label);
+    },
+    onEnter: function () {
+        this._super();
+
+        cc.eventManager.addListener({
+            event: cc.EventListener.MOUSE,
+            owner: this,
+            onMouseDown: function () {
+                var layer = this.owner;
+                layer._label.string = 'Mouse down - outside';
+            },
+            onMouseMove: function () {
+                var layer = this.owner;
+                layer._label.string = 'Mouse moved - outside';
+            },
+            onMouseUp: function () {
+                var layer = this.owner;
+                layer._label.string = 'Mouse up - outside';
+            }
+        }, this);
+
+        var node = createEntity(s_pathGrossini, cc.winSize.width/2, cc.winSize.height/2);
+        cc.director.getScene().addChild(node);
+
+        node.on(cc.Node.EventType.MOUSE_DOWN, function () {
+            this._label.string = 'Mouse down - Grossini';
+        }, this);
+        node.on(cc.Node.EventType.MOUSE_MOVED, function () {
+            this._label.string = 'Mouse moved - Grossini';
+        }, this);
+        node.on(cc.Node.EventType.MOUSE_UP, function () {
+            this._label.string = 'Mouse up - Grossini';
+        }, this);
+    }
+});
+
+var PropagationTest = ECSTestLayer.extend({
+    _title: 'Node Event Test',
+    _subtitle: 'Enable or disable propagation to see difference',
+
+    ctor: function () {
+        this._super(cc.color(0,0,0,255), cc.color(98,99,117,255), backHandler, NodeEventTestFlow);
+        this.propagate = true;
+    },
+    onEnter: function () {
+        this._super();
+
+        var node = createEntity('Images/CyanSquare.png', cc.winSize.width/2, cc.winSize.height/2);
+        cc.director.getScene().addChild(node);
+
+        var self = this;
+        node.on(cc.Node.EventType.TOUCH_BEGAN, function (event) {
+            this.opacity = 180;
+            if (self.propagate)
+                event.stopPropagation();
+        }, node);
+        node.on(cc.Node.EventType.TOUCH_MOVED, function (event) {
+            var delta = event.touch.getDelta();
+            this.x += delta.x;
+            this.y += delta.y;
+            if (self.propagate)
+                event.stopPropagation();
+        }, node);
+        node.on(cc.Node.EventType.TOUCH_ENDED, function (event) {
+            this.opacity = 255;
+            if (self.propagate)
+                event.stopPropagation();
+        }, node);
+
+        var magenta = createEntity('Images/MagentaSquare.png', 50, -50);
+        node.addChild(magenta);
+
+        magenta.on(cc.Node.EventType.TOUCH_BEGAN, function (event) {
+            this.opacity = 180;
+            if (self.propagate)
+                event.stopPropagation();
+        }, magenta);
+        magenta.on(cc.Node.EventType.TOUCH_MOVED, function (event) {
+            var delta = event.touch.getDelta();
+            this.x += delta.x;
+            this.y += delta.y;
+            if (self.propagate)
+                event.stopPropagation();
+        }, magenta);
+        magenta.on(cc.Node.EventType.TOUCH_ENDED, function (event) {
+            this.opacity = 255;
+            if (self.propagate)
+                event.stopPropagation();
+        }, magenta);
+
+        var yellow = createEntity('Images/YellowSquare.png', 50, 80);
+        magenta.addChild(yellow);
+
+        yellow.on(cc.Node.EventType.TOUCH_BEGAN, function (event) {
+            this.opacity = 180;
+            if (self.propagate)
+                event.stopPropagation();
+        }, yellow);
+        yellow.on(cc.Node.EventType.TOUCH_MOVED, function (event) {
+            var delta = event.touch.getDelta();
+            this.x += delta.x;
+            this.y += delta.y;
+            if (self.propagate)
+                event.stopPropagation();
+        }, yellow);
+        yellow.on(cc.Node.EventType.TOUCH_ENDED, function (event) {
+            this.opacity = 255;
+            if (self.propagate)
+                event.stopPropagation();
+        }, yellow);
+
+        var propagateItem = new cc.MenuItemFont('Propagation OFF', function() {
+            self.propagate = !self.propagate;
+            propagateItem.string = self.propagate ? 'Propagation OFF' : 'Propagation ON';
+        });
+
+        propagateItem.fontSize = 16;
+        propagateItem.x = cc.visibleRect.right.x - propagateItem.width/2-20;
+        propagateItem.y = cc.visibleRect.right.y;
+
+        var menu = new cc.Menu(propagateItem);
+        menu.setPosition(0, 0);
+        menu.setAnchorPoint(0, 0);
+        this.addChild(menu);
+    }
+});
+
+var HitTest = ECSTestLayer.extend({
+    _title: 'Node Event Test',
+
+    ctor: function () {
+        this._super(cc.color(0,0,0,255), cc.color(98,99,117,255), backHandler, NodeEventTestFlow);
+    }
+});
+
+var NodeEventTestFlow = new FlowControl([
+    TouchEventTest,
+    MouseEventTest,
+    PropagationTest,
+    HitTest,
+], true);
+
+window.NodeEventTestFlow = NodeEventTestFlow;
+
+})(window, BaseTestLayer);

--- a/test/visual-tests/src/tests-main.js
+++ b/test/visual-tests/src/tests-main.js
@@ -300,6 +300,15 @@ var testNames = [
         }
     },
     {
+        title:"Event Node Test",
+        resource:g_eventDispatcher,
+        platforms: PLATFORM_ALL,
+        linksrc:"src/NodeEventTest/NodeEventTest.js",
+        testScene:function () {
+            NodeEventTestFlow.start();
+        }
+    },
+    {
         title:"Extensions Test",
         resource:g_extensions,
         platforms: PLATFORM_ALL,


### PR DESCRIPTION
几个要点：
- 在Entity上可以直接对Touch / Mouse事件进行注册（on）和取消注册（off）等操作。
- 支持事件的冒泡传递。
- 基于Transfrom进行hit test。
- 仅在需要时向eventManager添加事件监听器，避免过高的性能损耗。
