### PR TITLE
should not sample in updateClip

### DIFF
--- a/cocos2d/core/components/CCAnimation.js
+++ b/cocos2d/core/components/CCAnimation.js
@@ -483,8 +483,6 @@ var Animation = cc.Class({
 
         oldState._clip = clip;
         this._animator.reloadClip(oldState);
-
-        this.sample();
     }
 });
 


### PR DESCRIPTION
把updateClip中的sample挪到scene事件中，在currentClip更改时只sample当前编辑的animation
@jareguo 
