### PR TITLE
fix sprite content size bug in jsb

### DIFF
--- a/jsb_engine.js
+++ b/jsb_engine.js
@@ -1183,14 +1183,6 @@ cc.Scheduler.prototype.unschedule = function (callback, target) {
 };
 
 // cc.Scale9Sprite
-cc.Scale9Sprite.prototype.setRenderingType = function (type) {
-    if (type === cc.SpriteType.SIMPLE) {
-        this.setScale9Enabled(false);
-    }
-    else {
-        this.setScale9Enabled(true);
-    }
-};
 cc.Scale9Sprite.prototype._setBlendFunc = cc.Scale9Sprite.prototype.setBlendFunc;
 cc.Scale9Sprite.prototype.setBlendFunc = function(blendFunc, dst) {
     if (dst !== undefined) {


### PR DESCRIPTION
修复JSB中，当设置contentsize时，scale9sprite效果不正确
