### PR TITLE
Fixed a bug about canvas clipping node

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNodeCanvasRenderCmd.js
+++ b/cocos2d/clipping-nodes/CCClippingNodeCanvasRenderCmd.js
@@ -86,8 +86,10 @@
         if (this._clipElemType) {
             var locCache = cc.ClippingNode.CanvasRenderCmd._getSharedCache();
             var canvas = context.canvas;
-            locCache.width = canvas.width;
-            locCache.height = canvas.height;                     //note: on some browser, it can't clear the canvas, e.g. baidu
+            if (locCache.width !== canvas.width)
+                locCache.width = canvas.width;
+            if (locCache.height !== canvas.height)
+                locCache.height = canvas.height;                     //note: on some browser, it can't clear the canvas, e.g. baidu
             var locCacheCtx = locCache.getContext("2d");
             locCacheCtx.drawImage(canvas, 0, 0);                //save the result to shareCache canvas
         } else {


### PR DESCRIPTION
问题症状：
21点游戏内，改成canvas模式，背景消失，scorllView内容错位

背景消失的原因：
重复设置canvas的大小。
canvas大小被更改（或者没更改，但是有去设置）的时候，会清空内容。所以造成了部分图像消失。

错位问题还没找到问题，大概是transform传递transformWorld计算错误造成的。

@zilongshanren 
