### PR TITLE
try to fix convertToWorldSpace in first frame

### DIFF
--- a/cocos2d/core/components/CCCanvas.js
+++ b/cocos2d/core/components/CCCanvas.js
@@ -163,8 +163,8 @@ var Canvas = cc.Class({
             }
         }
 
-        this.onResized();
         this.applySettings();
+        this.onResized();
     },
 
     onDestroy: function () {

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -1189,7 +1189,7 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
      * @return {Vec2}
      */
     convertToWorldSpaceAR: function (nodePoint) {
-        return this._sgNode.convertToWorldSpaceAR(nodePoint);
+        return cc.v2(this._sgNode.convertToWorldSpaceAR(nodePoint));
     },
 
     // _convertToWindowSpace: function (nodePoint) {


### PR DESCRIPTION
fix https://github.com/cocos-creator/fireball/issues/1565
重新确认了下，Canvas 并不是在 visit 中初始化的，是在 onLoad 中初始化的，我们现在的事件注册能保证 Canvas 的 onLoad 第一个调用。之后如果引入优先级队列，也要同样保证 Canvas 最先调用。
