### PR TITLE
add API onRestore for reset menu and undo operation

### DIFF
--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -490,7 +490,7 @@ var Component = cc.Class({
     //    return Timer.hasTimeoutKey(key);
     //},
 
-    // OVERRIDES
+    // VIRTUAL
 
     /**
      * If the component's bounding box is different from the node's, you can implement this method to supply
@@ -500,6 +500,34 @@ var Component = cc.Class({
      * @param {Rect} out_rect - the Rect to receive the bounding box
      */
     _getLocalBounds: null,
+
+    /**
+     * onRestore is called after the user clicks the Reset item in the Inspector's context menu or performs
+     * an undo operation on this component.
+     *
+     * If the component contains the "internal state", short for "temporary member variables which not included
+     * in its CCClass properties", then you may need to implement this function.
+     *
+     * The editor will call the getset accessors of your component to record/restore the component's state
+     * for undo/redo operation. However, in extreme cases, it may not works well. Then you should implement
+     * this function to manually synchronize your component's "internal states" with its public properties.
+     * Once you implement this function, all the getset accessors of your component will not be called when
+     * the user performs an undo/redo operation. Which means that only the properties with default value
+     * will be recorded or restored by editor.
+     *
+     * Similarly, the editor may failed to reset your component correctly in extreme cases. Then if you need
+     * to support the reset menu, you should manually synchronize your component's "internal states" with its
+     * properties in this function. Once you implement this function, all the getset accessors of your component
+     * will not be called during reset operation. Which means that only the properties with default value
+     * will be reset by editor.
+     *
+     * This function is only called in editor mode.
+     *
+     * @method onRestore
+     */
+    onRestore: null,
+
+    // OVERRIDE
 
     destroy: function () {
         if (CC_EDITOR) {


### PR DESCRIPTION
这个 API 不是用户必须重载的。由于我们的组件允许使用大量 getset，如果用户的 setter 之间有调用顺序上的耦合，或者耦合到其它全局状态，有可能导致 undo 或者 reset 失败。这时用户需要自己定义 onRestore，定义了之后 reset 和 undo 都不会操作任何 setter，避免了错误。用户如果需要刷新原先在 setter 中刷新的内部状态，可以在 onRestore 中进行判断刷新。

ref https://github.com/cocos-creator/fireball/issues/1840

@pandamicro please~
