### PR TITLE
Solve the warning of TiledMap when starting Creator.

### DIFF
--- a/extends.js
+++ b/extends.js
@@ -31,7 +31,9 @@ if (!(CC_EDITOR && Editor.isCoreLevel)) {
 }
 
 require('./cocos2d/tilemap/CCTiledMapAsset');
-require('./cocos2d/tilemap/CCTiledMap');
-require('./cocos2d/tilemap/CCTiledLayer');
+if (!(CC_EDITOR && Editor.isCoreLevel)) {
+    require('./cocos2d/tilemap/CCTiledMap');
+    require('./cocos2d/tilemap/CCTiledLayer');
+}
 
 require('./extensions/spine');


### PR DESCRIPTION
Changes proposed in this pull request:
- Solve the warning of TiledMap when starting Creator.

@cocos-creator/engine-admins
