### PR TITLE
实现新的 RendererInSG 组件

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -982,7 +982,7 @@ var Node = cc.Class({
             apy = this._anchorPoint.y,
             w = this.width,
             h = this.height;
-        var rect = cc.rect(-apx * w, -apy * h, w, h);
+        var rect = cc.rect(0, 0, w, h);
         var trans = this.getNodeToWorldTransform();
         cc._rectApplyAffineTransformIn(rect, trans);
         var left = point.x - rect.x,

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -828,7 +828,7 @@ var Node = cc.Class({
         // update components if also in scene graph
         for (var c = 0; c < this._components.length; ++c) {
             var comp = this._components[c];
-            if (comp instanceof cc._RendererBelowSG && comp.isValid && comp._sgNode) {
+            if (comp instanceof cc._SGComponent && comp.isValid && comp._sgNode) {
                 comp._sgNode.setColor(this._color);
                 if ( !this._cascadeOpacityEnabled ) {
                     comp._sgNode.setOpacity(this._opacity);
@@ -842,7 +842,7 @@ var Node = cc.Class({
         var opacity = this._cascadeOpacityEnabled ? 255 : this._opacity;
         for (var c = 0; c < this._components.length; ++c) {
             var comp = this._components[c];
-            if (comp instanceof cc._RendererBelowSG && comp.isValid && comp._sgNode) {
+            if (comp instanceof cc._SGComponent && comp.isValid && comp._sgNode) {
                 comp._sgNode.setOpacity(opacity);
             }
         }
@@ -852,7 +852,7 @@ var Node = cc.Class({
         // update components if also in scene graph
         for (var c = 0; c < this._components.length; ++c) {
             var comp = this._components[c];
-            if (comp instanceof cc._RendererBelowSG && comp.isValid && comp._sgNode) {
+            if (comp instanceof cc._SGComponent && comp.isValid && comp._sgNode) {
                 comp._sgNode.setAnchorPoint(this._anchorPoint);
                 comp._sgNode.ignoreAnchorPointForPosition(this._ignoreAnchorPointForPosition);
             }
@@ -862,7 +862,7 @@ var Node = cc.Class({
     _onOpacityModifyRGBChanged: function () {
         for (var c = 0; c < this._components.length; ++c) {
             var comp = this._components[c];
-            if (comp instanceof cc._RendererBelowSG && comp.isValid && comp._sgNode) {
+            if (comp instanceof cc._SGComponent && comp.isValid && comp._sgNode) {
                 comp._sgNode.setOpacityModifyRGB(this._opacityModifyRGB);
             }
         }

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -854,7 +854,7 @@ var Node = cc.Class({
             var comp = this._components[c];
             if (comp instanceof cc._SGComponent && comp.isValid && comp._sgNode) {
                 comp._sgNode.setAnchorPoint(this._anchorPoint);
-                comp._sgNode.ignoreAnchorPointForPosition(this._ignoreAnchorPointForPosition);
+                comp._sgNode.ignoreAnchorPointForPosition(this.__ignoreAnchor);
             }
         }
     },

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -828,7 +828,7 @@ var Node = cc.Class({
         // update components if also in scene graph
         for (var c = 0; c < this._components.length; ++c) {
             var comp = this._components[c];
-            if (comp instanceof cc._ComponentInSG && comp.isValid && comp._sgNode) {
+            if (comp instanceof cc._RendererBelowSG && comp.isValid && comp._sgNode) {
                 comp._sgNode.setColor(this._color);
                 if ( !this._cascadeOpacityEnabled ) {
                     comp._sgNode.setOpacity(this._opacity);
@@ -842,7 +842,7 @@ var Node = cc.Class({
         var opacity = this._cascadeOpacityEnabled ? 255 : this._opacity;
         for (var c = 0; c < this._components.length; ++c) {
             var comp = this._components[c];
-            if (comp instanceof cc._ComponentInSG && comp.isValid && comp._sgNode) {
+            if (comp instanceof cc._RendererBelowSG && comp.isValid && comp._sgNode) {
                 comp._sgNode.setOpacity(opacity);
             }
         }
@@ -852,7 +852,7 @@ var Node = cc.Class({
         // update components if also in scene graph
         for (var c = 0; c < this._components.length; ++c) {
             var comp = this._components[c];
-            if (comp instanceof cc._ComponentInSG && comp.isValid && comp._sgNode) {
+            if (comp instanceof cc._RendererBelowSG && comp.isValid && comp._sgNode) {
                 comp._sgNode.setAnchorPoint(this._anchorPoint);
                 comp._sgNode.ignoreAnchorPointForPosition(this._ignoreAnchorPointForPosition);
             }
@@ -862,7 +862,7 @@ var Node = cc.Class({
     _onOpacityModifyRGBChanged: function () {
         for (var c = 0; c < this._components.length; ++c) {
             var comp = this._components[c];
-            if (comp instanceof cc._ComponentInSG && comp.isValid && comp._sgNode) {
+            if (comp instanceof cc._RendererBelowSG && comp.isValid && comp._sgNode) {
                 comp._sgNode.setOpacityModifyRGB(this._opacityModifyRGB);
             }
         }

--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -31,11 +31,11 @@ var InputFlag = _ccsg.EditBox.InputFlag;
 /**
  * cc.EditBox is a component for inputing text, you can use it to gather small amounts of text from users.
  * @class EditBox
- * @extends _ComponentInSG
+ * @extends _RendererBelowSG
  */
 var EditBox = cc.Class({
     name: 'cc.EditBox',
-    extends: cc._ComponentInSG,
+    extends: cc._RendererBelowSG,
 
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.ui/EditBox',

--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -31,11 +31,11 @@ var InputFlag = _ccsg.EditBox.InputFlag;
 /**
  * cc.EditBox is a component for inputing text, you can use it to gather small amounts of text from users.
  * @class EditBox
- * @extends _RendererBelowSG
+ * @extends _RendererUnderSG
  */
 var EditBox = cc.Class({
     name: 'cc.EditBox',
-    extends: cc._RendererBelowSG,
+    extends: cc._RendererUnderSG,
 
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.ui/EditBox',

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -171,7 +171,7 @@ var Label = cc.Class({
 
         /**
          * The font URL of label.
-         * @property {URL} file
+         * @property {string} file
          */
         file: {
             default: "Arial",

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -29,11 +29,11 @@ var LabelType = _ccsg.Label.Type;
 /**
  *
  * @class Label
- * @extends _RendererBelowSG
+ * @extends _RendererUnderSG
  */
 var Label = cc.Class({
     name: 'cc.Label',
-    extends: cc._RendererBelowSG,
+    extends: cc._RendererUnderSG,
 
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.renderers/Label'

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -29,11 +29,11 @@ var LabelType = _ccsg.Label.Type;
 /**
  *
  * @class Label
- * @extends _ComponentInSG
+ * @extends _RendererBelowSG
  */
 var Label = cc.Class({
     name: 'cc.Label',
-    extends: cc._ComponentInSG,
+    extends: cc._RendererBelowSG,
 
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.renderers/Label'

--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -80,9 +80,9 @@ var Mask = cc.Class({
 
     _refreshStencil: function () {
         var contentSize = this.node.getContentSize();
+        var anchorPoint = this.node.getAnchorPoint();
         var width = contentSize.width;
         var height = contentSize.height;
-        var anchorPoint = this.node._anchorPoint;
         var x = - width * anchorPoint.x;
         var y = - height * anchorPoint.y;
         var rectangle = [ cc.v2(x, y),

--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -23,86 +23,76 @@
  ****************************************************************************/
 
 /**
- *
  * @class Mask
- * @extends Component
+ * @extends _RendererInSG
  */
 var Mask = cc.Class({
     name: 'cc.Mask',
-    extends: cc.Component,
+    extends: cc._RendererInSG,
 
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.ui/Mask',
-        executeInEditMode: true
     },
 
     properties: {
-        _clippingNode: {
-            default: null,
-            serializable: false,
-        },
         _clippingStencil: {
             default: null,
             serializable: false,
         },
     },
 
-    onLoad: function () {
+    _createSgNode: function () {
         this._clippingStencil = new cc.DrawNode();
-        this._clippingNode = new cc.ClippingNode(this._clippingStencil);
-        if (cc.sys.isNative) {
-            this._clippingStencil.retain();
-            this._clippingNode.retain();
-        }
+        this._clippingStencil.retain();
+        return new cc.ClippingNode(this._clippingStencil);
     },
 
-    onDestroy: function () {
-        if (cc.sys.isNative) {
-            this._clippingStencil && this._clippingStencil.release();
-            this._clippingNode && this._clippingNode.release();
-        }
+    _initSgNode: function () {
+        var clippingNode = this._sgNode;
+        clippingNode.setContentSize(this.node.getContentSize(true));
     },
-
-    _refreshStencil: function () {
-        var contentSize = this.node._contentSize;
-        var anchorPoint = this.node._anchorPoint;
-        var x = contentSize.width * anchorPoint.x;
-        var y = contentSize.height * anchorPoint.y;
-        this._clippingStencil.clear();
-        var rectangle = [cc.v2(-x, -y), cc.v2(contentSize.width - x, -y),
-            cc.v2(contentSize.width - x, contentSize.height - y),
-            cc.v2(-x, contentSize.height - y)];
-        this._clippingStencil.drawPoly(rectangle, cc.color(255, 255, 255, 0), 0, cc.color(255, 255, 255, 0));
-    },
-
+    
+    //onLoad: function () {
+    //    this._super();
+    //    // ignore node size
+    //    if (this.node._sizeProvider === this._sgNode) {
+    //        this.node._sizeProvider = null;
+    //    }
+    //},
+    
     onEnable: function () {
-        var oldNode = this.node._sgNode;
         this._refreshStencil();
-        this.node._replaceSgNode(this._clippingNode);
-        this.node.on('size-changed', this._onContentSizeChanged, this);
-        this.node.on('anchor-changed', this._onAnchorChanged, this);
+        this._super();
+        this.node.on('size-changed', this._refreshStencil, this);
+        this.node.on('anchor-changed', this._refreshStencil, this);
     },
 
     onDisable: function () {
-        var oldNode = this.node._sgNode;
-        var newNode = new _ccsg.Node();
-        this.node._replaceSgNode(newNode);
-        this.node.off('size-changed', this._onContentSizeChanged, this);
-        this.node.off('anchor-changed', this._onAnchorChanged, this);
+        this._super();
+        this.node.off('size-changed', this._refreshStencil, this);
+        this.node.off('anchor-changed', this._refreshStencil, this);
+    },
+    
+    onDestroy: function () {
+        this._super();
+        this._clippingStencil.release();
     },
 
-    _onContentSizeChanged: function () {
-        if (this._clippingStencil) {
-            this._refreshStencil();
-        }
-    },
-
-    _onAnchorChanged: function () {
-        if (this._clippingStencil) {
-            this._refreshStencil();
-        }
+    _refreshStencil: function () {
+        var contentSize = this.node.getContentSize();
+        var width = contentSize.width;
+        var height = contentSize.height;
+        var anchorPoint = this.node._anchorPoint;
+        var x = - width * anchorPoint.x;
+        var y = - height * anchorPoint.y;
+        var rectangle = [ cc.v2(x, y),
+                          cc.v2(x + width, y),
+                          cc.v2(x + width, y + height),
+                          cc.v2(x, y + height) ];
+        var color = cc.color(255, 255, 255, 0);
+        this._clippingStencil.clear();
+        this._clippingStencil.drawPoly(rectangle, color, 0, color);
     }
-
 });
 
 cc.Mask = module.exports = Mask;

--- a/cocos2d/core/components/CCRendererBelowSG.js
+++ b/cocos2d/core/components/CCRendererBelowSG.js
@@ -1,18 +1,18 @@
 var SceneGraphHelper = require('../utils/scene-graph-helper');
 
 /**
- * Component in scene graph.
- * This is the base class for components which will attach a node to the cocos2d scene graph.
+ * Rendering component in scene graph.
+ * This is the base class for components which will attach a leaf node to the cocos2d scene graph.
  *
  * You should override:
  * - _createSgNode
  * - _initSgNode
  *
- * @class _ComponentInSG
+ * @class _RendererBelowSG
  * @extends Component
  * @private
  */
-var ComponentInSG = cc.Class({
+var RendererBelowSG = cc.Class({
     extends: require('./CCComponent'),
 
     editor: CC_EDITOR && {
@@ -106,4 +106,4 @@ var ComponentInSG = cc.Class({
     }
 });
 
-cc._ComponentInSG = module.exports = ComponentInSG;
+cc._RendererBelowSG = module.exports = RendererBelowSG;

--- a/cocos2d/core/components/CCRendererBelowSG.js
+++ b/cocos2d/core/components/CCRendererBelowSG.js
@@ -1,30 +1,20 @@
-var SceneGraphHelper = require('../utils/scene-graph-helper');
 
 /**
  * Rendering component in scene graph.
  * This is the base class for components which will attach a leaf node to the cocos2d scene graph.
  *
- * You should override:
- * - _createSgNode
- * - _initSgNode
- *
  * @class _RendererBelowSG
- * @extends Component
+ * @extends _SGComponent
  * @private
  */
 var RendererBelowSG = cc.Class({
-    extends: require('./CCComponent'),
-
-    editor: CC_EDITOR && {
-        executeInEditMode: true,
-        disallowMultiple: true
-    },
+    extends: require('./CCSGComponent'),
 
     ctor: function () {
         /**
          * Reference to the instance of _ccsg.Node
          * If it is possible to return null from your overloaded _createSgNode,
-         * then you should always check for null before using this property.
+         * then you should always check for null before using this property and reimplement onLoad.
          *
          * @property {_ccsg.Node} _sgNode
          * @private
@@ -32,61 +22,36 @@ var RendererBelowSG = cc.Class({
         this._sgNode = this._createSgNode();
         if (this._sgNode) {
             // retain immediately
-            // will be released in SceneGraphHelper.removeSgNode
+            // will be released in onDestroy
             this._sgNode.retain();
         }
     },
 
+    // You should reimplement this function if your _sgNode maybe null.
     onLoad: function () {
-        this._initSgNode();
-        var sgNode = this._sgNode;
-        this._appendSgNode(sgNode);
-        if ( !this.node._sizeProvider ) {
-            this.node._sizeProvider = sgNode;
-        }
+        this._super();
+        this._appendSgNode(this._sgNode);
     },
     onEnable: function () {
         if (this._sgNode) {
-            this._sgNode.visible = true;
+            this._sgNode.setVisible(true);
         }
     },
     onDisable: function () {
         if (this._sgNode) {
-            this._sgNode.visible = false;
+            this._sgNode.setVisible(false);
         }
     },
-    onDestroy: function () {
-        if ( this.node._sizeProvider === this._sgNode ) {
-            this.node._sizeProvider = null;
-        }
-        this._removeSgNode();
-    },
-
-    /**
-     * Create and returns your new scene graph node (SGNode) to append to scene graph.
-     * You should call the setContentSize of the SGNode if its size should be the same with the node's.
-     *
-     * @method _createSgNode
-     * @return {_ccsg.Node}
-     * @private
-     */
-    _createSgNode: null,
-
-    /**
-     * @method _initSgNode
-     * @private
-     */
-    _initSgNode: null,
-
-    _removeSgNode: SceneGraphHelper.removeSgNode,
 
     _appendSgNode: function (sgNode) {
         if ( !sgNode ) {
             return;
         }
 
+        if ( !this.enabled ) {
+            sgNode.setVisible(false);
+        }
         var node = this.node;
-
         sgNode.setColor(node._color);
         if ( !node._cascadeOpacityEnabled ) {
             sgNode.setOpacity(node._opacity);

--- a/cocos2d/core/components/CCRendererInSG.js
+++ b/cocos2d/core/components/CCRendererInSG.js
@@ -1,0 +1,111 @@
+
+/**
+ * Rendering component in scene graph.
+ * This is the base class for components which maintains a node in the middle of cocos2d scene graph.
+ *
+ * @class _RendererInSG
+ * @extends _SGComponent
+ * @private
+ */
+var RendererInSG = cc.Class({
+    extends: require('./CCSGComponent'),
+
+    ctor: function () {
+        /**
+         * The current active _ccsg.Node for the entity where this component belongs
+         * @property {_ccsg.Node} _sgNode
+         * @private
+         */
+        this._sgNode = this._createSgNode();
+        if (this._sgNode) {
+            // retain immediately
+            // will be released in onDestroy
+            this._sgNode.retain();
+        }
+        else {
+            cc.error('Not support for asynchronous creating node in SG');
+        }
+        
+        // origin nodes
+        this._customNode = this._sgNode;
+        this._plainNode = new _ccsg.Node();
+    },
+
+    onEnable: function () {
+        this._replaceSgNode(this._customNode);
+    },
+    onDisable: function () {
+        this._replaceSgNode(this._plainNode);
+    },
+    onDestroy: function () {
+        this._super();
+        
+        var released = this._sgNode;
+        if (this._customNode !== released) {
+            this._customNode.release();
+        }
+        else {
+            this._plainNode.release();
+        }
+    },
+
+    // returns the node being replaced
+    _replaceSgNode: function (sgNode) {
+        if ( !(sgNode instanceof _ccsg.Node) && CC_EDITOR) {
+            throw new Error("Invalid sgNode. It must be an instance of _ccsg.Node");
+        }
+
+        var node = this.node;
+        var replaced = node._sgNode;
+
+        if (replaced === sgNode && CC_EDITOR) {
+            cc.warn('The same sgNode');
+            return;
+        }
+        
+        // apply node's property
+        
+        sgNode.setPosition(node._position);
+        sgNode.setRotationX(node._rotationX);
+        sgNode.setRotationY(node._rotationY);
+        sgNode.setScale(node._scaleX, node._scaleY);
+        sgNode.setSkewX(node._skewX);
+        sgNode.setSkewY(node._skewY);
+        sgNode.setAnchorPoint(node._anchorPoint);
+        sgNode.ignoreAnchorPointForPosition(node._ignoreAnchorPointForPosition);
+
+        sgNode.setLocalZOrder(node._localZOrder);
+        sgNode.setGlobalZOrder(node._globalZOrder);
+
+        sgNode.setVisible(node._active);
+        sgNode.setColor(node._color);
+        sgNode.setOpacity(node._opacity);
+        sgNode.setOpacityModifyRGB(node._opacityModifyRGB);
+        sgNode.setCascadeOpacityEnabled(node._cascadeOpacityEnabled);
+        sgNode.setTag(node._tag);
+
+        // rebuild scene graph
+        
+        // replace children
+        var children = replaced.getChildren().slice();
+        replaced.removeAllChildren();
+        sgNode.removeAllChildren();
+        for (var i = 0, len = children.length; i < len; ++i) {
+            sgNode.addChild(children[i]);
+        }
+        
+        // replace parent
+        var parentNode = replaced.getParent();
+        parentNode.removeChild(replaced);
+        parentNode.addChild(sgNode);
+        sgNode.arrivalOrder = replaced.arrivalOrder;
+        if (cc.renderer) {
+            cc.renderer.childrenOrderDirty = parentNode._reorderChildDirty = true;
+        }
+
+        // did
+        node._sgNode = sgNode;
+    },
+});
+
+cc._RendererInSG = module.exports = RendererInSG;

--- a/cocos2d/core/components/CCRendererInSG.js
+++ b/cocos2d/core/components/CCRendererInSG.js
@@ -33,9 +33,11 @@ var RendererInSG = cc.Class({
 
     onEnable: function () {
         this._replaceSgNode(this._customNode);
+        this.node.ignoreAnchor = true;
     },
     onDisable: function () {
         this._replaceSgNode(this._plainNode);
+        this.node.ignoreAnchor = false;
     },
     onDestroy: function () {
         this._super();

--- a/cocos2d/core/components/CCRendererUnderSG.js
+++ b/cocos2d/core/components/CCRendererUnderSG.js
@@ -1,13 +1,35 @@
+/****************************************************************************
+ Copyright (c) 2016 Chukong Technologies Inc.
+
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
 
 /**
- * Rendering component in scene graph.
- * This is the base class for components which will attach a leaf node to the cocos2d scene graph.
+ * The base rendering component which will attach a leaf node to the cocos2d scene graph.
  *
- * @class _RendererBelowSG
+ * @class _RendererUnderSG
  * @extends _SGComponent
  * @private
  */
-var RendererBelowSG = cc.Class({
+var RendererUnderSG = cc.Class({
     extends: require('./CCSGComponent'),
 
     ctor: function () {
@@ -58,7 +80,7 @@ var RendererBelowSG = cc.Class({
         }
 
         sgNode.setAnchorPoint(node._anchorPoint);
-        sgNode.ignoreAnchorPointForPosition(node._ignoreAnchorPointForPosition);
+        sgNode.ignoreAnchorPointForPosition(node.__ignoreAnchor);
 
         sgNode.setOpacityModifyRGB(node._opacityModifyRGB);
 
@@ -71,4 +93,4 @@ var RendererBelowSG = cc.Class({
     }
 });
 
-cc._RendererBelowSG = module.exports = RendererBelowSG;
+cc._RendererUnderSG = module.exports = RendererUnderSG;

--- a/cocos2d/core/components/CCSGComponent.js
+++ b/cocos2d/core/components/CCSGComponent.js
@@ -1,0 +1,59 @@
+var SceneGraphHelper = require('../utils/scene-graph-helper');
+
+/**
+ * Rendering component in scene graph. This is the base class for RendererBelowSG and RendererInSG.
+ *
+ * You should override:
+ * - _createSgNode
+ * - _initSgNode
+ *
+ * @class _SGComponent
+ * @extends Component
+ * @private
+ */
+var SGComponent = cc.Class({
+    extends: require('./CCComponent'),
+
+    editor: CC_EDITOR && {
+        executeInEditMode: true,
+        disallowMultiple: true
+    },
+
+    onLoad: function () {
+        this._initSgNode();
+        var sgNode = this._sgNode;
+        if ( !this.node._sizeProvider ) {
+            this.node._sizeProvider = sgNode;
+        }
+    },
+    onDestroy: function () {
+        if ( this.node._sizeProvider === this._sgNode ) {
+            this.node._sizeProvider = null;
+        }
+        this._removeSgNode();
+    },
+
+    /**
+     * Create and returns your new scene graph node (SGNode) to add to scene graph.
+     * You should call the setContentSize of the SGNode if its size should be the same with the node's.
+     *
+     * @method _createSgNode
+     * @return {_ccsg.Node}
+     * @private
+     */
+    _createSgNode: null,
+
+    /**
+     * @method _initSgNode
+     * @private
+     */
+    _initSgNode: null,
+    
+    /**
+     * @method _removeSgNode
+     * @private
+     */
+    _removeSgNode: SceneGraphHelper.removeSgNode,
+});
+
+cc._SGComponent = module.exports = SGComponent;

--- a/cocos2d/core/components/CCSGComponent.js
+++ b/cocos2d/core/components/CCSGComponent.js
@@ -1,7 +1,31 @@
+/****************************************************************************
+ Copyright (c) 2016 Chukong Technologies Inc.
+
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
 var SceneGraphHelper = require('../utils/scene-graph-helper');
 
 /**
- * Rendering component in scene graph. This is the base class for RendererBelowSG and RendererInSG.
+ * The base class for all rendering component in scene graph.
  *
  * You should override:
  * - _createSgNode
@@ -17,6 +41,13 @@ var SGComponent = cc.Class({
     editor: CC_EDITOR && {
         executeInEditMode: true,
         disallowMultiple: true
+    },
+    
+    properties: {
+        _sgNode: {
+            default: null,
+            serializable: false
+        }
     },
 
     onLoad: function () {

--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -512,13 +512,8 @@ var Sprite = cc.Class({
 
     _initSgNode: function () {
         var sgNode = this._sgNode;
-
-        if (!this.enabledInHierarchy) {
-            sgNode.setVisible(false);
-        }
-
+        
         this._validateSizeMode();
-
         this._applySpriteFrame(null);
 
         // should keep the size of the sg node the same as entity,

--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -61,11 +61,11 @@ var SizeMode = cc.Enum({
 /**
  * Renders a sprite in the scene.
  * @class Sprite
- * @extends _RendererBelowSG
+ * @extends _RendererUnderSG
  */
 var Sprite = cc.Class({
     name: 'cc.Sprite',
-    extends: require('./CCRendererBelowSG'),
+    extends: require('./CCRendererUnderSG'),
 
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.renderers/Sprite',

--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -61,11 +61,11 @@ var SizeMode = cc.Enum({
 /**
  * Renders a sprite in the scene.
  * @class Sprite
- * @extends _ComponentInSG
+ * @extends _RendererBelowSG
  */
 var Sprite = cc.Class({
     name: 'cc.Sprite',
-    extends: require('./CCComponentInSG'),
+    extends: require('./CCRendererBelowSG'),
 
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.renderers/Sprite',

--- a/cocos2d/core/components/index.js
+++ b/cocos2d/core/components/index.js
@@ -1,5 +1,6 @@
 require('./CCComponent');
-require('./CCComponentInSG');
+require('./CCRendererInSG');
+require('./CCRendererBelowSG');
 require('./CCComponentEventHandler');
 require('./missing-script');
 

--- a/cocos2d/core/components/index.js
+++ b/cocos2d/core/components/index.js
@@ -1,6 +1,6 @@
 require('./CCComponent');
 require('./CCRendererInSG');
-require('./CCRendererBelowSG');
+require('./CCRendererUnderSG');
 require('./CCComponentEventHandler');
 require('./missing-script');
 

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -1167,7 +1167,19 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
      * @return {AffineTransform}
      */
     getNodeToWorldTransform: function () {
-        return this._sgNode.getNodeToWorldTransform();
+        var computedSize = this._sgNode.getContentSize();
+        var expectedSize = this.getContentSize();
+        var mat = this._sgNode.getNodeToWorldTransform();
+        var anchorPointIgnored = (computedSize.width === 0 && computedSize.height === 0 &&
+                                 (expectedSize.width !== 0 || expectedSize.height !== 0));
+        if (anchorPointIgnored) {
+            // compute anchor
+            var tx = - expectedSize.width * this._anchorPoint.x;
+            var ty = - expectedSize.height * this._anchorPoint.y;
+            var offset = cc.affineTransformMake(1, 0, 0, 1, tx, ty);
+            mat = cc.affineTransformConcatIn(offset, mat);
+        }
+        return mat;
     },
 
     /**
@@ -1275,7 +1287,7 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
         var size = this.getContentSize();
         var width = size.width;
         var height = size.height;
-        var rect = cc.rect(-this.anchorX * width, -this.anchorY * height, width, height);
+        var rect = cc.rect(0, 0, width, height);
 
         var trans = (parentTransform === undefined) ? this.getNodeToParentTransform() : cc.affineTransformConcat(this.getNodeToParentTransform(), parentTransform);
         cc._rectApplyAffineTransformIn(rect, trans);

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -1171,8 +1171,8 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
         var expectedSize = this.getContentSize();
         var mat = this._sgNode.getNodeToWorldTransform();
         var anchorPointIgnored = (computedSize.width === 0 && computedSize.height === 0 &&
-                                 (expectedSize.width !== 0 || expectedSize.height !== 0));
-        if (anchorPointIgnored) {
+                                  (expectedSize.width !== 0 || expectedSize.height !== 0));
+        if (anchorPointIgnored || this._sgNode.isIgnoreAnchorPointForPosition()) {
             // compute anchor
             var tx = - expectedSize.width * this._anchorPoint.x;
             var ty = - expectedSize.height * this._anchorPoint.y;
@@ -1221,7 +1221,12 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
      * @return {Vec2}
      */
     convertToNodeSpaceAR: function (worldPoint) {
-        return this._sgNode.convertToNodeSpaceAR(worldPoint);
+        if (this._sgNode.isIgnoreAnchorPointForPosition()) {
+            return cc.v2(this._sgNode.convertToNodeSpace(worldPoint));
+        }
+        else {
+            return this._sgNode.convertToNodeSpaceAR(worldPoint);
+        }
     },
 
     /**
@@ -1232,7 +1237,12 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
      * @return {Vec2}
      */
     convertToWorldSpaceAR: function (nodePoint) {
-        return cc.v2(this._sgNode.convertToWorldSpaceAR(nodePoint));
+        if (this._sgNode.isIgnoreAnchorPointForPosition()) {
+            return cc.v2(this._sgNode.convertToWorldSpace(nodePoint));
+        }
+        else {
+            return cc.v2(this._sgNode.convertToWorldSpaceAR(nodePoint));
+        }
     },
 
     // _convertToWindowSpace: function (nodePoint) {

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -1447,56 +1447,6 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
     },
 
     _removeSgNode: SceneGraphHelper.removeSgNode,
-
-    _replaceSgNode: function(sgNode) {
-        if(sgNode instanceof _ccsg.Node) {
-            var oldSgNode = this._sgNode;
-
-            //apply property
-            sgNode.setPosition(this._position);
-            sgNode.setRotationX(this._rotationX);
-            sgNode.setRotationY(this._rotationY);
-            sgNode.setScale(this._scaleX, this._scaleY);
-            sgNode.setSkewX(this._skewX);
-            sgNode.setSkewY(this._skewY);
-
-            sgNode.setLocalZOrder(this._localZOrder);
-            sgNode.setGlobalZOrder(this._globalZOrder);
-
-            sgNode.setOpacity(this._opacity);
-            sgNode.setCascadeOpacityEnabled(this._cascadeOpacityEnabled);
-            sgNode.ignoreAnchorPointForPosition(this._ignoreAnchorPointForPosition);
-            sgNode.setTag(this._tag);
-            sgNode.setColor(this._color);
-            sgNode.setOpacityModifyRGB(this._opacityModifyRGB);
-
-            //rebuild scenegraph
-            var children = oldSgNode.getChildren().slice(0);
-            oldSgNode.removeAllChildren();
-
-            for(var index = 0; index < children.length; ++index) {
-                sgNode.addChild(children[index]);
-            }
-
-            var parentNode = oldSgNode.getParent();
-            parentNode.removeChild(oldSgNode);
-
-            // insert node
-            parentNode.addChild(sgNode);
-            sgNode.arrivalOrder = oldSgNode.arrivalOrder;
-            if (cc.renderer) {
-                cc.renderer.childrenOrderDirty = this._parent._sgNode._reorderChildDirty = true;
-            }
-
-            this._sgNode = sgNode;
-            if (cc.sys.isNative) {
-                oldSgNode.release();
-                sgNode.retain();
-            }
-        } else {
-            throw new Error("Invalid sgNode. It must an instance of _ccsg.Node");
-        }
-    },
 });
 
 

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -204,9 +204,7 @@ if (CC_DEV) {
         return cc.js.array.copy;
     });
 
-
-
-    Object.defineProperty(cc._RendererBelowSG.prototype, 'visible', {
+    Object.defineProperty(cc._SGComponent.prototype, 'visible', {
         get: function () {
             cc.warn('The "visible" property of %s is deprecated, use "enabled" instead please.', cc.js.getClassName(this));
             return this.enabled;
@@ -409,7 +407,7 @@ if (CC_DEV) {
             })(prop);
         }
     }
-    shouldNotUseNodeProp(cc._RendererBelowSG);
+    shouldNotUseNodeProp(cc._SGComponent);
 
 
     // cc.Sprite

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -133,7 +133,8 @@ if (CC_DEV) {
     js.obsoletes(cc, 'cc', {
         'Point': 'Vec2',
         'EScene': 'Scene',
-        'ENode': 'Node'
+        'ENode': 'Node',
+        '_ComponentInSG': '_RendererBelowSG'
     });
 
     /**
@@ -205,7 +206,7 @@ if (CC_DEV) {
 
 
 
-    Object.defineProperty(cc._ComponentInSG.prototype, 'visible', {
+    Object.defineProperty(cc._RendererBelowSG.prototype, 'visible', {
         get: function () {
             cc.warn('The "visible" property of %s is deprecated, use "enabled" instead please.', cc.js.getClassName(this));
             return this.enabled;
@@ -408,7 +409,7 @@ if (CC_DEV) {
             })(prop);
         }
     }
-    shouldNotUseNodeProp(cc._ComponentInSG);
+    shouldNotUseNodeProp(cc._RendererBelowSG);
 
 
     // cc.Sprite

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -134,7 +134,7 @@ if (CC_DEV) {
         'Point': 'Vec2',
         'EScene': 'Scene',
         'ENode': 'Node',
-        '_ComponentInSG': '_RendererBelowSG'
+        '_ComponentInSG': '_RendererUnderSG'
     });
 
     /**
@@ -363,7 +363,10 @@ if (CC_DEV) {
         'userData',
         'userObject',
         '_cascadeColorEnabled',
-        'cascadeColor'
+        'cascadeColor',
+        'ignoreAnchor',
+        'isIgnoreAnchorPointForPosition',
+        'ignoreAnchorPointForPosition'
     ]);
     provideClearError(cc.Node.prototype, {
         arrivalOrder: 'getSiblingIndex, setSiblingIndex',
@@ -435,7 +438,6 @@ if (CC_DEV) {
         createWithSpriteFrame: 'node.addComponent',
     });
     provideClearError(cc.Sprite.prototype, {
-        ignoreAnchorPointForPosition: 'instance.ignoreAnchor',
         getPreferredSize: 'node.getContentSize',
         setPreferredSize: 'node.setContentSize',
         updateWithSprite: 'spriteFrame',

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -520,11 +520,11 @@ properties.emitterMode.type = EmitterMode;
  * emitter.startSpin = 0;
  *
  * @class ParticleSystem
- * @extends cc._ComponentInSG
+ * @extends cc._RendererBelowSG
  */
 var ParticleSystem = cc.Class({
     name: 'cc.ParticleSystem',
-    extends: cc._ComponentInSG,
+    extends: cc._RendererBelowSG,
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.renderers/ParticleSystem',
         inspector: 'app://editor/page/inspector/particle-system/index.html',

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -520,11 +520,11 @@ properties.emitterMode.type = EmitterMode;
  * emitter.startSpin = 0;
  *
  * @class ParticleSystem
- * @extends cc._RendererBelowSG
+ * @extends cc._RendererUnderSG
  */
 var ParticleSystem = cc.Class({
     name: 'cc.ParticleSystem',
-    extends: cc._RendererBelowSG,
+    extends: cc._RendererUnderSG,
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.renderers/ParticleSystem',
         inspector: 'app://editor/page/inspector/particle-system/index.html',

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -25,11 +25,11 @@
 /**
  * Render the TMX layer.
  * @class TiledLayer
- * @extends _RendererBelowSG
+ * @extends _RendererUnderSG
  */
 var TiledLayer = cc.Class({
     name: 'cc.TiledLayer',
-    extends: require('./../core/components/CCRendererBelowSG'),
+    extends: cc._RendererUnderSG,
 
     editor: CC_EDITOR,
 

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -25,11 +25,11 @@
 /**
  * Render the TMX layer.
  * @class TiledLayer
- * @extends _ComponentInSG
+ * @extends _RendererBelowSG
  */
 var TiledLayer = cc.Class({
     name: 'cc.TiledLayer',
-    extends: require('./../core/components/CCComponentInSG'),
+    extends: require('./../core/components/CCRendererBelowSG'),
 
     editor: CC_EDITOR,
 

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -33,7 +33,6 @@ var TiledMap = cc.Class({
 
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.renderers/TiledMap',
-        executeInEditMode: true
     },
 
     properties: {

--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -44,7 +44,7 @@ function setEnumAttr (obj, propName, enumDef) {
  * Multiple skeletons can use the same SkeletonData which includes all animations, skins, and attachments.) <br/>
  *
  * @class Skeleton
- * @extends cc._ComponentInSG
+ * @extends cc._RendererBelowSG
  * @constructor
  */
 
@@ -52,7 +52,7 @@ function setEnumAttr (obj, propName, enumDef) {
 
 sp.Skeleton = cc.Class({
     name: 'sp.Skeleton',
-    extends: cc._ComponentInSG,
+    extends: cc._RendererBelowSG,
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.others/Spine Skeleton',
         //playOnFocus: true

--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -44,7 +44,7 @@ function setEnumAttr (obj, propName, enumDef) {
  * Multiple skeletons can use the same SkeletonData which includes all animations, skins, and attachments.) <br/>
  *
  * @class Skeleton
- * @extends cc._RendererBelowSG
+ * @extends cc._RendererUnderSG
  * @constructor
  */
 
@@ -52,7 +52,7 @@ function setEnumAttr (obj, propName, enumDef) {
 
 sp.Skeleton = cc.Class({
     name: 'sp.Skeleton',
-    extends: cc._RendererBelowSG,
+    extends: cc._RendererUnderSG,
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.others/Spine Skeleton',
         //playOnFocus: true

--- a/test/qunit/unit/test-node-serialization.js
+++ b/test/qunit/unit/test-node-serialization.js
@@ -31,7 +31,6 @@ if (TestEditorExtends) {
         '_skewY',
         '_anchorPoint',
         '_contentSize',
-        '_ignoreAnchorPointForPosition',
         'tag',
         '_name',
         '_opacity',
@@ -55,7 +54,6 @@ if (TestEditorExtends) {
             '_active' : getRandomBool(),
             '_anchorPoint' : cc.p(getRandomDouble(), getRandomDouble()),
             '_contentSize' : cc.size(getRandomDouble(), getRandomDouble()),
-            '_ignoreAnchorPointForPosition' : getRandomBool(),
             'tag' : getRandomInt(),
             '_name' : nodeName,
             '_opacity' : getSpecRandomInt(0, 256),
@@ -80,7 +78,6 @@ if (TestEditorExtends) {
         ret._active = getRandomBool();
         ret._anchorPoint = cc.p(getRandomDouble(), getRandomDouble());
         ret._contentSize = cc.size(getRandomDouble(), getRandomDouble());
-        ret._ignoreAnchorPointForPosition = getRandomBool();
         ret.tag = getRandomInt();
         ret._name = nodeName;
         ret._opacity = getSpecRandomInt(0, 256);


### PR DESCRIPTION
新的 RendererInSG 组件用于替换渲染树上的节点，用于实现 tilemap, mask, SpriteBatchNode 等

Re: cocos-creator/fireball#719

Changes proposed in this pull request:
- 将 ComponentInSG 重命名为 RendererBelowSG
- 加入 RendererInSG
- 提取 cc._SGComponent 作为 RendererInSG 和 RendererBelowSG 的共同基类，方便引擎统一处理
- 调整引擎的 anchor 计算操作以保证 RendererInSG 能适用我们新的 anchor 体系

@cocos-creator/engine-admins @2youyouo2 @zilongshanren 
