### PR TITLE
Remove callbacks after flowout an item to avoid duplicated callback calls

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -308,7 +308,8 @@ var game = /** @lends cc.game# */{
 
 //  @ Persist root node section
     /**
-     * Add a persistent root node to the game, the persistent node won't be destroyed during scene transition
+     * Add a persistent root node to the game, the persistent node won't be destroyed during scene transition.
+     * The target node must be placed in the root level of hierarchy, otherwise this API won't have any effect.
      * @method addPersistRootNode
      * @param {Node} node - The node to be made persistent
      */

--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -33,6 +33,7 @@ var loader = new Loader();
 /**
  * Loader for resource loading process. It's a singleton object.
  * @class loader
+ * @extends Pipeline
  * @static
  */
 cc.loader = new Pipeline([
@@ -146,6 +147,7 @@ JS.mixin(cc.loader, {
 
         function loadedCheck (item) {
             checker[item.src] = item;
+            self._items.remove(item.src, loadedCheck);
             if (item.error) {
                 error = error || [];
                 error.push(item.src);

--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -39,6 +39,7 @@ var JS = require('../platform/js');
  * Item can hold other custom properties
  * 
  * @class LoadingItems
+ * @extends CallbacksInvoker
  */
 var LoadingItems = function () {
     CallbacksInvoker.call(this);
@@ -126,7 +127,7 @@ JS.mixin(LoadingItems.prototype, CallbacksInvoker.prototype, {
      * Remove an item, can only remove completed item, ongoing item can not be removed
      * @param {String} url
      */
-    remove: function (url) {
+    removeItem: function (url) {
         if (this.completed[url]) {
             delete this.completed[url];
             delete this.map[url];

--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -318,8 +318,10 @@ JS.mixin(Pipeline.prototype, {
         var checker = {};
         var count = 0;
 
+        var items = this._items;
         function loadedCheck (item) {
             checker[item.src] = item;
+            items.remove(item.src, loadedCheck);
 
             for (var url in checker) {
                 // Not done yet
@@ -335,9 +337,9 @@ JS.mixin(Pipeline.prototype, {
             var url = urlList[i].src || urlList[i];
             if (typeof url !== 'string')
                 continue;
-            var item = this._items.map[url];
+            var item = items.map[url];
             if ( !item ) {
-                this._items.add(url, loadedCheck);
+                items.add(url, loadedCheck);
                 checker[url] = null;
                 count++;
             }
@@ -389,6 +391,9 @@ JS.mixin(Pipeline.prototype, {
         this.complete();
 
         items.invoke(url, item);
+
+        // remove all callbacks added for url
+        items.removeAll(url);
     },
 
     /**
@@ -443,7 +448,7 @@ JS.mixin(Pipeline.prototype, {
                 item.error = new Error('Canceled manually');
                 this.flowOut(item);
             }
-            this._items.remove(url);
+            this._items.removeItem(url);
         }
         else {
             return false;

--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -390,10 +390,7 @@ JS.mixin(Pipeline.prototype, {
 
         this.complete();
 
-        items.invoke(url, item);
-
-        // remove all callbacks added for url
-        items.removeAll(url);
+        items.invokeAndRemove(url, item);
     },
 
     /**

--- a/cocos2d/core/platform/callbacks-invoker.js
+++ b/cocos2d/core/platform/callbacks-invoker.js
@@ -219,6 +219,7 @@ CallbacksInvoker.prototype.invoke = function (key, p1, p2, p3, p4, p5) {
  * @param {any} [p5]
  */
 CallbacksInvoker.prototype.invokeAndRemove = function (key, p1, p2, p3, p4, p5) {
+    this._invoking = key;
     // this.invoke(key, p1, p2, p3, p4, p5);
     // 这里不直接调用invoke仅仅是为了减少调用堆栈的深度，方便调试
     var list = this._callbackTable[key], i, l, target;
@@ -235,6 +236,8 @@ CallbacksInvoker.prototype.invokeAndRemove = function (key, p1, p2, p3, p4, p5) 
             }
         }
     }
+    this._invoking = null;
+    this._toRemove.length = 0;
     this.removeAll(key);
 };
 


### PR DESCRIPTION
> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
> - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

Re: cocos-creator/fireball#2100

Changes proposed in this pull request:
- 之前的实现导致依赖资源的 callback 在多次加载之后会遗留，使得二次或多次加载的时候多次调用 callback，使得结果不可控，同时也存在内存泄漏。目前的方案在 flowOut 之后删除所有的资源事件监听器，相当于只通知一遍。

@cocos-creator/engine-admins
