### PR TITLE
	Optimize the implementation of TiledMap

### DIFF
--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -1453,7 +1453,9 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
         sgNode.setSkewY(this._skewY);
         sgNode.ignoreAnchorPointForPosition(this.__ignoreAnchor);
 
+        var arrivalOrder = sgNode.arrivalOrder;
         sgNode.setLocalZOrder(this._localZOrder);
+        sgNode.arrivalOrder = arrivalOrder;
         sgNode.setGlobalZOrder(this._globalZOrder);
 
         sgNode.setOpacity(this._opacity);

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -314,6 +314,13 @@ var TiledMap = cc.Class({
         this.node.off('child-reorder', this._reorderChildren, this);
     },
 
+    onDestroy: function() {
+        this._super();
+
+        // remove the TiledLayer entities
+        this._removeLayerEntities();
+    },
+
     _createSgNode: function () {
         return new _ccsg.TMXTiledMap();
     },

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -361,6 +361,9 @@ var TiledMap = cc.Class({
     },
 
     _moveLayersInSgNode: function(sgNode) {
+        // clear the detached layers info first
+        this._detachedLayers.length = 0;
+
         var children = sgNode.getChildren();
         for (var i = children.length - 1; i >= 0; i--) {
             var child = children[i];
@@ -509,12 +512,13 @@ var TiledMap = cc.Class({
         if (file) {
             self._isLoading = true;
             this._preloadTmx(file, function (err, results) {
-                if (err) {
-                    self._onMapLoaded(err);
-                } else {
+                if (!err) {
                     sgNode.initWithTMXFile(file);
-                    self._onMapLoaded();
+                    if (! self._enabled) {
+                        self._moveLayersInSgNode(sgNode);
+                    }
                 }
+                self._onMapLoaded(err);
             });
         } else {
             // tmx file is cleared


### PR DESCRIPTION
Changes proposed in this pull request:
- If the component TiledMap is disabled, should refresh the detached layers when apply a new tmx file.
- Just disable the TiledLayer components when the TiledMap component disabled. _(Before changed: TiledLayer entities are removed.)_
- Just remove the TiledLayer components when the tmxFile is cleared. _(Before changed: TiledLayer entities are removed.)_

@cocos-creator/engine-admins

@jareguo Please review the PR.
