### PR TITLE
Solve the error when a node with TiledMap component is destroyed.

### DIFF
--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -393,6 +393,10 @@ var TiledMap = cc.Class({
         var logicChildren = this.node.getChildren();
         for (var i = logicChildren.length - 1; i >= 0; i--) {
             var child = logicChildren[i];
+            if (!child.isValid) {
+                continue;
+            }
+
             var tmxLayer = child.getComponent(cc.TiledLayer);
             if (tmxLayer) {
                 child.removeComponent(cc.TiledLayer);


### PR DESCRIPTION
Changes proposed in this pull request:
- Solve the error when a node with TiledMap component is destroyed.

@cocos-creator/engine-admins
