### PR TITLE
fix getBoundingBoxToWorld

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -978,9 +978,7 @@ var Node = cc.Class({
     },
 
     _hitTest: function (point, listener) {
-        var apx = this._anchorPoint.x,
-            apy = this._anchorPoint.y,
-            w = this.width,
+        var w = this.width,
             h = this.height;
         var rect = cc.rect(0, 0, w, h);
         var trans = this.getNodeToWorldTransform();

--- a/cocos2d/core/components/CCRendererInSG.js
+++ b/cocos2d/core/components/CCRendererInSG.js
@@ -68,7 +68,7 @@ var RendererInSG = cc.Class({
         if (this._sgNode !== released) {
             this._sgNode.release();
         }
-        else {
+        else {  // if (this._plainNode !== released) {
             this._plainNode.release();
         }
     },


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/pull/391/files#diff-abc4ad6bb61a3ee5a7eb69d3e3111267L1274

Changes proposed in this pull request:
- 增加了 node.getNodeToWorldTransformAR 和 getNodeToParentTransformAR 两个 API
- 修正了 getBoundingBoxToWorld 的计算

@cocos-creator/engine-admins @zilongshanren 
