### PR TITLE
add api syntax for component's lifecycle methods to CCClass options

### DIFF
--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -405,12 +405,6 @@ var Component = cc.Class({
      */
     onDestroy: null,
 
-    ///**
-    // * Called when the engine starts rendering the scene.
-    // * @method onPreRender
-    // */
-    //onPreRender: null,
-
     /**
      * @method onFocusInEditor
      */

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -731,12 +731,25 @@ function declareProperties (cls, className, properties, baseClass, mixins) {
  * @param {Function} [options.extends] - The base class.
  * @param {Function} [options.ctor] - The constructor.
  * @param {Object} [options.properties] - The property definitions.
- * @param {Object} [options.editor] - The attributes for Component, see {{#crossLink "_ComponentAttributes"}}ComponentAttributes{{/crossLink}}.
  * @param {Object} [options.statics] - The static members.
  * @param {Function[]} [options.mixins]
  * 
+ * @param {Object} [options.editor] - attributes for Component, see {{#crossLink "_ComponentAttributes"}}ComponentAttributes{{/crossLink}}.
+ * 
+ * @param {Function} [options.update] - lifecycle method for Component, see {{#crossLink "Component/update:method"}}{{/crossLink}}
+ * @param {Function} [options.lateUpdate] - lifecycle method for Component, see {{#crossLink "Component/lateUpdate:method"}}{{/crossLink}}
+ * @param {Function} [options.onLoad] - lifecycle method for Component, see {{#crossLink "Component/onLoad:method"}}{{/crossLink}}
+ * @param {Function} [options.start] - lifecycle method for Component, see {{#crossLink "Component/start:method"}}{{/crossLink}}
+ * @param {Function} [options.onEnable] - lifecycle method for Component, see {{#crossLink "Component/onEnable:method"}}{{/crossLink}}
+ * @param {Function} [options.onDisable] - lifecycle method for Component, see {{#crossLink "Component/onDisable:method"}}{{/crossLink}}
+ * @param {Function} [options.onDestroy] - lifecycle method for Component, see {{#crossLink "Component/onDestroy:method"}}{{/crossLink}}
+ * @param {Function} [options.onFocusInEditor] - lifecycle method for Component, see {{#crossLink "Component/onFocusInEditor:method"}}{{/crossLink}}
+ * @param {Function} [options.onLostFocusInEditor] - lifecycle method for Component, see {{#crossLink "Component/onLostFocusInEditor:method"}}{{/crossLink}}
+ * @param {Function} [options.onRestore] - for Component only, see {{#crossLink "Component/onRestore:method"}}{{/crossLink}}
+ * @param {Function} [options._getLocalBounds] - for Component only, see {{#crossLink "Component/_getLocalBounds:method"}}{{/crossLink}}
+ * 
  * @return {Function} - the created class
- *
+ * 
  * @example
  // define base class
  var Node = cc.Class();


### PR DESCRIPTION
Re: cocos-creator/fireball#1323

Changes proposed in this pull request:
- 把组件的生命周期方法也加到 CCClass 的智能提示了

![image](https://cloud.githubusercontent.com/assets/1503156/13449107/44865a96-e063-11e5-902f-a0f76d03e5f2.png)

@cocos-creator/engine-admins
