### PR TITLE
add editbox background scale9 capInsets support

### DIFF
--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -74,7 +74,6 @@ var EditBox = cc.Class({
                 var backgroundSprite = sgNode.getBackgroundSprite();
                 if(this.backgroundImage) {
                     var sprite = this._createBackgroundSprite();
-                    sprite.setSpriteFrame(this.backgroundImage);
                     sprite.setContentSize(sgNode.getContentSize());
                 }
                 else {
@@ -246,6 +245,14 @@ var EditBox = cc.Class({
         InputMode: InputMode
     },
 
+    _applyCapInset: function (sprite) {
+        var backgroundImage = this.backgroundImage;
+        sprite.setInsetTop(backgroundImage.insetTop);
+        sprite.setInsetBottom(backgroundImage.insetBottom);
+        sprite.setInsetRight(backgroundImage.insetRight);
+        sprite.setInsetLeft(backgroundImage.insetLeft);
+    },
+
     _createSgNode: function() {
         return new _ccsg.EditBox(cc.size(160, 40));
     },
@@ -254,6 +261,8 @@ var EditBox = cc.Class({
         var sgNode = this._sgNode;
         var bgSprite = new cc.Scale9Sprite();
         bgSprite.setSpriteFrame(this.backgroundImage);
+        bgSprite.setRenderingType(cc.Scale9Sprite.RenderingType.SLICED);
+        this._applyCapInset(bgSprite);
         sgNode.initWithSizeAndBackgroundSprite(cc.size(160, 40), bgSprite);
         return bgSprite;
     },

--- a/cocos2d/core/editbox/CCSGEditBox.js
+++ b/cocos2d/core/editbox/CCSGEditBox.js
@@ -711,10 +711,9 @@ _ccsg.EditBox = _ccsg.Node.extend({
         this._nativeControl.show();
     },
 
-    _updateBackgroundSpriteSizeAndPosition: function (width, height) {
+    _updateBackgroundSpriteSize: function (width, height) {
         if(this._backgroundSprite) {
             this._backgroundSprite.setContentSize(width, height);
-            this._backgroundSprite.setPosition(cc.p(width/2, height/2));
         }
     },
 
@@ -724,7 +723,7 @@ _ccsg.EditBox = _ccsg.Node.extend({
         var newWidth = size.width || size;
         var newHeight = size.height || height;
 
-        this._updateBackgroundSpriteSizeAndPosition(newWidth, newHeight);
+        this._updateBackgroundSpriteSize(newWidth, newHeight);
         this._nativeControl.setSize(newWidth, newHeight);
     },
 
@@ -913,9 +912,10 @@ _ccsg.EditBox = _ccsg.Node.extend({
         this._backgroundSprite = normal9SpriteBg;
 
         if(this._backgroundSprite && !this._backgroundSprite.parent) {
+            this._backgroundSprite.setAnchorPoint(cc.p(0, 0));
             this.addChild(this._backgroundSprite);
 
-            this._updateBackgroundSpriteSizeAndPosition(size.width, size.height);
+            this._updateBackgroundSpriteSize(size.width, size.height);
         }
 
 


### PR DESCRIPTION
Re: cocos-creator/fireball#2175

Changes proposed in this pull request:
- 添加EditBox背景框的slice 9 border编辑功能
- fix替换EditBox背景框的背景图片可能产生的背景图片位移偏差问题。

@cocos-creator/engine-admins
