### PR TITLE
CCClass should be unable to define "constructor"

### DIFF
--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -853,6 +853,10 @@ function CCClass (options) {
         if (BUILTIN_ENTRIES.indexOf(funcName) >= 0) {
             continue;
         }
+        if (funcName === 'constructor' && CC_EDITOR) {
+            cc.error('Can not define a member called "constructor" in the class "%s", please use "ctor" instead.', name);
+            continue;
+        }
         var func = options[funcName];
         if (typeof func === 'function' || func === null) {
             // use defineProperty to redefine some super method defined as getter


### PR DESCRIPTION
Changes proposed in this pull request:
- 如果用户在 CCClass 定义了 constructor (不是 ctor)，会导致引擎无法获取对应实例的类型信息，导致场景数据丢失

@cocos-creator/engine-admins
