### PR TITLE
fix editbox capInsets error when bg is empty

### DIFF
--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -260,9 +260,12 @@ var EditBox = cc.Class({
     _createBackgroundSprite: function() {
         var sgNode = this._sgNode;
         var bgSprite = new cc.Scale9Sprite();
-        bgSprite.setSpriteFrame(this.backgroundImage);
         bgSprite.setRenderingType(cc.Scale9Sprite.RenderingType.SLICED);
-        this._applyCapInset(bgSprite);
+        if (this.backgroundImage) {
+
+            bgSprite.setSpriteFrame(this.backgroundImage);
+            this._applyCapInset(bgSprite);
+        }
         sgNode.initWithSizeAndBackgroundSprite(cc.size(160, 40), bgSprite);
         return bgSprite;
     },


### PR DESCRIPTION
Changes proposed in this pull request:
-  修复EditBox背景图片没有指定时的报错

@cocos-creator/engine-admins
