### PR TITLE
CCClass: export getDefault in edit mode

### DIFF
--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -1089,3 +1089,7 @@ module.exports = {
     },
     fastDefine: CCClass._fastDefine
 };
+
+if (CC_EDITOR) {
+    module.exports.getDefault = getDefault; 
+}

--- a/cocos2d/core/platform/attribute.js
+++ b/cocos2d/core/platform/attribute.js
@@ -125,6 +125,13 @@ cc.Integer = 'Integer';
  */
 cc.Float = 'Float';
 
+if (CC_EDITOR) {
+    JS.get(cc, 'Number', function () {
+        cc.warn('Use "cc.Float" or "cc.Integer" instead of "cc.Number" please. \uD83D\uDE02');
+        return cc.Float;
+    });
+}
+
 /**
  * Indicates that the elements in array should be type boolean.
  * @property {string} Boolean


### PR DESCRIPTION
Re: cocos-creator/fireball#1844

Changes proposed in this pull request:
- 编辑器下导出了获得 CCClass 默认值的方法
- 加入访问 cc.Number 的警告

@cocos-creator/engine-admins
