### PR TITLE
fix jsb bmfont error

### DIFF
--- a/jsb/jsb-label.js
+++ b/jsb/jsb-label.js
@@ -123,7 +123,8 @@ jsbLabel.prototype.setFontFileOrFamily = function (fontHandle) {
             this.setTTFConfig(this._ttfConfig);
         } else if (extName === '.fnt') {
             this._labelType = _ccsg.Label.Type.BMFont;
-            this.setBMFontFilePath(fontHandle, cc.v2(0, 0), this.getBMFontSize());
+            this.setBMFontFilePath(fontHandle);
+            this.setFontSize(this.getFontSize());
         }
     }
 };


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/2225

Changes proposed in this pull request:
-  修复jsb在3.10以前的引擎上崩溃的问题。

因为3.10给bmfont添加了修改fontSize的功能，所以3.10以前的版本，bmfont是无法修改size的。。

@cocos-creator/engine-admins
