### PR TITLE
fix jsb overflow none

### DIFF
--- a/cocos2d/core/editbox/CCSGEditBox.js
+++ b/cocos2d/core/editbox/CCSGEditBox.js
@@ -742,8 +742,8 @@ _ccsg.EditBox = _ccsg.Node.extend({
     _updateEditBoxSize: function(size, height) {
         this._oldSetContentSize(size, height);
 
-        var newWidth = size.width || size;
-        var newHeight = size.height || height;
+        var newWidth = (typeof size.width === 'number') ? size.width : size;
+        var newHeight = (typeof size.height === 'number') ? size.height : height;
 
         this._updateBackgroundSpriteSize(newWidth, newHeight);
         this._nativeControl.setSize(newWidth, newHeight);

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -632,8 +632,8 @@ cc.BMFontHelper = {
     },
 
     _setDimensions: function(size, height) {
-        var newWidth = size.width || size;
-        var newHeight = size.height || height;
+        var newWidth = (typeof size.width === 'number') ? size.width : size;
+        var newHeight = (typeof size.height === 'number') ? size.height : height;
 
         _ccsg.Node.prototype.setContentSize.call(this, size, height);
 

--- a/jsb/jsb-label.js
+++ b/jsb/jsb-label.js
@@ -45,6 +45,16 @@ if (!jsbLabel.prototype.setOverflow) {
 }
 if (!jsbLabel.prototype.getOverflow) {
     jsbLabel.prototype.getOverflow = function(){};
+
+//fix jsb system font overflow
+jsbLabel.prototype._setOverflow = jsbLabel.prototype.setOverflow;
+jsbLabel.prototype.setOverflow = function(overflow) {
+    this._overFlow = overflow;
+    this._setOverflow(this._overFlow);
+}
+
+jsbLabel.prototype.getOverflow = function() {
+    return this._overFlow;
 }
 
 if (!jsbLabel.prototype.isSystemFontUsed) {
@@ -98,12 +108,14 @@ jsbLabel.prototype.getTTFConfig = function () {
 };
 
 jsbLabel.prototype.setContentSize = function (size, height) {
-    if(height !== undefined){
-        this.setDimensions(size, height);
+    var newWidth = (typeof size.width === 'number') ? size.width : size;
+    var newHeight = (typeof size.height === 'number') ? size.height : height;
+
+    if(this.getOverflow() === cc.Label.Overflow.NONE) {
+        newWidth = 0;
+        newHeight = 0;
     }
-    else{
-        this.setDimensions(size.width, size.height);
-    }
+    this.setDimensions(newWidth, newHeight);
 };
 
 jsbLabel.prototype.setFontFileOrFamily = function (fontHandle) {


### PR DESCRIPTION
Re: cocos-creator/fireball#2283

Changes proposed in this pull request:
-  修复系统字体的overflow为none时，设置setContentSize的问题。

@cocos-creator/engine-admins
