### PR TITLE
Fix sprite frame can't be inited with a single texture in JSB

### DIFF
--- a/jsb/jsb-etc.js
+++ b/jsb/jsb-etc.js
@@ -120,6 +120,28 @@ cc.TextureCache.prototype.addImage = function(url, cb, target) {
     }
 };
 
+// cc.SpriteFrame
+cc.SpriteFrame.prototype._ctor = function (filename, rect, rotated, offset, originalSize) {
+    if (originalSize !== undefined) {
+        if(filename instanceof cc.Texture2D) {
+            this.initWithTexture(filename, rect, rotated, offset, originalSize);
+        }
+        else {
+            this.initWithTexture(filename, rect, rotated, offset, originalSize);
+        }
+    } else if (rect !== undefined) {
+        if(filename instanceof cc.Texture2D) {
+            this.initWithTexture(filename, rect);
+        }
+        else {
+            this.initWithTextureFilename(filename, rect);
+        }
+    } else if (filename instanceof cc.Texture2D) {
+        rect = cc.rect(0, 0, filename.getPixelWidth(), filename.getPixelHeight());
+        this.initWithTexture(filename, rect);
+    }
+};
+
 // ccsg
 window._ccsg = {
     Node: cc.Node,


### PR DESCRIPTION
> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
> - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

Re: cocos-creator/fireball#2317

Changes proposed in this pull request:
- 修复 SpriteFrame 无法用但一参数（texture）创建的问题（导致 LoadTexture 失败）

@cocos-creator/engine-admins
