### PR TITLE
Fixed a bug about Sprite opacity

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -167,8 +167,8 @@ var Sprite = cc.Class({
                 this._spriteFrame = value;
                 this._applySpriteFrame(lastSprite);
                 // color cleared after reset texture, should re-apply color
-                this._sgNode.setColor(this.node._color);
-                this._sgNode.setOpacity(this.node._opacity);
+                // this._sgNode.setColor(this.node._color);
+                // this._sgNode.setOpacity(this.node._opacity);
             },
             type: cc.SpriteFrame,
         },


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/2333

这里 sprite component 是不需要设置 opacity 的。

node 上的 sgNode hi父节点，负责更新 opacity。作为子节点的 component._sgNode 上的 opacity，是会和父节点叠加产生一个 _displayOpacity 的，如果直接设置到子节点上，子节点的 _realOpacity 就会被更改，更改后再修改父节点的 opacity 后，子节点已经没有办法产生正确的 displayOpacity嘞。
