### PR TITLE
change CCSprite Size Mode default value, and remove useOriginalSize

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -131,9 +131,7 @@ var Sprite = cc.Class({
             type: cc.SpriteFrame
         },
         _type: SpriteType.SIMPLE,
-        //FIXME:_useOriginalSize is deprecated, since v0.8, it need to be deleted
-        _useOriginalSize: true,
-        _sizeMode: -1,
+        _sizeMode: SizeMode.RAW,
         _fillType: 0,
         _fillCenter: cc.v2(0,0),
         _fillStart: 0,
@@ -345,20 +343,6 @@ var Sprite = cc.Class({
             tooltip: 'i18n:COMPONENT.sprite.dst_blend_factor'
         },
 
-        //FIXME:_useOriginalSize is deprecated, since v0.8, it need to be deleted
-        useOriginalSize: {
-            get: function () {
-                return this._useOriginalSize;
-            },
-            set: function (value) {
-                this._useOriginalSize = value;
-                if (value) {
-                    this._applySpriteSize();
-                }
-            },
-            animatable: false,
-            tooltip: 'i18n:COMPONENT.sprite.original_size',
-        },
         /**
          * !#en specify the size tracing mode.
          * !#zh 精灵尺寸调整模式
@@ -533,19 +517,6 @@ var Sprite = cc.Class({
         this.node.off('size-changed', this._resized, this);
     },
 
-    _validateSizeMode: function() {
-        //do processing
-        if (-1 === this._sizeMode) {
-            //FIXME:_useOriginalSize is deprecated, since v0.8, it need to be deleted
-            if (this._useOriginalSize) {
-                this._sizeMode = SizeMode.TRIMMED;
-            } else {
-                this._sizeMode = SizeMode.CUSTOM;
-            }
-            this._isTrimmedMode = true;
-        }
-    },
-
     _applyAtlas: CC_EDITOR && function (spriteFrame) {
         // Set atlas
         if (spriteFrame && spriteFrame._atlasUuid) {
@@ -624,7 +595,6 @@ var Sprite = cc.Class({
     _initSgNode: function () {
         var sgNode = this._sgNode;
         
-        this._validateSizeMode();
         this._applySpriteFrame(null);
 
         // should keep the size of the sg node the same as entity,

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -457,6 +457,7 @@ if (CC_DEV) {
         updateWithSprite: 'spriteFrame',
         getSpriteFrame: 'spriteFrame',
         setSpriteFrame: 'spriteFrame',
+        useOriginalSize: 'sizeMode',
     });
 
     // Particle


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
- 修改 Size Mode的默认值，这样让用户动态创建的时候，不需要再重新重新设置（之前是 -1）。

@cocos-creator/engine-admins
