### PR TITLE
Fixed a bug about WeChat

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -185,8 +185,14 @@ var View = cc._Class.extend({
         _t._targetDensityDPI = cc.macro.DENSITYDPI_HIGH;
     },
 
+    _resizeTimer: null,
     // Resize helper functions
     _resizeEvent: function () {
+        clearTimeout(this._resizeTimer);
+        this._resizeTimer = setTimeout(this._resizeHandle.bind(this), 10);
+    },
+
+    _resizeHandle: function () {
         var view;
         if(this.setDesignResolutionSize){
             view = this;
@@ -250,15 +256,15 @@ var View = cc._Class.extend({
             //enable
             if (!this.__resizeWithBrowserSize) {
                 this.__resizeWithBrowserSize = true;
-                window.addEventListener('resize', this._resizeEvent);
-                window.addEventListener('orientationchange', this._resizeEvent);
+                window.addEventListener('resize', this._resizeEvent.bind(this));
+                window.addEventListener('orientationchange', this._resizeEvent.bind(this));
             }
         } else {
             //disable
             if (this.__resizeWithBrowserSize) {
                 this.__resizeWithBrowserSize = false;
-                window.removeEventListener('resize', this._resizeEvent);
-                window.removeEventListener('orientationchange', this._resizeEvent);
+                window.removeEventListener('resize', this._resizeEvent.bind(this));
+                window.removeEventListener('orientationchange', this._resizeEvent.bind(this));
             }
         }
     },


### PR DESCRIPTION
修复IOS微信在切换场景的时候黑屏以及UC闪屏的问题。

原因：浏览器优化，延迟了渲染以及resize事件。

在触发 resize 的时候，执行了 setDesignResolutionSize 函数。函数内处理后，修改了canvas 以及 frame 的 size，这时候又重新调用了_resizeEvent，所以就闪来闪去了。

https://github.com/cocos-creator/fireball/issues/2555
