### PR TITLE
transform should become dirty if hierarchy changed

### DIFF
--- a/cocos2d/core/base-nodes/CCSGNode.js
+++ b/cocos2d/core/base-nodes/CCSGNode.js
@@ -867,6 +867,7 @@ _ccsg.Node = cc.Class({
      */
     setParent: function (parent) {
         this._parent = parent;
+        this._renderCmd.setDirtyFlag(_ccsg.Node._dirtyFlags.transformDirty);
     },
 
     /**


### PR DESCRIPTION
Re: cocos-creator/fireball#2613

Changes proposed in this pull request:
- 修改 parent 时，应该把 transform 标记为 dirty

@cocos-creator/engine-admins
