### PR TITLE
add missing layout tooltip

### DIFF
--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -208,7 +208,7 @@ var Layout = cc.Class({
          */
         resizeMode: {
             type: ResizeMode,
-            tooltip: 'i18n:COMPONENT.layout.auto_resize',
+            tooltip: 'i18n:COMPONENT.layout.resize_mode',
             get: function() {
                 return this._resize;
             },
@@ -237,6 +237,7 @@ var Layout = cc.Class({
          */
         cellSize: {
             default: cc.size(40, 40),
+            tooltip: 'i18n:COMPONENT.layout.cell_size',
             type: cc.Size,
             notify: function() {
                 this._doLayoutDirty();
@@ -253,6 +254,7 @@ var Layout = cc.Class({
          */
         startAxis: {
             default: AxisDirection.HORIZONTAL,
+            tooltip: 'i18n:COMPONENT.layout.start_axis',
             type: AxisDirection,
             notify: function() {
                 if (this._resize === ResizeMode.CONTAINER && CC_EDITOR && !cc.engine.isPlaying) {
@@ -272,6 +274,7 @@ var Layout = cc.Class({
          */
         padding: {
             default: 0,
+            tooltip: 'i18n:COMPONENT.layout.padding',
             notify: function() {
                 this._doLayoutDirty();
             },


### PR DESCRIPTION
Re: cocos-creator/fireball#2643

Changes proposed in this pull request:
-  修复layout的tooltip

@cocos-creator/engine-admins
