### PR TITLE
Can not use JSON.stringify to present Error

### DIFF
--- a/cocos2d/core/platform/CCAssetLibrary.js
+++ b/cocos2d/core/platform/CCAssetLibrary.js
@@ -191,7 +191,7 @@ var AssetLibrary = {
 
         Loader.load(item, function (error, asset) {
             if (error || !asset) {
-                error = new Error('[AssetLibrary] loading JSON or dependencies failed : ' + JSON.stringify(error));
+                error = new Error('[AssetLibrary] loading JSON or dependencies failed: ' + error.message);
             }
             if (thisTick) {
                 callInNextTick(function () {
@@ -229,7 +229,7 @@ var AssetLibrary = {
         };
         Loader.load(item, function (error, asset) {
             if (error) {
-                error = new Error('[AssetLibrary] loading JSON or dependencies failed : ' + JSON.stringify(error));
+                error = new Error('[AssetLibrary] loading JSON or dependencies failed: ' + error.message);
             }
             if (thisTick) {
                 callInNextTick(function () {

--- a/test/qunit/unit/test-js.js
+++ b/test/qunit/unit/test-js.js
@@ -34,7 +34,7 @@ test('test', function() {
 test('formatStr', function() {
     var a = '0';
     var b = 1;
-    var SEP = '    ';
+    var SEP = ' ';
     strictEqual(cc.js.formatStr("a: %s, b: %d", a, b), 'a: 0, b: 1', 'format');
     strictEqual(cc.js.formatStr('a:', null), 'a:' + SEP + 'null', 'join');
     strictEqual(cc.js.formatStr("a: %s, b: ", a, b), 'a: 0, b: ' + SEP + '1', 'format and join');


### PR DESCRIPTION
Changes proposed in this pull request:
- 修复了这个报错信息显示不出错误内容，只显示了一个 "{}" 的问题

![image](https://cloud.githubusercontent.com/assets/1503156/14418170/f06b9ef2-ffee-11e5-9dbe-ecc9e6d28f66.png)

@cocos-creator/engine-admins
