### PR TITLE
fix Sprite SizeMode init value

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -131,7 +131,7 @@ var Sprite = cc.Class({
             type: cc.SpriteFrame
         },
         _type: SpriteType.SIMPLE,
-        _sizeMode: SizeMode.RAW,
+        _sizeMode: SizeMode.TRIMMED,
         _fillType: 0,
         _fillCenter: cc.v2(0,0),
         _fillStart: 0,


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
- 修改 Sprite Size Mode 默认值为 TRIMMED

@cocos-creator/engine-admins
