### PR TITLE
Sprite execution should not  ‘size-changed’ at run time

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -499,7 +499,7 @@ var Sprite = cc.Class({
         return this._sgNode.getInsetBottom();
     },
 
-    onLoad: function () {
+    onLoad: CC_EDITOR && function () {
         this._super();
         this.node.on('size-changed', this._resized, this);
     },
@@ -512,7 +512,7 @@ var Sprite = cc.Class({
         }
     },
 
-    onDestroy: function () {
+    onDestroy: CC_EDITOR && function () {
         this._super();
         this.node.off('size-changed', this._resized, this);
     },
@@ -594,7 +594,7 @@ var Sprite = cc.Class({
 
     _initSgNode: function () {
         var sgNode = this._sgNode;
-        
+
         this._applySpriteFrame(null);
 
         // should keep the size of the sg node the same as entity,
@@ -613,7 +613,7 @@ var Sprite = cc.Class({
         sgNode.setBlendFunc(this._blendFunc);
     },
 
-    _resized: function () {
+    _resized: CC_EDITOR && function () {
         if (this._spriteFrame) {
             var actualSize = this.node.getContentSize();
             var expectedW = actualSize.width;


### PR DESCRIPTION
Re: cocos-creator/fireball#2686

Changes proposed in this pull request:
- Sprite 在运行时不应该执行 _resized 方法

@cocos-creator/engine-admins
