### PR TITLE
Solve the error effect in web when using rotated tile in TiledMap.

### DIFF
--- a/cocos2d/tilemap/CCSGTMXLayer.js
+++ b/cocos2d/tilemap/CCSGTMXLayer.js
@@ -796,7 +796,7 @@ _ccsg.TMXLayer = cc.SpriteBatchNode.extend(/** @lends _ccsg.TMXLayer# */{
         sprite.setFlippedY(false);
 
         // Rotation in tiled is achieved using 3 flipped states, flipping across the horizontal, vertical, and diagonal axes of the tiles.
-        if ((gid & cc.TiledMap.TileFlag.DIAGONAL_FLAG) >>> 0) {
+        if ((gid & cc.TiledMap.TileFlag.DIAGONAL) >>> 0) {
             // put the anchor in the middle for ease of rotation.
             sprite.anchorX = 0.5;
 	        sprite.anchorY = 0.5;


### PR DESCRIPTION
Re: cocos-creator/fireball#2716

Changes proposed in this pull request:
- Solve the error effect in web when using rotated tile in TiledMap.

@cocos-creator/engine-admins
