### PR TITLE
disallow ignoreAnchorPointForPosition in render tree to avoid rotation bug

### DIFF
--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -116,19 +116,8 @@ var Mask = cc.Class({
         return new cc.ClippingNode(this._clippingStencil);
     },
 
-    _initSgNode: function () {
-        var clippingNode = this._sgNode;
-        clippingNode.setContentSize(this.node.getContentSize(true));
-    },
-    
-    //onLoad: function () {
-    //    this._super();
-    //    // ignore node size
-    //    if (this.node._sizeProvider === this._sgNode) {
-    //        this.node._sizeProvider = null;
-    //    }
-    //},
-    
+    _initSgNode: function () {},
+
     onEnable: function () {
         this._refreshStencil();
         this._super();
@@ -177,7 +166,7 @@ var Mask = cc.Class({
             var center = cc.v2(x + width /2, y+height/2);
             var radius = {x: width/2, y: height/2};
             var segements = this._segements;
-            this._clippingStencil.drawPoly(this._calculateCircle(center,radius, segements), color, 0, color);
+            this._clippingStencil.drawPoly(this._calculateCircle(center, radius, segements), color, 0, color);
         }
     }
 });

--- a/cocos2d/core/components/CCRendererInSG.js
+++ b/cocos2d/core/components/CCRendererInSG.js
@@ -46,7 +46,7 @@ var RendererInSG = cc.Class({
             // will be released in onDestroy
             this._sgNode.retain();
         }
-        else {
+        else if (CC_EDITOR) {
             cc.error('Not support for asynchronous creating node in SG');
         }
         
@@ -55,17 +55,28 @@ var RendererInSG = cc.Class({
         this._plainNode.retain();
     },
 
+    onLoad: function () {
+        this._initSgNode();
+        if ( !this._sgNode.getContentSize().equals(cc.Size.ZERO) && CC_EDITOR ) {
+            cc.error('Renderer error: Size of the cc._RendererInSG._sgNode must be zero');
+        }
+    },
+
     onEnable: function () {
         this._replaceSgNode(this._sgNode);
-        this.node._ignoreAnchor = true;
+
+        // can not ignore anchor in render tree due to rotation bug which can't be fixed in JSB
+        // see https://github.com/cocos-creator/engine/pull/610
+        //this.node._ignoreAnchor = true;
     },
+
     onDisable: function () {
         this._replaceSgNode(this._plainNode);
-        this.node._ignoreAnchor = false;
+        //this.node._ignoreAnchor = false;
     },
+
     onDestroy: function () {
-        this._super();
-        
+        this._removeSgNode();
         var releasedByNode = this.node._sgNode;
         if (this._plainNode !== releasedByNode) {
             this._plainNode.release();

--- a/cocos2d/core/components/CCRendererUnderSG.js
+++ b/cocos2d/core/components/CCRendererUnderSG.js
@@ -52,18 +52,31 @@ var RendererUnderSG = cc.Class({
 
     // You should reimplement this function if your _sgNode maybe null.
     onLoad: function () {
-        this._super();
+        this._initSgNode();
+        var sgNode = this._sgNode;
+        if ( !this.node._sizeProvider ) {
+            this.node._sizeProvider = sgNode;
+        }
         this._appendSgNode(this._sgNode);
     },
+
     onEnable: function () {
         if (this._sgNode) {
             this._sgNode.setVisible(true);
         }
     },
+
     onDisable: function () {
         if (this._sgNode) {
             this._sgNode.setVisible(false);
         }
+    },
+
+    onDestroy: function () {
+        if ( this.node._sizeProvider === this._sgNode ) {
+            this.node._sizeProvider = null;
+        }
+        this._removeSgNode();
     },
 
     _appendSgNode: function (sgNode) {

--- a/cocos2d/core/components/CCSGComponent.js
+++ b/cocos2d/core/components/CCSGComponent.js
@@ -51,19 +51,12 @@ var SGComponent = cc.Class({
         }
     },
 
-    onLoad: function () {
-        this._initSgNode();
-        var sgNode = this._sgNode;
-        if ( !this.node._sizeProvider ) {
-            this.node._sizeProvider = sgNode;
-        }
-    },
-    onDestroy: function () {
-        if ( this.node._sizeProvider === this._sgNode ) {
-            this.node._sizeProvider = null;
-        }
-        this._removeSgNode();
-    },
+    //onLoad: function () {
+    //    this._initSgNode();
+    //},
+    //onDestroy: function () {
+    //    this._removeSgNode();
+    //},
 
     /**
      * Create and returns your new scene graph node (SGNode) to add to scene graph.

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -2090,32 +2090,6 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
  * node.setLocalZOrder(1);
  */
 
-/*
- * !#en
- * Returns whether the anchor point will be ignored when you position this node.<br/>
- * When anchor point ignored, position will be calculated based on the origin point (0, 0) in parent's coordinates.
- * !#zh
- * 返回这个节点位置时，是否会忽略这个锚点。<br/>
- * 当锚点被忽略时，在父坐标系中的原点（0，0）计算位置。
- * @method isIgnoreAnchorPointForPosition
- * @return {Boolean} true if the anchor point will be ignored when you position this node.
- */
-
-/*
- * !#en
- * Sets whether the anchor point will be ignored when you position this node.                              <br/>
- * When anchor point ignored, position will be calculated based on the origin point (0, 0) in parent's coordinates.  <br/>
- * This is an internal method, only used by CCLayer and CCScene. Don't call it outside framework.        <br/>
- * The default value is false, while in CCLayer and CCScene are true
- * !#zh
- * 设置抹点为（0，0）当你摆放这个节点的时候。
- * 这是一个内部方法，仅仅被 Layer 和 Scene 使用。不要在框架外调用。默认值是 false，但是在 Layer 和 Scene 中是 true.
- * @method ignoreAnchorPointForPosition
- * @param {Boolean} newValue - true if anchor point will be ignored when you position this node
- * @example
- * node.ignoreAnchorPointForPosition(true);
- */
-
 /**
  * !#en Returns whether node's opacity value affect its child nodes.
  * !#zh 返回节点的不透明度值是否影响其子节点。

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -569,6 +569,11 @@ var TiledMap = cc.Class({
         });
     },
 
+    _resetSgSize: function () {
+        this.node.setContentSize(this._sgNode.getContentSize());
+        this._sgNode.setContentSize(0, 0);
+    },
+
     _onMapLoaded: function(err) {
         this._isLoading = false;
         if ( !err ) {
@@ -578,6 +583,7 @@ var TiledMap = cc.Class({
             } else {
                 this._moveLayersInSgNode(this._sgNode);
             }
+            this._resetSgSize();
         }
 
         if (!CC_EDITOR) {

--- a/test/qunit/unit/test-deserialize.js
+++ b/test/qunit/unit/test-deserialize.js
@@ -83,7 +83,7 @@ if (TestEditorExtends) {
         var obj = {
             'null': null,
         };
-        var str = '{ "null": null }'
+        var str = '{ "null": null }';
         deepEqual(cc.deserialize(str), obj, 'can deserialize null');
 
         var MyAsset = cc.Class({
@@ -96,11 +96,11 @@ if (TestEditorExtends) {
             }
         });
 
-        str = '{ "__type__": "MyAsset" }'
+        str = '{ "__type__": "MyAsset" }';
         obj = new MyAsset();
         deepEqual(cc.deserialize(str), obj, 'use default value');
 
-        str = '{ "__type__": "MyAsset", "nil": null }'
+        str = '{ "__type__": "MyAsset", "nil": null }';
         obj = new MyAsset();
         obj.nil = null;
         deepEqual(cc.deserialize(str), obj, 'can override as null');
@@ -112,7 +112,7 @@ if (TestEditorExtends) {
         var obj = {
             'null': null,
         };
-        var str = '{ "null": null }'
+        var str = '{ "null": null }';
         deepEqual(cc.deserialize(str, null, {target: null}), obj, 'can deserialize null');
     });
 


### PR DESCRIPTION
Re: cocos-creator/fireball#2401

Changes proposed in this pull request:
- 修复 ignoreAnchorPointForPosition 引发的旋转轴心不对问题

@cocos-creator/engine-admins
