### PR TITLE
Change the TiledMapAsset from RawAsset to Asset.

### DIFF
--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -170,29 +170,23 @@ var TiledMap = cc.Class({
     },
 
     properties: {
-        _isLoading: {
-            default: false,
-            serializable: false,
-        },
-        
         // the detached array of TiledLayer 
         _detachedLayers: {
             default: [],
             serializable: false,
         },
 
-        /**
-         * !#en The tmx file.
-         * !#zh tmx 文件。
-         * @property {String} tmxFile
-         * @default ""
-         */
         _tmxFile: {
             default: '',
-            url: cc.TiledMapAsset
+            type: cc.TiledMapAsset
         },
-
-        tmxFile : {
+        /**
+         * !#en The TiledMap Asset.
+         * !#zh TiledMap 资源。
+         * @property {cc.TiledMapAsset} tmxAsset
+         * @default ""
+         */
+        tmxAsset : {
             get: function () {
                 return this._tmxFile;
             },
@@ -202,17 +196,7 @@ var TiledMap = cc.Class({
                     this._applyFile();
                 }
             },
-            url: cc.TiledMapAsset
-        },
-
-        /**
-         * !#en The event handler to be called when the map is loaded.
-         * !#zh 在加载在地图时要调用的事件处理程序。
-         * @property {Component.EventHandler} mapLoaded
-         */
-        mapLoaded: {
-            default: [],
-            type: cc.Component.EventHandler,
+            type: cc.TiledMapAsset
         }
     },
 
@@ -345,54 +329,12 @@ var TiledMap = cc.Class({
         this._sgNode.setProperties(properties);
     },
 
-    /*
-     * Initializes the instance of cc.TiledMap with tmxFile.
-     * The mapLoaded events will be emitted when the map is loaded.
-     * @method initWithTMXFile
-     * @param {String} tmxFile
-     */
     initWithTMXFile:function (tmxFile) {
-        this._tmxFile = tmxFile;
+        cc.error('Method "initWithTMXFile" is no effect now, please set property "tmxAsset" instead.');
     },
 
-    /*
-     * Initializes the instance of cc.TiledMap with tmxString.
-     * The mapLoaded events will be emitted when the map is loaded.
-     * @method initWithXML
-     * @param {String} tmxString
-     * @param {String} resourcePath
-     */
     initWithXML:function(tmxString, resourcePath){
-        // clear the tmx file
-        this._tmxFile = null;
-
-        // preload textures & init the _tileMap
-        var self = this;
-        var sgNode = self._sgNode;
-        var mapInfo = new cc.TMXMapInfo(tmxString, resourcePath);
-        if (!mapInfo) {
-            self._onMapLoaded(new Error('Parse map info failed.'));
-            return;
-        }
-
-        self._isLoading = true;
-        if (cc.sys.isNative) {
-            // TODO Consider to remove the setTimeout
-            // In native environment, the reason of using setTimeout:
-            // If not use setTimeout, the _sgNode of cc.TiledLayer
-            // will be removed from the scene graph.
-            setTimeout(function() {
-                sgNode.initWithXML(tmxString, resourcePath);
-                self._onMapLoaded();
-            }, 0);
-        } else {
-            this._preloadTextures(mapInfo, function (err, results) {
-                if (!err) {
-                    sgNode.initWithXML(tmxString, resourcePath);
-                }
-                self._onMapLoaded(err);
-            });
-        }
+        cc.error('Method "initWithXML" is no effect now, please set property "tmxAsset" instead.');
     },
 
     /**
@@ -486,9 +428,15 @@ var TiledMap = cc.Class({
     },
 
     onEnable: function () {
+        if (this._detachedLayers.length === 0) {
+            // When the TiledMap loaded first time, the detachedLayers is empty.
+            // Should move the layers in sgNode to detachedLayers.
+            this._moveLayersInSgNode(this._sgNode);
+        }
+
         this._super();
 
-        if (this._tmxFile && ! this._isLoading) {
+        if (this._tmxFile) {
             // refresh layer entities
             this._refreshLayerEntities();
         }
@@ -502,14 +450,7 @@ var TiledMap = cc.Class({
         this._super();
 
         // disable the TiledLayer component in logic children
-        var logicChildren = this.node.getChildren();
-        for (var i = logicChildren.length - 1; i >= 0; i--) {
-            var child = logicChildren[i];
-            var tmxLayer = child.getComponent(cc.TiledLayer);
-            if (tmxLayer) {
-                tmxLayer.enabled = false;
-            }
-        }
+        this._setLayersEnabled(false);
 
         // remove the sg children for tmx layers (which not maintained by TiledLayer)
         var restoredSgNode = this._plainNode;
@@ -535,54 +476,26 @@ var TiledMap = cc.Class({
         this._applyFile();
     },
 
-    _preloadTextures: function(mapInfo, cb) {
-        var sets = mapInfo.getTilesets();
-        if (sets) {
-            var textures = sets.map(function (set) {
-                return set.sourceImage;
-            });
+    _onMapLoaded: function() {
+        this._refreshLayerEntities();
+        if (this._enabled) {
+            this._anchorChanged();
+        } else {
+            this._moveLayersInSgNode(this._sgNode);
+        }
 
-            cc.loader.load(textures, function (err) {
-                cb(err, textures);
-            });
-        }
-        else {
-            if (cb) cb();
-        }
+        // enable / disable the TiledLayer component
+        this._setLayersEnabled(this._enabled);
     },
 
-    _preloadTmx: function(file, cb) {
-        var self = this;
-        cc.loader.load(file, function (err) {
-            if (err) {
-                if (cb) cb(err || new Error('Preload TMX failed: unknown error'));
-                return;
+    _setLayersEnabled: function(enabled) {
+        var logicChildren = this.node.getChildren();
+        for (var i = logicChildren.length - 1; i >= 0; i--) {
+            var child = logicChildren[i];
+            var tmxLayer = child.getComponent(cc.TiledLayer);
+            if (tmxLayer) {
+                tmxLayer.enabled = enabled;
             }
-
-            var mapInfo = new cc.TMXMapInfo(file);
-            if (!mapInfo) {
-                cb(new Error('Parse map info failed.'));
-                return;
-            }
-
-            self._preloadTextures(mapInfo, cb);
-        });
-    },
-
-    _onMapLoaded: function(err) {
-        this._isLoading = false;
-        if ( !err ) {
-            if (this._enabled) {
-                this._refreshLayerEntities();
-                this._anchorChanged();
-            } else {
-                this._moveLayersInSgNode(this._sgNode);
-            }
-        }
-
-        if (!CC_EDITOR) {
-            // if it's not in Editor, emit mapLoaded events.
-            cc.Component.EventHandler.emitEvents(this.mapLoaded, err);
         }
     },
 
@@ -775,26 +688,11 @@ var TiledMap = cc.Class({
         var file = this._tmxFile;
         var self = this;
         if (file) {
-            self._isLoading = true;
-            if (cc.sys.isNative) {
-                // TODO Consider to remove the setTimeout
-                // In native environment, the reason of using setTimeout:
-                // If not use setTimeout, the _sgNode of cc.TiledLayer
-                // will be removed from the scene graph.
-                setTimeout(function() {
-                    if (sgNode.initWithTMXFile(file)) {
-                        self._onMapLoaded();
-                    } else {
-                        self._onMapLoaded(new Error('Parse map info failed.'));
-                    }
-                }, 0);
-            } else {
-                this._preloadTmx(file, function (err, results) {
-                    if (!err) {
-                        sgNode.initWithTMXFile(file);
-                    }
-                    self._onMapLoaded(err);
-                });
+            var resPath = cc.url._rawAssets + file.tmxFolderPath;
+            resPath = cc.path._setEndWithSep(resPath, false);
+            var ret = sgNode.initWithXML(file.tmxXmlStr, resPath);
+            if (ret) {
+                self._onMapLoaded();
             }
         } else {
             // tmx file is cleared
@@ -804,13 +702,18 @@ var TiledMap = cc.Class({
                 sgNode.removeChild(layers[i]);
             }
 
-            // 2. if the component is enabled,
-            //    should remove the entities for tmx layers in node
-            if (self._enabled) {
-                self._removeLayerEntities();
-            }
+            // 2. clean the detached layers
+            this._detachedLayers.length = 0;
+
+            // 3. remove the logic nodes of TiledLayer
+            self._removeLayerEntities();
         }
     },
 });
 
 cc.TiledMap = module.exports = TiledMap;
+cc.js.obsolete(cc.TiledMap.prototype, 'cc.TiledMap.tmxFile', 'tmxAsset', true);
+cc.js.get(cc.TiledMap.prototype, 'mapLoaded', function () {
+    cc.error('Property "mapLoaded" is unused now. Please write the logic to the callback "start".');
+    return [];
+}, false);

--- a/cocos2d/tilemap/CCTiledMapAsset.js
+++ b/cocos2d/tilemap/CCTiledMapAsset.js
@@ -26,12 +26,47 @@
 /**
  * Class for tiled map asset handling.
  * @class TiledMapAsset
- * @extends RawAsset
+ * @extends Asset
  * @constructor
  */
 var TiledMapAsset = cc.Class({
     name: 'cc.TiledMapAsset',
-    extends: cc.RawAsset,
+    extends: cc.Asset,
+
+    ctor: function () {
+        this.tmxXmlStr = '';
+        this.tmxFolderPath = '';
+        this.textures = [];
+        this.tsxFiles = [];
+    },
+
+    properties: {
+        tmxXmlStr: {
+            default: ''
+        },
+
+        tmxFolderPath : {
+            default: ''
+        },
+
+        textures: {
+            default: [],
+            url: [cc.Texture2D]
+        },
+
+        tsxFiles: {
+            default: [],
+            url: [cc.RawAsset]
+        }
+    },
+
+    createNode: function (callback) {
+        var node = new cc.Node(this.name);
+        var tiledMap = node.addComponent(cc.TiledMap);
+        tiledMap.tmxFile = this;
+
+        return callback(null, node);
+    }
 });
 
 cc.TiledMapAsset = TiledMapAsset;

--- a/cocos2d/tilemap/CCTiledMapAsset.js
+++ b/cocos2d/tilemap/CCTiledMapAsset.js
@@ -60,7 +60,7 @@ var TiledMapAsset = cc.Class({
         }
     },
 
-    createNode: function (callback) {
+    createNode: CC_EDITOR && function (callback) {
         var node = new cc.Node(this.name);
         var tiledMap = node.addComponent(cc.TiledMap);
         tiledMap.tmxAsset = this;

--- a/cocos2d/tilemap/CCTiledMapAsset.js
+++ b/cocos2d/tilemap/CCTiledMapAsset.js
@@ -33,13 +33,6 @@ var TiledMapAsset = cc.Class({
     name: 'cc.TiledMapAsset',
     extends: cc.Asset,
 
-    ctor: function () {
-        this.tmxXmlStr = '';
-        this.tmxFolderPath = '';
-        this.textures = [];
-        this.tsxFiles = [];
-    },
-
     properties: {
         tmxXmlStr: {
             default: ''

--- a/cocos2d/tilemap/CCTiledMapAsset.js
+++ b/cocos2d/tilemap/CCTiledMapAsset.js
@@ -63,7 +63,7 @@ var TiledMapAsset = cc.Class({
     createNode: function (callback) {
         var node = new cc.Node(this.name);
         var tiledMap = node.addComponent(cc.TiledMap);
-        tiledMap.tmxFile = this;
+        tiledMap.tmxAsset = this;
 
         return callback(null, node);
     }

--- a/cocos2d/tilemap/editor/tiled-map.html
+++ b/cocos2d/tilemap/editor/tiled-map.html
@@ -1,0 +1,19 @@
+<link rel="import" href="packages://inspector/share/meta-header.html">
+
+<dom-module id="tiled-map-inspector">
+    <link rel="import" type="css" href="packages://inspector/share/common.css">
+
+    <template>
+        <inspector-meta-header
+            target="[[target]]"
+            icon="app://engine/cocos2d/tilemap/editor/tiled-map.png"
+            dirty="{{dirty}}"
+        >
+        </inspector-meta-header>
+    </template>
+
+    <script>
+        Editor.registerElement({
+        });
+    </script>
+</dom-module>

--- a/cocos2d/tilemap/editor/tiled-map.html
+++ b/cocos2d/tilemap/editor/tiled-map.html
@@ -6,7 +6,7 @@
     <template>
         <inspector-meta-header
             target="[[target]]"
-            icon="app://engine/cocos2d/tilemap/editor/tiled-map.png"
+            icon="unpack://engine/cocos2d/tilemap/editor/tiled-map.png"
             dirty="{{dirty}}"
         >
         </inspector-meta-header>

--- a/cocos2d/tilemap/editor/tiled-map.js
+++ b/cocos2d/tilemap/editor/tiled-map.js
@@ -1,11 +1,105 @@
 'use strict';
 
-class TiledMapMeta extends Editor.metas['raw-asset'] {
-  constructor ( assetdb ) {
-    super( assetdb );
+const CustomAssetMeta = Editor.metas['custom-asset'];
+
+const Fs = require('fire-fs');
+const Path = require('fire-path');
+const Url = require('fire-url');
+
+const DOMParser = require('xmldom').DOMParser;
+const TMX_ENCODING = { encoding: 'utf-8' };
+
+function searchDependFiles(tmxFile, cb) {
+  if (!Fs.existsSync(tmxFile)) {
+    return cb(new Error(`${tmxFile} is not found!`));
   }
 
+  var fileContent = Fs.readFileSync(tmxFile, 'utf-8');
+  var doc = new DOMParser().parseFromString(fileContent);
+  if (!doc) {
+    return cb(new Error(`Parse ${tmxFile} failed.`));
+  }
+
+  var textures = [];
+  var tsxFiles = [];
+  function parseTilesetImages(tilesetNode, sourcePath) {
+    var images = tilesetNode.getElementsByTagName('image');
+    for (var i = 0, n = images.length; i < n ; i++) {
+      var imageCfg = images[i].getAttribute('source');
+      if (imageCfg) {
+        var imgPath = cc.path.changeBasename(sourcePath, imageCfg);
+        textures.push(imgPath);
+      }
+    }
+  }
+
+  var rootElement = doc.documentElement;
+  var tilesetElements = rootElement.getElementsByTagName('tileset');
+  for (var i = 0, n = tilesetElements.length; i < n; i++) {
+    var tileset = tilesetElements[i];
+    var sourceTSX = tileset.getAttribute('source');
+    if (sourceTSX) {
+      var tsxPath = cc.path.changeBasename(tmxFile, sourceTSX);
+
+      if (Fs.existsSync(tsxPath)) {
+        tsxFiles.push(tsxPath);
+        var tsxContent = Fs.readFileSync(tsxPath, 'utf-8');
+        var tsxDoc = new DOMParser().parseFromString(tsxContent);
+        if (tsxDoc) {
+          parseTilesetImages(tsxDoc, tsxPath);
+        } else {
+          Editor.warn('Parse %s failed.', tsxPath);
+        }
+      }
+    }
+
+    // import images
+    parseTilesetImages(tileset, tmxFile);
+  }
+
+  cb(null, { textures: textures, tsxFiles: tsxFiles });
+}
+
+const AssetRootUrl = 'db://assets/';
+
+class TiledMapMeta extends CustomAssetMeta {
+  constructor (assetdb) {
+    super(assetdb);
+    this.textures = [];
+    this.tsxFiles = [];
+  }
+
+  static version () { return '1.0.1'; }
   static defaultType() { return 'tiled-map'; }
+
+  import (fspath, cb) {
+    Fs.readFile(fspath, TMX_ENCODING, (err, data) => {
+      if (err) {
+        return cb(err);
+      }
+
+      var db = this._assetdb;
+      var asset = new cc.TiledMapAsset();
+      asset.name = Path.basenameNoExt(fspath);
+      asset.tmxXmlStr = data;
+      asset.tmxFolderPath = Path.relative(AssetRootUrl, Url.dirname(db.fspathToUrl(fspath)));
+
+      searchDependFiles(fspath, (err, info) => {
+        if (err) {
+          return cb(err);
+        }
+
+        this.textures = info.textures.map(p => db.fspathToUrl(p));
+        this.tsxFiles = info.tsxFiles.map(p => db.fspathToUrl(p));
+
+        asset.textures = this.textures;
+        asset.tsxFiles = this.tsxFiles;
+
+        db.saveAssetToLibrary(this.uuid, asset);
+        cb();
+      });
+    });
+  }
 }
 
 TiledMapMeta.prototype.export = null;


### PR DESCRIPTION
Re: cocos-creator/fireball#2069

Changes proposed in this pull request:
- Move the tiled-map assets inspector from Creator to engine.
- Change the TiledMapAsset from RawAsset to Asset.

@cocos-creator/engine-admins
