### PR TITLE
fix editbox begin and end callback not called.

### DIFF
--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -465,8 +465,10 @@ var EditBox = cc.Class({
     },
 
     _registerEvent: function () {
-        this.node.on(cc.Node.EventType.TOUCH_START, this._onTouchBegan, this);
-        this.node.on(cc.Node.EventType.TOUCH_END, this._onTouchEnded, this);
+        if(!CC_JSB) {
+            this.node.on(cc.Node.EventType.TOUCH_START, this._onTouchBegan, this);
+            this.node.on(cc.Node.EventType.TOUCH_END, this._onTouchEnded, this);
+        }
     },
 
     _onTouchBegan: function(event) {
@@ -484,5 +486,15 @@ var EditBox = cc.Class({
     }
 
 });
+
+if(CC_JSB) {
+    EditBox.prototype.editBoxEditingDidBegin = function (sender) {
+        this.editBoxEditingDidBegan(sender);
+    }
+
+    EditBox.prototype.editBoxEditingDidEnd = function (sender) {
+        this.editBoxEditingDidEnded(sender);
+    }
+}
 
 cc.EditBox = module.exports = EditBox;

--- a/jsb/jsb-editbox.js
+++ b/jsb/jsb-editbox.js
@@ -50,16 +50,6 @@ _p.setMaxLength = function(maxLength) {
     this._setMaxLength(maxLength);
 }
 
-_p.editBoxEditingDidBegin = function (sender) {
-    this.editBoxEditingDidBegan(sender);
-}
-_p.editBoxEditingDidEnd = function (sender) {
-    this.editBoxEditingDidEnded(sender);
-}
-
-_p._onTouchBegan = function() {}
-_p._onTouchEnded = function() {}
-
 _p.setLineHeight = function () {}
 
 _p = null;


### PR DESCRIPTION
Re: cocos-creator/fireball#2811

Changes proposed in this pull request:
-   fix editbox begin and end callback not be called in jsb.

@cocos-creator/engine-admins
