### PR TITLE
Solve the error z-order when a TiledMap node has non-TiledLayer child.

### DIFF
--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -671,6 +671,7 @@ var TiledMap = cc.Class({
             var child = logicChildren[i];
             var tmxLayer = child.getComponent(cc.TiledLayer);
             var zOrderValue = child.getSiblingIndex();
+            child.setLocalZOrder(zOrderValue);
             if (tmxLayer) {
                 if (tmxLayer._sgNode) {
                     tmxLayer._sgNode.setLocalZOrder(zOrderValue);


### PR DESCRIPTION
Re: cocos-creator/fireball#2069

Changes proposed in this pull request:
- Solve the error z-order caused by the PR: https://github.com/cocos-creator/engine/pull/618

@cocos-creator/engine-admins
