### PR TITLE
fix Inherits from SGNode nodes can not overload a method in BaseNodeP…

### DIFF
--- a/cocos2d/core/base-nodes/BaseNodesPropertyDefine.js
+++ b/cocos2d/core/base-nodes/BaseNodesPropertyDefine.js
@@ -29,98 +29,33 @@ cc._tmp.PrototypeCCNode = function () {
 
     cc.defineGetterSetter(_p, "x", _p.getPositionX, _p.setPositionX);
     cc.defineGetterSetter(_p, "y", _p.getPositionY, _p.setPositionY);
-    /** @expose */
-    _p.width;
     cc.defineGetterSetter(_p, "width", _p._getWidth, _p._setWidth);
-    /** @expose */
-    _p.height;
     cc.defineGetterSetter(_p, "height", _p._getHeight, _p._setHeight);
-    /** @expose */
-    _p.anchorX;
     cc.defineGetterSetter(_p, "anchorX", _p._getAnchorX, _p._setAnchorX);
-    /** @expose */
-    _p.anchorY;
     cc.defineGetterSetter(_p, "anchorY", _p._getAnchorY, _p._setAnchorY);
-    /** @expose */
-    _p.skewX;
     cc.defineGetterSetter(_p, "skewX", _p.getSkewX, _p.setSkewX);
-    /** @expose */
-    _p.skewY;
     cc.defineGetterSetter(_p, "skewY", _p.getSkewY, _p.setSkewY);
-    /** @expose */
-    _p.zIndex;
     cc.defineGetterSetter(_p, "zIndex", _p.getLocalZOrder, _p.setLocalZOrder);
-    /** @expose */
-    _p.vertexZ;
     cc.defineGetterSetter(_p, "vertexZ", _p.getVertexZ, _p.setVertexZ);
-    /** @expose */
-    _p.rotation;
     cc.defineGetterSetter(_p, "rotation", _p.getRotation, _p.setRotation);
-    /** @expose */
-    _p.rotationX;
     cc.defineGetterSetter(_p, "rotationX", _p.getRotationX, _p.setRotationX);
-    /** @expose */
-    _p.rotationY;
     cc.defineGetterSetter(_p, "rotationY", _p.getRotationY, _p.setRotationY);
-    /** @expose */
-    _p.scale;
     cc.defineGetterSetter(_p, "scale", _p.getScale, _p.setScale);
-    /** @expose */
-    _p.scaleX;
     cc.defineGetterSetter(_p, "scaleX", _p.getScaleX, _p.setScaleX);
-    /** @expose */
-    _p.scaleY;
     cc.defineGetterSetter(_p, "scaleY", _p.getScaleY, _p.setScaleY);
-    /** @expose */
-    _p.children;
     cc.defineGetterSetter(_p, "children", _p.getChildren);
-    /** @expose */
-    _p.childrenCount;
     cc.defineGetterSetter(_p, "childrenCount", _p.getChildrenCount);
-    /** @expose */
-    _p.parent;
     cc.defineGetterSetter(_p, "parent", _p.getParent, _p.setParent);
-    /** @expose */
-    _p.visible;
     cc.defineGetterSetter(_p, "visible", _p.isVisible, _p.setVisible);
-    /** @expose */
-    _p.running;
     cc.defineGetterSetter(_p, "running", _p.isRunning);
-    /** @expose */
-    _p.ignoreAnchor;
     cc.defineGetterSetter(_p, "ignoreAnchor", _p.isIgnoreAnchorPointForPosition, _p.ignoreAnchorPointForPosition);
-    /** @expose */
-    _p.tag;
-    /** @expose */
-    _p.userData;
-    /** @expose */
-    _p.userObject;
-    /** @expose */
-    _p.arrivalOrder;
-    /** @expose */
-    _p.actionManager;
     cc.defineGetterSetter(_p, "actionManager", _p.getActionManager, _p.setActionManager);
-    /** @expose */
-    _p.scheduler;
     cc.defineGetterSetter(_p, "scheduler", _p.getScheduler, _p.setScheduler);
     //cc.defineGetterSetter(_p, "boundingBox", _p.getBoundingBox);
-    /** @expose */
-    _p.shaderProgram;
     cc.defineGetterSetter(_p, "shaderProgram", _p.getShaderProgram, _p.setShaderProgram);
-
-    /** @expose */
-    _p.opacity;
     cc.defineGetterSetter(_p, "opacity", _p.getOpacity, _p.setOpacity);
-    /** @expose */
-    _p.opacityModifyRGB;
     cc.defineGetterSetter(_p, "opacityModifyRGB", _p.isOpacityModifyRGB);
-    /** @expose */
-    _p.cascadeOpacity;
     cc.defineGetterSetter(_p, "cascadeOpacity", _p.isCascadeOpacityEnabled, _p.setCascadeOpacityEnabled);
-    /** @expose */
-    _p.color;
     cc.defineGetterSetter(_p, "color", _p.getColor, _p.setColor);
-    /** @expose */
-    _p.cascadeColor;
     cc.defineGetterSetter(_p, "cascadeColor", _p.isCascadeColorEnabled, _p.setCascadeColorEnabled);
 };

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1134,3 +1134,17 @@ _ccsg.Label.Overflow = cc.Enum({
     SHRINK: 2,
     RESIZE_HEIGHT: 3
 });
+
+
+// fireball#2856
+
+var labelPro = _ccsg.Label.prototype;
+Object.defineProperty(labelPro, 'width', {
+    get: labelPro._getWidth,
+    set: _ccsg.Node.prototype._setWidth
+});
+
+Object.defineProperty(labelPro, 'height', {
+    get: labelPro._getHeight,
+    set: _ccsg.Node.prototype._setHeight
+});

--- a/cocos2d/core/labelttf/CCLabelTTF.js
+++ b/cocos2d/core/labelttf/CCLabelTTF.js
@@ -859,4 +859,17 @@ cc.LabelTTF.__getFontHeightByDiv = function (fontName, fontSize) {
 
 };
 
+// fireball#2856
+
+var labelTTFPro = cc.LabelTTF.prototype;
+Object.defineProperty(labelTTFPro, 'width', {
+    get: labelTTFPro._getWidth,
+    set: _ccsg.Node.prototype._setWidth
+});
+
+Object.defineProperty(labelTTFPro, 'height', {
+    get: labelTTFPro._getHeight,
+    set: _ccsg.Node.prototype._setHeight
+});
+
 cc.LabelTTF.__fontHeightCache = {};

--- a/cocos2d/core/sprites/CCSGSprite.js
+++ b/cocos2d/core/sprites/CCSGSprite.js
@@ -999,3 +999,20 @@ cc.js.addon(_ccsg.Sprite.prototype, EventTarget.prototype);
 cc.assert(cc.js.isFunction(cc._tmp.PrototypeSprite), cc._LogInfos.MissingFile, "SpritesPropertyDefine.js");
 cc._tmp.PrototypeSprite();
 delete cc._tmp.PrototypeSprite;
+
+// fireball#2856
+
+var spritePro = _ccsg.Sprite.prototype;
+Object.defineProperty(spritePro, 'visible', {
+    get: _ccsg.Node.prototype.isVisible,
+    set: spritePro.setVisible
+});
+
+Object.defineProperty(spritePro, 'ignoreAnchor', {
+    get: _ccsg.Node.prototype.isIgnoreAnchorPointForPosition,
+    set: spritePro.ignoreAnchorPointForPosition
+});
+
+Object.defineProperty(spritePro, 'opacityModifyRGB', {
+    get: spritePro.isOpacityModifyRGB
+});

--- a/cocos2d/labels/CCLabelBMFont.js
+++ b/cocos2d/labels/CCLabelBMFont.js
@@ -866,3 +866,32 @@ cc.LabelBMFont = cc.SpriteBatchNode.extend(/** @lends cc.LabelBMFont# */{
 cc.LabelBMFont.create = function (str, fntFile, width, alignment, imageOffset) {
     return new cc.LabelBMFont(str, fntFile, width, alignment, imageOffset);
 };
+
+// fireball#2856
+
+var ccsgNodePro = _ccsg.Node.prototype;
+var labelBMFontPro = cc.LabelBMFont.prototype;
+Object.defineProperty(labelBMFontPro, 'anchorX', {
+    get: ccsgNodePro._getAnchorX,
+    set: labelBMFontPro._setAnchorX
+});
+
+Object.defineProperty(labelBMFontPro, 'anchorY', {
+    get: ccsgNodePro._getAnchorY,
+    set: labelBMFontPro._setAnchorY
+});
+
+Object.defineProperty(labelBMFontPro, 'scale', {
+    get: ccsgNodePro.getScale,
+    set: labelBMFontPro.setScale
+});
+
+Object.defineProperty(labelBMFontPro, 'scaleX', {
+    get: ccsgNodePro.getScaleX,
+    set: labelBMFontPro.setScaleX
+});
+
+Object.defineProperty(labelBMFontPro, 'scaleY', {
+    get: ccsgNodePro.getScaleY,
+    set: labelBMFontPro.setScaleY
+});

--- a/cocos2d/particle/CCSGParticleSystem.js
+++ b/cocos2d/particle/CCSGParticleSystem.js
@@ -2217,3 +2217,20 @@ _ccsg.ParticleSystem.Type = cc.Enum({
      */
     GROUPED: 2
 });
+
+// fireball#2856
+
+var particleSystemPro = _ccsg.ParticleSystem.prototype;
+Object.defineProperty(particleSystemPro, 'visible', {
+    get: _ccsg.Node.prototype.isVisible,
+    set: particleSystemPro.setVisible
+});
+
+Object.defineProperty(particleSystemPro, 'ignoreAnchor', {
+    get: _ccsg.Node.prototype.isIgnoreAnchorPointForPosition,
+    set: particleSystemPro.ignoreAnchorPointForPosition
+});
+
+Object.defineProperty(particleSystemPro, 'opacityModifyRGB', {
+    get: particleSystemPro.isOpacityModifyRGB
+});

--- a/cocos2d/progress-timer/CCProgressTimer.js
+++ b/cocos2d/progress-timer/CCProgressTimer.js
@@ -342,3 +342,15 @@ cc.ProgressTimer.Type = cc.Enum({
     RADIAL: 0,
     BAR: 1
 });
+
+// fireball#2856
+var progressTimerPro = cc.ProgressTimer.prototype;
+Object.defineProperty(progressTimerPro, 'color', {
+    get: progressTimerPro.getColor,
+    set: progressTimerPro.setColor
+});
+
+Object.defineProperty(progressTimerPro, 'opacity', {
+    get: progressTimerPro.getOpacity,
+    set: progressTimerPro.setOpacity
+});

--- a/extensions/spine/SGSkeleton.js
+++ b/extensions/spine/SGSkeleton.js
@@ -329,3 +329,10 @@ sp._SGSkeleton = _ccsg.Node.extend({
         this._skeleton.update(dt);
     }
 });
+
+
+// fireball#2856
+
+Object.defineProperty(sp._SGSkeleton.prototype, 'opacityModifyRGB', {
+    get: sp._SGSkeleton.prototype.isOpacityModifyRGB
+});


### PR DESCRIPTION
Re: cocos-creator/fireball#2856

Changes proposed in this pull request:
- 修复继承 SGNode 的类，无法重载 BaseNodesPropertyDefine.js 中的方法

@cocos-creator/engine-admins
…ropertyDefine.js
