### PR TITLE
fix Particle plist unzipBase64 error.

### DIFF
--- a/cocos2d/compression/ZipUtils.js
+++ b/cocos2d/compression/ZipUtils.js
@@ -24,8 +24,14 @@ cc.Codec.unzip = function () {
  * @returns {String} Unpacked byte string
  */
 cc.Codec.unzipBase64 = function () {
-    var tmpInput = cc.Codec.Base64.decode.apply(cc.Codec.Base64, arguments);
-    return cc.Codec.GZip.gunzip.apply(cc.Codec.GZip, [tmpInput]);
+    var buffer = cc.Codec.Base64.decode.apply(cc.Codec.Base64, arguments);
+    try {
+        return cc.Codec.GZip.gunzip.call(cc.Codec.GZip, buffer);
+    }
+    catch(e) {
+        // if not zipped, just skip
+        return buffer.slice(7); // get image data
+    }
 };
 
 /**


### PR DESCRIPTION
Re: cocos-creator/fireball#2772

Changes proposed in this pull request:
- 由于有的粒子图片编码没有进行Zip，所有不需要进行 Zip 解压操作 

@cocos-creator/engine-admins
