### PR TITLE
删除部分audio测试

### DIFF
--- a/test/qunit/unit/test-audioSource.js
+++ b/test/qunit/unit/test-audioSource.js
@@ -13,11 +13,11 @@ if (!isPhantomJS) {
 
         strictEqual(audioSource.isPlaying, true, 'audio scource default play state true');
 
-        audioSource.volume = 0.5;
-        strictEqual(audioSource.audio.volume, 0.5, 'audio scource volume true');
+        //audioSource.volume = 0.5;
+        //strictEqual(audioSource.audio.volume, 0.5, 'audio scource volume true');
 
-        audioSource.loop = true;
-        strictEqual(audioSource.audio.loop, true, 'audio scource loop true');
+        //audioSource.loop = true;
+        //strictEqual(audioSource.audio.loop, true, 'audio scource loop true');
 
         //audioSource.mute = true;
         //strictEqual(audioSource.audio.volume, 0, 'audio scource mute true');


### PR DESCRIPTION
因为之前 cc.Audio 存储了一份 volume 和 loop 等数据。

但后来重构的时候，发现 component 里面也是有一份一样的数据的，没有必要再存储到 cc.Audio 里面。所以删除了。

所以现在这两个测试例就没有意义了。
