### PR TITLE
Add property in Label component for the origin size of BMFont.

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -244,7 +244,7 @@ var Label = cc.Class({
             },
             set: function (value) {
                 this._N$file = value;
-                this.BMFontOriginSize = -1;
+                this.bmFontOriginalSize = -1;
                 if (this._sgNode) {
 
                     if ( typeof value === 'string' ) {
@@ -291,7 +291,8 @@ var Label = cc.Class({
             tooltip: 'i18n:COMPONENT.label.system_font',
         },
 
-        BMFontOriginSize: {
+        bmFontOriginalSize: {
+            displayName: 'BMFont Original Size',
             default: -1,
             serializable: false,
             readonly: true
@@ -395,7 +396,7 @@ var Label = cc.Class({
             }
 
             if (this._sgNode._labelType === LabelType.BMFont) {
-                this.BMFontOriginSize = this._sgNode.getBMFontOriginSize();
+                this.bmFontOriginalSize = this._sgNode.getBMFontOriginalSize();
             }
         }
     }

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -244,6 +244,7 @@ var Label = cc.Class({
             },
             set: function (value) {
                 this._N$file = value;
+                this.BMFontOriginSize = -1;
                 if (this._sgNode) {
 
                     if ( typeof value === 'string' ) {
@@ -288,6 +289,12 @@ var Label = cc.Class({
             },
             animatable: false,
             tooltip: 'i18n:COMPONENT.label.system_font',
+        },
+
+        BMFontOriginSize: {
+            default: -1,
+            serializable: false,
+            readonly: true
         }
 
         // TODO
@@ -385,6 +392,10 @@ var Label = cc.Class({
             }
             if ( !this.node._sizeProvider ) {
                 this.node._sizeProvider = this._sgNode;
+            }
+
+            if (this._sgNode._labelType === LabelType.BMFont) {
+                this.BMFontOriginSize = this._sgNode.getBMFontOriginSize();
             }
         }
     }

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1107,6 +1107,14 @@ cc.BMFontHelper = {
         }
     },
 
+    getBMFontOriginSize: function() {
+        if (this._config) {
+            return this._config.fontSize;
+        } else {
+            return -1;
+        }
+    },
+
     _setBMFontFile: function(filename, textureUrl) {
         if (filename) {
             this._fontHandle = filename;

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1107,7 +1107,7 @@ cc.BMFontHelper = {
         }
     },
 
-    getBMFontOriginSize: function() {
+    getBMFontOriginalSize: function() {
         if (this._config) {
             return this._config.fontSize;
         } else {


### PR DESCRIPTION
Re: cocos-creator/fireball#2610

Changes proposed in this pull request:
- Add property in Label component for the origin size of BMFont.

@cocos-creator/engine-admins
