### PR TITLE
fix update and start calling sequence bug

### DIFF
--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -115,16 +115,31 @@ function _registerEvent (self, on) {
         cc.director.once(cc.Director.EVENT_BEFORE_UPDATE, _callStart, self);
     }
 
-    if (self.update) {
-        if (on) cc.director.on(cc.Director.EVENT_COMPONENT_UPDATE, _callUpdate, self);
-        else cc.director.off(cc.Director.EVENT_COMPONENT_UPDATE, _callUpdate, self);
+    if (!self.update && !self.lateUpdate) {
+        return;
     }
 
-    if (self.lateUpdate) {
-        if (on) cc.director.on(cc.Director.EVENT_COMPONENT_LATE_UPDATE, _callLateUpdate, self);
-        else cc.director.off(cc.Director.EVENT_COMPONENT_LATE_UPDATE, _callLateUpdate, self);
+    if (on) {
+        cc.director.on(cc.Director.EVENT_BEFORE_UPDATE, _registerUpdateEvent, self);
+    }
+    else {
+        cc.director.off(cc.Director.EVENT_BEFORE_UPDATE, _registerUpdateEvent, self);
+        cc.director.off(cc.Director.EVENT_COMPONENT_UPDATE, _callUpdate, self);
+        cc.director.off(cc.Director.EVENT_COMPONENT_LATE_UPDATE, _callLateUpdate, self);
     }
 }
+
+var _registerUpdateEvent = function () {
+    cc.director.off(cc.Director.EVENT_BEFORE_UPDATE, _registerUpdateEvent, this);
+
+    if (this.update) {
+        cc.director.on(cc.Director.EVENT_COMPONENT_UPDATE, _callUpdate, this);
+    }
+
+    if (this.lateUpdate) {
+        cc.director.on(cc.Director.EVENT_COMPONENT_LATE_UPDATE, _callLateUpdate, this);
+    }
+};
 
 var _callStart = CC_EDITOR ? function () {
     callStartInTryCatch(this);

--- a/test/qunit/unit/test-component.js
+++ b/test/qunit/unit/test-component.js
@@ -52,6 +52,79 @@ test('should not cause an infinite loops if re-activated in onLoad', function ()
     ok('done');
 });
 
+// Since the modification event-listeners.js will lead to test ‘remove and add again during invoking’ infinite loop
+//test('start of the component which created during another start', function () {
+//    var TestComp = cc.Class({
+//        extends: cc.Component,
+//        start: function () {
+//            strictEqual(this.inited, true, 'should be called after another start finished');
+//        }
+//    });
+//
+//    var node = new cc.Node();
+//    cc.director.getScene().addChild(node);
+//    var comp = node.addComponent(cc.Component);
+//    comp.start = function () {
+//        var test = new cc.Node();
+//        var testComp = test.addComponent(TestComp);
+//        this.node.addChild(test);
+//        testComp.inited = true;
+//    };
+//});
+
+test('start', function () {
+    var TestComp = cc.Class({
+        extends: cc.Component,
+        start: function () {
+            this.inited = true;
+        },
+        update: function (dt) {
+            strictEqual(this.inited, true, 'should always invoke before update');
+            this.enable = false;
+        }
+    });
+
+    var node = new cc.Node();
+    var comp = node.addComponent(cc.Component);
+    comp.start = function () {
+        var test = new cc.Node();
+        test.addComponent(TestComp);
+        this.node.addChild(test);
+    };
+    cc.director.getScene().addChild(node);
+    // run comp
+    cc.game.step();
+    // run TestComp
+    cc.game.step();
+});
+
+test('lateUpdate', function () {
+    var TestComp = cc.Class({
+        extends: cc.Component,
+        update: function () {
+            this.updated = true;
+        },
+        lateUpdate: function (dt) {
+            strictEqual(this.updated, true, 'should always invoke before update');
+            this.enable = false;
+        }
+    });
+
+    var node = new cc.Node();
+    var comp = node.addComponent(cc.Component);
+    comp.update = function () {
+        var test = new cc.Node();
+        test.addComponent(TestComp);
+        this.node.addChild(test);
+        this.enabled = false;
+    };
+    cc.director.getScene().addChild(node);
+    // run comp
+    cc.game.step();
+    // run TestComp
+    cc.game.step();
+});
+
 //test('should not call lifecycle methods if not executeInEditMode', function () {
 //    var Comp = cc.Class({
 //        extends: CallbackTester,


### PR DESCRIPTION
Re: cocos-creator/fireball#2828

Changes proposed in this pull request:
- 修复自身的 start 和 update 之间的顺序，start 必须在 update 之前调用

@cocos-creator/engine-admins
