### PR TITLE
build a single js for preview

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -515,7 +515,7 @@ var Node = cc.Class({
         var parent = this._parent;
         var destroyByParent = parent && (parent._objFlags & Destroying);
         if ( !destroyByParent ) {
-            if (CC_DEV) {
+            if (CC_EDITOR || CC_TEST) {
                 this._registerIfAttached(false);
             }
         }
@@ -881,7 +881,7 @@ var Node = cc.Class({
 
     // INTERNAL
 
-    _registerIfAttached: CC_DEV && function (register) {
+    _registerIfAttached: (CC_EDITOR || CC_TEST) && function (register) {
         if (register) {
             cc.engine.attachedObjsForEditor[this.uuid] = this;
             cc.engine.emit('node-attach-to-scene', {target: this});
@@ -1000,7 +1000,7 @@ var Node = cc.Class({
             this._onActivatedInHierarchy(shouldActiveNow);
         }
         cc._widgetManager._nodesOrderDirty = true;
-        if (CC_DEV) {
+        if (CC_EDITOR || CC_TEST) {
             var scene = cc.director.getScene();
             var inCurrentSceneBefore = oldParent && oldParent.isChildOf(scene);
             var inCurrentSceneNow = newParent && newParent.isChildOf(scene);

--- a/cocos2d/core/CCScene.js
+++ b/cocos2d/core/CCScene.js
@@ -81,7 +81,7 @@ cc.Scene = cc.Class({
         active = (active !== false);
         var i, child, children = this._children, len = children.length;
 
-        if (CC_DEV) {
+        if (CC_EDITOR || CC_TEST) {
             // register all nodes to editor
             for (i = 0; i < len; ++i) {
                 child = children[i];

--- a/cocos2d/core/assets/CCPrefab.js
+++ b/cocos2d/core/assets/CCPrefab.js
@@ -58,7 +58,7 @@ var Prefab = cc.Class({
         // instantiate
         var node = cc.instantiate(this.data);
 
-        if (CC_DEV) {
+        if (CC_EDITOR || CC_TEST) {
             _Scene.PrefabUtils.linkPrefab(this, node);
         }
 

--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -280,7 +280,7 @@ var Component = cc.Class({
                 var id = this._id;
                 if ( !id ) {
                     id = this._id = idGenerater.getNewId();
-                    if (CC_DEV) {
+                    if (CC_EDITOR || CC_TEST) {
                         cc.engine.attachedObjsForEditor[id] = this;
                     }
                 }
@@ -709,7 +709,7 @@ var Component = cc.Class({
         // do remove component
         this.node._removeComponent(this);
 
-        if (CC_DEV) {
+        if (CC_EDITOR || CC_TEST) {
             delete cc.engine.attachedObjsForEditor[this._id];
         }
     },
@@ -800,7 +800,7 @@ var Component = cc.Class({
 
 Component._requireComponent = null;
 
-if (CC_DEV) {
+if (CC_EDITOR || CC_TEST) {
 
     // INHERITABLE STATIC MEMBERS
 
@@ -834,7 +834,7 @@ Object.defineProperty(Component, '_registerEditorProps', {
         if (reqComp) {
             cls._requireComponent = reqComp;
         }
-        if (CC_DEV) {
+        if (CC_EDITOR || CC_TEST) {
             var name = cc.js.getClassName(cls);
             for (var key in props) {
                 var val = props[key];

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -180,7 +180,7 @@ function defineGetSet (cls, name, propName, val, attrs) {
     var d = Object.getOwnPropertyDescriptor(proto, propName);
 
     if (getter) {
-        if (d && d.get && CC_DEV) {
+        if (CC_DEV && d && d.get) {
             cc.error('"%s": the getter of "%s" is already defined!', name, propName);
             return;
         }
@@ -847,7 +847,6 @@ function CCClass (options) {
                 if (INVALID_STATICS.indexOf(staticPropName) !== -1) {
                     cc.error('Cannot define %s.%s because static member name can not be "%s".', name, staticPropName,
                         staticPropName);
-                    continue;
                 }
             }
         }

--- a/cocos2d/core/platform/CCObject.js
+++ b/cocos2d/core/platform/CCObject.js
@@ -232,7 +232,7 @@ JS.get(prototype, 'isValid', function () {
     return !(this._objFlags & Destroyed);
 });
 
-if (CC_DEV) {
+if (CC_EDITOR || CC_TEST) {
     JS.get(prototype, 'isRealValid', function () {
         return !(this._objFlags & RealDestroyed);
     });
@@ -274,7 +274,7 @@ prototype.destroy = function () {
     return true;
 };
 
-if (CC_DEV) {
+if (CC_EDITOR || CC_TEST) {
     /*
      * !#en
      * In fact, Object's "destroy" will not trigger the destruct operation in Firebal Editor.
@@ -390,7 +390,7 @@ cc.isValid = function (value) {
     }
 };
 
-if (CC_DEV) {
+if (CC_EDITOR || CC_TEST) {
     Object.defineProperty(CCObject, '_willDestroy', {
         value: function (obj) {
             return !(obj._objFlags & Destroyed) && (obj._objFlags & ToDestroy) > 0;

--- a/cocos2d/core/platform/js.js
+++ b/cocos2d/core/platform/js.js
@@ -223,8 +223,8 @@ function getTempCID () {
     return TCID_PREFIX + (id++);
 }
 
-js._isTempClassId = function (id) {
-    return CC_DEV && (typeof id !== 'string' || id.startsWith(TCID_PREFIX));
+var isTempClassId = CC_DEV && function (id) {
+    return typeof id !== 'string' || id.startsWith(TCID_PREFIX);
 };
 
 // id 注册
@@ -348,7 +348,7 @@ cc.js.unregisterClass to remove the id of unused class';
         var res;
         if (typeof obj === 'function' && obj.prototype.hasOwnProperty('__cid__')) {
             res = obj.prototype.__cid__;
-            if (!allowTempId && js._isTempClassId(res)) {
+            if (!allowTempId && CC_DEV && isTempClassId(res)) {
                 return '';
             }
             return res;
@@ -357,7 +357,7 @@ cc.js.unregisterClass to remove the id of unused class';
             var prototype = obj.constructor.prototype;
             if (prototype && prototype.hasOwnProperty('__cid__')) {
                 res = obj.__cid__;
-                if (!allowTempId && js._isTempClassId(res)) {
+                if (!allowTempId && CC_DEV && isTempClassId(res)) {
                     return '';
                 }
                 return res;

--- a/cocos2d/core/platform/preprocess-attrs.js
+++ b/cocos2d/core/platform/preprocess-attrs.js
@@ -142,7 +142,7 @@ function postCheckType (val, type, className, propName) {
     }
 }
 
-function getBaseClassWherePropertyDefined (propName, cls) {
+function getBaseClassWherePropertyDefined_DEV (propName, cls) {
     if (CC_DEV) {
         var res;
         for (; cls && cls.__props__ && cls.__props__.indexOf(propName) !== -1; cls = cls.$super) {
@@ -208,7 +208,7 @@ module.exports = function (properties, className, cls) {
             }
             if (CC_DEV && !val.override && cls.__props__.indexOf(propName) !== -1) {
                 // check override
-                var baseClass = cc.js.getClassName(getBaseClassWherePropertyDefined(propName, cls));
+                var baseClass = cc.js.getClassName(getBaseClassWherePropertyDefined_DEV(propName, cls));
                 cc.warn('"%s.%s" hides inherited property "%s.%s". To make the current property override that implementation, add the `override: true` attribute please.', className, propName, baseClass, propName);
             }
             var notify = val.notify;

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -1227,6 +1227,9 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
             name = "";
         }
 
+        if (CC_DEV && !(child instanceof cc.Node)) {
+            return cc.error('addChild: The child to add must be instance of cc.Node, not %s.', cc.js.getClassName(child));
+        }
         cc.assert(child, cc._LogInfos.Node.addChild_3);
         cc.assert(child._parent === null, "child already added. It can't be added again");
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,27 +33,30 @@ MinifyOriginCocos2d = false;     // true - compile by closure, false - just conc
 paths = {
     src: './src',
     jsEntry: './index.js',
-    JSBEntries: [
-        './jsb/index.js',
-        './extends.js'
-    ],
     outDir: './bin',
     outFile: 'cocos2d-js.js',
-    JSBOutFile: 'jsb.js',
 
-    JSBSkipModules: [
-        '../../cocos2d/core/CCGame',
-        '../../cocos2d/core/textures/CCTexture2D',
-        '../../cocos2d/core/sprites/CCSpriteFrame',
-        '../../cocos2d/core/event/event',
-        '../../cocos2d/core/load-pipeline/audio-downloader',
-        '../../cocos2d/audio/CCAudio',
-        '../../extensions/spine/SGSkeleton',
-        '../../extensions/spine/SGSkeletonAnimation',
-        '../../extensions/spine/SGSkeletonCanvasRenderCmd',
-        '../../extensions/spine/SGSkeletonWebGLRenderCmd',
-        '../../extensions/spine/lib/spine',
-    ],
+    jsb: {
+        entries: [
+            './jsb/index.js',
+            './extends.js'
+        ],
+        outFile: 'jsb_polyfill.js',
+        outFileDev: 'jsb_polyfill.dev.js',
+        skipModules: [
+            '../../cocos2d/core/CCGame',
+            '../../cocos2d/core/textures/CCTexture2D',
+            '../../cocos2d/core/sprites/CCSpriteFrame',
+            '../../cocos2d/core/event/event',
+            '../../cocos2d/core/load-pipeline/audio-downloader',
+            '../../cocos2d/audio/CCAudio',
+            '../../extensions/spine/SGSkeleton',
+            '../../extensions/spine/SGSkeletonAnimation',
+            '../../extensions/spine/SGSkeletonCanvasRenderCmd',
+            '../../extensions/spine/SGSkeletonWebGLRenderCmd',
+            '../../extensions/spine/lib/spine',
+        ],
+    },
 
     test: {
         src: 'test/qunit/unit/**/*.js',
@@ -61,6 +64,10 @@ paths = {
         jsEntryEditorExtends: '../editor/test-utils/engine-extends-entry.js',     // only available in editor
         dest: 'bin/cocos2d-js-for-test.js',
         destEditorExtends: 'bin/cocos2d-js-extends-for-test.js'
+    },
+
+    preview: {
+        dest: 'bin/cocos2d-js-for-preview.js',
     },
 
     modularCocos2d: './bin/modular-cocos2d.js',

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ eval(
     'if(typeof CC_EDITOR=="undefined")' +
         'CC_EDITOR=typeof Editor=="object"&&typeof process=="object"&&"electron" in process.versions;' +
     'if(typeof CC_DEV=="undefined")' +
-        'CC_DEV=CC_EDITOR||CC_TEST;' +
+        'CC_DEV=CC_EDITOR||CC_TEST;' + /* CC_DEV contains CC_TEST and CC_EDITOR */
     'if(typeof CC_JSB=="undefined")' +
         'CC_JSB=false;'
 );


### PR DESCRIPTION
- 在发布版中，preview 用的是 release 版本的 js 代码，没办法加入繁杂的错误检测代码。所以这里增加了一个 cocos2d-js-for-preview.js，专门用在预览上。之后这个脚本也可以内嵌更多远程调试的支持。
- 加入了 addChild 的错误检查代码，避免用户 addChild 时传入 Component @nantas 

@cocos-creator/engine-admins
