### PR TITLE
Record the BMFont original size in the BitmapFont Asset object.

### DIFF
--- a/cocos2d/core/assets/CCBitmapFont.js
+++ b/cocos2d/core/assets/CCBitmapFont.js
@@ -43,7 +43,7 @@ var BitmapFont = cc.Class({
             url: cc.Texture2D
         },
 
-        originalSize: {
+        fontSize: {
             default: -1,
             readonly: true
         }

--- a/cocos2d/core/assets/CCBitmapFont.js
+++ b/cocos2d/core/assets/CCBitmapFont.js
@@ -44,8 +44,7 @@ var BitmapFont = cc.Class({
         },
 
         fontSize: {
-            default: -1,
-            readonly: true
+            default: -1
         }
     }
 });

--- a/cocos2d/core/assets/CCBitmapFont.js
+++ b/cocos2d/core/assets/CCBitmapFont.js
@@ -41,6 +41,11 @@ var BitmapFont = cc.Class({
         texture: {
             default: null,
             url: cc.Texture2D
+        },
+
+        originalSize: {
+            default: -1,
+            readonly: true
         }
     }
 });

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -244,7 +244,7 @@ var Label = cc.Class({
             },
             set: function (value) {
                 this._N$file = value;
-                this.bmFontOriginalSize = -1;
+                this._bmFontOriginalSize = -1;
                 if (this._sgNode) {
 
                     if ( typeof value === 'string' ) {
@@ -256,10 +256,10 @@ var Label = cc.Class({
                     var fntRawUrl = isAsset ? value.rawUrl : '';
                     var textureUrl = isAsset ? value.texture : '';
                     this._sgNode.setFontFileOrFamily(fntRawUrl, textureUrl);
+                }
 
-                    if (value instanceof cc.BitmapFont) {
-                        this.bmFontOriginalSize = value.originalSize;
-                    }
+                if (value instanceof cc.BitmapFont) {
+                    this._bmFontOriginalSize = value.fontSize;
                 }
             },
             type: cc.Font,
@@ -295,11 +295,13 @@ var Label = cc.Class({
             tooltip: 'i18n:COMPONENT.label.system_font',
         },
 
-        bmFontOriginalSize: {
+        _bmFontOriginalSize: {
             displayName: 'BMFont Original Size',
             default: -1,
             serializable: false,
-            readonly: true
+            readonly: true,
+            visible: true,
+            animatable: false
         }
 
         // TODO
@@ -361,6 +363,9 @@ var Label = cc.Class({
         var isAsset = this.font instanceof cc.Font;
         var fntRawUrl = isAsset ? this.font.rawUrl : '';
         var textureUrl = isAsset ? this.font.texture : '';
+        if (this.font instanceof cc.BitmapFont) {
+            this._bmFontOriginalSize = this.font.fontSize;
+        }
 
         var sgNode = this._sgNode = new _ccsg.Label(this.string, fntRawUrl, textureUrl);
         if (CC_JSB) {

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -256,6 +256,10 @@ var Label = cc.Class({
                     var fntRawUrl = isAsset ? value.rawUrl : '';
                     var textureUrl = isAsset ? value.texture : '';
                     this._sgNode.setFontFileOrFamily(fntRawUrl, textureUrl);
+
+                    if (value instanceof cc.BitmapFont) {
+                        this.bmFontOriginalSize = value.originalSize;
+                    }
                 }
             },
             type: cc.Font,
@@ -391,10 +395,6 @@ var Label = cc.Class({
             }
             if ( !this.node._sizeProvider ) {
                 this.node._sizeProvider = this._sgNode;
-            }
-
-            if (this._sgNode._labelType === LabelType.BMFont) {
-                this.bmFontOriginalSize = this._sgNode.getBMFontOriginalSize();
             }
         }
     }

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1113,14 +1113,6 @@ cc.BMFontHelper = {
         }
     },
 
-    getBMFontOriginalSize: function() {
-        if (this._config) {
-            return this._config.fontSize;
-        } else {
-            return -1;
-        }
-    },
-
     _setBMFontFile: function(filename, textureUrl) {
         if (filename) {
             this._fontHandle = filename;


### PR DESCRIPTION
Re: cocos-creator/fireball#2610

Changes proposed in this pull request:
- Record the BMFont original size in the BitmapFont Asset object.
- Remove the method `getBMFontOriginalSize` in _ccsg.Label.

@cocos-creator/engine-admins
