### PR TITLE
fix spine addAnimation without sending start events

### DIFF
--- a/extensions/spine/lib/spine.js
+++ b/extensions/spine/lib/spine.js
@@ -1680,8 +1680,9 @@ spine.AnimationState.prototype = {
             while (last.next)
                 last = last.next;
             last.next = entry;
-        } else
-            this.tracks[trackIndex] = entry;
+        } else {
+            this.setCurrent(trackIndex, entry);
+        }
 
         if (delay <= 0) {
             if (last)


### PR DESCRIPTION
Re: cocos-creator/fireball#3053

Changes proposed in this pull request:
-  修复 addAnimation 参数的 trackIndex 不同时候无法发出 onStart 事件的 bug

@cocos-creator/engine-admins
