### PR TITLE
fix canvas can not change opacity if contains editbox

### DIFF
--- a/cocos2d/core/editbox/CCdomNode.js
+++ b/cocos2d/core/editbox/CCdomNode.js
@@ -407,6 +407,7 @@ cc.DOM.methods = /** @lends cc.DOM# */{
         this.dom.remove();
     },
     setOpacity:function (o) {
+        _ccsg.Node.prototype.setOpacity.call(this, o);
         this._opacity = o;
         this.dom.style.opacity = o / 255;
     },


### PR DESCRIPTION
Re: cocos-creator/fireball#3085

Changes proposed in this pull request:
- 修正 EditBox 的父节点的 setOpacity 方法设置错误

@cocos-creator/engine-admins @zilongshanren 
