### PR TITLE
fix android UC Can not run example error. #fireball/issues/3112

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -711,6 +711,7 @@ else {
                 case sys.BROWSER_TYPE_UNKNOWN:
                 case sys.BROWSER_TYPE_360:
                 case sys.BROWSER_TYPE_MIUI:
+                default:
                     _supportWebGL = false;
                 }
             }


### PR DESCRIPTION
Re: cocos-creator/fireball#3112

Changes proposed in this pull request:
- 修复 android UC 无法打开范例项目，主要原因是因为开启了 WebGL

@cocos-creator/engine-admins
