### PR TITLE
fix bug of rotated spriteframe in Canvas

### DIFF
--- a/cocos2d/core/sprites/CCSpriteFrame.js
+++ b/cocos2d/core/sprites/CCSpriteFrame.js
@@ -248,10 +248,9 @@ cc.SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
                     var tempTexture = new cc.Texture2D();
                     tempTexture.initWithElement(tempElement);
                     tempTexture.handleLoadedTexture();
+                    // _refreshTexture will be recalled in setTexture
                     self.setTexture(tempTexture);
-
-                    var rect = self.getRect();
-                    self.setRect(cc.rect(0, 0, rect.width, rect.height));
+                    return;
                 }
                 var w = texture.width, h = texture.height;
 
@@ -382,10 +381,10 @@ cc.SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
             maxY += rect.height;
         }
         if (maxX > texture.getPixelWidth()) {
-            cc.error(cc._LogInfos.RectWidth, texture.url);
+            cc.error(cc._LogInfos.RectWidth, texture.url + '/' + this.name);
         }
         if (maxY > texture.getPixelHeight()) {
-            cc.error(cc._LogInfos.RectHeight, texture.url);
+            cc.error(cc._LogInfos.RectHeight, texture.url + '/' + this.name);
         }
     },
 


### PR DESCRIPTION
Re: cocos-creator/fireball#3157

Changes proposed in this pull request:
- 修复图集文件中有一张旋转而且宽度比atlas图片宽度大的spriteFrame时，在canvas渲染模式下报错

@cocos-creator/engine-admins
