### PR TITLE
CCClass should not omit type info if default value is defined by function

### DIFF
--- a/cocos2d/core/platform/attribute.js
+++ b/cocos2d/core/platform/attribute.js
@@ -241,6 +241,9 @@ function getTypeChecker (type, attrName) {
                         attrName, propInfo, defaultType);
                 }
             }
+            else {
+                return;
+            }
             delete mainPropAttrs.type;
         };
     }


### PR DESCRIPTION
Re: cocos-creator/fireball#3180

@cocos-creator/engine-admins
