### PR TITLE
fix find Bone after bone get worldX and worldY Is 0 bug.

### DIFF
--- a/extensions/spine/SGSkeleton.js
+++ b/extensions/spine/SGSkeleton.js
@@ -281,7 +281,6 @@ sp._SGSkeleton = _ccsg.Node.extend({
             this.setContentSize(skeletonData.width / cc.director.getContentScaleFactor(), skeletonData.height / cc.director.getContentScaleFactor());
 
         this._skeleton = new spine.Skeleton(skeletonData);
-        this._skeleton.updateWorldTransform();
         this._rootBone = this._skeleton.getRootBone();
         this._ownsSkeletonData = ownsSkeletonData;
 

--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -440,6 +440,25 @@ sp.Skeleton = cc.Class({
     // RENDERER
 
     /**
+     * !#en Computes the world SRT from the local SRT for each bone.
+     * !#zh 重新更新所有骨骼的世界 Transform，
+     * 当获取 bone 的数值未更新时，即可使用该函数进行更新数值。
+     * @method updateWorldTransform
+     * @example
+     * var bone = spine.findBone('head');
+     * cc.log(bone.worldX); // return 0;
+     * spine.setToSetupPose();
+     * spine.updateWorldTransform();
+     * bone = spine.findBone('head');
+     * cc.log(bone.worldX); // return -23.12;
+     */
+    updateWorldTransform: function () {
+        if (this._sgNode) {
+            this._sgNode.updateWorldTransform();
+        }
+    },
+
+    /**
      * !#en Sets the bones and slots to the setup pose.
      * !#zh 还原到起始动作
      * @method setToSetupPose


### PR DESCRIPTION
Re: cocos-creator/fireball#3186

Changes proposed in this pull request:
- 修复在 JSB 下，无法立即获取到 worldX 和 worldY 的数值 

@cocos-creator/engine-admins
