### PR TITLE
fix get spriteFrame name error for jsb

### DIFF
--- a/jsb/jsb-tex-sprite-frame.js
+++ b/jsb/jsb-tex-sprite-frame.js
@@ -62,13 +62,16 @@ cc.Texture2D.prototype.getPixelHeight = cc.Texture2D.prototype.getPixelsHigh;
 cc.Class._fastDefine('cc.SpriteFrame', cc.SpriteFrame, []);
 cc.SpriteFrame.$super = cc.Asset;
 
-cc.js.mixin(cc.SpriteFrame.prototype, cc.EventTarget.prototype);
-cc.SpriteFrame.prototype.textureLoaded = function () {
+var prototype = cc.SpriteFrame.prototype;
+
+cc.js.mixin(prototype, cc.EventTarget.prototype);
+prototype.textureLoaded = function () {
     return this.getTexture() !== null;
 };
 
 // cc.SpriteFrame
-cc.SpriteFrame.prototype._ctor = function (filename, rect, rotated, offset, originalSize) {
+prototype._ctor = function (filename, rect, rotated, offset, originalSize) {
+    this._name = '';
     if (filename !== undefined) {
         this.initWithTexture(filename, rect, rotated, offset, originalSize);
     } else {
@@ -76,12 +79,12 @@ cc.SpriteFrame.prototype._ctor = function (filename, rect, rotated, offset, orig
     }
 };
 
-cc.SpriteFrame.prototype._initWithTexture = cc.SpriteFrame.prototype.initWithTexture;
-cc.SpriteFrame.prototype.initWithTexture = function (texture, rect, rotated, offset, originalSize) {
+prototype._initWithTexture = prototype.initWithTexture;
+prototype.initWithTexture = function (texture, rect, rotated, offset, originalSize) {
     this.setTexture(texture, rect, rotated, offset, originalSize);
 };
 
-cc.SpriteFrame.prototype.setTexture = function (textureOrTextureFile, rect, rotated, offset, originalSize) {
+prototype.setTexture = function (textureOrTextureFile, rect, rotated, offset, originalSize) {
 
     if (rect) {
         this.setRect(rect);
@@ -113,7 +116,7 @@ cc.SpriteFrame.prototype.setTexture = function (textureOrTextureFile, rect, rota
     return true;
 };
 
-cc.SpriteFrame.prototype._refreshTexture = function (texture) {
+prototype._refreshTexture = function (texture) {
 
     if (this.getTexture() !== texture) {
 
@@ -149,7 +152,7 @@ cc.SpriteFrame.prototype._refreshTexture = function (texture) {
     }
 };
 
-cc.SpriteFrame.prototype._deserialize = function (data, handle) {
+prototype._deserialize = function (data, handle) {
     var rect = data.rect;
     if (rect) {
         this.setRect(new cc.Rect(rect[0], rect[1], rect[2], rect[3]));
@@ -178,7 +181,7 @@ cc.SpriteFrame.prototype._deserialize = function (data, handle) {
         handle.result.push(this, '_textureFilenameSetter', textureUuid);
     }
 };
-cc.SpriteFrame.prototype._checkRect = function (texture) {
+prototype._checkRect = function (texture) {
     var rect = this.getRect();
     var maxX = rect.x, maxY = rect.y;
     if (this.isRotated()) {
@@ -196,16 +199,27 @@ cc.SpriteFrame.prototype._checkRect = function (texture) {
         cc.error(cc._LogInfos.RectHeight, texture.url);
     }
 };
-cc.SpriteFrame.prototype._getTexture = cc.SpriteFrame.prototype.getTexture;
-cc.SpriteFrame.prototype.getTexture = function () {
+
+prototype._getTexture = prototype.getTexture;
+prototype.getTexture = function () {
     var tex = this._getTexture();
     this._texture = tex;
     return tex;
 };
-cc.js.set(cc.SpriteFrame.prototype, '_textureFilenameSetter', function (url) {
+
+cc.js.set(prototype, '_textureFilenameSetter', function (url) {
     this._textureFilename = url;
     if (url) {
         var texture = cc.textureCache.addImage(url);
         this._refreshTexture(texture);
     }
 });
+
+cc.js.getset(prototype, 'name',
+    function () {
+        return this._name;
+    },
+    function (value) {
+        this._name = value;
+    }
+);


### PR DESCRIPTION
Re: cocos-creator/fireball#3223

Changes proposed in this pull request:
- 修复在 JSB 获取 SpriteFrame 的 name 为 undefined 错误.

@cocos-creator/engine-admins
