### PR TITLE
fix start multiple runs

### DIFF
--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -111,8 +111,13 @@ function callOnEnable (self, enable) {
 function _registerEvent (self, on) {
     if (CC_EDITOR && !(self.constructor._executeInEditMode || cc.engine._isPlaying)) return;
 
-    if (on && self.start && !(self._objFlags & IsOnStartCalled)) {
-        cc.director.once(cc.Director.EVENT_BEFORE_UPDATE, _callStart, self);
+    if (self.start && !(self._objFlags & IsOnStartCalled)) {
+        if (on) {
+            cc.director.on(cc.Director.EVENT_BEFORE_UPDATE, _callStart, self);
+        }
+        else {
+            cc.director.off(cc.Director.EVENT_BEFORE_UPDATE, _callStart, self);
+        }
     }
 
     if (!self.update && !self.lateUpdate) {
@@ -142,9 +147,11 @@ var _registerUpdateEvent = function () {
 };
 
 var _callStart = CC_EDITOR ? function () {
+    cc.director.off(cc.Director.EVENT_BEFORE_UPDATE, _callStart, this);
     callStartInTryCatch(this);
     this._objFlags |= IsOnStartCalled;
 } : function () {
+    cc.director.off(cc.Director.EVENT_BEFORE_UPDATE, _callStart, this);
     this.start();
     this._objFlags |= IsOnStartCalled;
 };

--- a/test/qunit/unit/test-component.js
+++ b/test/qunit/unit/test-component.js
@@ -98,6 +98,39 @@ test('start', function () {
     cc.game.step();
 });
 
+test('start should only', function () {
+    var TestComp1 = cc.Class({
+        extends: cc.Component,
+        start: function () {
+            this.target = cc.find('node2');
+            this.target.active = false;
+            this.target.active = true;
+        }
+    });
+
+    var called = false;
+    var TestComp2 = cc.Class({
+        extends: cc.Component,
+        start: function () {
+            strictEqual(called, false, 'start should not been called');
+            called = true;
+        }
+    });
+
+    var node1 = new cc.Node();
+    cc.director.getScene().addChild(node1);
+    node1.addComponent(TestComp1);
+
+    var node2 = new cc.Node();
+    node2.name = 'node2';
+    cc.director.getScene().addChild(node2);
+    node2.addComponent(TestComp2);
+    // run TestComp1
+    cc.game.step();
+    // run TestComp2
+    cc.game.step();
+});
+
 test('lateUpdate', function () {
     var TestComp = cc.Class({
         extends: cc.Component,


### PR DESCRIPTION
Re: cocos-creator/fireball#3258

Changes proposed in this pull request:
- 修复脚本的start 接口在某些情况下会被调用多次

@cocos-creator/engine-admins
