### PR TITLE
Solve the error effect of TiledMap in Windows Creator.

### DIFF
--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -695,6 +695,14 @@ var TiledMap = cc.Class({
         if (file) {
             var resPath = cc.url._rawAssets + file.tmxFolderPath;
             resPath = cc.path._setEndWithSep(resPath, false);
+
+            if (CC_EDITOR && cc.sys.os === cc.sys.OS_WINDOWS) {
+                // In windows editor, the key of loaded textures are using '/'.
+                // But the value of cc.url._rawAssets is using '\'
+                // So, here should change the separater.
+                resPath = resPath.replace(/\\/g, '/');
+            }
+
             var ret = sgNode.initWithXML(file.tmxXmlStr, resPath);
             if (ret) {
                 self._onMapLoaded();

--- a/cocos2d/tilemap/editor/tiled-map.js
+++ b/cocos2d/tilemap/editor/tiled-map.js
@@ -94,7 +94,7 @@ class TiledMapMeta extends CustomAssetMeta {
     asset.name = Path.basenameNoExt(fspath);
     asset.tmxXmlStr = this._tmxData;
     asset.tmxFolderPath = Path.relative(AssetRootUrl, Url.dirname(db.fspathToUrl(fspath)));
-    asset.tmxFolderPath = asset.tmxFolderPath.replace('\\', '/');
+    asset.tmxFolderPath = asset.tmxFolderPath.replace(/\\/g, '/');
     asset.textures = this._textures.map(p => db.fspathToUrl(p));
     asset.tsxFiles = this._tsxFiles.map(p => db.fspathToUrl(p));
     db.saveAssetToLibrary(this.uuid, asset);


### PR DESCRIPTION
Re: cocos-creator/fireball#3268

Changes proposed in this pull request:
- Solve the error effect of TiledMap in Windows Creator.

> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
> - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

@cocos-creator/engine-admins
