### PR TITLE
fix Label string is null for webGL waring

### DIFF
--- a/cocos2d/core/label/CCSGLabelWebGLRenderCmd.js
+++ b/cocos2d/core/label/CCSGLabelWebGLRenderCmd.js
@@ -65,8 +65,8 @@ proto._updateDisplayOpacity = function (parentOpacity) {
 proto.rendering = function (ctx) {
     var node = this._node;
 
-    if(node._labelType === _ccsg.Label.Type.TTF ||
-      node._labelType === _ccsg.Label.Type.SystemFont){
+    if(node.getString() && (node._labelType === _ccsg.Label.Type.TTF ||
+       node._labelType === _ccsg.Label.Type.SystemFont)){
         var gl = ctx || cc._renderContext ;
 
         this._shaderProgram.use();


### PR DESCRIPTION
Re: cocos-creator/fireball#3012

Changes proposed in this pull request:
- 当 string 为 空的时候就不进行 WebGL rendering

@zilongshanren  你看一下吧，如果没问题的话让 @nantas 合并

@cocos-creator/engine-admins
