### PR TITLE
Chrome on Android is supporting WebGL since v. 30

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -308,7 +308,8 @@ sys.EDITOR_PAGE = 102;
 sys.EDITOR_CORE = 103;
 
 /**
- * BROWSER_TYPE_WECHAT
+ *
+ _WECHAT
  * @property {String} BROWSER_TYPE_WECHAT
  * @readOnly
  * @default "wechat"
@@ -551,8 +552,6 @@ else {
             browserType = sys.BROWSER_TYPE_MAXTHON;
         else if (browserType === "opr")
             browserType = sys.BROWSER_TYPE_OPERA;
-        else if (browserType === "chrome")
-            browserType = sys.BROWSER_TYPE_CHROME;
 
         sys.browserType = browserType;
     })();
@@ -691,12 +690,13 @@ else {
             }
 
             if (_supportWebGL && sys.os === sys.OS_ANDROID) {
+                var browserVer = parseFloat(sys.browserVersion);
+
                 switch (sys.browserType) {
                 case sys.BROWSER_TYPE_MOBILE_QQ:
                 case sys.BROWSER_TYPE_BAIDU:
                 case sys.BROWSER_TYPE_BAIDU_APP:
                     // QQ & Baidu Brwoser 6.2+ (using blink kernel)
-                    var browserVer = parseFloat(sys.browserVersion);
                     if (browserVer >= 6.2) {
                         _supportWebGL = true;
                     }
@@ -712,7 +712,6 @@ else {
                     break;
                 case sys.BROWSER_TYPE_CHROME:
                     // Chrome on android supports WebGL from v. 30
-                    var browserVer = parseFloat(sys.browserVersion);
                     if(browserVer >= 30.0) {
                       _supportWebGL = true;
                     } else {

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -306,10 +306,8 @@ sys.EDITOR_PAGE = 102;
  * @default 103
  */
 sys.EDITOR_CORE = 103;
-
 /**
- *
- _WECHAT
+ * BROWSER_TYPE_WECHAT
  * @property {String} BROWSER_TYPE_WECHAT
  * @readOnly
  * @default "wechat"

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -551,6 +551,8 @@ else {
             browserType = sys.BROWSER_TYPE_MAXTHON;
         else if (browserType === "opr")
             browserType = sys.BROWSER_TYPE_OPERA;
+        else if (browserType === "chrome")
+            browserType = sys.BROWSER_TYPE_CHROME;
 
         sys.browserType = browserType;
     })();
@@ -706,6 +708,15 @@ else {
                     // Android 5+ default browser
                     if (sys.osMainVersion && sys.osMainVersion >= 5) {
                         _supportWebGL = true;
+                    }
+                    break;
+                case sys.BROWSER_TYPE_CHROME:
+                    // Chrome on android supports WebGL from v. 30
+                    var browserVer = parseFloat(sys.browserVersion);
+                    if(browserVer >= 30.0) {
+                      _supportWebGL = true;
+                    } else {
+                      _supportWebGL = false;
                     }
                     break;
                 case sys.BROWSER_TYPE_UNKNOWN:


### PR DESCRIPTION
Enabling webGL on Android running newer version of Chrome. As stated here [webGL](http://googlechromereleases.blogspot.dk/2013/08/chrome-beta-for-android-update_22.html) Chrome on Android supports WebGL from version 30 and newer.
