### PR TITLE
fix scale of skeleton is readonly after upgrading from old version

### DIFF
--- a/cocos2d/core/components/CCCanvas.js
+++ b/cocos2d/core/components/CCCanvas.js
@@ -148,8 +148,11 @@ var Canvas = cc.Class({
     },
 
     __preload: function () {
-        var Flags = cc.Object.Flags;
-        this._objFlags |= (Flags.IsPositionLocked | Flags.IsAnchorLocked | Flags.IsSizeLocked);
+        if (CC_DEV) {
+            var Flags = cc.Object.Flags;
+            this._objFlags &= Flags.PersistentMask; // for 1.0 project
+            this._objFlags |= (Flags.IsPositionLocked | Flags.IsAnchorLocked | Flags.IsSizeLocked);
+        }
 
         if (Canvas.instance) {
             return cc.error("Can't init canvas '%s' because it conflicts with the existing '%s', the scene should only have one active canvas at the same time",

--- a/cocos2d/core/platform/CCObject.js
+++ b/cocos2d/core/platform/CCObject.js
@@ -11,8 +11,8 @@ var Dirty = 1 << 5;
 var DontDestroy = 1 << 6;
 var Destroying = 1 << 7;
 var Activating = 1 << 8;
-var HideInGame = 1 << 9;
-var HideInEditor = 1 << 10;
+//var HideInGame = 1 << 9;
+//var HideInEditor = 1 << 10;
 
 var IsOnEnableCalled = 1 << 11;
 var IsEditorOnEnableCalled = 1 << 12;
@@ -27,12 +27,15 @@ var IsAnchorLocked = 1 << 19;
 var IsSizeLocked = 1 << 20;
 var IsPositionLocked = 1 << 21;
 
-var Hide = HideInGame | HideInEditor;
+//var Hide = HideInGame | HideInEditor;
 // should not clone or serialize these flags
 var PersistentMask = ~(ToDestroy | Dirty | Destroying | DontDestroy | Activating |
                        IsPreloadCalled | IsOnLoadStarted | IsOnLoadCalled | IsOnStartCalled |
-                       IsOnEnableCalled | IsEditorOnEnableCalled
+                       IsOnEnableCalled | IsEditorOnEnableCalled |
+                       IsRotationLocked | IsScaleLocked | IsAnchorLocked | IsSizeLocked | IsPositionLocked
                        /*RegisteredInEditor*/);
+// TODO
+//var PersistentMask = Destroyed | RealDestroyed | DontSave | EditorOnly;
 
 /**
  * The base class of most of all the objects in Fireball.
@@ -99,36 +102,36 @@ CCObject.Flags = {
     Destroying: Destroying,
     Activating: Activating,
 
-    /**
-     * !#en
-     * Hide in game and hierarchy.
-     * This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
-     * !#zh
-     * 在游戏和层级中隐藏该对象。<br/>
-     * 该标记只读，它只能被用作 scene.addEntity()的一个参数。
-     * @property {Number} HideInGame
-     */
-    HideInGame: HideInGame,
+    ///**
+    // * !#en
+    // * Hide in game and hierarchy.
+    // * This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
+    // * !#zh
+    // * 在游戏和层级中隐藏该对象。<br/>
+    // * 该标记只读，它只能被用作 scene.addEntity()的一个参数。
+    // * @property {Number} HideInGame
+    // */
+    //HideInGame: HideInGame,
 
     // FLAGS FOR EDITOR
 
-    /**
-     * !#en This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
-     * !#zh 该标记只读，它只能被用作 scene.addEntity()的一个参数。
-     * @property {Number} HideInEditor
-     */
-    HideInEditor: HideInEditor,
+    ///**
+    // * !#en This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
+    // * !#zh 该标记只读，它只能被用作 scene.addEntity()的一个参数。
+    // * @property {Number} HideInEditor
+    // */
+    //HideInEditor: HideInEditor,
 
-    /**
-     * !#en
-     * Hide in game view, hierarchy, and scene view... etc.
-     * This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
-     * !#zh
-     * 在游戏视图，层级，场景视图等等...中隐藏该对象。
-     * 该标记只读，它只能被用作 scene.addEntity()的一个参数。
-     * @property {Number} Hide
-     */
-    Hide: Hide,
+    ///**
+    // * !#en
+    // * Hide in game view, hierarchy, and scene view... etc.
+    // * This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
+    // * !#zh
+    // * 在游戏视图，层级，场景视图等等...中隐藏该对象。
+    // * 该标记只读，它只能被用作 scene.addEntity()的一个参数。
+    // * @property {Number} Hide
+    // */
+    //Hide: Hide,
 
     //// UUID Registered in editor
     //RegisteredInEditor: RegisteredInEditor,

--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -342,8 +342,11 @@ sp.Skeleton = cc.Class({
 
     __preload: function () {
         // sgNode 的尺寸不是很可靠 同时 Node 的框框也没办法和渲染匹配 只好强制尺寸为零
-        var Flags = cc.Object.Flags;
-        this._objFlags |= (Flags.IsAnchorLocked | Flags.IsSizeLocked);
+        if (CC_DEV) {
+            var Flags = cc.Object.Flags;
+            this._objFlags &= Flags.PersistentMask; // for v1.0 project
+            this._objFlags |= (Flags.IsAnchorLocked | Flags.IsSizeLocked);
+        }
         this.node.setContentSize(0, 0);
         //
         this._refresh();


### PR DESCRIPTION
Re: cocos-creator/fireball#3333

Changes proposed in this pull request:
- 将组件所用标志位标记为不可保存

@cocos-creator/engine-admins
