### PR TITLE
Rename the method getTileset/setTileset to getTileSet/setTileSet.

### DIFF
--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -206,6 +206,24 @@ if (CC_DEV) {
         return cc.js.array.copy;
     });
 
+    /**
+     * Get the Tile set information for the layer.
+     * @memberof cc.TiledLayer
+     * @deprecated
+     * @return {TMXTilesetInfo}
+     * @function
+     */
+    js.obsolete(cc.TiledLayer.prototype, 'cc.TiledLayer.getTileset', 'getTileSet');
+
+    /**
+     * Set the Tile set information for the layer.
+     * @memberof cc.TiledLayer
+     * @deprecated
+     * @param {TMXTilesetInfo}
+     * @function
+     */
+    js.obsolete(cc.TiledLayer.prototype, 'cc.TiledLayer.setTileset', 'setTileSet');
+
     Object.defineProperty(cc._SGComponent.prototype, 'visible', {
         get: function () {
             cc.warn('The "visible" property of %s is deprecated, use "enabled" instead please.', cc.js.getClassName(this));

--- a/cocos2d/tilemap/CCSGTMXLayer.js
+++ b/cocos2d/tilemap/CCSGTMXLayer.js
@@ -205,7 +205,7 @@ _ccsg.TMXLayer = cc.SpriteBatchNode.extend(/** @lends _ccsg.TMXLayer# */{
      * Tile set information for the layer
      * @return {cc.TMXTilesetInfo}
      */
-    getTileset:function () {
+    getTileSet:function () {
         return this.tileset;
     },
 
@@ -213,7 +213,7 @@ _ccsg.TMXLayer = cc.SpriteBatchNode.extend(/** @lends _ccsg.TMXLayer# */{
      * Tile set information for the layer
      * @param {cc.TMXTilesetInfo} Var
      */
-    setTileset:function (Var) {
+    setTileSet:function (Var) {
         this.tileset = Var;
     },
 

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -441,14 +441,14 @@ var TiledLayer = cc.Class({
     /**
      * !#en Tile set information for the layer.
      * !#zh 获取 layer 的 Tileset 信息。
-     * @method getTileset
+     * @method getTileSet
      * @return {TMXTilesetInfo}
      * @example
-     * var tileset = tiledLayer.getTileset();
+     * var tileset = tiledLayer.getTileSet();
      */
-    getTileset:function () {
+    getTileSet:function () {
         if (this._sgNode) {
-            return this._sgNode.getTileset();
+            return this._sgNode.getTileSet();
         }
         return null;
     },
@@ -456,15 +456,42 @@ var TiledLayer = cc.Class({
     /**
      * !#en Tile set information for the layer.
      * !#zh 设置 layer 的 Tileset 信息。
+     * @method setTileSet
+     * @param {TMXTilesetInfo} tileset
+     * @example
+     * tiledLayer.setTileSet(tileset);
+     */
+    setTileSet:function (tileset) {
+        if (this._sgNode) {
+            this._sgNode.setTileSet(tileset);
+        }
+    },
+
+
+    /**
+     * !#en Tile set information for the layer.
+     * !#zh 获取 layer 的 Tileset 信息。
+     * @deprecated Please use getTileSet instead.
+     * @method getTileset
+     * @return {TMXTilesetInfo}
+     * @example
+     * var tileset = tiledLayer.getTileset();
+     */
+    getTileset:function () {
+        return this.getTileSet();
+    },
+
+    /**
+     * !#en Tile set information for the layer.
+     * !#zh 设置 layer 的 Tileset 信息。
+     * @deprecated Please use setTileSet instead.
      * @method setTileset
      * @param {TMXTilesetInfo} tileset
      * @example
      * tiledLayer.getTileset(tileset);
      */
     setTileset:function (tileset) {
-        if (this._sgNode) {
-            this._sgNode.setTileset(tileset);
-        }
+        this.setTileSet(tileset);
     },
 
     /**

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -467,33 +467,6 @@ var TiledLayer = cc.Class({
         }
     },
 
-
-    /**
-     * !#en Tile set information for the layer.
-     * !#zh 获取 layer 的 Tileset 信息。
-     * @deprecated Please use getTileSet instead.
-     * @method getTileset
-     * @return {TMXTilesetInfo}
-     * @example
-     * var tileset = tiledLayer.getTileset();
-     */
-    getTileset:function () {
-        return this.getTileSet();
-    },
-
-    /**
-     * !#en Tile set information for the layer.
-     * !#zh 设置 layer 的 Tileset 信息。
-     * @deprecated Please use setTileSet instead.
-     * @method setTileset
-     * @param {TMXTilesetInfo} tileset
-     * @example
-     * tiledLayer.getTileset(tileset);
-     */
-    setTileset:function (tileset) {
-        this.setTileSet(tileset);
-    },
-
     /**
      * !#en Layer orientation, which is the same as the map orientation.
      * !#zh 获取 Layer 方向(同地图方向)。


### PR DESCRIPTION
Re: cocos-creator/fireball#3324

Changes proposed in this pull request:
- Rename the method getTileset/setTileset to getTileSet/setTileSet.

@cocos-creator/engine-admins
