### PR TITLE
fix node.targetOff Interface registered event cannot be cancelled

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1172,7 +1172,7 @@ var Node = cc.Class({
      * node.targetOff(target);
      */
     targetOff: function (target) {
-        this._EventTargetTargetOff(this, target);
+        this._EventTargetTargetOff(target);
 
         this._checkTouchListeners();
         this._checkMouseListeners();


### PR DESCRIPTION
Re: cocos-creator/fireball#3368

Changes proposed in this pull request:
- 修复node.targetOff 接口无法取消已注册的事件

@cocos-creator/engine-admins
