### PR TITLE
prevent '/' in node name

### DIFF
--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -109,6 +109,10 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                 return this._name;
             },
             set: function (value) {
+                if (value.indexOf('/') !== -1) {
+                    cc.warn('Node name can not include \'/\'.');
+                    return;
+                }
                 this._name = value;
             },
         },


### PR DESCRIPTION
Re: cocos-creator/fireball#2565

Changes proposed in this pull request:
- prevent '/' in node name

@cocos-creator/engine-admins
