### PR TITLE
fix prefab save data error fireball/issues/3352

### DIFF
--- a/cocos2d/core/load-pipeline/uuid-loader.js
+++ b/cocos2d/core/load-pipeline/uuid-loader.js
@@ -46,15 +46,18 @@ function loadDepends (pipeline, item, asset, tdInfo, callback) {
     var ownerList = JS.array.copy(tdInfo.uuidObjList);
     var propList = JS.array.copy(tdInfo.uuidPropList);
 
-    var depends = new Array(dependsSrcs.length);
+    var depends = [];
     // load depends assets
     for (var i = 0; i < dependsSrcs.length; i++) {
         var dependSrc = dependsSrcs[i];
-        depends[i] = {
+        if (dependSrc === uuid) {
+            continue;
+        }
+        depends.push({
             id: dependSrc,
             type: 'uuid',
             uuid: dependSrc
-        };
+        });
     }
     // load raw
     if (tdInfo.rawProp) {
@@ -104,6 +107,9 @@ function loadDepends (pipeline, item, asset, tdInfo, callback) {
             }
             asset._uuid = uuid;
             callback(null, asset);
+            if (CC_EDITOR) {
+                cc.loader.removeItem(uuid);
+            }
         });
     }
     else {


### PR DESCRIPTION
Re: cocos-creator/fireball#3352

Changes proposed in this pull request:
- 这个问题是由于在加载依赖项的时候缓存了数据，导致 load 的时候是旧数据。

@cocos-creator/engine-admins
