### PR TITLE
fix get loaded scene name is null bug

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -800,6 +800,7 @@ cc.Director = Class.extend(/** @lends cc.Director# */{
                     scene = sceneAsset;
                 }
                 if (scene instanceof cc.Scene) {
+                    scene._name = sceneAsset._name;
                     self.runSceneImmediate(scene, onUnloaded, onLaunched);
                 }
                 else {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/790#event-693145456

Changes proposed in this pull request:
-  fix get loaded scene name is null bug

@cocos-creator/engine-admins
