### PR TITLE
fix bmfont long word wrap

### DIFF
--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1012,6 +1012,9 @@ cc.BMFontHelper = {
             //calculate the word boundary
 
             letterDef = this._fontAtlas.getLetterDefinitionForChar(character);
+            if (!letterDef) {
+                break;
+            }
             letterX = nextLetterX + letterDef._offsetX * this._bmfontScale;
 
             if(letterX + letterDef._width * this._bmfontScale > this._maxLineWidth && !this._isspace_unicode(character) && this._maxLineWidth > 0) {

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1004,8 +1004,22 @@ cc.BMFontHelper = {
         }
 
         var len = 1;
+        var nextLetterX = 0;
+        var letterDef;
+        var letterX;
         for (var index = startIndex + 1; index < textLen; ++index) {
             character = text.charAt(index);
+            //calculate the word boundary
+
+            letterDef = this._fontAtlas.getLetterDefinitionForChar(character);
+            letterX = nextLetterX + letterDef._offsetX * this._bmfontScale;
+
+            if(letterX + letterDef._width * this._bmfontScale > this._maxLineWidth && !this._isspace_unicode(character) && this._maxLineWidth > 0) {
+                if(len >= 2) {
+                    return len - 1;
+                }
+            }
+            nextLetterX += letterDef._xAdvance * this._bmfontScale + this._additionalKerning;
             if (character === "\n" || this._isspace_unicode(character) || this._isCJK_unicode(character)) {
                 break;
             }


### PR DESCRIPTION
Re: cocos-creator/fireball#3376

Changes proposed in this pull request:
- 当一个单词的宽度小于 label 的宽度的时候，把 此单词的换行模式由“按词换行” 改成“按字符换行”。

@cocos-creator/engine-admins
