### PR TITLE
Add method refreshUrl in CCLoader for Editor.

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -490,4 +490,10 @@ JS.mixin(cc.loader, {
     }
 });
 
+if (CC_EDITOR) {
+    cc.loader.refreshUrl = function (uuid, oldUrl, newUrl) {
+        this._items.refreshItemUrl(uuid, oldUrl, newUrl);
+    };
+}
+
 module.exports = cc.loader;

--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -267,4 +267,21 @@ JS.mixin(LoadingItems.prototype, CallbacksInvoker.prototype, {
     }
 });
 
+if (CC_EDITOR) {
+    LoadingItems.prototype.refreshItemUrl = function (id, oldUrl, newUrl) {
+        var item = this.map[id];
+        if (item) {
+            item.url = newUrl;
+        }
+
+        item = this.map[oldUrl];
+        if (item) {
+            item.id = newUrl;
+            item.url = newUrl;
+            this.map[newUrl] = item;
+            delete this.map[oldUrl];
+        }
+    };
+}
+
 module.exports = LoadingItems;


### PR DESCRIPTION
Re: cocos-creator/fireball#2215

Changes proposed in this pull request:
- Add method refreshUrl in CCLoader for Editor. (It will be used in Editor when asset moved.)

@cocos-creator/engine-admins
