### PR TITLE
fix bmfont and ttf shrink in editor

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -125,6 +125,12 @@ var Label = cc.Class({
     name: 'cc.Label',
     extends: cc._RendererUnderSG,
 
+    ctor: function() {
+        if(CC_EDITOR) {
+            this._userDefinedFontSize = 40;
+        }
+    },
+
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.renderers/Label',
         help: 'i18n:COMPONENT.help_url.label',
@@ -146,6 +152,9 @@ var Label = cc.Class({
                 if (this._sgNode) {
                     this._sgNode.setString(this.string);
                     this._updateNodeSize();
+                    if(CC_EDITOR && this.overflow === cc.Label.Overflow.SHRINK) {
+                        this.fontSize = this._userDefinedFontSize;
+                    }
                 }
             }
         },
@@ -199,6 +208,9 @@ var Label = cc.Class({
             },
             set: function(value){
                 this._fontSize = value;
+                if(CC_EDITOR) {
+                    this._userDefinedFontSize = value;
+                }
                 if (this._sgNode) {
                     this._sgNode.setFontSize(value);
                     this._updateNodeSize();
@@ -284,10 +296,15 @@ var Label = cc.Class({
                 return this._N$file;
             },
             set: function (value) {
+                //if delete the font, we should change isSystemFontUsed to true
+                if(!value) {
+                    this._isSystemFontUsed = true;
+                }
+
                 this._N$file = value;
                 this._bmFontOriginalSize = -1;
                 if (value && this._isSystemFontUsed)
-                    this.useSystemFont = false;
+                    this._isSystemFontUsed = false;
 
                 if (this._sgNode) {
 
@@ -323,6 +340,8 @@ var Label = cc.Class({
                 return this._isSystemFontUsed;
             },
             set: function(value){
+                if(!value && this._isSystemFontUsed) return;
+
                 this._isSystemFontUsed = !!value;
                 if (value) {
                     this.font = null;
@@ -421,6 +440,9 @@ var Label = cc.Class({
         sgNode.enableWrapText( this._enableWrapText );
         sgNode.setLineHeight(this._lineHeight);
         sgNode.setString(this.string);
+        if (CC_EDITOR) {
+            this._userDefinedFontSize = this.fontSize;
+        }
         if (CC_EDITOR && this._useOriginalSize) {
             this.node.setContentSize(sgNode.getContentSize());
             if (this.font instanceof cc.BitmapFont) {

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -467,7 +467,7 @@ _ccsg.Label = _ccsg.Node.extend({
 
     _updateLabel: function () {
         if (this._labelType === _ccsg.Label.Type.BMFont) {
-            var contentSize = this.getContentSize();
+            var contentSize = this._contentSize;
             var newWidth = contentSize.width;
             var newHeight = contentSize.height;
             this._setupBMFontOverflowMetrics(newWidth, newHeight);

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -448,8 +448,30 @@ _ccsg.Label = _ccsg.Node.extend({
         return new cc.BlendFunc(this._blendFunc.src, this._blendFunc.dst);
     },
 
+    _setupBMFontOverflowMetrics: function(newWidth, newHeight) {
+        if (this._overFlow === _ccsg.Label.Overflow.RESIZE_HEIGHT) {
+            newHeight = 0;
+        }
+
+        if (this._overFlow === _ccsg.Label.Overflow.NONE) {
+            newWidth = 0;
+            newHeight = 0;
+        }
+
+        this._labelWidth = newWidth;
+        this._labelHeight = newHeight;
+        this._labelDimensions.width = newWidth;
+        this._labelDimensions.height = newHeight;
+        this._maxLineWidth = newWidth;
+    },
+
     _updateLabel: function () {
         if (this._labelType === _ccsg.Label.Type.BMFont) {
+            var contentSize = this.getContentSize();
+            var newWidth = contentSize.width;
+            var newHeight = contentSize.height;
+            this._setupBMFontOverflowMetrics(newWidth, newHeight);
+
             this._updateContent();
             this.setColor(this.color);
         } else if (this._labelType === _ccsg.Label.Type.TTF
@@ -510,7 +532,7 @@ cc.BMFontHelper = {
 
             this._textDesiredHeight = 0;
             this._linesWidth = [];
-            if (this._maxLineWidth > 0 && !this._lineBreakWithoutSpaces) {
+            if (!this._lineBreakWithoutSpaces) {
                 this._multilineTextWrapByWord();
             } else {
                 this._multilineTextWrapByChar();
@@ -672,21 +694,7 @@ cc.BMFontHelper = {
 
         if (newHeight !== oldSize.height || newWidth !== oldSize.width) {
 
-            if (this._overFlow === _ccsg.Label.Overflow.RESIZE_HEIGHT) {
-                newHeight = 0;
-            }
-
-            if (this._overFlow === _ccsg.Label.Overflow.NONE) {
-                newWidth = 0;
-                newHeight = 0;
-            }
-
-            this._labelWidth = newWidth;
-            this._labelHeight = newHeight;
-            this._labelDimensions.width = newWidth;
-            this._labelDimensions.height = newHeight;
-
-            this._maxLineWidth = newWidth;
+            this._setupBMFontOverflowMetrics(newWidth, newHeight);
 
             if (this._drawFontsize > 0) {
                 this._restoreFontSize();
@@ -822,6 +830,7 @@ cc.BMFontHelper = {
         if (this._labelHeight <= 0) {
             contentSize.height = parseFloat(this._textDesiredHeight.toFixed(2));
         }
+
         _ccsg.Node.prototype.setContentSize.call(this, contentSize);
 
         this._tailoredTopY = contentSize.height;
@@ -902,7 +911,7 @@ cc.BMFontHelper = {
             this._fontAtlas.assignLetterDefinitions(tempLetterDefinition);
             this._fontAtlas.scaleFontLetterDefinition(scale);
             this._lineHeight = originalLineHeight * scale;
-            if (this._maxLineWidth > 0 && !this._lineBreakWithoutSpaces) {
+            if (!this._lineBreakWithoutSpaces) {
                 this._multilineTextWrapByWord();
             } else {
                 this._multilineTextWrapByChar();

--- a/cocos2d/core/label/CCSGLabelCanvasRenderCmd.js
+++ b/cocos2d/core/label/CCSGLabelCanvasRenderCmd.js
@@ -241,7 +241,9 @@
                 for (i = 0; i < paragraphedStrings.length; ++i) {
                     totalLength += ((paragraphLength[i] / canvasWidthNoMargin + 1) | 0) * canvasWidthNoMargin;
                 }
-                var scale = canvasWidthNoMargin * ((this._canvasSize.height / this._getLineHeight()) | 0) / totalLength;
+                var heightRatio = this._canvasSize.height / this._getLineHeight();
+                heightRatio = heightRatio < 1 ? 1: heightRatio;
+                var scale = canvasWidthNoMargin * (heightRatio | 0) / totalLength;
                 node._fontSize = (drawFontize * Math.min(Math.sqrt(scale), 1)) | 0;
                 fontDesc = node._fontSize.toString() + 'px ' + fontFamily;
 


### PR DESCRIPTION
Re: cocos-creator/fireball#3071  https://github.com/cocos-creator/fireball/issues/3389

Changes proposed in this pull request:
1. fix bmfont and ttf shrink font size doesn't restore to the original size when changing string.
2. fix bmfont shrink/clamp/resize_height issue when first added to the editor.
3. fix system font markup control shouldn't be unmarked when it's already use system font.

@cocos-creator/engine-admins
