### PR TITLE
spine should use postImport

### DIFF
--- a/extensions/spine/editor/spine-meta.js
+++ b/extensions/spine/editor/spine-meta.js
@@ -62,13 +62,18 @@ class TextureParser {
         var base = Path.dirname(this.atlasPath);
         var path = Path.resolve(base, name);
         var uuid = Editor.assetdb.fspathToUuid(path);
-        if (!uuid) {
-            Editor.error('Can not find texture "%s" for atlas "%s"', line, this.atlasPath);
-            return;
+        if (uuid) {
+            console.log('UUID is initialized for "%s".', path);
+            var url = Editor.assetdb.uuidToUrl(uuid);
+            this.textures.push(url);
         }
-        //var texture = Editor.serialize.asAsset(uuid);
-        var url = Editor.assetdb.uuidToUrl(uuid);
-        this.textures.push(url);
+        else if (!Fs.existsSync(path)) {
+            Editor.error('Can not find texture "%s" for atlas "%s"', line, this.atlasPath);
+        }
+        else {
+            // AssetDB may call postImport more than once, we can get uuid in the next time.
+            console.warn('WARN: UUID not yet initialized for "%s".', path);
+        }
     }
     unload () {}
 }

--- a/extensions/spine/editor/spine-meta.js
+++ b/extensions/spine/editor/spine-meta.js
@@ -9,7 +9,7 @@ const Fs = require('fire-fs');
 const Path = require('fire-path');
 const Spine = require('../lib/spine');
 
-const ATLAS_EXTS = ['.atlas', '.txt', ''];
+const ATLAS_EXTS = ['.atlas', '.txt', '.atlas.txt', ''];
 const SPINE_ENCODING = { encoding: 'utf-8' };
 
 const CustomAssetMeta = Editor.metas['custom-asset'];
@@ -63,12 +63,9 @@ class TextureParser {
         var path = Path.resolve(base, name);
         var uuid = Editor.assetdb.fspathToUuid(path);
         if (!uuid) {
+            Editor.error('Can not find texture "%s" for atlas "%s"', line, this.atlasPath);
             return;
         }
-        //if (!uuid) {
-        //    cc.error('Can not find texture "%s" for atlas "%s"', line, this.atlasPath);
-        //    return;
-        //}
         //var texture = Editor.serialize.asAsset(uuid);
         var url = Editor.assetdb.uuidToUrl(uuid);
         this.textures.push(url);
@@ -136,7 +133,7 @@ class SpineMeta extends CustomAssetMeta {
         return res;
     }
     
-    import (fspath, cb) {
+    postImport (fspath, cb) {
         Fs.readFile(fspath, SPINE_ENCODING, (err, data) => {
             if (err) {
                 return cb(err);


### PR DESCRIPTION
Re: cocos-creator/fireball#1869

Changes proposed in this pull request:
- 使用 postImport 来导入 spine，避免导入新资源时提示 `Please re-import because its textures is not initialized!...`
- 支持 .atlas.txt 后缀

@cocos-creator/engine-admins
