### PR TITLE
Remove Node event parameter of 'position-changed' and 'size-changed'

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1417,21 +1417,19 @@ if (CC_JSB) {
 }
 
 /**
- *
  * @event position-changed
  * @param {Event} event
- * @param {Vec2} event.detail - old position
+ * @param {Vec2} event.detail - The old position, but this parameter is only available in editor!
  */
 /**
 /**
  * @event size-changed
  * @param {Event} event
- * @param {Size} event.detail - old size
+ * @param {Size} event.detail - The old size, but this parameter is only available in editor!
  */
 /**
  * @event anchor-changed
  * @param {Event} event
- * @param {Vec2} event.detail - old anchor
  */
 /**
  * @event child-added

--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -393,19 +393,6 @@ var Sprite = cc.Class({
     },
 
     /**
-     * !#en Query the sprite's original size.
-     * !#zh 获取精灵原始大小
-     * @method getOriginalSize
-     * @return {Size} Sprite size.
-     * @example
-     * var originalSize = sprite.getOriginalSize();
-     * cc.log("Original Size:" + originalSize);
-     */
-    getOriginalSize: function () {
-        return this._sgNode.getOriginalSize();
-    },
-
-    /**
      * !#en Change the left sprite's cap inset.
      * !#zh 设置精灵左边框-用于九宫格。
      * @method setInsetLeft

--- a/cocos2d/core/event/event-listeners.js
+++ b/cocos2d/core/event/event-listeners.js
@@ -55,10 +55,11 @@ EventListeners.prototype.invoke = function (event) {
         else {
             endIndex = list.length - 1;
             if (key === cc.Director.EVENT_COMPONENT_UPDATE) {
+                var dt = event.detail;
                 for (i = 1; i <= endIndex; i += 2) {
                     target = list[i];
                     if (target !== REMOVE_PLACEHOLDER) {
-                        target.update(event.detail);
+                        target.update(dt);
                     }
                 }
             }

--- a/cocos2d/core/event/event-target.js
+++ b/cocos2d/core/event/event-target.js
@@ -324,16 +324,13 @@ JS.mixin(EventTarget.prototype, {
      * @param {*} [detail] - whatever argument the message needs
      */
     emit: function (message, detail) {
-        if (typeof message !== 'string') {
+        if (CC_DEV && typeof message !== 'string') {
             cc.error('The message must be provided');
             return;
         }
         //don't emit event when listeners are not exists.
-        if(!this._bubblingListeners && !this._capturingListeners) {
-            return;
-        }
-        var caplisteners = this._capturingListeners ? this._capturingListeners._callbackTable[message] : null;
-        var bublisteners = this._bubblingListeners ? this._bubblingListeners._callbackTable[message] : null;
+        var caplisteners = this._capturingListeners && this._capturingListeners._callbackTable[message];
+        var bublisteners = this._bubblingListeners && this._bubblingListeners._callbackTable[message];
         if ((!caplisteners || caplisteners.length === 0) && (!bublisteners || bublisteners.length === 0)) {
             return;
         }

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -23,7 +23,6 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-var JS = cc.js;
 var SgHelper = require('./scene-graph-helper');
 var Destroying = require('../platform/CCObject').Flags.Destroying;
 var Misc = require('./misc');
@@ -385,13 +384,18 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                 var localPosition = this._position;
                 if (value !== localPosition.x) {
                     if (!CC_EDITOR || isFinite(value)) {
-                        var oldValue = localPosition.x;
+                        if (CC_EDITOR) {
+                            var oldValue = localPosition.x;
+                        }
 
                         localPosition.x = value;
                         this._sgNode.x = value;
 
-                        if (this.emit) {
+                        if (CC_EDITOR) {
                             this.emit(POSITION_CHANGED, new cc.Vec2(oldValue, localPosition.y));
+                        }
+                        else {
+                            this.emit(POSITION_CHANGED);
                         }
                     }
                     else {
@@ -418,13 +422,18 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                 var localPosition = this._position;
                 if (value !== localPosition.y) {
                     if (!CC_EDITOR || isFinite(value)) {
-                        var oldValue = localPosition.y;
+                        if (CC_EDITOR) {
+                            var oldValue = localPosition.y;
+                        }
 
                         localPosition.y = value;
                         this._sgNode.y = value;
 
-                        if (this.emit) {
+                        if (CC_EDITOR) {
                             this.emit(POSITION_CHANGED, new cc.Vec2(localPosition.x, oldValue));
+                        }
+                        else {
+                            this.emit(POSITION_CHANGED);
                         }
                     }
                     else {
@@ -483,13 +492,12 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
             set: function (value) {
                 var anchorPoint = this._anchorPoint;
                 if (anchorPoint.x !== value) {
-                    var old = new cc.Vec2(anchorPoint);
                     anchorPoint.x = value;
                     var sizeProvider = this._sizeProvider;
                     if (sizeProvider instanceof _ccsg.Node) {
                         sizeProvider.setAnchorPoint(anchorPoint);
                     }
-                    this.emit(ANCHOR_CHANGED, old);
+                    this.emit(ANCHOR_CHANGED);
                 }
             },
         },
@@ -509,13 +517,12 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
             set: function (value) {
                 var anchorPoint = this._anchorPoint;
                 if (anchorPoint.y !== value) {
-                    var old = new cc.Vec2(anchorPoint);
                     anchorPoint.y = value;
                     var sizeProvider = this._sizeProvider;
                     if (sizeProvider instanceof _ccsg.Node) {
                         sizeProvider.setAnchorPoint(anchorPoint);
                     }
-                    this.emit(ANCHOR_CHANGED, old);
+                    this.emit(ANCHOR_CHANGED);
                 }
             },
         },
@@ -545,9 +552,16 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                     if (sizeProvider) {
                         sizeProvider.setContentSize(value, sizeProvider._getHeight());
                     }
-                    var clone = cc.size(this._contentSize);
+                    if (CC_EDITOR) {
+                        var clone = cc.size(this._contentSize);
+                    }
                     this._contentSize.width = value;
-                    this.emit(SIZE_CHANGED, clone);
+                    if (CC_EDITOR) {
+                        this.emit(SIZE_CHANGED, clone);
+                    }
+                    else {
+                        this.emit(SIZE_CHANGED);
+                    }
                 }
             },
         },
@@ -577,9 +591,16 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                     if (sizeProvider) {
                         sizeProvider.setContentSize(sizeProvider._getWidth(), value);
                     }
-                    var clone = cc.size(this._contentSize);
+                    if (CC_EDITOR) {
+                        var clone = cc.size(this._contentSize);
+                    }
                     this._contentSize.height = value;
-                    this.emit(SIZE_CHANGED, clone);
+                    if (CC_EDITOR) {
+                        this.emit(SIZE_CHANGED, clone);
+                    }
+                    else {
+                        this.emit(SIZE_CHANGED);
+                    }
                 }
             },
         },
@@ -606,7 +627,7 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                     if (sizeProvider instanceof _ccsg.Node && sizeProvider !== this._sgNode) {
                         sizeProvider.ignoreAnchor = value;
                     }
-                    this.emit(ANCHOR_CHANGED, this._anchorPoint);
+                    this.emit(ANCHOR_CHANGED);
                 }
             },
         },
@@ -929,7 +950,9 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
             return;
         }
 
-        var oldPosition = new cc.Vec2(locPosition);
+        if (CC_EDITOR) {
+            var oldPosition = new cc.Vec2(locPosition);
+        }
 
         if (!CC_EDITOR || isFinite(xValue)) {
             locPosition.x = xValue;
@@ -946,8 +969,11 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
 
         this._sgNode.setPosition(xValue, yValue);
 
-        if (this.emit) {
+        if (CC_EDITOR) {
             this.emit(POSITION_CHANGED, oldPosition);
+        }
+        else {
+            this.emit(POSITION_CHANGED);
         }
     },
 
@@ -999,17 +1025,14 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
      */
     setAnchorPoint: function (point, y) {
         var locAnchorPoint = this._anchorPoint;
-        var old;
         if (y === undefined) {
             if ((point.x === locAnchorPoint.x) && (point.y === locAnchorPoint.y))
                 return;
-            old = cc.v2(locAnchorPoint);
             locAnchorPoint.x = point.x;
             locAnchorPoint.y = point.y;
         } else {
             if ((point === locAnchorPoint.x) && (y === locAnchorPoint.y))
                 return;
-            old = cc.v2(locAnchorPoint);
             locAnchorPoint.x = point;
             locAnchorPoint.y = y;
         }
@@ -1017,7 +1040,7 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
         if (sizeProvider instanceof _ccsg.Node) {
             sizeProvider.setAnchorPoint(locAnchorPoint);
         }
-        this.emit(ANCHOR_CHANGED, old);
+        this.emit(ANCHOR_CHANGED);
     },
 
     /**
@@ -1079,20 +1102,29 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
         if (height === undefined) {
             if ((size.width === locContentSize.width) && (size.height === locContentSize.height))
                 return;
-            clone = cc.size(locContentSize);
+            if (CC_EDITOR) {
+                clone = cc.size(locContentSize);
+            }
             locContentSize.width = size.width;
             locContentSize.height = size.height;
         } else {
             if ((size === locContentSize.width) && (height === locContentSize.height))
                 return;
-            clone = cc.size(locContentSize);
+            if (CC_EDITOR) {
+                clone = cc.size(locContentSize);
+            }
             locContentSize.width = size;
             locContentSize.height = height;
         }
         if (this._sizeProvider) {
             this._sizeProvider.setContentSize(locContentSize);
         }
-        this.emit(SIZE_CHANGED, clone);
+        if (CC_EDITOR) {
+            this.emit(SIZE_CHANGED, clone);
+        }
+        else {
+            this.emit(SIZE_CHANGED);
+        }
     },
 
     /**

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -157,7 +157,7 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                 if (oldParent) {
                     if (!(oldParent._objFlags & Destroying)) {
                         var removeAt = oldParent._children.indexOf(this);
-                        if (removeAt < 0 && CC_EDITOR) {
+                        if (CC_DEV && removeAt < 0) {
                             return cc.error('Internal error, should not remove unknown node from parent.');
                         }
                         oldParent._children.splice(removeAt, 1);
@@ -389,13 +389,21 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                         }
 
                         localPosition.x = value;
-                        this._sgNode.x = value;
+                        this._sgNode.setPositionX(value);
 
-                        if (CC_EDITOR) {
-                            this.emit(POSITION_CHANGED, new cc.Vec2(oldValue, localPosition.y));
-                        }
-                        else {
-                            this.emit(POSITION_CHANGED);
+                        // fast check event
+                        var capListeners = this._capturingListeners &&
+                                           this._capturingListeners._callbackTable[POSITION_CHANGED];
+                        var bubListeners = this._bubblingListeners &&
+                                           this._bubblingListeners._callbackTable[POSITION_CHANGED];
+                        if ((capListeners && capListeners.length > 0) || (bubListeners && bubListeners.length > 0)) {
+                            // send event
+                            if (CC_EDITOR) {
+                                this.emit(POSITION_CHANGED, new cc.Vec2(oldValue, localPosition.y));
+                            }
+                            else {
+                                this.emit(POSITION_CHANGED);
+                            }
                         }
                     }
                     else {
@@ -427,13 +435,21 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                         }
 
                         localPosition.y = value;
-                        this._sgNode.y = value;
+                        this._sgNode.setPositionY(value);
 
-                        if (CC_EDITOR) {
-                            this.emit(POSITION_CHANGED, new cc.Vec2(localPosition.x, oldValue));
-                        }
-                        else {
-                            this.emit(POSITION_CHANGED);
+                        // fast check event
+                        var capListeners = this._capturingListeners &&
+                                           this._capturingListeners._callbackTable[POSITION_CHANGED];
+                        var bubListeners = this._bubblingListeners &&
+                                           this._bubblingListeners._callbackTable[POSITION_CHANGED];
+                        if ((capListeners && capListeners.length > 0) || (bubListeners && bubListeners.length > 0)) {
+                            // send event
+                            if (CC_EDITOR) {
+                                this.emit(POSITION_CHANGED, new cc.Vec2(localPosition.x, oldValue));
+                            }
+                            else {
+                                this.emit(POSITION_CHANGED);
+                            }
                         }
                     }
                     else {
@@ -666,12 +682,11 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
                 if (this._opacity !== value) {
                     this._opacity = value;
                     this._sgNode.setOpacity(value);
-                    var sizeProvider = this._sizeProvider;
-                    if ( !this._cascadeOpacityEnabled &&
-                         sizeProvider instanceof _ccsg.Node &&
-                         this._sgNode !== sizeProvider
-                    ) {
-                        sizeProvider.setOpacity(value);
+                    if (!this._cascadeOpacityEnabled) {
+                        var sizeProvider = this._sizeProvider;
+                        if (sizeProvider instanceof _ccsg.Node && sizeProvider !== this._sgNode) {
+                            sizeProvider.setOpacity(value);
+                        }
                     }
                 }
             },
@@ -969,11 +984,19 @@ var BaseNode = cc.Class(/** @lends cc.Node# */{
 
         this._sgNode.setPosition(xValue, yValue);
 
-        if (CC_EDITOR) {
-            this.emit(POSITION_CHANGED, oldPosition);
-        }
-        else {
-            this.emit(POSITION_CHANGED);
+        // fast check event
+        var capListeners = this._capturingListeners &&
+                           this._capturingListeners._callbackTable[POSITION_CHANGED];
+        var bubListeners = this._bubblingListeners &&
+                           this._bubblingListeners._callbackTable[POSITION_CHANGED];
+        if ((capListeners && capListeners.length > 0) || (bubListeners && bubListeners.length > 0)) {
+            // send event
+            if (CC_EDITOR) {
+                this.emit(POSITION_CHANGED, oldPosition);
+            }
+            else {
+                this.emit(POSITION_CHANGED);
+            }
         }
     },
 


### PR DESCRIPTION
Re: cocos-creator/fireball#3350

优化 Creator JSB 的性能 Part2：
- 移除了 'position-changed' 和 'size-changed' 这两个节点事件的参数
- setPosition 时预判断是否要执行 emit
- 在 JSB 中使用方法调用代替属性赋值

@cocos-creator/engine-admins
