### PR TITLE
IOS 加载音频必须等到超时的问题

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -764,6 +764,13 @@ else {
 
         __audioSupport = { ONLY_ONE: false, WEB_AUDIO: supportWebAudio, DELAY_CREATE_CTX: false };
 
+        if (sys.os === sys.OS_IOS) {
+            // IOS no event that used to parse completed callback
+            // this time is not complete, can not play
+            //
+            __audioSupport.USE_LOADER_EVENT = 'loadedmetadata';
+        }
+
         if (sys.browserType === sys.BROWSER_TYPE_FIREFOX) {
             __audioSupport.DELAY_CREATE_CTX = true;
             __audioSupport.USE_LOADER_EVENT = 'canplay';


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/3435

问题原因：
为了节省内存，音频加载全部改为dom，但是IOS上<audio>在解析完成后没有回调。。。

修改后：
- 可以正常加载进入场景而不必等到超时了
- 但是进入场景后，并不代表音频可以播放，还需要等待几百ms的解析时间。很蛋疼。暂时没有办法获知IOS是否解析完成。试过了所有的音频事件，都不能实现我们的需求。。。

让用户先进入场景，起码不能让用户加载4-5个音频需要等待一分钟。。。
