### PR TITLE
clear debug draw when disable collision debug draw

### DIFF
--- a/cocos2d/core/collider/CCCollisionManager.js
+++ b/cocos2d/core/collider/CCCollisionManager.js
@@ -385,6 +385,7 @@ cc.js.getset(CollisionManager.prototype, 'enabledDebugDraw',
             cc.director.on(cc.Director.EVENT_AFTER_SCENE_LAUNCH, this.onSceneLaunched, this);
         }
         else if (!value && this._enabledDebugDraw) {
+            this._debugDrawer.clear();
             cc.director.getScene()._sgNode.removeChild(this._debugDrawer);
             cc.director.off(cc.Director.EVENT_AFTER_SCENE_LAUNCH, this.onSceneLaunched, this);
         }


### PR DESCRIPTION
Re: cocos-creator/fireball#3480

Changes proposed in this pull request:
- clear debug draw when disable collision debug draw

@cocos-creator/engine-admins
