### PR TITLE
构建的时候删除 .cache

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,10 +142,12 @@ gulp.task('test-no-build', function (done) {
 
 gulp.task('build-dev', ['build-preview', 'build-jsb-extends-dev'], function (done) {
     // make dist version dirty
-    Del(['./bin/cocos2d-js.js', './bin/cocos2d-js-min.js', './bin/jsb_polyfill.js'], done);
+    Del(['./bin/cocos2d-js.js', './bin/cocos2d-js-min.js', './bin/jsb_polyfill.js', './bin/.cache'], done);
 });
 
-gulp.task('build', ['build-html5', 'build-preview', 'build-jsb-extends-min', 'build-jsb-extends-dev']);
+gulp.task('build', ['build-html5', 'build-preview', 'build-jsb-extends-min', 'build-jsb-extends-dev'], function (done) {
+    Del(['./bin/.cache'], done);
+});
 
 // default task
 gulp.task('default', ['build']);


### PR DESCRIPTION
在构建的时候删除 .cache 文件夹内的缓存，确保下次执行 engine 任务的时候，所有东西都没有缓存，基于新的引擎重新构建缓存。

https://github.com/cocos-creator/fireball/issues/3236
