### PR TITLE
should reinit AnimationStates if clips not contains AnimationState's clip

### DIFF
--- a/cocos2d/core/components/CCAnimation.js
+++ b/cocos2d/core/components/CCAnimation.js
@@ -346,7 +346,7 @@ var Animation = cc.Class({
         this._init();
         var state = this._nameToState[name];
 
-        if (CC_EDITOR && !state) {
+        if (CC_EDITOR && (!state || !cc.js.array.contains(this._clips, state.clip))) {
             this._didInit = false;
 
             if (this.animator) {
@@ -488,6 +488,8 @@ var Animation = cc.Class({
     },
 
     _createStates: function() {
+        this._nameToState = {};
+        
         // create animation states
         var state = null;
         var defaultClipState = false;


### PR DESCRIPTION
Re: cocos-creator/fireball#3605

Changes proposed in this pull request:
- should reinit AnimationStates if clips not contains AnimationState's clip

> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
> - To official teams:
>   - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
>   - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)

@cocos-creator/engine-admins
