### PR TITLE
pasted component should ordered after its required

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -783,6 +783,10 @@ var Node = cc.Class({
             }
         }
         if (ctor._requireComponent) {
+            if (index === this._components.length) {
+                // If comp should be last component, increase the index because required component added
+                ++index;
+            }
             var depend = this.addComponent(ctor._requireComponent);
             if (!depend) {
                 // depend conflicts


### PR DESCRIPTION
Re: cocos-creator/fireball#3619

Changes proposed in this pull request:
- Paste Component 时，如果有依赖的组件，则被依赖的组件应该在粘贴组件之前

@cocos-creator/engine-admins
