### PR TITLE
should not destroy persistRootNode

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -586,10 +586,12 @@ cc.Director = Class.extend(/** @lends cc.Director# */{
             for (id in persistNodes) {
                 node = persistNodes[id];
                 var existNode = scene.getChildByUuid(id);
-                // Scene contains the persist node, should not reattach, should update the persist node
                 if (existNode) {
-                    persistNodes[id] = existNode;
-                    existNode._persistNode = true;
+                    // scene also contains the persist node, select the old one
+                    var index = existNode.getSiblingIndex();
+                    existNode._destroyImmediate();
+                    node.parent = scene;
+                    node.setSiblingIndex(index);
                 }
                 else {
                     node.parent = scene;

--- a/cocos2d/core/platform/CCObject.js
+++ b/cocos2d/core/platform/CCObject.js
@@ -19,7 +19,7 @@ var IsEditorOnEnableCalled = 1 << 12;
 var IsPreloadCalled = 1 << 13;
 var IsOnLoadCalled = 1 << 14;
 var IsOnLoadStarted = 1 << 15;
-var IsOnStartCalled = 1 << 16;
+var IsStartCalled = 1 << 16;
 
 var IsRotationLocked = 1 << 17;
 var IsScaleLocked = 1 << 18;
@@ -30,7 +30,7 @@ var IsPositionLocked = 1 << 21;
 //var Hide = HideInGame | HideInEditor;
 // should not clone or serialize these flags
 var PersistentMask = ~(ToDestroy | Dirty | Destroying | DontDestroy | Activating |
-                       IsPreloadCalled | IsOnLoadStarted | IsOnLoadCalled | IsOnStartCalled |
+                       IsPreloadCalled | IsOnLoadStarted | IsOnLoadCalled | IsStartCalled |
                        IsOnEnableCalled | IsEditorOnEnableCalled |
                        IsRotationLocked | IsScaleLocked | IsAnchorLocked | IsSizeLocked | IsPositionLocked
                        /*RegisteredInEditor*/);
@@ -142,7 +142,7 @@ CCObject.Flags = {
     IsOnLoadCalled: IsOnLoadCalled,
     IsOnLoadStarted: IsOnLoadStarted,
     IsOnEnableCalled: IsOnEnableCalled,
-    IsOnStartCalled: IsOnStartCalled,
+    IsStartCalled: IsStartCalled,
     IsEditorOnEnableCalled: IsEditorOnEnableCalled,
 
     IsPositionLocked: IsPositionLocked,

--- a/jsb/jsb-director.js
+++ b/jsb/jsb-director.js
@@ -156,15 +156,17 @@ cc.js.mixin(cc.director, {
         if (scene instanceof cc.Scene) {
             this._scene = scene;
             sgScene = scene._sgNode;
-            
-            // Re-attach persist nodes
+
+            // Re-attach or replace persist nodes
             for (id in persistNodes) {
                 node = persistNodes[id];
                 var existNode = scene.getChildByUuid(id);
-                // Scene contains the persist node, should not reattach, should update the persist node
                 if (existNode) {
-                    persistNodes[id] = existNode;
-                    existNode._persistNode = true;
+                    // scene also contains the persist node, select the old one
+                    var index = existNode.getSiblingIndex();
+                    existNode._destroyImmediate();
+                    node.parent = scene;
+                    node.setSiblingIndex(index);
                 }
                 else {
                     node.parent = scene;

--- a/test/qunit/lib/qunit-assert-callback.js
+++ b/test/qunit/lib/qunit-assert-callback.js
@@ -46,7 +46,7 @@ function Callback(callbackFunction_opt) {
 
     var wrapper = function () {
         if (!enabled) {
-            var message = callbackName_ + ' can be called only after enable()'
+            var message = callbackName_ + ' can be called only after enable()';
             QUnit.push(false, message, message, msgWhenDisabled_);
             return;
         }

--- a/test/qunit/unit/_init.js
+++ b/test/qunit/unit/_init.js
@@ -192,6 +192,7 @@ function _resetGame (w, h) {
     }
     cc.director.purgeDirector();
     cc.loader.releaseAll();
+
     cc.director.runSceneImmediate(new cc.Scene());
     //cc.director.pause();
 }
@@ -201,11 +202,15 @@ _resetGame(64, 64);
 var SetupEngine = {
     setup: function () {
         _resetGame(256, 512);
-        //// check error
-        //Engine._renderContext.checkMatchCurrentScene(true);
     },
     teardown: function () {
-        //Engine._launchScene(new cc._Scene());
+        // remove persist nodes
+        var persistNodeUuids = Object.keys(cc.game._persistRootNodes);
+        for (var i = 0; i < persistNodeUuids.length; i++) {
+            var uuid = persistNodeUuids[i];
+            cc.game.removePersistRootNode(cc.game._persistRootNodes[uuid]);
+        }
+
         cc.game.pause();
         // check error
         cc._Test.SceneGraphUtils.checkMatchCurrentScene();


### PR DESCRIPTION
Re: cocos-creator/fireball#3536

Changes proposed in this pull request:
- 修复切换到新场景时，如果也包含同一个 persistRootNode，则会销毁原有节点的错误

@cocos-creator/engine-admins
