### PR TITLE
should not reset arrivalOrder of cc.Node

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -220,16 +220,14 @@ cc.Director = Class.extend(/** @lends cc.Director# */{
     calculateDeltaTime: function () {
         var now = Date.now();
 
-        // new delta time.
         if (this._nextDeltaTimeZero) {
             this._deltaTime = 0;
             this._nextDeltaTimeZero = false;
         } else {
             this._deltaTime = (now - this._lastUpdate) / 1000;
+            if ((cc.game.config[cc.game.CONFIG_KEY.debugMode] > 0) && (this._deltaTime > 1))
+                this._deltaTime = 1 / 60.0;
         }
-
-        if ((cc.game.config[cc.game.CONFIG_KEY.debugMode] > 0) && (this._deltaTime > 0.2))
-            this._deltaTime = 1 / 60.0;
 
         this._lastUpdate = now;
     },


### PR DESCRIPTION
Re: cocos-creator/fireball#3638

Changes proposed in this pull request:
- arrivalOrder已经在 web 端的渲染节点中设置过了，这里移除重复设置

@cocos-creator/engine-admins
