### PR TITLE
refactoring layout and label update timing

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -418,14 +418,6 @@ var Label = cc.Class({
             animatable: false
         }
 
-        // TODO
-        // enableRichText: {
-        //     default: false,
-        //     notify: function () {
-        //         this._sgNode.enableRichText = this.enableRichText;
-        //     }
-        // }
-
     },
 
     statics: {
@@ -453,16 +445,6 @@ var Label = cc.Class({
 
     },
 
-    onEnable: function() {
-        this._super();
-        cc.director.on(cc.Director.EVENT_BEFORE_VISIT, this._updateNodeSize, this);
-    },
-
-    onDisable: function() {
-        this._super();
-        cc.director.off(cc.Director.EVENT_BEFORE_VISIT, this._updateNodeSize, this);
-    },
-
     _createSgNode: function () {
         return null;
     },
@@ -487,9 +469,6 @@ var Label = cc.Class({
         if (CC_JSB) {
             sgNode.retain();
         }
-
-        // TODO
-        // sgNode.enableRichText = this.enableRichText;
 
         sgNode.setHorizontalAlign( this.horizontalAlign );
         sgNode.setVerticalAlign( this.verticalAlign );

--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -831,7 +831,15 @@ var Layout = cc.Class({
         }
     },
 
-    lateUpdate: function() {
+    onEnable: function () {
+        cc.director.on(cc.Director.EVENT_BEFORE_VISIT, this._updateLayout, this);
+    },
+
+    onDisable: function () {
+        cc.director.off(cc.Director.EVENT_BEFORE_VISIT, this._updateLayout, this);
+    },
+
+    _updateLayout: function() {
         if (this._layoutDirty && this.node.children.length > 0) {
             this._doLayout();
             this._layoutDirty = false;

--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -758,7 +758,7 @@ var ScrollView = cc.Class({
             //refresh content size
             var layout = this.content.getComponent(cc.Layout);
             if(layout) {
-                layout.lateUpdate();
+                layout._updateLayout();
             }
             var scrollViewSize = this.node.getContentSize();
 


### PR DESCRIPTION
Re: cocos-creator/fireball#3290

https://github.com/cocos-creator/fireball/issues/2041

Changes proposed in this pull request:
-  重构 layout的 doLayout 时机，让它在 widget 之后再 doLayout
- 移除Label 的 before_visit 事件的更新逻辑。

@cocos-creator/engine-admins
