### PR TITLE
should not disable widget if it is not a child of current editing animation

### DIFF
--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -183,11 +183,12 @@ function refreshScene () {
         } else {
             var i, node, nodes = widgetManager._nodesWithWidget, len = nodes.length;
             if (CC_EDITOR && _Scene.AnimUtils.curAnimState) {
+                var editingNode = _Scene.AnimUtils.curRootNode;
                 // always check isAlignOnce because animation mode maybe changed
                 for (i = len - 1; i >= 0; i--) {
                     node = nodes[i];
                     var widget = node._widget;
-                    if (widget.isAlignOnce) {
+                    if (widget.isAlignOnce && node.isChildOf(editingNode)) {
                         // widget contains in _nodesWithWidget should aligned at least once
                         widget.enabled = false;
                     }


### PR DESCRIPTION
Re: cocos-creator/fireball#3648

Changes proposed in this pull request:
- 编辑动画时不该 disable 场景中所有 alignOnce 的 widget

@cocos-creator/engine-admins @2youyou2 
