### PR TITLE
add return event to editbox

### DIFF
--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -380,6 +380,16 @@ var EditBox = cc.Class({
         editingDidEnded: {
             default: [],
             type: cc.Component.EventHandler,
+        },
+
+        /**
+         * !#en The event handler to be called when return key is pressed. Windows is not supported.
+         * !#zh 当用户按下回车按键时的事件回调，目前不支持 windows 平台
+         * @property {Component.EventHandler} editingReturn
+         */
+        editingReturn: {
+            default: [],
+            type: cc.Component.EventHandler
         }
 
     },
@@ -456,6 +466,10 @@ var EditBox = cc.Class({
 
     editBoxTextChanged: function(editBox, text) {
         cc.Component.EventHandler.emitEvents(this.textChanged, text, this);
+    },
+
+    editBoxEditingReturn: function() {
+        cc.Component.EventHandler.emitEvents(this.editingReturn, this);
     },
 
     __preload: function() {

--- a/cocos2d/core/editbox/CCSGEditBox.js
+++ b/cocos2d/core/editbox/CCSGEditBox.js
@@ -191,7 +191,7 @@ cc.EditBoxDelegate = cc._Class.extend({
      * This method is called when the return button was pressed.
      * @param {cc.EditBox} sender
      */
-    editBoxReturn: function (sender) {
+    editBoxEditingReturn: function (sender) {
     }
 });
 
@@ -565,8 +565,8 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
                 editBox._text = this.value;
                 thisPointer._updateEditBoxContentStyle();
                 thisPointer.hidden();
-                if (editBox._delegate && editBox._delegate.editBoxReturn) {
-                    editBox._delegate.editBoxReturn(editBox);
+                if (editBox._delegate && editBox._delegate.editBoxEditingReturn) {
+                    editBox._delegate.editBoxEditingReturn(editBox);
                 }
                 cc._canvas.focus();
             }
@@ -639,6 +639,17 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
                 editBox._delegate.editBoxEditingDidBegan(editBox);
             }
 
+        });
+        tmpEdTxt.addEventListener('keypress', function (e) {
+            var editBox = thisPointer._editBox;
+
+            if (e.keyCode === cc.KEY.enter) {
+                e.stopPropagation();
+
+                if (editBox._delegate && editBox._delegate.editBoxEditingReturn) {
+                    editBox._delegate.editBoxEditingReturn(editBox);
+                }
+            }
         });
         tmpEdTxt.addEventListener('blur', function () {
             var editBox = thisPointer._editBox;


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/3646

Changes proposed in this pull request:
- 给 EditBox 添加一个 return key 按下的回调，以区别于之前的 end 事件

@cocos-creator/engine-admins
