### PR TITLE
修复 Scale9Sprite 显示合图时的边缘黑线

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -740,6 +740,7 @@ else {
                 case sys.BROWSER_TYPE_UNKNOWN:
                 case sys.BROWSER_TYPE_360:
                 case sys.BROWSER_TYPE_MIUI:
+                case sys.BROWSER_TYPE_UC:
                     _supportWebGL = false;
                 }
             }

--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -886,16 +886,21 @@ var View = cc._Class.extend({
             selTouch, selPoint, selPrePoint, selStartPoint;
         for( var i = 0; i < touches.length; i ++){
             selTouch = touches[i];
+            hasStartPoint = selTouch._startPointCaptured;
             selPoint = selTouch._point;
             selPrePoint = selTouch._prevPoint;
-            selStartPoint = selTouch._startPoint;
 
             selPoint.x = (selPoint.x - locViewPortRect.x) / locScaleX;
             selPoint.y = (selPoint.y - locViewPortRect.y) / locScaleY;
             selPrePoint.x = (selPrePoint.x - locViewPortRect.x) / locScaleX;
             selPrePoint.y = (selPrePoint.y - locViewPortRect.y) / locScaleY;
-            selStartPoint.x = (selStartPoint.x - locViewPortRect.x) / locScaleX;
-            selStartPoint.y = (selStartPoint.y - locViewPortRect.y) / locScaleY;
+
+            if (!hasStartPoint) {
+                selStartPoint = selTouch._startPoint;
+                selStartPoint.x = selPoint.x;
+                selStartPoint.y = selPoint.y;
+                selTouch._startPointCaptured = true;
+            }
         }
     }
 });

--- a/cocos2d/core/sprites/CCScale9Sprite.js
+++ b/cocos2d/core/sprites/CCScale9Sprite.js
@@ -55,7 +55,8 @@ var dataPool = {
     }
 };
 
-var webgl, 
+var FIX_ARTIFACTS_BY_STRECHING_TEXEL = cc.macro.FIX_ARTIFACTS_BY_STRECHING_TEXEL,
+    webgl, 
     vl, vb, vt, vr, 
     cornerId = [];
 
@@ -162,22 +163,24 @@ var simpleQuadGenerator = {
 
         //uv computation should take spritesheet into account.
         var l, b, r, t;
+        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
+        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
 
         if (spriteFrame._rotated) {
-            l = textureRect.x / atlasWidth;
-            b = (textureRect.y + textureRect.width) / atlasHeight;
-            r = (textureRect.x + textureRect.height) / atlasWidth;
-            t = textureRect.y / atlasHeight;
+            l = textureRect.x / atlasWidth + texelCorrectX;
+            b = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
+            r = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
+            t = textureRect.y / atlasHeight + texelCorrectY;
             uvs[0] = l; uvs[1] = t;
             uvs[2] = l; uvs[3] = b;
             uvs[4] = r; uvs[5] = t;
             uvs[6] = r; uvs[7] = b;
         }
         else {
-            l = textureRect.x / atlasWidth;
-            b = (textureRect.y + textureRect.height) / atlasHeight;
-            r = (textureRect.x + textureRect.width) / atlasWidth;
-            t = textureRect.y / atlasHeight;
+            l = textureRect.x / atlasWidth + texelCorrectX;
+            b = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
+            r = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
+            t = textureRect.y / atlasHeight + texelCorrectY;
             uvs[0] = l; uvs[1] = b;
             uvs[2] = r; uvs[3] = b;
             uvs[4] = l; uvs[5] = t;
@@ -288,17 +291,19 @@ var scale9QuadGenerator = {
         var u = new Array(4);
         var v = new Array(4);
         var offset = 0, row, col;
+        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
+        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
 
         if (spriteFrame._rotated) {
-            u[0] = textureRect.x / atlasWidth;
-            u[1] = (bottomHeight + textureRect.x) / atlasWidth;
-            u[2] = (bottomHeight + centerHeight + textureRect.x) / atlasWidth;
-            u[3] = (textureRect.x + textureRect.height) / atlasWidth;
+            u[0] = textureRect.x / atlasWidth + texelCorrectX;
+            u[1] = (bottomHeight + textureRect.x) / atlasWidth - texelCorrectX;
+            u[2] = (bottomHeight + centerHeight + textureRect.x) / atlasWidth - texelCorrectX;
+            u[3] = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
 
-            v[3] = textureRect.y / atlasHeight;
-            v[2] = (leftWidth + textureRect.y) / atlasHeight;
-            v[1] = (leftWidth + centerWidth + textureRect.y) / atlasHeight;
-            v[0] = (textureRect.y + textureRect.width) / atlasHeight;
+            v[3] = textureRect.y / atlasHeight + texelCorrectY;
+            v[2] = (leftWidth + textureRect.y) / atlasHeight - texelCorrectY;
+            v[1] = (leftWidth + centerWidth + textureRect.y) / atlasHeight - texelCorrectY;
+            v[0] = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
             
             for (row = 0; row < 4; row++) {
                 for (col = 0; col < 4; col++) {
@@ -309,15 +314,15 @@ var scale9QuadGenerator = {
             }
         }
         else {
-            u[0] = textureRect.x / atlasWidth;
-            u[1] = (leftWidth + textureRect.x) / atlasWidth;
-            u[2] = (leftWidth + centerWidth + textureRect.x) / atlasWidth;
-            u[3] = (textureRect.x + textureRect.width) / atlasWidth;
+            u[0] = textureRect.x / atlasWidth + texelCorrectX;
+            u[1] = (leftWidth + textureRect.x) / atlasWidth - texelCorrectX;
+            u[2] = (leftWidth + centerWidth + textureRect.x) / atlasWidth - texelCorrectX;
+            u[3] = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
 
-            v[3] = textureRect.y / atlasHeight;
-            v[2] = (topHeight + textureRect.y) / atlasHeight;
-            v[1] = (topHeight + centerHeight + textureRect.y) / atlasHeight;
-            v[0] = (textureRect.y + textureRect.height) / atlasHeight;
+            v[3] = textureRect.y / atlasHeight + texelCorrectY;
+            v[2] = (topHeight + textureRect.y) / atlasHeight - texelCorrectY;
+            v[1] = (topHeight + centerHeight + textureRect.y) / atlasHeight - texelCorrectY;
+            v[0] = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
 
             for (row = 0; row < 4; row++) {
                 for (col = 0; col < 4; col++) {
@@ -342,17 +347,19 @@ var tiledQuadGenerator = {
 
         //uv computation should take spritesheet into account.
         var u0, v0, u1, v1;
+        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
+        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
         if (spriteFrame._rotated) {
-            u0 = textureRect.x / atlasWidth;
-            u1 = (textureRect.x + textureRect.height) / atlasWidth;
-            v0 = (textureRect.y + textureRect.width) / atlasHeight;
-            v1 = textureRect.y / atlasHeight;
+            u0 = textureRect.x / atlasWidth + texelCorrectX;
+            u1 = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
+            v0 = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
+            v1 = textureRect.y / atlasHeight + texelCorrectY;
         }
         else {
-            u0 = textureRect.x / atlasWidth;
-            u1 = (textureRect.x + textureRect.width) / atlasWidth;
-            v0 = (textureRect.y + textureRect.height) / atlasHeight;
-            v1 = textureRect.y / atlasHeight;
+            u0 = textureRect.x / atlasWidth + texelCorrectX;
+            u1 = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
+            v0 = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
+            v1 = textureRect.y / atlasHeight + texelCorrectY;
         }
         
         //build quads
@@ -455,17 +462,19 @@ var fillQuadGeneratorBar = {
         var textureRect = spriteFrame._rect;
         //uv computation should take spritesheet into account.
         var ul, vb, ur, vt;
+        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
+        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
         if (spriteFrame._rotated) {
-            ul = textureRect.x / atlasWidth;
-            vb = (textureRect.y + textureRect.width) / atlasHeight;
-            ur = (textureRect.x + textureRect.height) / atlasWidth;
-            vt = textureRect.y / atlasHeight;
+            ul = textureRect.x / atlasWidth + texelCorrectX;
+            vb = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
+            ur = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
+            vt = textureRect.y / atlasHeight + texelCorrectY;
         }
         else {
-            ul = textureRect.x / atlasWidth;
-            vb = (textureRect.y + textureRect.height) / atlasHeight;
-            ur = (textureRect.x + textureRect.width) / atlasWidth;
-            vt = textureRect.y / atlasHeight;
+            ul = textureRect.x / atlasWidth + texelCorrectX;
+            vb = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
+            ur = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
+            vt = textureRect.y / atlasHeight + texelCorrectY;
         }
 
         if (vertices.length < 8) {
@@ -894,22 +903,23 @@ var fillQuadGeneratorRadial = {
         var textureRect = spriteFrame._rect;
 
         //uv computation should take spritesheet into account.
-        var u0, u3;
-        var v0, v3;
+        var u0, u3, v0, v3;
+        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
+        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
 
         if (spriteFrame._rotated) {
-            u0 = textureRect.x / atlasWidth;
-            u3 = (textureRect.x + textureRect.height) / atlasWidth;
+            u0 = textureRect.x / atlasWidth + texelCorrectX;
+            u3 = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
 
-            v0 = textureRect.y / atlasHeight;
-            v3 = (textureRect.y + textureRect.width) / atlasHeight;
+            v0 = textureRect.y / atlasHeight + texelCorrectY;
+            v3 = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
         }
         else {
-            u0 = textureRect.x / atlasWidth;
-            u3 = (textureRect.x + textureRect.width) / atlasWidth;
+            u0 = textureRect.x / atlasWidth + texelCorrectX;
+            u3 = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
 
-            v0 = textureRect.y / atlasHeight;
-            v3 = (textureRect.y + textureRect.height) / atlasHeight;
+            v0 = textureRect.y / atlasHeight + texelCorrectY;
+            v3 = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
         }
 
         this._uvs[0].x = u0;

--- a/cocos2d/core/sprites/CCScale9Sprite.js
+++ b/cocos2d/core/sprites/CCScale9Sprite.js
@@ -163,24 +163,23 @@ var simpleQuadGenerator = {
 
         //uv computation should take spritesheet into account.
         var l, b, r, t;
-        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
-        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
+        var texelCorrect = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 : 0;
 
         if (spriteFrame._rotated) {
-            l = textureRect.x / atlasWidth + texelCorrectX;
-            b = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
-            r = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
-            t = textureRect.y / atlasHeight + texelCorrectY;
+            l = (textureRect.x + texelCorrect) / atlasWidth;
+            b = (textureRect.y + textureRect.width - texelCorrect) / atlasHeight;
+            r = (textureRect.x + textureRect.height - texelCorrect) / atlasWidth;
+            t = (textureRect.y + texelCorrect) / atlasHeight;
             uvs[0] = l; uvs[1] = t;
             uvs[2] = l; uvs[3] = b;
             uvs[4] = r; uvs[5] = t;
             uvs[6] = r; uvs[7] = b;
         }
         else {
-            l = textureRect.x / atlasWidth + texelCorrectX;
-            b = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
-            r = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
-            t = textureRect.y / atlasHeight + texelCorrectY;
+            l = (textureRect.x + texelCorrect) / atlasWidth;
+            b = (textureRect.y + textureRect.height - texelCorrect) / atlasHeight;
+            r = (textureRect.x + textureRect.width - texelCorrect) / atlasWidth;
+            t = (textureRect.y + texelCorrect) / atlasHeight;
             uvs[0] = l; uvs[1] = b;
             uvs[2] = r; uvs[3] = b;
             uvs[4] = l; uvs[5] = t;
@@ -291,19 +290,18 @@ var scale9QuadGenerator = {
         var u = new Array(4);
         var v = new Array(4);
         var offset = 0, row, col;
-        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
-        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
+        var texelCorrect = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 : 0;
 
         if (spriteFrame._rotated) {
-            u[0] = textureRect.x / atlasWidth + texelCorrectX;
-            u[1] = (bottomHeight + textureRect.x) / atlasWidth - texelCorrectX;
-            u[2] = (bottomHeight + centerHeight + textureRect.x) / atlasWidth - texelCorrectX;
-            u[3] = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
+            u[0] = (textureRect.x + texelCorrect) / atlasWidth;
+            u[1] = (bottomHeight + textureRect.x - texelCorrect) / atlasWidth;
+            u[2] = (bottomHeight + centerHeight + textureRect.x - texelCorrect) / atlasWidth;
+            u[3] = (textureRect.x + textureRect.height - texelCorrect) / atlasWidth;
 
-            v[3] = textureRect.y / atlasHeight + texelCorrectY;
-            v[2] = (leftWidth + textureRect.y) / atlasHeight - texelCorrectY;
-            v[1] = (leftWidth + centerWidth + textureRect.y) / atlasHeight - texelCorrectY;
-            v[0] = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
+            v[3] = (textureRect.y + texelCorrect) / atlasHeight;
+            v[2] = (leftWidth + textureRect.y - texelCorrect) / atlasHeight;
+            v[1] = (leftWidth + centerWidth + textureRect.y - texelCorrect) / atlasHeight;
+            v[0] = (textureRect.y + textureRect.width - texelCorrect) / atlasHeight;
             
             for (row = 0; row < 4; row++) {
                 for (col = 0; col < 4; col++) {
@@ -314,15 +312,15 @@ var scale9QuadGenerator = {
             }
         }
         else {
-            u[0] = textureRect.x / atlasWidth + texelCorrectX;
-            u[1] = (leftWidth + textureRect.x) / atlasWidth - texelCorrectX;
-            u[2] = (leftWidth + centerWidth + textureRect.x) / atlasWidth - texelCorrectX;
-            u[3] = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
+            u[0] = (textureRect.x + texelCorrect) / atlasWidth;
+            u[1] = (leftWidth + textureRect.x - texelCorrect) / atlasWidth;
+            u[2] = (leftWidth + centerWidth + textureRect.x - texelCorrect) / atlasWidth;
+            u[3] = (textureRect.x + textureRect.width - texelCorrect) / atlasWidth;
 
-            v[3] = textureRect.y / atlasHeight + texelCorrectY;
-            v[2] = (topHeight + textureRect.y) / atlasHeight - texelCorrectY;
-            v[1] = (topHeight + centerHeight + textureRect.y) / atlasHeight - texelCorrectY;
-            v[0] = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
+            v[3] = (textureRect.y + texelCorrect) / atlasHeight;
+            v[2] = (topHeight + textureRect.y - texelCorrect) / atlasHeight;
+            v[1] = (topHeight + centerHeight + textureRect.y - texelCorrect) / atlasHeight;
+            v[0] = (textureRect.y + textureRect.height - texelCorrect) / atlasHeight;
 
             for (row = 0; row < 4; row++) {
                 for (col = 0; col < 4; col++) {
@@ -347,19 +345,18 @@ var tiledQuadGenerator = {
 
         //uv computation should take spritesheet into account.
         var u0, v0, u1, v1;
-        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
-        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
+        var texelCorrect = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 : 0;
         if (spriteFrame._rotated) {
-            u0 = textureRect.x / atlasWidth + texelCorrectX;
-            u1 = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
-            v0 = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
-            v1 = textureRect.y / atlasHeight + texelCorrectY;
+            u0 = (textureRect.x + texelCorrect) / atlasWidth;
+            u1 = (textureRect.x + textureRect.height - texelCorrect) / atlasWidth;
+            v0 = (textureRect.y + textureRect.width - texelCorrect) / atlasHeight;
+            v1 = (textureRect.y + texelCorrect) / atlasHeight;
         }
         else {
-            u0 = textureRect.x / atlasWidth + texelCorrectX;
-            u1 = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
-            v0 = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
-            v1 = textureRect.y / atlasHeight + texelCorrectY;
+            u0 = (textureRect.x + texelCorrect) / atlasWidth;
+            u1 = (textureRect.x + textureRect.width - texelCorrect) / atlasWidth;
+            v0 = (textureRect.y + textureRect.height - texelCorrect) / atlasHeight;
+            v1 = (textureRect.y + texelCorrect) / atlasHeight;
         }
         
         //build quads
@@ -462,19 +459,18 @@ var fillQuadGeneratorBar = {
         var textureRect = spriteFrame._rect;
         //uv computation should take spritesheet into account.
         var ul, vb, ur, vt;
-        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
-        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
+        var texelCorrect = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 : 0;
         if (spriteFrame._rotated) {
-            ul = textureRect.x / atlasWidth + texelCorrectX;
-            vb = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
-            ur = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
-            vt = textureRect.y / atlasHeight + texelCorrectY;
+            ul = (textureRect.x + texelCorrect) / atlasWidth;
+            vb = (textureRect.y + textureRect.width - texelCorrect) / atlasHeight;
+            ur = (textureRect.x + textureRect.height - texelCorrect) / atlasWidth;
+            vt = (textureRect.y + texelCorrect) / atlasHeight;
         }
         else {
-            ul = textureRect.x / atlasWidth + texelCorrectX;
-            vb = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
-            ur = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
-            vt = textureRect.y / atlasHeight + texelCorrectY;
+            ul = (textureRect.x + texelCorrect) / atlasWidth;
+            vb = (textureRect.y + textureRect.height - texelCorrect) / atlasHeight;
+            ur = (textureRect.x + textureRect.width - texelCorrect) / atlasWidth;
+            vt = (textureRect.y + texelCorrect) / atlasHeight;
         }
 
         if (vertices.length < 8) {
@@ -904,22 +900,21 @@ var fillQuadGeneratorRadial = {
 
         //uv computation should take spritesheet into account.
         var u0, u3, v0, v3;
-        var texelCorrectX = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasWidth : 0;
-        var texelCorrectY = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 / atlasHeight : 0;
+        var texelCorrect = FIX_ARTIFACTS_BY_STRECHING_TEXEL ? 0.5 : 0;
 
         if (spriteFrame._rotated) {
-            u0 = textureRect.x / atlasWidth + texelCorrectX;
-            u3 = (textureRect.x + textureRect.height) / atlasWidth - texelCorrectX;
+            u0 = (textureRect.x + texelCorrect) / atlasWidth;
+            u3 = (textureRect.x + textureRect.height - texelCorrect) / atlasWidth;
 
-            v0 = textureRect.y / atlasHeight + texelCorrectY;
-            v3 = (textureRect.y + textureRect.width) / atlasHeight - texelCorrectY;
+            v0 = (textureRect.y + texelCorrect) / atlasHeight;
+            v3 = (textureRect.y + textureRect.width - texelCorrect) / atlasHeight;
         }
         else {
-            u0 = textureRect.x / atlasWidth + texelCorrectX;
-            u3 = (textureRect.x + textureRect.width) / atlasWidth - texelCorrectX;
+            u0 = (textureRect.x + texelCorrect) / atlasWidth;
+            u3 = (textureRect.x + textureRect.width - texelCorrect) / atlasWidth;
 
-            v0 = textureRect.y / atlasHeight + texelCorrectY;
-            v3 = (textureRect.y + textureRect.height) / atlasHeight - texelCorrectY;
+            v0 = (textureRect.y + texelCorrect) / atlasHeight;
+            v3 = (textureRect.y + textureRect.height - texelCorrect) / atlasHeight;
         }
 
         this._uvs[0].x = u0;

--- a/jsb/jsb-loader.js
+++ b/jsb/jsb-loader.js
@@ -63,6 +63,22 @@ cc.loader.addDownloadHandlers({
     'mp4' : downloadAudio,
     'm4a' : downloadAudio,
 
+    // Txt
+    'txt' : empty,
+    'xml' : empty,
+    'vsh' : empty,
+    'fsh' : empty,
+    'atlas' : empty,
+
+    'tmx' : empty,
+    'tsx' : empty,
+
+    'json' : empty,
+    'ExportJson' : empty,
+    'plist' : empty,
+
+    'fnt' : empty,
+
     // Font
     'font' : empty,
     'eot' : empty,
@@ -70,6 +86,8 @@ cc.loader.addDownloadHandlers({
     'woff' : empty,
     'svg' : empty,
     'ttc' : empty,
+
+    'default' : empty
 });
 
 

--- a/jsb/jsb-tex-sprite-frame.js
+++ b/jsb/jsb-tex-sprite-frame.js
@@ -51,18 +51,22 @@ cc.textureCache.getTextureForKey = function (key) {
 cc.Class._fastDefine('cc.Texture2D', cc.Texture2D, []);
 cc.Texture2D.$super = cc.RawAsset;
 
-cc.Texture2D.prototype.isLoaded = function () {
+var prototype = cc.Texture2D.prototype;
+
+prototype.isLoaded = function () {
     return true;
 };
-cc.Texture2D.prototype.getPixelWidth = cc.Texture2D.prototype.getPixelsWide;
-cc.Texture2D.prototype.getPixelHeight = cc.Texture2D.prototype.getPixelsHigh;
+prototype.getPixelWidth = prototype.getPixelsWide;
+prototype.getPixelHeight = prototype.getPixelsHigh;
+cc.js.get(prototype, 'pixelWidth', prototype.getPixelWidth);
+cc.js.get(prototype, 'pixelHeight', prototype.getPixelHeight);
 
 // cc.SpriteFrame
 
 cc.Class._fastDefine('cc.SpriteFrame', cc.SpriteFrame, []);
 cc.SpriteFrame.$super = cc.Asset;
 
-var prototype = cc.SpriteFrame.prototype;
+prototype = cc.SpriteFrame.prototype;
 
 cc.js.mixin(prototype, cc.EventTarget.prototype);
 prototype.textureLoaded = function () {


### PR DESCRIPTION
Re: cocos-creator/fireball#3675

Changes proposed in this pull request:
- 修复 Scale9Sprite 显示合图时的边缘黑线
- 在 UC 上关闭 WebGL
- 修复 touch start point 被错误更新的问题
- 更新 JSB downloaders
- 修复 JSB 上 Texture2D 的 pixelWidth 和 pixelHeight 属性问题

> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
> - To official teams:
>   - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
>   - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)

@cocos-creator/engine-admins
