### PR TITLE
add math polyfill

### DIFF
--- a/polyfill/math.js
+++ b/polyfill/math.js
@@ -1,0 +1,8 @@
+
+Math.sign = Math.sign || function(x) {
+  x = +x; // convert to a number
+  if (x === 0 || isNaN(x)) {
+    return x;
+  }
+  return x > 0 ? 1 : -1;
+};

--- a/predefine.js
+++ b/predefine.js
@@ -51,6 +51,7 @@ cc._initDebugSetting(cc.DebugMode.INFO);
 // polyfills
 /* require('./polyfill/bind'); */
 require('./polyfill/string');
+require('./polyfill/math');
 
 // predefine some modules for cocos
 require('./cocos2d/core/platform/js');


### PR DESCRIPTION
Re: cocos-creator/fireball#3716

Changes proposed in this pull request:
- add Math.sign polyfill

reference : 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign

@cocos-creator/engine-admins
