### PR TITLE
Improve visit performance by removing recursive invocation

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -268,7 +268,7 @@ cc.Director = Class.extend(/** @lends cc.Director# */{
                 renderer.clearRenderCommands();
                 cc.renderer.assignedZ = 0;
                 this._runningScene._renderCmd._curLevel = 0; //level start from 0;
-                this._runningScene.visit();
+                this._runningScene._renderCmd.visit();
                 renderer.resetFlag();
             }
             else if (renderer.transformDirty()) {


### PR DESCRIPTION
Re: cocos-creator/fireball#3611

Changes proposed in this pull request:
- 非递归 visit

虽然实现了非递归，但是 bunnymark 性能并没有提升，主要是 bunnymark 的层级不够深，所以影响不大，麻烦先看下逻辑吧

@zilongshanren @jareguo 

@cocos-creator/engine-admins
