### PR TITLE
Fix _pixelWidth not exist in Canvas render mode issue

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -268,7 +268,7 @@ cc.Director = Class.extend(/** @lends cc.Director# */{
                 renderer.clearRenderCommands();
                 cc.renderer.assignedZ = 0;
                 this._runningScene._renderCmd._curLevel = 0; //level start from 0;
-                this._runningScene.visit();
+                this._runningScene._renderCmd.visit();
                 renderer.resetFlag();
             }
             else if (renderer.transformDirty()) {

--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -39,7 +39,7 @@ var game = /** @lends cc.game# */{
     /**
      * Event triggered when game hide to background.
      * Please note that this event is not 100% guaranteed to be fired.
-     * @constant
+     * @property
      * @type {String}
      * @example
      * cc.game.on(cc.game.EVENT_HIDE, function () {
@@ -52,21 +52,21 @@ var game = /** @lends cc.game# */{
     /**
      * Event triggered when game back to foreground
      * Please note that this event is not 100% guaranteed to be fired.
-     * @constant
+     * @property
      * @type {String}
      */
     EVENT_SHOW: "game_on_show",
 
     /**
      * Event triggered after game inited, at this point all engine objects and game scripts are loaded
-     * @constant
+     * @property
      * @type {String}
      */
     EVENT_GAME_INITED: "game_inited",
 
     /**
      * Event triggered after renderer inited, at this point you will be able to use the render context
-     * @constant
+     * @property
      * @type {String}
      */
     EVENT_RENDERER_INITED: "renderer_inited",
@@ -80,7 +80,7 @@ var game = /** @lends cc.game# */{
 
     /**
      * Key of config
-     * @constant
+     * @property
      * @type {Object}
      */
     CONFIG_KEY: {

--- a/cocos2d/core/sprites/CCScale9Sprite.js
+++ b/cocos2d/core/sprites/CCScale9Sprite.js
@@ -151,8 +151,8 @@ var simpleQuadGenerator = {
 
     _calculateUVs: function (sprite, spriteFrame) {
         var uvs = sprite._uvs;
-        var atlasWidth = spriteFrame._texture._pixelsWide;
-        var atlasHeight = spriteFrame._texture._pixelsHigh;
+        var atlasWidth = spriteFrame._texture._pixelWidth;
+        var atlasHeight = spriteFrame._texture._pixelHeight;
         var textureRect = spriteFrame._rect;
 
         if (uvs.length < 8) {
@@ -265,8 +265,8 @@ var scale9QuadGenerator = {
     _calculateUVs: function (sprite, spriteFrame, insetLeft, insetRight, insetTop, insetBottom) {
         var uvs = sprite._uvs;
         var rect = spriteFrame._rect;
-        var atlasWidth = spriteFrame._texture._pixelsWide;
-        var atlasHeight = spriteFrame._texture._pixelsHigh;
+        var atlasWidth = spriteFrame._texture._pixelWidth;
+        var atlasHeight = spriteFrame._texture._pixelHeight;
 
         //caculate texture coordinate
         var leftWidth, centerWidth, rightWidth;
@@ -339,8 +339,8 @@ var tiledQuadGenerator = {
             wt = sprite._renderCmd._worldTransform,
             uvs = sprite._uvs;
         //build uvs
-        var atlasWidth = spriteFrame._texture._pixelsWide;
-        var atlasHeight = spriteFrame._texture._pixelsHigh;
+        var atlasWidth = spriteFrame._texture._pixelWidth;
+        var atlasHeight = spriteFrame._texture._pixelHeight;
         var textureRect = spriteFrame._rect;
 
         //uv computation should take spritesheet into account.
@@ -454,8 +454,8 @@ var fillQuadGeneratorBar = {
         var l = 0, b = 0, 
             r = contentSize.width, t = contentSize.height;
         //build uvs
-        var atlasWidth = spriteFrame._texture._pixelsWide;
-        var atlasHeight = spriteFrame._texture._pixelsHigh;
+        var atlasWidth = spriteFrame._texture._pixelWidth;
+        var atlasHeight = spriteFrame._texture._pixelHeight;
         var textureRect = spriteFrame._rect;
         //uv computation should take spritesheet into account.
         var ul, vb, ur, vt;
@@ -894,8 +894,8 @@ var fillQuadGeneratorRadial = {
     },
 
     _calculateUVs : function (spriteFrame) {
-        var atlasWidth = spriteFrame._texture._pixelsWide;
-        var atlasHeight = spriteFrame._texture._pixelsHigh;
+        var atlasWidth = spriteFrame._texture._pixelWidth;
+        var atlasHeight = spriteFrame._texture._pixelHeight;
         var textureRect = spriteFrame._rect;
 
         //uv computation should take spritesheet into account.

--- a/cocos2d/core/sprites/CCScale9SpriteCanvasRenderCmd.js
+++ b/cocos2d/core/sprites/CCScale9SpriteCanvasRenderCmd.js
@@ -83,8 +83,8 @@ proto.rendering = function (ctx, scaleX, scaleY) {
         }
         var sx,sy,sw,sh;
         var x, y, w,h;
-        var textureWidth = this._textureToRender.getPixelWidth();
-        var textureHeight = this._textureToRender.getPixelHeight();
+        var textureWidth = this._textureToRender._pixelWidth;
+        var textureHeight = this._textureToRender._pixelHeight;
         var image = this._textureToRender._htmlElementObj;
         var vertices = node._vertices;
         var uvs = node._uvs;

--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -85,6 +85,8 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
         this._textureLoaded = false;
         this._htmlElementObj = null;
         this._contentSize = cc.size(0, 0);
+        this._pixelWidth = 0;
+        this._pixelHeight = 0;
 
         if (cc._renderType === game.RENDER_TYPE_CANVAS) {
             this._pattern = "";
@@ -96,8 +98,6 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
         else if (cc._renderType === game.RENDER_TYPE_WEBGL) {
             this._hasPremultipliedAlpha = false;
             this._pixelFormat = Texture2D.defaultPixelFormat;
-            this._pixelsWide = 0;
-            this._pixelsHigh = 0;
             this._hasPremultipliedAlpha = false;
             this._hasMipmaps = false;
 
@@ -111,7 +111,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @return {Number}
      */
     getPixelWidth: function () {
-        return this._contentSize.width;
+        return this._pixelWidth;
     },
 
     /**
@@ -120,7 +120,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @return {Number}
      */
     getPixelHeight: function () {
-        return this._contentSize.height;
+        return this._pixelHeight;
     },
 
     /**
@@ -162,8 +162,8 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
         if (!element)
             return;
         this._htmlElementObj = element;
-        this._contentSize.width = element.width;
-        this._contentSize.height = element.height;
+        this._pixelWidth = this._contentSize.width = element.width;
+        this._pixelHeight = this._contentSize.height = element.height;
         this._textureLoaded = true;
     },
 
@@ -229,8 +229,8 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
             return;
 
         var locElement = self._htmlElementObj;
-        self._contentSize.width = locElement.width;
-        self._contentSize.height = locElement.height;
+        self._pixelWidth = self._contentSize.width = locElement.width;
+        self._pixelHeight = self._contentSize.height = locElement.height;
         self._textureLoaded = true;
 
         //dispatch load event to listener.
@@ -716,13 +716,6 @@ game.once(game.EVENT_RENDERER_INITED, function () {
 
     } else if (cc._renderType === game.RENDER_TYPE_WEBGL) {
         JS.mixin(Texture2D.prototype, {
-            getPixelWidth: function () {
-                return this._pixelsWide;
-            },
-
-            getPixelHeight: function () {
-                return this._pixelsHigh;
-            },
 
             initWithData: function (data, pixelFormat, pixelsWide, pixelsHigh, contentSize) {
                 var self = this, tex2d = Texture2D;
@@ -784,8 +777,8 @@ game.once(game.EVENT_RENDERER_INITED, function () {
 
                 self._contentSize.width = contentSize.width;
                 self._contentSize.height = contentSize.height;
-                self._pixelsWide = pixelsWide;
-                self._pixelsHigh = pixelsHigh;
+                self._pixelWidth = pixelsWide;
+                self._pixelHeight = pixelsHigh;
                 self._pixelFormat = pixelFormat;
 
                 self._hasPremultipliedAlpha = false;
@@ -863,8 +856,8 @@ game.once(game.EVENT_RENDERER_INITED, function () {
                 var pixelsWide = self._htmlElementObj.width;
                 var pixelsHigh = self._htmlElementObj.height;
 
-                self._pixelsWide = self._contentSize.width = pixelsWide;
-                self._pixelsHigh = self._contentSize.height = pixelsHigh;
+                self._pixelWidth = self._contentSize.width = pixelsWide;
+                self._pixelHeight = self._contentSize.height = pixelsHigh;
                 self._pixelFormat = Texture2D.PIXEL_FORMAT_RGBA8888;
 
                 self._hasPremultipliedAlpha = premultiplied;
@@ -882,7 +875,7 @@ game.once(game.EVENT_RENDERER_INITED, function () {
                 if(magFilter !== undefined)
                     texParams = {minFilter: texParams, magFilter: magFilter, wrapS: wrapS, wrapT: wrapT};
 
-                cc.assert((_t._pixelsWide === misc.NextPOT(_t._pixelsWide) && _t._pixelsHigh === misc.NextPOT(_t._pixelsHigh)) ||
+                cc.assert((_t._pixelWidth === misc.NextPOT(_t._pixelWidth) && _t._pixelHeight === misc.NextPOT(_t._pixelHeight)) ||
                     (texParams.wrapS === gl.CLAMP_TO_EDGE && texParams.wrapT === gl.CLAMP_TO_EDGE),
                     "WebGLRenderingContext.CLAMP_TO_EDGE should be used in NPOT textures");
 
@@ -917,7 +910,7 @@ game.once(game.EVENT_RENDERER_INITED, function () {
 
             generateMipmap: function () {
                 var _t = this;
-                cc.assert(_t._pixelsWide === misc.NextPOT(_t._pixelsWide) && _t._pixelsHigh === misc.NextPOT(_t._pixelsHigh), "Mimpap texture only works in POT textures");
+                cc.assert(_t._pixelWidth === misc.NextPOT(_t._pixelWidth) && _t._pixelHeight === misc.NextPOT(_t._pixelHeight), "Mimpap texture only works in POT textures");
 
                 cc.gl.bindTexture2D(_t);
                 cc._renderContext.generateMipmap(cc._renderContext.TEXTURE_2D);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/pull/950

Changes proposed in this pull request:
- Fix _pixelWidth not exist in Canvas render mode issue caused in #950

> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
> - To official teams:
>   - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
>   - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)

@cocos-creator/engine-admins
