### PR TITLE
make widget's enable state persist when animation editor not changed

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -379,15 +379,6 @@ var Sprite = cc.Class({
         SizeMode: SizeMode,
     },
 
-    /**
-     * !#en Sets whether the sprite is visible or not.
-     * !#zh 设置精灵是否可见
-     * @method setVisible
-     * @param {Boolean} visible
-     * @override
-     * @example
-     * sprite.setVisible(false);
-     */
     setVisible: function (visible) {
         this.enabled = visible;
     },

--- a/cocos2d/core/platform/deserialize.js
+++ b/cocos2d/core/platform/deserialize.js
@@ -467,12 +467,13 @@ var _Deserializer = (function () {
  * @return {object} the main data(asset)
  */
 cc.deserialize = function (data, result, options) {
-    var classFinder = (options && options.classFinder) || JS._getClassById;
+    options = options || {};
+    var classFinder = options.classFinder || JS._getClassById;
     // 启用 createAssetRefs 后，如果有 url 属性则会被统一强制设置为 { uuid: 'xxx' }，必须后面再特殊处理
-    var createAssetRefs = (options && options.createAssetRefs) || cc.sys.platform === cc.sys.EDITOR_CORE;
-    var target = CC_DEV && (options && options.target);
-    var customEnv = options && options.customEnv;
-    var ignoreEditorOnly = options && options.ignoreEditorOnly;
+    var createAssetRefs = options.createAssetRefs || cc.sys.platform === cc.sys.EDITOR_CORE;
+    var target = CC_DEV && options.target;
+    var customEnv = options.customEnv;
+    var ignoreEditorOnly = options.ignoreEditorOnly;
 
     if (CC_EDITOR && Buffer.isBuffer(data)) {
         data = data.toString();


### PR DESCRIPTION
Re: cocos-creator/fireball#3829

Changes proposed in this pull request:
- 修复 alignOnce 的 widget 组件的 enabled 无法在动画暂停状态下保持

@cocos-creator/engine-admins
