### PR TITLE
fix label displayed wrong in webGL

### DIFF
--- a/cocos2d/core/label/CCSGLabelWebGLRenderCmd.js
+++ b/cocos2d/core/label/CCSGLabelWebGLRenderCmd.js
@@ -104,16 +104,11 @@ proto.uploadData = function (f32buffer, ui32buffer, vertexDataOffset) {
         return 0;
 
     // Fill in vertex data with quad information (4 vertices for sprite)
+    //use 255 because color has been set when baking label
     var opacity = this._displayedOpacity;
-    var r = this._displayedColor.r,
-        g = this._displayedColor.g,
-        b = this._displayedColor.b;
-    if (node._opacityModifyRGB) {
-        var a = opacity / 255;
-        r *= a;
-        g *= a;
-        b *= a;
-    }
+    var r = 255,
+        g = 255,
+        b = 255;
     this._color[0] = ((opacity<<24) | (b<<16) | (g<<8) | r);
     var z = node._vertexZ;
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
- Fix label displayed black in webGL

> Makes sure these boxes are checked before submitting your PR - thank you!
> - [X] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [X] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
> - To official teams:
>   - [X] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
>   - [X] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)

@cocos-creator/engine-admins

@pandamicro 
the first one is webGL, displayed blacker than specified color(#AD0000)
<img width="860" alt="2016-08-02 11 24 19" src="https://cloud.githubusercontent.com/assets/4794489/17316097/bbd1eac6-58a3-11e6-93ff-35755a8257e1.png">

<img width="899" alt="2016-08-02 11 24 24" src="https://cloud.githubusercontent.com/assets/4794489/17316103/c89e5b54-58a3-11e6-8dbc-bb56e647f495.png">
