### PR TITLE
if hoverSprite is null, don't process hover event

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -446,7 +446,7 @@ var Button = cc.Class({
     },
 
     _onMouseMoveIn: function () {
-        if (this._pressed || !this.interactable || !this.enabledInHierarchy) return;
+        if (!this.hoverSprite || this._pressed || !this.interactable || !this.enabledInHierarchy) return;
 
         if (!this._hovered) {
             this._hovered = true;


### PR DESCRIPTION
Re: cocos-creator/fireball#3848

Changes proposed in this pull request:
-  如果用户没有设置 hoverSprite，则不处理 mouseOver 事件

@cocos-creator/engine-admins
