### PR TITLE
init graphics sgNode size with node size

### DIFF
--- a/cocos2d/core/graphics/graphics.js
+++ b/cocos2d/core/graphics/graphics.js
@@ -178,6 +178,8 @@ var Graphics = cc.Class({
         sgNode.strokeColor = this._strokeColor;
         sgNode.fillColor = this._fillColor;
         sgNode.miterLimit = this._miterLimit;
+
+        sgNode.setContentSize(this.node.getContentSize(true));
     },
 
     /**


### PR DESCRIPTION
Re: cocos-creator/fireball#3910

Changes proposed in this pull request:
- init graphics sgNode size with node size

@cocos-creator/engine-admins
