### PR TITLE
don't execute adjust content logic in editor

### DIFF
--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -129,7 +129,7 @@ var ScrollView = cc.Class({
     editor: CC_EDITOR && {
         menu: 'i18n:MAIN_MENU.component.ui/ScrollView',
         help: 'i18n:COMPONENT.help_url.scrollview',
-        executeInEditMode: true,
+        executeInEditMode: false,
     },
 
     ctor: function() {


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/4125

Changes proposed in this pull request:
- 由于 Scrollview 现在不支持节点 scale，而在编辑器里面 canvas 经常会 scale，导致 content 的位置调整是错误的，而且表现随机。  这个修改让调整的逻辑只在运行时生效，后面需要修改 scrollview 的逻辑，让它支持节点 scale.

@cocos-creator/engine-admins
