### PR TITLE
remove redundant variable for _antiAliasEnabled

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -153,8 +153,6 @@ var View = cc._Class.extend({
     _targetDensityDPI: null,
     _antiAliasEnabled: true,
 
-    _antiAliasEnabled: false,
-
     /**
      * Constructor of View
      */


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
- 合并的时候，多加了一个 _antiAliasEnabled 变量 目前删除它

@cocos-creator/engine-admins
