### PR TITLE
fallback particle texture to plist if non-existent

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -186,6 +186,10 @@ var properties = {
         set: function (value) {
             this._texture = value;
             this._sgNode.texture = value ? cc.textureCache.addImage( value ) : null;
+            if (!value && this._file) {
+                // fallback to plist
+                this._applyFile();
+            }
         },
         url: cc.Texture2D
     },


### PR DESCRIPTION
Re: cocos-creator/fireball#4054

Changes proposed in this pull request:
- 当粒子为 custom 的时候，清空掉 texture ，场景中没有更新效果

@cocos-creator/engine-admins
