### PR TITLE
should not use cc.arrayRemoveObject

### DIFF
--- a/cocos2d/core/renderer/RendererWebGL.js
+++ b/cocos2d/core/renderer/RendererWebGL.js
@@ -179,7 +179,7 @@ cc.rendererWebGL = {
         }
 
         var locIDs = this._cacheInstanceIds;
-        cc.arrayRemoveObject(locIDs, instanceID);
+        cc.js.array.remove(locIDs, instanceID);
     },
 
     /**


### PR DESCRIPTION
fix [CC.RenderTexture.end() uses deprecated : arrayRemoveObject](http://discuss.cocos2d-x.org/t/cc-rendertexture-end-uses-deprecated-arrayremoveobject/32213)

@pandamicro 
