### PR TITLE
Fix some browser orientation can't be forced issue

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -324,7 +324,9 @@ var View = cc._Class.extend({
             cc.container.style.transformOrigin = '0px 0px 0px';
             this._isRotated = true;
         }
-        this._orientationChanging = false;
+        setTimeout(function () {
+            cc.view._orientationChanging = false;
+        }, 1000);
     },
 
     // hack


### PR DESCRIPTION
在部分浏览器上，转屏过程中 orientation 事件之后还会触发几次 resize 事件，导致强制旋转被取消。

修复 https://github.com/cocos-creator/engine/pull/1055 中遗留的问题。
相关 issue：https://github.com/cocos-creator/fireball/issues/3288

> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
> - To official teams:
>   - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
>   - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)

@cocos-creator/engine-admins
