### PR TITLE
Refactor CCLoader to support multi queues and better progression

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -24,12 +24,16 @@
  THE SOFTWARE.
  ****************************************************************************/
 
+var EventTarget = require('../core/event/event-target');
+
 var touchBinded = false;
 var touchPlayList = [
     //{ offset: 0, audio: audio }
 ];
 
 var Audio = function (src) {
+    EventTarget.call(this);
+
     this.src = src;
     this._audioType = Audio.Type.UNKNOWN;
     this._element = null;
@@ -70,47 +74,16 @@ Audio.State = {
                 }
             });
         }
-        audio.mount(item.element || item.buffer);
-        audio.emit('load');
+        else if (item.complete) {
+            audio.mount(item.element || item.buffer);
+            audio.emit('load');
+        }
     };
 
-    proto.on = function (event, callback) {
-        var list = this._eventList[event];
-        if (!list) {
-            list = this._eventList[event] = [];
-        }
-        list.push(callback);
-    };
-    proto.once = function (event, callback) {
-        var onceCallback = function (elem) {
-            callback.call(this, elem);
-            this.off(event, onceCallback);
-        };
-        this.on(event, onceCallback);
-    };
-    proto.emit = function (event) {
-        var list = this._eventList[event];
-        if (!list) return;
-        for (var i=0; i<list.length; i++) {
-            list[i].call(this, this);
-        }
-    };
-    proto.off = function (event, callback) {
-        var list = this._eventList[event];
-        if (!list) return false;
-        if (!callback) {
-            this._eventList[event] = [];
-            return true;
-        }
-
-        for (var i=0; i<list.length; i++) {
-            if (list[i] === callback) {
-                list.splice(i, 1);
-                break;
-            }
-        }
-        return true;
-    };
+    proto.on = EventTarget.prototype.on;
+    proto.once = EventTarget.prototype.once;
+    proto.emit = EventTarget.prototype.emit;
+    proto.off = EventTarget.prototype.off;
 
     proto.mount = function (elem) {
         if (elem instanceof HTMLElement) {

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -43,6 +43,8 @@ var Audio = function (src) {
     this._loaded = false;
 };
 
+cc.js.extend(Audio, EventTarget);
+
 Audio.Type = {
     DOM: 'AUDIO',
     WEBAUDIO: 'WEBAUDIO',
@@ -79,11 +81,6 @@ Audio.State = {
             audio.emit('load');
         }
     };
-
-    proto.on = EventTarget.prototype.on;
-    proto.once = EventTarget.prototype.once;
-    proto.emit = EventTarget.prototype.emit;
-    proto.off = EventTarget.prototype.off;
 
     proto.mount = function (elem) {
         if (elem instanceof HTMLElement) {

--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -1453,7 +1453,8 @@ cc.DisplayLinkDirector = cc.Director.extend(/** @lends cc.Director# */{
     },
 
     /**
-     * Sets animation interval
+     * Sets animation interval, this doesn't control the main loop.
+     * To control the game's frame rate overall, please use {{#crossLink "Game.setFrameRate"}}cc.game.setFrameRate{{/crossLink}}
      * @param {Number} value - The animation interval desired.
      */
     setAnimationInterval: function (value) {

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -188,7 +188,7 @@ var AudioSource = cc.Class({
 
     onDestroy: function () {
         this.stop();
-        audioEngine.uncache(this._clip);
+        cc.audioEngine.uncache(this._clip);
     },
 
     /**

--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -25,6 +25,7 @@
 
 var JS = require('../platform/js');
 var Pipeline = require('./pipeline');
+var LoadingItems = require('./loading-items');
 var Downloader = require('./downloader');
 var Loader = require('./loader');
 var AssetTable = require('./asset-table');
@@ -32,6 +33,10 @@ var callInNextTick = require('../platform/utils').callInNextTick;
 var AutoReleaseUtils = require('./auto-release-utils');
 
 var resources = new AssetTable();
+
+function getXMLHttpRequest () {
+    return window.XMLHttpRequest ? new window.XMLHttpRequest() : new ActiveXObject('MSXML2.XMLHTTP');
+}
 
 /**
  * Loader for resource loading process. It's a singleton object.
@@ -76,7 +81,7 @@ JS.mixin(CCLoader.prototype, {
      * Get XMLHttpRequest.
      * @returns {XMLHttpRequest}
      */
-    getXMLHttpRequest: Pipeline.getXMLHttpRequest,
+    getXMLHttpRequest: getXMLHttpRequest,
 
     /**
      * Add custom supported types handler or modify existing type handler for download process.
@@ -155,96 +160,61 @@ JS.mixin(CCLoader.prototype, {
         }
 
         var self = this;
-        var singleRes = false;
+        var singleRes = null;
         if (!(resources instanceof Array)) {
+            singleRes = resources;
             resources = resources ? [resources] : [];
-            singleRes = true;
-        }
-        // Return directly if no resources
-        if (resources.length === 0) {
-            if (completeCallback) {
-                callInNextTick(function () {
-                    completeCallback.call(self, null, self._items);
-                    completeCallback = null;
-                });
-            }
-            return;
         }
 
-        // Resolve callback
-        var error = null;
-        var checker = {};
-        var totalCount = 0;
-        var completedCount = 0;
-
-        function loadedCheck (item) {
-            checker[item.id] = item;
-            if (item.error) {
-                error = error || [];
-                error.push(item.id);
-            }
-            completedCount++;
-
-            progressCallback && progressCallback.call(self, completedCount, totalCount, item);
-
-            for (var url in checker) {
-                // Not done yet
-                if (!checker[url]) {
-                    return;
-                }
-            }
-            // All url completed
-            if (completeCallback) {
-                callInNextTick(function () {
-                    if (singleRes) {
-                        completeCallback.call(self, item.error, item.content);
-                    }
-                    else {
-                        completeCallback.call(self, error, self._items);
-                    }
-                    completeCallback = null;
-                });
-            }
-        }
-
-        // Add loaded listeners
         for (var i = 0; i < resources.length; ++i) {
             var url = resources[i].id || resources[i];
             if (typeof url !== 'string')
                 continue;
             var item = this.getItem(url);
-            if ( !item || (item && !item.complete) ) {
-                this._items.addListener(url, loadedCheck);
-                checker[url] = null;
-                totalCount++;
-            }
-            else if (item && item.complete) {
-                checker[url] = item;
-                totalCount++;
-                completedCount++;
+            if (item) {
+                resources[i] = item;
             }
         }
 
-        // No new resources, complete directly
-        if (totalCount === completedCount) {
-            var id = resources[0].id || resources[0];
-            var content = this._items.getContent(id);
-            var error = this._items.getError(id);
-            if (completeCallback) {
-                callInNextTick(function () {
-                    if (singleRes) {
-                        completeCallback.call(self, error, content);
-                    }
-                    else {
-                        completeCallback.call(self, null, self._items);
-                    }
-                    completeCallback = null;
-                });
+        LoadingItems.create(this, progressCallback, function (errors, items) {
+            callInNextTick(function () {
+                if (!completeCallback)
+                    return;
+
+                if (singleRes) {
+                    var id = singleRes.id || singleRes;
+                    completeCallback.call(self, items.getError(id), items.getContent(id));
+                }
+                else {
+                    completeCallback.call(self, errors, items);
+                }
+                completeCallback = null;
+                items.destroy();
+
+                if (CC_EDITOR) {
+                    // raw assets are not cached in the CC_EDITOR fix fireball/issues/4158
+                    self.clear();
+                }
+            });
+        }, resources);
+    },
+
+    flowInDeps: function (urlList, callback) {
+        for (var i = 0; i < urlList.length; ++i) {
+            var url = urlList[i].id || urlList[i];
+            if (typeof url !== 'string')
+                continue;
+            var item = this.getItem(url);
+            if (item) {
+                urlList[i] = item;
             }
         }
-        else {
-            this.flowIn(resources);
-        }
+
+        var deps = LoadingItems.create(this, null, function (errors, items) {
+            callback(errors, items);
+            items.destroy();
+        });
+        return deps.append(urlList);
     },
 
     _resources: resources,
@@ -382,41 +352,26 @@ JS.mixin(CCLoader.prototype, {
         var uuids = resources.getUuidArray(url, type);
         var remain = uuids.length;
         if (remain > 0) {
+            var res = [];
             var results = [];
-            var aborted = false;
-            function loaded (err, res) {
-                if (aborted) {
-                    return;
-                }
-                if (err) {
-                    aborted = true;
-                    if (completeCallback) {
-                        completeCallback(err, null);
-                    }
-                    return;
-                }
-                results.push(res);
-                --remain;
-                if (remain === 0) {
-                    for (var i = 0; i < uuids.length; i++) {
-                        self.setAutoReleaseRecursively(uuids[i], false);
-                    }
-                    if (completeCallback) {
-                        completeCallback(null, results);
-                    }
-                }
-            }
             for (var i = 0, len = remain; i < len; ++i) {
                 var uuid = uuids[i];
-                self.load(
-                    {
-                        id: uuid,
-                        type: 'uuid',
-                        uuid: uuid
-                    },
-                    loaded
-                );
+                res.push({
+                    id: uuid,
+                    type: 'uuid',
+                    uuid: uuid
+                });
             }
+            this.load(res, function (item) {
+                results.push(item.content);
+            }, function (errors, items) {
+                for (var i = 0; i < results.length; i++) {
+                    self.setAutoReleaseRecursively(results[i], false);
+                }
+                if (completeCallback) {
+                    completeCallback(errors, results);
+                }
+            });
         }
         else {
             callInNextTick(function () {
@@ -438,10 +393,10 @@ JS.mixin(CCLoader.prototype, {
      * @returns {*}
      */
     getRes: function (url) {
-        var item = this._items.getContent(url);
+        var item = this._cache[url];
         if (!item) {
             var uuid = this._getResUuid(url);
-            item = this._items.getContent(uuid);
+            item = this._cache[uuid];
         }
         return item;
     },
@@ -451,24 +406,7 @@ JS.mixin(CCLoader.prototype, {
      * @returns {Number}
      */
     getResCount: function () {
-        return this._items.totalCount;
-    },
-
-    /**
-     * Returns an item in pipeline.
-     * @method getItem
-     * @return {Object}
-     */
-    getItem: function (url) {
-        var item = this._items.map[url];
-
-        if (!item)
-            return item;
-
-        if (item.alias)
-            item = this._items.map[item.alias];
-
-        return item;
+        return this._cache.length;
     },
 
     /**
@@ -521,11 +459,9 @@ JS.mixin(CCLoader.prototype, {
 
     // AUTO RELEASE
 
-    _baseRemoveItem: Pipeline.prototype.removeItem,
-
     // override
     removeItem: function (key) {
-        var removed = this._baseRemoveItem(key);
+        var removed = Pipeline.prototype.removeItem.call(this, key);
         delete this._autoReleaseSetting[key];
         return removed;
     },
@@ -644,7 +580,18 @@ cc.loader = new CCLoader();
 
 if (CC_EDITOR) {
     cc.loader.refreshUrl = function (uuid, oldUrl, newUrl) {
-        this._items.refreshItemUrl(uuid, oldUrl, newUrl);
+        var item = this._cache[uuid];
+        if (item) {
+            item.url = newUrl;
+        }
+
+        item = this._cache[oldUrl];
+        if (item) {
+            item.id = newUrl;
+            item.url = newUrl;
+            this._cache[newUrl] = item;
+            delete this._cache[oldUrl];
+        }
     };
 }
 

--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -66,7 +66,7 @@ function loadDomAudio (item, callback) {
 function loadWebAudio (item, callback) {
     if (!context) return;
 
-    var request = Pipeline.getXMLHttpRequest();
+    var request = cc.loader.getXMLHttpRequest();
     request.open("GET", item.url, true);
     request.responseType = "arraybuffer";
 
@@ -103,7 +103,7 @@ function downloadAudio (item, callback) {
 
     // Get a header
     // check audio size
-    var request = Pipeline.getXMLHttpRequest();
+    var request = cc.loader.getXMLHttpRequest();
     request.open("HEAD", item.url, true);
     // Our asynchronous callback
     request.onload = function () {

--- a/cocos2d/core/load-pipeline/binary-downloader.js
+++ b/cocos2d/core/load-pipeline/binary-downloader.js
@@ -86,7 +86,7 @@ if (_IEFilter) {
 
 function downloadBinary (url, callback) {
     var self = this;
-    var xhr = this.getXMLHttpRequest(),
+    var xhr = cc.loader.getXMLHttpRequest(),
         errInfo = 'Load ' + url + ' failed!';
     xhr.open('GET', url, true);
     if (_IEFilter) {

--- a/cocos2d/core/load-pipeline/downloader.js
+++ b/cocos2d/core/load-pipeline/downloader.js
@@ -337,15 +337,6 @@ JS.mixin(Downloader.prototype, {
         var self = this;
         var downloadFunc = this.extMap[item.type] || this.extMap['default'];
         if (this._curConcurrent < this.maxConcurrent) {
-            if (CC_EDITOR) {
-                // raw assets are not cached in the CC_EDITOR fix fireball/issues/4158
-                self.pipeline._items.addListener(item.id, function (item) {
-                    if (item.isRawAsset) {
-                        cc.loader.removeItem(item.url);
-                    }
-                    cc.loader.removeItem(item.id);
-                });
-            }
             this._curConcurrent++;
             downloadFunc.call(this, item, function (err, result) {
                 // Concurrent logic

--- a/cocos2d/core/load-pipeline/downloader.js
+++ b/cocos2d/core/load-pipeline/downloader.js
@@ -25,6 +25,7 @@
 var JS = require('../platform/js');
 var Path = require('../utils/CCPath');
 var Pipeline = require('./pipeline');
+var LoadingItems = require('./loading-items');
 var PackDownloader = require('./pack-downloader');
 // var downloadBinary = require('./binary-downloader');
 var downloadText = require('./text-downloader');
@@ -64,7 +65,7 @@ function downloadScript (item, callback, isAsync) {
 
 function downloadTextSync (item) {
     var url = item.url;
-    var xhr = Pipeline.getXMLHttpRequest();
+    var xhr = cc.loader.getXMLHttpRequest();
     xhr.open('GET', url, false);
     if (/msie/i.test(window.navigator.userAgent) && !/opera/i.test(window.navigator.userAgent)) {
         // IE-specific logic here
@@ -190,6 +191,8 @@ function downloadFont (item, callback) {
     }
 }
 
+var reusedArray = [];
+
 function downloadUuid (item, callback) {
     var uuid = item.id;
     var self = this;
@@ -207,7 +210,9 @@ function downloadUuid (item, callback) {
                     return;
                 }
                 ext = ext.substr(1);
-                self.pipeline._items.map[url] = {
+                var queue = LoadingItems.getQueue(item.queueId);
+                reusedArray[0] = {
+                    queueId: item.queueId,
                     id: url,
                     url: url,
                     type: ext,
@@ -215,6 +220,7 @@ function downloadUuid (item, callback) {
                     alias: item.id,
                     complete: true
                 };
+                queue.append(reusedArray);
                 // Dispatch to other raw type downloader
                 var downloadFunc = self.extMap[ext] || self.extMap['default'];
                 item.type = ext;

--- a/cocos2d/core/load-pipeline/downloader.js
+++ b/cocos2d/core/load-pipeline/downloader.js
@@ -210,7 +210,7 @@ function downloadUuid (item, callback) {
                     return;
                 }
                 ext = ext.substr(1);
-                var queue = LoadingItems.getQueue(item.queueId);
+                var queue = LoadingItems.getQueue(item);
                 reusedArray[0] = {
                     queueId: item.queueId,
                     id: url,

--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -24,7 +24,62 @@
  ****************************************************************************/
 
 var CallbacksInvoker = require('../platform/callbacks-invoker');
+var Path = require('../utils/CCPath');
 var JS = require('../platform/js');
+
+var _qid = (0|(Math.random()*998));
+var _queues = {};
+var _pool = [];
+var _POOL_MAX_LENGTH = 10;
+
+var ItemState = {
+    WORKING: 1,
+    COMPLETE: 2,
+    ERROR: 3
+};
+
+function isIdValid (id) {
+    var realId = id.id || id;
+    return (typeof realId === 'string');
+}
+function createItem (id, queueId) {
+    var result;
+    if (typeof id === 'object' && id.id) {
+        if (!id.type) {
+            id.type = Path.extname(id.id).toLowerCase().substr(1);
+        }
+        result = {
+            queueId: queueId,
+            url: id.url || id.id,
+            error: null,
+            content: null,
+            complete: false,
+            states: {}
+        };
+        JS.mixin(result, id);
+    }
+    else if (typeof id === 'string') {
+        result = {
+            queueId: queueId,
+            id: id,
+            url: id,
+            type: Path.extname(id).toLowerCase().substr(1),
+            error: null,
+            content: null,
+            complete: false,
+            states: {}
+        };
+    }
+
+    if (result.skips) {
+        for (var i = 0, l = result.skips.length; i < l; i++) {
+            var skip = result.skips[i];
+            result.states[skip] = ItemState.COMPLETE;
+        }
+    }
+
+    return result;
+}
 
 /**
  * !#en
@@ -48,7 +103,7 @@ var JS = require('../platform/js');
  * - url：路径 </br>
  * - type: 类型，它这是默认的 URL 的扩展名，可以手动指定赋值。</br>
  * - error：pipeline 中发生的错误将被保存在这个属性中。</br>
- * - content: pipeline 中处理的内容时，最终的结果也将被存储在这个属性中。</br>
+ * - content: pipeline 中处理的临时结果，最终的结果也将被存储在这个属性中。</br>
  * - complete：该标志表明该对象是否通过 pipeline 完成。</br>
  * - states：该对象存储每个管道中对象经历的状态，状态可以是 Pipeline.ItemState.WORKING | Pipeline.ItemState.ERROR | Pipeline.ItemState.COMPLETE</br>
  * </br>
@@ -57,8 +112,20 @@ var JS = require('../platform/js');
  * @class LoadingItems
  * @extends CallbacksInvoker
  */
-var LoadingItems = function () {
+var LoadingItems = function (pipeline, onProgress, onComplete, urlList) {
     CallbacksInvoker.call(this);
+
+    this._id = ++_qid;
+
+    _queues[this._id] = this;
+
+    this._pipeline = pipeline;
+
+    this._errorUrls = [];
+
+    this.onProgress = onProgress;
+
+    this.onComplete = onComplete;
 
     /**
      * !#en The map of all items.
@@ -91,22 +158,124 @@ var LoadingItems = function () {
      * @type {Number}
      */
     this.completedCount = 0;
+
+    /**
+     * !#en Activated or not.
+     * !#zh 是否启用。
+     * @property active
+     * @type {Boolean}
+     */
+    if (this._pipeline) {
+        this.active = true;
+    }
+    else {
+        this.active = false;
+    }
+
+    if (urlList && urlList.length > 0) {
+        this.append(urlList);
+    }
+};
+
+LoadingItems.ItemState = new cc.Enum(ItemState);
+
+LoadingItems.create = function (pipeline, onProgress, onComplete, urlList) {
+    var queue = _pool.pop();
+    if (queue) {
+        queue._pipeline = pipeline;
+        queue.onProgress = onProgress;
+        queue.onComplete = onComplete;
+        _queues[queue._id] = queue;
+        if (queue._pipeline) {
+            queue.active = true;
+        }
+        if (urlList && urlList.length > 0) {
+            queue.append(urlList);
+        }
+    }
+    else {
+        queue = new LoadingItems(pipeline, onProgress, onComplete, urlList);
+    }
+    return queue;
+};
+
+LoadingItems.getQueue = function (id) {
+    return _queues[id];
+};
+
+LoadingItems.itemComplete = function (item) {
+    var queue = _queues[item.queueId];
+    if (queue) {
+        console.log('----- Completed by pipeline ' + item.id + ', rest: ' + (queue.totalCount - queue.completedCount-1));
+        queue.itemComplete(item.id);
+    }
 };
 
 JS.mixin(LoadingItems.prototype, CallbacksInvoker.prototype, {
-    append: function (items) {
-        var list = [];
-        for (var i = 0; i < items.length; ++i) {
-            var item = items[i];
-            var id = item.id;
-            // No duplicated url
-            if (!this.map[id]) {
-                this.map[item.id] = item;
-                list.push(item);
+    append: function (urlList) {
+        if (!this.active) {
+            return [];
+        }
+
+        var accepted = [], i, url, item;
+        for (i = 0; i < urlList.length; ++i) {
+            url = urlList[i];
+
+            // Already queued in another items queue, url is actually the item
+            if (url.queueId && !this.map[url.id]) {
+                this.map[url.id] = url;
+                // Queued and has a alias, consider as completed
+                if (true) {//url.complete) {
+                    this.totalCount++;
+                    console.log('----- Completed already ' + url.id + ', rest: ' + (this.totalCount - this.completedCount-1));
+                    this.itemComplete(url.id);
+                    continue;
+                }
+                // Not completed yet, should wait it
+                else {
+                    var self = this;
+                    var queue = _queues[url.queueId];
+                    if (queue) {
+                        this.totalCount++;
+                        console.log('+++++ Waited ' + url.id);
+                        queue.addListener(url.id, function (item) {
+                            console.log('----- Completed by waiting ' + item.id + ', rest: ' + (self.totalCount - self.completedCount-1));
+                            self.itemComplete(item.id);
+                        });
+                        continue;
+                    }
+                    // if queue not found and it's not completed, then requeue it.
+                }
+            }
+            // Queue new items
+            if (isIdValid(url)) {
+                item = createItem(url, this._id);
+                var id = item.id;
+                // No duplicated url
+                if (!this.map[id]) {
+                    this.map[item.id] = item;
+                    this.totalCount++;
+                    accepted.push(item);
+                    console.log('+++++ Appended ' + item.id);
+                }
             }
         }
-        this.totalCount += list.length;
-        return list;
+
+        // Manually complete
+        if (this.completedCount === this.totalCount) {
+            this.allComplete();
+        }
+        else {
+            this._pipeline.flowIn(accepted);
+        }
+        return accepted;
+    },
+
+    allComplete: function () {
+        var errors = this._errorUrls.length === 0 ? null : this._errorUrls;
+        if (this.onComplete) {
+            this.onComplete(errors, this);
+        }
     },
 
     /**
@@ -257,31 +426,61 @@ JS.mixin(LoadingItems.prototype, CallbacksInvoker.prototype, {
         this.totalCount--;
     },
 
-    complete: function (url) {
-        if (this.map[url] && !this.completed[url]) {
-            var item = this.map[url];
-            item.complete = true;
-            this.completed[url] = item;
-            this.completedCount++;
+    itemComplete: function (id) {
+        var item = this.map[id];
+        if (!item) {
+            return;
+        }
+
+        // Register or unregister errors
+        var errorListId = this._errorUrls.indexOf(id);
+        if (item.error && errorListId === -1) {
+            this._errorUrls.push(id);
+        }
+        else if (!item.error && errorListId !== -1) {
+            this._errorUrls.splice(errorListId, 1);
+        }
+
+        item.complete = true;
+        this.completed[id] = item;
+        this.completedCount++;
+
+        this.onProgress && this.onProgress(this.completedCount, this.totalCount, item);
+
+        // All completed
+        if (this.completedCount >= this.totalCount) {
+            console.log('===== All Completed ');
+            this.allComplete();
+        }
+
+        this.invokeAndRemove(id, item);
+    },
+
+    destroy: function () {
+        this.active = false;
+        this._pipeline = null;
+        this._errorUrls.length = 0;
+        this.onProgress = null;
+        this.onComplete = null;
+
+        // Reinitialize CallbacksInvoker, generate three new objects, could be improved
+        CallbacksInvoker.call(this);
+
+        for (var key in this.map) {
+            delete this.map[key];
+        }
+        for (key in this.completed) {
+            delete this.completed[key];
+        }
+
+        this.totalCount = 0;
+        this.completedCount = 0;
+
+        _queues[this._id] = null;
+        if (_pool.indexOf(this) === -1 && _pool.length < _POOL_MAX_LENGTH) {
+            _pool.push(this);
         }
     }
 });
-
-if (CC_EDITOR) {
-    LoadingItems.prototype.refreshItemUrl = function (id, oldUrl, newUrl) {
-        var item = this.map[id];
-        if (item) {
-            item.url = newUrl;
-        }
-
-        item = this.map[oldUrl];
-        if (item) {
-            item.id = newUrl;
-            item.url = newUrl;
-            this.map[newUrl] = item;
-            delete this.map[oldUrl];
-        }
-    };
-}
 
 module.exports = LoadingItems;

--- a/cocos2d/core/load-pipeline/pack-downloader.js
+++ b/cocos2d/core/load-pipeline/pack-downloader.js
@@ -96,16 +96,13 @@ module.exports = {
 
         var unpacker = globalUnpackers[packUuid];
         if (unpacker) {
-            // ensure async
-            setTimeout(function () {
-                var json = unpacker.retrieve(uuid);
-                if (json) {
-                    callback(null, json);
-                }
-                else {
-                    error(callback, uuid, packUuid);
-                }
-            }, 0);
+            var json = unpacker.retrieve(uuid);
+            if (json) {
+                callback(null, json);
+            }
+            else {
+                error(callback, uuid, packUuid);
+            }
         }
         else {
             this._loadNewPack(uuid, packUuid, callback);

--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -281,18 +281,19 @@ JS.mixin(Pipeline.prototype, {
      * @param {Function} callback
      * @return {Array} Items accepted by the pipeline
      */
-    flowInDeps: function (urlList, callback) {
-        var deps = LoadingItems.create(this, null, function (errors, items) {
+    flowInDeps: function (owner, urlList, callback) {
+        var deps = LoadingItems.create(this, function (errors, items) {
             callback(errors, items);
             items.destroy();
         });
-        return deps.append(urlList);
+        return deps.append(urlList, owner);
     },
 
     flowOut: function (item) {
         if (!this._cache[item.id]) {
             this._cache[item.id] = item;
         }
+        item.complete = true;
         LoadingItems.itemComplete(item);
     },
 

--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -24,14 +24,8 @@
  ****************************************************************************/
 
 var JS = require('../platform/js');
-var Path = require('../utils/CCPath');
 var LoadingItems = require('./loading-items');
-
-var ItemState = {
-    WORKING: 1,
-    COMPLETE: 2,
-    ERROR: 3
-};
+var ItemState = LoadingItems.ItemState;
 
 function asyncFlow (item) {
     var pipeId = this.id;
@@ -114,51 +108,6 @@ function syncFlow (item) {
     }
 }
 
-function isIdValid (id) {
-    var realId = id.id || id;
-    return (typeof realId === 'string');
-}
-function createItem (id) {
-    var result;
-    if (typeof id === 'object' && id.id) {
-        if (!id.type) {
-            id.type = Path.extname(id.id).toLowerCase().substr(1);
-        }
-        result = {
-            url: id.url || id.id,
-            error: null,
-            content: null,
-            complete: false,
-            states: {}
-        };
-        JS.mixin(result, id);
-    }
-    else if (typeof id === 'string') {
-        result = {
-            id: id,
-            url: id,
-            type: Path.extname(id).toLowerCase().substr(1),
-            error: null,
-            content: null,
-            complete: false,
-            states: {}
-        };
-    }
-
-    if (result.skips) {
-        for (var i = 0, l = result.skips.length; i < l; i++) {
-            var skip = result.skips[i];
-            result.states[skip] = ItemState.COMPLETE;
-        }
-    }
-
-    return result;
-}
-
-function getXMLHttpRequest () {
-    return window.XMLHttpRequest ? new window.XMLHttpRequest() : new ActiveXObject('MSXML2.XMLHTTP');
-}
-
 /**
  * !#en
  * A pipeline describes a sequence of manipulations, each manipulation is called a pipe.</br>
@@ -201,9 +150,7 @@ function getXMLHttpRequest () {
  */
 var Pipeline = function (pipes) {
     this._pipes = pipes;
-    this._items = new LoadingItems();
-    this._errorUrls = [];
-    this._flowing = false;
+    this._cache = {};
 
     for (var i = 0; i < pipes.length; ++i) {
         var pipe = pipes[i];
@@ -218,8 +165,7 @@ var Pipeline = function (pipes) {
     }
 };
 
-Pipeline.ItemState = new cc.Enum(ItemState);
-Pipeline.getXMLHttpRequest = getXMLHttpRequest;
+Pipeline.ItemState = ItemState;
 
 JS.mixin(Pipeline.prototype, {
     /**
@@ -289,8 +235,7 @@ JS.mixin(Pipeline.prototype, {
      * 也通过添加一个 包含 ‘skips’ 属性的 item 对象，你就可以跳过 skips 中包含的 pipe。</br>
      * 该对象可以包含任何附加属性。
      * @method flowIn
-     * @param {Array} urlList
-     * @return {Array} Items accepted by the pipeline
+     * @param {Array} items
      * @example
      *  pipeline.flowIn([
      *      'res/Background.png',
@@ -302,36 +247,20 @@ JS.mixin(Pipeline.prototype, {
      *      }
      *  ]);
      */
-    flowIn: function (urlList) {
-        var items = [], i, url, item;
-        for (i = 0; i < urlList.length; ++i) {
-            url = urlList[i];
-            if (isIdValid(url)) {
-                item = createItem(url);
-                items.push(item);
-            }
-            else {
-                throw new Error('Pipeline flowIn: Invalid url: ' + (url.id || url));
-            }
-        }
-        var acceptedItems = this._items.append(items);
-
-        // Manually complete
-        if (this._pipes.length === 0 || acceptedItems.length === 0) {
-            this.complete();
-            return acceptedItems;
-        }
-        
-        this._flowing = true;
-        
-        // Flow in after appended to loading items
-        var pipe = this._pipes[0];
+    flowIn: function (items) {
+        var i, pipe = this._pipes[0], item;
         if (pipe) {
-            for (i = 0; i < acceptedItems.length; i++) {
-                pipe.flowIn(acceptedItems[i]);
+            for (i = 0; i < items.length; i++) {
+                item = items[i];
+                this._cache[item.id] = item;
+                pipe.flowIn(item);
             }
         }
-        return acceptedItems;
+        else {
+            for (i = 0; i < items.length; i++) {
+                this.flowOut(items[i]);
+            }
+        }
     },
 
     /**
@@ -347,93 +276,24 @@ JS.mixin(Pipeline.prototype, {
      * 例如：</br>
      * 我们需要加载一个场景配置的 JSON 文件，该场景会将所有的依赖项全部都加载完毕以后，进行回调表示加载完毕。
      * @method flowInDeps
+     * @deprecated since v1.3
      * @param {Array} urlList
      * @param {Function} callback
      * @return {Array} Items accepted by the pipeline
      */
     flowInDeps: function (urlList, callback) {
-        var checker = {};
-
-        var items = this._items;
-        function loadedCheck (item) {
-            checker[item.id] = item;
-
-            for (var url in checker) {
-                // Not done yet
-                if (!checker[url]) {
-                    return;
-                }
-            }
-            // All url completed
-            callback && callback.call(this, checker);
-            callback = null;
-        }
-        // Add loaded listeners
-        for (var i = 0; i < urlList.length; ++i) {
-            var url = urlList[i].id || urlList[i];
-            if (typeof url !== 'string' || checker[url]) {
-                continue;
-            }
-            var item = items.map[url];
-            if ( !item ) {
-                items.addListener(url, loadedCheck);
-                checker[url] = null;
-            }
-            else {
-                checker[url] = item;
-            }
-        }
-        var accepted = this.flowIn(urlList);
-        // No new resources, complete directly
-        if (accepted.length === 0) {
-            callback && callback.call(this, checker);
-            callback = null;
-        }
-        return accepted;
-    },
-
-    complete: function () {
-        // All completed
-        if (this._items.isCompleted()) {
-            this._flowing = false;
-            var error = this._errorUrls.length === 0 ? null : this._errorUrls;
-            if (this.onComplete) {
-                this.onComplete(error, this._items);
-            }
-            // Remove all errored items, so that they can be flowed in again
-            for (var i = 0; i < this._errorUrls.length; ++i) {
-                var id = this._errorUrls[i];
-                this._items.removeItem(id);
-            }
-            this._errorUrls = [];
-        }
+        var deps = LoadingItems.create(this, null, function (errors, items) {
+            callback(errors, items);
+            items.destroy();
+        });
+        return deps.append(urlList);
     },
 
     flowOut: function (item) {
-        var id = item.id;
-        var items = this._items;
-        var exists = items.map[id];
-        // Not exist or already completed
-        if (!exists || exists.complete) {
-            return;
+        if (!this._cache[item.id]) {
+            this._cache[item.id] = item;
         }
-
-        // Register or unregister errors
-        var errorListId = this._errorUrls.indexOf(id);
-        if (item.error && errorListId === -1) {
-            this._errorUrls.push(id);
-        }
-        else if (!item.error && errorListId !== -1) {
-            this._errorUrls.splice(errorListId, 1);
-        }
-
-        items.complete(item.id);
-
-        this.onProgress && this.onProgress(items.completedCount, items.totalCount, item);
-
-        this.complete();
-
-        items.invokeAndRemove(id, item);
+        LoadingItems.itemComplete(item);
     },
 
     /**
@@ -470,9 +330,10 @@ JS.mixin(Pipeline.prototype, {
      * !#zh 获取 pipeline 当前是否正在处理中。
      * @method isFlowing
      * @return {Boolean}
+     * @deprecated since v1.3
      */
     isFlowing: function () {
-        return this._flowing;
+        return true;
     },
 
     /**
@@ -480,40 +341,46 @@ JS.mixin(Pipeline.prototype, {
      * !#zh 获取 pipeline 中的所有 items。
      * @method getItems
      * @return {LoadingItems}
+     * @deprecated since v1.3
      */
     getItems: function () {
-        return this._items;
+        return null;
     },
 
     /**
      * !#en Returns an item in pipeline.
-     * !#zh 获取指定 item。
+     * !#zh 根据 id 获取一个 item
      * @method getItem
-     * @return {LoadingItems}
+     * @param {Object} id The id of the item
+     * @return {Object}
      */
-    getItem: function (url) {
-        return this._items.map[url];
+    getItem: function (id) {
+        var item = this._cache[id];
+
+        if (!item)
+            return item;
+
+        if (item.alias)
+            item = this._cache[item.alias];
+
+        return item;
     },
 
     /**
      * !#en Removes an item in pipeline, no matter it's in progress or completed.
      * !#zh 移除指定 item，无论是进行时还是已完成。
      * @method removeItem
+     * @param {Object} id The id of the item
      * @return {Boolean} succeed or not
      */
-    removeItem: function (url) {
-        var item = this._items.map[url];
-        if (item) {
-            if (!item.complete) {
-                item.error = new Error('Canceled manually');
-                this.flowOut(item);
-            }
-            this._items.removeItem(url);
-            return true;
+    removeItem: function (id) {
+        var removed = this._cache[id];
+        delete this._cache[id];
+        if (removed && !removed.complete) {
+            removed.error = new Error('Canceled manually');
+            this.flowOut(removed);
         }
-        else {
-            return false;
-        }
+        return removed;
     },
 
     /**
@@ -522,20 +389,14 @@ JS.mixin(Pipeline.prototype, {
      * @method clear
      */
     clear: function () {
-        if (this._flowing) {
-            var items = this._items.map;
-            for (var url in items) {
-                var item = items[url];
-                if (!item.complete) {
-                    item.error = new Error('Canceled manually');
-                    this.flowOut(item);
-                }
+        for (var id in this._cache) {
+            var item = this._cache[id];
+            delete this._cache[id];
+            if (!item.complete) {
+                item.error = new Error('Canceled manually');
+                this.flowOut(item);
             }
         }
-
-        this._items = new LoadingItems();
-        this._errorUrls = [];
-        this._flowing = false;
     },
 
     /**

--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -290,7 +290,10 @@ JS.mixin(Pipeline.prototype, {
     },
 
     flowOut: function (item) {
-        if (!this._cache[item.id]) {
+        if (item.error) {
+            delete this._cache[item.id];
+        }
+        else if (!this._cache[item.id]) {
             this._cache[item.id] = item;
         }
         item.complete = true;

--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -401,39 +401,7 @@ JS.mixin(Pipeline.prototype, {
                 this.flowOut(item);
             }
         }
-    },
-
-    /**
-     * !#en This is a callback which will be invoked while an item flow out the pipeline, you should overwrite this function.
-     * !#zh 这个回调函数将在 item 流出 pipeline 时被调用，你应该重写该函数。
-     * @method onProgress
-     * @param {Number} completedCount The number of the items that are already completed.
-     * @param {Number} totalCount The total number of the items.
-     * @param {Object} item The latest item which flow out the pipeline.
-     * @example
-     *  pipeline.onProgress = function (completedCount, totalCount, item) {
-     *      var progress = (100 * completedCount / totalCount).toFixed(2);
-     *      cc.log(progress + '%');
-     *  }
-     */
-    onProgress: null,
-
-    /**
-     * !#en This is a callback which will be invoked while all items flow out the pipeline,
-     * you should overwirte this function.
-     * !#zh 该函数将在所有 item 流出 pipeline 时被调用，你应该重写该函数。
-     * @method onComplete
-     * @param {Array} error All errored urls will be stored in this array, if no error happened, then it will be null
-     * @param {LoadingItems} items All items.
-     * @example
-     *  pipeline.onComplete = function (error, items) {
-     *      if (error)
-     *          cc.log('Completed with ' + error.length + ' errors');
-     *      else
-     *          cc.log('Completed ' + items.totalCount + ' items');
-     *  }
-     */
-    onComplete: null
+    }
 });
 
 cc.Pipeline = module.exports = Pipeline;

--- a/cocos2d/core/load-pipeline/text-downloader.js
+++ b/cocos2d/core/load-pipeline/text-downloader.js
@@ -12,12 +12,11 @@ if (CC_JSB) {
     }
 }
 else {
-    var Pipeline = require('./pipeline');
     var urlAppendTimestamp = require('./utils').urlAppendTimestamp;
 
     module.exports = function (item, callback) {
         var url = item.url,
-            xhr = Pipeline.getXMLHttpRequest(),
+            xhr = cc.loader.getXMLHttpRequest(),
             errInfo = 'Load ' + url + ' failed!',
             navigator = window.navigator;
 

--- a/cocos2d/core/load-pipeline/uuid-loader.js
+++ b/cocos2d/core/load-pipeline/uuid-loader.js
@@ -139,7 +139,7 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
                         prop: dependProp
                     };
                     // Hack to get a better behavior
-                    var queue = LoadingItems.getQueue(item.queueId);
+                    var queue = LoadingItems.getQueue(item);
                     var list = queue._callbackTable[dependSrc];
                     if (list) {
                         list.unshift(loadCallback, target);

--- a/cocos2d/core/load-pipeline/uuid-loader.js
+++ b/cocos2d/core/load-pipeline/uuid-loader.js
@@ -25,6 +25,7 @@
 
 var JS = require('../platform/js');
 require('../platform/deserialize');
+var LoadingItems = require('./loading-items');
 
 // temp deserialize info
 var _tdInfo = new cc.deserialize.Details();
@@ -74,15 +75,18 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
     else {
         objList = JS.array.copy(tdInfo.uuidObjList);
         propList = JS.array.copy(tdInfo.uuidPropList);
-        depends = new Array(uuidList.length);
+        depends = [];
         // declare depends assets
         for (i = 0; i < uuidList.length; i++) {
             dependUuid = uuidList[i];
-            depends[i] = {
+            if (dependUuid === uuid) {
+                continue;
+            }
+            depends.push({
                 id: dependUuid,
                 type: 'uuid',
                 uuid: dependUuid
-            };
+            });
         }
     }
     // declare raw
@@ -100,10 +104,10 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
     // cache dependencies for auto release
     var dependKeys = item.dependKeys = [];
 
-    pipeline.flowInDeps(depends, function (items) {
+    pipeline.flowInDeps(depends, function (errors, items) {
         var item;
-        for (var src in items) {
-            item = items[src];
+        for (var src in items.map) {
+            item = items.map[src];
             if (item.uuid && item.content) {
                 item.content._uuid = item.uuid;
             }
@@ -112,7 +116,7 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
             var dependSrc = depends[i].uuid;
             var dependObj = objList[i];
             var dependProp = propList[i];
-            item = items[dependSrc];
+            item = items.map[dependSrc];
             if (item) {
                 if (item.complete) {
                     if (item.error) {
@@ -136,12 +140,13 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
                         prop: dependProp
                     };
                     // Hack to get a better behavior
-                    var list = pipeline.getItems()._callbackTable[dependSrc];
+                    var queue = LoadingItems.getQueue(item.queueId);
+                    var list = queue._callbackTable[dependSrc];
                     if (list) {
                         list.unshift(loadCallback, target);
                     }
                     else {
-                        pipeline.getItems().add(dependSrc, loadCallback, target);
+                        queue.addListener(dependSrc, loadCallback, target);
                     }
                 }
             }

--- a/cocos2d/core/load-pipeline/uuid-loader.js
+++ b/cocos2d/core/load-pipeline/uuid-loader.js
@@ -102,7 +102,7 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
     var dependKeys = item.dependKeys = [];
 
     // Predefine content for dependencies usage
-    // item.content = asset;
+    item.content = asset;
     pipeline.flowInDeps(item, depends, function (errors, items) {
         var item;
         for (var src in items.map) {

--- a/cocos2d/core/load-pipeline/uuid-loader.js
+++ b/cocos2d/core/load-pipeline/uuid-loader.js
@@ -75,18 +75,15 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
     else {
         objList = JS.array.copy(tdInfo.uuidObjList);
         propList = JS.array.copy(tdInfo.uuidPropList);
-        depends = [];
+        depends = new Array(uuidList.length);
         // declare depends assets
         for (i = 0; i < uuidList.length; i++) {
             dependUuid = uuidList[i];
-            if (dependUuid === uuid) {
-                continue;
-            }
-            depends.push({
+            depends[i] = {
                 id: dependUuid,
                 type: 'uuid',
                 uuid: dependUuid
-            });
+            };
         }
     }
     // declare raw
@@ -104,7 +101,9 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
     // cache dependencies for auto release
     var dependKeys = item.dependKeys = [];
 
-    pipeline.flowInDeps(depends, function (errors, items) {
+    // Predefine content for dependencies usage
+    // item.content = asset;
+    pipeline.flowInDeps(item, depends, function (errors, items) {
         var item;
         for (var src in items.map) {
             item = items.map[src];
@@ -118,7 +117,7 @@ function loadDepends (pipeline, item, asset, tdInfo, deferredLoadRawAssetsInRunt
             var dependProp = propList[i];
             item = items.map[dependSrc];
             if (item) {
-                if (item.complete) {
+                if (item.complete || item.content) {
                     if (item.error) {
                         cc._throw(item.error);
                     }

--- a/extensions/ccb-reader/CCBReader.js
+++ b/extensions/ccb-reader/CCBReader.js
@@ -215,7 +215,7 @@ cc.BuilderReader = cc._Class.extend({
 
     _loadBinarySync : function(url){
         var self = this;
-        var req = this.getXMLHttpRequest();
+        var req = cc.loader.getXMLHttpRequest();
         var errInfo = "load " + url + " failed!";
         req.open('GET', url, false);
         var arrayInfo = null;

--- a/modules.json
+++ b/modules.json
@@ -45,7 +45,7 @@
   {
     "name": "ParticleSystem",
     "entries": [
-      "./cocos2d/particle.CCParticleSystem.js"
+      "./cocos2d/particle/CCParticleSystem.js"
     ]
   },
   {

--- a/test/qunit/unit/test-audioSource.js
+++ b/test/qunit/unit/test-audioSource.js
@@ -1,7 +1,7 @@
 if (!isPhantomJS) {
     largeModule('AudioScource');
 
-    test('basic test', function () {
+    asyncTest('basic test', function () {
         var node = new cc.Node();
         cc.director.getScene().addChild(node);
 
@@ -11,7 +11,15 @@ if (!isPhantomJS) {
 
         audioSource.play();
 
-        strictEqual(audioSource.isPlaying, true, 'audio scource default play state true');
+        audioSource.audio.on('load', function () {
+            strictEqual(audioSource.isPlaying, true, 'audio scource play state true after preload');
+            start();
+        });
+
+        var timerId = setTimeout(function () {
+            ok(false, 'time out!');
+            start();
+        }, 10000);
 
         //audioSource.volume = 0.5;
         //strictEqual(audioSource.audio.volume, 0.5, 'audio scource volume true');

--- a/test/qunit/unit/test-loader.js
+++ b/test/qunit/unit/test-loader.js
@@ -29,7 +29,7 @@ asyncTest('Load', function () {
         ok(items.isCompleted(), 'be able to load all resources');
 
         loader.releaseAll();
-        strictEqual(Object.keys(this.getItems().map).length, 0, 'should clear loading items after releaseAll called');
+        strictEqual(Object.keys(loader._cache).length, 0, 'should clear loading items after releaseAll called');
 
         clearTimeout(timeoutId);
         start();
@@ -83,7 +83,7 @@ asyncTest('Load with dependencies', function () {
             dep2,
             dep3
         ];
-        this.pipeline.flowInDeps(resources, function (deps) {
+        this.pipeline.flowInDeps(null, resources, function (deps) {
             callback(null, result);
         });
     }
@@ -106,19 +106,13 @@ asyncTest('Load with dependencies', function () {
 
     var total = resources.length;
 
-    var items = loader.getItems();
-
     var progressCallback = new Callback(function (completedCount, totalCount, item) {
         if (item.id === json1.id) {
-            var depsLoaded = items.isItemCompleted(dep1) &&
-                             items.isItemCompleted(dep2) &&
-                             items.isItemCompleted(dep3);
-            ok(depsLoaded, 'should load all dependencies before complete parent resources');
-            var dep = this.getRes(dep1);
+            var dep = loader.getRes(dep1);
             ok(dep instanceof cc.Texture2D, 'should correctly load dependent image1');
-            dep = this.getRes(dep2);
+            dep = loader.getRes(dep2);
             strictEqual(dep.width, 89, 'should correctly load dependent JSON');
-            dep = this.getRes(dep3);
+            dep = loader.getRes(dep3);
             ok(dep instanceof cc.Texture2D, 'should correctly load dependent image2');
 
             strictEqual(item.content.__type__, 'TestTexture', 'should give correct js object as result of deps type');


### PR DESCRIPTION
Re: cocos-creator/fireball#3395

Changes proposed in this pull request:
- 支持每次 Load 独立的队列
- 更好的进度信息

这个 PR 的思路是把所有 item 的数据管理从 pipeline 中抽离出来，全部由 LoadingItems 来管理，让 pipeline 仅仅负责在管道中运送数据，Loader 可以同时有多个 LoadingItems 队列，某个资源的依赖也是通过 LoadingItems 队列来进行加载和完成回调。

关于循环依赖，对于已经存在于 Loader 的某个队列中的资源，不重复加载，视为其已经加载完成，在 depends 设置的时候根据 item.complete 状态来决定要等待其加载完成还是直接设置依赖属性。

> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
> - To official teams:
>   - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
>   - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)

@cocos-creator/engine-admins
