### PR TITLE
isMobile error

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -490,7 +490,7 @@ else {
          * Indicate whether system is mobile system
          * @property {Boolean} isMobile
          */
-        sys.isMobile = /mobile|android|mqqbrowser|micromessenger|miuibrowser/.test(ua);
+        sys.isMobile = /mobile|android|iphone|ipad/.test(ua);
 
         /**
          * Indicate the running platform


### PR DESCRIPTION
不能这样判断 QQ/WECHAT/MIUI 浏览器。

qq 浏览器是刚好移动端的多个 m 所以可以判断，而微信浏览器桌面端和移动端的识别码 micromessenger 是一样的，就会造成判断错误。

直接判断移动设备就行了，直接使用 iphone ipad android 来判断是否是移动端（黑莓那些个这些软件都没更新的就无视掉吧）。
