### PR TITLE
Output tips when cc._RendererInSG onEnabled if the node has actions.

### DIFF
--- a/cocos2d/core/CCActionManager.js
+++ b/cocos2d/core/CCActionManager.js
@@ -268,11 +268,11 @@ cc.ActionManager = cc._Class.extend(/** @lends cc.ActionManager# */{
      *  - 如果您正在运行 7 个动作组成的序列动作（Sequence），这个函数将返回 1。<br/>
      *  - 如果你正在运行 2 个序列动作（Sequence）和 5 个普通动作，这个函数将返回 7。<br/>
      *
-     * @method numberOfRunningActionsInTarget
+     * @method getNumberOfRunningActionsInTarget
      * @param {Object} target
      * @return {Number}
      */
-    numberOfRunningActionsInTarget:function (target) {
+    getNumberOfRunningActionsInTarget:function (target) {
         var element = this._hashTargets[target.__instanceId];
         if (element)
             return (element.actions) ? element.actions.length : 0;

--- a/cocos2d/core/components/CCRendererInSG.js
+++ b/cocos2d/core/components/CCRendererInSG.js
@@ -71,6 +71,11 @@ var RendererInSG = cc.Class({
     },
 
     onEnable: function () {
+        if (CC_JSB && cc.director.getActionManager().getNumberOfRunningActionsInTarget(this.node) > 0) {
+            cc.log('The node "%s" has a component inherited from "cc._RendererInSG"', this.node.name);
+            cc.log('JSB environment is not support invoke node.runAction before the "cc._RendererInSG" component enabled.');
+            cc.log('Please use runAction in the method "start" instead.');
+        }
         this._replaceSgNode(this._sgNode);
     },
 

--- a/jsb/jsb-action.js
+++ b/jsb/jsb-action.js
@@ -318,7 +318,7 @@ var targetRelatedFuncs = [
     ['removeAllActionsFromTarget', 0],
     ['removeActionByTag', 1],
     ['getActionByTag', 1],
-    ['numberOfRunningActionsInTarget', 0],
+    ['getNumberOfRunningActionsInTarget', 0],
     ['pauseTarget', 0],
     ['resumeTarget', 0]
 ];


### PR DESCRIPTION
Re: cocos-creator/fireball#4243

Changes proposed in this pull request:
- Output tips when cc._RendererInSG onEnabled if the node has actions.

@cocos-creator/engine-admins
