### PR TITLE
Improve editbox webchat v1.3

### DIFF
--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -353,6 +353,22 @@ var EditBox = cc.Class({
         },
 
         /**
+         * !#en The input is always visible and be on top of the game view.
+         * !zh 输入框总是可见，并且永远在游戏视图的上面
+         * Note: only available on Web at the moment.
+         * @property {Boolean} stayOnTop
+         */
+        stayOnTop: {
+            tooltip: 'i18n:COMPONENT.editbox.stay_on_top',
+            default: false,
+            notify: function () {
+                if(!CC_JSB) {
+                    this._sgNode.stayOnTop(this.stayOnTop);
+                }
+            }
+        },
+
+        /**
          * !#en The event handler to be called when EditBox began to edit text.
          * !#zh 开始编辑文本输入框触发的事件回调。
          * @property {Component.EventHandler} editingDidBegin
@@ -452,6 +468,7 @@ var EditBox = cc.Class({
         sgNode.inputFlag = this.inputFlag;
         sgNode.returnType = this.returnType;
         sgNode.setLineHeight(this.lineHeight);
+        sgNode.stayOnTop(this.stayOnTop);
 
         sgNode.setDelegate(this);
     },

--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -364,6 +364,8 @@ var EditBox = cc.Class({
             notify: function () {
                 if(!CC_JSB) {
                     this._sgNode.stayOnTop(this.stayOnTop);
+                    this._sgNode.fontSize = this.fontSize;
+                    this._sgNode.fontColor = this.fontColor;
                 }
             }
         },

--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -370,6 +370,19 @@ var EditBox = cc.Class({
             }
         },
 
+        _tabIndex: 0,
+
+        tabIndex: {
+            tooltip: 'i18n:COMPONENT.editbox.stay_on_top',
+            get: function () {
+                return this._tabIndex;
+            },
+            set: function (value) {
+                this._tabIndex = value;
+                this._sgNode.setTabIndex(value);
+            }
+        },
+
         /**
          * !#en The event handler to be called when EditBox began to edit text.
          * !#zh 开始编辑文本输入框触发的事件回调。
@@ -471,6 +484,7 @@ var EditBox = cc.Class({
         sgNode.returnType = this.returnType;
         sgNode.setLineHeight(this.lineHeight);
         sgNode.stayOnTop(this.stayOnTop);
+        sgNode.setTabIndex(this.tabIndex);
 
         sgNode.setDelegate(this);
     },
@@ -518,6 +532,20 @@ var EditBox = cc.Class({
             this._sgNode._onTouchEnded();
         }
         event.stopPropagation();
+    },
+
+    setFocus: function() {
+        if(this._sgNode) {
+            this._sgNode.setFocus();
+        }
+    },
+
+    isFocused: function () {
+        var isFocused = false;
+        if (this._sgNode) {
+            isFocused = this._sgNode.isFocused();
+        }
+        return isFocused;
     }
 
 });

--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -372,8 +372,13 @@ var EditBox = cc.Class({
 
         _tabIndex: 0,
 
+        /**
+         * !#en Set the tabIndex of the DOM input element, only useful on Web.
+         * !#zh 修改 DOM 输入元素的 tabIndex，这个属性只有在 Web 上面修改有意义。
+         * @property {Number} tabIndex
+         */
         tabIndex: {
-            tooltip: 'i18n:COMPONENT.editbox.stay_on_top',
+            tooltip: 'i18n:COMPONENT.editbox.tab_index',
             get: function () {
                 return this._tabIndex;
             },
@@ -534,12 +539,24 @@ var EditBox = cc.Class({
         event.stopPropagation();
     },
 
+    /**
+     * !#en Let the EditBox get focus, only valid when stayOnTop is true.
+     * !#zh 让当前 EditBox 获得焦点，只有在 stayOnTop 为 true 的时候设置有效
+     * Note: only available on Web at the moment.
+     * @method setFocus
+     */
     setFocus: function() {
         if(this._sgNode) {
             this._sgNode.setFocus();
         }
     },
 
+    /**
+     * !#en Determine whether EditBox is getting focus or not.
+     * !#zh 判断 EditBox 是否获得了焦点
+     * Note: only available on Web at the moment.
+     * @method isFocused
+     */
     isFocused: function () {
         var isFocused = false;
         if (this._sgNode) {

--- a/cocos2d/core/editbox/CCSGEditBox.js
+++ b/cocos2d/core/editbox/CCSGEditBox.js
@@ -280,6 +280,34 @@ _ccsg.EditBox = _ccsg.Node.extend({
         }
     },
 
+    setTabIndex: function(index) {
+        if(this._renderCmd._edTxt) {
+            this._renderCmd._edTxt.tabIndex = index;
+        }
+    },
+
+    getTabIndex: function() {
+        if(this._renderCmd._edTxt) {
+            return this._renderCmd._edTxt.tabIndex;
+        }
+        cc.warn('The dom control is not created!');
+        return -1;
+    },
+
+    setFocus: function() {
+        if(this._renderCmd._edTxt) {
+            this._renderCmd._edTxt.focus();
+        }
+    },
+
+    isFocused: function() {
+        if(this._renderCmd._edTxt) {
+            return document.activeElement === this._renderCmd._edTxt;
+        }
+        cc.warn('The dom control is not created!');
+        return false;
+    },
+
     stayOnTop: function (flag) {
         if(this._alwaysOnTop === flag) return;
 

--- a/cocos2d/core/editbox/CCSGEditBox.js
+++ b/cocos2d/core/editbox/CCSGEditBox.js
@@ -281,6 +281,8 @@ _ccsg.EditBox = _ccsg.Node.extend({
     },
 
     stayOnTop: function (flag) {
+        if(this._alwaysOnTop === flag) return;
+
         this._alwaysOnTop = flag;
         this._renderCmd.stayOnTop(this._alwaysOnTop);
     },
@@ -570,6 +572,8 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
             this._edTxt.style.display = '';
         } else {
             this._createLabels();
+            this._edTxt.style.display = 'none';
+            this._updateLabelString();
         }
     };
 
@@ -637,6 +641,8 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
             var editBox = thisPointer._editBox;
             this.style.fontSize = thisPointer._edFontSize + 'px';
             this.style.color = cc.colorToHex(editBox._textColor);
+            thisPointer._hiddenLabels();
+
             if(cc.view.isAutoFullScreenEnabled()) {
                 thisPointer.__fullscreen = true;
                 cc.view.enableAutoFullScreen(false);
@@ -712,6 +718,7 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
 
         tmpEdTxt.addEventListener('focus', function () {
             var editBox = thisPointer._editBox;
+            thisPointer._hiddenLabels();
 
             this.style.fontSize = thisPointer._edFontSize + 'px';
             this.style.color = cc.colorToHex(editBox._textColor);
@@ -766,31 +773,30 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
     };
 
     proto._createLabels = function () {
-        if(this._textLabel || this._placeholderLabel) return;
-
         var editBoxSize = this._editBox.getContentSize();
-        this._textLabel = new _ccsg.Label();
-        this._textLabel.setVisible(false);
-        this._textLabel.setAnchorPoint(cc.p(0, 1));
-        this._textLabel.setOverflow(_ccsg.Label.Overflow.CLAMP);
-        this._editBox.addChild(this._textLabel, 100);
+        if(!this._textLabel) {
+            this._textLabel = new _ccsg.Label();
+            this._textLabel.setVisible(false);
+            this._textLabel.setAnchorPoint(cc.p(0, 1));
+            this._textLabel.setOverflow(_ccsg.Label.Overflow.CLAMP);
+            this._editBox.addChild(this._textLabel, 100);
+        }
 
-        this._placeholderLabel = new _ccsg.Label();
-        this._placeholderLabel.setAnchorPoint(cc.p(0, 1));
-        this._placeholderLabel.setColor(cc.Color.GRAY);
-        this._editBox.addChild(this._placeholderLabel, 100);
+        if(!this._placeholderLabel) {
+            this._placeholderLabel = new _ccsg.Label();
+            this._placeholderLabel.setAnchorPoint(cc.p(0, 1));
+            this._placeholderLabel.setColor(cc.Color.GRAY);
+            this._editBox.addChild(this._placeholderLabel, 100);
+        }
 
         this._updateLabelPosition(editBoxSize);
     };
 
     proto._removeLabels = function () {
-        if(!this._textLabel || !this._placeholderLabel) return;
+        if(!this._textLabel) return;
 
         this._editBox.removeChild(this._textLabel);
         this._textLabel = null;
-
-        this._editBox.removeChild(this._placeholderLabel);
-        this._placeholderLabel = null;
     };
 
     proto._updateLabelPosition = function (editBoxSize) {
@@ -889,11 +895,10 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
         if(!this._editBox._alwaysOnTop) {
             if (this._edTxt.style.display === 'none') {
                 this._edTxt.style.display = '';
-                cc._canvas.focus();
                 this._edTxt.focus();
-                this._hiddenLabels();
             }
         }
+        this._hiddenLabels();
     };
 
     proto.hidden = function() {

--- a/jsb/jsb-editbox.js
+++ b/jsb/jsb-editbox.js
@@ -57,3 +57,4 @@ _p.setTabIndex = function () {};
 _p.getTabIndex = function () { return -1; };
 _p.setFocus = function () {};
 _p.isFocused = function () { return false; };
+_p.stayOnTop = function () {};

--- a/jsb/jsb-editbox.js
+++ b/jsb/jsb-editbox.js
@@ -51,3 +51,9 @@ _p.setMaxLength = function(maxLength) {
 };
 
 _p.setLineHeight = function () {};
+
+
+_p.setTabIndex = function () {};
+_p.getTabIndex = function () { return -1; };
+_p.setFocus = function () {};
+_p.isFocused = function () { return false; };


### PR DESCRIPTION
Re: cocos-creator/fireball#3885  cocos-creator/fireball#3655  cocos-creator/fireball#4180 

Changes proposed in this pull request:
-  提供一个选项让 editBox 的 DOM 元素永远显示在 canvas 上面
- 新增一个 setFocus API 用来指定某一个 editBox 获取焦点，但是这种方法在 iOS 微信的iframe里面会导致无法输入文字
- 新增 tabIndex 属性和 stayOnTop 属性，当 stayOnTop 为 true 则，可以通过设置 tabIndex 来控件 Tab 键的 focus 行为

**如果想在 iOS 微信 iframe 里面使用 EditBox，需要把 stayOnTop 属性设置为 true 就可以了。**

@cocos-creator/engine-admins
