### PR TITLE
Mark needs to be restored

### DIFF
--- a/cocos2d/core/renderer/RendererCanvas.js
+++ b/cocos2d/core/renderer/RendererCanvas.js
@@ -369,6 +369,7 @@ cc.rendererCanvas = {
 
     proto.restore = function () {
         this._context.restore();
+        this._currentAlpha = this._context.globalAlpha;
         this._saveCount--;
     };
 


### PR DESCRIPTION
在 setGlobalAlpha 函数中，设置了一个标记 - this._currentAlpha，但是这个标记在 restore 的时候没有更新，造成了标记和实际数值之间有差异，所以全局的 alpha 值就会出现问题。

@fusijie 

@nantas @pandamicro @jareguo

实际表现就是斩妖游戏中，点击开始熔炼，出现了一个渐变透明的提示框，这个框在渐变过程中，调用了restore 和 setGlobalAlpha ，然后就造成了最后一次 setGlobalAlpha 无效，整个游戏都变成半透明的了。
