### PR TITLE
don't enable auto gray effect by default

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -185,7 +185,7 @@ var Button = cc.Class({
          * @property {Boolean} enableAutoGrayEffect
          */
         enableAutoGrayEffect: {
-            default: true,
+            default: false,
             tooltip: 'i18n:COMPONENT.button.auto_gray_effect',
             notify: function () {
                 this._updateDisabledState();


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
-  This is a new feature in v1.3, for back compatibility issue, this feature should be turned off by default

@cocos-creator/engine-admins
