### PR TITLE
修复若干音频问题

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -28,7 +28,7 @@ var EventTarget = require('../core/event/event-target');
 
 var touchBinded = false;
 var touchPlayList = [
-    //{ offset: 0, audio: audio }
+    //{ instance: Audio, offset: 0, audio: audio }
 ];
 
 var Audio = function (src) {
@@ -110,7 +110,7 @@ Audio.State = {
             this._element.src = elem.src;
             this._audioType = Audio.Type.DOM;
         } else {
-            this._element = new WebAudioElement(elem);
+            this._element = new WebAudioElement(elem, this);
             this._audioType = Audio.Type.WEBAUDIO;
         }
         this._bindEnded();
@@ -124,9 +124,9 @@ Audio.State = {
         this.emit('play');
         this._state = Audio.State.PLAYING;
 
-        if (this._audioType = Audio.Type.DOM && this._element.paused) {
+        if (this._audioType === Audio.Type.DOM && this._element.paused) {
             this.stop();
-            touchPlayList.push({ offset: 0, audio: this._element });
+            touchPlayList.push({ instance: this, offset: 0, audio: this._element });
         }
 
         if (touchBinded) return;
@@ -163,6 +163,13 @@ Audio.State = {
             this._element.currentTime = 0;
         } catch (error) {}
         this._element.pause();
+        // remove touchPlayList
+        for (var i=0; i<touchPlayList; i++) {
+            if (touchPlayList[i].instance === this) {
+                touchPlayList.splice(i, 1);
+                break;
+            }
+        }
         this.emit('ended');
         this.emit('stop');
         this._state = Audio.State.PAUSED;
@@ -220,7 +227,8 @@ Audio.State = {
 })(Audio.prototype);
 
 // Encapsulated WebAudio interface
-var WebAudioElement = function (buffer) {
+var WebAudioElement = function (buffer, audio) {
+    this._audio = audio;
     this._context = cc.sys.__audioSupport.context;
     this._buffer = buffer;
     this._volume = this._context['createGain']();
@@ -241,6 +249,7 @@ var WebAudioElement = function (buffer) {
     proto.play = function (offset) {
         // If repeat play, you need to stop before an audio
         if (this._currentSource && !this.paused) {
+            this._currentSource.onended = null;
             this._currentSource.stop(0);
             this.playedLength = 0;
         }
@@ -292,6 +301,7 @@ var WebAudioElement = function (buffer) {
             this._currextTimer = setTimeout(function () {
                 if (self._context.currentTime === 0) {
                     touchPlayList.push({
+                        instance: self._audio,
                         offset: offset,
                         audio: self
                     });
@@ -301,6 +311,7 @@ var WebAudioElement = function (buffer) {
     };
 
     proto.pause = function () {
+        clearTimeout(this._currextTimer);
         if (this.paused) return;
         // Record the time the current has been played
         this.playedLength = this._context.currentTime - this._startTime;

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -82,7 +82,7 @@ var audioEngine = {
 
     AudioState: Audio.State,
 
-    _maxWebAudioSize: 307200, // 300kb * 1024
+    _maxWebAudioSize: 2097152, // 2048kb * 1024
     _maxAudioInstance: 24,
 
     _id2audio: id2audio,
@@ -106,6 +106,7 @@ var audioEngine = {
             audio.setVolume(volume || 1);
             audio.play();
         };
+        audio.__callback = callback;
         audio.on('load', callback);
         audio.preload();
 
@@ -368,6 +369,7 @@ var audioEngine = {
         var audio = getAudioFromId(audioID);
         if (!audio || !audio.stop)
             return false;
+        audio.off('load', audio.__callback);
         audio.stop();
         audio.emit('ended');
         return true;
@@ -386,6 +388,7 @@ var audioEngine = {
             var audio = id2audio[id];
             if (audio && audio.stop) {
                 audio.stop();
+                audio.off('load', audio.__callback);
                 audio.emit('ended');
             }
         }

--- a/cocos2d/audio/deprecated.js
+++ b/cocos2d/audio/deprecated.js
@@ -41,48 +41,49 @@ exports.deprecated = function (audioEngine) {
 	var effectsVolume = 1;
 	var pauseIDCache = [];
 	js.get(audioEngine, 'playMusic', function () {
-		cc.warn(INFO, 'audioEngine.playMusic', 'audioEngine.play');
+		// cc.warn(INFO, 'audioEngine.playMusic', 'audioEngine.play');
 		return function (url, loop) {
+			audioEngine.stop(musicId);
 			musicId = audioEngine.play(url, loop, musicVolume);
 			return musicId;
 		}
 	});
 	js.get(audioEngine, 'stopMusic', function () {
-		cc.warn(INFO, 'audioEngine.stopMusic', 'audioEngine.stop');
+		// cc.warn(INFO, 'audioEngine.stopMusic', 'audioEngine.stop');
 		return function () {
 			audioEngine.stop(musicId);
 			return musicId;
 		}
 	});
 	js.get(audioEngine, 'pauseMusic', function () {
-		cc.warn(INFO, 'audioEngine.pauseMusic', 'audioEngine.pause');
+		// cc.warn(INFO, 'audioEngine.pauseMusic', 'audioEngine.pause');
 		return function () {
 			audioEngine.pause(musicId);
 			return musicId;
 		}
 	});
 	js.get(audioEngine, 'resumeMusic', function () {
-		cc.warn(INFO, 'audioEngine.resumeMusic', 'audioEngine.resume');
+		// cc.warn(INFO, 'audioEngine.resumeMusic', 'audioEngine.resume');
 		return function () {
 			audioEngine.resume(musicId);
 			return musicId;
 		}
 	});
 	js.get(audioEngine, 'rewindMusic', function () {
-		cc.warn(INFO, 'audioEngine.rewindMusic', 'audioEngine.setCurrentTime');
+		// cc.warn(INFO, 'audioEngine.rewindMusic', 'audioEngine.setCurrentTime');
 		return function () {
 			audioEngine.setCurrentTime(musicId, 0);
 			return musicId;
 		}
 	});
 	js.get(audioEngine, 'getMusicVolume', function () {
-		cc.warn(INFO, 'audioEngine.getMusicVolume', 'audioEngine.getVolume');
+		// cc.warn(INFO, 'audioEngine.getMusicVolume', 'audioEngine.getVolume');
 		return function () {
 			return musicVolume;
 		}
 	});
 	js.get(audioEngine, 'setMusicVolume', function () {
-		cc.warn(INFO, 'audioEngine.setMusicVolume', 'audioEngine.setVolume');
+		// cc.warn(INFO, 'audioEngine.setMusicVolume', 'audioEngine.setVolume');
 		return function (volume) {
 			musicVolume = volume;
 			audioEngine.setVolume(musicId, musicVolume);
@@ -90,20 +91,20 @@ exports.deprecated = function (audioEngine) {
 		}
 	});
 	js.get(audioEngine, 'isMusicPlaying', function () {
-		cc.warn(INFO, 'audioEngine.isMusicPlaying', 'audioEngine.getState');
+		// cc.warn(INFO, 'audioEngine.isMusicPlaying', 'audioEngine.getState');
 		return function () {
 			return audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING;
 		}
 	});
 	js.get(audioEngine, 'playEffect', function () {
-		cc.warn(INFO, 'audioEngine.playEffect', 'audioEngine.play');
+		// cc.warn(INFO, 'audioEngine.playEffect', 'audioEngine.play');
 
 		return function (url, loop, volume) {
 			return audioEngine.play(url, loop, volume === undefined ? effectsVolume : volume);
 		}
 	});
 	js.get(audioEngine, 'setEffectsVolume', function (volume) {
-		cc.warn(INFO, 'audioEngine.setEffectsVolume', 'audioEngine.setVolume');
+		// cc.warn(INFO, 'audioEngine.setEffectsVolume', 'audioEngine.setVolume');
 		return function (volume) {
 			effectsVolume = volume;
 			var id2audio = audioEngine._id2audio;
@@ -114,20 +115,20 @@ exports.deprecated = function (audioEngine) {
 		}
 	});
 	js.get(audioEngine, 'getEffectsVolume', function () {
-		cc.warn(INFO, 'audioEngine.getEffectsVolume', 'audioEngine.getVolume');
+		// cc.warn(INFO, 'audioEngine.getEffectsVolume', 'audioEngine.getVolume');
 		return function () {
 			return effectsVolume;
 		}
 	});
 	js.get(audioEngine, 'pauseEffect', function () {
-		cc.warn(INFO, 'audioEngine.pauseEffect', 'audioEngine.pause');
+		// cc.warn(INFO, 'audioEngine.pauseEffect', 'audioEngine.pause');
 
 		return function (id) {
 			return audioEngine.pause(id);
 		}
 	});
 	js.get(audioEngine, 'pauseAllEffects', function () {
-		cc.warn(INFO, 'audioEngine.pauseAllEffects', 'audioEngine.pauseAll');
+		// cc.warn(INFO, 'audioEngine.pauseAllEffects', 'audioEngine.pauseAll');
 
 		return function () {
 			var id2audio = audioEngine._id2audio;
@@ -143,13 +144,13 @@ exports.deprecated = function (audioEngine) {
 		}
 	});
 	js.get(audioEngine, 'resumeEffect', function () {
-		cc.warn(INFO, 'audioEngine.resumeEffect', 'audioEngine.resume');
+		// cc.warn(INFO, 'audioEngine.resumeEffect', 'audioEngine.resume');
 		return function (id) {
 			audioEngine.resume(id);
 		}
 	});
 	js.get(audioEngine, 'resumeAllEffects', function () {
-		cc.warn(INFO, 'audioEngine.resumeEffect', 'audioEngine.resume');
+		// cc.warn(INFO, 'audioEngine.resumeEffect', 'audioEngine.resume');
 		return function () {
 			var id2audio = audioEngine._id2audio;
 			while (pauseIDCache.length > 0) {
@@ -161,13 +162,13 @@ exports.deprecated = function (audioEngine) {
 		}
 	});
 	js.get(audioEngine, 'stopEffect', function () {
-		cc.warn(INFO, 'audioEngine.stopEffect', 'audioEngine.stop');
+		// cc.warn(INFO, 'audioEngine.stopEffect', 'audioEngine.stop');
 		return function (id) {
 			return audioEngine.stop(id);
 		}
 	});
 	js.get(audioEngine, 'stopAllEffects', function () {
-		cc.warn(INFO, 'audioEngine.stopAllEffects', 'audioEngine.stopAll');
+		// cc.warn(INFO, 'audioEngine.stopAllEffects', 'audioEngine.stopAll');
 		return function () {
 			var id2audio = audioEngine._id2audio;
 			for (var id in id2audio) {
@@ -181,7 +182,7 @@ exports.deprecated = function (audioEngine) {
 		}
 	});
 	js.get(audioEngine, 'unloadEffect', function () {
-		cc.warn(INFO, 'audioEngine.unloadEffect', 'audioEngine.stop');
+		// cc.warn(INFO, 'audioEngine.unloadEffect', 'audioEngine.stop');
 		return function (id) {
 			return audioEngine.stop(id);
 		}
@@ -189,7 +190,7 @@ exports.deprecated = function (audioEngine) {
 
 	if (!CC_JSB) {
 		js.get(audioEngine, 'end', function () {
-			cc.warn(INFO, 'audioEngine.end', 'audioEngine.stopAll');
+			// cc.warn(INFO, 'audioEngine.end', 'audioEngine.stopAll');
 			return function () {
 				return audioEngine.stopAll();
 			}


### PR DESCRIPTION
1. 移除旧接口的 warn 信息，让用户继续使用，等确定了使用接口后，再进行标记
2. 修复 playMusic 不会停止上一个背景音乐的问题
3. 修复 IOS 上 webAudio 在未加载的情况下，执行 audioEngine.play ，当前对象会被异常回收，造成 audioID 索引丢失无法控制音频的问题
4. 修复 IOS 上 webAudio 在未加载完成的情况下，执行 stop 操作后，在下次点击屏幕的时候还会播放的问题
5. 修复 IOS 上 dom audio 在未预加载的情况下，在加载完成时，会自动销毁之前的 audioID，造成索引丢失的问题

https://github.com/cocos-creator/fireball/issues/4339
