### PR TITLE
ensure no error on prefab data which created from nested auto-sync prefabs

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -905,7 +905,10 @@ var Node = cc.Class({
     _onBatchCreated: function () {
         var prefabInfo = this._prefab;
         if (prefabInfo && prefabInfo.sync && !prefabInfo._synced) {
-            PrefabHelper.syncWithPrefab(this);
+            // checks to ensure no recursion, recursion will caused only on old data.
+            if (prefabInfo.root === this) {
+                PrefabHelper.syncWithPrefab(this);
+            }
         }
 
         this._updateDummySgNode();


### PR DESCRIPTION
Re: cocos-creator/fireball#4278

Changes proposed in this pull request:
- 防止自动关联的 prefab 被嵌套后场景无法打开

@cocos-creator/engine-admins
