### PR TITLE
Fixed a bug about jsb - audioEngine.pauseAllEffects

### DIFF
--- a/cocos2d/audio/deprecated.js
+++ b/cocos2d/audio/deprecated.js
@@ -130,7 +130,18 @@ exports.deprecated = function (audioEngine) {
 	js.get(audioEngine, 'pauseAllEffects', function () {
 		// cc.warn(INFO, 'audioEngine.pauseAllEffects', 'audioEngine.pauseAll');
 
+		if (CC_JSB) {
+			return function () {
+				var musicPlayState = audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING;
+				audioEngine.pauseAll();
+				if (musicPlayState) {
+					audioEngine.resume(musicId);
+				}
+			}
+		}
+
 		return function () {
+			pauseIDCache.length = 0;
 			var id2audio = audioEngine._id2audio;
 			for (var id in id2audio) {
 				if (id === musicId) continue;
@@ -151,6 +162,17 @@ exports.deprecated = function (audioEngine) {
 	});
 	js.get(audioEngine, 'resumeAllEffects', function () {
 		// cc.warn(INFO, 'audioEngine.resumeEffect', 'audioEngine.resume');
+
+		if (CC_JSB) {
+			return function () {
+				var musicPlayState = audioEngine.getState(musicId) === audioEngine.AudioState.PAUSED;
+				audioEngine.resumeAll();
+				if (musicPlayState && audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING) {
+					audioEngine.pause(musicId);
+				}
+			};
+		}
+
 		return function () {
 			var id2audio = audioEngine._id2audio;
 			while (pauseIDCache.length > 0) {

--- a/cocos2d/audio/deprecated.js
+++ b/cocos2d/audio/deprecated.js
@@ -37,6 +37,8 @@ exports.removed = function (audioEngine) {
 exports.deprecated = function (audioEngine) {
 	
 	var musicId = -1;
+	var musicPath = 1;
+	var musicLoop = 1;
 	var musicVolume = 1;
 	var effectsVolume = 1;
 	var pauseIDCache = [];
@@ -45,6 +47,8 @@ exports.deprecated = function (audioEngine) {
 		return function (url, loop) {
 			audioEngine.stop(musicId);
 			musicId = audioEngine.play(url, loop, musicVolume);
+			musicPath = url;
+			musicLoop = loop;
 			return musicId;
 		}
 	});
@@ -132,9 +136,9 @@ exports.deprecated = function (audioEngine) {
 
 		if (CC_JSB) {
 			return function () {
-				var musicPlayState = audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING;
+				var musicPlay = audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING;
 				audioEngine.pauseAll();
-				if (musicPlayState) {
+				if (musicPlay) {
 					audioEngine.resume(musicId);
 				}
 			}
@@ -165,9 +169,9 @@ exports.deprecated = function (audioEngine) {
 
 		if (CC_JSB) {
 			return function () {
-				var musicPlayState = audioEngine.getState(musicId) === audioEngine.AudioState.PAUSED;
+				var musicPaused = audioEngine.getState(musicId) === audioEngine.AudioState.PAUSED;
 				audioEngine.resumeAll();
-				if (musicPlayState && audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING) {
+				if (musicPaused && audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING) {
 					audioEngine.pause(musicId);
 				}
 			};
@@ -191,6 +195,19 @@ exports.deprecated = function (audioEngine) {
 	});
 	js.get(audioEngine, 'stopAllEffects', function () {
 		// cc.warn(INFO, 'audioEngine.stopAllEffects', 'audioEngine.stopAll');
+
+		if (CC_JSB) {
+			return function () {
+				var musicPlay = audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING;
+				var currentTime = audioEngine.getCurrentTime(musicId);
+				audioEngine.stopAll();
+				if (musicPlay) {
+					musicId = audioEngine.play(musicPath, musicLoop);
+					audioEngine.setCurrentTime(currentTime);
+				}
+			}
+		}
+
 		return function () {
 			var id2audio = audioEngine._id2audio;
 			for (var id in id2audio) {


### PR DESCRIPTION
pauseAllEffects 需要考虑到 jsb 使用新的 audioEngine 后，和 web 端出现的差异。

web 端可以直接取到所有音频的索引，并且循环，但是 jsb 需要手动判断背景音的状态然后调用 All 接口操作所有的音频，最后根据背景音状态，还原背景音乐的播放/暂停
