### PR TITLE
支持在 engine-extends 中使用 ES6

### DIFF
--- a/cocos2d/core/load-pipeline/uuid-loader.js
+++ b/cocos2d/core/load-pipeline/uuid-loader.js
@@ -210,7 +210,7 @@ function loadUuid (item, callback) {
         return Object;
     };
 
-    var tdInfo = CC_JSB ? new cc.deserialize.Details() : (item.deserializeInfo || _tdInfo);
+    var tdInfo = CC_JSB ? new cc.deserialize.Details() : _tdInfo;
 
     var asset;
     try {
@@ -221,6 +221,7 @@ function loadUuid (item, callback) {
         });
     }
     catch (e) {
+        tdInfo.reset();
         var err = CC_JSB ? (e + '\n' + e.stack) : e.stack;
         callback( new Error('Uuid Loader: Deserialize asset [' + item.id + '] failed : ' + err) );
         return;

--- a/cocos2d/core/platform/CCAssetLibrary.js
+++ b/cocos2d/core/platform/CCAssetLibrary.js
@@ -63,8 +63,6 @@ var AssetLibrary = {
      * @param {Boolean} options.readMainCache - Default is true. If false, the asset and all its depends assets will reload and create new instances from library.
      * @param {Boolean} options.writeMainCache - Default is true. If true, the result will cache to AssetLibrary, and MUST be unload by user manually.
      * @param {Asset} options.existingAsset - load to existing asset, this argument is only available in editor
-     * @param {deserialize.Details} options.deserializeInfo - specified a DeserializeInfo object if you want,
-     *                                                        this parameter is only available in editor.
      * @private
      */
     loadAsset: function (uuid, callback, options) {
@@ -77,9 +75,6 @@ var AssetLibrary = {
             id: uuid,
             type: 'uuid'
         };
-        if (options && options.deserializeInfo) {
-            item.deserializeInfo = options.deserializeInfo;
-        }
         if (options && options.existingAsset) {
             item.existingAsset = options.existingAsset;
         }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,10 +122,12 @@ gulp.task('clean-test', function (done) {
 });
 
 gulp.task('build-test', ['build-modular-cocos2d', 'clean-test'], function (done) {
-    Test.build('./index.js', './bin/cocos2d-js-for-test.js', done);
+    Test.build('./index.js', './bin/cocos2d-js-for-test.js',
+               '../editor/test-utils/engine-extends-entry.js','./bin/cocos2d-js-extends-for-test.js',
+               done);
 });
 
-gulp.task('unit-runner', [], function (done) {
+gulp.task('unit-runner', ['build-test'], function (done) {
     Test.unit('./bin', [
         './bin/cocos2d-js-for-test.js'
     ], done);

--- a/test/qunit/unit/test-json-pack-unpack.js
+++ b/test/qunit/unit/test-json-pack-unpack.js
@@ -1,6 +1,11 @@
 module('JSON packer/unpacker');
 
 (function () {
+
+    if (!TestEditorExtends) {
+        return;
+    }
+
     var KEY1 = 'amitabha';
     var JSON1 = {
         __born__: 1985,


### PR DESCRIPTION
Re: cocos-creator/fireball#4466

Changes proposed in this pull request:
- 支持在 engine-extends 中使用 ES6
- 移除 loadingItem 中的 deserializeInfo

@cocos-creator/engine-admins
