### PR TITLE
don't emit EventCustom in Toggle

### DIFF
--- a/cocos2d/core/components/CCToggle.js
+++ b/cocos2d/core/components/CCToggle.js
@@ -167,10 +167,10 @@ var Toggle = cc.Class({
         }
     },
 
-    _emitToggleEvents: function (event) {
+    _emitToggleEvents: function () {
         this.node.emit('toggle', this);
         if(this.checkEvents) {
-            cc.Component.EventHandler.emitEvents(this.checkEvents, event, this);
+            cc.Component.EventHandler.emitEvents(this.checkEvents, this);
         }
     },
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
-  统一 toggle 两种方式注册事件的回调参数

这个不需要进 change log

@cocos-creator/engine-admins
