### PR TITLE
Fixed a bug about audio.ended

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -82,7 +82,7 @@ var audioEngine = {
     AudioState: Audio.State,
 
     _maxWebAudioSize: 2097152, // 2048kb * 1024
-    _maxAudioInstance: 1,
+    _maxAudioInstance: 24,
 
     _id2audio: id2audio,
 

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -48,9 +48,7 @@ var getAudioFromPath = function (path) {
         var id = this.instanceId;
         delete id2audio[id];
         var index = list.indexOf(id);
-        if (index !== -1) {
-            list.splice(index, 1);
-        }
+        cc.js.array.fastRemoveAt(list, index);
     });
     id2audio[id] = audio;
 

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -37,26 +37,25 @@ var getAudioFromPath = function (path) {
         list = url2id[path] = [];
     }
     var audio;
-    if (audioEngine._maxAudioInstance > list.length) {
-        audio = new Audio(path);
-        id2audio[id] = audio;
-    } else {
+    if (audioEngine._maxAudioInstance <= list.length) {
         var oldId = list.shift();
-        audio = id2audio[id] = id2audio[oldId];
-        delete id2audio[oldId];
-        var index = list.indexOf(oldId);
-        index !== -1 && list.splice(index, 1);
+        var oldAudio = id2audio[oldId];
+        oldAudio.stop();
     }
-    audio.instanceId = id;
-    list.push(id);
 
-    //
+    audio = new Audio(path);
     audio.on('ended', function () {
         var id = this.instanceId;
         delete id2audio[id];
         var index = list.indexOf(id);
-        index !== -1 && list.splice(index, 1);
+        if (index !== -1) {
+            list.splice(index, 1);
+        }
     });
+    id2audio[id] = audio;
+
+    audio.instanceId = id;
+    list.push(id);
 
     return audio;
 };
@@ -83,7 +82,7 @@ var audioEngine = {
     AudioState: Audio.State,
 
     _maxWebAudioSize: 2097152, // 2048kb * 1024
-    _maxAudioInstance: 24,
+    _maxAudioInstance: 1,
 
     _id2audio: id2audio,
 


### PR DESCRIPTION
因为复用了 Audio 这个壳，导致 audio 事件重复触发。
现在每次都会重新new 一个 Audio 对象，但是对象内的 buffer 等数据是公用的。不会增加太多的额外开销。
去除了部分多余的逻辑

@jareguo 
