### PR TITLE
Fix loader issue that mistaken remove item when multiple queue is in progress

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -194,7 +194,9 @@ JS.mixin(CCLoader.prototype, {
 
                 if (CC_EDITOR) {
                     for (var id in self._cache) {
-                        self.removeItem(id);
+                        if (self._cache[id].complete) {
+                            self.removeItem(id);
+                        }
                     }
                 }
                 items.destroy();


### PR DESCRIPTION
Fix issue caused in #1221

Changes proposed in this pull request:
- Fix loader issue that mistaken remove item when multiple queue is in progress

> Makes sure these boxes are checked before submitting your PR - thank you!
> - [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
> - [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
> - To official teams:
>   - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
>   - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)

@cocos-creator/engine-admins
