### PR TITLE
fix android ACCELERATION for  fireball/issues/4410

### DIFF
--- a/cocos2d/core/event-manager/CCSystemEvent.js
+++ b/cocos2d/core/event-manager/CCSystemEvent.js
@@ -105,12 +105,20 @@ var SystemEvent = cc.Class({
         }
 
         // Acceleration
+        var tempAcc = cc.p();
         if (!accelerationListener && type === EventType.DEVICEMOTION) {
             accelerationListener = cc.EventListener.create({
                 event: cc.EventListener.ACCELERATION,
                 callback: function (accelEvent, event) {
                     event.type = EventType.DEVICEMOTION;
-                    if (CC_JSB) {
+                    // fix android acc values are opposite
+                    if (cc.sys.os === cc.sys.OS_ANDROID &&
+                        cc.sys.browserType !== cc.sys.BROWSER_TYPE_MOBILE_QQ) {
+                        tempAcc.x = accelEvent.x * -1;
+                        tempAcc.y = accelEvent.y * -1;
+                        event.acc = tempAcc;
+                    }
+                    else {
                         event.acc = accelEvent;
                     }
                     cc.systemEvent.dispatchEvent(event);


### PR DESCRIPTION
Re: cocos-creator/fireball#4410

Changes proposed in this pull request:
- 由于 android 移动平台中除了 qq 浏览器以外，其他浏览器的重力感应数值都是与 IOS 相反方向，为了统一进行了适配

@cocos-creator/engine-admins
