### PR TITLE
Update New AudioEngine

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -24,42 +24,236 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-var JS = require('../core/platform/js');
+var EventTarget = require('../core/event/event-target');
 
-/**
- * Encapsulate DOM and webAudio
- */
-cc.Audio = function (url) {
-    this.src = url;
-    this._element = null;
-    this._AUDIO_TYPE = 'AUDIO';
-};
-
-cc.Audio.touchPlayList = [
-    //{ offset: 0, audio: audio }
+var touchBinded = false;
+var touchPlayList = [
+    //{ instance: Audio, offset: 0, audio: audio }
 ];
 
-cc.Audio.bindTouch = false;
-cc.Audio.touchStart = function () {
-    var list = cc.Audio.touchPlayList;
-    var item = null;
-    while (item = list.pop()) {
-        item.audio.loop = !!item.loop;
-        item.audio.play(item.offset);
-    }
+var Audio = function (src) {
+    EventTarget.call(this);
+
+    this._src = src;
+    this._audioType = Audio.Type.UNKNOWN;
+    this._element = null;
+
+    this._eventList = {};
+    this._state = Audio.State.INITIALZING;
+    this._loaded = false;
+
+    this._onended = function () {
+        this.emit('ended');
+    }.bind(this);
 };
 
-cc.Audio.WebAudio = function (buffer) {
-    this.buffer = buffer;
-    this.context = cc.sys.__audioSupport.context;
+cc.js.extend(Audio, EventTarget);
 
-    var volume = this.context['createGain']();
-    volume['gain'].value = 1;
-    volume['connect'](this.context['destination']);
-    this._volume = volume;
+Audio.Type = {
+    DOM: 'AUDIO',
+    WEBAUDIO: 'WEBAUDIO',
+    NATIVE: 'NATIVE',
+    UNKNOWN: 'UNKNOWN'
+};
 
+/**
+ * !#en Audio state.
+ * !#zh 声音播放状态
+ * @enum audioEngine.AudioState
+ * @memberof cc
+ */
+
+Audio.State = {
+    /**
+     * @property {Number} ERROR
+     */
+    ERROR : -1,
+    /**
+     * @property {Number} INITIALZING
+     */
+    INITIALZING: 0,
+    /**
+     * @property {Number} PLAYING
+     */
+    PLAYING: 1,
+    /**
+     * @property {Number} PAUSED
+     */
+    PAUSED: 2
+};
+
+(function (proto) {
+
+    proto.preload = function () {
+        var src = this._src,
+            audio = this;
+        var item = cc.loader.getItem(src);
+
+        // If the resource does not exist
+        if (!item) {
+            return cc.loader.load(src, function (error) {
+                if (!error) {
+                    var item = cc.loader.getItem(src);
+                    audio.mount(item.element || item.buffer);
+                    audio.emit('load');
+                }
+            });
+        } else if (item.complete) {
+            audio.mount(item.element || item.buffer);
+            audio.emit('load');
+        }
+
+        // current and  volume
+    };
+
+    proto._bindEnded = function (callback) {
+        callback = callback || this._onended;
+        if (this._audioType === Audio.Type.DOM) {
+            this._element.addEventListener('ended', callback);
+        } else {
+            this._element.onended = callback;
+        }
+    };
+
+    proto._unbindEnded = function () {
+        if (this._audioType === Audio.Type.DOM) {
+            this._element.removeEventListener('ended', this._onended);
+        } else {
+            this._element.onended = null;
+        }
+    };
+
+    proto.mount = function (elem) {
+        if (elem instanceof HTMLElement) {
+            this._element = document.createElement('audio');
+            this._element.src = elem.src;
+            this._audioType = Audio.Type.DOM;
+        } else {
+            this._element = new WebAudioElement(elem, this);
+            this._audioType = Audio.Type.WEBAUDIO;
+        }
+        this._bindEnded();
+        this._state = Audio.State.INITIALZING;
+        this._loaded = true;
+    };
+
+    proto.play = function () {
+        if (!this._element) return;
+        this._element.play();
+        this.emit('play');
+        this._state = Audio.State.PLAYING;
+
+        if (this._audioType === Audio.Type.DOM && this._element.paused) {
+            this.stop();
+            touchPlayList.push({ instance: this, offset: 0, audio: this._element });
+        }
+
+        if (touchBinded) return;
+        touchBinded = true;
+
+        // Listen to the touchstart body event and play the audio when necessary.
+        cc.game.canvas.addEventListener('touchstart', function () {
+            var item;
+            while (item = touchPlayList.pop()) {
+                item.audio.play(item.offset);
+            }
+        });
+    };
+
+    proto.pause = function () {
+        if (!this._element) return;
+        this._unbindEnded();
+        this._element.pause();
+        this.emit('pause');
+        this._state = Audio.State.PAUSED;
+    };
+
+    proto.resume = function () {
+        if (!this._element || this._element.currentTime === 0) return;
+        this._bindEnded();
+        this._element.play();
+        this.emit('resume');
+        this._state = Audio.State.PLAYING;
+    };
+
+    proto.stop = function () {
+        if (!this._element) return;
+        try {
+            this._element.currentTime = 0;
+        } catch (error) {}
+        this._element.pause();
+        // remove touchPlayList
+        for (var i=0; i<touchPlayList; i++) {
+            if (touchPlayList[i].instance === this) {
+                touchPlayList.splice(i, 1);
+                break;
+            }
+        }
+        this.emit('ended');
+        this.emit('stop');
+        this._state = Audio.State.PAUSED;
+    };
+
+    proto.setLoop = function (loop) {
+        if (!this._element) return;
+        this._element.loop = loop;
+    };
+    proto.getLoop = function () {
+        return this._element && this._element.loop;
+    };
+
+    proto.setVolume = function (num) {
+        if (!this._element) return;
+        this._element.volume = num;
+    };
+    proto.getVolume = function () {
+        return this._element ? this._element.volume : 1;
+    };
+
+    proto.setCurrentTime = function (num) {
+        if (!this._element) return;
+        this._unbindEnded();
+        this._bindEnded(function () {
+            this._bindEnded();
+        }.bind(this));
+        this._element.currentTime = num;
+    };
+    proto.getCurrentTime = function () {
+        return this._element ? this._element.currentTime : 0;
+    };
+
+    proto.getDuration = function () {
+        return this._element ? this._element.duration : 0;
+    };
+
+    proto.getState = function () {
+        var elem = this._element;
+        if (Audio.State.PLAYING === this._state && elem.paused) {
+            this._state = Audio.State.PAUSED;
+        }
+        return this._state;
+    };
+
+    proto.__defineGetter__('src', function () {
+        return this._src;
+    });
+    proto.__defineSetter__('src', function (string) {
+        return this._src = string;
+    });
+
+    // setFinishCallback
+
+})(Audio.prototype);
+
+// Encapsulated WebAudio interface
+var WebAudioElement = function (buffer, audio) {
+    this._audio = audio;
+    this._context = cc.sys.__audioSupport.context;
+    this._buffer = buffer;
+    this._volume = this._context['createGain']();
+    this._volume['gain'].value = 1;
+    this._volume['connect'](this._context['destination']);
     this._loop = false;
-
     // The time stamp on the audio time axis when the recording begins to play.
     this._startTime = -1;
     // Record the currently playing 'Source'
@@ -70,10 +264,86 @@ cc.Audio.WebAudio = function (buffer) {
     this._currextTimer = null;
 };
 
-cc.Audio.WebAudio.prototype = {
-    constructor: cc.Audio.WebAudio,
+(function (proto) {
+    proto.play = function (offset) {
+        // If repeat play, you need to stop before an audio
+        if (this._currentSource && !this.paused) {
+            this._currentSource.onended = null;
+            this._currentSource.stop(0);
+            this.playedLength = 0;
+        }
 
-    get paused () {
+        var audio = this._context["createBufferSource"]();
+        audio.buffer = this._buffer;
+        audio["connect"](this._volume);
+        audio.loop = this._loop;
+
+        this._startTime = this._context.currentTime;
+        offset = offset || this.playedLength;
+        if (offset) {
+            this._startTime -= offset;
+        }
+        var duration = this._buffer.duration;
+
+        var startTime = offset;
+        var endTime;
+        if (this._loop) {
+            if (audio.start)
+                audio.start(0, startTime);
+            else if (audio["notoGrainOn"])
+                audio["noteGrainOn"](0, startTime);
+            else
+                audio["noteOn"](0, startTime);
+        } else {
+            endTime = duration - offset;
+            if (audio.start)
+                audio.start(0, startTime, endTime);
+            else if (audio["notoGrainOn"])
+                audio["noteGrainOn"](0, startTime, endTime);
+            else
+                audio["noteOn"](0, startTime, endTime);
+        }
+
+        this._currentSource = audio;
+
+        audio.onended = function () {
+            if (this.onended) {
+                this.onended(this);
+            }
+        }.bind(this);
+
+        // If the current audio context time stamp is 0
+        // There may be a need to touch events before you can actually start playing audio
+        if (this._context.currentTime === 0) {
+            var self = this;
+            clearTimeout(this._currextTimer);
+            this._currextTimer = setTimeout(function () {
+                if (self._context.currentTime === 0) {
+                    touchPlayList.push({
+                        instance: self._audio,
+                        offset: offset,
+                        audio: self
+                    });
+                }
+            }, 10);
+        }
+    };
+
+    proto.pause = function () {
+        clearTimeout(this._currextTimer);
+        if (this.paused) return;
+        // Record the time the current has been played
+        this.playedLength = this._context.currentTime - this._startTime;
+        // If more than the duration of the audio, Need to take the remainder
+        this.playedLength %= this._buffer.duration;
+        var audio = this._currentSource;
+        this._currentSource = null;
+        this._startTime = -1;
+        if (audio)
+            audio.stop(0);
+    };
+
+    proto.__defineGetter__('paused', function () {
         // If the current audio is a loop, paused is false
         if (this._currentSource && this._currentSource.loop)
             return false;
@@ -83,634 +353,53 @@ cc.Audio.WebAudio.prototype = {
             return true;
 
         // Current time -  Start playing time > Audio duration
-        return this.context.currentTime - this._startTime > this.buffer.duration;
-    },
+        return this._context.currentTime - this._startTime > this._buffer.duration;
+    });
 
-    get loop () { return this._loop; },
-    set loop (bool) { return this._loop = bool; },
+    proto.__defineGetter__('loop', function () { return this._loop; });
+    proto.__defineSetter__('loop', function (bool) {
+        if (this._currentSource)
+            this._currentSource.loop = bool;
 
-    get volume () { return this._volume['gain'].value; },
-    set volume (num) { return this._volume['gain'].value = num; },
+        return this._loop = bool;
+    });
 
-    get currentTime () { return this.playedLength; },
-    set currentTime (num) { return this.playedLength = num; },
-
-    play: function (offset) {
-
-        // If repeat play, you need to stop before an audio
-        if (this._currentSource && !this.paused) {
-            this._currentSource.stop(0);
-            this.playedLength = 0;
+    proto.__defineGetter__('volume', function () { return this._volume['gain'].value; });
+    proto.__defineSetter__('volume', function (num) {
+        this._volume['gain'].value = num;
+        if (cc.sys.os === cc.sys.OS_IOS && !this.paused) {
+            // IOS must be stop webAudio
+            this.pause();
+            this.play();
         }
+        return num;
+    });
 
-        var audio = this.context["createBufferSource"]();
-        audio.buffer = this.buffer;
-        audio["connect"](this._volume);
-        audio.loop = this._loop;
-
-        this._startTime = this.context.currentTime;
-        offset = offset || this.playedLength;
-
-        var duration = this.buffer.duration;
-        if (!this._loop) {
-            if (audio.start)
-                audio.start(0, offset, duration - offset);
-            else if (audio["notoGrainOn"])
-                audio["noteGrainOn"](0, offset, duration - offset);
-            else
-                audio["noteOn"](0, offset, duration - offset);
-        } else {
-            if (audio.start)
-                audio.start(0);
-            else if (audio["notoGrainOn"])
-                audio["noteGrainOn"](0);
-            else
-                audio["noteOn"](0);
+    proto.__defineGetter__('currentTime', function () {
+        if (this.paused) {
+            return this.playedLength;
         }
-
-        this._currentSource = audio;
-
-        // If the current audio context time stamp is 0
-        // There may be a need to touch events before you can actually start playing audio
-        if (this.context.currentTime === 0) {
-            var self = this;
-            clearTimeout(this._currextTimer);
-            this._currextTimer = setTimeout(function () {
-                if (self.context.currentTime === 0) {
-                    cc.Audio.touchPlayList.push({
-                        offset: offset,
-                        audio: self
-                    });
-                }
-            }, 10);
-        }
-    },
-    pause: function () {
         // Record the time the current has been played
-        this.playedLength = this.context.currentTime - this._startTime;
+        this.playedLength = this._context.currentTime - this._startTime;
         // If more than the duration of the audio, Need to take the remainder
-        this.playedLength %= this.buffer.duration;
-        var audio = this._currentSource;
-        this._currentSource = null;
-        this._startTime = -1;
-        if (audio)
-            audio.stop(0);
-    }
-};
-
-JS.mixin(cc.Audio.prototype, {
-    setBuffer: function (buffer) {
-        this._AUDIO_TYPE = "WEBAUDIO";
-        this._element = new cc.Audio.WebAudio(buffer);
-    },
-
-    setElement: function (element) {
-        this._AUDIO_TYPE = "AUDIO";
-        this._element = element;
-
-        // Prevent partial browser from playing after the end does not reset the paused tag
-        element.addEventListener('ended', function () {
-            if (!element.loop) {
-                element.paused = true;
-            }
-        });
-    },
-
-    play: function (offset, loop) {
-        if (!this._element) return;
-        this._element.loop = loop;
-        this._element.play();
-
-        if (this._AUDIO_TYPE === 'AUDIO' && this._element.paused) {
-            this.stop();
-            cc.Audio.touchPlayList.push({ loop: loop, offset: offset, audio: this._element });
-        }
-
-        if (cc.Audio.bindTouch === false) {
-            cc.Audio.bindTouch = true;
-            // Listen to the touchstart body event and play the audio when necessary.
-            cc.game.canvas.addEventListener('touchstart', cc.Audio.touchStart);
-        }
-    },
-
-    getPlaying: function () {
-        if (!this._element) return true;
-        return !this._element.paused;
-    },
-
-    stop: function () {
-        if (!this._element) return;
-        this._element.pause();
-        try{
-            this._element.currentTime = 0;
-        } catch (err) {}
-    },
-
-    pause: function () {
-        if (!this._element) return;
-        this._element.pause();
-    },
-
-    resume: function () {
-        if (!this._element) return;
-        this._element.play();
-    },
-
-    setVolume: function (volume) {
-        if (!this._element) return;
-        this._element.volume = volume;
-    },
-
-    getVolume: function () {
-        if (!this._element) return;
-        return this._element.volume;
-    },
-
-    cloneNode: function () {
-        var audio = new cc.Audio(this.src);
-        if (this._AUDIO_TYPE === "AUDIO") {
-            var elem = document.createElement("audio");
-            var sources = elem.getElementsByTagName('source');
-            for (var i=0; i<sources.length; i++) {
-                elem.appendChild(sources[i]);
-            }
-            elem.src = this.src;
-            audio.setElement(elem);
+        this.playedLength %= this._buffer.duration;
+        return this.playedLength;
+    });
+    proto.__defineSetter__('currentTime', function (num) {
+        if (!this.paused) {
+            this.pause();
+            this.playedLength = num;
+            this.play();
         } else {
-            audio.setBuffer(this._element.buffer);
+            this.playedLength = num;
         }
-        return audio;
-    }
-});
+        return num;
+    });
 
-(function(polyfill){
+    proto.__defineGetter__('duration', function () {
+        return this._buffer.duration;
+    });
 
-    var SWA = polyfill.WEB_AUDIO, SWB = polyfill.ONLY_ONE;
+})(WebAudioElement.prototype);
 
-    /**
-     * !#en cc.audioEngine is the singleton object, it provide simple audio APIs.
-     * !#zh
-     * cc.audioengine是单例对象。<br/>
-     * 主要用来播放背景音乐和音效，背景音乐同一时间只能播放一个，而音效则可以同时播放多个。<br/>
-     * 注意：<br/>
-     * 在 Android 系统浏览器上，不同浏览器，不同版本的效果不尽相同。<br/>
-     * 比如说：大多数浏览器都需要用户物理交互才可以开始播放音效，有一些不支持 WebAudio，<br/>
-     * 有一些不支持多音轨播放。总之如果对音乐依赖比较强，请做尽可能多的测试。
-     * @class audioEngine
-     * @static
-     */
-    cc.audioEngine = {
-        _currMusic: null,
-        _musicVolume: 1,
-
-        features: polyfill,
-
-        /**
-         * !#en Play music.
-         * !#zh
-         * 播放指定音乐，并可以设置是否循环播放。<br/>
-         * 注意：音乐播放接口不支持多音轨，同一时间只能播放一个音乐。
-         * @method playMusic
-         * @param {String} url - The path of the music file without filename extension.
-         * @param {Boolean} loop - Whether the music loop or not.
-         * @example
-         * //example
-         * cc.audioEngine.playMusic(path, false);
-         */
-        playMusic: function(url, loop){
-            var bgMusic = this._currMusic;
-            if (bgMusic && bgMusic.getPlaying()) {
-                bgMusic.stop();
-            }
-            var item = cc.loader.getItem(url);
-            var audio = item && item.audio ? item.audio : null;
-            if (!audio) {
-                var self = this;
-                cc.loader.load(url, function (error) {
-                    if (!error) {
-                        var item = cc.loader.getItem(url);
-                        var audio = item && item.audio ? item.audio : null;
-                        audio.play(0, loop || false);
-                        audio.setVolume(self._musicVolume);
-                        self._currMusic = audio;
-                    }
-                });
-                item = cc.loader.getItem(url);
-                return item && item.audio ? item.audio : null;
-            }
-            audio.play(0, loop);
-            audio.setVolume(this._musicVolume);
-
-            this._currMusic = audio;
-            return audio;
-        },
-
-        /**
-         * !#en Stop playing music.
-         * !#zh 停止当前音乐。
-         * @method stopMusic
-         * @param {Boolean} [releaseData] - If release the music data or not.As default value is false.
-         * @example
-         * //example
-         * cc.audioEngine.stopMusic();
-         */
-        stopMusic: function(releaseData){
-            var audio = this._currMusic;
-            if (audio) {
-                audio.stop();
-                if (releaseData)
-                    cc.loader.release(audio.src);
-            }
-        },
-
-        /**
-         * !#en Pause playing music.
-         * !#zh 暂停正在播放音乐。
-         * @method pauseMusic
-         * @example
-         * //example
-         * cc.audioEngine.pauseMusic();
-         */
-        pauseMusic: function(){
-            var audio = this._currMusic;
-            if (audio)
-                audio.pause();
-        },
-
-        /**
-         * !#en Resume playing music.
-         * !#zh 恢复音乐播放。
-         * @method resumeMusic
-         * @example
-         * //example
-         * cc.audioEngine.resumeMusic();
-         */
-        resumeMusic: function(){
-            var audio = this._currMusic;
-            if (audio)
-                audio.resume();
-        },
-
-        /**
-         * !#en Rewind playing music.
-         * !#zh 从头开始重新播放当前音乐。
-         * @method rewindMusic
-         * @example
-         * //example
-         * cc.audioEngine.rewindMusic();
-         */
-        rewindMusic: function(){
-            var audio = this._currMusic;
-            if (audio) {
-                audio.stop();
-                audio.play();
-            }
-        },
-
-        /**
-         * !#en The volume of the music max value is 1.0,the min value is 0.0 .
-         * !#zh 获取音量（0.0 ~ 1.0）。
-         * @method getMusicVolume
-         * @return {Number}
-         * @example
-         * //example
-         * var volume = cc.audioEngine.getMusicVolume();
-         */
-        getMusicVolume: function(){
-            return this._musicVolume;
-        },
-
-        /**
-         * !#en Set the volume of music.
-         * !#zh 设置音量（0.0 ~ 1.0）。
-         * @method setMusicVolume
-         * @param {Number} volume Volume must be in 0.0~1.0 .
-         * @example
-         * //example
-         * cc.audioEngine.setMusicVolume(0.5);
-         */
-        setMusicVolume: function(volume){
-            volume = volume - 0;
-            if (isNaN(volume)) volume = 1;
-            if (volume > 1) volume = 1;
-            if (volume < 0) volume = 0;
-
-            this._musicVolume = volume;
-            var audio = this._currMusic;
-            if (audio) {
-                audio.setVolume(volume);
-            }
-        },
-
-        /**
-         * !#en Whether the music is playing.
-         * !#zh 音乐是否正在播放。
-         * @method isMusicPlaying
-         * @return {Boolean} If is playing return true,or return false.
-         * @example
-         * //example
-         *  if (cc.audioEngine.isMusicPlaying()) {
-         *      cc.log("music is playing");
-         *  }
-         *  else {
-         *      cc.log("music is not playing");
-         *  }
-         */
-        isMusicPlaying: function(){
-            var audio = this._currMusic;
-            if (audio) {
-                return audio.getPlaying();
-            } else {
-                return false;
-            }
-        },
-
-        _audioPool: {},
-        _maxAudioInstance: 10,
-        _effectVolume: 1,
-        /**
-         * !#en Play sound effect.
-         * !#zh
-         * 播放指定音效，并可以设置是否循环播放。<br/>
-         * 注意：在部分不支持多音轨的浏览器上，这个接口会失效，请使用 playMusic
-         * @method playEffect
-         * @param {String} url The path of the sound effect with filename extension.
-         * @param {Boolean} loop Whether to loop the effect playing, default value is false
-         * @param {Boolean} volume
-         * @return {Number|null} the audio id
-         * @example
-         * //example
-         * var soundId = cc.audioEngine.playEffect(path);
-         */
-        playEffect: function(url, loop, volume){
-            volume = volume === undefined ? this._effectVolume : volume;
-
-            // 如果只能够播放一个音频，则优先保证背景音乐
-            if (SWB && this._currMusic && this._currMusic.getPlaying()) {
-                cc.log('Browser is only allowed to play one audio');
-                return null;
-            }
-
-            var effectList = this._audioPool[url];
-            if (!effectList) {
-                effectList = this._audioPool[url] = [];
-            }
-
-            var i;
-            for(i = 0; i < effectList.length; i++){
-                if (!effectList[i].getPlaying()) {
-                    break;
-                }
-            }
-
-            if (!SWA && i > this._maxAudioInstance) {
-                var first = effectList.shift();
-                first.stop();
-                effectList.push(first);
-                i = effectList.length - 1;
-                // cc.log("Error: %s greater than %d", url, this._maxAudioInstance);
-            }
-
-            var audio;
-            if (effectList[i]) {
-                audio = effectList[i];
-                audio.setVolume(volume);
-                audio.play(0, loop || false);
-                return audio;
-            }
-
-            var item = cc.loader.getItem(url);
-            audio = item && item.audio ? item.audio : null;
-            if (SWA && audio && audio._AUDIO_TYPE != "WEBAUDIO") {
-                //delete cc.loader.getRes(url);
-                cc.loader.release(url);
-                audio = null;
-            }
-
-            if (!audio) {
-                // Force using webaudio for effects
-                cc.Audio.useWebAudio = true;
-                audio = new cc.Audio(url);
-                cc.loader.load(url, function (error, url) {
-                    if (error) return;
-                    var item = cc.loader.getItem(url);
-                    var loadAudio = item && item.audio ? item.audio : null;
-
-                    if (loadAudio._AUDIO_TYPE === 'WEBAUDIO')
-                        audio.setBuffer(loadAudio._element.buffer);
-                    else
-                        audio.setElement(loadAudio._element);
-
-                    audio.setVolume(volume);
-                    audio.play(0, loop || false);
-                    effectList.push(audio);
-                });
-                cc.Audio.useWebAudio = false;
-                return audio;
-            }
-
-            audio = audio.cloneNode();
-            audio.setVolume(volume);
-            audio.play(0, loop || false);
-            effectList.push(audio);
-
-            return audio;
-        },
-
-        /**
-         * !#en Set the volume of sound effects.
-         * !#zh 设置音效音量（0.0 ~ 1.0）。
-         * @method setEffectsVolume
-         * @param {Number} volume Volume must be in 0.0~1.0 .
-         * @example
-         * //example
-         * cc.audioEngine.setEffectsVolume(0.5);
-         */
-        setEffectsVolume: function(volume){
-            volume = volume - 0;
-            if(isNaN(volume)) volume = 1;
-            if(volume > 1) volume = 1;
-            if(volume < 0) volume = 0;
-
-            this._effectVolume = volume;
-            var audioPool = this._audioPool;
-            for(var p in audioPool){
-                var audioList = audioPool[p];
-                if(Array.isArray(audioList))
-                    for(var i=0; i<audioList.length; i++){
-                        audioList[i].setVolume(volume);
-                    }
-            }
-        },
-
-        /**
-         * !#en The volume of the effects max value is 1.0,the min value is 0.0 .
-         * !#zh 获取音效音量（0.0 ~ 1.0）。
-         * @method getEffectsVolume
-         * @return {Number}
-         * @example
-         * //example
-         * var effectVolume = cc.audioEngine.getEffectsVolume();
-         */
-        getEffectsVolume: function(){
-            return this._effectVolume;
-        },
-
-        /**
-         * !#en Pause playing sound effect.
-         * !#zh 暂停指定的音效。
-         * @method pauseEffect
-         * @param {Number} audio - The return value of function playEffect.
-         * @example
-         * //example
-         * cc.audioEngine.pauseEffect(audioID);
-         */
-        pauseEffect: function(audio){
-            if(audio){
-                audio.pause();
-            }
-        },
-
-        /**
-         * !#en Pause all playing sound effect.
-         * !#zh 暂停现在正在播放的所有音效。
-         * @method pauseAllEffects
-         * @example
-         * //example
-         * cc.audioEngine.pauseAllEffects();
-         */
-        pauseAllEffects: function(){
-            var ap = this._audioPool;
-            for(var p in ap){
-                var list = ap[p];
-                for(var i=0; i<ap[p].length; i++){
-                    if(list[i].getPlaying()){
-                        list[i].pause();
-                    }
-                }
-            }
-        },
-
-        /**
-         * !#en Resume playing sound effect.
-         * !#zh 恢复播放指定的音效。
-         * @method resumeEffect
-         * @param {Number} audioID - The return value of function playEffect.
-         * @audioID
-         * //example
-         * cc.audioEngine.resumeEffect(audioID);
-         */
-        resumeEffect: function(audio){
-            if(audio)
-                audio.resume();
-        },
-
-        /**
-         * !#en Resume all playing sound effect.
-         * !#zh 恢复播放所有之前暂停的所有音效。
-         * @method resumeAllEffects
-         * @example
-         * //example
-         * cc.audioEngine.resumeAllEffects();
-         */
-        resumeAllEffects: function(){
-            var ap = this._audioPool;
-            for(var p in ap){
-                var list = ap[p];
-                for(var i=0; i<ap[p].length; i++){
-                    list[i].resume();
-                }
-            }
-        },
-
-        /**
-         * !#en Stop playing sound effect.
-         * !#zh 停止播放指定音效。
-         * @method stopEffect
-         * @param {Number} audioID - The return value of function playEffect.
-         * @example
-         * //example
-         * cc.audioEngine.stopEffect(audioID);
-         */
-        stopEffect: function(audio){
-            if(audio)
-                audio.stop();
-        },
-
-        /**
-         * !#en Stop all playing sound effects.
-         * !#zh 停止正在播放的所有音效。
-         * @method stopAllEffects
-         * @example
-         * //example
-         * cc.audioEngine.stopAllEffects();
-         */
-        stopAllEffects: function(){
-            var ap = this._audioPool;
-            for(var p in ap){
-                var list = ap[p];
-                for(var i=0; i<ap[p].length; i++){
-                    list[i].stop();
-                }
-            }
-        },
-
-        /**
-         * !#en Unload the preloaded effect from internal buffer.
-         * !#zh 卸载预加载的音效。
-         * @method unloadEffect
-         * @param {String} url
-         * @example
-         * //example
-         * cc.audioEngine.unloadEffect(EFFECT_FILE);
-         */
-        unloadEffect: function(url){
-            if(!url){
-                return;
-            }
-
-            cc.loader.release(url);
-            var pool = this._audioPool[url];
-            if(pool) pool.length = 0;
-            delete this._audioPool[url];
-        },
-
-        /**
-         * !#en End music and effects.
-         * !#zh 停止所有音乐和音效的播放。
-         * @method end
-         */
-        end: function(){
-            this.stopMusic();
-            this.stopAllEffects();
-        },
-
-        _pauseCache: [],
-        _pausePlaying: function(){
-            var bgMusic = this._currMusic;
-            if(bgMusic && bgMusic.getPlaying()){
-                bgMusic.pause();
-                this._pauseCache.push(bgMusic);
-            }
-            var ap = this._audioPool;
-            for(var p in ap){
-                var list = ap[p];
-                for(var i=0; i<ap[p].length; i++){
-                    if(list[i].getPlaying()){
-                        list[i].pause();
-                        this._pauseCache.push(list[i]);
-                    }
-                }
-            }
-        },
-
-        _resumePlaying: function(){
-            var list = this._pauseCache;
-            for(var i=0; i<list.length; i++){
-                list[i].resume();
-            }
-            list.length = 0;
-        }
-    };
-
-})(cc.sys.__audioSupport);
+module.exports = cc.Audio =  Audio;

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -1,0 +1,527 @@
+/****************************************************************************
+ Copyright (c) 2008-2010 Ricardo Quesada
+ Copyright (c) 2011-2012 cocos2d-x.org
+ Copyright (c) 2013-2014 Chukong Technologies Inc.
+
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+var Audio = require('./CCAudio');
+
+var instanceId = 0;
+var id2audio = {};
+var url2id = {};
+
+var getAudioFromPath = function (path) {
+    var id = instanceId++;
+    var list = url2id[path];
+    if (!list) {
+        list = url2id[path] = [];
+    }
+    var audio;
+    if (audioEngine._maxAudioInstance <= list.length) {
+        var oldId = list.shift();
+        var oldAudio = id2audio[oldId];
+        oldAudio.stop();
+    }
+
+    audio = new Audio(path);
+    audio.on('ended', function () {
+        var id = this.instanceId;
+        delete id2audio[id];
+        var index = list.indexOf(id);
+        cc.js.array.removeAt(list, index);
+    });
+    id2audio[id] = audio;
+
+    audio.instanceId = id;
+    list.push(id);
+
+    return audio;
+};
+
+var getAudioFromId = function (id) {
+    return id2audio[id];
+};
+
+/**
+ * !#en cc.audioEngine is the singleton object, it provide simple audio APIs.
+ * !#zh
+ * cc.audioengine是单例对象。<br/>
+ * 主要用来播放音频，播放的时候会返回一个 audioID，之后都可以通过这个 audioID 来操作这个音频对象。<br/>
+ * 不使用的时候，请使用 cc.audioEngine.uncache(filePath); 进行资源释放 <br/>
+ * 注意：<br/>
+ * 在 Android 系统浏览器上，不同浏览器，不同版本的效果不尽相同。<br/>
+ * 比如说：大多数浏览器都需要用户物理交互才可以开始播放音效，有一些不支持 WebAudio，<br/>
+ * 有一些不支持多音轨播放。总之如果对音乐依赖比较强，请做尽可能多的测试。
+ * @class audioEngine
+ * @static
+ */
+var audioEngine = {
+
+    AudioState: Audio.State,
+
+    _maxWebAudioSize: 2097152, // 2048kb * 1024
+    _maxAudioInstance: 24,
+
+    _id2audio: id2audio,
+
+    /**
+     * !#en Play audio.
+     * !#zh 播放音频
+     * @method play
+     * @param {String} filePath - The path of the audio file without filename extension.
+     * @param {Boolean} loop - Whether the music loop or not.
+     * @param {Number} volume - Volume size.
+     * @return {Number} audioId
+     * @example
+     * //example
+     * var audioID = cc.audioEngine.play(path, false, 0.5);
+     */
+    play: function (filePath, loop, volume/*, profile*/) {
+        var audio = getAudioFromPath(filePath);
+        var callback = function () {
+            audio.setLoop(loop || false);
+            audio.setVolume(volume || 1);
+            audio.play();
+        };
+        audio.__callback = callback;
+        audio.on('load', callback);
+        audio.preload();
+
+        return audio.instanceId;
+    },
+
+    /**
+     * !#en Set audio loop.
+     * !#zh 设置音频是否循环。
+     * @method setLoop
+     * @param {Number} audioID - audio id.
+     * @param {Boolean} loop - Whether cycle.
+     * @example
+     * //example
+     * cc.audioEngine.setLoop(id, true);
+     */
+    setLoop: function (audioID, loop) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.setLoop)
+            return;
+        audio.setLoop(loop);
+    },
+
+    /**
+     * !#en Get audio cycle state.
+     * !#zh 获取音频的循环状态。
+     * @method isLoop
+     * @param {Number} audioID - audio id.
+     * @return {Boolean} Whether cycle.
+     * @example
+     * //example
+     * cc.audioEngine.isLoop(id);
+     */
+    isLoop: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.isLoop)
+            return false;
+        return audio.isLoop();
+    },
+
+    /**
+     * !#en Set the volume of audio.
+     * !#zh 设置音量（0.0 ~ 1.0）。
+     * @method setVolume
+     * @param {Number} audioID audio id.
+     * @param {Number} volume Volume must be in 0.0~1.0 .
+     * @example
+     * //example
+     * cc.audioEngine.setVolume(id, 0.5);
+     */
+    setVolume: function (audioID, volume) {
+        var audio = getAudioFromId(audioID);
+        if (!audio) return;
+        if (!audio._loaded) {
+            audio.once('load', function () {
+                if (audio.setVolume)
+                    audio.setVolume(volume);
+            });
+        }
+        if (audio.setVolume)
+            audio.setVolume(volume);
+    },
+
+    /**
+     * !#en The volume of the music max value is 1.0,the min value is 0.0 .
+     * !#zh 获取音量（0.0 ~ 1.0）。
+     * @method getVolume
+     * @param {Number} audioID audio id.
+     * @return {Boolean}
+     * @example
+     * //example
+     * var volume = cc.audioEngine.getVolume(id);
+     */
+    getVolume: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.getVolume)
+            return 1;
+        return audio.getVolume();
+    },
+
+    /**
+     * !#en Set current time
+     * !#zh 设置当前的音频时间。
+     * @method setCurrentTime
+     * @param {Number} audioID audio id.
+     * @param {Number} sec current time.
+     * @return {Boolean}
+     * @example
+     * //example
+     * cc.audioEngine.setCurrentTime(id, 2);
+     */
+    setCurrentTime: function (audioID, sec) {
+        var audio = getAudioFromId(audioID);
+        if (!audio) return false;
+        if (!audio._loaded) {
+            audio.once('load', function () {
+                if (audio.setCurrentTime)
+                    audio.setCurrentTime(sec);
+            });
+            return true;
+        }
+        if (audio.setCurrentTime)
+            audio.setCurrentTime(sec);
+        return true;
+    },
+
+    /**
+     * !#en Get current time
+     * !#zh 获取当前的音频播放时间。
+     * @method getCurrentTime
+     * @param {Number} audioID audio id.
+     * @return {Number} audio current time.
+     * @example
+     * //example
+     * var time = cc.audioEngine.getCurrentTime(id);
+     */
+    getCurrentTime: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.getCurrentTime)
+            return 0;
+        return audio.getCurrentTime();
+    },
+
+    /**
+     * !#en Get audio duration
+     * !#zh 获取音频总时长。
+     * @method getDuration
+     * @param {Number} audioID audio id.
+     * @return {Number} audio duration.
+     * @example
+     * //example
+     * var time = cc.audioEngine.getDuration(id);
+     */
+    getDuration: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.getDuration)
+            return 0;
+        return audio.getDuration();
+    },
+
+    /**
+     * !#en Get audio state
+     * !#zh 获取音频状态。
+     * @method getState
+     * @param {Number} audioID audio id.
+     * @return {audioEngine.AudioState} audio duration.
+     * @example
+     * //example
+     * var state = cc.audioEngine.getState(id);
+     */
+    getState: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.getState)
+            return this.AudioState.ERROR;
+        return audio.getState();
+    },
+
+    /**
+     * !#en Get audio state
+     * !#zh 获取音频状态。
+     * @method getState
+     * @param {Number} audioID audio id.
+     * @param {Function} callback loaded callback.
+     * @example
+     * //example
+     * cc.audioEngine.setFinishCallback(id, function () {});
+     */
+    setFinishCallback: function (audioID, callback) {
+        var audio = getAudioFromId(audioID);
+        if (!audio)
+            return;
+
+        audio.off('ended');
+        audio.on('ended', callback);
+    },
+
+    /**
+     * !#en Pause playing audio.
+     * !#zh 暂停正在播放音频。
+     * @method pause
+     * @param {Number} audioID - The return value of function play.
+     * @example
+     * //example
+     * cc.audioEngine.pause(audioID);
+     */
+    pause: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.pause)
+            return false;
+        audio.pause();
+        return true;
+    },
+
+    _pauseIDCache: [],
+    /**
+     * !#en Pause all playing audio
+     * !#zh 暂停现在正在播放的所有音频。
+     * @method pauseAll
+     * @example
+     * //example
+     * cc.audioEngine.pauseAll();
+     */
+    pauseAll: function () {
+        for (var id in id2audio) {
+            var audio = id2audio[id];
+            var state = audio.getState();
+            if (state === Audio.State.PLAYING) {
+                this._pauseIDCache.push(id);
+                audio.pause();
+            }
+        }
+    },
+
+    /**
+     * !#en Resume playing audio.
+     * !#zh 恢复播放指定的音频。
+     * @method resume
+     * @param {Number} audioID - The return value of function play.
+     * //example
+     * cc.audioEngine.resume(audioID);
+     */
+    resume: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.resume)
+            return false;
+        if (audio.getCurrentTime() === 0) {
+            audio.play();
+        } else {
+            audio.resume();
+        }
+    },
+
+    /**
+     * !#en Resume all playing audio.
+     * !#zh 恢复播放所有之前暂停的所有音频。
+     * @method resumeAll
+     * @example
+     * //example
+     * cc.audioEngine.resumeAll();
+     */
+    resumeAll: function () {
+        while (this._pauseIDCache.length > 0) {
+            var id = this._pauseIDCache.pop();
+            var audio = getAudioFromId(id);
+            if (audio && audio.resume)
+                audio.resume();
+        }
+    },
+
+    /**
+     * !#en Stop playing audio.
+     * !#zh 停止播放指定音频。
+     * @method stop
+     * @param {Number} audioID - The return value of function play.
+     * @example
+     * //example
+     * cc.audioEngine.stop(audioID);
+     */
+    stop: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (!audio || !audio.stop)
+            return false;
+        audio.off('load', audio.__callback);
+        audio.stop();
+        audio.emit('ended');
+        return true;
+    },
+
+    /**
+     * !#en Stop all playing audio.
+     * !#zh 停止正在播放的所有音频。
+     * @method stopAll
+     * @example
+     * //example
+     * cc.audioEngine.stopAll();
+     */
+    stopAll: function () {
+        for (var id in id2audio) {
+            var audio = id2audio[id];
+            if (audio && audio.stop) {
+                audio.stop();
+                audio.off('load', audio.__callback);
+                audio.emit('ended');
+            }
+        }
+    },
+
+    /**
+     * !#en Set up an audio can generate a few examples.
+     * !#zh 设置一个音频可以设置几个实例
+     * @method setMaxAudioInstance
+     * @param {Number} num a number of instances to be created from within an audio
+     * @example
+     * //example
+     * cc.audioEngine.setMaxAudioInstance(20);
+     */
+    setMaxAudioInstance: function (num) {
+        return this._maxAudioInstance = num;
+    },
+
+    /**
+     * !#en Getting audio can produce several examples.
+     * !#zh 获取一个音频可以设置几个实例
+     * @method getMaxAudioInstance
+     * @return {Number} a number of instances to be created from within an audio
+     * @example
+     * //example
+     * cc.audioEngine.getMaxAudioInstance();
+     */
+    getMaxAudioInstance: function () {
+        return this._maxAudioInstance;
+    },
+
+    /**
+     * !#en Unload the preloaded audio from internal buffer.
+     * !#zh 卸载预加载的音频。
+     * @method uncache
+     * @param {String} filePath
+     * @example
+     * //example
+     * cc.audioEngine.uncache(filePath);
+     */
+    uncache: function (filePath) {
+        var list = url2id[filePath];
+        if (!list) return;
+        while (list.length > 0) {
+            var id = list.pop();
+            var audio = id2audio[id];
+            if (audio) {
+                audio.stop();
+                delete id2audio[id];
+            }
+        }
+    },
+
+    /**
+     * !#en Unload all audio from internal buffer.
+     * !#zh 卸载所有音频。
+     * @method uncacheAll
+     * @example
+     * //example
+     * cc.audioEngine.uncacheAll();
+     */
+    uncacheAll: function () {
+        this.stopAll();
+        id2audio = {};
+        url2id = {};
+    },
+
+    /**
+     * !#en Gets an audio profile by name.
+     *
+     * @param profileName A name of audio profile.
+     * @return The audio profile.
+     */
+    getProfile: function (profileName) {},
+
+    /**
+     * !#en Preload audio file.
+     * !#zh 预加载一个音频
+     * @param filePath The file path of an audio.
+     * @param callback The callback of an audio.
+     * @method preload
+     * @example
+     * //example
+     * cc.audioEngine.preload(path);
+     */
+    preload: function (filePath, callback) {
+        cc.loader.load(filePath, function (error) {
+            if (!error) {
+                callback();
+            }
+        });
+    },
+
+    /**
+     * !#en Set a size, the unit is KB，Over this size is directly resolved into DOM nodes
+     * !#zh 设置一个以kb为单位的尺寸，大于这个尺寸的音频在加载的时候会强制使用 dom 方式加载
+     * @param kb The file path of an audio.
+     * @method setMaxWebAudioSize
+     * @example
+     * //example
+     * cc.audioEngine.setMaxWebAudioSize(300);
+     */
+    // Because webAudio takes up too much memory，So allow users to manually choose
+    setMaxWebAudioSize: function (kb) {
+        this._maxWebAudioSize = kb * 1024;
+    },
+
+    _breakCache: null,
+    _break: function () {
+        this._breakCache = [];
+        for (var id in id2audio) {
+            var audio = id2audio[id];
+            var state = audio.getState();
+            if (state === Audio.State.PLAYING) {
+                this._breakCache.push(id);
+                audio.pause();
+            }
+        }
+    },
+
+    _restore: function () {
+        if (!this._breakCache) return;
+
+        while (this._breakCache.length > 0) {
+            var id = this._breakCache.pop();
+            var audio = getAudioFromId(id);
+            if (audio && audio.resume)
+                audio.resume();
+        }
+        this._breakCache = null;
+    }
+};
+
+module.exports = cc.audioEngine = audioEngine;
+
+// deprecated
+var Module = require('./deprecated');
+Module.removed(audioEngine);
+Module.deprecated(audioEngine);

--- a/cocos2d/audio/deprecated.js
+++ b/cocos2d/audio/deprecated.js
@@ -1,0 +1,238 @@
+/****************************************************************************
+ Copyright (c) 2008-2010 Ricardo Quesada
+ Copyright (c) 2011-2012 cocos2d-x.org
+ Copyright (c) 2013-2014 Chukong Technologies Inc.
+
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+var js = cc.js;
+var INFO = cc._LogInfos.deprecated;
+
+exports.removed = function (audioEngine) {
+	function willPlayMusicError () {
+		cc.error('Sorry, cc.audioEngine.willPlayMusic is removed.');
+	}
+	js.getset(audioEngine, 'willPlayMusic', willPlayMusicError, willPlayMusicError);
+};
+
+exports.deprecated = function (audioEngine) {
+	
+	var musicId = -1;
+	var musicPath = 1;
+	var musicLoop = 1;
+	var musicVolume = 1;
+	var effectsVolume = 1;
+	var pauseIDCache = [];
+	js.get(audioEngine, 'playMusic', function () {
+		// cc.warn(INFO, 'audioEngine.playMusic', 'audioEngine.play');
+		return function (url, loop) {
+			audioEngine.stop(musicId);
+			musicId = audioEngine.play(url, loop, musicVolume);
+			musicPath = url;
+			musicLoop = loop;
+			return musicId;
+		}
+	});
+	js.get(audioEngine, 'stopMusic', function () {
+		// cc.warn(INFO, 'audioEngine.stopMusic', 'audioEngine.stop');
+		return function () {
+			audioEngine.stop(musicId);
+			return musicId;
+		}
+	});
+	js.get(audioEngine, 'pauseMusic', function () {
+		// cc.warn(INFO, 'audioEngine.pauseMusic', 'audioEngine.pause');
+		return function () {
+			audioEngine.pause(musicId);
+			return musicId;
+		}
+	});
+	js.get(audioEngine, 'resumeMusic', function () {
+		// cc.warn(INFO, 'audioEngine.resumeMusic', 'audioEngine.resume');
+		return function () {
+			audioEngine.resume(musicId);
+			return musicId;
+		}
+	});
+	js.get(audioEngine, 'rewindMusic', function () {
+		// cc.warn(INFO, 'audioEngine.rewindMusic', 'audioEngine.setCurrentTime');
+		return function () {
+			audioEngine.setCurrentTime(musicId, 0);
+			return musicId;
+		}
+	});
+	js.get(audioEngine, 'getMusicVolume', function () {
+		// cc.warn(INFO, 'audioEngine.getMusicVolume', 'audioEngine.getVolume');
+		return function () {
+			return musicVolume;
+		}
+	});
+	js.get(audioEngine, 'setMusicVolume', function () {
+		// cc.warn(INFO, 'audioEngine.setMusicVolume', 'audioEngine.setVolume');
+		return function (volume) {
+			musicVolume = volume;
+			audioEngine.setVolume(musicId, musicVolume);
+			return musicVolume;
+		}
+	});
+	js.get(audioEngine, 'isMusicPlaying', function () {
+		// cc.warn(INFO, 'audioEngine.isMusicPlaying', 'audioEngine.getState');
+		return function () {
+			return audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING;
+		}
+	});
+	js.get(audioEngine, 'playEffect', function () {
+		// cc.warn(INFO, 'audioEngine.playEffect', 'audioEngine.play');
+
+		return function (url, loop, volume) {
+			return audioEngine.play(url, loop, volume === undefined ? effectsVolume : volume);
+		}
+	});
+	js.get(audioEngine, 'setEffectsVolume', function (volume) {
+		// cc.warn(INFO, 'audioEngine.setEffectsVolume', 'audioEngine.setVolume');
+		return function (volume) {
+			effectsVolume = volume;
+			var id2audio = audioEngine._id2audio;
+			for (var id in id2audio) {
+				if (id === musicId) continue;
+				audioEngine.setVolume(id, volume);
+			}
+		}
+	});
+	js.get(audioEngine, 'getEffectsVolume', function () {
+		// cc.warn(INFO, 'audioEngine.getEffectsVolume', 'audioEngine.getVolume');
+		return function () {
+			return effectsVolume;
+		}
+	});
+	js.get(audioEngine, 'pauseEffect', function () {
+		// cc.warn(INFO, 'audioEngine.pauseEffect', 'audioEngine.pause');
+
+		return function (id) {
+			return audioEngine.pause(id);
+		}
+	});
+	js.get(audioEngine, 'pauseAllEffects', function () {
+		// cc.warn(INFO, 'audioEngine.pauseAllEffects', 'audioEngine.pauseAll');
+
+		if (CC_JSB) {
+			return function () {
+				var musicPlay = audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING;
+				audioEngine.pauseAll();
+				if (musicPlay) {
+					audioEngine.resume(musicId);
+				}
+			}
+		}
+
+		return function () {
+			pauseIDCache.length = 0;
+			var id2audio = audioEngine._id2audio;
+			for (var id in id2audio) {
+				if (id === musicId) continue;
+				var audio = id2audio[id];
+				var state = audio.getState();
+				if (state === audioEngine.AudioState.PLAYING) {
+					pauseIDCache.push(id);
+					audio.pause();
+				}
+			}
+		}
+	});
+	js.get(audioEngine, 'resumeEffect', function () {
+		// cc.warn(INFO, 'audioEngine.resumeEffect', 'audioEngine.resume');
+		return function (id) {
+			audioEngine.resume(id);
+		}
+	});
+	js.get(audioEngine, 'resumeAllEffects', function () {
+		// cc.warn(INFO, 'audioEngine.resumeEffect', 'audioEngine.resume');
+
+		if (CC_JSB) {
+			return function () {
+				var musicPaused = audioEngine.getState(musicId) === audioEngine.AudioState.PAUSED;
+				audioEngine.resumeAll();
+				if (musicPaused && audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING) {
+					audioEngine.pause(musicId);
+				}
+			};
+		}
+
+		return function () {
+			var id2audio = audioEngine._id2audio;
+			while (pauseIDCache.length > 0) {
+				var id = pauseIDCache.pop();
+				var audio = id2audio[id];
+				if (audio && audio.resume)
+					audio.resume();
+			}
+		}
+	});
+	js.get(audioEngine, 'stopEffect', function () {
+		// cc.warn(INFO, 'audioEngine.stopEffect', 'audioEngine.stop');
+		return function (id) {
+			return audioEngine.stop(id);
+		}
+	});
+	js.get(audioEngine, 'stopAllEffects', function () {
+		// cc.warn(INFO, 'audioEngine.stopAllEffects', 'audioEngine.stopAll');
+
+		if (CC_JSB) {
+			return function () {
+				var musicPlay = audioEngine.getState(musicId) === audioEngine.AudioState.PLAYING;
+				var currentTime = audioEngine.getCurrentTime(musicId);
+				audioEngine.stopAll();
+				if (musicPlay) {
+					musicId = audioEngine.play(musicPath, musicLoop);
+					audioEngine.setCurrentTime(currentTime);
+				}
+			}
+		}
+
+		return function () {
+			var id2audio = audioEngine._id2audio;
+			for (var id in id2audio) {
+				if (id === musicId) continue;
+				var audio = id2audio[id];
+				var state = audio.getState();
+				if (state === audioEngine.AudioState.PLAYING) {
+					audio.stop();
+				}
+			}
+		}
+	});
+	js.get(audioEngine, 'unloadEffect', function () {
+		// cc.warn(INFO, 'audioEngine.unloadEffect', 'audioEngine.stop');
+		return function (id) {
+			return audioEngine.stop(id);
+		}
+	});
+
+	if (!CC_JSB) {
+		js.get(audioEngine, 'end', function () {
+			// cc.warn(INFO, 'audioEngine.end', 'audioEngine.stopAll');
+			return function () {
+				return audioEngine.stopAll();
+			}
+		});
+	}
+};

--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -29,7 +29,7 @@ if (!(CC_EDITOR && Editor.isMainProcess)) {
     View = require('./platform/CCView');
 }
 
-var _isMusicPlaying = false;
+require('../audio/CCAudioEngine');
 
 /**
  * !#en An object to boot the game.
@@ -254,9 +254,7 @@ var game = {
         this._paused = true;
         // Pause audio engine
         if (cc.audioEngine) {
-            _isMusicPlaying = cc.audioEngine.isMusicPlaying();
-            cc.audioEngine.stopAllEffects();
-            cc.audioEngine.pauseMusic();
+            cc.audioEngine.pauseAll();
         }
         // Pause main loop
         if (this._intervalId)
@@ -274,8 +272,8 @@ var game = {
         if (!this._paused) return;
         this._paused = false;
         // Resume audio engine
-        if (cc.audioEngine && _isMusicPlaying) {
-            cc.audioEngine.resumeMusic();
+        if (cc.audioEngine) {
+            cc.audioEngine.resumeAll();
         }
         // Resume main loop
         this._runMainLoop();
@@ -299,7 +297,9 @@ var game = {
     restart: function () {
         cc.director.popToSceneStackLevel(0);
         // Clean up audio
-        cc.audioEngine && cc.audioEngine.end();
+        if (cc.audioEngine) {
+            cc.audioEngine.uncacheAll();
+        }
 
         game.onStart();
     },

--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -5,11 +5,11 @@
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated engine source code (the "Software"), a limited,
-  worldwide, royalty-free, non-assignable, revocable and  non-exclusive license
+ worldwide, royalty-free, non-assignable, revocable and  non-exclusive license
  to use Cocos Creator solely to develop games on your target platforms. You shall
-  not use Cocos Creator software for developing other software or tools that's
-  used for developing games. You are not granted to publish, distribute,
-  sublicense, and/or sell copies of Cocos Creator.
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
 
  The software or tools in this License Agreement are licensed, not sold.
  Chukong Aipu reserves all rights not expressly granted to you.
@@ -26,63 +26,36 @@
 var Path = require('../utils/CCPath');
 var Sys = require('../platform/CCSys');
 var Pipeline = require('./pipeline');
-require('../../audio/CCAudio');
+var audioEngine = require('../../audio/CCAudioEngine');
 
 var __audioSupport = Sys.__audioSupport;
 var formatSupport = __audioSupport.format;
 var context = __audioSupport.context;
 
-function loadAudioFromExtList (url, typeList, audio, cb){
-    if(typeList.length === 0){
-        var ERRSTR = 'can not found the resource of audio! Last match url is : ';
-        ERRSTR += url.replace(/\.(.*)?$/, '(');
-        formatSupport.forEach(function(ext){
-            ERRSTR += ext + '|';
-        });
-        ERRSTR = ERRSTR.replace(/\|$/, ')');
-        return cb({status: 520, errorMessage: ERRSTR}, null);
-    }
-
-    if (__audioSupport.WEB_AUDIO && cc.Audio.useWebAudio) {
-        loadWebAudio(url, typeList, audio, cb);
-    } else {
-        loadDomAudio(url, typeList, audio, cb);
-    }
-}
-
-function loadDomAudio (url, typeList, audio, cb) {
-    var num = __audioSupport.ONE_SOURCE ? 1 : typeList.length;
-
-    // 加载统一使用dom
+function loadDomAudio (item, callback) {
     var dom = document.createElement('audio');
-    for (var i=0; i<num; i++) {
-        var source = document.createElement('source');
-        source.src = cc.path.changeExtname(url, typeList[i]);
-        dom.appendChild(source);
-    }
-
-    audio.setElement(dom);
-
-    var timer = setTimeout(function(){
-        if (dom.readyState === 0) {
-            failure();
-        } else {
-            success();
-        }
-    }, 8000);
-
-    var success = function () {
+    dom.src = item.url;
+    var clearEvent = function () {
+        clearTimeout(timer);
         dom.removeEventListener("canplaythrough", success, false);
         dom.removeEventListener("error", failure, false);
-        dom.removeEventListener("emptied", success, false);
-        if (__audioSupport.USE_LOADER_EVENT)
+        if(__audioSupport.USE_LOADER_EVENT)
             dom.removeEventListener(__audioSupport.USE_LOADER_EVENT, success, false);
-        clearTimeout(timer);
-        cb(null, url);
+    };
+    var timer = setTimeout(function () {
+        if (dom.readyState === 0)
+            failure();
+        else
+            success();
+    }, 8000);
+    var success = function () {
+        clearEvent();
+        item.element = dom;
+        callback(null, item.url);
     };
     var failure = function () {
-        cc.log('load audio failure - ' + url);
-        success();
+        clearEvent();
+        cc.log('load audio failure - ' + item.url);
     };
     dom.addEventListener("canplaythrough", success, false);
     dom.addEventListener("error", failure, false);
@@ -90,27 +63,27 @@ function loadDomAudio (url, typeList, audio, cb) {
         dom.addEventListener(__audioSupport.USE_LOADER_EVENT, success, false);
 }
 
-function loadWebAudio (url, typeList, audio, cb) {
+function loadWebAudio (item, callback) {
     if (!context) return;
 
-    var request = Pipeline.getXMLHttpRequest();
-    request.open("GET", url, true);
+    var request = cc.loader.getXMLHttpRequest();
+    request.open("GET", item.url, true);
     request.responseType = "arraybuffer";
 
     // Our asynchronous callback
     request.onload = function () {
         context["decodeAudioData"](request.response, function(buffer){
             //success
-            audio.setBuffer(buffer);
-            cb(null, url);
+            item.buffer = buffer;
+            callback(null, item.url);
         }, function(){
             //error
-            cb('decode error - ' + url, url);
+            callback('decode error - ' + item.url, null);
         });
     };
 
     request.onerror = function(){
-        cb('request error - ' + url, url);
+        callback('request error - ' + item.url, null);
     };
 
     request.send();
@@ -121,25 +94,30 @@ function downloadAudio (item, callback) {
         return callback( new Error('Audio Downloader: audio not supported on this browser!') );
     }
 
-    var url = item.url,
-        extname = Path.extname(url),
-        typeList = [extname],
-        i, audio;
+    item.content = item.url;
 
-    // Generate all types
-    for (i = 0; i < formatSupport.length; i++) {
-        if (extname !== formatSupport[i]) {
-            typeList.push(formatSupport[i]);
-        }
+    if (!__audioSupport.WEB_AUDIO) {
+        // If WebAudio is not supported, load using DOM mode
+        return loadDomAudio(item, callback);
     }
 
-    audio = new cc.Audio(url);
-
-    // hack for audio to be found before loaded
-    item.content = url;
-    item.audio = audio;
-    loadAudioFromExtList(url, typeList, audio, callback);
+    // Get a header
+    // check audio size
+    var request = cc.loader.getXMLHttpRequest();
+    request.open("HEAD", item.url, true);
+    // Our asynchronous callback
+    request.onload = function () {
+        var bit = this.getResponseHeader('Content-Length');
+        if (bit > audioEngine._maxWebAudioSize) {
+            return loadDomAudio(item, callback);
+        }
+        return loadWebAudio(item, callback);
+    };
+    request.onerror = function () {
+        var ERRSTR = 'can not found the resource of audio! Last match url is : ' + item.url;
+        return callback({status: 520, errorMessage: ERRSTR}, null);
+    };
+    request.send();
 }
-
 
 module.exports = downloadAudio;

--- a/jsb/index.js
+++ b/jsb/index.js
@@ -103,6 +103,7 @@ require('./jsb-enums');
 require('./jsb-event');
 require('./jsb-action');
 require('./jsb-etc');
+require('./jsb-audio');
 
 if (cc.runtime) {
     require('./versions/jsb-polyfill-runtime');

--- a/jsb/jsb-audio.js
+++ b/jsb/jsb-audio.js
@@ -1,0 +1,151 @@
+/****************************************************************************
+ Copyright (c) 2013-2016 Chukong Technologies Inc.
+
+ http://www.cocos.com
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated engine source code (the "Software"), a limited,
+ worldwide, royalty-free, non-assignable, revocable and  non-exclusive license
+ to use Cocos Creator solely to develop games on your target platforms. You shall
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
+
+ The software or tools in this License Agreement are licensed, not sold.
+ Chukong Aipu reserves all rights not expressly granted to you.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+cc.Audio = function (src) {
+    this.src = src;
+    this.volume = 1;
+    this.loop = false;
+
+    this.id = -1;
+    this._eventList = {};
+
+    this.type = cc.Audio.Type.NATIVE;
+};
+
+cc.Audio.Type = {
+    DOM: 'AUDIO',
+    WEBAUDIO: 'WEBAUDIO',
+    NATIVE: 'NATIVE',
+    UNKNOWN: 'UNKNOWN'
+};
+
+(function (proto, audioEngine) {
+
+    // Using the new audioEngine
+    cc.audioEngine = audioEngine;
+    audioEngine.play = audioEngine.play2d;
+    audioEngine.setMaxWebAudioSize = function () {};
+    // deprecated
+    var Module = require('../cocos2d/audio/deprecated');
+    Module.removed(audioEngine);
+    Module.deprecated(audioEngine);
+
+    proto.State = audioEngine.AudioState;
+
+    proto.play = function () {
+        audioEngine.stop(this.id);
+        this.id = audioEngine.play2d(this.src, this.loop, this.volume);
+    };
+
+    proto.pause = function () {
+        audioEngine.pause(this.id);
+    };
+
+    proto.resume = function () {
+        audioEngine.resume(this.id);
+    };
+
+    proto.stop = function () {
+        audioEngine.stop(this.id);
+    };
+
+    proto.setLoop = function (loop) {
+        this.loop = loop;
+        audioEngine.setLoop(this.id, loop)
+    };
+
+    proto.getLoop = function () {
+        return audioEngine.getLoop(this.id)
+    };
+
+    proto.setVolume = function (volume) {
+        this.volume = volume;
+        return audioEngine.setVolume(this.id, volume)
+    };
+
+    proto.getVolume = function () {
+        return audioEngine.getVolume(this.id)
+    };
+
+    proto.setCurrentTime = function (time) {
+        audioEngine.setCurrentTime(this.id, time);
+    };
+
+    proto.getCurrentTime = function () {
+        return audioEngine.getCurrentTime(this.id)
+    };
+
+    proto.getDuration = function () {
+        return audioEngine.getDuration(this.id)
+    };
+
+    proto.getState = function () {
+        return audioEngine.getState(this.id)
+    };
+
+    proto.preload = function () {
+        this._loaded = true;
+        this.emit('load');
+    };
+
+    proto.on = function (event, callback) {
+        var list = this._eventList[event];
+        if (!list) {
+            list = this._eventList[event] = [];
+        }
+        list.push(callback);
+    };
+    proto.once = function (event, callback) {
+        var onceCallback = function (elem) {
+            callback.call(this, elem);
+            this.off(event, onceCallback);
+        };
+        this.on(event, onceCallback);
+    };
+    proto.emit = function (event) {
+        var list = this._eventList[event];
+        if (!list) return;
+        for (var i=0; i<list.length; i++) {
+            list[i].call(this, this);
+        }
+    };
+    proto.off = function (event, callback) {
+        var list = this._eventList[event];
+        if (!list) return false;
+        if (!callback) {
+            this._eventList[event] = [];
+            return true;
+        }
+
+        for (var i=0; i<list.length; i++) {
+            if (list[i] === callback) {
+                list.splice(i, 1);
+                break;
+            }
+        }
+        return true;
+    };
+
+})(cc.Audio.prototype, jsb.AudioEngine);

--- a/jsb/jsb-etc.js
+++ b/jsb/jsb-etc.js
@@ -227,3 +227,7 @@ cc.formatStr = cc.js.formatStr;
 if (cc.Image && cc.Image.setPNGPremultipliedAlphaEnabled) {
     cc.Image.setPNGPremultipliedAlphaEnabled(false);
 }
+
+if (cc.audioEngine) {
+    cc.audioEngine.setMaxWebAudioSize = function () {};
+}

--- a/modules.json
+++ b/modules.json
@@ -144,7 +144,7 @@
   {
     "name": "Audio",
     "entries": [
-      "./cocos2d/audio/CCAudio.js"
+      "./cocos2d/audio/CCAudioEngine.js"
     ]
   },
   {


### PR DESCRIPTION
**不需要合并**
在 1.2 的基础上升级 js 层的 audioEngine。

web 使用新的加载逻辑来判断使用 dom 还是 webAudio 解析数据。
native 层实际调用的是 jsb.audioEngine。

请注意，如果使用了audioEngine.end 请使用 audioEngine.uncacheAll 来替代