### PR TITLE
should not auto release in editor because scene.dependAssets is unavailable for dynamic scene

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -556,9 +556,11 @@ cc.Director = Class.extend(/** @lends cc.Director# */{
 
         var oldScene = this._scene;
 
-        // auto release assets
-        var autoReleaseAssets = oldScene && oldScene.autoReleaseAssets && oldScene.dependAssets;
-        AutoReleaseUtils.autoRelease(cc.loader, autoReleaseAssets, scene.dependAssets);
+        if (!CC_EDITOR) {
+            // auto release assets
+            var autoReleaseAssets = oldScene && oldScene.autoReleaseAssets && oldScene.dependAssets;
+            AutoReleaseUtils.autoRelease(cc.loader, autoReleaseAssets, scene.dependAssets);
+        }
 
         // unload scene
         if (cc.isValid(oldScene)) {


### PR DESCRIPTION
Re: cocos-creator/fireball#4611

Changes proposed in this pull request:
 * 修复自动释放资源的场景，重新加载后贴图会变黑的问题

@cocos-creator/engine-admins