### PR TITLE
Fix texture issue on Android browser by always set vertexAttribPointer

### DIFF
--- a/cocos2d/core/CCDrawingPrimitivesWebGL.js
+++ b/cocos2d/core/CCDrawingPrimitivesWebGL.js
@@ -85,12 +85,12 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
         this._shader.setUniformLocationWith1f(this._pointSizeLocation, this._pointSize);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, new Float32Array([point.x, point.y]), glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
 
@@ -114,12 +114,12 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
         this._shader.setUniformLocationWith1f(this._pointSizeLocation, this._pointSize);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, this._pointsToTypeArray(points), glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
 
@@ -149,11 +149,11 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, this._pointsToTypeArray([origin, destination]), glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
 
@@ -204,11 +204,11 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, this._pointsToTypeArray(vertices), glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
 
@@ -235,11 +235,11 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, this._pointsToTypeArray(poli), glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
         glContext.drawArrays(glContext.TRIANGLE_FAN, 0, poli.length);
@@ -283,11 +283,11 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, vertices, glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
 
@@ -321,11 +321,11 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, vertices, glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
 
@@ -360,11 +360,11 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, vertices, glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
         glContext.drawArrays(glContext.LINE_STRIP, 0, segments + 1);
@@ -420,11 +420,11 @@ cc.DrawingPrimitiveWebGL = cc._Class.extend(/** @lends cc.DrawingPrimitiveWebGL#
         var glContext = this._renderContext;
         this._shader.use();
         this._shader.setUniformForModelViewAndProjectionMatrixWithMat4();
-        cc.gl.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
+        glContext.enableVertexAttribArray(macro.VERTEX_ATTRIB_FLAG_POSITION);
         this._shader.setUniformLocationWith4fv(this._colorLocation, this._colorArray);
 
         var pointBuffer = glContext.createBuffer();
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, pointBuffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, vertices, glContext.STATIC_DRAW);
         glContext.vertexAttribPointer(macro.VERTEX_ATTRIB_POSITION, 2, glContext.FLOAT, false, 0, 0);
         glContext.drawArrays(glContext.LINE_STRIP, 0, segments + 1);

--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -648,7 +648,7 @@ var game = {
         var el = this.config[game.CONFIG_KEY.id],
             win = window,
             element = cc.$(el) || cc.$('#' + el),
-            localCanvas, localContainer;
+            localCanvas, localContainer, localConStyle;
 
         if (element.tagName === "CANVAS") {
             width = width || element.width;

--- a/cocos2d/core/graphics/graphics-webgl-cmd.js
+++ b/cocos2d/core/graphics/graphics-webgl-cmd.js
@@ -310,10 +310,10 @@ Js.mixin(_p, {
         var vertsBuffer = this._vertsBuffer;
         if (!vertsBuffer || vertsBuffer.length === 0 || this._cmds.length === 0) return;
 
-        var gl = cc._renderContext, ccgl = cc.gl;
+        var gl = cc._renderContext;
 
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._vertsVBO);
-        ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesVBO);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._vertsVBO);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesVBO);
 
         if (this._vertsDirty) {
             gl.bufferData(gl.ARRAY_BUFFER, vertsBuffer, gl.STREAM_DRAW);
@@ -329,7 +329,7 @@ Js.mixin(_p, {
             cc.warn('Too many graphics vertices generated, only 65536 vertices support.');
         }
 
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+        gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
         gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 2, gl.FLOAT, false, VERTS_BYTE_LENGTH, 0);
 
         var shader = this._shader;

--- a/cocos2d/core/layers/CCLayerWebGLRenderCmd.js
+++ b/cocos2d/core/layers/CCLayerWebGLRenderCmd.js
@@ -82,7 +82,6 @@
 
     proto.rendering = function (ctx) {
         var context = ctx || cc._renderContext;
-        var ccgl = cc.gl;
         var node = this._node;
 
         var wt = this._worldTransform, mat = this._matrix.mat;
@@ -95,17 +94,17 @@
 
         this._shaderProgram.use();
         this._shaderProgram._setUniformForMVPMatrixWithMat4(this._matrix);
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-        ccgl.blendFunc(node._blendFunc.src, node._blendFunc.dst);
+        context.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+        context.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+        cc.gl.blendFunc(node._blendFunc.src, node._blendFunc.dst);
 
         //
         // Attributes
         //
-        ccgl.bindBuffer(context.ARRAY_BUFFER, this._verticesFloat32Buffer);
+        context.bindBuffer(context.ARRAY_BUFFER, this._verticesFloat32Buffer);
         context.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 3, context.FLOAT, false, 0, 0);
 
-        ccgl.bindBuffer(context.ARRAY_BUFFER, this._colorsUint8Buffer);
+        context.bindBuffer(context.ARRAY_BUFFER, this._colorsUint8Buffer);
         context.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_COLOR, 4, context.UNSIGNED_BYTE, true, 0, 0);
 
         context.drawArrays(context.TRIANGLE_STRIP, 0, this._squareVertices.length);
@@ -145,13 +144,13 @@
 
     proto._bindLayerVerticesBufferData = function(){
         var glContext = cc._renderContext;
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, this._verticesFloat32Buffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, this._verticesFloat32Buffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, this._squareVerticesAB, glContext.DYNAMIC_DRAW);
     };
 
     proto._bindLayerColorsBufferData = function(){
         var glContext = cc._renderContext;
-        cc.gl.bindBuffer(glContext.ARRAY_BUFFER, this._colorsUint8Buffer);
+        glContext.bindBuffer(glContext.ARRAY_BUFFER, this._colorsUint8Buffer);
         glContext.bufferData(glContext.ARRAY_BUFFER, this._squareColorsAB, glContext.STATIC_DRAW);
     };
 
@@ -289,7 +288,7 @@
     };
 
     proto.rendering = function (ctx) {
-        var context = ctx || cc._renderContext, ccgl = cc.gl, node = this._node;
+        var context = ctx || cc._renderContext, node = this._node;
 
         //it is too expensive to use stencil to clip, so it use Scissor,
         //but it has a bug when layer rotated and layer's content size less than canvas's size.
@@ -308,15 +307,15 @@
         //draw gradient layer
         this._shaderProgram.use();
         this._shaderProgram._setUniformForMVPMatrixWithMat4(this._matrix);
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-        ccgl.blendFunc(node._blendFunc.src, node._blendFunc.dst);
+        context.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+        context.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+        cc.gl.blendFunc(node._blendFunc.src, node._blendFunc.dst);
         //
         // Attributes
         //
-        ccgl.bindBuffer(context.ARRAY_BUFFER, this._verticesFloat32Buffer);
+        context.bindBuffer(context.ARRAY_BUFFER, this._verticesFloat32Buffer);
         context.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 3, context.FLOAT, false, 0, 0);
-        ccgl.bindBuffer(context.ARRAY_BUFFER, this._colorsUint8Buffer);
+        context.bindBuffer(context.ARRAY_BUFFER, this._colorsUint8Buffer);
         context.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_COLOR, 4, context.UNSIGNED_BYTE, true, 0, 0);
         context.drawArrays(context.TRIANGLE_STRIP, 0, this._squareVertices.length);
 

--- a/cocos2d/core/renderer/RendererWebGL.js
+++ b/cocos2d/core/renderer/RendererWebGL.js
@@ -384,7 +384,7 @@ cc.rendererWebGL = {
         cc.gl.blendFunc(_batchedInfo.blendSrc, _batchedInfo.blendDst);
         cc.gl.bindTexture2DN(0, texture);                   // = cc.gl.bindTexture2D(texture);
 
-        var _bufferchanged = !gl.bindBuffer(gl.ARRAY_BUFFER, _vertexBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, _vertexBuffer);
         // upload the vertex data to the gl buffer
         if (uploadAll) {
             gl.bufferData(gl.ARRAY_BUFFER, _vertexDataF32, gl.DYNAMIC_DRAW);
@@ -394,14 +394,12 @@ cc.rendererWebGL = {
             gl.bufferData(gl.ARRAY_BUFFER, view, gl.DYNAMIC_DRAW);
         }
 
-        if (_bufferchanged) {
-            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
-            gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 3, gl.FLOAT, false, 24, 0);
-            gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_COLOR, 4, gl.UNSIGNED_BYTE, true, 24, 12);
-            gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_TEX_COORDS, 2, gl.FLOAT, false, 24, 16);
-        }
+        gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+        gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+        gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
+        gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 3, gl.FLOAT, false, 24, 0);
+        gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_COLOR, 4, gl.UNSIGNED_BYTE, true, 24, 12);
+        gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_TEX_COORDS, 2, gl.FLOAT, false, 24, 16);
 
         gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _indexBuffer);
         if (!_prevIndexSize || !_pureQuad || _indexSize > _prevIndexSize) {

--- a/cocos2d/core/renderer/RendererWebGL.js
+++ b/cocos2d/core/renderer/RendererWebGL.js
@@ -135,8 +135,6 @@ cc.rendererWebGL = {
         gl.disable(gl.CULL_FACE);
         gl.disable(gl.DEPTH_TEST);
 
-        cc.gl.initStateCache(gl);
-
         this.mat4Identity = new cc.math.Matrix4();
         this.mat4Identity.identity();
         initQuadBuffer(BATCH_QUAD_COUNT);
@@ -374,7 +372,6 @@ cc.rendererWebGL = {
         }
 
         var gl = cc._renderContext;
-        var ccgl = cc.gl;
         var texture = _batchedInfo.texture;
         var shader = _batchedInfo.shader;
         var uploadAll = _batchingSize > _maxVertexSize * 0.5;
@@ -384,10 +381,10 @@ cc.rendererWebGL = {
             shader._updateProjectionUniform();
         }
 
-        ccgl.blendFunc(_batchedInfo.blendSrc, _batchedInfo.blendDst);
-        ccgl.bindTexture2DN(0, texture);                   // = ccgl.bindTexture2D(texture);
+        cc.gl.blendFunc(_batchedInfo.blendSrc, _batchedInfo.blendDst);
+        cc.gl.bindTexture2DN(0, texture);                   // = cc.gl.bindTexture2D(texture);
 
-        var _bufferchanged = !ccgl.bindBuffer(gl.ARRAY_BUFFER, _vertexBuffer);
+        var _bufferchanged = !gl.bindBuffer(gl.ARRAY_BUFFER, _vertexBuffer);
         // upload the vertex data to the gl buffer
         if (uploadAll) {
             gl.bufferData(gl.ARRAY_BUFFER, _vertexDataF32, gl.DYNAMIC_DRAW);
@@ -398,15 +395,15 @@ cc.rendererWebGL = {
         }
 
         if (_bufferchanged) {
-            ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-            ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-            ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
+            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
             gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 3, gl.FLOAT, false, 24, 0);
             gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_COLOR, 4, gl.UNSIGNED_BYTE, true, 24, 12);
             gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_TEX_COORDS, 2, gl.FLOAT, false, 24, 16);
         }
 
-        ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _indexBuffer);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _indexBuffer);
         if (!_prevIndexSize || !_pureQuad || _indexSize > _prevIndexSize) {
             if (uploadAll) {
                 gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, _indexData, gl.DYNAMIC_DRAW);
@@ -440,7 +437,7 @@ cc.rendererWebGL = {
             context = ctx || cc._renderContext;
 
         // Reset buffer for rendering
-        cc.gl.bindBuffer(context.ARRAY_BUFFER, null);
+        context.bindBuffer(context.ARRAY_BUFFER, null);
 
         for (i = 0, len = locCmds.length; i < len; ++i) {
             cmd = locCmds[i];

--- a/cocos2d/core/textures/CCTextureAtlas.js
+++ b/cocos2d/core/textures/CCTextureAtlas.js
@@ -639,12 +639,12 @@ if (cc._renderType === game.RENDER_TYPE_WEBGL) {
 
         _mapBuffers: function () {
             var _t = this;
-            var gl = cc._renderContext, ccgl = cc.gl;
+            var gl = cc._renderContext;
 
-            ccgl.bindBuffer(gl.ARRAY_BUFFER, _t._quadsWebBuffer);
+            gl.bindBuffer(gl.ARRAY_BUFFER, _t._quadsWebBuffer);
             gl.bufferData(gl.ARRAY_BUFFER, _t._quadsArrayBuffer, gl.DYNAMIC_DRAW);
 
-            ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _t._buffersVBO[1]);
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _t._buffersVBO[1]);
             gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, _t._indices, gl.STATIC_DRAW);
 
             //cc.checkGLErrorDebug();
@@ -660,19 +660,19 @@ if (cc._renderType === game.RENDER_TYPE_WEBGL) {
             if (0 === n || !_t.texture || !_t.texture.isLoaded())
                 return;
 
-            var gl = cc._renderContext, ccgl = cc.gl;
-            ccgl.bindTexture2D(_t.texture);
+            var gl = cc._renderContext;
+            cc.gl.bindTexture2D(_t.texture);
 
             //
             // Using VBO without VAO
             //
             //vertices
-            ccgl.bindBuffer(gl.ARRAY_BUFFER, _t._buffersVBO[0]);
+            //gl.bindBuffer(gl.ARRAY_BUFFER, _t._buffersVBO[0]);
             // XXX: update is done in draw... perhaps it should be done in a timer
-            ccgl.bindBuffer(gl.ARRAY_BUFFER, _t._quadsWebBuffer);
-            ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-            ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-            ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
+            gl.bindBuffer(gl.ARRAY_BUFFER, _t._quadsWebBuffer);
+            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+            gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
             if (_t.dirty){
                 gl.bufferData(gl.ARRAY_BUFFER, _t._quadsArrayBuffer, gl.DYNAMIC_DRAW);
                 _t.dirty = false;
@@ -682,7 +682,7 @@ if (cc._renderType === game.RENDER_TYPE_WEBGL) {
             gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_COLOR, 4, gl.UNSIGNED_BYTE, true, 24, 12);          // colors
             gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_TEX_COORDS, 2, gl.FLOAT, false, 24, 16);            // tex coords
 
-            ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _t._buffersVBO[1]);
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _t._buffersVBO[1]);
 
             if (cc.macro.TEXTURE_ATLAS_USE_TRIANGLE_STRIP)
                 gl.drawElements(gl.TRIANGLE_STRIP, n * 6, gl.UNSIGNED_SHORT, start * 6 * _t._indices.BYTES_PER_ELEMENT);

--- a/cocos2d/effects/CCGrid.js
+++ b/cocos2d/effects/CCGrid.js
@@ -451,8 +451,7 @@ cc.Grid3D = cc.GridBase.extend(/** @lends cc.Grid3D# */{
 
     blit:function (target) {
         var n = this._gridSize.width * this._gridSize.height;
-        var ccgl = cc.gl;
-        ccgl.enableVertexAttribs(cc.macro.VERTEX_ATTRIB_FLAG_POSITION | cc.macro.VERTEX_ATTRIB_FLAG_TEX_COORDS);
+        cc.gl.enableVertexAttribs(cc.macro.VERTEX_ATTRIB_FLAG_POSITION | cc.macro.VERTEX_ATTRIB_FLAG_TEX_COORDS);
         this._shaderProgram.use();
         //this._shaderProgram.setUniformsForBuiltins();
         this._shaderProgram._setUniformForMVPMatrixWithMat4(target._renderCmd._stackMatrix);
@@ -462,18 +461,18 @@ cc.Grid3D = cc.GridBase.extend(/** @lends cc.Grid3D# */{
         // Attributes
         //
         // position
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
         if (locDirty)
             gl.bufferData(gl.ARRAY_BUFFER, this._vertices, gl.DYNAMIC_DRAW);
         gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 3, gl.FLOAT, false, 0, 0);
 
         // texCoords
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordinateBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordinateBuffer);
         if (locDirty)
             gl.bufferData(gl.ARRAY_BUFFER, this._texCoordinates, gl.DYNAMIC_DRAW);
         gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_TEX_COORDS, 2, gl.FLOAT, false, 0, 0);
 
-        ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesBuffer);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesBuffer);
         if (locDirty)
             gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this._indices, gl.STATIC_DRAW);
         gl.drawElements(gl.TRIANGLES, n * 6, gl.UNSIGNED_SHORT, 0);
@@ -492,7 +491,7 @@ cc.Grid3D = cc.GridBase.extend(/** @lends cc.Grid3D# */{
     },
 
     calculateVertexPoints:function () {
-        var gl = cc._renderContext, ccgl = cc.gl;
+        var gl = cc._renderContext;
 
         var width = this._texture.getPixelWidth();
         var height = this._texture.getPixelHeight();
@@ -559,11 +558,11 @@ cc.Grid3D = cc.GridBase.extend(/** @lends cc.Grid3D# */{
         }
         this._originalVertices = new Float32Array(this._vertices);
 
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, this._vertices, gl.DYNAMIC_DRAW);
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordinateBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordinateBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, this._texCoordinates, gl.DYNAMIC_DRAW);
-        ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesBuffer);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesBuffer);
         gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this._indices, gl.STATIC_DRAW);
         this._dirty = true;
     },
@@ -705,22 +704,22 @@ cc.TiledGrid3D = cc.GridBase.extend(/** @lends cc.TiledGrid3D# */{
         //
         // Attributes
         //
-        var gl = cc._renderContext, ccgl = cc.gl, locDirty = this._dirty;
-        ccgl.enableVertexAttribs(cc.macro.VERTEX_ATTRIB_FLAG_POSITION | cc.macro.VERTEX_ATTRIB_FLAG_TEX_COORDS);
+        var gl = cc._renderContext, locDirty = this._dirty;
+        cc.gl.enableVertexAttribs(cc.macro.VERTEX_ATTRIB_FLAG_POSITION | cc.macro.VERTEX_ATTRIB_FLAG_TEX_COORDS);
 
         // position
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
         if (locDirty)
             gl.bufferData(gl.ARRAY_BUFFER, this._vertices, gl.DYNAMIC_DRAW);
         gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 3, gl.FLOAT, false, 0, this._vertices);
 
         // texCoords
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordinateBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordinateBuffer);
         if (locDirty)
             gl.bufferData(gl.ARRAY_BUFFER, this._texCoordinates, gl.DYNAMIC_DRAW);
         gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_TEX_COORDS, 2, gl.FLOAT, false, 0, this._texCoordinates);
 
-        ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesBuffer);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesBuffer);
         if (locDirty)
             gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this._indices, gl.STATIC_DRAW);
         gl.drawElements(gl.TRIANGLES, n * 6, gl.UNSIGNED_SHORT, 0);
@@ -749,7 +748,7 @@ cc.TiledGrid3D = cc.GridBase.extend(/** @lends cc.TiledGrid3D# */{
         this._texCoordinates = new Float32Array(numQuads * 8);
         this._indices = new Uint16Array(numQuads * 6);
 
-        var gl = cc._renderContext, ccgl = cc.gl;
+        var gl = cc._renderContext;
         if(this._verticesBuffer)
             gl.deleteBuffer(this._verticesBuffer);
         this._verticesBuffer = gl.createBuffer();
@@ -814,11 +813,11 @@ cc.TiledGrid3D = cc.GridBase.extend(/** @lends cc.TiledGrid3D# */{
         }
         this._originalVertices = new Float32Array(this._vertices);
 
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, this._vertices, gl.DYNAMIC_DRAW);
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordinateBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordinateBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, this._texCoordinates, gl.DYNAMIC_DRAW);
-        ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesBuffer);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._indicesBuffer);
         gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this._indices, gl.DYNAMIC_DRAW);
         this._dirty = true;
     }

--- a/cocos2d/motion-streak/CCSGMotionStreak.js
+++ b/cocos2d/motion-streak/CCSGMotionStreak.js
@@ -394,17 +394,16 @@ _ccsg.MotionStreak = _ccsg.Node.extend({
         this._texCoords = new Float32Array(locMaxPoints * 4);
         this._colorPointer = new Uint8Array(locMaxPoints * 8);
 
-        var gl = cc._renderContext, ccgl = cc.gl;
         this._verticesBuffer = gl.createBuffer();
         this._texCoordsBuffer = gl.createBuffer();
         this._colorPointerBuffer = gl.createBuffer();
 
         //bind buffer
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._verticesBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, this._vertices, gl.DYNAMIC_DRAW);
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordsBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._texCoordsBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, this._texCoords, gl.DYNAMIC_DRAW);
-        ccgl.bindBuffer(gl.ARRAY_BUFFER, this._colorPointerBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this._colorPointerBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, this._colorPointer, gl.DYNAMIC_DRAW);
     },
 

--- a/cocos2d/motion-streak/CCSGMotionStreakWebGLRenderCmd.js
+++ b/cocos2d/motion-streak/CCSGMotionStreakWebGLRenderCmd.js
@@ -33,14 +33,13 @@ _ccsg.MotionStreak.WebGLRenderCmd = function(renderableObject){
 _ccsg.MotionStreak.WebGLRenderCmd.prototype = Object.create(_ccsg.Node.WebGLRenderCmd.prototype);
 _ccsg.MotionStreak.WebGLRenderCmd.prototype.constructor = _ccsg.Sprite.WebGLRenderCmd;
 
-_ccsg.MotionStreak.WebGLRenderCmd.prototype.rendering = function (ctx) {
+_ccsg.MotionStreak.WebGLRenderCmd.prototype.rendering = function(ctx){
     var node = this._node;
     if (node._nuPoints <= 1)
         return;
 
     if (node.texture && node.texture.isLoaded()) {
         ctx = ctx || cc._renderContext;
-        var ccgl = cc.gl;
 
         // update the color
         this._updateDisplayColor();
@@ -55,26 +54,26 @@ _ccsg.MotionStreak.WebGLRenderCmd.prototype.rendering = function (ctx) {
 
         this._shaderProgram.use();
         this._shaderProgram._setUniformForMVPMatrixWithMat4(this._matrix);
-        ccgl.blendFunc(node._blendFunc.src, node._blendFunc.dst);
+        cc.gl.blendFunc(node._blendFunc.src, node._blendFunc.dst);
 
-        ccgl.bindTexture2DN(0, node.texture);
+        cc.gl.bindTexture2DN(0, node.texture);
 
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
+        ctx.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+        ctx.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+        ctx.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
 
         //position
-        ccgl.bindBuffer(ctx.ARRAY_BUFFER, node._verticesBuffer);
+        ctx.bindBuffer(ctx.ARRAY_BUFFER, node._verticesBuffer);
         ctx.bufferData(ctx.ARRAY_BUFFER, node._vertices, ctx.DYNAMIC_DRAW);
         ctx.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 2, ctx.FLOAT, false, 0, 0);
 
         //texcoords
-        ccgl.bindBuffer(ctx.ARRAY_BUFFER, node._texCoordsBuffer);
+        ctx.bindBuffer(ctx.ARRAY_BUFFER, node._texCoordsBuffer);
         ctx.bufferData(ctx.ARRAY_BUFFER, node._texCoords, ctx.DYNAMIC_DRAW);
         ctx.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_TEX_COORDS, 2, ctx.FLOAT, false, 0, 0);
 
         //colors
-        ccgl.bindBuffer(ctx.ARRAY_BUFFER, node._colorPointerBuffer);
+        ctx.bindBuffer(ctx.ARRAY_BUFFER, node._colorPointerBuffer);
         ctx.bufferData(ctx.ARRAY_BUFFER, node._colorPointer, ctx.DYNAMIC_DRAW);
         ctx.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_COLOR, 4, ctx.UNSIGNED_BYTE, true, 0, 0);
 

--- a/cocos2d/particle/CCSGParticleSystemWebGLRenderCmd.js
+++ b/cocos2d/particle/CCSGParticleSystemWebGLRenderCmd.js
@@ -186,7 +186,7 @@ proto.rendering = function (ctx) {
     if (!node._texture)
         return;
 
-    var gl = ctx || cc._renderContext, ccgl = cc.gl;
+    var gl = ctx || cc._renderContext;
 
     var wt = this._worldTransform, mat = this._matrix.mat;
     mat[0] = wt.a;
@@ -199,22 +199,22 @@ proto.rendering = function (ctx) {
     this._shaderProgram.use();
     this._shaderProgram._setUniformForMVPMatrixWithMat4(this._matrix);     //;
 
-    ccgl.bindTexture2DN(0, node._texture);
-    ccgl.blendFuncForParticle(node._blendFunc.src, node._blendFunc.dst);
+    cc.gl.bindTexture2DN(0, node._texture);
+    cc.gl.blendFuncForParticle(node._blendFunc.src, node._blendFunc.dst);
 
     //
     // Using VBO without VAO
     //
-    ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-    ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-    ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
+    gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+    gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+    gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
 
-    ccgl.bindBuffer(gl.ARRAY_BUFFER, this._buffersVBO[0]);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this._buffersVBO[0]);
     gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 3, gl.FLOAT, false, 24, 0);               // vertices
     gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_COLOR, 4, gl.UNSIGNED_BYTE, true, 24, 12);          // colors
     gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_TEX_COORDS, 2, gl.FLOAT, false, 24, 16);            // tex coords
 
-    ccgl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._buffersVBO[1]);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._buffersVBO[1]);
     gl.drawElements(gl.TRIANGLES, node._particleIdx * 6, gl.UNSIGNED_SHORT, 0);
 };
 
@@ -333,11 +333,11 @@ proto._setupVBO = function(){
 
     //gl.deleteBuffer(this._buffersVBO[0]);
     this._buffersVBO[0] = gl.createBuffer();
-    cc.gl.bindBuffer(gl.ARRAY_BUFFER, this._buffersVBO[0]);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this._buffersVBO[0]);
     gl.bufferData(gl.ARRAY_BUFFER, this._quadsArrayBuffer, gl.DYNAMIC_DRAW);
 
     this._buffersVBO[1] = gl.createBuffer();
-    cc.gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._buffersVBO[1]);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._buffersVBO[1]);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this._indices, gl.STATIC_DRAW);
 
     //cc.checkGLErrorDebug();
@@ -370,7 +370,7 @@ proto._allocMemory = function(){
 
 proto.postStep = function(){
     var gl = cc._renderContext;
-    cc.gl.bindBuffer(gl.ARRAY_BUFFER, this._buffersVBO[0]);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this._buffersVBO[0]);
     gl.bufferSubData(gl.ARRAY_BUFFER, 0, this._quadsArrayBuffer);
 };
 

--- a/cocos2d/progress-timer/CCProgressTimerWebGLRenderCmd.js
+++ b/cocos2d/progress-timer/CCProgressTimerWebGLRenderCmd.js
@@ -60,7 +60,7 @@
 
     proto.rendering = function (ctx) {
         var node = this._node;
-        var context = ctx || cc._renderContext, ccgl = cc.gl;
+        var context = ctx || cc._renderContext;
         if (this._vertexDataCount === 0 || !node._sprite)
             return;
 
@@ -68,13 +68,13 @@
         this._shaderProgram._updateProjectionUniform();
 
         var blendFunc = node._sprite._blendFunc;
-        ccgl.blendFunc(blendFunc.src, blendFunc.dst);
-        ccgl.bindTexture2D(node._sprite.texture);
-        ccgl.bindBuffer(context.ARRAY_BUFFER, this._vertexWebGLBuffer);
+        cc.gl.blendFunc(blendFunc.src, blendFunc.dst);
+        cc.gl.bindTexture2D(node._sprite.texture);
+        context.bindBuffer(context.ARRAY_BUFFER, this._vertexWebGLBuffer);
 
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-        ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
+        context.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+        context.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+        context.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
 
         if (this._vertexDataDirty) {
             context.bufferSubData(context.ARRAY_BUFFER, 0, this._float32View);
@@ -221,7 +221,7 @@
             }
 
             // Init buffer data
-            cc.gl.bindBuffer(gl.ARRAY_BUFFER, this._vertexWebGLBuffer);
+            gl.bindBuffer(gl.ARRAY_BUFFER, this._vertexWebGLBuffer);
             gl.bufferData(gl.ARRAY_BUFFER, this._float32View, gl.DYNAMIC_DRAW);
 
             this._vertexDataCount = 0;

--- a/cocos2d/shaders/CCGLStateCache.js
+++ b/cocos2d/shaders/CCGLStateCache.js
@@ -56,10 +56,6 @@ if (ENABLE_GL_STATE_CACHE) {
         if (_currBuffers[target] !== buffer) {
             this.glBindBuffer(target, buffer);
             _currBuffers[target] = buffer;
-            return false;
-        }
-        else {
-            return true;
         }
     };
 

--- a/cocos2d/shaders/CCGLStateCache.js
+++ b/cocos2d/shaders/CCGLStateCache.js
@@ -36,95 +36,88 @@ var MAX_ACTIVETEXTURE = 0,
     _blendingDest = 0,
     _GLServerState = 0,
     _uVAO = 0;
+if (ENABLE_GL_STATE_CACHE) {
+    MAX_ACTIVETEXTURE = 16;
+    _currentShaderProgram = -1;
+    _currentBoundTexture = [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1];
+    _blendingSource = -1;
+    _blendingDest = -1;
+    _GLServerState = 0;
+    if(macro.TEXTURE_ATLAS_USE_VAO)
+        _uVAO = 0;
+
+    var _currBuffers = {};
+
+    // IE 10 WebGLRenderingContext does not exist
+    if (!window.WebGLRenderingContext) return;
+
+    WebGLRenderingContext.prototype.glBindBuffer = WebGLRenderingContext.prototype.bindBuffer;
+    WebGLRenderingContext.prototype.bindBuffer = function (target, buffer) {
+        if (_currBuffers[target] !== buffer) {
+            this.glBindBuffer(target, buffer);
+            _currBuffers[target] = buffer;
+            return false;
+        }
+        else {
+            return true;
+        }
+    };
+
+    WebGLRenderingContext.prototype.glEnableVertexAttribArray = WebGLRenderingContext.prototype.enableVertexAttribArray;
+    WebGLRenderingContext.prototype.enableVertexAttribArray = function (index) {
+        if (index === macro.VERTEX_ATTRIB_FLAG_POSITION) {
+            if (!this._vertexAttribPosition) {
+                this.glEnableVertexAttribArray(index);
+                this._vertexAttribPosition = true;
+            }
+        }
+        else if (index === macro.VERTEX_ATTRIB_FLAG_COLOR) {
+            if (!this._vertexAttribColor) {
+                this.glEnableVertexAttribArray(index);
+                this._vertexAttribColor = true;
+            }
+        }
+        else if (index === macro.VERTEX_ATTRIB_FLAG_TEX_COORDS) {
+            if (!this._vertexAttribTexCoords) {
+                this.glEnableVertexAttribArray(index);
+                this._vertexAttribTexCoords = true;
+            }
+        }
+        else {
+            this.glEnableVertexAttribArray(index);
+        }
+    };
+
+    WebGLRenderingContext.prototype.glDisableVertexAttribArray = WebGLRenderingContext.prototype.disableVertexAttribArray;
+    WebGLRenderingContext.prototype.disableVertexAttribArray = function (index) {
+        if (index === macro.VERTEX_ATTRIB_FLAG_COLOR) {
+            if (this._vertexAttribColor) {
+                this.glDisableVertexAttribArray(index);
+                this._vertexAttribColor = false;
+            }
+        }
+        else if (index === macro.VERTEX_ATTRIB_FLAG_TEX_COORDS) {
+            if (this._vertexAttribTexCoords) {
+                this.glDisableVertexAttribArray(index);
+                this._vertexAttribTexCoords = false;
+            }
+        }
+        else if (index !== 0) {
+            this.glDisableVertexAttribArray(index);
+        }
+    };
+}
 
 // GL State Cache functions
 
-var ccgl = cc.gl = {
-    _vertexAttribPosition: false,
-    _vertexAttribColor: false,
-    _vertexAttribTexCoords: false,
-
-    bindBuffer: null,
-    enableVertexAttribArray: null,
-    disableVertexAttribArray: null,
-
-    initStateCache: ENABLE_GL_STATE_CACHE ? function () {
-        MAX_ACTIVETEXTURE = 16;
-        _currentShaderProgram = -1;
-        _currentBoundTexture = [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1];
-        _blendingSource = -1;
-        _blendingDest = -1;
-        _GLServerState = 0;
-        if(macro.TEXTURE_ATLAS_USE_VAO)
-            _uVAO = 0;
-
-        var _currBuffers = {};
-
-        this.bindBuffer = function (target, buffer) {
-            if (_currBuffers[target] !== buffer) {
-                cc._renderContext.bindBuffer(target, buffer);
-                _currBuffers[target] = buffer;
-                return false;
-            }
-            else {
-                return true;
-            }
-        };
-
-        this.enableVertexAttribArray = function (index) {
-            if (index === macro.VERTEX_ATTRIB_FLAG_POSITION) {
-                if (!this._vertexAttribPosition) {
-                    cc._renderContext.enableVertexAttribArray(index);
-                    this._vertexAttribPosition = true;
-                }
-            }
-            else if (index === macro.VERTEX_ATTRIB_FLAG_COLOR) {
-                if (!this._vertexAttribColor) {
-                    cc._renderContext.enableVertexAttribArray(index);
-                    this._vertexAttribColor = true;
-                }
-            }
-            else if (index === macro.VERTEX_ATTRIB_FLAG_TEX_COORDS) {
-                if (!this._vertexAttribTexCoords) {
-                    cc._renderContext.enableVertexAttribArray(index);
-                    this._vertexAttribTexCoords = true;
-                }
-            }
-            else {
-                cc._renderContext.enableVertexAttribArray(index);
-            }
-        };
-
-        this.disableVertexAttribArray = function (index) {
-            if (index === macro.VERTEX_ATTRIB_FLAG_COLOR) {
-                if (this._vertexAttribColor) {
-                    cc._renderContext.disableVertexAttribArray(index);
-                    this._vertexAttribColor = false;
-                }
-            }
-            else if (index === macro.VERTEX_ATTRIB_FLAG_TEX_COORDS) {
-                if (this._vertexAttribTexCoords) {
-                    cc._renderContext.disableVertexAttribArray(index);
-                    this._vertexAttribTexCoords = false;
-                }
-            }
-            else if (index !== 0) {
-                cc._renderContext.disableVertexAttribArray(index);
-            }
-        };
-    } : function (gl) {
-        this.bindBuffer = gl.bindBuffer.bind(gl);
-        this.enableVertexAttribArray = gl.enableVertexAttribArray.bind(gl);
-        this.disableVertexAttribArray = gl.disableVertexAttribArray.bind(gl);
-    }
-};
+cc.gl = {};
 
 /*
  * Invalidates the GL state cache.<br/>
  * If cc.macro.ENABLE_GL_STATE_CACHE it will reset the GL state cache.
  * @function
  */
-ccgl.invalidateStateCache = function () {
+cc.gl.invalidateStateCache = function () {
     cc.math.glFreeAll();
     _currentProjectionMatrix = -1;
     if (ENABLE_GL_STATE_CACHE) {
@@ -144,7 +137,7 @@ ccgl.invalidateStateCache = function () {
  * @function
  * @param {WebGLProgram} program
  */
-ccgl.useProgram = ENABLE_GL_STATE_CACHE ? function (program) {
+cc.gl.useProgram = ENABLE_GL_STATE_CACHE ? function (program) {
     if (program !== _currentShaderProgram) {
         _currentShaderProgram = program;
         cc._renderContext.useProgram(program);
@@ -159,7 +152,7 @@ ccgl.useProgram = ENABLE_GL_STATE_CACHE ? function (program) {
  * @function
  * @param {WebGLProgram} program
  */
-ccgl.deleteProgram = function (program) {
+cc.gl.deleteProgram = function (program) {
     if (ENABLE_GL_STATE_CACHE) {
         if (program === _currentShaderProgram)
             _currentShaderProgram = -1;
@@ -172,7 +165,7 @@ ccgl.deleteProgram = function (program) {
  * @param {Number} sfactor
  * @param {Number} dfactor
  */
-ccgl.setBlending = function (sfactor, dfactor) {
+cc.gl.setBlending = function (sfactor, dfactor) {
     var ctx = cc._renderContext;
     if ((sfactor === ctx.ONE) && (dfactor === ctx.ZERO)) {
         ctx.disable(ctx.BLEND);
@@ -191,20 +184,20 @@ ccgl.setBlending = function (sfactor, dfactor) {
  * @param {Number} sfactor
  * @param {Number} dfactor
  */
-ccgl.blendFunc = ENABLE_GL_STATE_CACHE ? function (sfactor, dfactor) {
+cc.gl.blendFunc = ENABLE_GL_STATE_CACHE ? function (sfactor, dfactor) {
     if ((sfactor !== _blendingSource) || (dfactor !== _blendingDest)) {
         _blendingSource = sfactor;
         _blendingDest = dfactor;
-        ccgl.setBlending(sfactor, dfactor);
+        cc.gl.setBlending(sfactor, dfactor);
     }
-} : ccgl.setBlending;
+} : cc.gl.setBlending;
 
 /**
  * @function
  * @param {Number} sfactor
  * @param {Number} dfactor
  */
-ccgl.blendFuncForParticle = function(sfactor, dfactor) {
+cc.gl.blendFuncForParticle = function(sfactor, dfactor) {
     if ((sfactor !== _blendingSource) || (dfactor !== _blendingDest)) {
         _blendingSource = sfactor;
         _blendingDest = dfactor;
@@ -225,20 +218,20 @@ ccgl.blendFuncForParticle = function(sfactor, dfactor) {
  * If cc.macro.ENABLE_GL_STATE_CACHE is disabled, it will just set the default blending mode using GL_FUNC_ADD.
  * @function
  */
-ccgl.blendResetToCache = function () {
+cc.gl.blendResetToCache = function () {
     var ctx = cc._renderContext;
     ctx.blendEquation(ctx.FUNC_ADD);
     if (ENABLE_GL_STATE_CACHE)
-        ccgl.setBlending(_blendingSource, _blendingDest);
+        cc.gl.setBlending(_blendingSource, _blendingDest);
     else
-        ccgl.setBlending(ctx.BLEND_SRC, ctx.BLEND_DST);
+        cc.gl.setBlending(ctx.BLEND_SRC, ctx.BLEND_DST);
 };
 
 /**
  * sets the projection matrix as dirty
  * @function
  */
-ccgl.setProjectionMatrixDirty = function () {
+cc.gl.setProjectionMatrixDirty = function () {
     _currentProjectionMatrix = -1;
 };
 
@@ -248,8 +241,8 @@ ccgl.setProjectionMatrixDirty = function () {
  * @function
  * @param {Texture2D} textureId
  */
-ccgl.bindTexture2D = function (textureId) {
-    ccgl.bindTexture2DN(0, textureId);
+cc.gl.bindTexture2D = function (textureId) {
+    cc.gl.bindTexture2DN(0, textureId);
 };
 
 /**
@@ -259,7 +252,7 @@ ccgl.bindTexture2D = function (textureId) {
  * @param {Number} textureUnit
  * @param {Texture2D} textureId
  */
-ccgl.bindTexture2DN = ENABLE_GL_STATE_CACHE ? function (textureUnit, textureId) {
+cc.gl.bindTexture2DN = ENABLE_GL_STATE_CACHE ? function (textureUnit, textureId) {
     if (_currentBoundTexture[textureUnit] === textureId)
         return;
     _currentBoundTexture[textureUnit] = textureId;
@@ -285,8 +278,8 @@ ccgl.bindTexture2DN = ENABLE_GL_STATE_CACHE ? function (textureUnit, textureId) 
  * @function
  * @param {Texture2D} textureId
  */
-ccgl.deleteTexture2D = function (textureId) {
-    ccgl.deleteTexture2DN(0, textureId);
+cc.gl.deleteTexture2D = function (textureId) {
+    cc.gl.deleteTexture2DN(0, textureId);
 };
 
 /**
@@ -296,7 +289,7 @@ ccgl.deleteTexture2D = function (textureId) {
  * @param {Number} textureUnit
  * @param {Texture2D} textureId
  */
-ccgl.deleteTexture2DN = function (textureUnit, textureId) {
+cc.gl.deleteTexture2DN = function (textureUnit, textureId) {
     if (ENABLE_GL_STATE_CACHE) {
         if (textureId === _currentBoundTexture[ textureUnit ])
             _currentBoundTexture[ textureUnit ] = -1;
@@ -310,7 +303,7 @@ ccgl.deleteTexture2DN = function (textureUnit, textureId) {
  * @function
  * @param {Number} vaoId
  */
-ccgl.bindVAO = function (vaoId) {
+cc.gl.bindVAO = function (vaoId) {
     if (!macro.TEXTURE_ATLAS_USE_VAO)
         return;
 
@@ -331,7 +324,7 @@ ccgl.bindVAO = function (vaoId) {
  * @function
  * @param {Number} flags
  */
-ccgl.enable = function (flags) {
+cc.gl.enable = function (flags) {
     if (ENABLE_GL_STATE_CACHE) {
         /*var enabled;
 

--- a/cocos2d/shaders/index.js
+++ b/cocos2d/shaders/index.js
@@ -23,7 +23,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-require('./CCGLStateCache');
 require('./CCShaders');
 require('./CCShaderCache');
 require('./CCGLProgram');
+require('./CCGLStateCache');

--- a/cocos2d/shape-nodes/CCDrawNode.js
+++ b/cocos2d/shape-nodes/CCDrawNode.js
@@ -589,18 +589,17 @@ cc.game.once(cc.game.EVENT_RENDERER_INITED, function () {
 
             _render:function () {
                 var gl = cc._renderContext;
-                var ccgl = cc.gl;
 
-                ccgl.bindBuffer(gl.ARRAY_BUFFER, this._trianglesWebBuffer);
+                gl.bindBuffer(gl.ARRAY_BUFFER, this._trianglesWebBuffer);
                 if (this._dirty) {
                     gl.bufferData(gl.ARRAY_BUFFER, this._trianglesArrayBuffer, gl.STREAM_DRAW);
                     this._dirty = false;
                 }
                 var triangleSize = cc.V2F_C4B_T2F.BYTES_PER_ELEMENT;
 
-                ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
-                ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
-                ccgl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
+                gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_POSITION);
+                gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_COLOR);
+                gl.enableVertexAttribArray(cc.macro.VERTEX_ATTRIB_TEX_COORDS);
 
                 // vertex
                 gl.vertexAttribPointer(cc.macro.VERTEX_ATTRIB_POSITION, 2, gl.FLOAT, false, triangleSize, 0);

--- a/extensions/cocostudio/armature/display/CCSkinWebGLRenderCmd.js
+++ b/extensions/cocostudio/armature/display/CCSkinWebGLRenderCmd.js
@@ -98,17 +98,17 @@
         if (!node._textureLoaded)
             return;
 
-        var gl = ctx || cc._renderContext, ccgl = cc.gl, locTexture = node._texture;
+        var gl = ctx || cc._renderContext, locTexture = node._texture;
         if (locTexture && locTexture._textureLoaded) {
             this._shaderProgram.use();
             this._shaderProgram.setUniformForModelViewAndProjectionMatrixWithMat4();
 
-            ccgl.blendFunc(node._blendFunc.src, node._blendFunc.dst);
+            cc.gl.blendFunc(node._blendFunc.src, node._blendFunc.dst);
             //optimize performance for javascript
-            ccgl.bindTexture2DN(0, locTexture);                   // = ccgl.bindTexture2D(locTexture);
-            ccgl.enableVertexAttribs(cc.macro.VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
+            cc.gl.bindTexture2DN(0, locTexture);                   // = cc.gl.bindTexture2D(locTexture);
+            cc.gl.enableVertexAttribs(cc.macro.VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
 
-            ccgl.bindBuffer(gl.ARRAY_BUFFER, this._quadWebBuffer);
+            gl.bindBuffer(gl.ARRAY_BUFFER, this._quadWebBuffer);
             if (this._quadDirty) {
                 gl.bufferData(gl.ARRAY_BUFFER, this._quad.arrayBuffer, gl.DYNAMIC_DRAW);
                 this._quadDirty = false;


### PR DESCRIPTION
Re: cocos-creator/fireball#4598

Previous PR actually doesn't work, the real reason the texture was messed up in Vivo and Smartisan is because we had a GL State Cache to avoid repeatly reset vertexAttribPointer for the same buffer. Obviously, on these devices, the vertexAttribPointers is messed up between frames.

So in this PR, I revert all changes in previous one, then force to set vertexAttribPointer each time we call bindBuffer.

This will affect the performance, because there will be more vertexAttribPointer calls than before, the cost is different on different devices and browsers, but no big performance drop is expected.

If we want this to be fixed and keep the performance for the most part of devices, we need to have a test on many devices (maybe via cloud testing service) and then rule the broken ones out by detecting their ua (not guaranteed).

Changes proposed in this pull request:
 * Revert https://github.com/cocos-creator/engine/pull/1259
 * Always set vertexAttribPointer after bindBuffer

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)

@cocos-creator/engine-admins
