### PR TITLE
Using URL cache(loader)

### DIFF
--- a/cocos2d/core/load-pipeline/downloader.js
+++ b/cocos2d/core/load-pipeline/downloader.js
@@ -42,7 +42,7 @@ else {
 
 function downloadScript (item, callback, isAsync) {
     var url = item.url,
-        d = document, 
+        d = document,
         s = document.createElement('script');
     s.async = isAsync;
     s.src = urlAppendTimestamp(url);
@@ -129,8 +129,8 @@ var FONT_TYPE = {
     '.svg' : 'svg'
 };
 function _loadFont (name, srcs, type){
-    var doc = document, 
-        path = cc.path, 
+    var doc = document,
+        path = cc.path,
         fontStyle = document.createElement('style');
     fontStyle.type = 'text/css';
     doc.body.appendChild(fontStyle);
@@ -167,8 +167,8 @@ function _loadFont (name, srcs, type){
 }
 function downloadFont (item, callback) {
     var url = item.url,
-        type = item.type, 
-        name = item.name, 
+        type = item.type,
+        name = item.name,
         srcs = item.srcs;
     if (name && srcs) {
         if (srcs.indexOf(url) === -1) {
@@ -194,7 +194,7 @@ function downloadFont (item, callback) {
 var reusedArray = [];
 
 function downloadUuid (item, callback) {
-    var uuid = item.id;
+    var uuid = item.uuid;
     var self = this;
     cc.AssetLibrary.queryAssetInfo(uuid, function (error, url, isRawAsset) {
         if (error) {
@@ -308,7 +308,7 @@ var ID = 'Downloader';
  *      // This will match all url with `.scene` extension or all url with `scene` type
  *      'scene' : function (url, callback) {}
  *  });
- * 
+ *
  * @method Downloader
  * @param {Object} extMap Custom supported types with corresponded handler
  */

--- a/cocos2d/core/platform/CCAssetLibrary.js
+++ b/cocos2d/core/platform/CCAssetLibrary.js
@@ -75,6 +75,7 @@ var AssetLibrary = {
         // var writeMainCache = typeof (options && options.writeMainCache) !== 'undefined' ? writeMainCache : true;
         var item = {
             id: uuid,
+            uuid: uuid,
             type: 'uuid'
         };
         if (options && options.deserializeInfo) {
@@ -145,6 +146,15 @@ var AssetLibrary = {
                 url: url,
                 raw: false,
             };
+        }
+    },
+
+    _getAssetUrl: function (uuid) {
+        var info = _uuidToRawAsset[uuid];
+        if (info) {
+            return _rawAssetsBase + info.url;
+        } else {
+            return null;
         }
     },
 


### PR DESCRIPTION
1. 新增了一个 _getAssetUrl 用于将 uuid 转成 url
2. 将 item 的 id 和 uuid 功能区分开来， id 可以是 uuid 但是也不能作为加载的 uuid 使用，还是要在每个 item 里面加上 uuid 属性。
3. getItem 中做了兼容处理，允许传入 uuid 和 url，因为之前是 uuid 索引，传入 uuid，现在改成 url 索引，uuid 已经找不到缓存了，所以主动去 AssetLib 里面找一次，再回来查找缓存。

@pandamicro @jareguo @jwu 

因为修改的比较底层的加载流程，AssetLib 和 item 的部分逻辑也不是很熟悉，需要大家帮忙 download 下来测试一下相关流程是否还在预期之中。

https://github.com/cocos-creator/fireball/issues/4674