### PR TITLE
don't trigger loadTTF when ttf is not exists

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -248,7 +248,8 @@ var RichText = cc.Class({
     },
 
     _onTTFLoaded: function () {
-        if(!this._getFontRawUrl()) return;
+        var rawUrl = this._getFontRawUrl();
+        if(!rawUrl) return;
 
         var self = this;
 
@@ -257,7 +258,7 @@ var RichText = cc.Class({
             self._updateRichText();
         };
 
-        cc.CustomFontLoader.loadTTF(this._getFontRawUrl(), callback);
+        cc.CustomFontLoader.loadTTF(rawUrl, callback);
     },
 
     _measureText: function (styleIndex, string) {

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -248,6 +248,8 @@ var RichText = cc.Class({
     },
 
     _onTTFLoaded: function () {
+        if(!this._getFontRawUrl()) return;
+
         var self = this;
 
         var callback = function () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/4766

Changes proposed in this pull request:
 * fix richText custom TTF load issue

@cocos-creator/engine-admins

