### PR TITLE
fix cc.Node:getActionByTag returns undefined for engine/issues/1300

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1418,7 +1418,7 @@ var Node = cc.Class({
             cc.log(cc._LogInfos.Node.getActionByTag);
             return null;
         }
-        cc.director.getActionManager().getActionByTag(tag, this);
+        return cc.director.getActionManager().getActionByTag(tag, this);
     },
 
     /**


### PR DESCRIPTION
https://github.com/cocos-creator/engine/issues/1300

Changes proposed in this pull request:
 * fix cc.Node:getActionByTag returns undefined

@cocos-creator/engine-admins

