### PR TITLE
default value in CCClass should not accept constructor

### DIFF
--- a/cocos2d/core/platform/preprocess-attrs.js
+++ b/cocos2d/core/platform/preprocess-attrs.js
@@ -202,6 +202,11 @@ module.exports = function (properties, className, cls) {
                         cc.error('The "default" value of "%s.%s" should not be used with a "set" function.',
                             className, propName);
                     }
+                    else if (cc.Class._isCCClass(val.default)) {
+                        val.default = null;
+                        cc.error('The "default" value of "%s.%s" can not be an constructor. Set default to null please.',
+                            className, propName);
+                    }
                 }
                 else if (!val.get && !val.set) {
                     cc.error('Property "%s.%s" must define at least one of "default", "get" or "set".',


### PR DESCRIPTION
Re: cocos-creator/fireball#4821

Changes proposed in this pull request:
 * 修复 CCClass 的 default 直接设为构造函数时，编辑器下会提示全局变量被修改的 bug

@cocos-creator/engine-admins

