### PR TITLE
Fixing CCSGParticleSystem to read rotationIsDir is not a string error

### DIFF
--- a/cocos2d/particle/CCSGParticleSystem.js
+++ b/cocos2d/particle/CCSGParticleSystem.js
@@ -1339,8 +1339,10 @@ _ccsg.ParticleSystem = _ccsg.Node.extend({
                 locModeA.tangentialAccelVar = (pszTmp) ? parseFloat(pszTmp) : 0;
 
                 // rotation is dir
-                var locRotationIsDir = locValueForKey("rotationIsDir", dictionary).toLowerCase();
-                locModeA.rotationIsDir = (locRotationIsDir != null && (locRotationIsDir === "true" || locRotationIsDir === "1"));
+                var locRotationIsDir = locValueForKey("rotationIsDir", dictionary);
+                locRotationIsDir = ("" + locRotationIsDir).toLowerCase();
+                locModeA.rotationIsDir = (locRotationIsDir === "true" || locRotationIsDir === "1");
+
             } else if (this.emitterMode === _ccsg.ParticleSystem.Mode.RADIUS) {
                 // or Mode B: radius movement
                 var locModeB = this.modeB;


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 * 修复当读取的粒子 plist 中的 rotationIsDir 不是字符串的时候会报错

@cocos-creator/engine-admins

