### PR TITLE
Fixed a dead loop when the file texture uuid is undefined for firebal…

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -918,6 +918,10 @@ var ParticleSystem = cc.Class({
                 // so use the texutreUuid instead of textureImageData
                 if (content.textureUuid) {
                     cc.AssetLibrary.queryAssetInfo(content.textureUuid, function (err, url, raw) {
+                        if (err) {
+                            cc.error(err);
+                            return;
+                        }
                         self.texture = url;
                     });
                 }


### PR DESCRIPTION
Re: cocos-creator/fireball#4822

Changes proposed in this pull request:
 * 修复当 ParticleSystem 加载 textureUuid 为 undefined 时，会导致 ParticleSystem 重复加载死循环

@cocos-creator/engine-admins

…l/issues/4822