### PR TITLE
Repair loader._items.map to cc.loader._cache for enableAntiAlias

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -442,9 +442,9 @@ var View = cc._Class.extend({
         }
         this._antiAliasEnabled = enabled;
         if(cc._renderType === cc.game.RENDER_TYPE_WEBGL) {
-            var map = cc.loader._items.map;
-            for (var key in map) {
-                var item = map[key];
+            var cache = cc.loader._cache;
+            for (var key in cache) {
+                var item = cache[key];
                 var tex = item && item.content instanceof cc.Texture2D ? item.content : null;
                 if (tex) {
                     if (enabled) {


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 *  修改  enableAntiAlias 中 loader._items.map 为 cc.loader._cache 的代码

@cocos-creator/engine-admins

