### PR TITLE
fix jsb mask this._clippingStencil is null

### DIFF
--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -322,8 +322,10 @@ if (CC_JSB) {
     Mask.prototype.__superOnDestroy = Base.prototype.onDestroy;
     Mask.prototype.onDestroy = function () {
         this.__superOnDestroy();
-        this._clippingStencil.release();
-        this._clippingStencil = null;
+        if (this._clippingStencil) {
+            this._clippingStencil.release();
+            this._clippingStencil = null;
+        }
     };
 }
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 * 修复 CCMask jsb onDestroy 的时候 this._clippingStencil 为 null 报错信息

@cocos-creator/engine-admins

