### PR TITLE
Loader support url param

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -121,7 +121,7 @@ JS.mixin(CCLoader.prototype, {
      * The progression callback is the same as Pipeline's {{#crossLink "Pipeline/onProgress:method"}}onProgress{{/crossLink}}
      * The complete callback is almost the same as Pipeline's {{#crossLink "Pipeline/onComplete:method"}}onComplete{{/crossLink}}
      * The only difference is when user pass a single url as resources, the complete callback will set its result directly as the second parameter.
-     * 
+     *
      * @example
      * cc.loader.load('a.png', function (err, tex) {
      *     cc.log('Result should be a texture: ' + (tex instanceof cc.Texture2D));
@@ -134,7 +134,7 @@ JS.mixin(CCLoader.prototype, {
      * cc.loader.load({id: 'http://example.com/getImageREST?file=a.png', type: 'png'}, function (err, tex) {
      *     cc.log('Should load a texture from RESTful API by specify the type: ' + (tex instanceof cc.Texture2D));
      * });
-     *  
+     *
      * cc.loader.load(['a.png', 'b.json'], function (errors, results) {
      *     if (errors) {
      *         for (var i = 0; i < errors.length; i++) {
@@ -146,19 +146,19 @@ JS.mixin(CCLoader.prototype, {
      * });
      *
      * @method load
-     * @param {String|Array} resources - Url list in an array 
+     * @param {String|Array} resources - Url list in an array
      * @param {Function} [progressCallback] - Callback invoked when progression change
      * @param {Function} completeCallback - Callback invoked when all resources loaded
      */
     load: function(resources, progressCallback, completeCallback) {
-        
+
         // COMPATIBLE WITH 0.X
         if (CC_DEV && typeof resources === 'string' && resources.startsWith('resources://')) {
             cc.warn('Sorry, the "resources://" protocol is obsoleted, use cc.loader.loadRes instead please.');
             this.loadRes(resources.slice('resources://'.length), progressCallback, completeCallback);
             return;
         }
-        
+
         if (completeCallback === undefined) {
             completeCallback = progressCallback;
             progressCallback = this.onProgress || null;
@@ -258,6 +258,10 @@ JS.mixin(CCLoader.prototype, {
 
     _resources: resources,
     _getResUuid: function (url, type) {
+        // Ignore parameter
+        var index = url.indexOf('?');
+        if (index !== -1)
+            url = url.substr(0, index);
         var uuid = resources.getUuid(url, type);
         if ( !uuid ) {
             var extname = cc.path.extname(url);
@@ -277,7 +281,7 @@ JS.mixin(CCLoader.prototype, {
      * Load resources from the "resources" folder inside the "assets" folder of your project.<br>
      * <br>
      * Note: All asset urls in Creator use forward slashes, urls using backslashes will not work.
-     * 
+     *
      * @method loadRes
      * @param {String} url - Url of the target resource.
      *                       The url is relative to the "resources" folder, extensions must be omitted.
@@ -285,9 +289,9 @@ JS.mixin(CCLoader.prototype, {
      * @param {Function} completeCallback - Callback invoked when the resource loaded.
      * @param {Error} completeCallback.error - The error info or null if loaded successfully.
      * @param {Object} completeCallback.resource - The loaded resource if it can be found otherwise returns null.
-     * 
+     *
      * @example
-     * 
+     *
      * // load the prefab (project/assets/resources/misc/character/cocos) from resources folder
      * cc.loader.loadRes('misc/character/cocos', function (err, prefab) {
      *     if (err) {
@@ -459,7 +463,7 @@ JS.mixin(CCLoader.prototype, {
     /**
      * !#en Get all resource dependencies of the requested asset in an array, including itself.
      * The owner parameter accept the following types: 1. The asset itself; 2. The resource url; 3. The asset's uuid.
-     * The returned array stores the dependencies with their uuids, after retrieve dependencies, 
+     * The returned array stores the dependencies with their uuids, after retrieve dependencies,
      * you can release them, access dependent assets by passing the uuid to {{#crossLink "loader/getRes:method"}}{{/crossLink}}, or other stuffs you want.
      * For release all dependencies of an asset, please refer to {{#crossLink "loader/release:method"}}{{/crossLink}}
      * Here is some examples:
@@ -468,7 +472,7 @@ JS.mixin(CCLoader.prototype, {
      * 返回的数组将仅保存依赖资源的 uuid，获取这些 uuid 后，你可以从 loader 释放这些资源；通过 {{#crossLink "loader/getRes:method"}}{{/crossLink}} 获取某个资源或者其他你需要的处理。
      * 想要释放一个资源及其依赖资源，可以参考 {{#crossLink "loader/release:method"}}{{/crossLink}}。
      * 下面是一些示例代码：
-     * 
+     *
      * @example
      * // Release all dependencies of a loaded prefab
      * var deps = cc.loader.getDependsRecursively(prefab);
@@ -482,7 +486,7 @@ JS.mixin(CCLoader.prototype, {
      *         textures.push(item);
      *     }
      * }
-     * 
+     *
      * @param {Asset|RawAsset|String} owner The owner asset or the resource url or the asset's uuid
      * @returns {Array}
      */
@@ -499,7 +503,7 @@ JS.mixin(CCLoader.prototype, {
         else if (typeof owner === 'object') {
             uuid = owner._uuid || null;
         }
-        
+
         if (uuid) {
             var assets = AutoReleaseUtils.getDependsRecursively(uuid);
             assets.push(uuid);

--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -97,7 +97,7 @@ function downloadAudio (item, callback) {
     item.content = item.url;
 
     // If WebAudio is not supported, load using DOM mode
-    if (!__audioSupport.WEB_AUDIO || (item.param && item.param['useDom'])) {
+    if (!__audioSupport.WEB_AUDIO || (item.urlParam && item.urlParam['useDom'])) {
         return loadDomAudio(item, callback);
     }
 

--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -96,28 +96,12 @@ function downloadAudio (item, callback) {
 
     item.content = item.url;
 
-    if (!__audioSupport.WEB_AUDIO) {
-        // If WebAudio is not supported, load using DOM mode
+    // If WebAudio is not supported, load using DOM mode
+    if (!__audioSupport.WEB_AUDIO || (item.param && item.param['useDom'])) {
         return loadDomAudio(item, callback);
     }
 
-    // Get a header
-    // check audio size
-    var request = cc.loader.getXMLHttpRequest();
-    request.open("HEAD", item.url, true);
-    // Our asynchronous callback
-    request.onload = function () {
-        var bit = this.getResponseHeader('Content-Length');
-        if (bit > audioEngine._maxWebAudioSize) {
-            return loadDomAudio(item, callback);
-        }
-        return loadWebAudio(item, callback);
-    };
-    request.onerror = function () {
-        var ERRSTR = 'can not found the resource of audio! Last match url is : ' + item.url;
-        return callback({status: 520, errorMessage: ERRSTR}, null);
-    };
-    request.send();
+    return loadWebAudio(item, callback);
 }
 
 module.exports = downloadAudio;

--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -75,7 +75,7 @@ function createItem (id, queueId) {
         result = {
             queueId: queueId,
             url: urlItem.url,
-            param: urlItem.param,
+            urlParam: urlItem.param,
             error: null,
             content: null,
             complete: false,
@@ -90,7 +90,7 @@ function createItem (id, queueId) {
             queueId: queueId,
             id: urlItem.url,
             url: urlItem.url,
-            param: urlItem.param,
+            urlParam: urlItem.param,
             type: Path.extname(id).toLowerCase().substr(1),
             error: null,
             content: null,

--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -39,20 +39,43 @@ var ItemState = {
 };
 
 var _queueDeps = {};
+var _parseUrl = function (url) {
+    var result = {};
+    if (!url)
+        return result;
+
+    var split = url.split('?');
+    if (!split || !split[0]) {
+        return result;
+    }
+    result.url = split[0];
+    if (!split[1]) {
+        return result;
+    }
+    result.param = {};
+    split = split[1].split('&');
+    split.forEach(function (item) {
+        var itemSplit = item.split('=');
+        result.param[itemSplit[0]] = itemSplit[1];
+    });
+    return result;
+};
 
 function isIdValid (id) {
     var realId = id.id || id;
     return (typeof realId === 'string');
 }
 function createItem (id, queueId) {
-    var result;
+    var result, urlItem;
     if (typeof id === 'object' && id.id) {
         if (!id.type) {
             id.type = Path.extname(id.id).toLowerCase().substr(1);
         }
+        urlItem = _parseUrl(id.url);
         result = {
             queueId: queueId,
-            url: id.url,
+            url: urlItem.url,
+            param: urlItem.param,
             error: null,
             content: null,
             complete: false,
@@ -62,10 +85,12 @@ function createItem (id, queueId) {
         JS.mixin(result, id);
     }
     else if (typeof id === 'string') {
+        urlItem = _parseUrl(id);
         result = {
             queueId: queueId,
-            id: id,
-            url: id,
+            id: urlItem.url,
+            url: urlItem.url,
+            param: urlItem.param,
             type: Path.extname(id).toLowerCase().substr(1),
             error: null,
             content: null,


### PR DESCRIPTION
cocos-creator/fireball#4748

在 laoder.load 与 loader.loadRes 里增加了 url 参数的判断，会在生成的 item 里面增加一个 param 对象，用于保存 url 参数。

由于冲突较多，所以手动同步了之前的 pr 内容。

之前的 pr：
https://github.com/cocos-creator/engine/pull/1316