### PR TITLE
Fixed a bug about missing url

### DIFF
--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -69,9 +69,9 @@ function createItem (id, queueId) {
     var result, urlItem;
     if (typeof id === 'object' && id.id) {
         if (!id.type) {
-            id.type = Path.extname(id.id).toLowerCase().substr(1);
+            id.type = Path.extname(id.url).toLowerCase().substr(1);
         }
-        urlItem = _parseUrl(id.url || id.id);
+        urlItem = _parseUrl(id.url);
         result = {
             queueId: queueId,
             url: urlItem.url,

--- a/cocos2d/core/load-pipeline/pack-downloader.js
+++ b/cocos2d/core/load-pipeline/pack-downloader.js
@@ -83,7 +83,7 @@ module.exports = {
     _loadNewPack: function (uuid, packUuid, callback) {
         var self = this;
         var packUrl = cc.AssetLibrary.getImportedDir(packUuid) + '/' + packUuid + '.json';
-        LoadingItems.create(cc.loader, [{id: packUrl, ignoreMaxConcurrency: true}], function (err, queue) {
+        LoadingItems.create(cc.loader, [{url: packUrl, ignoreMaxConcurrency: true}], function (err, queue) {
             if (err) {
                 cc.error('Failed to download package for ' + uuid);
                 return callback(err);

--- a/test/qunit/unit/test-pipeline.js
+++ b/test/qunit/unit/test-pipeline.js
@@ -40,7 +40,7 @@ test('items', function () {
     var items = cc.LoadingItems.create(pipeline, [
         'res/Background.png',
         {
-            id: 'res/scene.json',
+            url: 'res/scene.json',
             type: 'scene',
             name: 'scene'
         }
@@ -111,7 +111,7 @@ test('pipeline flow', function () {
     var items = cc.LoadingItems.create(pipeline, [
         'res/Background.png',
         {
-            id: 'res/scene.json',
+            url: 'res/scene.json',
             type: 'scene',
             name: 'scene'
         },
@@ -222,7 +222,7 @@ asyncTest('content manipulation', function () {
     var items = cc.LoadingItems.create(pipeline, [
         'res/Background.png',
         {
-            id: 'res/scene.json',
+            url: 'res/scene.json',
             type: 'scene'
         },
         'res/role.plist',


### PR DESCRIPTION
需要区分 uuid / url / id 的意义，不能混肴这三个东西

uuid: 用于索引资源的唯一标识
url: 用于索引资源的链接地址
id: 用于标识缓存索引的字段

如果混用 id 和 url 会造成缓存的索引混乱

@pandamicro @jareguo 