### PR TITLE
fileId of child of prefab should not cloned from existing node

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1089,6 +1089,11 @@ var Node = cc.Class({
         }
 
         var thisPrefabInfo = this._prefab;
+        if (CC_EDITOR && thisPrefabInfo) {
+            if (this !== thisPrefabInfo.root) {
+                _Scene.PrefabUtils.initClonedChildOfPrefab(cloned);
+            }
+        }
         var syncing = thisPrefabInfo && this === thisPrefabInfo.root && thisPrefabInfo.sync;
         if (syncing) {
             // copy non-serialized property


### PR DESCRIPTION
Re: cocos-creator/fireball#4981

Changes proposed in this pull request:
 * 修复复制 Prefab 中的节点后无法正确还原 Prefab 的 Bug

@cocos-creator/engine-admins
