### PR TITLE
prevent method name duplicate with property name

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -299,7 +299,8 @@ if (CC_DEV) {
         "3644": "Please define 'type' parameter of %s.%s as the actual constructor.", //parseAttributes
         "3645": "Please define 'type' parameter of %s.%s as the constructor of %s.", //parseAttributes_2
         "3646": "Unknown 'type' parameter of %s.%s：%s", //parseAttributes_3                
-        "3647": "The length of range array must be equal or greater than 2", //parseAttributes_4             
+        "3647": "The length of range array must be equal or greater than 2", //parseAttributes_4
+        "3648": "Can not declare %s.%s method, it is already defined in the properties of %s.",
         //Prefab: 3700
         "3700": "internal error: _prefab is undefined", //_doInstantiate
         "3701": "Failed to load prefab asset for node '%s'", //syncWithPrefab


### PR DESCRIPTION
Re: cocos-creator/fireball#3543

Changes proposed in this pull request:
 * 当 CCClass 子类方法和父类属性重名时将会报错

@cocos-creator/engine-admins
