### PR TITLE
initialization callback for game.run should be invoked before cc.game.EVENT_GAME_INITED

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -384,13 +384,13 @@ var game = {
                 cc.loader.load(jsList, function (err) {
                     if (err) throw new Error(JSON.stringify(err));
                     self._prepared = true;
-                    self.emit(self.EVENT_GAME_INITED);
                     if (cb) cb();
+                    self.emit(self.EVENT_GAME_INITED);
                 });
             }
             else {
-                self.emit(self.EVENT_GAME_INITED);
                 if (cb) cb();
+                self.emit(self.EVENT_GAME_INITED);
             }
 
             return;

--- a/jsb/jsb-game.js
+++ b/jsb/jsb-game.js
@@ -107,13 +107,13 @@ cc.js.mixin(cc.game, {
                 cc.loader.load(jsList, function (err) {
                     if (err) throw new Error(JSON.stringify(err));
                     self._prepared = true;
-                    self.emit(self.EVENT_GAME_INITED);
                     if (cb) cb();
+                    self.emit(self.EVENT_GAME_INITED);
                 });
             }
             else {
-                self.emit(self.EVENT_GAME_INITED);
                 if (cb) cb();
+                self.emit(self.EVENT_GAME_INITED);
             }
 
             return;


### PR DESCRIPTION
Re: cocos-creator/fireball#5003

Changes proposed in this pull request:
 * 修复 cc.game.EVENT_GAME_INITED 触发时，引擎初始化仍未彻底完成的 Bug

@cocos-creator/engine-admins
