### PR TITLE
support empty path in loadResDir

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -370,7 +370,6 @@ if (CC_DEV) {
         //AutoReleaseUtils: 4800
         "4800": "unknown asset type %s", //getKey
         //Loader: 4900
-        "4900": "Sorry, the 'resources://' protocol is obsoleted, use cc.loader.loadRes instead please.", //load
         "4901": "loadRes: should not specify the extname in %s %s", //_getResUuid
         "4902": "No need to release non-cached asset.", //setAutoRelease
         "4903": "Can not get class '%s'", //uuid-loader.loadUuid

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1308,10 +1308,6 @@ The dom control is not created!
 
 unknown asset type
 
-### 4900
-
-Sorry, the 'resources://' protocol is obsoleted, use cc.loader.loadRes instead please.
-
 ### 4901
 
 loadRes: should not specify the extname in %s %s

--- a/cocos2d/core/load-pipeline/asset-table.js
+++ b/cocos2d/core/load-pipeline/asset-table.js
@@ -73,7 +73,7 @@ cc.js.mixin(AssetTable.prototype, {
         return '';
     },
 
-    getUuidArray: function (path, type) {
+    getUuidArray: function (path, type, out_uuidToUrl) {
         path = cc.url.normalize(path);
         if (path[path.length - 1] === '/') {
             path = path.slice(0, -1);
@@ -89,12 +89,18 @@ cc.js.mixin(AssetTable.prototype, {
                         var entry = item[i];
                         if (!type || isChildClassOf(entry.type, type)) {
                             uuids.push(entry.uuid);
+                            if (out_uuidToUrl) {
+                                out_uuidToUrl[entry.uuid] = p;
+                            }
                         }
                     }
                 }
                 else {
                     if (!type || isChildClassOf(item.type, type)) {
                         uuids.push(item.uuid);
+                        if (out_uuidToUrl) {
+                            out_uuidToUrl[item.uuid] = p;
+                        }
                     }
                 }
             }

--- a/cocos2d/core/load-pipeline/asset-table.js
+++ b/cocos2d/core/load-pipeline/asset-table.js
@@ -80,38 +80,20 @@ cc.js.mixin(AssetTable.prototype, {
         }
         var path2uuid = this._pathToUuid;
         var uuids = [];
-        var p, i;
-        if (type) {
-            var isChildClassOf = cc.isChildClassOf;
-            for (p in path2uuid) {
-                if (p.startsWith(path) && isMatchByWord(p, path)) {
-                    var item = path2uuid[p];
-                    if (Array.isArray(item)) {
-                        for (i = 0; i < item.length; i++) {
-                            var entry = item[i];
-                            if (isChildClassOf(entry.type, type)) {
-                                uuids.push(entry.uuid);
-                            }
-                        }
-                    }
-                    else {
-                        if (isChildClassOf(item.type, type)) {
-                            uuids.push(item.uuid);
+        var isChildClassOf = cc.isChildClassOf;
+        for (var p in path2uuid) {
+            if ((p.startsWith(path) && isMatchByWord(p, path)) || !path) {
+                var item = path2uuid[p];
+                if (Array.isArray(item)) {
+                    for (var i = 0; i < item.length; i++) {
+                        var entry = item[i];
+                        if (!type || isChildClassOf(entry.type, type)) {
+                            uuids.push(entry.uuid);
                         }
                     }
                 }
-            }
-        }
-        else {
-            for (p in path2uuid) {
-                if (p.startsWith(path) && isMatchByWord(p, path)) {
-                    var item = path2uuid[p];
-                    if (Array.isArray(item)) {
-                        for (i = 0; i < item.length; i++) {
-                            uuids.push(item[i].uuid);
-                        }
-                    }
-                    else {
+                else {
+                    if (!type || isChildClassOf(item.type, type)) {
                         uuids.push(item.uuid);
                     }
                 }

--- a/test/qunit/unit/test-loader.js
+++ b/test/qunit/unit/test-loader.js
@@ -31,14 +31,8 @@ asyncTest('Load', function () {
         loader.releaseAll();
         strictEqual(Object.keys(loader._cache).length, 0, 'should clear loading items after releaseAll called');
 
-        clearTimeout(timeoutId);
         start();
     });
-
-    var timeoutId = setTimeout(function () {
-        ok(false, 'time out!');
-        start();
-    }, 5000);
 });
 
 asyncTest('Load single file', function () {
@@ -56,14 +50,8 @@ asyncTest('Load single file', function () {
         ok(texture instanceof cc.Texture2D, 'the single result should be Texture2D');
 
         loader.releaseAll();
-        clearTimeout(timeoutId);
         start();
     });
-
-    var timeoutId = setTimeout(function () {
-        ok(false, 'time out!');
-        start();
-    }, 5000);
 });
 
 asyncTest('Load with dependencies', function () {
@@ -134,14 +122,8 @@ asyncTest('Load with dependencies', function () {
         progressCallback.expect(total, 'should call ' + total + ' times progress callback for ' + total + ' resources');
         loader.releaseAll();
         
-        clearTimeout(timeoutId);
         start();
     });
-
-    var timeoutId = setTimeout(function () {
-        ok(false, 'time out!');
-        start();
-    }, 5000);
 });
 
 asyncTest('Loading font', function () {
@@ -174,12 +156,6 @@ asyncTest('Loading font', function () {
         ok(items.isCompleted(), 'be able to load all resources');
         progressCallback.expect(total, 'should call ' + total + ' times progress callback for ' + total + ' resources');
 
-        clearTimeout(timeoutId);
         start();
     });
-
-    var timeoutId = setTimeout(function () {
-        ok(false, 'time out!');
-        start();
-    }, 5000);
 });

--- a/test/qunit/unit/test-resources-loader.js
+++ b/test/qunit/unit/test-resources-loader.js
@@ -112,4 +112,36 @@
             start();
         });
     });
+
+    test('parse loadRes arguments', function () {
+        var args;
+        function onProgress () {}
+        function onComplete () {}
+
+        function assert (args, type, onProgress, onComplete, testName) {
+            strictEqual(args.type, type, 'type of ' + testName + ' should be correct');
+            equal(args.onProgress, onProgress, 'progress of ' + testName + ' should be correct');
+            equal(args.onComplete, onComplete, 'complete of ' + testName + ' should be correct');
+        }
+
+        args = cc.loader._parseLoadResArgs(TestSprite, onProgress, onComplete);
+        assert(args, TestSprite, onProgress, onComplete, 'case 1');
+        args = cc.loader._parseLoadResArgs(TestSprite, onProgress, null);
+        assert(args, TestSprite, onProgress, null, 'case 2');
+        args = cc.loader._parseLoadResArgs(TestSprite, null, onComplete);
+        assert(args, TestSprite, null, onComplete, 'case 3');
+        args = cc.loader._parseLoadResArgs(TestSprite, onComplete);
+        assert(args, TestSprite, null, onComplete, 'case 4');
+        args = cc.loader._parseLoadResArgs(TestSprite);
+        assert(args, TestSprite, null, null, 'case 5');
+        args = cc.loader._parseLoadResArgs(onProgress, onComplete);
+        assert(args, null, onProgress, onComplete, 'case 6');
+        args = cc.loader._parseLoadResArgs(null, onComplete);
+        assert(args, null, null, onComplete, 'case 7');
+        args = cc.loader._parseLoadResArgs(onProgress, null);
+        assert(args, null, onProgress, null, 'case 8');
+        args = cc.loader._parseLoadResArgs(onComplete);
+        assert(args, null, null, onComplete, 'case 9');
+    });
+
 })();

--- a/test/qunit/unit/test-resources-loader.js
+++ b/test/qunit/unit/test-resources-loader.js
@@ -99,6 +99,19 @@
         });
     });
 
+    asyncTest('url dict of loadResDir', function () {
+        cc.loader.loadResDir('', cc.Texture2D, function (err, results, urlToRes) {
+            var urls = Object.keys(urlToRes);
+            strictEqual(results.length, urls.length, 'url dict should contains the same count with array');
+
+            var url = urls[0];
+            cc.loader.loadRes(url, cc.Texture2D, function (err, result) {
+                strictEqual(result, urlToRes[url], 'url is correct');
+                start();
+            });
+        });
+    });
+
     asyncTest('loadResArray', function () {
         var urls = [
             'grossini/grossini',

--- a/test/qunit/unit/test-resources-loader.js
+++ b/test/qunit/unit/test-resources-loader.js
@@ -1,21 +1,25 @@
 (function () {
 
+    var Assets;
+
     module('load resources', {
         setup: function () {
             _resetGame();
-            AssetLibrary.init({
+            Assets = {
+                '0000001': ['resources/grossini/grossini.png', cc.js._getClassId(cc.Texture2D)],
+                '123201':  ['resources/grossini/grossini', cc.js._getClassId(TestSprite), 1],
+                '0000000': ['resources/grossini.png', cc.js._getClassId(cc.Texture2D)],
+                '1232218': ['resources/grossini', cc.js._getClassId(TestSprite), 1],   // sprite in texture
+                '123200':  ['resources/grossini', cc.js._getClassId(TestSprite), 1],   // sprite in plist
+            };
+            var options = {
                 libraryPath: assetDir + '/library',
                 rawAssetsBase: cc.path.dirname(cc.path._setEndWithSep(assetDir, false) + '.dummyExtForDirname') + '/',
                 rawAssets: {
-                    assets: {
-                        '0000001': ['resources/grossini/grossini.png', cc.js._getClassId(cc.Texture2D)],
-                        '123201':  ['resources/grossini/grossini', cc.js._getClassId(TestSprite), 1],
-                        '0000000': ['resources/grossini.png', cc.js._getClassId(cc.Texture2D)],
-                        '1232218': ['resources/grossini', cc.js._getClassId(TestSprite), 1],   // sprite in texture
-                        '123200':  ['resources/grossini', cc.js._getClassId(TestSprite), 1],   // sprite in plist
-                    }
+                    assets: Assets
                 }
-            });
+            };
+            AssetLibrary.init(options);
             cc.loader.releaseAll();
         },
     });
@@ -42,15 +46,9 @@
 
             cc.loader.loadRes('grossini/grossini', function (err, texture) {
                 ok(texture instanceof cc.Texture2D, 'should be able to load texture without file extname');
-                clearTimeout(timeoutId);
                 start();
             });
         //});
-
-        var timeoutId = setTimeout(function () {
-            ok(false, 'time out!');
-            start();
-        }, 5000);
     });
 
     asyncTest('load single by type', function () {
@@ -59,18 +57,12 @@
 
             cc.loader.loadRes('grossini', cc.Texture2D, function (err, texture) {
                 ok(texture instanceof cc.Texture2D, 'should be able to load asset by type');
-                clearTimeout(timeoutId);
                 start();
             });
         });
-
-        var timeoutId = setTimeout(function () {
-            ok(false, 'time out!');
-            start();
-        }, 5000);
     });
 
-    asyncTest('load main asset and sub asset by loadAll', function () {
+    asyncTest('load main asset and sub asset by loadResDir', function () {
         cc.loader.loadResDir('grossini', function (err, results) {
             ok(Array.isArray(results), 'result should be an array');
             ['123200', '1232218', '123201'].forEach(function (uuid) {
@@ -83,14 +75,8 @@
                     return item.url && item.url.endsWith(url);
                 }), 'checking url ' + url);
             });
-            clearTimeout(timeoutId);
             start();
         });
-
-        var timeoutId = setTimeout(function () {
-            ok(false, 'time out!');
-            start();
-        }, 5000);
     });
 
     asyncTest('loadResDir by type', function () {
@@ -99,13 +85,17 @@
             var sprite = results[0];
             ok(sprite instanceof TestSprite, 'should be able to load test sprite');
 
-            clearTimeout(timeoutId);
             start();
         });
+    });
 
-        var timeoutId = setTimeout(function () {
-            ok(false, 'time out!');
+    asyncTest('load all resources by loadResDir', function () {
+        cc.loader.loadResDir('', function (err, results) {
+            ok(Array.isArray(results), 'result should be an array');
+            var expectCount = Object.keys(Assets).length;
+            strictEqual(results.length, expectCount, 'should load ' + expectCount + ' assets');
+
             start();
-        }, 5000);
+        });
     });
 })();

--- a/test/qunit/unit/test-resources-loader.js
+++ b/test/qunit/unit/test-resources-loader.js
@@ -98,4 +98,18 @@
             start();
         });
     });
+
+    asyncTest('loadResArray', function () {
+        var urls = [
+            'grossini/grossini',
+            'grossini'
+        ];
+        cc.loader.loadResArray(urls, TestSprite, function (err, results) {
+            ok(Array.isArray(results), 'result should be an array');
+            var expectCount = urls.length;
+            strictEqual(results.length, expectCount, 'should load ' + expectCount + ' assets');
+
+            start();
+        });
+    });
 })();


### PR DESCRIPTION
Changes proposed in this pull request:
 * 允许 loader.loadResDir 传入空路径以便加载所有 resources 资源（cocos-creator/fireball#5018）
 * 增加 loader.loadResArray 这个接口，允许加载一个数组中的 resources 资源（cocos-creator/fireball#3228）
 * 为 loader.loadRes, loader.loadResDir, loader.loadResArray 增加 onProgress 回调参数
 * 为 loader.loadResDir 的回调增加一个 url 返回参数，便于获取资源路径名（cocos-creator/fireball#5005）

@cocos-creator/engine-admins
