### PR TITLE
Fixed a bug about ios setVolume

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -381,7 +381,6 @@ var WebAudioElement = function (buffer, audio) {
             this._currentSource.onended = null;
             this.pause();
             this.play();
-            this._currentSource.onended = this._endCallback;
         }
         return num;
     });

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -269,6 +269,12 @@ var WebAudioElement = function (buffer, audio) {
     this.playedLength = 0;
 
     this._currextTimer = null;
+
+    this._endCallback = function () {
+        if (this.onended) {
+            this.onended(this);
+        }
+    }.bind(this);
 };
 
 (function (proto) {
@@ -313,11 +319,7 @@ var WebAudioElement = function (buffer, audio) {
 
         this._currentSource = audio;
 
-        audio.onended = function () {
-            if (this.onended) {
-                this.onended(this);
-            }
-        }.bind(this);
+        audio.onended = this._endCallback;
 
         // If the current audio context time stamp is 0
         // There may be a need to touch events before you can actually start playing audio
@@ -374,10 +376,12 @@ var WebAudioElement = function (buffer, audio) {
     proto.__defineGetter__('volume', function () { return this._volume['gain'].value; });
     proto.__defineSetter__('volume', function (num) {
         this._volume['gain'].value = num;
-        if (cc.sys.os === cc.sys.OS_IOS && !this.paused) {
+        if (cc.sys.os === cc.sys.OS_IOS && !this.paused && this._currentSource) {
             // IOS must be stop webAudio
+            this._currentSource.onended = null;
             this.pause();
             this.play();
+            this._currentSource.onended = this._endCallback;
         }
         return num;
     });

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -114,11 +114,7 @@ var AudioSource = cc.Class({
                 return this._volume;
             },
             set: function (value) {
-                if (value < 0) {
-                    value = 0;
-                } else if (value > 1) {
-                    value = 1;
-                }
+                value = cc.clamp01(value);
                 this._volume = value;
                 var audio = this.audio;
                 if (audio && !this._mute) {

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -114,6 +114,11 @@ var AudioSource = cc.Class({
                 return this._volume;
             },
             set: function (value) {
+                if (value < 0) {
+                    value = 0;
+                } else if (value > 1) {
+                    value = 1;
+                }
                 this._volume = value;
                 var audio = this.audio;
                 if (audio && !this._mute) {


### PR DESCRIPTION
IOS 设置音效不会对已经播放的音频产生效果，所以在设置的时候，先暂停了一下，在播放。

而这个暂停现在会直接触发 onEnded，造成外层元素以为音频已经播放完了，导致 CCAudio 脱离 AudioEngine 控制的事情发生。

所以在暂停之前，需要先将 onEnded 设置成 null。回复播放之后，重新绑定事件。