### PR TITLE
MP4 may be not audio

### DIFF
--- a/cocos2d/core/load-pipeline/downloader.js
+++ b/cocos2d/core/load-pipeline/downloader.js
@@ -252,7 +252,6 @@ var defaultMap = {
     'mp3' : downloadAudio,
     'ogg' : downloadAudio,
     'wav' : downloadAudio,
-    'mp4' : downloadAudio,
     'm4a' : downloadAudio,
 
     // Txt


### PR DESCRIPTION
Mp4 不一定是 audio。

大部分的 mp4 都是视频。所以建议不要使用 mp4 格式的音频。。。音频尽量使用音频独占的格式。。。

@jareguo @pandamicro