### PR TITLE
Fix bmfont lazy loading

### DIFF
--- a/cocos2d/core/components/CCVideoPlayer.js
+++ b/cocos2d/core/components/CCVideoPlayer.js
@@ -253,13 +253,15 @@ var VideoPlayer = cc.Class({
             sgNode.setContentSize(this.node.getContentSize());
             this.pause();
 
-            sgNode.setEventListener(EventType.PLAYING, this.onPlaying.bind(this));
-            sgNode.setEventListener(EventType.PAUSED, this.onPasued.bind(this));
-            sgNode.setEventListener(EventType.STOPPED, this.onStopped.bind(this));
-            sgNode.setEventListener(EventType.COMPLETED, this.onCompleted.bind(this));
-            sgNode.setEventListener(EventType.META_LOADED, this.onMetaLoaded.bind(this));
-            sgNode.setEventListener(EventType.CLICKED, this.onClicked.bind(this));
-            sgNode.setEventListener(EventType.READY_TO_PLAY, this.onReadyToPlay.bind(this));
+            if (!CC_EDITOR) {
+                sgNode.setEventListener(EventType.PLAYING, this.onPlaying.bind(this));
+                sgNode.setEventListener(EventType.PAUSED, this.onPasued.bind(this));
+                sgNode.setEventListener(EventType.STOPPED, this.onStopped.bind(this));
+                sgNode.setEventListener(EventType.COMPLETED, this.onCompleted.bind(this));
+                sgNode.setEventListener(EventType.META_LOADED, this.onMetaLoaded.bind(this));
+                sgNode.setEventListener(EventType.CLICKED, this.onClicked.bind(this));
+                sgNode.setEventListener(EventType.READY_TO_PLAY, this.onReadyToPlay.bind(this));
+            }
         }
     },
 

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1258,26 +1258,22 @@ cc.BMFontHelper = {
 
                 self._config = FntLoader.parseFnt(fntDataStr);
                 self._createFontChars();
-                var texture = spriteFrame.getTexture();
                 self._spriteFrame = spriteFrame;
 
-                var locIsLoaded = texture.isLoaded();
-                self._textureLoaded = locIsLoaded;
-                if (!locIsLoaded) {
-                    texture.once("load", function() {
-                        var self = this;
-
-                        if (!self._spriteBatchNode) {
-                            self._createSpriteBatchNode(texture);
-                        }
-                        self._textureLoaded = true;
-                        self.emit("load");
-                    }, self);
-                } else {
+                var createLabelSprites = function () {
+                    var texture = spriteFrame.getTexture();
+                    self._textureLoaded = texture.isLoaded();
                     if (!self._spriteBatchNode) {
                         self._createSpriteBatchNode(texture);
                         self.emit("load");
                     }
+                };
+
+                if (spriteFrame.textureLoaded()) {
+                    createLabelSprites();
+                } else {
+                    spriteFrame.once('load', createLabelSprites);
+                    spriteFrame.ensureLoadTexture();
                 }
             }
         }

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1263,10 +1263,8 @@ cc.BMFontHelper = {
                 var createLabelSprites = function () {
                     var texture = spriteFrame.getTexture();
                     self._textureLoaded = texture.isLoaded();
-                    if (!self._spriteBatchNode) {
-                        self._createSpriteBatchNode(texture);
-                        self.emit("load");
-                    }
+                    self._createSpriteBatchNode(texture);
+                    self.emit("load");
                 };
 
                 if (spriteFrame.textureLoaded()) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/5101

Changes proposed in this pull request:
 * 修复 bmfont 延迟加载的错误
 * 禁止 videoplayer 在编辑器里面的事件回调，因为有可能在编辑器下面会播放视频，这个不太好。

@cocos-creator/engine-admins
