### PR TITLE
Solve the DragonBones event listeners will be missed when armature is changed in JSB.

### DIFF
--- a/extensions/dragonbones/ArmatureDisplay.js
+++ b/extensions/dragonbones/ArmatureDisplay.js
@@ -391,6 +391,13 @@ dragonBones.ArmatureDisplay = cc.Class({
 
             if (listenersBefore) {
                 sgNode._bubblingListeners = listenersBefore; // using the listeners added before
+                if (CC_JSB && !sgNode.hasEventCallback()) {
+                    // In JSB, should set event callback of the new sgNode
+                    // to make the listeners work well.
+                    sgNode.setEventCallback(function (eventObject) {
+                        sgNode.emit(eventObject.type, eventObject);
+                    });
+                }
             }
 
             self._initSgNode();


### PR DESCRIPTION
Re: cocos-creator/fireball#4921

Changes proposed in this pull request:
 * Solve the DragonBones event listeners will be missed when armature is changed in JSB.

@cocos-creator/engine-admins
