### PR TITLE
fix destroy missing component

### DIFF
--- a/cocos2d/core/components/missing-script.js
+++ b/cocos2d/core/components/missing-script.js
@@ -109,7 +109,8 @@ var MissingScript = cc.Class({
             return null;
         },
         getMissingWrapper: function (id, data) {
-            if (data.node && (CC_EDITOR && Editor.Utils.UuidUtils.isUuid(id))) {
+            if (data.node && /^[0-9a-zA-Z+/]{23}$/.test(id)) {
+                // is component
                 return MissingScript;
             }
             else {


### PR DESCRIPTION
Re: cocos-creator/fireball#5117

Changes proposed in this pull request:
 * 修复 1.4 destroy 脚本丢失的组件时的报错

@cocos-creator/engine-admins
