### PR TITLE
Fixed a bug about audio loader

### DIFF
--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -55,7 +55,9 @@ function loadDomAudio (item, callback) {
     };
     var failure = function () {
         clearEvent();
-        cc.log('load audio failure - ' + item.url);
+        var message = 'load audio failure - ' + item.url;
+        cc.log(message);
+        callback(message, item.url);
     };
     dom.addEventListener("canplaythrough", success, false);
     dom.addEventListener("error", failure, false);


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/5179
https://github.com/cocos-creator/fireball/issues/5181
https://github.com/cocos-creator/fireball/issues/5182

audio 在 dom 模式加载失败的时候没有回调。造成了 load 中断。