### PR TITLE
fix callInNextTick execution sequence for #fireball/issues/5157

### DIFF
--- a/cocos2d/core/platform/utils.js
+++ b/cocos2d/core/platform/utils.js
@@ -71,7 +71,7 @@ module.exports = {
             CC_JSB ?
                 function (callback, p1, p2) {
                     if (callback) {
-                        cc.director.once(cc.Director.EVENT_BEFORE_UPDATE, function () {
+                        cc.director.once(cc.Director._EVENT_NEXT_TICK, function () {
                             callback(p1, p2);
                         });
                     }

--- a/jsb/jsb-director.js
+++ b/jsb/jsb-director.js
@@ -398,9 +398,12 @@ cc.Director.EVENT_BEFORE_SCENE_LAUNCH = 'director_before_scene_launch';
 cc.Director.EVENT_AFTER_SCENE_LAUNCH = "director_after_scene_launch";
 cc.Director.EVENT_COMPONENT_UPDATE = 'director_component_update';
 cc.Director.EVENT_COMPONENT_LATE_UPDATE = 'director_component_late_update';
+cc.Director._EVENT_NEXT_TICK = '_director_next_tick';
 
 cc.eventManager.addCustomListener(cc.Director.EVENT_BEFORE_UPDATE, function () {
     var dt = cc.director.getDeltaTime();
+    // cocos-creator/fireball#5157
+    cc.director.emit(cc.Director._EVENT_NEXT_TICK);
     // Call start for new added components
     cc.director.emit(cc.Director.EVENT_BEFORE_UPDATE);
     // Update for components


### PR DESCRIPTION
Re: cocos-creator/fireball#5157

Changes proposed in this pull request:
 * 加了一个私有事件，让 callInNextTick 在 EVENT_BEFORE_UPDATE 之前执行

@cocos-creator/engine-admins
