### PR TITLE
Use argsArr to wrap arguments in cc.xxxID and fix assertID logic issue

### DIFF
--- a/CCDebugger.js
+++ b/CCDebugger.js
@@ -312,58 +312,74 @@ cc._initDebugSetting = function (mode) {
     var errorMapUrl = 'https://github.com/cocos-creator/engine/blob/master/EngineErrorMap.md';
 
     cc.warnID = function (id) { // id in number
+        var argsArr = new Array(arguments.length);
+        argsArr[0] = cc._LogInfos[id];
+        for (var i = 1; i < argsArr.length; ++i) {
+            argsArr[i] = arguments[i];
+        }
         if (CC_DEV) {
-            arguments[0] = cc._LogInfos[id];
-            cc.warn.apply(cc, arguments);
+            cc.warn.apply(cc, argsArr);
         } else {
             var args = '';
             if (arguments.length === 2) {
                 args = 'Arguments: ' + arguments[1];
             } else if (arguments.length > 2) {
                 args = 'Arguments: ' + Array.apply(null, arguments).slice(1).join(', ');
-            }            
+            }
             cc.warn('Warning ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details. ' + args);
         }
     };
 
     cc.errorID = function (id) {
+        var argsArr = new Array(arguments.length);
+        argsArr[0] = cc._LogInfos[id];
+        for (var i = 1; i < argsArr.length; ++i) {
+            argsArr[i] = arguments[i];
+        }
         if (CC_DEV) {
-            arguments[0] = cc._LogInfos[id];
-            cc.error.apply(cc, arguments);            
+            cc.error.apply(cc, argsArr);
         } else {
             var args = '';
             if (arguments.length === 2) {
-                args = 'Arguments: ' + arguments[1];
+                args = 'Arguments: ' + argsArr[1];
             } else if (arguments.length > 2) {
-                args = 'Arguments: ' + Array.apply(null, arguments).slice(1).join(', ');
+                args = 'Arguments: ' + argsArr.slice(1).join(', ');
             }
             cc.error('Error ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details. ' + args);
         }        
     };
     cc.logID = function (id) {
+        var argsArr = new Array(arguments.length);
+        argsArr[0] = cc._LogInfos[id];
+        for (var i = 1; i < argsArr.length; ++i) {
+            argsArr[i] = arguments[i];
+        }
         if (CC_DEV) {
-            arguments[0] = cc._LogInfos[id];
-            cc.log.apply(cc, arguments);
+            cc.log.apply(cc, argsArr);
         } else {
             var args = '';
             if (arguments.length === 2) {
                 args = 'Arguments: ' + arguments[1];
             } else if (arguments.length > 2) {
-                args = 'Arguments: ' + Array.apply(null, arguments).slice(1).join(', ');
+                args = 'Arguments: ' + argsArr.slice(1).join(', ');
             }
             cc.log('Log ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details. ' + args);
         }        
     };
     cc.assertID = function (cond, id) {
+        var argsArr = new Array(arguments.length);
+        for(var i = 0; i < argsArr.length; ++i) {
+            argsArr[i] = arguments[i];
+        }
+        argsArr[1] = cc._LogInfos[id];
         if (CC_DEV) {
-            arguments[1] = cc._LogInfos[id];
-            cc.assert(cond, cc._LogInfos[id], arguments);
+            cc.assert(cond, argsArr[1], argsArr);
         } else {
             var args = '';
             if (arguments.length === 3) {
                 args = 'Arguments: ' + arguments[2];
             } else if (arguments.length > 3) {
-                args = 'Arguments: ' + Array.apply(null, arguments).slice(2).join(', ');
+                args = 'Arguments: ' + argsArr.slice(2).join(', ');
             }
             cc.assert(cond, 'Assert ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details. ' + args);
         }

--- a/CCDebugger.js
+++ b/CCDebugger.js
@@ -311,68 +311,41 @@ cc._initDebugSetting = function (mode) {
 
     var errorMapUrl = 'https://github.com/cocos-creator/engine/blob/master/EngineErrorMap.md';
 
-    cc.warnID = function (id) { // id in number
-        var argsArr = new Array(arguments.length);
-        argsArr[0] = cc._LogInfos[id];
-        for (var i = 1; i < argsArr.length; ++i) {
-            argsArr[i] = arguments[i];
-        }
-        if (CC_DEV) {
-            cc.warn.apply(cc, argsArr);
-        } else {
-            var args = '';
-            if (arguments.length === 2) {
-                args = 'Arguments: ' + arguments[1];
-            } else if (arguments.length > 2) {
-                args = 'Arguments: ' + Array.apply(null, arguments).slice(1).join(', ');
+    function genLogFunc (func, type) {
+        return function (id) {
+            if (arguments.length === 1) {
+                CC_DEV ? func(cc._LogInfos[id]) : func(type + ' ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details.');
+                return;
             }
-            cc.warn('Warning ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details. ' + args);
-        }
-    };
+            var argsArr = new Array(arguments.length);
+            for (var i = 0; i < argsArr.length; ++i) {
+                argsArr[i] = arguments[i];
+            }
+            if (CC_DEV) {
+                argsArr[0] = cc._LogInfos[id];
+                func.apply(cc, argsArr);
+            } else {
+                var args = '';
+                if (arguments.length === 2) {
+                    args = 'Arguments: ' + arguments[1];
+                } else if (arguments.length > 2) {
+                    args = 'Arguments: ' + argsArr.slice(1).join(', ');
+                }
+                func(type + ' ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details. ' + args);
+            }
+        };
+    }
 
-    cc.errorID = function (id) {
-        var argsArr = new Array(arguments.length);
-        argsArr[0] = cc._LogInfos[id];
-        for (var i = 1; i < argsArr.length; ++i) {
-            argsArr[i] = arguments[i];
-        }
-        if (CC_DEV) {
-            cc.error.apply(cc, argsArr);
-        } else {
-            var args = '';
-            if (arguments.length === 2) {
-                args = 'Arguments: ' + argsArr[1];
-            } else if (arguments.length > 2) {
-                args = 'Arguments: ' + argsArr.slice(1).join(', ');
-            }
-            cc.error('Error ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details. ' + args);
-        }        
-    };
-    cc.logID = function (id) {
-        var argsArr = new Array(arguments.length);
-        argsArr[0] = cc._LogInfos[id];
-        for (var i = 1; i < argsArr.length; ++i) {
-            argsArr[i] = arguments[i];
-        }
-        if (CC_DEV) {
-            cc.log.apply(cc, argsArr);
-        } else {
-            var args = '';
-            if (arguments.length === 2) {
-                args = 'Arguments: ' + arguments[1];
-            } else if (arguments.length > 2) {
-                args = 'Arguments: ' + argsArr.slice(1).join(', ');
-            }
-            cc.log('Log ' + id + ', please go to ' + errorMapUrl + '#' + id + ' to see details. ' + args);
-        }        
-    };
+    cc.warnID = genLogFunc(cc.warn, 'Warning');
+    cc.errorID = genLogFunc(cc.error, 'Error');
+    cc.logID = genLogFunc(cc.log, 'Log');
     cc.assertID = function (cond, id) {
         var argsArr = new Array(arguments.length);
         for(var i = 0; i < argsArr.length; ++i) {
             argsArr[i] = arguments[i];
         }
-        argsArr[1] = cc._LogInfos[id];
         if (CC_DEV) {
+            argsArr[1] = cc._LogInfos[id];
             cc.assert(cond, argsArr[1], argsArr);
         } else {
             var args = '';


### PR DESCRIPTION
Re: cocos-creator/fireball#5231

Changes proposed in this pull request:
 * Use argsArr to wrap arguments in cc.xxxID and fix assertID logic issue

不应该在任何时候修改 arguments 数组，这会导致函数无法被加速，也有 arguments leak 的风险：
https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
