### PR TITLE
only set spacingX when label is bmfont

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -516,7 +516,9 @@ var Label = cc.Class({
         sgNode.enableWrapText( this._enableWrapText );
         sgNode.setLineHeight(this._lineHeight);
         sgNode.setString(this.string);
-        sgNode.setSpacingX(this.spacingX);
+        if (this.font instanceof cc.BitmapFont) {
+            sgNode.setSpacingX(this.spacingX);
+        }
         if (CC_EDITOR) {
             this._userDefinedFontSize = this.fontSize;
             this._userDefinedFont = this.font;


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 * 
@cocos-creator/engine-admins
