### PR TITLE
define rotation property for dragonbone on native

### DIFF
--- a/jsb/jsb-dragonbones.js
+++ b/jsb/jsb-dragonbones.js
@@ -53,3 +53,6 @@ armatureProto.removeEventListener = function (type, listener, target) {
     jsb.unregisterNativeRef(this, display);
     display.removeEvent(type, listener, target);
 };
+
+var transformProto = dragonBones.Transform.prototype;
+cc.js.getset(transformProto, 'rotation', transformProto.getRotation, transformProto.setRotation);


### PR DESCRIPTION
Re: cocos-creator/fireball#5230

Changes proposed in this pull request:
 * 修复 dragonBones 原生平台未定义 Transform.rotation 属性的问题

@cocos-creator/engine-admins
