### PR TITLE
fix updateAlignment when using widget with alignOnce enabled

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -474,9 +474,12 @@ var Node = cc.Class({
         }
     },
 
-    //statics: {
-    //    _DirtyFlags: require('./utils/misc').DirtyFlags
-    //},
+    statics: {
+        // is node but not scene
+        isNode: function (obj) {
+            return obj instanceof Node && (obj.constructor === Node || !(obj instanceof cc.Scene));
+        }
+    },
 
     // OVERRIDES
 

--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -409,10 +409,11 @@ var activeWidgets = [];
 // updateAlignment from scene to node recursively
 function updateAlignment (node) {
     var parent = node._parent;
-    if (parent) {
+    if (cc.Node.isNode(parent)) {
         updateAlignment(parent);
     }
-    var widget = node._widget;
+    var widget = node._widget ||
+                 node.getComponent(cc.Widget);  // node._widget will be null when widget is disabled
     if (widget) {
         align(node, widget);
     }


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/5455

Changes proposed in this pull request:
 * 修复 Widget 选中 align once 后调用 updateAlignment 无效的 bug


@cocos-creator/engine-admins
