### PR TITLE
should not skip onLoad when previous sibling node is deactivated

### DIFF
--- a/cocos2d/core/node-activator.js
+++ b/cocos2d/core/node-activator.js
@@ -66,12 +66,8 @@ function createActivateTask () {
         for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
             let comp = array[iterator.i];
             callOnLoadInTryCatch(comp);
-            if (!comp.node._activeInHierarchy) {
-                // deactivated during onLoad
-                break;
-            }
         }
-    } : CompScheduler.createInvokeImpl('c.onLoad();if(!c.node._activeInHierarchy)break;');
+    } : CompScheduler.createInvokeImpl('c.onLoad();');
     return {
         preload: new UnsortedInvoker(invokePreload),
         onLoad: new CompScheduler.OneOffInvoker(invokeOnLoad),

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -179,8 +179,7 @@ function defineGetSet (cls, name, propName, val, es6) {
 
         var attrs = parseAttributes(cls, val, name, propName, true);
         for (var i = 0; i < attrs.length; i++) {
-            var attr = attrs[i];
-            Attr.attr(cls, propName, attr);
+            Attr.attr(cls, propName, attrs[i]);
         }
         attrs.length = 0;
 

--- a/test/qunit/unit-es5/test-component-scheduler.js
+++ b/test/qunit/unit-es5/test-component-scheduler.js
@@ -201,7 +201,15 @@ test('disable component during onEnable', function () {
     }
 
     test('could deactivate self node in onLoad', function () {
-        var node = new cc.Node();
+        var nodes = createNodes({
+            node: {
+            },
+            sibling: {
+                comps: cc.Component,
+            }
+        });
+
+        var node = nodes.node;
 
         var previousComp = createOnlyOnLoadComp(node, 'previous');
 
@@ -224,11 +232,16 @@ test('disable component during onEnable', function () {
         }
 
         node.runAction(cc.delayTime(0));
-        cc.director.getScene().addChild(node);
+
+        var siblingComp = nodes.siblingComps[0];
+        siblingComp.onLoad = new Callback().enable();
+
+        cc.director.getScene().addChild(nodes.root);
 
         strictEqual(node.active, false, 'node should be deactivated');
         strictEqual(cc.director.getActionManager().isTargetPaused_TEST(node), true, 'action should be paused');
         previousComp.onLoad.once('onLoad of previous component should be called').disable();
+        siblingComp.onLoad.once('onLoad of sibling node should still be called');
 
         if (StillInvokeRestCompsOnSameNode) {
             compShouldBeActivated(restComp, 'rest');


### PR DESCRIPTION
Re: cocos-creator/fireball#5669

Changes proposed in this pull request:
 * 修复在 onLoad 中禁用节点时有可能导致后续的 onLoad 没触发的 bug

@cocos-creator/engine-admins
