### PR TITLE
fixed animation

### DIFF
--- a/cocos2d/core/components/CCAnimation.js
+++ b/cocos2d/core/components/CCAnimation.js
@@ -176,11 +176,15 @@ var Animation = cc.Class({
     },
 
     onEnable: function () {
-        this.resume();
+        if (this._animator) {
+            this._animator.resume();
+        }
     },
 
     onDisable: function () {
-        this.pause();
+        if (this._animator) {
+            this._animator.pause();
+        }
     },
 
     onDestroy: function () {
@@ -305,7 +309,7 @@ var Animation = cc.Class({
             }
         }
         else {
-            this._animator.pause();
+            this.enabled = false;
         }
     },
 
@@ -326,7 +330,7 @@ var Animation = cc.Class({
             }
         }
         else {
-            this._animator.resume();
+            this.enabled = true;
         }
     },
 

--- a/test/qunit/unit-es5/test-animation.js
+++ b/test/qunit/unit-es5/test-animation.js
@@ -1451,3 +1451,40 @@ test('animation delay', function () {
 
     strictEqual(state._delayTime, 5, 'delay time should reset when replay');
 });
+
+test('animation pause/resume', function () {
+    var entity = new cc.Node();
+    entity.parent = cc.director.getScene();
+
+    var animation = entity.addComponent(cc.Animation);
+
+    clip = new cc.AnimationClip();
+    clip._name = 'test';
+    clip._duration = 1;
+    clip.curveData = {
+        props: {
+            x: [
+                {frame: 0, value: 0},
+                {frame: 1, value: 100}
+            ]
+        }
+    };
+
+    animation.addClip(clip);
+
+    animation.play('test');
+
+    animation.pause();
+    strictEqual(animation._animator._isPaused, true, 'animation should be paused');
+
+    entity.active = false;
+    strictEqual(animation._animator._isPaused, true, 'animation should be paused');
+
+    entity.active = true;
+    strictEqual(animation._animator._isPaused, true, 'animation should be paused');
+
+    animation.resume();
+    strictEqual(animation._animator._isPaused, false, 'animation should not be paused');
+    
+    entity.parent = null;
+});


### PR DESCRIPTION

Re: cocos-creator/fireball#5640

Changes proposed in this pull request:
 * should not resume animation in onEnable if animation paused by user before onDisable

@cocos-creator/engine-admins
