### PR TITLE
remove unneeded warning msg

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -364,9 +364,6 @@ if (CC_DEV) {
         "4300": "can not found the %s page.", //removePage
         //RichText: 4400
         "4400": "Invalid RichText img tag! The sprite frame name can\'t be found in the ImageAtlas!", //_addRichTextImageElement
-        //ToggleGroup: 4500
-        "4500": "Toggle alreay in ToggleGroup. Something bad happened, please report this issue to the Creator developer, thanks.", //addToggle
-        "4501": "Toggle is not in ToggleGroup. Something bad happened, please report this issue to the Creator developer, thanks.", //removeToggle
         //MissingScript: 4600
         "4600": "Script attached to '%s' is missing or invalid.", //onLoad
         //EditBox: 4700

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1288,14 +1288,6 @@ can not found the %s page.
 
 Invalid RichText img tag! The sprite frame name can't be found in the ImageAtlas!
 
-### 4500
-
-Toggle alreay in ToggleGroup. Something bad happened, please report this issue to the Creator developer, thanks.
-
-### 4501
-
-Toggle is not in ToggleGroup. Something bad happened, please report this issue to the Creator developer, thanks.
-
 ### 4600
 
 Script attached to '%s' is missing or invalid.

--- a/cocos2d/core/components/CCToggleGroup.js
+++ b/cocos2d/core/components/CCToggleGroup.js
@@ -81,9 +81,7 @@ var ToggleGroup = cc.Class({
 
     addToggle: function (toggle) {
         var index = this._toggleItems.indexOf(toggle);
-        if (index > -1) {
-            cc.warnID(4500);
-        } else {
+        if (index === -1) {
             this._toggleItems.push(toggle);
         }
         this._allowOnlyOneToggleChecked();
@@ -93,8 +91,6 @@ var ToggleGroup = cc.Class({
         var index = this._toggleItems.indexOf(toggle);
         if(index > -1) {
             this._toggleItems.splice(index, 1);
-        } else {
-            cc.warnID(4501);
         }
         this._makeAtLeastOneToggleChecked();
     },


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 * 根据这个帖子的讨论 http://forum.cocos.com/t/toggleprefab-warn-toggle-alreay-in-togglegroup-something-bad-happened/46411/4

我把这个警告消息移除了，因为这个警告目前确实意义不大，而且容易引起用户心理恐慌


@cocos-creator/engine-admins
