### PR TITLE
async Load Assets caused MASK to be invalid for fireball/issues/5802

### DIFF
--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -248,6 +248,9 @@ var Mask = cc.Class({
 
     onEnable: function () {
         this._super();
+        if (this.spriteFrame) {
+            this.spriteFrame.ensureLoadTexture();
+        }
         this.node.on('size-changed', this._refreshStencil, this);
         this.node.on('anchor-changed', this._refreshStencil, this);
     },


### PR DESCRIPTION
Re: cocos-creator/fireball#5802

Changes proposed in this pull request:
 * 修复Mask IMAGE_STENCIL 在场景勾选延迟加载资源时无效

@cocos-creator/engine-admins
