### PR TITLE
Update CCTextUtils.js to fix word wrap

### DIFF
--- a/cocos2d/core/label/CCTextUtils.js
+++ b/cocos2d/core/label/CCTextUtils.js
@@ -200,9 +200,9 @@ var CustomFontLoader = {
 var TextUtils = {
     label_wordRex : /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûа-яА-ЯЁё]+|\S)/,
     label_symbolRex : /^[!,.:;}\]%\?>、‘“》？。，！]/,
-    label_lastWordRex : /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûа-яА-ЯЁё]+|\S)$/,
-    label_lastEnglish : /[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûа-яА-ЯЁё]+$/,
-    label_firsrEnglish : /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûа-яА-ЯЁё]/,
+    label_lastWordRex : /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõ-яА-ЯЁё]+|\S)$/,
+    label_lastEnglish : /[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõ-яА-ЯЁё]+$/,
+    label_firsrEnglish : /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõ-яА-ЯЁё]/,
     label_wrapinspection : true,
 
     isUnicodeCJK: function(ch) {


### PR DESCRIPTION
Original issue: https://github.com/cocos-creator/engine/issues/1671

Changes proposed in this pull request:

 * Updated character list to fix word wrap. This fix includes Spanish, Catalan, Hungarian,French and Portuguese. This should be good for most of Romance Languages.