### PR TITLE
remove scheduler call for custom font loader

### DIFF
--- a/cocos2d/core/label/CCTextUtils.js
+++ b/cocos2d/core/label/CCTextUtils.js
@@ -67,7 +67,7 @@ var CustomFontLoader = {
         }
 
         if (this._timerId === 0) {
-            this._timerId = setTimeout(this._checkFontLoaded.bind(this), 0.1);
+            this._timerId = setTimeout(this._checkFontLoaded.bind(this), 100);
         }
     },
 

--- a/cocos2d/core/label/CCTextUtils.js
+++ b/cocos2d/core/label/CCTextUtils.js
@@ -53,7 +53,7 @@ var CustomFontLoader = {
     _canvasContext: null,
     _testString: "BESbswy",
     _allFontsLoaded: false,
-    _timerId: 0,
+    _intervalId: 0,
     loadTTF: function (url, callback) {
         //these platforms support window.FontFace, but it sucks sometimes.
         var useFontFace = (cc.sys.browserType !== cc.sys.BROWSER_TYPE_BAIDU
@@ -66,8 +66,8 @@ var CustomFontLoader = {
             this._loadWithCSS(url, callback);
         }
 
-        if (this._timerId === 0) {
-            this._timerId = setTimeout(this._checkFontLoaded.bind(this), 100);
+        if (this._intervalId === 0) {
+            this._intervalId = setInterval(this._checkFontLoaded.bind(this), 100);
         }
     },
 
@@ -90,8 +90,8 @@ var CustomFontLoader = {
         }
 
         if(this._allFontsLoaded) {
-            clearTimeout(this._timerId);
-            this._timerId = 0;
+            clearInterval(this._intervalId);
+            this._intervalId = 0;
         }
     },
 

--- a/cocos2d/core/label/CCTextUtils.js
+++ b/cocos2d/core/label/CCTextUtils.js
@@ -53,6 +53,7 @@ var CustomFontLoader = {
     _canvasContext: null,
     _testString: "BESbswy",
     _allFontsLoaded: false,
+    _timerId: 0,
     loadTTF: function (url, callback) {
         //these platforms support window.FontFace, but it sucks sometimes.
         var useFontFace = (cc.sys.browserType !== cc.sys.BROWSER_TYPE_BAIDU
@@ -65,8 +66,8 @@ var CustomFontLoader = {
             this._loadWithCSS(url, callback);
         }
 
-        if(!cc.director.getScheduler().isScheduled(this._checkFontLoaded, this)) {
-            cc.director.getScheduler().schedule(this._checkFontLoaded, this, 0.1);
+        if (this._timerId === 0) {
+            this._timerId = setTimeout(this._checkFontLoaded.bind(this), 0.1);
         }
     },
 
@@ -89,7 +90,8 @@ var CustomFontLoader = {
         }
 
         if(this._allFontsLoaded) {
-            cc.director.getScheduler().unschedule(this._checkFontLoaded, this);
+            clearTimeout(this._timerId);
+            this._timerId = 0;
         }
     },
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/5843

Changes proposed in this pull request:
 * use setTimeout when loading custom ttf


@cocos-creator/engine-admins
