### PR TITLE
should not throw error if builtin component is cut

### DIFF
--- a/cocos2d/core/components/missing-script.js
+++ b/cocos2d/core/components/missing-script.js
@@ -24,6 +24,7 @@
  ****************************************************************************/
 
 var JS = cc.js;
+var isBuiltinClassId = require('../utils/misc').isBuiltinClassId;
 
 /*
  * A temp fallback to contain the original serialized data which can not be loaded.
@@ -109,7 +110,7 @@ var MissingScript = cc.Class({
             return null;
         },
         getMissingWrapper: function (id, data) {
-            if (data.node && /^[0-9a-zA-Z+/]{23}$/.test(id)) {
+            if (data.node && (/^[0-9a-zA-Z+/]{23}$/.test(id) || isBuiltinClassId(id))) {
                 // is component
                 return MissingScript;
             }

--- a/cocos2d/core/platform/js.js
+++ b/cocos2d/core/platform/js.js
@@ -24,7 +24,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-const tempCIDGenerater = new (require('./id-generater'))('cc.TmpCId.');
+const tempCIDGenerater = new (require('./id-generater'))('TmpCId.');
 
 
 function _getPropertyDescriptor (obj, name) {

--- a/cocos2d/core/utils/misc.js
+++ b/cocos2d/core/utils/misc.js
@@ -124,4 +124,8 @@ misc.imagePool.get = function () {
 };
 misc.imagePool._smallImg = "data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=";
 
+misc.isBuiltinClassId = function (id) {
+    return id.startsWith('cc.') || id.startsWith('dragonBones.') || id.startsWith('sp.') || id.startsWith('ccsg.');
+};
+
 module.exports = misc;


### PR DESCRIPTION
Re: cocos-creator/fireball#5857

Changes proposed in this pull request:
 * 修复裁剪掉项目正使用的模块会引起 "component._destroyImmediate is not a function" 的问题

@cocos-creator/engine-admins
