### PR TITLE
add renderTexture back

### DIFF
--- a/cocos2d/index.js
+++ b/cocos2d/index.js
@@ -17,3 +17,6 @@ require('./core/sprites/CCSpriteBatchNode.js');
 require('./shape-nodes/CCDrawNode.js');
 require('./shape-nodes/CCDrawNodeCanvasRenderCmd.js');
 require('./shape-nodes/CCDrawNodeWebGLRenderCmd.js');
+require('./render-texture/CCRenderTexture.js');
+require('./render-texture/CCRenderTextureCanvasRenderCmd.js');
+require('./render-texture/CCRenderTextureWebGLRenderCmd.js');


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 *  把 RenderTexture 加回来，不影响模块化。之前的模块化修改会导致预览的模板里面缺少 RenderTexture.

@cocos-creator/engine-admins
