### PR TITLE
Avoid duplicated asset entry in loader caused by synchronous process

### DIFF
--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -229,9 +229,13 @@ proto.appendPipe = function (pipe) {
 proto.flowIn = function (items) {
     var i, pipe = this._pipes[0], item;
     if (pipe) {
+        // Cache all items first, in case synchronous loading flow same item repeatly
         for (i = 0; i < items.length; i++) {
             item = items[i];
             this._cache[item.id] = item;
+        }
+        for (i = 0; i < items.length; i++) {
+            item = items[i];
             flow(pipe, item);
         }
     }


### PR DESCRIPTION
Re: cocos-creator/fireball#5828

Changes proposed in this pull request:
 * 避免同步下载过程导致 loader 中出现重复资源

问题描述：

1. 第一个加载列表包含 [A, B, C]，而 A 依赖于 C
2. flow A 的时候，如果它的 packed json 已经下载好，会同步解析出它的结果，并将 C 再次 flowIn
3. 由于第一个加载列表的 flowIn 循环还没有处理到 C，所以 C 不在 cache 中，让 loader 误以为第二次 flowIn 的 C 是一个新资源
4. 最终 loader 中 flow 了两个 C，虽然 cache 会被覆盖，但是 C asset 的确被加载了两次
5. 我遇到的案例是 SpriteAtlas 依赖的 SpriteFrame 和 Node 依赖的 SpriteFrame 对象不统一

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
