### PR TITLE
improve progressbar, make error msg explicitly

### DIFF
--- a/cocos2d/core/components/CCProgressBar.js
+++ b/cocos2d/core/components/CCProgressBar.js
@@ -154,25 +154,34 @@ var ProgressBar = cc.Class({
                     totalWidth = entitySize.width;
                     totalHeight = this.totalLength;
                     break;
-                case Mode.FILLED:
+            }
+
+            //handling filled mode
+            if (this.mode === Mode.FILLED) {
+                if (this.barSprite.type !== cc.Sprite.Type.FILLED) {
+                    cc.warn('ProgressBar FILLED mode only works when barSprite\'s Type is FILLED!');
+                } else {
                     if (this.reverse) {
                         actualLenth = actualLenth * -1;
                     }
                     this.barSprite.fillRange = actualLenth;
-                    break;
+                }
+            } else {
+                if (this.barSprite.type !== cc.Sprite.Type.FILLED) {
+
+                    var anchorOffsetX = anchorPoint.x - entityAnchorPoint.x;
+                    var anchorOffsetY = anchorPoint.y - entityAnchorPoint.y;
+                    var finalPosition = cc.p(totalWidth * anchorOffsetX, totalHeight * anchorOffsetY);
+
+                    entity.setPosition(cc.pAdd(entityPosition, finalPosition));
+
+                    entity.setAnchorPoint(anchorPoint);
+                    entity.setContentSize(finalContentSize);
+                } else {
+                    cc.warn('ProgressBar non-FILLED mode only works when barSprite\'s Type is non-FILLED!');
+                }
             }
 
-            if (this.barSprite.type !== cc.Sprite.Type.FILLED) {
-
-                var anchorOffsetX = anchorPoint.x - entityAnchorPoint.x;
-                var anchorOffsetY = anchorPoint.y - entityAnchorPoint.y;
-                var finalPosition = cc.p(totalWidth * anchorOffsetX, totalHeight * anchorOffsetY);
-
-                entity.setPosition(cc.pAdd(entityPosition, finalPosition));
-
-                entity.setAnchorPoint(anchorPoint);
-                entity.setContentSize(finalContentSize);
-            }
 
 
         }
@@ -221,16 +230,23 @@ var ProgressBar = cc.Class({
             animatable: false
         },
 
+        _totalLength: 1,
         /**
          * !#en The total width or height of the bar sprite.
          * !#zh 进度条实际的总长度
          * @property {Number} totalLength
          */
         totalLength: {
-            default: 1,
             range: [0, Number.MAX_VALUE],
             tooltip: CC_DEV && 'i18n:COMPONENT.progress.total_length',
-            notify: function(value) {
+            get: function () {
+                return this._totalLength;
+            },
+            set: function(value) {
+                if (this.mode === Mode.FILLED) {
+                    value = cc.clamp01(value);
+                }
+                this._totalLength = value;
                 this._updateBarStatus();
             }
         },


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 * clamp totalLength to 1 when progressBar mode is FILLED
 * add explicit warning message when the barSprite type and progressBar's mode is mismatch

@cocos-creator/engine-admins
