### PR TITLE
improve scrollview events timing

### DIFF
--- a/cocos2d/core/components/CCPageView.js
+++ b/cocos2d/core/components/CCPageView.js
@@ -218,14 +218,14 @@ var PageView = cc.Class({
     onEnable: function () {
         this._super();
         if(!CC_EDITOR) {
-            this.node.on('scroll-ended', this._dispatchPageTurningEvent, this);
+            this.node.on('scroll-ended-with-threshold', this._dispatchPageTurningEvent, this);
         }
     },
 
     onDisable: function () {
         this._super();
         if(!CC_EDITOR) {
-            this.node.off('scroll-ended', this._dispatchPageTurningEvent, this);
+            this.node.off('scroll-ended-with-threshold', this._dispatchPageTurningEvent, this);
         }
     },
 

--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -179,9 +179,10 @@ var ScrollView = cc.Class({
         this._outOfBoundaryAmountDirty = true;
         this._stopMouseWheel = false;
         this._mouseWheelEventElapsedTime = 0.0;
-        this._isScrollEndedEventFired = false;
+        this._isScrollEndedWithThresholdEventFired = false;
         //use bit wise operations to indicate the direction
         this._scrollEventEmitMask = 0;
+        this._isBouncing = false;
     },
 
     properties: {
@@ -1183,9 +1184,9 @@ var ScrollView = cc.Class({
         var reachedEnd = Math.abs(percentage - 1) <= EPSILON;
 
         var fireEvent = Math.abs(percentage - 1) <= this.getScrollEndedEventTiming();
-        if(fireEvent && !this._isScrollEndedEventFired) {
+        if(fireEvent && !this._isScrollEndedWithThresholdEventFired) {
             this._dispatchEvent('scroll-ended-with-threshold');
-            this._isScrollEndedEventFired = true;
+            this._isScrollEndedWithThresholdEventFired = true;
         }
 
         if (this.elastic) {
@@ -1284,7 +1285,7 @@ var ScrollView = cc.Class({
         this._autoScrollTotalTime = timeInSecond;
         this._autoScrollAccumulatedTime = 0;
         this._autoScrollBraking = false;
-        this._isScrollEndedEventFired = false;
+        this._isScrollEndedWithThresholdEventFired = false;
         this._autoScrollBrakingStartPosition = cc.p(0, 0);
 
         var currentOutOfBoundary = this._getHowMuchOutOfBoundary();


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/5848

Changes proposed in this pull request:
 *  添加 scroll-ended-with-threshold，主要是给 PageView 使用
 * 修复 scroll-ended 事件发送时，scrollview 还会往前滚动一小段距离
 * 拖动 ScrollView 到边界后松手，只发送一次 bounce 事件
 * 当自动滚动发生时，如果点击立马松手，将触发 scroll-ended 事件
 * 自动滚动开始后也会发送 scrolling 事件

@cocos-creator/engine-admins
