### PR TITLE
fix editbox can't input on UC browser

### DIFF
--- a/cocos2d/core/editbox/CCSGEditBox.js
+++ b/cocos2d/core/editbox/CCSGEditBox.js
@@ -969,7 +969,13 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
         if (!this._editBox._alwaysOnTop) {
             if (this._edTxt.style.display === 'none') {
                 this._edTxt.style.display = '';
-                this._edTxt.focus();
+                if (cc.sys.browserType === cc.sys.BROWSER_TYPE_UC) {
+                    setTimeout(function () {
+                        this._edTxt.focus();
+                    }.bind(this), TIMER_NAME);
+                } else {
+                    this._edTxt.focus();
+                }
             }
         }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/4903

Changes proposed in this pull request:
 * 修复 UC 浏览器不能正确弹出输入框的 bug



@cocos-creator/engine-admins
