### PR TITLE
remove unneeded api in particle sgNode

### DIFF
--- a/cocos2d/particle/CCSGParticleSystem.js
+++ b/cocos2d/particle/CCSGParticleSystem.js
@@ -1477,16 +1477,7 @@ _ccsg.ParticleSystem = _ccsg.Node.extend({
         this._renderCmd._initWithTotalParticles(numberOfParticles);
         return true;
     },
-
-    /**
-     * Unschedules the "update" method.
-     * @function
-     * @see scheduleUpdate();
-     */
-    destroyParticleSystem:function () {
-        this.unscheduleUpdate();
-    },
-
+    
     /**
      * Add a particle to the emitter
      * @return {Boolean}


### PR DESCRIPTION
Changes proposed in this pull request:
 * 移除 destroyParticleSystem，不需要调用，本来就会 cleanup，误导人

@cocos-creator/engine-admins
