### PR TITLE
Optimize bmfont load speed

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -531,7 +531,7 @@ var Label = cc.Class({
                         sgNode = this._sgNode = new _ccsg.Label(this.string, JSON.stringify(font._fntConfig), font.spriteFrame);
                     } else {
                         cc.warnID(4012, font.name);
-                        sgNode = this._sgNode = _ccsg.Label.pool.get(this.string);
+                        sgNode = this._sgNode = new _ccsg.Label(this.string);
                     }
                 } else {
                     sgNode = this._sgNode = _ccsg.Label.pool.get(this.string, "", font.spriteFrame, font);
@@ -595,11 +595,10 @@ var Label = cc.Class({
     },
 
     onDestroy: function () {
-        var sgNode = this._sgNode;
-        //FIXME:: call order matters
+        var sgNodeBeforeDestroy = this._sgNode;
         this._super();
-        if (sgNode) {
-            _ccsg.Label.pool.put(sgNode);
+        if (sgNodeBeforeDestroy) {
+            _ccsg.Label.pool.put(sgNodeBeforeDestroy);
         }
     }
  });

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -404,10 +404,10 @@ var Label = cc.Class({
                     if (font instanceof cc.BitmapFont) {
                         if (font.spriteFrame) {
                             if (!CC_JSB) {
-                                this._sgNode.setFontFileOrFamily(font.fntDataStr, font.spriteFrame, font);
+                                this._sgNode.setFontFileOrFamily("", font.spriteFrame, font);
                             } else {
                                 if (font.spriteFrame.textureLoaded()) {
-                                    this._sgNode.setFontFileOrFamily(font.fntDataStr, font.spriteFrame);
+                                    this._sgNode.setFontFileOrFamily(JSON.stringify(font._fntConfig), font.spriteFrame);
                                 }
                                 else {
                                     cc.warnID(4012, font.name);
@@ -528,13 +528,13 @@ var Label = cc.Class({
             if (font.spriteFrame) {
                 if (CC_JSB) {
                     if (font.spriteFrame.textureLoaded()) {
-                        sgNode = this._sgNode = new _ccsg.Label(this.string, font.fntDataStr, font.spriteFrame);
+                        sgNode = this._sgNode = new _ccsg.Label(this.string, JSON.stringify(font._fntConfig), font.spriteFrame);
                     } else {
                         cc.warnID(4012, font.name);
                         sgNode = this._sgNode = new _ccsg.Label(this.string);
                     }
                 } else {
-                    sgNode = this._sgNode = new _ccsg.Label(this.string, font.fntDataStr, font.spriteFrame, font);
+                    sgNode = this._sgNode = new _ccsg.Label(this.string, "", font.spriteFrame, font);
                 }
             } else {
                 cc.warnID(4011, font.name);

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -769,6 +769,7 @@ var RichText = cc.Class({
         this._super();
 
         for (var i = 0; i < this._labelSegments.length; ++i) {
+            this._labelSegments[i].removeFromParent(true);
             _ccsg.Label.pool.put(this._labelSegments[i]);
         }
         this._resetState();

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1257,8 +1257,9 @@ _ccsg.Label.pool = new JS.Pool(function (label) {
     label._resetBMFont();
     label._renderCmd._labelCanvas.width = 1;
     label._renderCmd._labelCanvas.height = 1;
-    label.removeFromParent(true);
-    // label._parent = null;
+    if (CC_DEV) {
+        cc.assert(!label._parent, 'Recycling label\'s parent should be null!');
+    }
     label._updateLabel();
     return true;
 }, 20);

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -26,95 +26,6 @@
 require('./CCTextUtils.js');
 var EventTarget = require("../event/event-target");
 
-var FntLoader = {
-    INFO_EXP: /info [^\n]*(\n|$)/gi,
-    COMMON_EXP: /common [^\n]*(\n|$)/gi,
-    PAGE_EXP: /page [^\n]*(\n|$)/gi,
-    CHAR_EXP: /char [^\n]*(\n|$)/gi,
-    KERNING_EXP: /kerning [^\n]*(\n|$)/gi,
-    ITEM_EXP: /\w+=[^ \r\n]+/gi,
-    INT_EXP: /^[\-]?\d+$/,
-
-    _parseStrToObj: function (str) {
-        var arr = str.match(this.ITEM_EXP);
-        var obj = {};
-        if (arr) {
-            for (var i = 0, li = arr.length; i < li; i++) {
-                var tempStr = arr[i];
-                var index = tempStr.indexOf("=");
-                var key = tempStr.substring(0, index);
-                var value = tempStr.substring(index + 1);
-                if (value.match(this.INT_EXP)) value = parseInt(value);
-                else if (value[0] === '"') value = value.substring(1, value.length - 1);
-                obj[key] = value;
-            }
-        }
-        return obj;
-    },
-
-    /**
-     * Parse Fnt string.
-     * @param fntStr
-     * @returns {{}}
-     */
-    parseFnt: function (fntStr) {
-        var self = this, fnt = {};
-        //padding
-        var infoResult = fntStr.match(self.INFO_EXP);
-        if (!infoResult) return fnt;
-
-        var infoObj = self._parseStrToObj(infoResult[0]);
-        var paddingArr = infoObj["padding"].split(",");
-        var padding = {
-            left: parseInt(paddingArr[0]),
-            top: parseInt(paddingArr[1]),
-            right: parseInt(paddingArr[2]),
-            bottom: parseInt(paddingArr[3])
-        };
-
-        //common
-        var commonObj = self._parseStrToObj(fntStr.match(self.COMMON_EXP)[0]);
-        fnt.commonHeight = commonObj["lineHeight"];
-        fnt.fontSize = infoObj["size"];
-
-        if (cc._renderType === cc.game.RENDER_TYPE_WEBGL) {
-            var texSize = cc.configuration.getMaxTextureSize();
-            if (commonObj["scaleW"] > texSize.width || commonObj["scaleH"] > texSize.height)
-                cc.log("cc.LabelBMFont._parseCommonArguments(): page can't be larger than supported");
-        }
-        if (commonObj["pages"] !== 1) cc.log("cc.LabelBMFont._parseCommonArguments(): only supports 1 page");
-
-        //page
-        var pageObj = self._parseStrToObj(fntStr.match(self.PAGE_EXP)[0]);
-        if (pageObj["id"] !== 0) cc.log("cc.LabelBMFont._parseImageFileName() : file could not be found");
-        fnt.atlasName = pageObj["file"];
-
-        //char
-        var charLines = fntStr.match(self.CHAR_EXP);
-        var fontDefDictionary = fnt.fontDefDictionary = {};
-        for (var i = 0, li = charLines.length; i < li; i++) {
-            var charObj = self._parseStrToObj(charLines[i]);
-            var charId = charObj["id"];
-            fontDefDictionary[charId] = {
-                rect: {x: charObj["x"], y: charObj["y"], width: charObj["width"], height: charObj["height"]},
-                xOffset: charObj["xoffset"],
-                yOffset: charObj["yoffset"],
-                xAdvance: charObj["xadvance"]
-            };
-        }
-
-        //kerning
-        var kerningDict = fnt.kerningDict = {};
-        var kerningLines = fntStr.match(self.KERNING_EXP);
-        if (kerningLines) {
-            for (i = 0, li = kerningLines.length; i < li; i++) {
-                var kerningObj = self._parseStrToObj(kerningLines[i]);
-                kerningDict[(kerningObj["first"] << 16) | (kerningObj["second"] & 0xffff)] = kerningObj["amount"];
-            }
-        }
-        return fnt;
-    }
-};
 
 var FontLetterDefinition = function() {
     this._u = 0;
@@ -1303,8 +1214,7 @@ _ccsg.Label = _ccsg.Node.extend({
                 if (fntConfig) {
                     self._config = fntConfig;
                 } else {
-                    self._config = FntLoader.parseFnt(fntDataStr);
-                    this._fontAsset._fntConfig = self._config;
+                    cc.warn('Invalid BMFont Assets!');
                 }
                 self._createFontChars();
                 self._spriteFrame = spriteFrame;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/5917

Changes proposed in this pull request:
 * 优化 BMFont 解析速度，目前 BMFont 的解析直接在编辑器导入的时候就完成了，不需要运行时解析。

Todo: （下一个 PR 要做的，为了简单暂时不在这个 PR 内）

1. 修改 TTF font 的 raw assets为 assets
2. 优化 sgLabel 的 API.


@cocos-creator/engine-admins
