### PR TITLE
#5920 Audio preload error

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -85,8 +85,17 @@ Audio.State = {
 (function (proto) {
 
     proto.preload = function () {
-        var src = this._src,
-            audio = this;
+        var src = this._src, audio = this;
+
+        if (!src) {
+            this._src = '';
+            this._audioType = Audio.Type.UNKNOWN;
+            this._element = null;
+            this._state = Audio.State.INITIALZING;
+            this._loaded = false;
+            return;
+        }
+
         var item = cc.loader.getItem(src);
 
         if (!item) {
@@ -125,14 +134,6 @@ Audio.State = {
         } else {
             this._element.onended = null;
         }
-    };
-
-    proto.unmount = function () {
-        this._src = '';
-        this._audioType = Audio.Type.UNKNOWN;
-        this._element = null;
-        this._state = Audio.State.INITIALZING;
-        this._loaded = false;
     };
 
     proto.mount = function (elem) {

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -127,6 +127,14 @@ Audio.State = {
         }
     };
 
+    proto.unmount = function () {
+        this._src = '';
+        this._audioType = Audio.Type.UNKNOWN;
+        this._element = null;
+        this._state = Audio.State.INITIALZING;
+        this._loaded = false;
+    };
+
     proto.mount = function (elem) {
         if (elem instanceof HTMLElement) {
             this._element = document.createElement('audio');

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -41,7 +41,11 @@ var AudioSource = cc.Class({
     },
 
     ctor: function () {
-        this.audio = new cc.Audio(this._clip);
+        this.audio = new cc.Audio();
+    },
+
+    onLoad: function () {
+        this.clip = this._clip;
     },
 
     properties: {
@@ -93,8 +97,12 @@ var AudioSource = cc.Class({
                 this._clip = value;
                 this.audio.stop();
                 this.audio.src = this._clip;
-                if (this.audio.preload) {
-                    this.audio.preload();
+                if (value) {
+                    if (this.audio.preload) {
+                        this.audio.preload();
+                    }
+                } else {
+                    this.audio.unmount();
                 }
             },
             url: cc.AudioClip,

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -97,12 +97,8 @@ var AudioSource = cc.Class({
                 this._clip = value;
                 this.audio.stop();
                 this.audio.src = this._clip;
-                if (value) {
-                    if (this.audio.preload) {
-                        this.audio.preload();
-                    }
-                } else {
-                    this.audio.unmount();
+                if (this.audio.preload) {
+                    this.audio.preload();
                 }
             },
             url: cc.AudioClip,


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/5920

如果 clip 设置成空字符串 “”，则 preload 会报错，这时候不应该去 preload，应该清空 audio 内的信息。

@jareguo 