### PR TITLE
jsb_polyfill should be marked as expired when gulp-update

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,8 +173,7 @@ gulp.task('test-no-build', function (done) {
 
 // fast build, only for develop
 gulp.task('build-dev', ['build-html5-preview', 'build-jsb-preview'], function (done) {
-    // make dist version dirty
-    Del(['./bin/.cache'], done);
+    Del(['./bin/jsb_polyfill.js', './bin/jsb_polyfill.dev.js', './bin/.cache'], done);
 });
 
 // only build preview for html5 since it will built by editor


### PR DESCRIPTION
Changes proposed in this pull request:
 * 修复 1.6 gulp update 后构建原生平台可能报错

@cocos-creator/engine-admins
