### PR TITLE
#6032 Audio bug

### DIFF
--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -94,6 +94,9 @@ var AudioSource = cc.Class({
                 return this._clip;
             },
             set: function (value) {
+                if (value === this._clip) {
+                    return;
+                }
                 this._clip = value;
                 this.audio.stop();
                 this.audio.src = this._clip;

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -44,10 +44,6 @@ var AudioSource = cc.Class({
         this.audio = new cc.Audio();
     },
 
-    onLoad: function () {
-        this.clip = this._clip;
-    },
-
     properties: {
         _clip: {
             default: '',


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/6032

在 AudioSource onLoad 的时候，会执行一个操作:

```
this.clip = this._clip;
```

这个操作的意思 AudioSource 在场景生成的时候，拿到的数据在 _clip 内，并没有执行预加载等初始化的操作，所以在 onLoad 的时候手动触发一次。

但是这个触发会引起 audio 停止。所以在里面判断一下是否相同，相同的话，没必要执行更新/加载等操作。

@jareguo 