### PR TITLE
fix Mask node 'setContentSize' is invalid for fireball/issues/6056

### DIFF
--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -244,15 +244,12 @@ var Mask = cc.Class({
         }
     },
 
-    __preload: function () {
-        this._refreshStencil();
-    },
-
     onEnable: function () {
         this._super();
         if (this.spriteFrame) {
             this.spriteFrame.ensureLoadTexture();
         }
+        this._refreshStencil();
         this.node.on('size-changed', this._refreshStencil, this);
         this.node.on('anchor-changed', this._refreshStencil, this);
     },


### PR DESCRIPTION
Re: cocos-creator/fireball#6056

Changes proposed in this pull request:
 * 调整一下 _refreshStencil 的调用位置，让用户在 onLoad 的时候设置 contentSize 有效果

@cocos-creator/engine-admins
