### PR TITLE
fix audioEngine deprecated code for fireball/issues/6058

### DIFF
--- a/cocos2d/audio/deprecated.js
+++ b/cocos2d/audio/deprecated.js
@@ -102,9 +102,8 @@ exports.deprecated = function (audioEngine) {
 	});
 	js.get(audioEngine, 'playEffect', function () {
 		// cc.warn(INFO, 'audioEngine.playEffect', 'audioEngine.play');
-
 		return function (url, loop, volume) {
-			return audioEngine.play(url, loop, volume === undefined ? effectsVolume : volume);
+			return audioEngine.play(url, loop || false, volume === undefined ? effectsVolume : volume);
 		}
 	});
 	js.get(audioEngine, 'setEffectsVolume', function (volume) {


### PR DESCRIPTION
Re: cocos-creator/fireball#6058

Changes proposed in this pull request:
 * 这里是由于 audioEngine deprecated 中的 playEffect 参数传入的 loop 为 undefined, 导致 C++ 变量类型转换出错

@cocos-creator/engine-admins
