### PR TITLE
md5 cache respect libraryPath and rawAssetsPath

### DIFF
--- a/cocos2d/core/load-pipeline/md5-pipe.js
+++ b/cocos2d/core/load-pipeline/md5-pipe.js
@@ -40,10 +40,12 @@ MD5Pipe.ID = ID;
 
 MD5Pipe.prototype.handle = function(item) {
     var key = item.url;
-    if (item.url.startsWith(this.libraryBase)) {
+    if (key.startsWith(this.libraryBase)) {
         key = key.slice(this.libraryBase.length);
-    } else {
+    } else if(key.startsWith(this.rawAssetsBase)) {
         key = key.slice(this.rawAssetsBase.length);
+    } else {
+        return item;
     }
     let hashValue = this.md5AssetsMap[key];
     if (hashValue) {

--- a/cocos2d/core/load-pipeline/md5-pipe.js
+++ b/cocos2d/core/load-pipeline/md5-pipe.js
@@ -28,16 +28,24 @@ var Pipeline = require('./pipeline');
 var ID = 'MD5Pipe';
 var ExtnameRegex = /(\.[^.\n\\/]*)$/;
 
-var MD5Pipe = function (md5AssetsMap) {
+var MD5Pipe = function (md5AssetsMap, libraryBase, rawAssetsBase) {
     this.id = ID;
     this.async = false;
     this.pipeline = null;
     this.md5AssetsMap = md5AssetsMap;
+    this.libraryBase = libraryBase;
+    this.rawAssetsBase = rawAssetsBase;
 };
 MD5Pipe.ID = ID;
 
 MD5Pipe.prototype.handle = function(item) {
-    let hashValue = this.md5AssetsMap[item.url];
+    var key = item.url;
+    if (item.url.startsWith(this.libraryBase)) {
+        key = key.slice(this.libraryBase.length);
+    } else {
+        key = key.slice(this.rawAssetsBase.length);
+    }
+    let hashValue = this.md5AssetsMap[key];
     if (hashValue) {
         var matched = false;
         item.url  = item.url.replace(ExtnameRegex, function(match, p1) {

--- a/cocos2d/core/platform/CCAssetLibrary.js
+++ b/cocos2d/core/platform/CCAssetLibrary.js
@@ -275,10 +275,6 @@ var AssetLibrary = {
             return;
         }
 
-        var md5AssetsMap = options.md5AssetsMap;
-        if (md5AssetsMap) {
-            cc.loader.insertPipeAfter(cc.loader.assetLoader, new MD5Pipe(md5AssetsMap));
-        }
 
         // 这里将路径转 url，不使用路径的原因是有的 runtime 不能解析 "\" 符号。
         // 不使用 url.format 的原因是 windows 不支持 file:// 和 /// 开头的协议，所以只能用 replace 操作直接把路径转成 URL。
@@ -287,6 +283,11 @@ var AssetLibrary = {
         _libraryBase = cc.path._setEndWithSep(libraryPath, '/');
 
         _rawAssetsBase = options.rawAssetsBase;
+
+        var md5AssetsMap = options.md5AssetsMap;
+        if (md5AssetsMap) {
+            cc.loader.insertPipeAfter(cc.loader.assetLoader, new MD5Pipe(md5AssetsMap, _libraryBase, _rawAssetsBase));
+        }
 
         // init raw assets
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 * md5 assets support prefix url



@cocos-creator/engine-admins
