### PR TITLE
#6048 currentTime error

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -228,7 +228,18 @@ Audio.State = {
         this._bindEnded(function () {
             this._bindEnded();
         }.bind(this));
-        this._element.currentTime = num;
+        try {
+            this._element.currentTime = num;
+        } catch (err) {
+            var _element = this._element;
+            if (_element.addEventListener) {
+                var func = function () {
+                    _element.removeEventListener('loadedmetadata', func);
+                    _element.currentTime = num;
+                };
+                _element.addEventListener('loadedmetadata', func);
+            }
+        }
     };
     proto.getCurrentTime = function () {
         return this._element ? this._element.currentTime : 0;


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/6048

某些版本的 IE 11 在 audio 没加载完成的情况下，设置 currentTime 会报错。

@jareguo 