### PR TITLE
优化单元测试编译速度

### DIFF
--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -784,7 +784,7 @@ sp.Skeleton = cc.Class({
      */
     addAnimation: function (trackIndex, name, loop, delay) {
         if (this._sgNode) {
-            return this._sgNode.addAnimation(trackIndex, name, loop, delay);
+            return this._sgNode.addAnimation(trackIndex, name, loop, delay || 0);
         }
         return null;
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,7 +146,12 @@ gulp.task('build-test-cases', ['clean-test-cases'], function (done) {
 gulp.task('build-test', ['clean-test', 'build-test-cases'], function (done) {
     Test.build('./index.js', './bin/cocos2d-js-for-test.js',
                '../editor/test-utils/engine-extends-entry.js', './bin/cocos2d-js-extends-for-test.js',
-               done);
+               false, done);
+});
+gulp.task('build-test-sm', ['clean-test', 'build-test-cases'], function (done) {
+    Test.build('./index.js', './bin/cocos2d-js-for-test.js',
+               '../editor/test-utils/engine-extends-entry.js', './bin/cocos2d-js-extends-for-test.js',
+               true, done);
 });
 
 gulp.task('unit-runner', ['build-test'], function (done) {

--- a/test/qunit/run.sh
+++ b/test/qunit/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo Run unit tests in Chrome \(sh test/qunit/run.sh\)
-echo \(You need to run \"gulp build-test\" before testing.\)
+echo \(You need to run \"gulp build-test-sm\" before testing.\)
 echo
 sh test/qunit/run-helper.sh &
 node test/qunit/server.js


### PR DESCRIPTION
Changes proposed in this pull request:
 * 优化单元测试编译速度
   `...args` 移除之后单元测试就不用 uglify 了

@cocos-creator/engine-admins
