### PR TITLE
fix ttf font size in web

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -553,9 +553,7 @@ var Label = cc.Class({
         sgNode.setVisible(false);
         sgNode.setHorizontalAlign( this.horizontalAlign );
         sgNode.setVerticalAlign( this.verticalAlign );
-        if (!(font instanceof cc.TTFFont)) {
-            sgNode.setFontSize( this._fontSize );
-        }
+        sgNode.setFontSize( this._fontSize );
         if (this.useSystemFont) {
             sgNode.setFontFamily(this.fontFamily);
         }


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 * 因为 web 的 ttf font 没有采用和 native 一样的 cache 策略，所以需要设置 fontSize
 * native ttf font 重复调用 setFontSize 也没有问题。


@cocos-creator/engine-admins
