### PR TITLE
[Editor] Fix aliased item couldn't be retrieved issue

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -226,7 +226,7 @@ proto.load = function(resources, progressCallback, completeCallback) {
         var res = getResWithUrl(resource);
         if (!res.url && !res.uuid)
             continue;
-        var item = this.getItem(res.url);
+        var item = this._cache[res.url];
         _sharedResources.push(item || res);
     }
 
@@ -265,7 +265,7 @@ proto.flowInDeps = function (owner, urlList, callback) {
         var res = getResWithUrl(urlList[i]);
         if (!res.url && ! res.uuid)
             continue;
-        var item = this.getItem(res.url);
+        var item = this._cache[res.url];
         if (item) {
             _sharedList.push(item);
         }
@@ -647,7 +647,7 @@ proto.getRes = function (url, type) {
         }
     }
     if (item && item.alias) {
-        item = this._cache[item.alias];
+        item = item.alias;
     }
     return (item && item.complete) ? item.content : null;
 };

--- a/cocos2d/core/load-pipeline/asset-loader.js
+++ b/cocos2d/core/load-pipeline/asset-loader.js
@@ -65,7 +65,7 @@ AssetLoader.prototype.handle = function (item, callback) {
                     url: url,
                     type: ext,
                     error: null,
-                    alias: item.id,
+                    alias: item,
                     complete: true
                 };
                 if (CC_EDITOR) {

--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -595,7 +595,7 @@ proto.getContent = function (id) {
             ret = item.content;
         }
         else if (item.alias) {
-            ret = this.getContent(item.alias);
+            ret = item.alias.content;
         }
     }
 
@@ -616,7 +616,7 @@ proto.getError = function (id) {
         if (item.error) {
             ret = item.error;
         } else if (item.alias) {
-            ret = this.getError(item.alias);
+            ret = item.alias.error;
         }
     }
 
@@ -688,8 +688,8 @@ proto.removeItem = function (url) {
     delete this.completed[url];
     delete this.map[url];
     if (item.alias) {
-        delete this.completed[item.alias];
-        delete this.map[item.alias];
+        delete this.completed[item.alias.id];
+        delete this.map[item.alias.id];
     }
 
     this.completedCount--;

--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -384,7 +384,7 @@ proto.getItem = function (id) {
 
     // downloader.js downloadUuid
     if (item.alias)
-        item = this._cache[item.alias];
+        item = item.alias;
 
     return item;
 };


### PR DESCRIPTION
Re: cocos-creator/fireball#6141

Changes proposed in this pull request:
 * [Editor] Fix aliased item couldn't be retrieved issue

作出这个修改有两个原因：

1. Loader 在构建加载列表的时候，使用 getItem 获取的已存在 item 时，同名 id 可能只是一个 alias，getItem 的结果是真实资源，它的 id 就不同了。这种情况下 singleRes 获取的回调结果是空。
2. 编辑器环境下，如果同时发起多个队列，每个队列完成时都会清空 loader，如果后完成的队列依赖于之前队列的结果（通过 alias），那么会取不到真实的资源 item，所以现在将 item.alias 直接映射到对象上了，而不是只保存 id。

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
