### PR TITLE
fix load tilemap erro for md5

### DIFF
--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -639,6 +639,7 @@ cc.TMXMapInfo = cc.SAXParser.extend(/** @lends cc.TMXMapInfo# */{
             tilesets.push(map);
         }
 
+        var md5Pipe = cc.loader.md5Pipe;
         for (i = 0; i < tilesets.length; i++) {
             var selTileset = tilesets[i];
             // If this is an external tileset then start parsing that
@@ -675,6 +676,11 @@ cc.TMXMapInfo = cc.SAXParser.extend(/** @lends cc.TMXMapInfo# */{
                 } else {
                     tileset.sourceImage = this._resources + (this._resources ? "/" : "") + imagename;
                 }
+                // transform md5 URL
+                if (md5Pipe) {
+                    tileset.sourceImage = md5Pipe.transformURL(tileset.sourceImage);
+                }
+
                 this.setTilesets(tileset);
 
                 // parse tile offset


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
 * 修复当开启 MD5 后，tilemap 加载依赖资源的 url 错误，导致无法完成加载

@cocos-creator/engine-admins
