### PR TITLE
fix Bmfont click useSystemFont, showing two label bug

### DIFF
--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -453,6 +453,7 @@ _ccsg.Label = _ccsg.Node.extend({
     },
 
     setFontFamily: function (fontFamily) {
+        this._resetBMFont();
         this._fontHandle = fontFamily || "Arial";
         this._labelType = _ccsg.Label.Type.SystemFont;
         this._blendFunc = cc.BlendFunc._alphaPremultiplied();


### PR DESCRIPTION
Re: cocos-creator/fireball#3777

Changes proposed in this pull request:
 *  修复 Label 为 bmfont 时点击 useSystemFont 导致会出现 2 个 label 的 bug

@cocos-creator/engine-admins
