### PR TITLE
not auto calculate polygon points when reset polygon collider

### DIFF
--- a/cocos2d/core/collider/CCPolygonCollider.js
+++ b/cocos2d/core/collider/CCPolygonCollider.js
@@ -69,10 +69,6 @@ cc.Collider.Polygon = cc.Class({
         }
     },
 
-    resetInEditor: CC_EDITOR && function () {
-        this.resetPointsByContour();
-    },
-
     resetPointsByContour: CC_EDITOR && function () {
         _Scene.PhysicsUtils.resetPoints(this, {threshold: this.threshold});
     }


### PR DESCRIPTION
Re: cocos-creator/fireball#6160

Changes proposed in this pull request:
 * not auto calculate polygon points when reset polygon collider

@cocos-creator/engine-admins
