### PR TITLE
Fix setting alpha with color warning during tint action

### DIFF
--- a/jsb/jsb-action.js
+++ b/jsb/jsb-action.js
@@ -468,7 +468,13 @@ function syncColorUpdate (dt) {
     this._jsbUpdate(dt);
     var target = this._getSgTarget();
     if (target._owner) {
-        target._owner.color = target.getColor();
+        var color = target.getColor();
+        var alpha = color.a;
+        if (alpha !== 255) {
+            target._owner.opacity = alpha;
+            color.a = 255;
+        }
+        target._owner.color = color;
     }
 }
 


### PR DESCRIPTION
Re: cocos-creator/fireball#6163

Changes proposed in this pull request:
 * Fix setting alpha with color warning during tint action

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
