### PR TITLE
Less strict check for schedule, use warn instead of assert when paused state doesn't match

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -62,6 +62,7 @@ if (CC_DEBUG) {
         "1508": "Argument callback must not be empty", //isScheduled
         "1509": "Argument target must be non-nullptr", //isScheduled
         "1510": "cc.Scheduler: Illegal target which doesn't have uuid or instanceId",
+        "1511": "cc.Scheduler: pause state of the scheduled task doesn't match the element pause state in Scheduler, the given paused state will be ignored",
         //Node: 1600
         "1600": "getZOrder is deprecated. Please use getLocalZOrder instead.", //getZOrder
         "1601": "setZOrder is deprecated. Please use setLocalZOrder instead.", //setZOrder

--- a/cocos2d/core/CCScheduler.js
+++ b/cocos2d/core/CCScheduler.js
@@ -550,8 +550,8 @@ cc.Scheduler = cc._Class.extend({
             element = HashTimerEntry.get(null, target, 0, null, null, paused);
             this._arrayForTimers.push(element);
             this._hashForTimers[instanceId] = element;
-        } else {
-            cc.assert(element.paused === paused, '');
+        } else if (element.paused !== paused) {
+            cc.warnID(1511);
         }
 
         var timer, i;


### PR DESCRIPTION
…

Re: cocos-creator/fireball#6179

Changes proposed in this pull request:
 * Less strict check for schedule, use warn instead of assert when paused state doesn't match

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
