### PR TITLE
不要在主循环中使用webgl getError方法，会导致极高的性能开销

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -464,7 +464,7 @@ cc.Director = Class.extend(/** @lends cc.Director# */{
         // Clear all caches
         this.purgeCachedData();
 
-        cc.checkGLErrorDebug();
+        // cc.checkGLErrorDebug();
     },
 
     /**

--- a/cocos2d/core/graphics/graphics-webgl-cmd.js
+++ b/cocos2d/core/graphics/graphics-webgl-cmd.js
@@ -411,7 +411,7 @@ _p._render = function () {
         cc.g_NumberOfDraws++;
     }
 
-    cc.checkGLErrorDebug();
+    // cc.checkGLErrorDebug();
 };
 
 _p.rendering = function () {

--- a/cocos2d/shaders/CCGLProgram.js
+++ b/cocos2d/shaders/CCGLProgram.js
@@ -164,7 +164,7 @@ cc.GLProgram = cc._Class.extend(/** @lends cc.GLProgram# */{
 
         if (this._vertShader)
             locGL.attachShader(this._programObj, this._vertShader);
-        cc.checkGLErrorDebug();
+        // cc.checkGLErrorDebug();
 
         if (this._fragShader)
             locGL.attachShader(this._programObj, this._fragShader);
@@ -173,7 +173,7 @@ cc.GLProgram = cc._Class.extend(/** @lends cc.GLProgram# */{
             delete this._hashForUniforms[key];
         }
 
-        cc.checkGLErrorDebug();
+        // cc.checkGLErrorDebug();
         return true;
     },
 


### PR DESCRIPTION
getError getError方法存在极大的性能问题，不应该轻易在线上产品使用。
实际调试发现getError及其消耗性能，注销后能是Render时间从10ms降至2ms(vivo x9)，提高5倍性能。

参考资料：
https://docs.google.com/presentation/d/12AGAUmElB0oOBgbEEBfhABkIMCL3CUX7kdAPLuwZ964/edit#slide=id.i93
https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices

