### PR TITLE
Avoid releasing textures still in use in JSB

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -395,6 +395,7 @@ if (CC_DEBUG) {
         "4920": "Sorry, you shouldn\'t use id as item identity any more, please use url or uuid instead, the current id is being set as url: (%s)", // load
         "4921": "Invalid pipe or invalid index provided!", //pipeline.insertPipe
         "4922": "The pipe to be inserted is already in the pipeline!", //pipeline.insertPipe
+        "4923": "Sorry, the texture asset (%s) hasn't be released because it's still in use, please check.", //cc.loader.release
         //CCObject: 5000
         "5000": "object already destroyed", //destroy
         "5001": "object not yet destroyed", //realDestroyInEditor


### PR DESCRIPTION
Re: cocos-creator/fireball#6206

Changes proposed in this pull request:
 * Avoid releasing textures still in use in JSB

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
