### PR TITLE
fix default value of typescript after build

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -302,8 +302,39 @@ if (CC_DEBUG) {
         "3647": "The length of range array must be equal or greater than 2", //parseAttributes_4
         "3648": "Can not declare %s.%s method, it is already defined in the properties of %s.",
         "3649": "CCClass %s have conflict between its ctor and __ctor__.",
-        "3650": "No need to specifiy '%s' attribute for '%s' in class \"%s\".",
+        "3650": "No need to specifiy \"%s\" attribute for \"%s\" property in \"%s\" class.",    // 已废弃，提示信息仅用于生成 markdown 给旧版本用户查阅
         "3651": "Can not call `_super` or `prototype.ctor` in ES6 Classes \"%s\", use `super` instead please.",
+        "3652": "Failed to construct a dummy instance of the \"%s\" class using `new` behind the scenes. This is for getting default values declared in TypeScript. Please ensure the class will be able to construct during script's initialization. %s",
+        "3653": "Please do not specifiy \"default\" attribute in decorator of \"%s\" property in \"%s\" class.\n" +
+                "  Default value must be initialized at their declaration: \uD83D\uDE02\n" +
+                "    // Before:\n" +
+                "    @property({\n" +
+                "      type: cc.Integer\n" +
+                "      default: 0  // <--\n" +
+                "    })\n" +
+                "    value;\n\n" +
+                "    // After:\n" +
+                "    @property({\n" +
+                "      type: cc.Integer\n" +
+                "    })\n" +
+                "    value = 0;    // <--",
+        "3654": "Please specifiy a default value for \"%s\" property at its declaration: \uD83D\uDE02\n" +
+                "    // Before:\n" +
+                "    @property(...)\n" +
+                "    value;\n\n" +
+                "    // After:\n" +
+                "    @property(...)\n" +
+                "    value = 0;",
+        "3655": "Can not specifiy \"get\" or \"set\"  attribute in decorator for \"%s\" property in \"%s\" class.\n" +
+                "  Please use:\n" +
+                "    @property(...)\n" +
+                "    get %s () {\n" +
+                "      ...\n" +
+                "    }\n" +
+                "    @property\n" +
+                "    set %s (value) {\n" +
+                "      ...\n" +
+                "    }",
         //Prefab: 3700
         "3700": "internal error: _prefab is undefined", //_doInstantiate
         "3701": "Failed to load prefab asset for node '%s'", //syncWithPrefab

--- a/cocos2d/core/platform/CCClassDecorator.js
+++ b/cocos2d/core/platform/CCClassDecorator.js
@@ -319,7 +319,6 @@ var ccclass = checkCtorArgument(function (ctor, name) {
  * @param {Boolean} [options.editorOnly]
  * @param {Boolean} [options.override]
  * @param {Boolean} [options.animatable]
- * @param {Any} [options.default] - for TypeScript only.
  * @example
  * const {ccclass, property} = cc._decorator;
  *
@@ -389,6 +388,13 @@ var ccclass = checkCtorArgument(function (ctor, name) {
  *             }
  *         },
  *
+ *         offset: new cc.Vec2(100, 100)
+ *
+ *         offsets: {
+ *             default: [],
+ *             type: cc.Vec2
+ *         }
+ *
  *         texture: {
  *             default: "",
  *             url: cc.Texture2D
@@ -396,7 +402,7 @@ var ccclass = checkCtorArgument(function (ctor, name) {
  *     }
  * });
  * @typescript
- * property(options?: {type?: any; url?: typeof cc.RawAsset; visible?: boolean|(() => boolean); displayName?: string; tooltip?: string; multiline?: boolean; readonly?: boolean; min?: number; max?: number; step?: number; range?: number[]; slide?: boolean; serializable?: boolean; editorOnly?: boolean; override?: boolean; animatable?: boolean; default?: any} | any[]|Function|cc.ValueType|number|string|boolean): Function
+ * property(options?: {type?: any; url?: typeof cc.RawAsset; visible?: boolean|(() => boolean); displayName?: string; tooltip?: string; multiline?: boolean; readonly?: boolean; min?: number; max?: number; step?: number; range?: number[]; slide?: boolean; serializable?: boolean; editorOnly?: boolean; override?: boolean; animatable?: boolean} | any[]|Function|cc.ValueType|number|string|boolean): Function
  * property(_target: Object, _key: any, _desc?: any): void
  */
 function property (ctorProtoOrOptions, propName, desc) {


### PR DESCRIPTION
Re: cocos-creator/fireball#6223

Changes proposed in this pull request:
 * 修复构建后 TypeScript 默认值可能出错的问题
 * TypeScript 不再需要在装饰器重复指定属性的默认值

例如
```
    // 之前：
    @property({
        type: cc.Node,
        default: null         // <--
    })
    target: cc.Node;

    // 现在：
    @property({
        type: cc.Node
    })
    target: cc.Node = null;   // <--
```
```
    // 之前：
    @property(-1)
    value: number = -1;

    // 现在：
    @property()
    value: number = -1;
```

 * 所有 ES6 Classes 和 TypeScript 中的属性默认值都需要在属性定义时提供

例如
```
    // 之前：
    @property(cc.Node)
    target;

    // 现在：
    @property(cc.Node)
    target = null;
```
```
    // 之前：
    @property({
        default: true
    })
    value;

    // 现在：
    @property()
    value = true;
```

@cocos-creator/engine-admins
