### PR TITLE
Repair label with outline in Richtext, the vertical height calculatio…

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -676,6 +676,10 @@ var RichText = cc.Class({
             if(label instanceof cc.Scale9Sprite) {
                 positionY += (this.lineHeight - label.getContentSize().height) / 2;
             }
+            
+            if( label._outlined && label._outlineWidth ) {
+                positionY += ( label._outlineWidth * 2 );
+            }
 
             label.setPositionY(positionY);
 


### PR DESCRIPTION
Changes proposed in this pull request:
 * 修复在带有oultine的label，垂直高度计算偏移的问题

因为不知道怎么把代码弄给你们，发一个pull看比较清楚，你们再合并到某一个pull里就可以
感谢各位大神 

@cocos-creator/engine-admins