### PR TITLE
Extend the RichText <img> tag's attributes to support height and width

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -505,23 +505,39 @@ var RichText = cc.Class({
 
             var spriteRect = spriteFrame.getRect();
             var scaleFactor = 1;
-            if(spriteRect.height > this.lineHeight) {
-                scaleFactor = this.lineHeight / spriteRect.height;
+            var spriteWidth = spriteRect.width;
+            var spriteHeight = spriteRect.height;
+            var expectWidht = richTextElement.style.imageWidth;
+            var expectHeight = richTextElement.style.imageHeight;
+
+            //follow the original rule, the image height must less then lineHeight
+            if(expectHeight && expectHeight > 0 && expectHeight < this.lineHeight )
+            {
+                scaleFactor = expectHeight / spriteRect.height;
+                spriteWidth = spriteWidth * scaleFactor;
+                spriteHeight = spriteHeight * scaleFactor;
             }
+            else if(spriteRect.height > this.lineHeight) {
+                scaleFactor = this.lineHeight / spriteRect.height;
+                spriteWidth = spriteWidth * scaleFactor;
+                spriteHeight = spriteHeight * scaleFactor;
+            }
+            if(expectWidht && expectWidht > 0) spriteWidth = expectWidht;
+
             if(this.maxWidth > 0) {
-                if(this._lineOffsetX + spriteRect.width * scaleFactor > this.maxWidth) {
+                if(this._lineOffsetX + spriteWidth > this.maxWidth) {
                     this._updateLineInfo();
                 }
-                this._lineOffsetX += spriteRect.width * scaleFactor;
+                this._lineOffsetX += spriteWidth;
 
             } else {
-                this._lineOffsetX += spriteRect.width * scaleFactor;
+                this._lineOffsetX += spriteWidth;
                 if(this._lineOffsetX > this._labelWidth) {
                     this._labelWidth = this._lineOffsetX;
                 }
             }
             this._applySpriteFrame(spriteFrame);
-            sprite.setContentSize(spriteRect.width * scaleFactor, spriteRect.height * scaleFactor);
+            sprite.setContentSize(spriteWidth, spriteHeight);
             sprite._lineCount = this._lineCount;
 
             if(richTextElement.style.event) {

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -507,22 +507,21 @@ var RichText = cc.Class({
             var scaleFactor = 1;
             var spriteWidth = spriteRect.width;
             var spriteHeight = spriteRect.height;
-            var expectWidht = richTextElement.style.imageWidth;
+            var expectWidth = richTextElement.style.imageWidth;
             var expectHeight = richTextElement.style.imageHeight;
 
-            //follow the original rule, the image height must less then lineHeight
-            if(expectHeight && expectHeight > 0 && expectHeight < this.lineHeight )
-            {
-                scaleFactor = expectHeight / spriteRect.height;
+            //follow the original rule, expectHeight must less then lineHeight
+            if(expectHeight > 0 && expectHeight < this.lineHeight ) {
+                scaleFactor = expectHeight / spriteHeight;
+                spriteWidth = spriteWidth * scaleFactor;
+                spriteHeight = spriteHeight * scaleFactor;
+            } else {
+                scaleFactor = this.lineHeight / spriteHeight;
                 spriteWidth = spriteWidth * scaleFactor;
                 spriteHeight = spriteHeight * scaleFactor;
             }
-            else if(spriteRect.height > this.lineHeight) {
-                scaleFactor = this.lineHeight / spriteRect.height;
-                spriteWidth = spriteWidth * scaleFactor;
-                spriteHeight = spriteHeight * scaleFactor;
-            }
-            if(expectWidht && expectWidht > 0) spriteWidth = expectWidht;
+
+            if(expectWidth > 0) spriteWidth = expectWidth;
 
             if(this.maxWidth > 0) {
                 if(this._lineOffsetX + spriteWidth > this.maxWidth) {

--- a/cocos2d/core/label/CCHtmlTextParser.js
+++ b/cocos2d/core/label/CCHtmlTextParser.js
@@ -127,6 +127,7 @@ cc.HtmlTextParser.prototype = {
                 header = attribute.match(imageAttrReg);
                 var tagValue;
                 var remainingArgument;
+                var isValidImageTag = false;
                 while (header) {
                     //skip the invalid tags at first
                     attribute = attribute.substring(attribute.indexOf(header[0]));
@@ -142,8 +143,14 @@ cc.HtmlTextParser.prototype = {
                     attribute = remainingArgument.substring(nextSpace).trim();
                     if (tagName === "src") {
                         obj.isImage = true
-                        if( tagValue.indexOf('\'')===0 ) tagValue = tagValue.substring( 1, tagValue.length - 1 );
-                        if( tagValue.indexOf('\"')===0 ) tagValue = tagValue.substring( 1, tagValue.length - 1 );
+                        if( tagValue.endsWith( '\/' ) ) tagValue = tagValue.substring( 0, tagValue.length - 1 );
+                        if( tagValue.indexOf('\'')===0 ) {
+                            isValidImageTag = true;
+                            tagValue = tagValue.substring( 1, tagValue.length - 1 );
+                        } else if( tagValue.indexOf('"')===0 ) {
+                            isValidImageTag = true;
+                            tagValue = tagValue.substring( 1, tagValue.length - 1 );
+                        }
                         obj.src = tagValue;
                     } else if (tagName === "height") {
                         obj.imageHeight = parseInt(tagValue);
@@ -155,7 +162,7 @@ cc.HtmlTextParser.prototype = {
                     header = attribute.match(imageAttrReg);
                 }
 
-                if( obj.isImage )
+                if( isValidImageTag && obj.isImage )
                 {
                     this._resultObjectArray.push({text: "", style: obj});
                 }

--- a/cocos2d/core/label/CCHtmlTextParser.js
+++ b/cocos2d/core/label/CCHtmlTextParser.js
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 var eventRegx = /^(click)(\s)*=/;
+var imageAttrReg = /(\s)*src(\s)*=|(\s)*height(\s)*=|(\s)*width(\s)*=|(\s)*click(\s)*=/;
 /**
  * A utils class for parsing HTML texts. The parsed results will be an object array.
  */
@@ -123,7 +124,6 @@ cc.HtmlTextParser.prototype = {
         if(header && header[0].length > 0) {
             tagName = header[0].trim();
             if(tagName.startsWith("img") && tagName[tagName.length-1] === "/") {
-                var imageAttrReg = /(\s)*src(\s)*=|(\s)*height(\s)*=|(\s)*width(\s)*=|(\s)*click(\s)*=/;
                 header = attribute.match(imageAttrReg);
                 var tagValue;
                 var remainingArgument;


### PR DESCRIPTION
follow the original principle: the image line height must not exceed the RichText line height

Changes proposed in this pull request:
 * 扩充RichText组件，使<img>标签支持设定height及width，但维持基础原则"图像高不超过设定高行"

这是之前有提过的需求，你们看看是否可行

@cocos-creator/engine-admins
