### PR TITLE
Fix JSB_EditboxDelegate crash if js delegate has already been garbage collected

### DIFF
--- a/cocos2d/core/components/CCEditBox.js
+++ b/cocos2d/core/components/CCEditBox.js
@@ -518,6 +518,11 @@ var EditBox = cc.Class({
         this.node.emit('editing-return', this);
     },
 
+    onDestroy: function () {
+        this._sgNode.setDelegate(null);
+        this._super();
+    },
+
     __preload: function() {
         this._super();
 


### PR DESCRIPTION
Re: cocos-creator/fireball#6288

Changes proposed in this pull request:
 * Fix JSB_EditboxDelegate crash if js delegate has already been garbage collected

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
