### PR TITLE
should ignore animation playOnLoad if already play an animation

### DIFF
--- a/cocos2d/core/components/CCAnimation.js
+++ b/cocos2d/core/components/CCAnimation.js
@@ -169,10 +169,12 @@ var Animation = cc.Class({
     },
 
     start: function () {
-        var isPlaying = this._animator && this._animator.isPlaying;
-        if (!CC_EDITOR && !isPlaying && this.playOnLoad && this._defaultClip) {
-            var state = this.getAnimationState(this._defaultClip.name);
-            this._animator.playState(state);
+        if (!CC_EDITOR && this.playOnLoad && this._defaultClip) {
+            var isPlaying = this._animator && this._animator.isPlaying;
+            if (!isPlaying) {
+                var state = this.getAnimationState(this._defaultClip.name);
+                this._animator.playState(state);
+            }
         }
     },
 

--- a/cocos2d/core/components/CCAnimation.js
+++ b/cocos2d/core/components/CCAnimation.js
@@ -169,7 +169,8 @@ var Animation = cc.Class({
     },
 
     start: function () {
-        if (!CC_EDITOR && this.playOnLoad && this._defaultClip) {
+        var isPlaying = this._animator && this._animator.isPlaying;
+        if (!CC_EDITOR && !isPlaying && this.playOnLoad && this._defaultClip) {
             var state = this.getAnimationState(this._defaultClip.name);
             this._animator.playState(state);
         }

--- a/test/qunit/unit-es5/test-animation.js
+++ b/test/qunit/unit-es5/test-animation.js
@@ -1553,3 +1553,35 @@ test('animation pause/resume should remove animation-actor from animation manage
 
     strictEqual(manager._animators.array.length, 0, 'should remove animation from animation manager');
 });
+
+
+test('animation play on load', function () {
+    var entity = new cc.Node();
+
+    var animation = entity.addComponent(cc.Animation);
+    animation.playOnLoad = true;
+
+    var clip1 = new cc.AnimationClip();
+    clip1._name = 'clip1';
+    clip1._duration = 1;
+
+    var clip2 = new cc.AnimationClip();
+    clip2._name = 'clip2';
+    clip2._duration = 1;
+
+
+    animation.addClip(clip1);
+    animation.addClip(clip2);
+
+    animation._defaultClip = clip1;
+
+    animation.play('clip2');
+    
+    entity.parent = cc.director.getScene();
+    animation.start();
+
+    strictEqual(animation.getAnimationState('clip1').isPlaying, false, 'default clip should not be played if there is playing animation');
+    strictEqual(animation.getAnimationState('clip2').isPlaying, true, 'should play the specified animation');
+
+    entity.parent = null;
+});


### PR DESCRIPTION
Re: cocos-creator/fireball#5869

Changes proposed in this pull request:
 * should ignore animation playOnLoad if already play an animation

@cocos-creator/engine-admins
