### PR TITLE
should not enumerate getter values while creating ccclass in TypeScript

### DIFF
--- a/cocos2d/core/platform/CCClassDecorator.js
+++ b/cocos2d/core/platform/CCClassDecorator.js
@@ -280,13 +280,14 @@ var ccclass = checkCtorArgument(function (ctor, name) {
 
     // validate methods
     if (CC_DEV) {
-        var methods = Object.getOwnPropertyNames(ctor.prototype);
-        for (var i = 0; i < methods.length; ++i) {
-            var methodName = methods[i];
-            if (methodName !== 'constructor') {
-                var func = ctor.prototype[methodName];
+        var propNames = Object.getOwnPropertyNames(ctor.prototype);
+        for (var i = 0; i < propNames.length; ++i) {
+            var prop = propNames[i];
+            if (prop !== 'constructor') {
+                var desc = Object.getOwnPropertyDescriptor(ctor.prototype, prop);
+                var func = desc && desc.value;
                 if (typeof func === 'function') {
-                    Preprocess.doValidateMethodWithProps_DEV(func, methodName, JS.getClassName(ctor), ctor, base);
+                    Preprocess.doValidateMethodWithProps_DEV(func, prop, JS.getClassName(ctor), ctor, base);
                 }
             }
         }


### PR DESCRIPTION
Re: cocos-creator/fireball#6339

Changes proposed in this pull request:
 * 修复在 TypeScript 中定义 Class 的 getter 时可能报错的 bug

@cocos-creator/engine-admins
