### PR TITLE
support formerlySerializedAs attribute

### DIFF
--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -1110,6 +1110,8 @@ function parseAttributes (cls, attrs, className, propName, usedInGetter) {
             (attrsProto || getAttrsProto())[attrsProtoKey + 'serializable'] = false;
         }
     }
+    parseSimpleAttr('formerlySerializedAs', 'string');
+
     if (CC_EDITOR) {
         if ('animatable' in attrs && !attrs.animatable) {
             (attrsProto || getAttrsProto())[attrsProtoKey + 'animatable'] = false;

--- a/cocos2d/core/platform/CCClassDecorator.js
+++ b/cocos2d/core/platform/CCClassDecorator.js
@@ -319,6 +319,7 @@ var ccclass = checkCtorArgument(function (ctor, name) {
  * @param {Boolean} [options.editorOnly]
  * @param {Boolean} [options.override]
  * @param {Boolean} [options.animatable]
+ * @param {String} [options.formerlySerializedAs]
  * @example
  * const {ccclass, property} = cc._decorator;
  *
@@ -402,7 +403,7 @@ var ccclass = checkCtorArgument(function (ctor, name) {
  *     }
  * });
  * @typescript
- * property(options?: {type?: any; url?: typeof cc.RawAsset; visible?: boolean|(() => boolean); displayName?: string; tooltip?: string; multiline?: boolean; readonly?: boolean; min?: number; max?: number; step?: number; range?: number[]; slide?: boolean; serializable?: boolean; editorOnly?: boolean; override?: boolean; animatable?: boolean} | any[]|Function|cc.ValueType|number|string|boolean): Function
+ * property(options?: {type?: any; url?: typeof cc.RawAsset; visible?: boolean|(() => boolean); displayName?: string; tooltip?: string; multiline?: boolean; readonly?: boolean; min?: number; max?: number; step?: number; range?: number[]; slide?: boolean; serializable?: boolean; formerlySerializedAs?: string; editorOnly?: boolean; override?: boolean; animatable?: boolean} | any[]|Function|cc.ValueType|number|string|boolean): Function
  * property(_target: Object, _key: any, _desc?: any): void
  */
 function property (ctorProtoOrOptions, propName, desc) {

--- a/gulp/tasks/engine.js
+++ b/gulp/tasks/engine.js
@@ -151,6 +151,8 @@ exports.buildPreview = function (sourceFile, outputFile, callback) {
 };
 
 exports.buildJsbPreview = function (sourceFile, outputFile, jsbSkipModules, callback) {
+    var FixJavaScriptCore = require('../util/fix-jsb-javascriptcore');
+
     var outFile = Path.basename(outputFile);
     var outDir = Path.dirname(outputFile);
 
@@ -163,6 +165,7 @@ exports.buildJsbPreview = function (sourceFile, outputFile, jsbSkipModules, call
         .pipe(HandleErrors())
         .pipe(Source(outFile))
         .pipe(Buffer())
+        .pipe(FixJavaScriptCore())
         .pipe(Minify(Utils.getUglifyOptions('preview', true, false)))
         .pipe(Optimizejs({
             sourceMap: false

--- a/test/qunit/unit-es5/test-deserialize.js
+++ b/test/qunit/unit-es5/test-deserialize.js
@@ -209,6 +209,29 @@ if (TestEditorExtends) {
         //deepEqual(Editor.serialize(deserializedAsset), serializedAsset, 'test deserialize');
     });
 
+    test('reference to main asset with formerlySerializedAs', function () {
+        var MyAsset = cc.Class({
+            name: 'MyAsset',
+            properties: {
+                newRefSelf: {
+                    default: null,
+                    formerlySerializedAs: 'oldRefSelf'
+                },
+            }
+        });
+        var asset = new MyAsset();
+        asset.newRefSelf = asset;
+
+        var serializedAsset = Editor.serialize(asset);
+        serializedAsset = serializedAsset.replace(/newRefSelf/g, 'oldRefSelf');
+        var deserializedAsset = cc.deserialize(serializedAsset);
+
+        ok(deserializedAsset.newRefSelf === deserializedAsset, 'should ref to self');
+        //deepEqual(Editor.serialize(deserializedAsset), serializedAsset, 'test deserialize');
+
+        cc.js.unregisterClass(MyAsset);
+    });
+
     test('reference to main asset with target', function () {
         var asset = {};
         asset.refSelf = asset;

--- a/test/qunit/unit-es5/test-serialize.js
+++ b/test/qunit/unit-es5/test-serialize.js
@@ -500,4 +500,32 @@
 
         cc.js.unregisterClass(Data);
     });
+
+    test('formerlySerializedAs attribute', function () {
+        var MyAsset = cc.Class({
+            name: 'MyAsset',
+            properties: {
+                newRefSelf: {
+                    default: null,
+                    formerlySerializedAs: 'oldRefSelf'
+                },
+            }
+        });
+        var asset = new MyAsset();
+        asset.newRefSelf = asset;
+
+        var expect = {
+            __type__: 'MyAsset',
+            newRefSelf: {
+                __id__: 0
+            },
+            oldRefSelf: {
+                __id__: 0
+            },
+        };
+
+        match(asset, expect, 'test');
+
+        cc.js.unregisterClass(MyAsset);
+    });
 }


### PR DESCRIPTION
Re: cocos-creator/fireball#6335

Changes proposed in this pull request:
 * CCClass 增加 formerlySerializedAs 参数以便在属性重命名的同时支持兼容数据

@cocos-creator/engine-admins
