### PR TITLE
should not create component if conflict with canvas

### DIFF
--- a/cocos2d/core/components/CCSGComponent.js
+++ b/cocos2d/core/components/CCSGComponent.js
@@ -93,6 +93,9 @@ var SGComponent = cc.Class({
             else {
                 cc.errorID(3628, name);
             }
+            if (CC_EDITOR) {
+                this.destroy();
+            }
         }
     }
 });


### PR DESCRIPTION
Re: cocos-creator/fireball#5984

Changes proposed in this pull request:
 * 组件无法添加到 Canvas 节点上时，强制移除组件。

@cocos-creator/engine-admins
