### PR TITLE
fix sometime will play twice the audio on WKWebView when requiringUserAction is false

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -341,9 +341,9 @@ var WebAudioElement = function (buffer, audio) {
 
         audio.onended = this._endCallback;
 
-        // If the current audio context time stamp is 0
+        // If the current audio context time stamp is 0 and audio context state is suspended
         // There may be a need to touch events before you can actually start playing audio
-        if (this._context.currentTime === 0) {
+        if (audio.context.state === "suspended" && this._context.currentTime === 0) {
             var self = this;
             clearTimeout(this._currextTimer);
             this._currextTimer = setTimeout(function () {

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -343,7 +343,7 @@ var WebAudioElement = function (buffer, audio) {
 
         // If the current audio context time stamp is 0 and audio context state is suspended
         // There may be a need to touch events before you can actually start playing audio
-        if (audio.context.state === "suspended" && this._context.currentTime === 0) {
+        if ((!audio.context.state || audio.context.state === "suspended") && this._context.currentTime === 0) {
             var self = this;
             clearTimeout(this._currextTimer);
             this._currextTimer = setTimeout(function () {


### PR DESCRIPTION
## 现象
在 WKWebView 上，如果使用了`config.mediaTypesRequiringUserActionForPlayback = []` 或者其他使 `requiringUserAction  = false`的操作，有一定概率`self._context.currentTime` 仍为0 (CCAudio.js line 350)，从而导致该 audio 被 push 到`touchPlayList`， 当  `touchstart` 时触发播放 `touchPlayList` 里的 audio （CCAudio.js line 167）播放两次 audio。

## 解决方案
- 当`requiringUserAction  = true` 时，`audio.context.state` 为 "suspended"
- 当`requiringUserAction  = false` 时，`audio.context.state` 为 "running"
- 其他平台，`audio.context.state` 为 "running"

所以要是**只是为了判断是否需要用户点击才能播放音频**，用`audio.context.state` 判断会更好

我把判断是非需要 push 到`touchPlayList`的逻辑
```js
if (this._context.currentTime === 0)
```
改成了
```js
if (audio.context.state === "suspended" && this._context.currentTime === 0) 
```
