### PR TITLE
can not set content size of RichText by using public function…

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -559,7 +559,6 @@ var RichText = cc.Class({
         }
 
         this._textArray = newTextArray;
-        var sgNode = this._sgNode;
         this._resetState();
 
         var lastEmptyLine = false;
@@ -627,7 +626,10 @@ var RichText = cc.Class({
         }
         this._labelHeight = this._lineCount * this.lineHeight;
 
+        // trigger "size-changed" event
         this.node.setContentSize(this._labelWidth, this._labelHeight);
+        // use _setContentSize because sgNode.setContentSize is banned.
+        this._sgNode._setContentSize(this._labelWidth, this._labelHeight);
 
         this._updateRichTextPosition();
         this._layoutDirty = false;


### PR DESCRIPTION
Re: cocos-creator/fireball#6346

Changes proposed in this pull request:
 * 修复 RichText 尺寸为 0 的 bug

@cocos-creator/engine-admins
