### PR TITLE
Refactor Texture2D API to adopt new renderer design

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -230,7 +230,6 @@ if (CC_DEBUG) {
         "3107": "initWithETCFile does not support on HTML5", //initWithETCFile_2
         "3108": "initWithPVRFile does not support on HTML5", //initWithPVRFile_2
         "3109": "initWithPVRTCData does not support on HTML5", //initWithPVRTCData_2
-        "3110": "bitsPerPixelForFormat: %s, cannot give useful result, it's a illegal pixel format", //bitsPerPixelForFormat
         "3111": "cocos2d: cc.Texture2D: Using RGB565 texture since image has no alpha", //_initPremultipliedATextureWithImage
         "3112": "cc.Texture.addImage(): path should be non-null", //addImage_2
         "3113": "NSInternalInconsistencyException", //initWithData

--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -230,6 +230,7 @@ if (CC_DEBUG) {
         "3107": "initWithETCFile does not support on HTML5", //initWithETCFile_2
         "3108": "initWithPVRFile does not support on HTML5", //initWithPVRFile_2
         "3109": "initWithPVRTCData does not support on HTML5", //initWithPVRTCData_2
+        "3110": "bitsPerPixelForFormat: %s, cannot give useful result, it's a illegal pixel format", //bitsPerPixelForFormat
         "3111": "cocos2d: cc.Texture2D: Using RGB565 texture since image has no alpha", //_initPremultipliedATextureWithImage
         "3112": "cc.Texture.addImage(): path should be non-null", //addImage_2
         "3113": "NSInternalInconsistencyException", //initWithData

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -816,6 +816,10 @@ initWithPVRFile does not support on HTML5
 
 initWithPVRTCData does not support on HTML5
 
+### 3110
+
+bitsPerPixelForFormat: %s, cannot give useful result, it's a illegal pixel format
+
 ### 3111
 
 cocos2d: cc.Texture2D: Using RGB565 texture since image has no alpha

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -816,10 +816,6 @@ initWithPVRFile does not support on HTML5
 
 initWithPVRTCData does not support on HTML5
 
-### 3110
-
-bitsPerPixelForFormat: %s, cannot give useful result, it's a illegal pixel format
-
 ### 3111
 
 cocos2d: cc.Texture2D: Using RGB565 texture since image has no alpha

--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -696,10 +696,6 @@ var game = {
             cc.renderer = cc.rendererWebGL;
             win.gl = this._renderContext; // global variable declared in CCMacro.js
             cc.renderer.init();
-            cc.textureCache._initializingRenderer();
-            cc.glExt = {};
-            cc.glExt.instanced_arrays = win.gl.getExtension("ANGLE_instanced_arrays");
-            cc.glExt.element_uint = win.gl.getExtension("OES_element_index_uint");
         } else {
             cc._renderType = game.RENDER_TYPE_CANVAS;
             cc.renderer = cc.rendererCanvas;

--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -1234,7 +1234,7 @@ _ccsg.Label = _ccsg.Node.extend({
 
                 var createLabelSprites = function () {
                     var texture = spriteFrame.getTexture();
-                    self._textureLoaded = texture.isLoaded();
+                    self._textureLoaded = texture.loaded;
                     self._createSpriteBatchNode(texture);
                     self.emit("load");
                 };

--- a/cocos2d/core/label/CCSGLabelCanvasRenderCmd.js
+++ b/cocos2d/core/label/CCSGLabelCanvasRenderCmd.js
@@ -445,9 +445,9 @@
             }
         }
 
-        this._texture._textureLoaded = false;
-        // Hack. because we delete _htmlElementObj after usage in WEBGL mode
-        this._texture._htmlElementObj = this._labelCanvas;
+        this._texture.loaded = false;
+        // Hack. because we delete _image after usage in WEBGL mode
+        this._texture._image = this._labelCanvas;
         this._texture.handleLoadedTexture(true);
     };
 
@@ -545,7 +545,7 @@
                 sw = textureWidth;
                 sh = textureHeight;
 
-                var image = this._texture._htmlElementObj;
+                var image = this._texture._image;
                 if (this._texture._pattern !== '') {
                     wrapper.setFillStyle(context.createPattern(image, this._texture._pattern));
                     context.fillRect(x, y, w, h);

--- a/cocos2d/core/renderer/RendererWebGL.js
+++ b/cocos2d/core/renderer/RendererWebGL.js
@@ -134,12 +134,31 @@ cc.rendererWebGL = {
         var gl = cc._renderContext;
         gl.disable(gl.CULL_FACE);
         gl.disable(gl.DEPTH_TEST);
+        this._initExtensions([
+            'OES_element_index_uint'
+        ]);
 
         this.mat4Identity = new cc.math.Matrix4();
         this.mat4Identity.identity();
         initQuadBuffer(cc.macro.BATCH_VERTEX_COUNT);
         if (cc.sys.os === cc.sys.OS_IOS) {
             _IS_IOS = true;
+        }
+    },
+
+    _initExtensions: function (extensions) {
+        this._extensions = this._extensions || {};
+        for (var i = 0; i < extensions.length; ++i) {
+            var name = extensions[i];
+      
+            try {
+                var ext = gl.getExtension(name);
+                if (ext) {
+                    this._extensions[name] = ext;
+                }
+            } catch (e) {
+                cc.error(e);
+            }
         }
     },
 

--- a/cocos2d/core/sprites/CCSGSprite.js
+++ b/cocos2d/core/sprites/CCSGSprite.js
@@ -516,7 +516,7 @@ _ccsg.Sprite = _ccsg.Node.extend({
         _t._offsetPosition.x = 0;
         _t._offsetPosition.y = 0;
 
-        var locTextureLoaded = texture.isLoaded();
+        var locTextureLoaded = texture.loaded;
         _t._textureLoaded = locTextureLoaded;
 
         if (!locTextureLoaded) {
@@ -671,7 +671,7 @@ _ccsg.Sprite = _ccsg.Node.extend({
         if(isFileName)
             texture = cc.textureCache.addImage(texture);
 
-        if(texture._textureLoaded){
+        if(texture.loaded){
             this._setTexture(texture, isFileName);
             this.setColor(this._realColor);
             this._textureLoaded = true;

--- a/cocos2d/core/sprites/CCSGSpriteCanvasRenderCmd.js
+++ b/cocos2d/core/sprites/CCSGSpriteCanvasRenderCmd.js
@@ -48,7 +48,7 @@ proto.setDirtyRecursively = function (value) {};
 proto._setTexture = function (texture) {
     var node = this._node;
     if (node._texture !== texture) {
-        node._textureLoaded = texture ? texture._textureLoaded : false;
+        node._textureLoaded = texture ? texture.loaded : false;
         node._texture = texture;
         var texSize = texture._contentSize;
         var rect = cc.rect(0, 0, texSize.width, texSize.height);
@@ -102,7 +102,7 @@ proto.rendering = function (ctx, scaleX, scaleY) {
 
     var texture = this._textureToRender || node._texture;
 
-    if ((texture && (locTextureCoord.width === 0 || locTextureCoord.height === 0|| !texture._textureLoaded)) || alpha === 0)
+    if ((texture && (locTextureCoord.width === 0 || locTextureCoord.height === 0|| !texture.loaded)) || alpha === 0)
         return;
 
     var wrapper = ctx || cc._renderContext, context = wrapper.getContext();
@@ -140,8 +140,8 @@ proto.rendering = function (ctx, scaleX, scaleY) {
     w = locWidth;
     h = locHeight;
 
-    if (texture&& texture._htmlElementObj) {
-        image = texture._htmlElementObj;
+    if (texture&& texture._image) {
+        image = texture._image;
         if (texture._pattern !== "") {
             wrapper.setFillStyle(context.createPattern(image, texture._pattern));
             context.fillRect(x, y, w, h);
@@ -184,7 +184,7 @@ proto._updateForSetSpriteFrame = function (pNewTexture, textureLoaded){
     this._colorized = false;
     this._textureCoord.renderX = this._textureCoord.x;
     this._textureCoord.renderY = this._textureCoord.y;
-    textureLoaded = textureLoaded || pNewTexture._textureLoaded;
+    textureLoaded = textureLoaded || pNewTexture.loaded;
     if (textureLoaded) {
         var curColor = this._node.getColor();
         if (curColor.r !== 255 || curColor.g !== 255 || curColor.b !== 255)

--- a/cocos2d/core/sprites/CCSGSpriteWebGLRenderCmd.js
+++ b/cocos2d/core/sprites/CCSGSpriteWebGLRenderCmd.js
@@ -68,7 +68,7 @@ proto._handleTextureForRotatedTexture = function (texture) {
 
 proto.isFrameDisplayed = function (frame) {
     var node = this._node;
-    return (cc.rectEqualToRect(frame.getRect(), node._rect) && frame.getTexture().getName() === node._texture.getName()
+    return (cc.rectEqualToRect(frame.getRect(), node._rect) && frame.getTexture().url === node._texture.url
         && cc.pointEqualToPoint(frame.getOffset(), node._unflippedOffsetPositionFromCenter));
 };
 
@@ -204,7 +204,7 @@ proto._setTexture = function (texture) {
     var node = this._node;
 
     if(node._texture !== texture){
-        node._textureLoaded = texture ? texture._textureLoaded : false;
+        node._textureLoaded = texture ? texture.loaded : false;
         node._texture = texture;
         this._updateBlendFunc();
 
@@ -260,7 +260,7 @@ proto.needDraw = function () {
 
 proto.uploadData = function (f32buffer, ui32buffer, vertexDataOffset) {
     var node = this._node, locTexture = node._texture;
-    if (!(locTexture && locTexture._textureLoaded && node._rect.width && node._rect.height) || !this._displayedOpacity)
+    if (!(locTexture && locTexture.loaded && node._rect.width && node._rect.height) || !this._displayedOpacity)
         return 0;
 
     // Fill in vertex data with quad information (4 vertices for sprite)

--- a/cocos2d/core/sprites/CCScale9Sprite.js
+++ b/cocos2d/core/sprites/CCScale9Sprite.js
@@ -169,8 +169,8 @@ var simpleQuadGenerator = {
 
     _calculateUVs: function (sprite, spriteFrame) {
         var uvs = sprite._uvs;
-        var atlasWidth = spriteFrame._texture._pixelWidth;
-        var atlasHeight = spriteFrame._texture._pixelHeight;
+        var atlasWidth = spriteFrame._texture.width;
+        var atlasHeight = spriteFrame._texture.height;
         var textureRect = spriteFrame._rect;
 
         if (uvs.length < 8) {
@@ -291,8 +291,8 @@ var scale9QuadGenerator = {
     _calculateUVs: function (sprite, spriteFrame, insetLeft, insetRight, insetTop, insetBottom) {
         var uvs = sprite._uvs;
         var rect = spriteFrame._rect;
-        var atlasWidth = spriteFrame._texture._pixelWidth;
-        var atlasHeight = spriteFrame._texture._pixelHeight;
+        var atlasWidth = spriteFrame._texture.width;
+        var atlasHeight = spriteFrame._texture.height;
 
         //caculate texture coordinate
         var leftWidth, centerWidth, rightWidth;
@@ -369,8 +369,8 @@ var tiledQuadGenerator = {
             wt = sprite._renderCmd._worldTransform,
             uvs = sprite._uvs;
         //build uvs
-        var atlasWidth = spriteFrame._texture._pixelWidth;
-        var atlasHeight = spriteFrame._texture._pixelHeight;
+        var atlasWidth = spriteFrame._texture.width;
+        var atlasHeight = spriteFrame._texture.height;
         var textureRect = spriteFrame._rect;
 
         //uv computation should take spritesheet into account.
@@ -509,8 +509,8 @@ var fillQuadGeneratorBar = {
         var l = 0, b = 0,
             r = contentSize.width, t = contentSize.height;
         //build uvs
-        var atlasWidth = spriteFrame._texture._pixelWidth;
-        var atlasHeight = spriteFrame._texture._pixelHeight;
+        var atlasWidth = spriteFrame._texture.width;
+        var atlasHeight = spriteFrame._texture.height;
         var textureRect = spriteFrame._rect;
         //uv computation should take spritesheet into account.
         var ul, vb, ur, vt;
@@ -968,8 +968,8 @@ var fillQuadGeneratorRadial = {
     },
 
     _calculateUVs : function (spriteFrame) {
-        var atlasWidth = spriteFrame._texture._pixelWidth;
-        var atlasHeight = spriteFrame._texture._pixelHeight;
+        var atlasWidth = spriteFrame._texture.width;
+        var atlasHeight = spriteFrame._texture.height;
         var textureRect = spriteFrame._rect;
 
         //uv computation should take spritesheet into account.

--- a/cocos2d/core/sprites/CCScale9SpriteCanvasRenderCmd.js
+++ b/cocos2d/core/sprites/CCScale9SpriteCanvasRenderCmd.js
@@ -97,9 +97,9 @@ proto.rendering = function (ctx, scaleX, scaleY) {
         }
         var sx,sy,sw,sh;
         var x, y, w,h;
-        var textureWidth = this._textureToRender._pixelWidth;
-        var textureHeight = this._textureToRender._pixelHeight;
-        var image = this._textureToRender._htmlElementObj;
+        var textureWidth = this._textureToRender.width;
+        var textureHeight = this._textureToRender.height;
+        var image = this._textureToRender._image;
         var vertices = node._vertices;
         var uvs = node._uvs;
         var i = 0, off = 0;

--- a/cocos2d/core/sprites/CCSpriteBatchNode.js
+++ b/cocos2d/core/sprites/CCSpriteBatchNode.js
@@ -185,7 +185,7 @@ cc.SpriteBatchNode = _ccsg.Node.extend(/** @lends cc.SpriteBatchNode# */{
     setTexture: function(texture){
         this._texture = texture;
 
-        if (texture._textureLoaded) {
+        if (texture.loaded) {
             var children = this._children, i, len = children.length;
             for (i = 0; i < len; ++i) {
                 children[i].setTexture(texture);

--- a/cocos2d/core/sprites/CCSpriteFrame.js
+++ b/cocos2d/core/sprites/CCSpriteFrame.js
@@ -264,7 +264,7 @@ cc.SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
     _refreshTexture: function (texture) {
         var self = this;
         if (self._texture !== texture) {
-            var locLoaded = texture.isLoaded();
+            var locLoaded = texture.loaded;
             this._textureLoaded = locLoaded;
             this._texture = texture;
             function textureLoadedCallback () {

--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -23,40 +23,161 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-var EventTarget = require('../event/event-target');
-var sys = require('../platform/CCSys');
-var JS = require('../platform/js');
-var misc = require('../utils/misc');
-var game = require('../CCGame');
+const EventTarget = require('../event/event-target');
+const sys = require('../platform/CCSys');
+const JS = require('../platform/js');
+const misc = require('../utils/misc');
+const game = require('../CCGame');
 require('../platform/_CCClass');
 require('../platform/CCClass');
+
+const GL_ALPHA = 6406;            // gl.ALPHA
+const GL_RGB = 6407;              // gl.RGB
+const GL_RGBA = 6408;             // gl.RGBA
+const GL_LUMINANCE = 6409;        // gl.LUMINANCE
+const GL_LUMINANCE_ALPHA = 6410;  // gl.LUMINANCE_ALPHA
+const GL_UNSIGNED_BYTE = 5121;            // gl.UNSIGNED_BYTE
+const GL_UNSIGNED_SHORT = 5123;           // gl.UNSIGNED_SHORT
+const GL_UNSIGNED_INT = 5125;             // gl.UNSIGNED_INT
+const GL_FLOAT = 5126;                    // gl.FLOAT
+const GL_UNSIGNED_SHORT_5_6_5 = 33635;    // gl.UNSIGNED_SHORT_5_6_5
+const GL_UNSIGNED_SHORT_4_4_4_4 = 32819;  // gl.UNSIGNED_SHORT_4_4_4_4
+const GL_UNSIGNED_SHORT_5_5_5_1 = 32820;  // gl.UNSIGNED_SHORT_5_5_5_1
+
+const GL_NEAREST = 9728;                // gl.NEAREST
+const GL_LINEAR = 9729;                 // gl.LINEAR
+const GL_REPEAT = 10497;                // gl.REPEAT
+const GL_CLAMP_TO_EDGE = 33071;         // gl.CLAMP_TO_EDGE
+const GL_MIRRORED_REPEAT = 33648;       // gl.MIRRORED_REPEAT
+
+const _textureFmtGL = [
+    // R5_G6_B5: 0
+    { format: GL_RGB, internalFormat: GL_RGB, pixelType: GL_UNSIGNED_SHORT_5_6_5 },
+    // R5_G5_B5_A1: 1
+    { format: GL_RGBA, internalFormat: GL_RGBA, pixelType: GL_UNSIGNED_SHORT_5_5_5_1 },
+    // R4_G4_B4_A4: 2
+    { format: GL_RGBA, internalFormat: GL_RGBA, pixelType: GL_UNSIGNED_SHORT_4_4_4_4 },
+    // RGB8: 3
+    { format: GL_RGB, internalFormat: GL_RGB, pixelType: GL_UNSIGNED_BYTE },
+    // RGBA8: 4
+    { format: GL_RGBA, internalFormat: GL_RGBA, pixelType: GL_UNSIGNED_BYTE },
+    // A8: 5
+    { format: GL_ALPHA, internalFormat: GL_ALPHA, pixelType: GL_UNSIGNED_BYTE },
+    // L8: 6
+    { format: GL_LUMINANCE, internalFormat: GL_LUMINANCE, pixelType: GL_UNSIGNED_BYTE },
+    // L8_A8: 7
+    { format: GL_LUMINANCE_ALPHA, internalFormat: GL_LUMINANCE_ALPHA, pixelType: GL_UNSIGNED_BYTE }
+];
+
+/**
+ * The texture pixel format, default value is RGBA8888
+ * @enum Texture2D.PixelFormat
+ */
+const PixelFormat = cc.Enum({
+    /**
+     * 16-bit texture without Alpha channel, not supported yet
+     * @property RGB565
+     * @readonly
+     * @type {Number}
+     */
+    RGB565: 0,
+    /**
+     * 16-bit textures: RGB5A1, not supported yet
+     * @property RGB5A1
+     * @readonly
+     * @type {Number}
+     */
+    RGB5A1: 1,
+    /**
+     * 16-bit textures: RGBA4444, not supported yet
+     * @property RGBA4444
+     * @readonly
+     * @type {Number}
+     */
+    RGBA4444: 2,
+    /**
+     * 24-bit texture: RGB888, not supported yet
+     * @property RGB888
+     * @readonly
+     * @type {Number}
+     */
+    RGB888: 3,
+    /**
+     * 32-bit texture: RGBA8888
+     * @property RGBA8888
+     * @readonly
+     * @type {Number}
+     */
+    RGBA8888: 4,
+    /**
+     * 8-bit textures used as masks, not supported yet
+     * @property A8
+     * @readonly
+     * @type {Number}
+     */
+    A8: 5,
+    /**
+     * 8-bit intensity texture, not supported yet
+     * @property I8
+     * @readonly
+     * @type {Number}
+     */
+    I8: 6,
+    /**
+     * 16-bit textures used as masks, not supported yet
+     * @property AI88
+     * @readonly
+     * @type {Number}
+     */
+});
 
 /**
  * The texture wrap mode
  * @enum Texture2D.WrapMode
  */
-var WrapMode = cc.Enum({
+const WrapMode = cc.Enum({
     /**
      * The constant variable equals gl.REPEAT for texture
      * @property REPEAT
      * @type {Number}
      * @readonly
      */
-    REPEAT: 0x2901,
+    REPEAT: GL_REPEAT,
     /**
      * The constant variable equals gl.CLAMP_TO_EDGE for texture
      * @property CLAMP_TO_EDGE
      * @type {Number}
      * @readonly
      */
-    CLAMP_TO_EDGE: 0x812f,
+    CLAMP_TO_EDGE: GL_CLAMP_TO_EDGE,
     /**
      * The constant variable equals gl.MIRRORED_REPEAT for texture
      * @property MIRRORED_REPEAT
      * @type {Number}
      * @readonly
      */
-    MIRRORED_REPEAT: 0x8370
+    MIRRORED_REPEAT: GL_MIRRORED_REPEAT
+});
+
+/**
+ * The texture filter mode
+ * @enum Texture2D.Filter
+ */
+const Filter = cc.Enum({
+    /**
+     * The constant variable equals gl.LINEAR for texture
+     * @property LINEAR
+     * @type {Number}
+     * @readonly
+     */
+    LINEAR: GL_LINEAR,
+    /**
+     * The constant variable equals gl.NEAREST for texture
+     * @property NEAREST
+     * @type {Number}
+     * @readonly
+     */
+    NEAREST: GL_NEAREST
 });
 
 /**
@@ -77,17 +198,62 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
     extends: require('../assets/CCRawAsset'),
     mixins: [EventTarget],
 
-    statics: {
-        WrapMode: WrapMode
+    properties: {
+        _hasMipmap: false,
+        _format: PixelFormat.RGBA8888,
+        _compressed: false,
+        _premultiplyAlpha: false,
+        _minFilter: Filter.LINEAR,
+        _magFilter: Filter.LINEAR,
+        _wrapS: WrapMode.CLAMP_TO_EDGE,
+        _wrapT: WrapMode.CLAMP_TO_EDGE
     },
 
-    ctor: function () {
+    statics: {
+        PixelFormat: PixelFormat,
+        WrapMode: WrapMode,
+        Filter: Filter
+    },
+
+    ctor: function (gl) {
+        /**
+         * !#en
+         * The url of the texture, this coule be empty if the texture wasn't created via a file.
+         * !#zh
+         * 贴图文件的 url，当贴图不是由文件创建时值可能为空
+         * @property url
+         * @type {String}
+         */
         this.url = null;
-        this._textureLoaded = false;
-        this._htmlElementObj = null;
-        this._contentSize = cc.size(0, 0);
-        this._pixelWidth = 0;
-        this._pixelHeight = 0;
+        /**
+         * !#en
+         * Whether the texture is loaded or not
+         * !#zh
+         * 贴图是否已经成功加载
+         * @property loaded
+         * @type {Boolean}
+         */
+        this.loaded = false;
+        /**
+         * !#en
+         * Texture width in pixel
+         * !#zh
+         * 贴图像素宽度
+         * @property width
+         * @type {Number}
+         */
+        this.width = 0;
+        /**
+         * !#en
+         * Texture height in pixel
+         * !#zh
+         * 贴图像素高度
+         * @property height
+         * @type {Number}
+         */
+        this.height = 0;
+
+        this._image = null;
 
         if (cc._renderType === game.RENDER_TYPE_CANVAS) {
             this._pattern = "";
@@ -97,55 +263,73 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
             this._isGray = false;
         }
         else if (cc._renderType === game.RENDER_TYPE_WEBGL) {
-            this._pixelFormat = Texture2D.defaultPixelFormat;
-            this._hasPremultipliedAlpha = false;
-            this._hasMipmaps = false;
-
-            this._webTextureObj = null;
+            this._gl = gl || cc._renderContext;
+            this._glID = null;
         }
+    },
+
+    /**
+     * Update texture options, only available in WebGL render mode
+     * @method update
+     * @param {Object} options
+     * @param {DOMImageElement} options.image
+     * @param {Boolean} options.mipmap
+     * @param {PixelFormat} options.format
+     * @param {Filter} options.minFilter
+     * @param {Filter} options.magFilter
+     * @param {Filter} options.mipFilter
+     * @param {WrapMode} options.wrapS
+     * @param {WrapMode} options.wrapT
+     * @param {Boolean} options.premultiplyAlpha
+     */
+    update(options) {
     },
 
     /**
      * Get width in pixels.
      * @method getPixelWidth
      * @return {Number}
+     * @deprecated use width or height property instead
      */
     getPixelWidth: function () {
-        return this._pixelWidth;
+        return this.width;
     },
 
     /**
      * Get height of in pixels.
      * @method getPixelHeight
      * @return {Number}
+     * @deprecated use width or height property instead
      */
     getPixelHeight: function () {
-        return this._pixelHeight;
+        return this.height;
     },
 
     /**
      * Get content size.
      * @method getContentSize
      * @returns {Size}
+     * @deprecated use width or height property instead
      */
     getContentSize: function () {
-        return cc.size(this._contentSize.width, this._contentSize.height);
+        return cc.size(this.width, this.height);
     },
 
     _getWidth: function () {
-        return this._contentSize.width;
+        return this.width;
     },
     _getHeight: function () {
-        return this._contentSize.height;
+        return this.height;
     },
 
     /**
      * Get content size in pixels.
      * @method getContentSizeInPixels
      * @returns {Size}
+     * @deprecated use width or height property instead
      */
     getContentSizeInPixels: function () {
-        return this._contentSize;
+        return this.getContentSize();
     },
 
     /**
@@ -161,23 +345,23 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
     initWithElement: function (element) {
         if (!element)
             return;
-        this._htmlElementObj = element;
-        this._pixelWidth = this._contentSize.width = element.width;
-        this._pixelHeight = this._contentSize.height = element.height;
-        this._textureLoaded = true;
+        this._image = element;
+        this.width = element.width;
+        this.height = element.height;
+        this.loaded = true;
     },
 
     /**
      * Intializes with a texture2d with data.
      * @method initWithData
-     * @param {Array} data
+     * @param {TypedArray} data
      * @param {Number} pixelFormat
-     * @param {Number} pixelsWide
-     * @param {Number} pixelsHigh
+     * @param {Number} pixelsWidth
+     * @param {Number} pixelsHeight
      * @param {Size} contentSize
      * @return {Boolean}
      */
-    initWithData: function (data, pixelFormat, pixelsWide, pixelsHigh, contentSize) {
+    initWithData: function (data, pixelFormat, pixelsWidth, pixelsHeight, contentSize) {
         //support only in WebGl rendering mode
         return false;
     },
@@ -202,16 +386,17 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @return {HTMLImageElement|HTMLCanvasElement}
      */
     getHtmlElementObj: function () {
-        return this._htmlElementObj;
+        return this._image;
     },
 
     /**
      * Check whether texture is loaded.
      * @method isLoaded
      * @returns {Boolean}
+     * @deprecated use loaded property instead
      */
     isLoaded: function () {
-        return this._textureLoaded;
+        return this.loaded;
     },
 
     /**
@@ -220,17 +405,16 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @param {Boolean} [premultiplied]
      */
     handleLoadedTexture: function () {
-        var self = this;
-        if (!self._htmlElementObj || !self._htmlElementObj.width || !self._htmlElementObj.height)
+        if (!this._image || !this._image.width || !this._image.height)
             return;
 
-        var locElement = self._htmlElementObj;
-        self._pixelWidth = self._contentSize.width = locElement.width;
-        self._pixelHeight = self._contentSize.height = locElement.height;
-        self._textureLoaded = true;
+        var locElement = this._image;
+        this.width = locElement.width;
+        this.height = locElement.height;
+        this.loaded = true;
 
         //dispatch load event to listener.
-        self.emit("load");
+        this.emit("load");
     },
 
     /**
@@ -239,7 +423,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @returns {String}
      */
     description: function () {
-        return "<cc.Texture2D | Name = " + this.getName() + " | Dimensions = " + this.getPixelWidth() + " x " + this.getPixelHeight() + ">";
+        return "<cc.Texture2D | Name = " + this.url + " | Dimensions = " + this.width + " x " + this.height + ">";
     },
 
     /**
@@ -247,13 +431,9 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @method releaseTexture
      */
     releaseTexture: function () {
-        if (this._webTextureObj) {
-            cc._renderContext.deleteTexture(this._webTextureObj);
+        if (this._glID !== null) {
+            this._gl.deleteTexture(this._glID);
         }
-    },
-
-    getName: function () {
-        return this._webTextureObj || null;
     },
 
     /**
@@ -263,7 +443,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      */
     getPixelFormat: function () {
         //support only in WebGl rendering mode
-        return this._pixelFormat || null;
+        return this._format;
     },
 
     /**
@@ -273,7 +453,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @return {Boolean}
      */
     hasPremultipliedAlpha: function () {
-        return this._hasPremultipliedAlpha || false;
+        return this._premultiplyAlpha || false;
     },
 
     /**
@@ -282,7 +462,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @return {Boolean}
      */
     hasMipmaps: function () {
-        return this._hasMipmaps || false;
+        return this._hasMipmap || false;
     },
 
     /**
@@ -293,26 +473,24 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @param {Number} [magFilter]
      * @param {Texture2D.WrapMode} [wrapS]
      * @param {Texture2D.WrapMode} [wrapT]
+     * @deprecated use update function with filter and wrap options instead
      */
     setTexParameters: function (texParams, magFilter, wrapS, wrapT) {
-        if(magFilter !== undefined)
+        if (magFilter !== undefined)
             texParams = {minFilter: texParams, magFilter: magFilter, wrapS: wrapS, wrapT: wrapT};
 
-        if(texParams.wrapS === WrapMode.REPEAT && texParams.wrapT === WrapMode.REPEAT){
+        if (texParams.wrapS === WrapMode.REPEAT && texParams.wrapT === WrapMode.REPEAT) {
             this._pattern = "repeat";
             return;
         }
-
-        if(texParams.wrapS === WrapMode.REPEAT ){
+        if (texParams.wrapS === WrapMode.REPEAT ) {
             this._pattern = "repeat-x";
             return;
         }
-
-        if(texParams.wrapT === WrapMode.REPEAT){
+        if (texParams.wrapT === WrapMode.REPEAT) {
             this._pattern = "repeat-y";
             return;
         }
-
         this._pattern = "";
     },
 
@@ -322,6 +500,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      *  - GL_TEXTURE_MAG_FILTER = GL_NEAREST           <br/>
      * supported only in native or WebGl rendering mode
      * @method setAntiAliasTexParameters
+     * @deprecated use update function with filter options instead
      */
     setAntiAliasTexParameters: function () {
         //support only in WebGl rendering mode
@@ -333,168 +512,16 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      *   GL_TEXTURE_MAG_FILTER = GL_NEAREST           <br/>
      * supported only in native or WebGl rendering mode
      * @method setAliasTexParameters
+     * @deprecated use update function with filter options instead
      */
     setAliasTexParameters: function () {
         //support only in WebGl rendering mode
-    },
-
-    /**
-     *  Generates mipmap images for the texture.<br/>
-     *  It only works if the texture size is POT (power of 2).
-     */
-    generateMipmap: function () {
-        //support only in WebGl rendering mode
-    },
-
-    /**
-     * returns the pixel format.
-     * @return {String}
-     */
-    stringForFormat: function () {
-        //support only in WebGl rendering mode
-        return "";
-    },
-
-    /**
-     * returns the bits-per-pixel of the in-memory OpenGL texture
-     * @return {Number}
-     */
-    bitsPerPixelForFormat: function (format) {
-        //support only in WebGl rendering mode
-        return -1;
     }
 });
-
-Texture2D.WrapMode = WrapMode;
-
-var _c = Texture2D;
-
-/**
- * 32-bit texture: RGBA8888
- * @property PIXEL_FORMAT_RGBA8888
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_RGBA8888 = 2;
-
-/**
- * 24-bit texture: RGB888, not supported yet
- * @property PIXEL_FORMAT_RGB888
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_RGB888 = 3;
-
-/**
- * 16-bit texture without Alpha channel, not supported yet
- * @property PIXEL_FORMAT_RGB565
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_RGB565 = 4;
-
-/**
- * 8-bit textures used as masks, not supported yet
- * @property PIXEL_FORMAT_A8
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_A8 = 5;
-
-/**
- * 8-bit intensity texture, not supported yet
- * @property PIXEL_FORMAT_I8
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_I8 = 6;
-
-/**
- * 16-bit textures used as masks, not supported yet
- * @property PIXEL_FORMAT_AI88
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_AI88 = 7;
-
-/**
- * 16-bit textures: RGBA4444, not supported yet
- * @property PIXEL_FORMAT_RGBA4444
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_RGBA4444 = 8;
-
-/**
- * 16-bit textures: RGB5A1, not supported yet
- * @property PIXEL_FORMAT_RGB5A1
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_RGB5A1 = 7;
-
-/**
- * 4-bit PVRTC-compressed texture: PVRTC4, not supported yet
- * @property PIXEL_FORMAT_PVRTC4
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_PVRTC4 = 9;
-
-/**
- * 2-bit PVRTC-compressed texture: PVRTC2, not supported yet
- * @property PIXEL_FORMAT_PVRTC2
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_PVRTC2 = 10;
-
-/**
- * Default texture format: RGBA8888
- * @property PIXEL_FORMAT_DEFAULT
- * @static
- * @type {Number}
- */
-_c.PIXEL_FORMAT_DEFAULT = _c.PIXEL_FORMAT_RGBA8888;
-
-/**
- * The default pixel format
- * @property defaultPixelFormat
- * @static
- * @type {Number}
- */
-_c.defaultPixelFormat = _c.PIXEL_FORMAT_DEFAULT;
-
-var _M = Texture2D._M = {};
-_M[_c.PIXEL_FORMAT_RGBA8888] = "RGBA8888";
-_M[_c.PIXEL_FORMAT_RGB888] = "RGB888";
-_M[_c.PIXEL_FORMAT_RGB565] = "RGB565";
-_M[_c.PIXEL_FORMAT_A8] = "A8";
-_M[_c.PIXEL_FORMAT_I8] = "I8";
-_M[_c.PIXEL_FORMAT_AI88] = "AI88";
-_M[_c.PIXEL_FORMAT_RGBA4444] = "RGBA4444";
-_M[_c.PIXEL_FORMAT_RGB5A1] = "RGB5A1";
-_M[_c.PIXEL_FORMAT_PVRTC4] = "PVRTC4";
-_M[_c.PIXEL_FORMAT_PVRTC2] = "PVRTC2";
-
-var _B = Texture2D._B = {};
-_B[_c.PIXEL_FORMAT_RGBA8888] = 32;
-_B[_c.PIXEL_FORMAT_RGB888] = 24;
-_B[_c.PIXEL_FORMAT_RGB565] = 16;
-_B[_c.PIXEL_FORMAT_A8] = 8;
-_B[_c.PIXEL_FORMAT_I8] = 8;
-_B[_c.PIXEL_FORMAT_AI88] = 16;
-_B[_c.PIXEL_FORMAT_RGBA4444] = 16;
-_B[_c.PIXEL_FORMAT_RGB5A1] = 16;
-_B[_c.PIXEL_FORMAT_PVRTC4] = 4;
-_B[_c.PIXEL_FORMAT_PVRTC2] = 3;
 
 var _p = Texture2D.prototype;
 
 // Extended properties
-/** @expose */
-_p.name;
-cc.defineGetterSetter(_p, "name", _p.getName);
 /** @expose */
 _p.pixelFormat;
 cc.defineGetterSetter(_p, "pixelFormat", _p.getPixelFormat);
@@ -504,16 +531,9 @@ cc.defineGetterSetter(_p, "pixelWidth", _p.getPixelWidth);
 /** @expose */
 _p.pixelHeight;
 cc.defineGetterSetter(_p, "pixelHeight", _p.getPixelHeight);
-/** @expose */
-_p.width;
-cc.defineGetterSetter(_p, "width", _p._getWidth);
-/** @expose */
-_p.height;
-cc.defineGetterSetter(_p, "height", _p._getHeight);
 
 game.once(game.EVENT_RENDERER_INITED, function () {
-    if(cc._renderType === game.RENDER_TYPE_CANVAS) {
-
+    if (cc._renderType === game.RENDER_TYPE_CANVAS) {
         var renderToCache = function(image, cache){
             var w = image.width;
             var h = image.height;
@@ -578,29 +598,29 @@ game.once(game.EVENT_RENDERER_INITED, function () {
                 document.createElement("canvas")
             ];
             //todo texture onload
-            renderToCache(this._htmlElementObj, textureCache);
+            renderToCache(this._image, textureCache);
             return this.channelCache = textureCache;
         };
 
         _p._switchToGray = function(toGray){
-            if(!this._textureLoaded || this._isGray === toGray)
+            if(!this.loaded || this._isGray === toGray)
                 return;
             this._isGray = toGray;
             if(this._isGray){
-                this._backupElement = this._htmlElementObj;
+                this._backupElement = this._image;
                 if(!this._grayElementObj)
-                    this._grayElementObj = generateGrayTexture(this._htmlElementObj);
-                this._htmlElementObj = this._grayElementObj;
+                    this._grayElementObj = generateGrayTexture(this._image);
+                this._image = this._grayElementObj;
             } else {
                 if(this._backupElement !== null)
-                    this._htmlElementObj = this._backupElement;
+                    this._image = this._backupElement;
             }
         };
 
         _p._generateGrayTexture = function() {
-            if(!this._textureLoaded)
+            if(!this.loaded)
                 return null;
-            var grayElement = generateGrayTexture(this._htmlElementObj);;
+            var grayElement = generateGrayTexture(this._image);;
             var newTexture = new Texture2D();
             newTexture.initWithElement(grayElement);
             newTexture.handleLoadedTexture();
@@ -614,7 +634,7 @@ game.once(game.EVENT_RENDERER_INITED, function () {
                 onlyCanvas = true;
             else
                 canvas = document.createElement("canvas");
-            var textureImage = this._htmlElementObj;
+            var textureImage = this._image;
             if(!rect)
                 rect = cc.rect(0, 0, textureImage.width, textureImage.height);
 
@@ -652,7 +672,7 @@ game.once(game.EVENT_RENDERER_INITED, function () {
                 onlyCanvas = true;
             else
                 canvas = document.createElement("canvas");
-            var textureImage = this._htmlElementObj;
+            var textureImage = this._image;
             if(!rect)
                 rect = cc.rect(0, 0, textureImage.width, textureImage.height);
 
@@ -690,343 +710,217 @@ game.once(game.EVENT_RENDERER_INITED, function () {
         };
 
     } else if (cc._renderType === game.RENDER_TYPE_WEBGL) {
-        _p.initWithData = function (data, pixelFormat, pixelsWide, pixelsHigh, contentSize) {
-            var self = this, tex2d = Texture2D;
-            var gl = cc._renderContext;
-            var format = gl.RGBA, type = gl.UNSIGNED_BYTE;
 
-            var bitsPerPixel = Texture2D._B[pixelFormat];
+        function _glTextureFmt (pixelFormat) {
+            var glFmt = _textureFmtGL[pixelFormat];
+            cc.assertID(glFmt, 3113);
+            return glFmt;
+        }
 
-            var bytesPerRow = pixelsWide * bitsPerPixel / 8;
-            if (bytesPerRow % 8 === 0) {
-                gl.pixelStorei(gl.UNPACK_ALIGNMENT, 8);
-            } else if (bytesPerRow % 4 === 0) {
-                gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
-            } else if (bytesPerRow % 2 === 0) {
-                gl.pixelStorei(gl.UNPACK_ALIGNMENT, 2);
+        function _isPow2 (v) {
+            return !(v & (v - 1)) && (!!v);
+        }
+
+        var _sharedOpts = {
+            width: undefined,
+            height: undefined,
+            minFilter: undefined,
+            magFilter: undefined,
+            wrapS: undefined,
+            wrapT: undefined,
+            format: undefined,
+            mipmap: undefined,
+            image: undefined,
+            premultiplyAlpha: undefined
+        }
+        function _getSharedOptions () {
+            for (var key in _sharedOpts) {
+                _sharedOpts[key] = undefined;
+            }
+            return _sharedOpts;
+        }
+
+        _p.update = function (options) {
+            var genMipmap = this._hasMipmap;
+            var gl = this._gl;
+            var updateImage = false;
+
+            if (options) {
+                if (options.width !== undefined) {
+                    this.width = options.width;
+                }
+                if (options.height !== undefined) {
+                    this.height = options.height;
+                }
+                if (options.minFilter !== undefined) {
+                    this._minFilter = options.minFilter;
+                }
+                if (options.magFilter !== undefined) {
+                    this._magFilter = options.magFilter;
+                }
+                if (options.wrapS !== undefined) {
+                    this._wrapS = options.wrapS;
+                }
+                if (options.wrapT !== undefined) {
+                    this._wrapT = options.wrapT;
+                }
+                if (options.format !== undefined) {
+                    this._format = options.format;
+                    updateImage = true;
+                }
+                if (options.premultiplyAlpha !== undefined) {
+                    this._premultiplyAlpha = options.premultiplyAlpha;
+                    updateImage = true;
+                }
+                if (options.image !== undefined) {
+                    this._image = options.image;
+                    updateImage = true;
+                }
+                if (options.mipmap !== undefined) {
+                    genMipmap = this._hasMipmap = options.mipmap;
+                }
+            }
+
+            if (this._image) {
+                if (updateImage) {
+                    // Release previous gl texture if existed
+                    this.releaseTexture();
+                    this._glID = gl.createTexture();
+                    gl.activeTexture(gl.TEXTURE0);
+                    gl.bindTexture(gl.TEXTURE_2D, this._glID);
+                    this._setImage(this._image, this.width, this.height, _glTextureFmt(this._format), this._premultiplyAlpha);
+                }
+                else {
+                    gl.activeTexture(gl.TEXTURE0);
+                    gl.bindTexture(gl.TEXTURE_2D, this._glID);
+                }
+                this._setTexInfo();
+
+                if (genMipmap) {
+                    cc.assertID(_isPow2(this.width) && _isPow2(this.height), 3117);
+                    gl.hint(gl.GENERATE_MIPMAP_HINT, gl.NICEST);
+                    gl.generateMipmap(gl.TEXTURE_2D);
+                }
+                gl.bindTexture(gl.TEXTURE_2D, null);
+            }
+        };
+
+        _p._setImage = function (img, width, height, glFmt, premultiplyAlpha) {
+            var gl = this._gl;
+            gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultiplyAlpha);
+            if (
+                img instanceof HTMLCanvasElement ||
+                img instanceof HTMLImageElement ||
+                img instanceof HTMLVideoElement
+            ) {
+                gl.texImage2D(
+                    gl.TEXTURE_2D,
+                    0,
+                    glFmt.internalFormat,
+                    glFmt.format,
+                    glFmt.pixelType,
+                    img
+                );
             } else {
-                gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
+                gl.texImage2D(
+                    gl.TEXTURE_2D,
+                    0,
+                    glFmt.internalFormat,
+                    width,
+                    height,
+                    0,
+                    glFmt.format,
+                    glFmt.pixelType,
+                    img
+                );
             }
-
-            self._webTextureObj = gl.createTexture();
-            cc.gl.bindTexture2D(self);
-
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-            // Specify OpenGL texture image
-            switch (pixelFormat) {
-                case tex2d.PIXEL_FORMAT_RGBA8888:
-                    format = gl.RGBA;
-                    break;
-                case tex2d.PIXEL_FORMAT_RGB888:
-                    format = gl.RGB;
-                    break;
-                case tex2d.PIXEL_FORMAT_RGBA4444:
-                    type = gl.UNSIGNED_SHORT_4_4_4_4;
-                    break;
-                case tex2d.PIXEL_FORMAT_RGB5A1:
-                    type = gl.UNSIGNED_SHORT_5_5_5_1;
-                    break;
-                case tex2d.PIXEL_FORMAT_RGB565:
-                    type = gl.UNSIGNED_SHORT_5_6_5;
-                    break;
-                case tex2d.PIXEL_FORMAT_AI88:
-                    format = gl.LUMINANCE_ALPHA;
-                    break;
-                case tex2d.PIXEL_FORMAT_A8:
-                    format = gl.ALPHA;
-                    break;
-                case tex2d.PIXEL_FORMAT_I8:
-                    format = gl.LUMINANCE;
-                    break;
-                default:
-                    cc.assertID(0, 3113);
+        };
+        
+        _p._setTexInfo = function () {
+            var gl = this._gl;
+            var pot = _isPow2(this.width) && _isPow2(this.height);
+        
+            // WebGL1 doesn't support all wrap modes with NPOT textures
+            if (!pot && (this._wrapS !== WrapMode.CLAMP_TO_EDGE || this._wrapT !== WrapMode.CLAMP_TO_EDGE)) {
+                cc.warnID(3116);
+                this._wrapS = WrapMode.CLAMP_TO_EDGE;
+                this._wrapT = WrapMode.CLAMP_TO_EDGE;
             }
-            gl.texImage2D(gl.TEXTURE_2D, 0, format, pixelsWide, pixelsHigh, 0, format, type, data);
+        
+            if (this._minFilter === Filter.LINEAR) {
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this._hasMipmap ? gl.LINEAR_MIPMAP_NEAREST : gl.LINEAR);
+            }
+            else {
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this._hasMipmap ? gl.NEAREST_MIPMAP_NEAREST : gl.NEAREST);
+            }
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this._magFilter);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, this._wrapS);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, this._wrapT);
+        };
 
-
-            self._contentSize.width = contentSize.width;
-            self._contentSize.height = contentSize.height;
-            self._pixelWidth = pixelsWide;
-            self._pixelHeight = pixelsHigh;
-            self._pixelFormat = pixelFormat;
-
-            self._hasPremultipliedAlpha = false;
-            self._hasMipmaps = false;
-
-            self._textureLoaded = true;
-
+        _p.initWithData = function (data, pixelFormat, pixelsWidth, pixelsHeight, contentSize) {
+            var opts = _getSharedOptions();
+            opts.image = data;
+            opts.format = pixelFormat;
+            opts.width = pixelsWidth;
+            opts.height = pixelsHeight;
+            this.update(opts);
+            this.width = contentSize.width;
+            this.height = contentSize.height;
+            this.loaded = true;
+            this.emit("load");
             return true;
         };
 
-        _p.initWithImage = function (uiImage) {
-            if (uiImage == null) {
-                cc.logID(3104);
-                return false;
-            }
-
-            var imageWidth = uiImage.getWidth();
-            var imageHeight = uiImage.getHeight();
-
-            var maxTextureSize = cc.configuration.getMaxTextureSize();
-            if (imageWidth > maxTextureSize || imageHeight > maxTextureSize) {
-                cc.logID(3105, imageWidth, imageHeight, maxTextureSize, maxTextureSize);
-                return false;
-            }
-            this._textureLoaded = true;
-
-            // always load premultiplied images
-            return this._initPremultipliedATextureWithImage(uiImage, imageWidth, imageHeight);
-        };
-
         _p.initWithElement = function (element) {
-            if (!element)
+            if (!element || element.width === 0 || element.height === 0)
                 return;
-            this._webTextureObj = cc._renderContext.createTexture();
-            this._htmlElementObj = element;
-            this._textureLoaded = true;
+            
+            this._image = element;
+            return true;
         };
 
         // [premultiplied=false]
         _p.handleLoadedTexture = function (premultiplied) {
-            premultiplied = !!premultiplied;
-            var self = this;
-            // Not sure about this ! Some texture need to be updated even after loaded
-            if (!game._rendererInitialized) {
-                return;
-            }
-            if (!self._htmlElementObj || !self._htmlElementObj.width || !self._htmlElementObj.height) {
+            if (!this._image || !this._image.width || !this._image.height) {
                 return;
             }
 
-            //upload image to buffer
-            var gl = cc._renderContext;
+            var opts = _getSharedOptions();
+            opts.image = this._image;
+            opts.format = PixelFormat.RGBA8888;
+            opts.width = this._image.width;
+            opts.height = this._image.height;
+            opts.premultiplyAlpha = !!premultiplied;
+            opts.minFilter = cc.view._antiAliasEnabled ? Filter.LINEAR : Filter.NEAREST;
+            this.update(opts);
 
-            cc.gl.bindTexture2D(self);
-
-            gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
-            if(premultiplied)
-                gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
-
-            // Specify OpenGL texture image
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, self._htmlElementObj);
-
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-            cc.gl.bindTexture2D(null);
-            if(premultiplied)
-                gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
-
-            var pixelsWide = self._htmlElementObj.width;
-            var pixelsHigh = self._htmlElementObj.height;
-
-            self._pixelWidth = self._contentSize.width = pixelsWide;
-            self._pixelHeight = self._contentSize.height = pixelsHigh;
-            self._pixelFormat = Texture2D.PIXEL_FORMAT_RGBA8888;
-
-            self._hasPremultipliedAlpha = premultiplied;
-            self._hasMipmaps = false;
-            self._textureLoaded = true;
-
-            if (cc.view._antiAliasEnabled) {
-                self.setAntiAliasTexParameters();
-            }
-            else {
-                self.setAliasTexParameters();
-            }
-
-            self._htmlElementObj = null;
-
-            //dispatch load event to listener.
-            self.emit("load");
+            this._image = null;
+            this.loaded = true;
+            this.emit("load");
         };
 
         _p.setTexParameters = function (texParams, magFilter, wrapS, wrapT) {
-            var _t = this;
-            var gl = cc._renderContext;
-
-            if(magFilter !== undefined)
+            if (magFilter !== undefined)
                 texParams = {minFilter: texParams, magFilter: magFilter, wrapS: wrapS, wrapT: wrapT};
-
-            cc.assertID((_t._pixelWidth === misc.NextPOT(_t._pixelWidth) && _t._pixelHeight === misc.NextPOT(_t._pixelHeight)) ||
-                (texParams.wrapS === gl.CLAMP_TO_EDGE && texParams.wrapT === gl.CLAMP_TO_EDGE),
-                3116);
-
-            cc.gl.bindTexture2D(_t);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, texParams.minFilter);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, texParams.magFilter);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, texParams.wrapS);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, texParams.wrapT);
+            this.update(texParams);
         };
 
         _p.setAntiAliasTexParameters = function () {
-            var gl = cc._renderContext;
-
-            cc.gl.bindTexture2D(this);
-            if (!this._hasMipmaps)
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-            else
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+            var opts = _getSharedOptions();
+            opts.minFilter = Filter.LINEAR;
+            opts.magFilter = Filter.LINEAR;
+            this.update(opts);
         };
 
         _p.setAliasTexParameters = function () {
-            var gl = cc._renderContext;
-
-            cc.gl.bindTexture2D(this);
-            if (!this._hasMipmaps)
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-            else
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-        };
-
-        _p.generateMipmap = function () {
-            var _t = this;
-            cc.assertID(_t._pixelWidth === misc.NextPOT(_t._pixelWidth) && _t._pixelHeight === misc.NextPOT(_t._pixelHeight), 3117);
-
-            cc.gl.bindTexture2D(_t);
-            cc._renderContext.generateMipmap(cc._renderContext.TEXTURE_2D);
-            _t._hasMipmaps = true;
-        };
-
-        _p.stringForFormat = function () {
-            return Texture2D._M[this._pixelFormat];
-        };
-
-        _p.bitsPerPixelForFormat = function (format) {//TODO I want to delete the format argument, use this._pixelFormat
-            format = format || this._pixelFormat;
-            var value = Texture2D._B[format];
-            if (value != null) return value;
-            cc.logID(3110, format);
-            return -1;
-        };
-
-        _p._initPremultipliedATextureWithImage = function (uiImage, width, height) {
-            var tex2d = Texture2D;
-            var tempData = uiImage.getData();
-            var inPixel32 = null;
-            var inPixel8 = null;
-            var outPixel16 = null;
-            var hasAlpha = uiImage.hasAlpha();
-            var imageSize = cc.size(uiImage.getWidth(), uiImage.getHeight());
-            var pixelFormat = tex2d.defaultPixelFormat;
-            var bpp = uiImage.getBitsPerComponent();
-            var i;
-
-            // compute pixel format
-            if (!hasAlpha) {
-                if (bpp >= 8) {
-                    pixelFormat = tex2d.PIXEL_FORMAT_RGB888;
-                } else {
-                    cc.logID(3111);
-                    pixelFormat = tex2d.PIXEL_FORMAT_RGB565;
-                }
-            }
-
-            // Repack the pixel data into the right format
-            var length = width * height;
-
-            if (pixelFormat === tex2d.PIXEL_FORMAT_RGB565) {
-                if (hasAlpha) {
-                    // Convert "RRRRRRRRRGGGGGGGGBBBBBBBBAAAAAAAA" to "RRRRRGGGGGGBBBBB"
-                    tempData = new Uint16Array(width * height);
-                    inPixel32 = uiImage.getData();
-
-                    for (i = 0; i < length; ++i) {
-                        tempData[i] =
-                            ((((inPixel32[i] >> 0) & 0xFF) >> 3) << 11) | // R
-                                ((((inPixel32[i] >> 8) & 0xFF) >> 2) << 5) | // G
-                                ((((inPixel32[i] >> 16) & 0xFF) >> 3) << 0);    // B
-                    }
-                } else {
-                    // Convert "RRRRRRRRRGGGGGGGGBBBBBBBB" to "RRRRRGGGGGGBBBBB"
-                    tempData = new Uint16Array(width * height);
-                    inPixel8 = uiImage.getData();
-
-                    for (i = 0; i < length; ++i) {
-                        tempData[i] =
-                            (((inPixel8[i] & 0xFF) >> 3) << 11) | // R
-                                (((inPixel8[i] & 0xFF) >> 2) << 5) | // G
-                                (((inPixel8[i] & 0xFF) >> 3) << 0);    // B
-                    }
-                }
-            } else if (pixelFormat === tex2d.PIXEL_FORMAT_RGBA4444) {
-                // Convert "RRRRRRRRRGGGGGGGGBBBBBBBBAAAAAAAA" to "RRRRGGGGBBBBAAAA"
-                tempData = new Uint16Array(width * height);
-                inPixel32 = uiImage.getData();
-
-                for (i = 0; i < length; ++i) {
-                    tempData[i] =
-                        ((((inPixel32[i] >> 0) & 0xFF) >> 4) << 12) | // R
-                            ((((inPixel32[i] >> 8) & 0xFF) >> 4) << 8) | // G
-                            ((((inPixel32[i] >> 16) & 0xFF) >> 4) << 4) | // B
-                            ((((inPixel32[i] >> 24) & 0xFF) >> 4) << 0);  // A
-                }
-            } else if (pixelFormat === tex2d.PIXEL_FORMAT_RGB5A1) {
-                // Convert "RRRRRRRRRGGGGGGGGBBBBBBBBAAAAAAAA" to "RRRRRGGGGGBBBBBA"
-                tempData = new Uint16Array(width * height);
-                inPixel32 = uiImage.getData();
-
-                for (i = 0; i < length; ++i) {
-                    tempData[i] =
-                        ((((inPixel32[i] >> 0) & 0xFF) >> 3) << 11) | // R
-                            ((((inPixel32[i] >> 8) & 0xFF) >> 3) << 6) | // G
-                            ((((inPixel32[i] >> 16) & 0xFF) >> 3) << 1) | // B
-                            ((((inPixel32[i] >> 24) & 0xFF) >> 7) << 0);  // A
-                }
-            } else if (pixelFormat === tex2d.PIXEL_FORMAT_A8) {
-                // Convert "RRRRRRRRRGGGGGGGGBBBBBBBBAAAAAAAA" to "AAAAAAAA"
-                tempData = new Uint8Array(width * height);
-                inPixel32 = uiImage.getData();
-
-                for (i = 0; i < length; ++i) {
-                    tempData[i] = (inPixel32 >> 24) & 0xFF;  // A
-                }
-            }
-
-            if (hasAlpha && pixelFormat === tex2d.PIXEL_FORMAT_RGB888) {
-                // Convert "RRRRRRRRRGGGGGGGGBBBBBBBBAAAAAAAA" to "RRRRRRRRGGGGGGGGBBBBBBBB"
-                inPixel32 = uiImage.getData();
-                tempData = new Uint8Array(width * height * 3);
-
-                for (i = 0; i < length; ++i) {
-                    tempData[i * 3] = (inPixel32 >> 0) & 0xFF; // R
-                    tempData[i * 3 + 1] = (inPixel32 >> 8) & 0xFF; // G
-                    tempData[i * 3 + 2] = (inPixel32 >> 16) & 0xFF; // B
-                }
-            }
-
-            this.initWithData(tempData, pixelFormat, width, height, imageSize);
-
-            if (tempData != uiImage.getData())
-                tempData = null;
-
-            this._hasPremultipliedAlpha = uiImage.isPremultipliedAlpha();
-            return true;
+            var opts = _getSharedOptions();
+            opts.minFilter = Filter.NEAREST;
+            opts.magFilter = Filter.NEAREST;
+            this.update(opts);
         };
     }
 });
-
-/**
- * WebGLTexture Object.
- * @property name
- * @type {WebGLTexture}
- * @readonly
- */
-
-/**
- * The source file's url for the texture, it could be empty if the texture wasn't created via a file.
- * @property url
- * @type {String}
- * @readonly
- */
 
 /**
  * Pixel format of the texture.
@@ -1040,6 +934,7 @@ game.once(game.EVENT_RENDERER_INITED, function () {
  * @property pixelWidth
  * @type {Number}
  * @readonly
+ * @deprecated please use width instead
  */
 
 /**
@@ -1047,18 +942,7 @@ game.once(game.EVENT_RENDERER_INITED, function () {
  * @property pixelHeight
  * @type {Number}
  * @readonly
- */
-
-/**
- * Content width in points.
- * @property width
- * @type {Number}
- */
-
-/**
- * Content height in points.
- * @property height
- * @type {Number}
+ * @deprecated please use height instead
  */
 
 cc.Texture2D = module.exports = Texture2D;

--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -129,6 +129,7 @@ const PixelFormat = cc.Enum({
      * @readonly
      * @type {Number}
      */
+    AI8: 7
 });
 
 /**
@@ -269,7 +270,8 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
     },
 
     /**
-     * Update texture options, only available in WebGL render mode
+     * Update texture options, not available in Canvas render mode. 
+     * image, format, premultiplyAlpha can not be updated in native.
      * @method update
      * @param {Object} options
      * @param {DOMImageElement} options.image
@@ -277,7 +279,6 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @param {PixelFormat} options.format
      * @param {Filter} options.minFilter
      * @param {Filter} options.magFilter
-     * @param {Filter} options.mipFilter
      * @param {WrapMode} options.wrapS
      * @param {WrapMode} options.wrapT
      * @param {Boolean} options.premultiplyAlpha

--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -315,13 +315,6 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
         return cc.size(this.width, this.height);
     },
 
-    _getWidth: function () {
-        return this.width;
-    },
-    _getHeight: function () {
-        return this.height;
-    },
-
     /**
      * Get content size in pixels.
      * @method getContentSizeInPixels
@@ -431,7 +424,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @method releaseTexture
      */
     releaseTexture: function () {
-        if (this._glID !== null) {
+        if (this._gl && this._glID !== null) {
             this._gl.deleteTexture(this._glID);
         }
     },

--- a/cocos2d/core/textures/CCTextureCache.js
+++ b/cocos2d/core/textures/CCTextureCache.js
@@ -36,21 +36,7 @@ var textureCache = /** @lends cc.textureCache# */{
     _textureColorsCache: {},
     _textureKeySeq: (0 | Math.random() * 1000),
 
-    _loadedTexturesBefore: {},
-
     handleLoadedTexture: null,
-
-    _initializingRenderer: function () {
-        var selPath;
-        //init texture from _loadedTexturesBefore
-        var locLoadedTexturesBefore = this._loadedTexturesBefore, locTextures = this._textures;
-        for (selPath in locLoadedTexturesBefore) {
-            var tex2d = locLoadedTexturesBefore[selPath];
-            tex2d.handleLoadedTexture();
-            locTextures[selPath] = tex2d;
-        }
-        this._loadedTexturesBefore = {};
-    },
 
     /**
      * Description
@@ -229,34 +215,6 @@ var textureCache = /** @lends cc.textureCache# */{
     },
 
     /**
-     * <p>Returns a Texture2D object given an UIImage image<br />
-     * If the image was not previously loaded, it will create a new Texture2D object and it will return it.<br />
-     * Otherwise it will return a reference of a previously loaded image<br />
-     * The "key" parameter will be used as the "key" for the cache.<br />
-     * If "key" is null, then a new texture will be created each time.</p>
-     * @method addUIImage
-     * @param {HTMLImageElement|HTMLCanvasElement} image
-     * @param {String} key
-     * @return {Texture2D}
-     */
-    addUIImage: function (image, key) {
-        cc.assertID(image, 3008);
-
-        if (key && this._textures[key]) {
-            return this._textures[key];
-        }
-
-        // prevents overloading the autorelease pool
-        var texture = new Texture2D();
-        texture.initWithImage(image);
-        if (key != null)
-            this._textures[key] = texture;
-        else
-            cc.logID(3004);
-        return texture;
-    },
-
-    /**
      * <p>Output to cc.log the current contents of this TextureCache <br />
      * This will attempt to calculate the size of each texture, and the total texture memory in use. </p>
      */
@@ -293,7 +251,6 @@ var textureCache = /** @lends cc.textureCache# */{
         this._textures = {};
         this._textureColorsCache = {};
         this._textureKeySeq = (0 | Math.random() * 1000);
-        this._loadedTexturesBefore = {};
     }
 };
 
@@ -354,10 +311,6 @@ game.once(game.EVENT_RENDERER_INITED, function () {
         
         _p.handleLoadedTexture = function (url) {
             var locTexs = this._textures, tex, premultiplied;
-            //remove judge(webgl)
-            if (!cc.game._rendererInitialized) {
-                locTexs = this._loadedTexturesBefore;
-            }
             tex = locTexs[url];
             if (!tex) {
                 cc.assertID(url, 3009);
@@ -372,10 +325,6 @@ game.once(game.EVENT_RENDERER_INITED, function () {
             cc.assertID(url, 3112);
 
             var locTexs = this._textures;
-            //remove judge(webgl)
-            if (!cc.game._rendererInitialized) {
-                locTexs = this._loadedTexturesBefore;
-            }
             var tex = locTexs[url];
             if (tex) {
                 if(tex.isLoaded()) {

--- a/cocos2d/core/textures/CCTextureCache.js
+++ b/cocos2d/core/textures/CCTextureCache.js
@@ -97,7 +97,7 @@ var textureCache = /** @lends cc.textureCache# */{
      * @example {@link utils/api/engine/docs/cocos2d/core/textures/getTextureColors.js}
      */
     getTextureColors: function (texture) {
-        var image = texture._htmlElementObj;
+        var image = texture._image;
         var key = this.getKeyByTexture(image);
         if (!key) {
             if (image instanceof HTMLImageElement)

--- a/cocos2d/particle/CCSGParticleSystem.js
+++ b/cocos2d/particle/CCSGParticleSystem.js
@@ -970,7 +970,7 @@ _ccsg.ParticleSystem = _ccsg.Node.extend({
         if(!texture)
             return;
 
-        if(texture.isLoaded()){
+        if(texture.loaded){
             this.setTextureWithRect(texture, cc.rect(0, 0, texture.width, texture.height));
         } else {
             this._textureLoaded = false;

--- a/cocos2d/particle/CCSGParticleSystemCanvasRenderCmd.js
+++ b/cocos2d/particle/CCSGParticleSystemCanvasRenderCmd.js
@@ -91,7 +91,7 @@ proto.rendering = function (ctx, scaleX, scaleY) {
     var particleCount = this._node.particleCount, particles = this._node._particles;
     if (node._texture) {
         // Delay drawing until the texture is fully loaded by the browser
-        if (!node._texture._textureLoaded) {
+        if (!node._texture.loaded) {
             wrapper.restore();
             return;
         }

--- a/cocos2d/render-texture/CCRenderTexture.js
+++ b/cocos2d/render-texture/CCRenderTexture.js
@@ -80,11 +80,11 @@ cc.RenderTexture = _ccsg.Node.extend(/** @lends cc.RenderTexture# */{
         _ccsg.Node.prototype.ctor.call(this);
         this._cascadeColorEnabled = true;
         this._cascadeOpacityEnabled = true;
-        this._pixelFormat = cc.Texture2D.PIXEL_FORMAT_RGBA8888;
+        this._pixelFormat = cc.Texture2D.PixelFormat.RGBA8888;
         this._clearColor = new cc.Color(0, 0, 0, 255);
 
         if (width !== undefined && height !== undefined) {
-            format = format || cc.Texture2D.PIXEL_FORMAT_RGBA8888;
+            format = format || cc.Texture2D.PixelFormat.RGBA8888;
             depthStencilFormat = depthStencilFormat || 0;
             this.initWithWidthAndHeight(width, height, format, depthStencilFormat);
         }

--- a/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
+++ b/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
@@ -135,7 +135,7 @@ proto.updateClearColor = function(clearColor){ };
 
 proto.initWithWidthAndHeight = function(width, height, format, depthStencilFormat){
     var node = this._node;
-    if(format === cc.Texture2D.PIXEL_FORMAT_A8)
+    if(format === cc.Texture2D.PixelFormat.A8)
         cc.log( "cc.RenderTexture._initWithWidthAndHeightForWebGL() : only RGB and RGBA formats are valid for a render texture;");
 
     var gl = cc._renderContext;

--- a/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
+++ b/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
@@ -188,7 +188,7 @@ proto.initWithWidthAndHeight = function(width, height, format, depthStencilForma
     gl.bindFramebuffer(gl.FRAMEBUFFER, this._fBO);
 
     // associate texture with FBO
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, locTexture._webTextureObj, 0);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, locTexture._glID, 0);
 
     if (depthStencilFormat !== 0) {
         //create and attach depth buffer
@@ -237,12 +237,10 @@ proto.begin = function(){
     var director = cc.director;
     director.setProjection(director.getProjection());
 
-    var texSize = node._texture.getContentSizeInPixels();
-
     // Calculate the adjustment ratios based on the old and new projections
     var size = cc.director.getWinSizeInPixels();
-    var widthRatio = size.width / texSize.width;
-    var heightRatio = size.height / texSize.height;
+    var widthRatio = size.width / node._texture.width;
+    var heightRatio = size.height / node._texture.height;
 
     var orthoMatrix = cc.math.Matrix4.createOrthographicProjection(-1.0 / widthRatio, 1.0 / widthRatio,
         -1.0 / heightRatio, 1.0 / heightRatio, -1, 1);
@@ -268,10 +266,10 @@ proto.begin = function(){
      */
     if (cc.configuration.checkForGLExtension("GL_QCOM")) {
         // -- bind a temporary texture so we can clear the render buffer without losing our texture
-        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this._textureCopy._webTextureObj, 0);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this._textureCopy._glID, 0);
         //cc.checkGLErrorDebug();
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, node._texture._webTextureObj, 0);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, node._texture._glID, 0);
     }
 };
 

--- a/cocos2d/shaders/CCGLStateCache.js
+++ b/cocos2d/shaders/CCGLStateCache.js
@@ -175,10 +175,10 @@ cc.gl.setProjectionMatrixDirty = function () {
  * If the texture is not already bound, it binds it.<br/>
  * If cc.macro.ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
  * @function
- * @param {Texture2D} textureId
+ * @param {Texture2D} texture
  */
-cc.gl.bindTexture2D = function (textureId) {
-    cc.gl.bindTexture2DN(0, textureId);
+cc.gl.bindTexture2D = function (texture) {
+    cc.gl.bindTexture2DN(0, texture);
 };
 
 /**
@@ -186,24 +186,24 @@ cc.gl.bindTexture2D = function (textureId) {
  * If cc.macro.ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
  * @function
  * @param {Number} textureUnit
- * @param {Texture2D} textureId
+ * @param {Texture2D} texture
  */
-cc.gl.bindTexture2DN = ENABLE_GL_STATE_CACHE ? function (textureUnit, textureId) {
-    if (_currentBoundTexture[textureUnit] === textureId)
+cc.gl.bindTexture2DN = ENABLE_GL_STATE_CACHE ? function (textureUnit, texture) {
+    if (_currentBoundTexture[textureUnit] === texture)
         return;
-    _currentBoundTexture[textureUnit] = textureId;
+    _currentBoundTexture[textureUnit] = texture;
 
     var ctx = cc._renderContext;
     ctx.activeTexture(ctx.TEXTURE0 + textureUnit);
-    if(textureId)
-        ctx.bindTexture(ctx.TEXTURE_2D, textureId._webTextureObj);
+    if(texture)
+        ctx.bindTexture(ctx.TEXTURE_2D, texture._glID);
     else
         ctx.bindTexture(ctx.TEXTURE_2D, null);
-} : function (textureUnit, textureId) {
+} : function (textureUnit, texture) {
     var ctx = cc._renderContext;
     ctx.activeTexture(ctx.TEXTURE0 + textureUnit);
-    if(textureId)
-        ctx.bindTexture(ctx.TEXTURE_2D, textureId._webTextureObj);
+    if(texture)
+        ctx.bindTexture(ctx.TEXTURE_2D, texture._glID);
     else
         ctx.bindTexture(ctx.TEXTURE_2D, null);
 };
@@ -212,10 +212,10 @@ cc.gl.bindTexture2DN = ENABLE_GL_STATE_CACHE ? function (textureUnit, textureId)
  * It will delete a given texture. If the texture was bound, it will invalidate the cached. <br/>
  * If cc.macro.ENABLE_GL_STATE_CACHE is disabled, it will call glDeleteTextures() directly.
  * @function
- * @param {Texture2D} textureId
+ * @param {Texture2D} texture
  */
-cc.gl.deleteTexture2D = function (textureId) {
-    cc.gl.deleteTexture2DN(0, textureId);
+cc.gl.deleteTexture2D = function (texture) {
+    cc.gl.deleteTexture2DN(0, texture);
 };
 
 /**
@@ -223,14 +223,14 @@ cc.gl.deleteTexture2D = function (textureId) {
  * If cc.macro.ENABLE_GL_STATE_CACHE is disabled, it will call glDeleteTextures() directly.
  * @function
  * @param {Number} textureUnit
- * @param {Texture2D} textureId
+ * @param {Texture2D} texture
  */
-cc.gl.deleteTexture2DN = function (textureUnit, textureId) {
+cc.gl.deleteTexture2DN = function (textureUnit, texture) {
     if (ENABLE_GL_STATE_CACHE) {
-        if (textureId === _currentBoundTexture[ textureUnit ])
+        if (texture === _currentBoundTexture[ textureUnit ])
             _currentBoundTexture[ textureUnit ] = -1;
     }
-    cc._renderContext.deleteTexture(textureId._webTextureObj);
+    cc._renderContext.deleteTexture(texture._glID);
 };
 
 /**

--- a/cocos2d/tilemap/CCTMXLayerCanvasRenderCmd.js
+++ b/cocos2d/tilemap/CCTMXLayerCanvasRenderCmd.js
@@ -148,7 +148,7 @@ proto.rendering = function (ctx, scaleX, scaleY) {
                 continue;
             }
             tex = node._textures[grid.texId];
-            if (!tex || !tex._htmlElementObj) {
+            if (!tex || !tex._image) {
                 continue;
             }
 
@@ -205,7 +205,7 @@ proto.rendering = function (ctx, scaleX, scaleY) {
                 context.scale(1, -1);
             }
 
-            context.drawImage(tex._htmlElementObj,
+            context.drawImage(tex._image,
                 grid.x, grid.y, grid.width, grid.height,
                 left, top, dw, dh);
             // Revert flip

--- a/jsb/jsb-tex-sprite-frame.js
+++ b/jsb/jsb-tex-sprite-frame.js
@@ -91,14 +91,68 @@ cc.textureCache.removeTextureForKey = function (key) {
 cc.Class._fastDefine('cc.Texture2D', cc.Texture2D, []);
 cc.js.value(cc.Texture2D, '$super', cc.RawAsset);   // not inheritable in JSB and TypeScript
 
+const GL_NEAREST = 9728;                // gl.NEAREST
+const GL_LINEAR = 9729;                 // gl.LINEAR
+const GL_REPEAT = 10497;                // gl.REPEAT
+const GL_CLAMP_TO_EDGE = 33071;         // gl.CLAMP_TO_EDGE
+const GL_MIRRORED_REPEAT = 33648;       // gl.MIRRORED_REPEAT
+
+cc.Texture2D.PixelFormat = cc.Enum({
+    RGB565: cc.Texture2D.PIXEL_FORMAT_RGB565,
+    RGB5A1: cc.Texture2D.PIXEL_FORMAT_RGB5A1,
+    RGBA4444: cc.Texture2D.PIXEL_FORMAT_RGBA4444,
+    RGB888: cc.Texture2D.PIXEL_FORMAT_RGB888,
+    RGBA8888: cc.Texture2D.PIXEL_FORMAT_RGBA8888,
+    A8: cc.Texture2D.PIXEL_FORMAT_A8,
+    I8: cc.Texture2D.PIXEL_FORMAT_I8,
+    AI8: cc.Texture2D.PIXEL_FORMAT_AI8
+});
+
 cc.Texture2D.WrapMode = cc.Enum({
-    REPEAT: 0x2901,
-    CLAMP_TO_EDGE: 0x812f,
-    MIRRORED_REPEAT: 0x8370
+    REPEAT: GL_REPEAT,
+    CLAMP_TO_EDGE: GL_CLAMP_TO_EDGE,
+    MIRRORED_REPEAT: GL_MIRRORED_REPEAT
+});
+
+cc.Texture2D.Filter = cc.Enum({
+    LINEAR: GL_LINEAR,
+    NEAREST: GL_NEAREST
 });
 
 var prototype = cc.Texture2D.prototype;
 
+prototype.loaded = true;
+prototype.update = function (options) {
+    var updateTexParam = false;
+    var genMipmap = false;
+    if (options) {
+        if (options.minFilter !== undefined) {
+            this._minFilter = options.minFilter;
+            updateTexParam = true;
+        }
+        if (options.magFilter !== undefined) {
+            this._magFilter = options.magFilter;
+            updateTexParam = true;
+        }
+        if (options.wrapS !== undefined) {
+            this._wrapS = options.wrapS;
+            updateTexParam = true;
+        }
+        if (options.wrapT !== undefined) {
+            this._wrapT = options.wrapT;
+            updateTexParam = true;
+        }
+        if (options.mipmap !== undefined) {
+            genMipmap = this._hasMipmap = options.mipmap;
+        }
+    }
+    if (updateTexParam) {
+        this.setTexParameters(options);
+    }
+    if (genMipmap) {
+        this.generateMipmap();
+    }
+}
 prototype.isLoaded = function () {
     return true;
 };


### PR DESCRIPTION
Re: cocos-creator/fireball#6119

Texture2D changes proposed in this pull request:
 * Add Texture2D.Filter and Texture2D.PixelFormat to replace some constants
 * Use width and height to replace pixelWidth/pixelHeight and contentSize
 * Expose loaded, width, height directly
 * Removed getName, generateMipmap, stringForFormat, bitsPerPixelForFormat
 * Removed Texture2D::initWithImage, TextureCache::addUIImage
 * Add update to support setting texture parameters (wrap, filter, premultiplyAlpha, mipmap)
 * Deprecated getPixelWidth, getPixelHeight, getContentSize, getContentSizeInPixels, isLoaded, setTexParameters, setAntiAliasTexParameters, setAliasTexParameters

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
