### PR TITLE
fix memory leak of texture

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -761,7 +761,7 @@ proto.release = function (asset) {
                 }
             }
             else if (asset instanceof cc.Texture2D) {
-                cc.textureCache.removeTextureForKey(item.url);
+                cc.textureCache.removeTextureForKey(item.rawUrl || item.url);
             }
         }
     }


### PR DESCRIPTION
Changes proposed in this pull request:
 * 修复启用 md5 后可能会导致贴图内存泄露的 bug

问题来自 https://github.com/cocos-creator/engine/pull/1863
当时我说过：


![image](https://user-images.githubusercontent.com/1503156/30959279-3cf0fd38-a405-11e7-8136-cbe3f74b5ddf.png)


然而…… 并没有，结果贴图就不释放了

@cocos-creator/engine-admins
