### PR TITLE
event listener should not add more than once when using once

### DIFF
--- a/cocos2d/ToMerge/qunit/test-event-system.js
+++ b/cocos2d/ToMerge/qunit/test-event-system.js
@@ -48,43 +48,6 @@ test('emit', function () {
     cb1.once('callback1 should be invoked by fire event');
 });
 
-test('once', function () {
-    var target = new cc.EventTarget();
-    var fireEvent = new cc.Event('fire');
-    var cb1 = new Callback();
-
-    // once
-    target.once('fire', cb1.enable());
-    target.dispatchEvent(fireEvent);
-    cb1.once('should be invoked if registered by once')
-       .disable('should only invoke once 1');
-    target.dispatchEvent(fireEvent);
-
-    // once + on
-    var cb2 = new Callback().enable();
-
-    target.once('fire', cb1.enable());
-    target.on('fire', cb2);
-
-    target.dispatchEvent(fireEvent);
-    cb1.once('should be invoked if registered by once and before other callback');
-    cb2.once('should still be invoked if previous event was removed');
-
-    cb1.disable('should only invoke once 2');
-    target.dispatchEvent(fireEvent);
-    cb2.once('should not remove common event');
-
-    // on + once
-
-    target.once('fire', cb1.enable());
-    target.dispatchEvent(fireEvent);
-    cb2.once();
-    cb1.once('should be invoked if registered by once and after other callback')
-       .disable('should only invoke once 3');
-    target.dispatchEvent(fireEvent);
-    cb2.once();
-});
-
 test('test useCapture in on/off', function () {
     var target = new cc.EventTarget();
     var event = new cc.Event('fire');

--- a/cocos2d/core/load-pipeline/binary-downloader.js
+++ b/cocos2d/core/load-pipeline/binary-downloader.js
@@ -71,8 +71,7 @@ if (_IEFilter) {
         var byteMapping = {};
         for (var i = 0; i < 256; i++) {
             for (var j = 0; j < 256; j++) {
-                byteMapping[ String.fromCharCode(i + j * 256) ] =
-                    String.fromCharCode(i) + String.fromCharCode(j);
+                byteMapping[ String.fromCharCode(i + j * 256) ] = String.fromCharCode(i, j);
             }
         }
         var rawBytes = IEBinaryToArray_ByteStr(binary);

--- a/test/qunit/unit-es5/test-event-system.js
+++ b/test/qunit/unit-es5/test-event-system.js
@@ -1,0 +1,52 @@
+﻿
+module('EventTarget');
+
+test('once', function () {
+    var target = new cc.EventTarget();
+    var fireEvent = new cc.Event('fire');
+    var cb1 = new Callback();
+
+    // once
+    target.once('fire', cb1.enable());
+    target.dispatchEvent(fireEvent);
+    cb1.once('should be invoked if registered by once')
+    .disable('should only invoke once 1');
+    target.dispatchEvent(fireEvent);
+
+    // once + on
+    var cb2 = new Callback().enable();
+
+    target.once('fire', cb1.enable());
+    target.on('fire', cb2);
+
+    target.dispatchEvent(fireEvent);
+    cb1.once('should be invoked if registered by once and before other callback');
+    cb2.once('should still be invoked if previous event was removed');
+
+    cb1.disable('should only invoke once 2');
+    target.dispatchEvent(fireEvent);
+    cb2.once('should not remove common event');
+
+    // on + once
+
+    target.once('fire', cb1.enable());
+    target.dispatchEvent(fireEvent);
+    cb2.once();
+    cb1.once('should be invoked if registered by once and after other callback')
+    .disable('should only invoke once 3');
+    target.dispatchEvent(fireEvent);
+    cb2.once();
+});
+
+test('call "once" twice', function () {
+    var target = new cc.EventTarget();
+    var cb1 = new Callback().enable();
+    var ctx = {};
+
+    target.once('fire', cb1, ctx, true);
+    target.once('fire', cb1, ctx, true);
+    target.emit('fire');
+    cb1.once('should be invoked only once')
+    .disable('should only invoke once');
+    target.emit('fire');
+});


### PR DESCRIPTION
Re: cocos-creator/fireball#6398

Changes proposed in this pull request:
 * 修复多次用 once 注册相同事件时事件会重复注册的 bug

@cocos-creator/engine-admins
