### PR TITLE
update unschedule code  jsb-etc.js fix fireball/issues/6432

### DIFF
--- a/jsb/jsb-etc.js
+++ b/jsb/jsb-etc.js
@@ -82,8 +82,12 @@ cc.Scheduler.prototype.unschedule = function (callback, target) {
         target = callback;
         callback = tmp;
     }
+    if (callback.__callbackId === undefined) {
+        return;
+    }
+
     var instanceId = target.__instanceId || target.uuid;
-    cc.assertID(instanceId !== undefined && callback.__callbackId !== undefined, 1510);
+    cc.assertID(instanceId !== undefined, 1510);
     var key = instanceId + '_' + callback.__callbackId;
     this._unschedule(key, target);
 };


### PR DESCRIPTION
Re: cocos-creator/fireball#6432

Changes proposed in this pull request:
 * 由于只有 schedule 时 callback 才会加上 __callbackId，所以如果 schedule  前执行 unschedule 会导致报错，从而移除 __callbackId 的判断

@cocos-creator/engine-admins
