### PR TITLE
Fix sys.os being undefined on Ubuntu Mate, now equals to sys.OS_LINUX

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -199,11 +199,6 @@ sys.OS_MARMALADE = "Marmalade";
  */
 sys.OS_LINUX = "Linux";
 /**
- * @property {String} OS_UNIX
- * @readOnly
- */
-sys.OS_UNIX = "Unix";
-/**
  * @property {String} OS_BADA
  * @readOnly
  */
@@ -567,8 +562,7 @@ else {
     else if (iOS) osName = sys.OS_IOS;
     else if (nav.appVersion.indexOf("Mac") !== -1) osName = sys.OS_OSX;
     else if (isAndroid) osName = sys.OS_ANDROID;
-    else if (nav.appVersion.indexOf("Linux") !== -1 || ua.indexOf("ubuntu") !== -1) osName = sys.OS_LINUX;
-    else if (nav.appVersion.indexOf("X11") !== -1 && nav.appVersion.indexOf("Linux") === -1) osName = sys.OS_UNIX;
+    else if (nav.appVersion.indexOf("Linux") !== -1 || ua.indexOf("ubuntu") !== -1 || nav.appVersion.indexOf("X11") !== -1) osName = sys.OS_LINUX;
 
     /**
      * Indicate the running os name

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -199,6 +199,11 @@ sys.OS_MARMALADE = "Marmalade";
  */
 sys.OS_LINUX = "Linux";
 /**
+ * @property {String} OS_UNIX
+ * @readOnly
+ */
+sys.OS_UNIX = "Unix";
+/**
  * @property {String} OS_BADA
  * @readOnly
  */
@@ -561,9 +566,9 @@ else {
     if (nav.appVersion.indexOf("Win") !== -1) osName = sys.OS_WINDOWS;
     else if (iOS) osName = sys.OS_IOS;
     else if (nav.appVersion.indexOf("Mac") !== -1) osName = sys.OS_OSX;
-    else if (nav.appVersion.indexOf("X11") !== -1 && nav.appVersion.indexOf("Linux") === -1) osName = sys.OS_UNIX;
     else if (isAndroid) osName = sys.OS_ANDROID;
     else if (nav.appVersion.indexOf("Linux") !== -1 || ua.indexOf("ubuntu") !== -1) osName = sys.OS_LINUX;
+    else if (nav.appVersion.indexOf("X11") !== -1 && nav.appVersion.indexOf("Linux") === -1) osName = sys.OS_UNIX;
 
     /**
      * Indicate the running os name


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changes proposed in this pull request:
* Added missing cc.sys.OS_UNIX value (='Unix')
* Changed test order when deciding os name, to check for 'ubuntu' before 'X11'

(Tested on Windows, Android, and Ubuntu Mate, using Firefox or Chrome)

> Makes sure these boxes are checked before submitting your PR - thank you!
>
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID

@cocos-creator/engine-admins
