### PR TITLE
prefab should be synced if jit can not be used

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -340,7 +340,7 @@ if (CC_DEBUG) {
         "3700": "internal error: _prefab is undefined", //_doInstantiate
         "3701": "Failed to load prefab asset for node '%s'", //syncWithPrefab
         //Game: 3800
-        "3800": "The target can not be made persist because it\'s not a cc.Node or it doesn\'t have _id property.", //addPersistRootNode
+        "3800": "The target can not be made persist because it\'s invalid or it doesn\'t have _id property.", //addPersistRootNode
         "3801": "The node can not be made persist because it\'s not under root node.", //addPersistRootNode_2
         "3802": "The node can not be made persist because it\'s not in current scene.", //addPersistRootNode_3
         "3803": "The target can not be made persist because it\'s not a cc.Node or it doesn\'t have _id property.", //addPersistRootNode_4

--- a/cocos2d/core/assets/CCPrefab.js
+++ b/cocos2d/core/assets/CCPrefab.js
@@ -96,14 +96,16 @@ var Prefab = cc.Class({
     _instantiate: function () {
         var node;
         if (cc.supportJit) {
-          // instantiate node
-          node = this._doInstantiate();
-          // initialize node
-          this.data._instantiate(node);
+            // instantiate node
+            node = this._doInstantiate();
+            // initialize node
+            this.data._instantiate(node);
         }
         else {
-          // instantiate node
-          node = this.data._instantiate();
+            // prefab asset is always synced
+            this.data._prefab._synced = true;
+            // instantiate node
+            node = this.data._instantiate();
         }
         
         // link prefab in editor

--- a/cocos2d/core/utils/prefab-helper.js
+++ b/cocos2d/core/utils/prefab-helper.js
@@ -81,7 +81,20 @@ module.exports = {
 
         // instantiate prefab
         cc.game._isCloning = true;
-        _prefab.asset._doInstantiate(node);
+        if (cc.supportJit) {
+            _prefab.asset._doInstantiate(node);
+        }
+        else {
+            // root in prefab asset is always synced
+            var prefabRoot = _prefab.asset.data;
+            prefabRoot._prefab._synced = true;
+
+            // use node as the instantiated prefabRoot to make references to prefabRoot in prefab redirect to node
+            prefabRoot._iN$t = node;
+
+            // instantiate prefab and apply to node
+            cc.instantiate._clone(prefabRoot, prefabRoot);
+        }
         cc.game._isCloning = false;
 
         // restore preserved props

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -227,6 +227,9 @@ if (CC_DEV) {
     });
 
     function deprecateEnum (obj, oldPath, newPath, hasTypePrefixBefore) {
+        if (!cc.supportJit) {
+            return;
+        }
         hasTypePrefixBefore = hasTypePrefixBefore !== false;
         var enumDef = Function('return ' + newPath)();
         var entries = cc.Enum.getList(enumDef);


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/6567

修复自动同步的 prefab 在 eval 不支持时无法创建的 bug