### PR TITLE
spine's __preload should not reinvoked in dev mode

### DIFF
--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -390,9 +390,8 @@ sp.Skeleton = cc.Class({
     // IMPLEMENT
 
     __preload: function () {
-        if (CC_EDITOR || CC_DEV) {
+        if (CC_EDITOR) {
             var Flags = cc.Object.Flags;
-            this._objFlags &= Flags.PersistentMask; // for v1.0 project
             this._objFlags |= (Flags.IsAnchorLocked | Flags.IsSizeLocked);
         }
         // sgNode 的尺寸不是很可靠 同时 Node 的框框也没办法和渲染匹配 只好强制尺寸为零


### PR DESCRIPTION
Changes proposed in this pull request:
 * 修复 spine 在调试模式下激活时会重复创建渲染对象的 bug

@cocos-creator/engine-admins
