### PR TITLE
add jsb-label SystemFont not supported lineHeight warn

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -388,6 +388,7 @@ if (CC_DEBUG) {
         "4010": "cc.LabelBMFont.setFntFile() : Impossible to create font. Please check file", //BMFont.setFntFile
         "4011": "Property spriteFrame of Font '%s' is invalid. Using system font instead.", // BMFont spriteFrame is invalid.
         "4012": "The texture of Font '%s' must be already loaded on JSB. Using system font instead.",
+        "4013": "Sorry, lineHeight of system font not supported on JSB.",
         //Layout: 4100
         "4100": "Property padding is deprecated, please use paddingLeft, paddingRight, paddingTop and paddingBottom instead", //padding
         //Mask: 4200

--- a/jsb/jsb-label.js
+++ b/jsb/jsb-label.js
@@ -112,6 +112,9 @@ jsbLabel.prototype.setLineHeight = function (height) {
     if (this._labelType !== _ccsg.Label.Type.SystemFont) {
         this._setLineHeight(height);
     }
+    else {
+        cc.warnID(4013);
+    }
 };
 
 jsbLabel.prototype._setColor = jsbLabel.prototype.setColor;


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 添加系统字体不支持 lineHeight 的警告
