### PR TITLE
system font does not set line height

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -543,9 +543,11 @@ var Label = cc.Class({
         if (this.useSystemFont) {
             sgNode.setFontFamily(this.fontFamily);
         }
+        else {
+            sgNode.setLineHeight(this._lineHeight);
+        }
         sgNode.setOverflow( this.overflow );
         sgNode.enableWrapText( this._enableWrapText );
-        sgNode.setLineHeight(this._lineHeight);
         sgNode.setString(this.string);
         if (font instanceof cc.BitmapFont) {
             sgNode.setSpacingX(this.spacingX);


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 目前系统字体不支持 line height 