### PR TITLE
fix tilemap layer is empty error

### DIFF
--- a/cocos2d/tilemap/CCTMXLayerCanvasRenderCmd.js
+++ b/cocos2d/tilemap/CCTMXLayerCanvasRenderCmd.js
@@ -50,7 +50,7 @@ proto.rendering = function (ctx, scaleX, scaleY) {
         tiles = node.tiles,
         alpha = node._opacity / 255;
 
-    if (!tiles || alpha <= 0) {
+    if (!tiles || alpha <= 0 || !node.tileset) {
         return;
     }
 

--- a/cocos2d/tilemap/CCTMXLayerWebGLRenderCmd.js
+++ b/cocos2d/tilemap/CCTMXLayerWebGLRenderCmd.js
@@ -72,9 +72,10 @@ proto.uploadData = function (f32buffer, ui32buffer, vertexDataOffset) {
 
     var node = this._node,
         layerOrientation = node.layerOrientation,
-        tiles = node.tiles;
+        tiles = node.tiles,
+        alpha = node._opacity / 255;
 
-    if (!tiles || !node.tileset) {
+    if (!tiles || alpha <= 0 || !node.tileset) {
         return 0;
     }
 

--- a/cocos2d/tilemap/CCTMXLayerWebGLRenderCmd.js
+++ b/cocos2d/tilemap/CCTMXLayerWebGLRenderCmd.js
@@ -74,7 +74,7 @@ proto.uploadData = function (f32buffer, ui32buffer, vertexDataOffset) {
         layerOrientation = node.layerOrientation,
         tiles = node.tiles;
 
-    if (!tiles) {
+    if (!tiles || !node.tileset) {
         return 0;
     }
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 修复 Tilemap 的 layer 没有元素的时候会报错（加个保护）

@pandamicro 有空也看看吧
