### PR TITLE
fix label warp bug for cocos-creator/engine/issues/2151

### DIFF
--- a/cocos2d/core/label/CCTextUtils.js
+++ b/cocos2d/core/label/CCTextUtils.js
@@ -204,10 +204,10 @@ var CustomFontLoader = {
 
 var TextUtils = {
     label_wordRex : /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûа-яА-ЯЁё]+|\S)/,
-    label_symbolRex : /^[!,.:;}\]%\?>、‘“》？。，！]/,
+    label_symbolRex : /^[!,.:;'}\]%\?>、‘“》？。，！]/,
     label_lastWordRex : /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]+|\S)$/,
     label_lastEnglish : /[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]+$/,
-    label_firsrEnglish : /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]/,
+    label_firstEnglish : /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]/,
     label_wrapinspection : true,
 
     isUnicodeCJK: function(ch) {
@@ -288,7 +288,7 @@ var TextUtils = {
             }
 
             //To judge whether a English words are truncated
-            if (this.label_firsrEnglish.test(sLine)) {
+            if (this.label_firstEnglish.test(sLine)) {
                 result = this.label_lastEnglish.exec(sText);
                 if (result && sText !== result[0]) {
                     fuzzyLen -= result[0].length;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/2151

Changelog:
 * 修复 <whole word “autowrap’s” to drop to second line> 的 bug 's 应该是跟单词一体的所以也应该加入正则

@pandamicro 有空看看，没问题就合并吧，已测试
