### PR TITLE
fix CCTilemap bug for  cocos-creator/engine/issues/2046

### DIFF
--- a/cocos2d/tilemap/CCTMXLayerWebGLRenderCmd.js
+++ b/cocos2d/tilemap/CCTMXLayerWebGLRenderCmd.js
@@ -67,13 +67,14 @@ var proto = _ccsg.TMXLayer.WebGLRenderCmd.prototype = Object.create(_ccsg.Node.W
 proto.constructor = _ccsg.TMXLayer.WebGLRenderCmd;
 
 proto.uploadData = function (f32buffer, ui32buffer, vertexDataOffset) {
-    // enable Depth Test
-    cc.renderer.setDepthTest(true);
-
     var node = this._node,
         layerOrientation = node.layerOrientation,
         tiles = node.tiles,
         alpha = node._opacity / 255;
+
+    // enable Depth Test (fix cocos-creator/engine/issues/2046,
+    // but it's not perfect, and the follow-up needs to be improved)
+    cc.renderer.setDepthTest(node.layerOrientation === Orientation.ORTHO);
 
     if (!tiles || alpha <= 0 || !node.tileset) {
         return 0;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/2046

Changelog:
 * fix 由 setDepthTest 引起的 TileMap bug，暂时先这样修复，后续等 panda 的渲染完成以后会进行完善

@pandamicro 你看看，没问题就合并了
