### PR TITLE
Oops, previous PR doesn't improve performance after all

### DIFF
--- a/cocos2d/core/renderer/render-component-walker.js
+++ b/cocos2d/core/renderer/render-component-walker.js
@@ -249,6 +249,11 @@ RenderComponentWalker.prototype = {
                     vertexOffset = this._vOffset;
                     indiceOffset = this._iOffset;
                 }
+                if (needNewBuf) {
+                    verts = this._verts;
+                    uintVerts = this._uintVerts;
+                    indices = this._indices;
+                }
                 currEffect = effect;
             }
 


### PR DESCRIPTION
Re: cocos-creator/fireball#6639

There was a bug in https://github.com/cocos-creator/engine/pull/2172, it wasn't rendering all sprites

So the performance boost in v8 wasn't true, but it has a better code layout, so we are keeping this version, and improvement will be made based on this version