### PR TITLE
fix always show toggleGroup tips bug

### DIFF
--- a/cocos2d/core/components/CCToggle.js
+++ b/cocos2d/core/components/CCToggle.js
@@ -64,7 +64,7 @@ var Toggle = cc.Class({
         toggleGroup: {
             default: null,
             tooltip: CC_DEV && 'i18n:COMPONENT.toggle.toggleGroup',
-            type: cc.ToggleGroup
+            type: require('./CCToggleGroup')
         },
 
         /**

--- a/modules.json
+++ b/modules.json
@@ -96,13 +96,9 @@
   {
     "name": "Toggle",
     "entries": [
-      "./cocos2d/core/components/CCToggle.js"
-    ]
-  },
-  {
-    "name": "ToggleGroup",
-    "entries": [
-      "./cocos2d/core/components/CCToggleGroup.js"
+      "./cocos2d/core/components/CCToggle.js",
+      "./cocos2d/core/components/CCToggleGroup.js",
+      "./cocos2d/core/components/CCToggleContainer.js"
     ]
   },
   {


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 修复所有编辑器打开后，都会提示 The 'cc.ToggleGroup' will be removed in v2.0, please use 'cc.ToggleContainer' instead. 的 bug
