### PR TITLE
fix Container scale strategys bug for fireball/issues/6733

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -1181,6 +1181,7 @@ cc.ContentStrategy = cc._Class.extend(/** @lends cc.ContentStrategy# */{
             else {
                 containerStyle.margin = '0px';
             }
+            containerStyle.padding = "0px";
         }
     });
 


### PR DESCRIPTION
Re: cocos-creator/fireball#6733

Changelog:
 * 在 ProportionalToFrame 转换到 EqualToFrame 应该也要去重置 padding 数值


@pandamicro 
