### PR TITLE
fix button bug

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -311,6 +311,10 @@ var Button = cc.Class({
             type: cc.SpriteFrame,
             displayName: 'Pressed',
             tooltip: CC_DEV && 'i18n:COMPONENT.button.pressed_sprite',
+            formerlySerializedAs: 'pressedSprite',
+            notify: function () {
+                this._updateState();
+            }
         },
 
         /**
@@ -323,6 +327,10 @@ var Button = cc.Class({
             type: cc.SpriteFrame,
             displayName: 'Hover',
             tooltip: CC_DEV && 'i18n:COMPONENT.button.hover_sprite',
+            formerlySerializedAs: 'hoverSprite',
+            notify: function () {
+                this._updateState();
+            }
         },
 
         /**

--- a/cocos2d/core/platform/preprocess-class.js
+++ b/cocos2d/core/platform/preprocess-class.js
@@ -33,6 +33,7 @@ var SerializableAttrs = {
     serializable: {},
     editorOnly: {},
     rawType: {},
+    formerlySerializedAs: {}
 };
 
 var TYPO_TO_CORRECT_DEV = CC_DEV && {


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 补上 pressedSprite  和 hoverSprite 的 notify

才不会导致删掉 button 用的资源以后出现 miss 错误效果

![tim 20171220154243](https://user-images.githubusercontent.com/7564028/34196365-c6483dde-e59c-11e7-8c2d-eb5965791e7c.png)

正确的应该是 Normal 的效果
