### PR TITLE
lock uglifyjs to new version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,11 +3,14 @@ Re: cocos-creator/fireball#
 Changelog:
  * 
 
-> Makes sure these boxes are checked before submitting your PR - thank you!
->
+<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
+
 - [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
 - [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
+
 - To official teams:
   - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
   - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
-  - [ ] Make sure any runtime log information in `cc.log` , `cc.error`, `cc.warn` or `cc.assert` has been moved into `DebugInfos.js` with an ID
+  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.
+
+-->

--- a/gulp/util/utils.js
+++ b/gulp/util/utils.js
@@ -35,6 +35,7 @@ exports.getUglifyOptions = function (platform, isJSB, isDebugBuild) {
                 sequences: false,
                 keep_infinity: true,    // reduce jsc file size
                 typeofs: false,
+                inline: false,          // embed simple functions, disable temporarily due to https://github.com/mishoo/UglifyJS2/issues/2683
             }
         };
     }
@@ -43,6 +44,7 @@ exports.getUglifyOptions = function (platform, isJSB, isDebugBuild) {
         return {
             compress: {
                 global_defs: global_defs,
+                inline: false           // embed simple functions, disable temporarily due to https://github.com/mishoo/UglifyJS2/issues/2683
             },
             output: {
                 ascii_only: true,
@@ -60,26 +62,30 @@ exports.getUglifyOptions = function (platform, isJSB, isDebugBuild) {
                 ascii_only: true,
             },
             compress: {
-                // https://github.com/mishoo/UglifyJS2#compressor-options
+                // https://github.com/mishoo/UglifyJS2/tree/harmony#compress-options
                 global_defs: global_defs,
                 sequences: false,  // join consecutive statements with the “comma operator”
                 properties: false,  // optimize property access: a["foo"] → a.foo
-                //dead_code: true,  // discard unreachable code
+                // dead_code: true,  // discard unreachable code
                 drop_debugger: false,  // discard “debugger” statements
+                // ecma: 5, // transform ES5 code into smaller ES6+ equivalent forms
+                // evaluate: true,  // evaluate constant expressions
                 unsafe: false, // some unsafe optimizations (see below)
-                //conditionals: false,  // optimize if-s and conditional expressions
+                // computed_props: true,
+                // conditionals: false,  // optimize if-s and conditional expressions
                 comparisons: false,  // optimize comparisons
-                //evaluate: true,  // evaluate constant expressions
                 booleans: false,  // optimize boolean expressions
                 typeofs: false,  // Transforms typeof foo == "undefined" into foo === void 0. Note: recommend to set this value to false for IE10 and earlier versions due to known issues.
                 loops: false,  // optimize loops
                 unused: false,  // drop unused variables/functions
                 hoist_funs: false,  // hoist function declarations
+                hoist_props: false,
                 hoist_vars: false, // hoist variable declarations
                 if_return: false,  // optimize if-s followed by return/continue
-                inline: false,  // embed simple functions
+                inline: false,  // embed simple functions, disable temporarily due to https://github.com/mishoo/UglifyJS2/issues/2683
                 join_vars: false,  // join var declarations
                 collapse_vars: false,   // Collapse single-use non-constant variables - side effects permitting.
+                reduce_funcs: false,
                 reduce_vars: false, // Improve optimization on variables assigned with and used as constant values.
                 //warnings: true,
                 negate_iife: false,
@@ -90,7 +96,7 @@ exports.getUglifyOptions = function (platform, isJSB, isDebugBuild) {
                 keep_fargs: true,
                 keep_fnames: true,
                 keep_infinity: true,  // Pass true to prevent Infinity from being compressed into 1/0, which may cause performance issues on Chrome.
-                side_effects: false  // drop side-effect-free statements
+                side_effects: false,  // drop side-effect-free statements
             }
         };
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jshint-stylish": "2.1.0",
     "multipipe": "0.3.0",
     "persistify": "^1.1.1",
-    "uglify-es": "^3.0.26",
+    "uglify-es": "~3.3.2",
     "vinyl": "1.1.0",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.0.0",


### PR DESCRIPTION
Re: cocos-creator/fireball#

lock uglifyjs to new version

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->