### PR TITLE
fix bug of asset type on JSB

### DIFF
--- a/cocos2d/core/assets/CCRawAsset.js
+++ b/cocos2d/core/assets/CCRawAsset.js
@@ -24,6 +24,7 @@
  ****************************************************************************/
 
 var CCObject = require('../platform/CCObject');
+var JS = require('../platform/js');
 
 /**
  * !#en
@@ -81,18 +82,13 @@ cc.RawAsset = cc.Class({
  * @static
  * @private
  */
-Object.defineProperty(cc.RawAsset, 'isRawAssetType', {
-    value: function (ctor) {
-        return cc.isChildClassOf(ctor, cc.RawAsset) && !cc.isChildClassOf(ctor, cc.Asset);
-    }
-    // enumerable is false by default
+JS.value(cc.RawAsset, 'isRawAssetType', function (ctor) {
+    return cc.isChildClassOf(ctor, cc.RawAsset) && !cc.isChildClassOf(ctor, cc.Asset);
 });
 
 // TODO - DELME after 2.0
-Object.defineProperty(cc.RawAsset, 'wasRawAssetType', {
-    value: function (ctor) {
-        return ctor === cc.Texture2D;
-    }
+JS.value(cc.RawAsset, 'wasRawAssetType', function (ctor) {
+    return ctor === cc.Texture2D;
 });
 
 module.exports = cc.RawAsset;

--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -765,7 +765,7 @@ proto.release = function (asset) {
             var removed = this.removeItem(id);
             asset = item.content;
             // TODO: AUDIO
-            if (asset instanceof cc.Asset) {
+            if (cc.Class.isInstanceOf(asset, cc.Asset)) {
                 if (asset.nativeUrl) {
                     this.release(asset.nativeUrl);
                 }

--- a/cocos2d/core/load-pipeline/auto-release-utils.js
+++ b/cocos2d/core/load-pipeline/auto-release-utils.js
@@ -57,7 +57,7 @@ function visitComponent (comp, excludeMap) {
             if (Array.isArray(value)) {
                 for (let j = 0; j < value.length; j++) {
                     let val = value[j];
-                    if (val instanceof cc.RawAsset) {
+                    if (cc.Class.isInstanceOf(val, cc.RawAsset)) {
                         visitAsset(val, excludeMap);
                     }
                 }
@@ -66,12 +66,12 @@ function visitComponent (comp, excludeMap) {
                 let keys = Object.getOwnPropertyNames(value);
                 for (let j = 0; j < keys.length; j++) {
                     let val = value[keys[j]];
-                    if (val instanceof cc.RawAsset) {
+                    if (cc.Class.isInstanceOf(val, cc.RawAsset)) {
                         visitAsset(val, excludeMap);
                     }
                 }
             }
-            else if (value instanceof cc.RawAsset) {
+            else if (cc.Class.isInstanceOf(value, cc.RawAsset)) {
                 visitAsset(value, excludeMap);
             }
         }

--- a/cocos2d/core/load-pipeline/uuid-loader.js
+++ b/cocos2d/core/load-pipeline/uuid-loader.js
@@ -185,7 +185,7 @@ function canDeferredLoad (asset, item, isScene) {
     var res = item.deferredLoadRaw;
     if (res) {
         // check if asset support deferred
-        if (asset instanceof cc.Asset && asset.constructor.preventDeferredLoadDependents) {
+        if (cc.Class.isInstanceOf(asset, cc.Asset) && asset.constructor.preventDeferredLoadDependents) {
             res = false;
         }
     }

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -1060,7 +1060,7 @@ cc.isChildClassOf = function (subclass, superclass) {
     return false;
 };
 
-/**
+/*
  * Return all super classes
  * @method getInheritanceChain
  * @param {Function} constructor
@@ -1078,6 +1078,21 @@ CCClass.getInheritanceChain = function (klass) {
         }
     }
     return chain;
+};
+
+/*
+ * Is instance of for JSB.
+ * `obj` can be native object such as cc.Texture2D or cc.SpriteFrame.
+ * `klass` can be base class of native object such as cc.Asset, cc.RawAsset or cc.Object.
+ * @method isInstanceOf
+ * @param {Object} obj
+ * @param {Function} klass
+ * @returns {Boolean}
+ */
+CCClass.isInstanceOf = CC_JSB ? function (obj, klass) {
+    return obj && cc.isChildClassOf(obj.constructor, klass);
+} : function (obj__skip_jsb_warning, klass) {
+    return obj__skip_jsb_warning instanceof klass;
 };
 
 var PrimitiveTypes = {

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -1089,6 +1089,7 @@ CCClass.getInheritanceChain = function (klass) {
  * @param {Function} klass
  * @returns {Boolean}
  */
+// TODO - remove at 2.0 if all assets implemented in pure js
 CCClass.isInstanceOf = CC_JSB ? function (obj, klass) {
     return obj && cc.isChildClassOf(obj.constructor, klass);
 } : function (obj__skip_jsb_warning, klass) {

--- a/cocos2d/core/platform/instantiate-jit.js
+++ b/cocos2d/core/platform/instantiate-jit.js
@@ -404,7 +404,7 @@ proto.enumerateField = function (obj, key, value) {
         return escapeForJS(value);
     }
     else {
-        if (key === '_objFlags' && obj instanceof CCObject) {
+        if (key === '_objFlags' && cc.Class.isInstanceOf(obj, CCObject)) {
             value &= PersistentMask;
         }
         return value;
@@ -445,7 +445,7 @@ proto.instantiateObj = function (obj) {
     if (obj instanceof cc.ValueType) {
         return CCClass.getNewValueTypeCode(obj);
     }
-    if (obj instanceof cc.Asset) {
+    if (cc.Class.isInstanceOf(obj, cc.Asset)) {
         // register to asset list and just return the reference.
         return this.getObjRef(obj);
     }

--- a/cocos2d/core/platform/instantiate.js
+++ b/cocos2d/core/platform/instantiate.js
@@ -77,7 +77,7 @@ function instantiate (original, internal_force) {
     }
 
     var clone;
-    if (original instanceof CCObject) {
+    if (cc.Class.isInstanceOf(original, CCObject)) {
         // Invoke _instantiate method if supplied.
         // The _instantiate callback will be called only on the root object, its associated object will not be called.
         // @callback associated
@@ -90,7 +90,7 @@ function instantiate (original, internal_force) {
             cc.game._isCloning = false;
             return clone;
         }
-        else if (original instanceof cc.Asset) {
+        else if (cc.Class.isInstanceOf(original, cc.Asset)) {
             // 不允许用通用方案实例化资源
             if (CC_DEV) {
                 cc.errorID(6903);
@@ -209,7 +209,7 @@ function enumerateObject (obj, clone, parent) {
             }
         }
     }
-    if (obj instanceof CCObject) {
+    if (cc.Class.isInstanceOf(obj, CCObject)) {
         clone._objFlags &= PersistentMask;
     }
 }
@@ -222,7 +222,7 @@ function instantiateObj (obj, parent) {
     if (obj instanceof cc.ValueType) {
         return obj.clone();
     }
-    if (obj instanceof cc.Asset) {
+    if (cc.Class.isInstanceOf(obj, cc.Asset)) {
         // 所有资源直接引用，不需要拷贝
         return obj;
     }

--- a/gulp/tasks/engine.js
+++ b/gulp/tasks/engine.js
@@ -210,6 +210,7 @@ exports.buildPreview = function (sourceFile, outputFile, callback, devMode) {
 
 exports.buildJsbPreview = function (sourceFile, outputFile, excludes, callback) {
     var FixJavaScriptCore = require('../util/fix-jsb-javascriptcore');
+    var CheckInstanceof = require('../util/check-jsb-instanceof');
 
     var outFile = Path.basename(outputFile);
     var outDir = Path.dirname(outputFile);
@@ -220,7 +221,8 @@ exports.buildJsbPreview = function (sourceFile, outputFile, excludes, callback) 
     excludes.forEach(function (module) {
         bundler.ignore(require.resolve(module));
     });
-    bundler.bundle()
+    bundler.transform(CheckInstanceof)
+        .bundle()
         .on('error', HandleErrors.handler)
         .pipe(HandleErrors())
         .pipe(Source(outFile))

--- a/gulp/util/check-jsb-instanceof.js
+++ b/gulp/util/check-jsb-instanceof.js
@@ -1,0 +1,41 @@
+
+// A browserify transform that check instanceof expression for polyfilled native constructor
+
+const ES = require('event-stream');
+
+const BaseClassesToCheck = ['cc.Asset', 'cc.RawAsset', 'cc.Object'];
+const IgnoreVarSuffix = 'skip_jsb_warning';
+
+var re = (function () {
+    const types = BaseClassesToCheck.map(x => x.match(/[^.]+$/)[0]).join('|');
+    // console.log(types);
+    return RegExp(`(${IgnoreVarSuffix})?\\s+(instanceof\\s+\\w*\\.?(${types}))`, 'gi');
+})();
+
+module.exports = function (file) {
+    const Path = require('path');
+    return ES.through(function (buff, encode) {
+        // console.log('parsing ' + file);
+        var code = buff.toString(encode);
+
+        re.lastIndex = 0;
+        var execRes;
+        while ((execRes = re.exec(code)) !== null) {
+            if (execRes[1] === IgnoreVarSuffix) {
+                continue;
+            }
+            var exp = execRes[2];
+            var type = execRes[3];
+            var hasLowerCaseInstanceOf = execRes[0].indexOf('instanceof') !== -1;
+            if (hasLowerCaseInstanceOf) {
+                var path = Path.relative(process.cwd(), file);
+                console.warn(
+                    `Checking \`${exp}\` will fail on JSB if the object is native asset such as cc.Texture2D and cc.SpriteFrame.\n` +
+                    `  Use \`${type}.is***(obj)\` instead please.\n` +
+                    `  You can also use \`***_${IgnoreVarSuffix} instanceof ${type}\` to suppress this warning.\n` +
+                    `  File: ${path}`);
+            }
+        }
+        this.emit('data', buff);
+    });
+};

--- a/gulp/util/fix-jsb-javascriptcore.js
+++ b/gulp/util/fix-jsb-javascriptcore.js
@@ -1,3 +1,6 @@
+
+// fix `typeof constructor` on JavaScriptCore
+
 const ES = require('event-stream');
 const Path = require('path');
 


### PR DESCRIPTION
Re: cocos-creator/fireball#6757

JSB 上不能用 instanceof 判断 cc.Texture2D 和 cc.SpriteFrame 对象

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->