### PR TITLE
fix page hide event on wechat mini game

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -788,6 +788,11 @@ var game = {
             win.onfocus = function(){ onShow() };
         }
 
+        if (CC_WECHATGAME) {
+            wx.onShow = onShow;
+            wx.onHide = onHidden;
+        }
+
         if ("onpageshow" in window && "onpagehide" in window) {
             win.addEventListener("pagehide", onHidden, false);
             win.addEventListener("pageshow", onShow, false);


### PR DESCRIPTION
Re: cocos-creator/fireball#6795

Changelog:
 * 修复微信小游戏上切换到后台的事件不触发的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->