### PR TITLE
update autoReleaseAssets default value

### DIFF
--- a/cocos2d/core/CCScene.js
+++ b/cocos2d/core/CCScene.js
@@ -46,7 +46,10 @@ cc.Scene = cc.Class({
          * @property {Boolean} autoReleaseAssets
          * @default false
          */
-        autoReleaseAssets: undefined,
+        autoReleaseAssets: {
+            default: undefined,
+            type: cc.Boolean
+        },
 
     },
 

--- a/cocos2d/core/platform/deserialize.js
+++ b/cocos2d/core/platform/deserialize.js
@@ -550,6 +550,7 @@ var _Deserializer = (function () {
     };
 
     var compileDeserialize = CC_SUPPORT_JIT ? function (self, klass) {
+        var TYPE = Attr.DELIMETER + 'type';
         var RAW_TYPE = Attr.DELIMETER + 'rawType';
         var EDITOR_ONLY = Attr.DELIMETER + 'editorOnly';
         var SERIALIZABLE = Attr.DELIMETER + 'serializable';
@@ -607,10 +608,21 @@ var _Deserializer = (function () {
                 // function undefined object(null) string boolean number
                 var defaultValue = CCClass.getDefault(attrs[propName + DEFAULT]);
                 if (fastMode) {
-                    var defaultType = typeof defaultValue;
-                    var isPrimitiveType = (defaultType === 'string' && !attrs[propName + SAVE_URL_AS_ASSET]) ||
-                                          defaultType === 'number' ||
-                                          defaultType === 'boolean';
+                    var isPrimitiveType;
+                    var userType = attrs[propName + TYPE];
+                    if (defaultValue === undefined && userType) {
+                        isPrimitiveType = userType === cc.String ||
+                            userType === cc.Integer ||
+                            userType === cc.Float ||
+                            userType === cc.Boolean;
+                    }
+                    else {
+                        var defaultType = typeof defaultValue;
+                        isPrimitiveType = (defaultType === 'string' && !attrs[propName + SAVE_URL_AS_ASSET]) ||
+                            defaultType === 'number' ||
+                            defaultType === 'boolean';
+                    }
+
                     if (isPrimitiveType) {
                         sources.push(`o${accessorToSet}=prop;`);
                     }


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 如果 autoReleaseAssets 默认值设置为 undefined 的话，反序列化会把该数值变为 {} 而不是 bool 数值