### PR TITLE
dragonBones EventObject Type issue.

### DIFF
--- a/extensions/dragonbones/lib/dragonBones.d.ts
+++ b/extensions/dragonbones/lib/dragonBones.d.ts
@@ -1598,55 +1598,55 @@ declare namespace dragonBones {
          * 动画开始。
          * @version DragonBones 4.5
          */
-        static START: string;
+        static START: dragonBones.EventObject;
         /**
          * @language zh_CN
          * 动画循环播放一次完成。
          * @version DragonBones 4.5
          */
-        static LOOP_COMPLETE: string;
+        static LOOP_COMPLETE: dragonBones.EventObject;
         /**
          * @language zh_CN
          * 动画播放完成。
          * @version DragonBones 4.5
          */
-        static COMPLETE: string;
+        static COMPLETE: dragonBones.EventObject;
         /**
          * @language zh_CN
          * 动画淡入开始。
          * @version DragonBones 4.5
          */
-        static FADE_IN: string;
+        static FADE_IN: dragonBones.EventObject;
         /**
          * @language zh_CN
          * 动画淡入完成。
          * @version DragonBones 4.5
          */
-        static FADE_IN_COMPLETE: string;
+        static FADE_IN_COMPLETE: dragonBones.EventObject;
         /**
          * @language zh_CN
          * 动画淡出开始。
          * @version DragonBones 4.5
          */
-        static FADE_OUT: string;
+        static FADE_OUT: dragonBones.EventObject;
         /**
          * @language zh_CN
          * 动画淡出完成。
          * @version DragonBones 4.5
          */
-        static FADE_OUT_COMPLETE: string;
+        static FADE_OUT_COMPLETE: dragonBones.EventObject;
         /**
          * @language zh_CN
          * 动画帧事件。
          * @version DragonBones 4.5
          */
-        static FRAME_EVENT: string;
+        static FRAME_EVENT: dragonBones.EventObject;
         /**
          * @language zh_CN
          * 动画声音事件。
          * @version DragonBones 4.5
          */
-        static SOUND_EVENT: string;
+        static SOUND_EVENT: dragonBones.EventObject;
         /**
          * @private
          */


### PR DESCRIPTION
hi, i'm cocos lover.
    
dragonBones EventObject Type is string. so there is type isuue. it is as in the following

    [code]
    this._armatureDisplay.addEventListener(dragonBones.EventObject.COMPLETE, this._animationEventHandler, this);

    [alert message]
    [ts] Argument of type 'string' is not assignable to parameter of type 'EventObject'.
    (property) dragonBones.EventObject.COMPLETE: string

    so, i think EventObject need dragonBones.EventObject Type.
    plz comment to my oppinion.

Re: cocos-creator/fireball#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->