### PR TITLE
add destroy for fireball/issues/6888

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -175,6 +175,12 @@ Audio.State = {
         });
     };
 
+    proto.destroy = function () {
+        if (CC_WECHATGAME) {
+            this._element.destroy();
+        }
+    };
+
     proto.pause = function () {
         if (!this._element) return;
         this._unbindEnded();

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -425,6 +425,7 @@ var audioEngine = {
             var audio = id2audio[id];
             if (audio) {
                 audio.stop();
+                audio.destroy();
                 delete id2audio[id];
             }
         }
@@ -439,6 +440,12 @@ var audioEngine = {
      */
     uncacheAll: function () {
         this.stopAll();
+        for (var id in id2audio) {
+            var audio = id2audio[id];
+            if (audio) {
+                audio.destroy();
+            }
+        }
         id2audio = {};
         url2id = {};
     },

--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -37,6 +37,8 @@ var ReleasedAssetChecker = CC_DEBUG && require('./released-asset-checker');
 
 var resources = new AssetTable();
 
+var AUDIO_TYPES = ['mp3', 'ogg', 'wav', 'm4a'];
+
 function getXMLHttpRequest () {
     return window.XMLHttpRequest ? new window.XMLHttpRequest() : new ActiveXObject('MSXML2.XMLHTTP');
 }
@@ -764,7 +766,6 @@ proto.release = function (asset) {
         if (item) {
             var removed = this.removeItem(id);
             asset = item.content;
-            // TODO: AUDIO
             if (asset instanceof cc.Asset) {
                 if (CC_JSB && asset instanceof cc.SpriteFrame && removed) {
                     // for the "Temporary solution" in deserialize.js
@@ -777,6 +778,9 @@ proto.release = function (asset) {
             }
             else if (asset instanceof cc.Texture2D) {
                 cc.textureCache.removeTextureForKey(item.rawUrl || item.url);
+            }
+            else if (AUDIO_TYPES.indexOf(item.type) !== -1) {
+                cc.audioEngine.uncache(item.rawUrl || item.url);
             }
             if (CC_DEBUG && removed) {
                 this._releasedAssetChecker_DEBUG.setReleased(item, id);


### PR DESCRIPTION
Re: cocos-creator/fireball#6888

Changelog:
 * 当 audio stop 的时候，destroy 掉 _element（InnerAudioContext）避免内存泄漏