### PR TITLE
fixed texture destroy

### DIFF
--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -415,7 +415,7 @@ var Texture2D = cc.Class({
      */
     destroy () {
         this._image = null;
-        this._texture.destroy();
+        this._texture && this._texture.destroy();
         // TODO cc.textureUtil ?
         // cc.textureCache.removeTextureForKey(this.url);  // item.rawUrl || item.url
         this._super();
@@ -506,7 +506,7 @@ var Texture2D = cc.Class({
      */
     releaseTexture () {
         this._image = null;
-        this._texture.destroy();
+        this._texture && this._texture.destroy();
     },
 
     /**


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/19702899/35208040-28a37edc-ff81-11e7-91da-56425983d90a.png)

Safari不支持webp，不能正确生成texture，CCTexture2D在destroy时没有进行判空。