### PR TITLE
Fix supportsNPOT and ignore contentSize in Texture.initWithData

### DIFF
--- a/DebugInfos.js
+++ b/DebugInfos.js
@@ -64,6 +64,7 @@ if (CC_DEBUG) {
         "1509": "Argument target must be non-nullptr", //isScheduled
         "1510": "cc.Scheduler: Illegal target which doesn't have uuid or instanceId",
         "1511": "cc.Scheduler: pause state of the scheduled task doesn't match the element pause state in Scheduler, the given paused state will be ignored",
+        "1512": "cc.Scheduler: updateFunc parameter is deprecated in scheduleUpdate function, and will be removed in v2.0",
         //Node: 1600
         "1600": "getZOrder is deprecated. Please use getLocalZOrder instead.", //getZOrder
         "1601": "setZOrder is deprecated. Please use setLocalZOrder instead.", //setZOrder
@@ -239,6 +240,7 @@ if (CC_DEBUG) {
         "3115": "Frame Grabber: could not attach texture to framebuffer", //CCGrabber.grab
         "3116": "WebGLRenderingContext.CLAMP_TO_EDGE should be used in NPOT textures", //setTexParameters
         "3117": "Mimpap texture only works in POT textures", //generateMipmap
+        "3118": "contentSize parameter is deprecated and ignored for cc.Texture2D initWithData function", // initWithData
         //RectWidth: 3300
         "3300": "Rect width exceeds maximum margin: %s", //RectWidth
         //RectHeight: 3400

--- a/cocos2d/core/CCConfiguration.js
+++ b/cocos2d/core/CCConfiguration.js
@@ -244,7 +244,7 @@ cc.configuration = /** @lends cc.configuration# */{
         this._supportsPVRTC = this.checkForGLExtension("GL_IMG_texture_compression_pvrtc");
         locValueDict["gl.supports_PVRTC"] = this._supportsPVRTC;
 
-        this._supportsNPOT = false; //true;
+        this._supportsNPOT = true;
         locValueDict["gl.supports_NPOT"] = this._supportsNPOT;
 
         this._supportsBGRA8888 = this.checkForGLExtension("GL_IMG_texture_format_BGRA888");

--- a/cocos2d/core/CCScheduler.js
+++ b/cocos2d/core/CCScheduler.js
@@ -618,6 +618,10 @@ cc.Scheduler = cc._Class.extend({
             }
         }
 
+        if (updateFunc) {
+            cc.warnID(1512);
+        }
+
         var listElement = ListEntry.get(null, null, updateFunc, target, priority, paused, false);
         var ppList;
 

--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -854,6 +854,9 @@ game.once(game.EVENT_RENDERER_INITED, function () {
         };
 
         _p.initWithData = function (data, pixelFormat, pixelsWidth, pixelsHeight, contentSize) {
+            if (contentSize) {
+                cc.warnID(3118);
+            }
             var opts = _getSharedOptions();
             opts.image = data;
             opts.format = pixelFormat;

--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -352,7 +352,7 @@ var Texture2D = cc.Class(/** @lends cc.Texture2D# */{
      * @param {Number} pixelFormat
      * @param {Number} pixelsWidth
      * @param {Number} pixelsHeight
-     * @param {Size} contentSize
+     * @param {Size} contentSize contentSize is deprecated and ignored
      * @return {Boolean}
      */
     initWithData: function (data, pixelFormat, pixelsWidth, pixelsHeight, contentSize) {
@@ -860,8 +860,8 @@ game.once(game.EVENT_RENDERER_INITED, function () {
             opts.width = pixelsWidth;
             opts.height = pixelsHeight;
             this.update(opts);
-            this.width = contentSize.width;
-            this.height = contentSize.height;
+            this.width = pixelsWidth;
+            this.height = pixelsHeight;
             this.loaded = true;
             this.emit("load");
             return true;

--- a/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
+++ b/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
@@ -172,7 +172,7 @@ proto.initWithWidthAndHeight = function(width, height, format, depthStencilForma
     if (!node._texture)
         return false;
 
-    locTexture.initWithData(data, node._pixelFormat, powW, powH, cc.size(width, height));
+    locTexture.initWithData(data, node._pixelFormat, powW, powH);
     //free( data );
 
     var oldRBO = gl.getParameter(gl.RENDERBUFFER_BINDING);
@@ -181,7 +181,7 @@ proto.initWithWidthAndHeight = function(width, height, format, depthStencilForma
         this._textureCopy = new cc.Texture2D();
         if (!this._textureCopy)
             return false;
-        this._textureCopy.initWithData(data, node._pixelFormat, powW, powH, cc.size(width, height));
+        this._textureCopy.initWithData(data, node._pixelFormat, powW, powH);
     }
 
     // generate FBO


### PR DESCRIPTION
Re: cocos-creator/fireball#6576

fix issue reported from internal game team

Changelog:
 * Fix supportsNPOT and ignore contentSize in Texture.initWithData

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->