### PR TITLE
Use vec3 scale instead of scaleX & scaleY

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -368,8 +368,9 @@ var Node = cc.Class({
         _contentSize: cc.Size,
         _anchorPoint: cc.v2(0.5, 0.5),
         _position: cc.Vec3,
-        _scaleX: 1.0,
-        _scaleY: 1.0,
+        _scaleX: undefined,
+        _scaleY: undefined,
+        _scale: cc.Vec3,
         _rotationX: 0.0,
         _rotationY: 0.0,
         _skewX: 0.0,
@@ -610,11 +611,11 @@ var Node = cc.Class({
          */
         scaleX: {
             get () {
-                return this._scaleX;
+                return this._scale.x;
             },
             set (value) {
-                if (this._scaleX !== value) {
-                    this._scaleX = value;
+                if (this._scale.x !== value) {
+                    this._scale.x = value;
                     this._localMatDirty = true;
 
                     var cache = this._hasListenerCache;
@@ -636,11 +637,11 @@ var Node = cc.Class({
          */
         scaleY: {
             get () {
-                return this._scaleY;
+                return this._scale.y;
             },
             set (value) {
-                if (this._scaleY !== value) {
-                    this._scaleY = value;
+                if (this._scale.y !== value) {
+                    this._scale.y = value;
                     this._localMatDirty = true;
 
                     var cache = this._hasListenerCache;
@@ -892,6 +893,9 @@ var Node = cc.Class({
         // Mouse event listener
         this._mouseListener = null;
 
+        // default scale z
+        this._scale.z = 1;
+
         this._matrix = mathPools.mat4.get();
         this._worldMatrix = mathPools.mat4.get();
         this._localMatDirty = true;
@@ -997,6 +1001,17 @@ var Node = cc.Class({
      * The initializer for Node which will be called before all components onLoad
      */
     _onBatchCreated () {
+        // Upgrade scaleX, scaleY from v1.x
+        // TODO: remove in future version, 3.0 ?
+        if (this._scaleX !== undefined) {
+            this._scale.x = this._scaleX;
+            this._scaleX = undefined;
+        }
+        if (this._scaleY !== undefined) {
+            this._scale.y = this._scaleY;
+            this._scaleY = undefined;
+        }
+
         var prefabInfo = this._prefab;
         if (prefabInfo && prefabInfo.sync && prefabInfo.root === this) {
             if (CC_DEV) {
@@ -1533,9 +1548,9 @@ var Node = cc.Class({
      * cc.log("Node Scale: " + node.getScale());
      */
     getScale () {
-        if (this._scaleX !== this._scaleY)
+        if (this._scale.x !== this._scale.y)
             cc.logID(1603);
-        return this._scaleX;
+        return this._scale.x;
     },
 
     /**
@@ -1556,9 +1571,9 @@ var Node = cc.Class({
         else {
             scaleY = (scaleY || scaleY === 0) ? scaleY : scaleX;
         }
-        if (this._scaleX !== scaleX || this._scaleY !== scaleY) {
-            this._scaleX = scaleX;
-            this._scaleY = scaleY;
+        if (this._scale.x !== scaleX || this._scale.y !== scaleY) {
+            this._scale.x = scaleX;
+            this._scale.y = scaleY;
             this._localMatDirty = true;
 
             var cache = this._hasListenerCache;
@@ -1826,10 +1841,10 @@ var Node = cc.Class({
             }
 
             // scale
-            t.m00 = a *= this._scaleX;
-            t.m01 = b *= this._scaleX;
-            t.m04 = c *= this._scaleY;
-            t.m05 = d *= this._scaleY;
+            t.m00 = a *= this._scale.x;
+            t.m01 = b *= this._scale.x;
+            t.m04 = c *= this._scale.y;
+            t.m05 = d *= this._scale.y;
 
             // skew
             if (hasSkew) {

--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -46,8 +46,8 @@ function getReadonlyNodeSize (parent) {
 }
 
 function computeInverseTransForTarget (widgetNode, target, out_inverseTranslate, out_inverseScale) {
-    var scaleX = widgetNode._parent._scaleX;
-    var scaleY = widgetNode._parent._scaleY;
+    var scaleX = widgetNode._parent._scale.x;
+    var scaleY = widgetNode._parent._scale.y;
     var translateX = 0;
     var translateY = 0;
     for (var node = widgetNode._parent;;) {
@@ -62,8 +62,8 @@ function computeInverseTransForTarget (widgetNode, target, out_inverseTranslate,
             return;
         }
         if (node !== target) {
-            var sx = node._scaleX;
-            var sy = node._scaleY;
+            var sx = node._scale.x;
+            var sy = node._scale.y;
             translateX *= sx;
             translateY *= sy;
             scaleX *= sx;
@@ -126,7 +126,7 @@ function align (node, widget) {
             localRight *= inverseScale.x;
         }
 
-        var width, anchorX = anchor.x, scaleX = node._scaleX;
+        var width, anchorX = anchor.x, scaleX = node._scale.x;
         if (scaleX < 0) {
             anchorX = 1.0 - anchorX;
             scaleX = -scaleX;

--- a/test/qunit/unit-es5/test-serialize-node.js
+++ b/test/qunit/unit-es5/test-serialize-node.js
@@ -24,8 +24,7 @@ if (TestEditorExtends) {
         '_globalZOrder',
         '_rotationX',
         '_rotationY',
-        '_scaleX',
-        '_scaleY',
+        '_scale',
         '_position',
         '_skewX',
         '_skewY',
@@ -48,7 +47,7 @@ if (TestEditorExtends) {
             '_rotationY' : getRandomDouble(),
             '_scaleX' : 1.5,
             '_scaleY' : 1.5,
-            '_position' : cc.p(getRandomDouble(), getRandomDouble()),
+            '_position' : cc.v3(getRandomDouble(), getRandomDouble(), 0),
             '_skewX' : getRandomDouble(),
             '_skewY' : getRandomDouble(),
             '_active' : getRandomBool(),
@@ -70,8 +69,8 @@ if (TestEditorExtends) {
         ret._globalZOrder = getRandomInt();
         ret._rotationX = getRandomDouble();
         ret._rotationY = getRandomDouble();
-        ret._scaleX = 1.5;
-        ret._scaleY = 1.5;
+        ret._scale.x = 1.5;
+        ret._scale.y = 1.5;
         ret._position = cc.p(getRandomDouble(), getRandomDouble());
         ret._skewX = getRandomDouble();
         ret._skewY = getRandomDouble();


### PR DESCRIPTION
Re: cocos-creator/fireball#6909

Changelog:
 * Node use vec3 scale instead of scaleX & scaleY