### PR TITLE
The audio cache id does not match

### DIFF
--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -84,15 +84,15 @@ function loadWebAudio (item, callback) {
         context["decodeAudioData"](request.response, function(buffer){
             //success
             item.buffer = buffer;
-            callback(null, item.url);
+            callback(null, item.id);
         }, function(){
             //error
-            callback('decode error - ' + item.url, null);
+            callback('decode error - ' + item.id, null);
         });
     };
 
     request.onerror = function(){
-        callback('request error - ' + item.url, null);
+        callback('request error - ' + item.id, null);
     };
 
     request.send();


### PR DESCRIPTION
Update https://github.com/cocos-creator/fireball/issues/6910

比如加载 xxx.mp3
缓存内 id 就为 xxx.mp3
但是加载后返回的地址是 xxx.md5.mp3
如果用户拿这个地址再去播放，就会重新加载一次

@pandamicro @jareguo 