### PR TITLE
Fix types of CCPolygonCollier and CCPhysicsChainCollider

### DIFF
--- a/cocos2d/core/collider/CCPolygonCollider.js
+++ b/cocos2d/core/collider/CCPolygonCollider.js
@@ -59,7 +59,7 @@ cc.Collider.Polygon = cc.Class({
          * !#en Polygon points
          * !#zh 多边形顶点数组
          * @property points
-         * @type {[Vec2]}
+         * @type {Vec2[]}
          */
         points: {
             tooltip: CC_DEV && 'i18n:COMPONENT.physics.physics_collider.points',

--- a/cocos2d/core/physics/collider/CCPhysicsChainCollider.js
+++ b/cocos2d/core/physics/collider/CCPhysicsChainCollider.js
@@ -53,7 +53,7 @@ var PhysicsChainCollider = cc.Class({
          * !#en Chain points
          * !#zh 链条顶点数组
          * @property points
-         * @type {[Vec2]}
+         * @type {Vec2[]}
          */
         points: {
             default: function () {


### PR DESCRIPTION
Types of `PolygonCollider` and `PhysicsChainCollider` in creator.d.ts seemds to be wrong.
I thank `points` should be Vec2[], not [Vec2].

Changelog:
 * Change types of points in CCPolygonCollier and CCPhysicsChainCollider to Vec2[].