### PR TITLE
Audio - Prevent repeated callbacks

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -114,7 +114,7 @@ Audio.State = {
         // If the resource does not exist
         if (!item || !item.complete) {
             return cc.loader.load(src, function (error) {
-                if (!error) {
+                if (!error && src === audio._src) {
                     var item = cc.loader.getItem(src);
                     audio.mount(item.element || item.buffer);
                     audio.emit('load');

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -44,7 +44,7 @@ var Audio = function (src) {
     this._state = Audio.State.INITIALZING;
     this._loaded = false;
 
-    this._preloadSrc = null;
+    this._isLoading = false;
 
     this._onended = function () {
         this.emit('ended');
@@ -91,10 +91,10 @@ Audio.State = {
     proto.preload = function () {
         var src = this._src, audio = this;
 
-        if (this._preloadSrc === src) {
+        if (this._isLoading) {
             return;
         }
-        this._preloadSrc = src;
+        this._isLoading = true;
 
         if (!src) {
             this._src = '';
@@ -280,6 +280,9 @@ Audio.State = {
         return this._src;
     });
     proto.__defineSetter__('src', function (string) {
+        if (string !== this._src) {
+            this._isLoading = false;
+        }
         return this._src = string;
     });
 

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -44,6 +44,8 @@ var Audio = function (src) {
     this._state = Audio.State.INITIALZING;
     this._loaded = false;
 
+    this._preloadSrc = null;
+
     this._onended = function () {
         this.emit('ended');
     }.bind(this);
@@ -88,6 +90,11 @@ Audio.State = {
 
     proto.preload = function () {
         var src = this._src, audio = this;
+
+        if (this._preloadSrc === src) {
+            return;
+        }
+        this._preloadSrc = src;
 
         if (!src) {
             this._src = '';


### PR DESCRIPTION
1. 多次调用 audio.preload 会造成多次执行 cc.loader.load 方法，最终会多次回调，并触发多次的 emit('load') 导致用户监听的 load 事件被多次执行。

而不管加载几次，load 应该只应该 emit 一次。

所以这里增加一个 preloadSrc 记录之前 preload 的 src，如果没有更改，则不需要重新 preload。

2. src 如果更改了，进行了多次的 preload， cc.loader.load 内的回调应该判断如果是过期的 src 则忽略不进行处理