### PR TITLE
The loading process should determine whether or not ‘cc.engine’ exists.

### DIFF
--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -445,7 +445,7 @@ var widgetManager = cc._widgetManager = module.exports = {
     init: function (director) {
         director.on(cc.Director.EVENT_BEFORE_VISIT, refreshScene);
 
-        if (CC_EDITOR) {
+        if (CC_EDITOR && cc.engine) {
             cc.engine.on('design-resolution-changed', this.onResized.bind(this));
         }
         else if (!CC_JSB) {


### PR DESCRIPTION
判断 cc.engine 是否存在。

这里导致了和编辑器的强耦合。这么做是会有问题的。。。