### PR TITLE
optimize getComponent performance

### DIFF
--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -922,6 +922,11 @@ function CCClass (options) {
         name = cc.js.getClassName(cls);
     }
 
+    cls._sealed = true;
+    if (base) {
+        base._sealed = false;
+    }
+
     // define Properties
     var properties = options.properties;
     if (typeof properties === 'function' ||

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -51,20 +51,40 @@ function getConstructor(typeOrClassName) {
 }
 
 function findComponent(node, constructor) {
-    for (var i = 0; i < node._components.length; ++i) {
-        var comp = node._components[i];
-        if (comp instanceof constructor) {
-            return comp;
+    if (constructor._sealed) {
+        for (let i = 0; i < node._components.length; ++i) {
+            let comp = node._components[i];
+            if (comp.constructor === constructor) {
+                return comp;
+            }
+        }
+    }
+    else {
+        for (let i = 0; i < node._components.length; ++i) {
+            let comp = node._components[i];
+            if (comp instanceof constructor) {
+                return comp;
+            }
         }
     }
     return null;
 }
 
 function findComponents(node, constructor, components) {
-    for (var i = 0; i < node._components.length; ++i) {
-        var comp = node._components[i];
-        if (comp instanceof constructor) {
-            components.push(comp);
+    if (constructor._sealed) {
+        for (let i = 0; i < node._components.length; ++i) {
+            let comp = node._components[i];
+            if (comp.constructor === constructor) {
+                components.push(comp);
+            }
+        }
+    }
+    else {
+        for (let i = 0; i < node._components.length; ++i) {
+            let comp = node._components[i];
+            if (comp instanceof constructor) {
+                components.push(comp);
+            }
         }
     }
 }


### PR DESCRIPTION
Re: #2394 

Changelog:
在getComponent 时，component.sealed===true（不存在子类）情况下，将 instanceof class 改为 constructor compare  
性能对比：
在component.sealed === false 时，instanceof class 的效率会高一点（只高了6%）
在component.sealed === true 时，constructor compare  的效率会明显高于 instanceof class （20%~40%）