### PR TITLE
refactor sprite assembler to optimize performance

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1966,6 +1966,7 @@ var Node = cc.Class({
         if (this._localMatDirty) {
             this._updateLocalMatrix();
         }
+        
         // Assume parent world matrix is correct
         if (this._parent) {
             let parentMat = this._parent._worldMatrix;
@@ -1974,8 +1975,9 @@ var Node = cc.Class({
         else {
             math.mat4.copy(this._worldMatrix, this._matrix);
         }
-        this.emit(WORLD_MATRIX_CHANGED);
         this._worldMatDirty = false;
+
+        this.emit(WORLD_MATRIX_CHANGED);
 
         for (let i = 0, len = this._children.length; i < len; ++i) {
             let child = this._children[i];

--- a/cocos2d/core/renderer/assemblers/label/bmfont-assembler.js
+++ b/cocos2d/core/renderer/assemblers/label/bmfont-assembler.js
@@ -31,7 +31,7 @@ const Overflow = Label.Overflow;
 
 const TextUtils = require('../../../utils/text-utils').TextUtils;
 
-const spriteAssembler = require('../sprite/simple');
+const ttf = require('./ttf-assembler');
 
 let FontLetterDefinition = function() {
     this._u = 0;
@@ -158,7 +158,7 @@ module.exports = {
         this._resetProperties();
     },
 
-    fillVertexBuffer: spriteAssembler.fillVertexBuffer,
+    fillVertexBuffer: ttf.fillVertexBuffer,
 
     fillIndexBuffer (comp, offset, vertexId, ibuf) {
         let renderData = comp._renderData;

--- a/cocos2d/core/renderer/assemblers/mask-assembler.js
+++ b/cocos2d/core/renderer/assemblers/mask-assembler.js
@@ -124,8 +124,7 @@ let maskFrontAssembler = js.addon({
 
             // vertex buffer
             if (mask._type === Mask.Type.IMAGE_STENCIL) {
-                spriteAssembler.fillVertexBuffer(mask, batchData.byteOffset / 4, vbuf, uintbuf);
-                spriteAssembler.fillIndexBuffer(mask, batchData.indiceOffset, vertexId, ibuf);
+                spriteAssembler.fillBuffers(mask, batchData, vertexId, vbuf, uintbuf, ibuf);
             }
             else {
                 // Share node for correct global matrix

--- a/cocos2d/core/renderer/assemblers/sprite/bar-filled.js
+++ b/cocos2d/core/renderer/assemblers/sprite/bar-filled.js
@@ -29,14 +29,6 @@ const FillType = Sprite.FillType;
 const simpleRenderUtil = require('./simple');
 
 module.exports = {
-    createData (sprite) {
-        let renderData = sprite.requestRenderData();
-        renderData.dataLength = 4;
-        renderData.vertexCount = 4;
-        renderData.indiceCount = 6;
-        return renderData;
-    },
-    
     update (sprite) {
         let renderData = sprite._renderData;
         let uvDirty = renderData.uvDirty,
@@ -70,6 +62,9 @@ module.exports = {
         }
         if (vertDirty) {
             this.updateVerts(sprite, fillStart, fillEnd);
+        }
+        if (renderData.worldMatDirty) {
+            this.updateWorldVerts(sprite);
         }
     },
 
@@ -136,13 +131,13 @@ module.exports = {
 
         renderData.uvDirty = false;
     },
+
     updateVerts (sprite, fillStart, fillEnd) {
         let renderData = sprite._renderData,
             data = renderData._data,
-            width = renderData._width,
-            height = renderData._height,
-            appx = renderData._pivotX * width,
-            appy = renderData._pivotY * height;
+            node = sprite.node,
+            width = node.width, height = node.height,
+            appx = node.anchorX * width, appy = node.anchorY * height;
 
         let l = -appx, b = -appy,
             r = width-appx, t = height-appy;
@@ -168,18 +163,19 @@ module.exports = {
                 break;
         }
 
-        data[0].x = l;
-        data[0].y = b;
-        data[1].x = r;
-        data[1].y = b;
-        data[2].x = l;
-        data[2].y = t;
-        data[3].x = r;
-        data[3].y = t;
+        data[4].x = l;
+        data[4].y = b;
+        data[5].x = r;
+        data[5].y = b;
+        data[6].x = l;
+        data[6].y = t;
+        data[7].x = r;
+        data[7].y = t;
 
         renderData.vertDirty = false;
     },
 
-    fillVertexBuffer: simpleRenderUtil.fillVertexBuffer,
-    fillIndexBuffer: simpleRenderUtil.fillIndexBuffer
+    updateWorldVerts: simpleRenderUtil.updateWorldVerts,
+    createData: simpleRenderUtil.createData,
+    fillBuffers: simpleRenderUtil.fillBuffers
 };

--- a/cocos2d/core/renderer/assemblers/sprite/radial-filled.js
+++ b/cocos2d/core/renderer/assemblers/sprite/radial-filled.js
@@ -239,11 +239,9 @@ module.exports = {
     },
 
     _calculateVertices : function (sprite) {
-        let renderData = sprite._renderData,
-            width = renderData._width,
-            height = renderData._height,
-            appx = renderData._pivotX * width,
-            appy = renderData._pivotY * height;
+        let node = sprite.node,
+            width = node.width, height = node.height,
+            appx = node.anchorX * width, appy = node.anchorY * height;
 
         let l = -appx, b = -appy,
             r = width-appx, t = height-appy;
@@ -315,12 +313,32 @@ module.exports = {
         }
     },
 
-    fillVertexBuffer: simpleRenderUtil.fillVertexBuffer,
+    fillBuffers (sprite, batchData, vertexId, vbuf, uintbuf, ibuf) {
+        let vertexOffset = batchData.byteOffset / 4,
+            indiceOffset = batchData.indiceOffset;
 
-    fillIndexBuffer (sprite, offset, vertexId, ibuf) {
-        let renderData = sprite._renderData;
-        for (let i = 0, l = renderData.vertexCount; i < l; i++) {
-            ibuf[offset+i] = vertexId+i;
+        let data = sprite._renderData._data;
+        let node = sprite.node;
+        let z = node._position.z;
+        let color = node._color._val;
+    
+        let matrix = node._worldMatrix;
+            a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
+            tx = matrix.m12, ty = matrix.m13;
+
+        let count = data.length;
+        for (let i = 0; i < count; i++) {
+            let vert = data[i];
+            vbuf[vertexOffset ++] = vert.x * a + vert.y * c + tx;
+            vbuf[vertexOffset ++] = vert.x * b + vert.y * d + ty;
+            vbuf[vertexOffset ++] = z;
+            uintbuf[vertexOffset ++] = color;
+            vbuf[vertexOffset ++] = vert.u;
+            vbuf[vertexOffset ++] = vert.v;
+        }
+
+        for (let i = 0; i < count; i++) {
+            ibuf[indiceOffset+i] = vertexId+i;
         }
     }
 };

--- a/cocos2d/core/renderer/assemblers/sprite/tiled.js
+++ b/cocos2d/core/renderer/assemblers/sprite/tiled.js
@@ -42,8 +42,12 @@ module.exports = {
             texh = texture._height;
         let frame = sprite.spriteFrame;
         let rect = frame._rect;
-        let contentWidth = Math.abs(renderData._width);
-        let contentHeight = Math.abs(renderData._height);
+
+        let node = sprite.node,
+            contentWidth = Math.abs(node.width),
+            contentHeight = Math.abs(node.height),
+            appx = node.anchorX * contentWidth,
+            appy = node.anchorY * contentHeight;
 
         let rectWidth = rect.width;
         let rectHeight = rect.height;
@@ -104,9 +108,6 @@ module.exports = {
             data[7].v = data[6].v;
         }
 
-        let appx = renderData._pivotX * contentWidth,
-            appy = renderData._pivotY * contentHeight;
-
         for (let i = 0; i <= col; ++i) {
             data[i].x = Math.min(rectWidth * i, contentWidth) - appx;
         }
@@ -122,7 +123,11 @@ module.exports = {
         renderData.vertDirty = false;
     },
 
-    fillVertexBuffer (sprite, index, vbuf, uintbuf) {
+    fillBuffers (sprite, batchData, vertexId, vbuf, uintbuf, ibuf) {
+        let vertexOffset = batchData.byteOffset / 4,
+            indiceOffset = batchData.indiceOffset;
+
+        // update verts
         let node = sprite.node;
         let renderData = sprite._renderData;
         let data = renderData._data;
@@ -130,8 +135,8 @@ module.exports = {
         let color = node._color._val;
 
         let rect = sprite.spriteFrame._rect;
-        let contentWidth = Math.abs(renderData._width);
-        let contentHeight = Math.abs(renderData._height);
+        let contentWidth = Math.abs(node.width);
+        let contentHeight = Math.abs(node.height);
         let hRepeat = contentWidth / rect.width;
         let vRepeat = contentHeight / rect.height;
         let row = Math.ceil(vRepeat), 
@@ -157,50 +162,48 @@ module.exports = {
                 x1 = data[xindex+1].x;
 
                 // lb
-                vbuf[index++] = x * a + y * c + tx;
-                vbuf[index++] = x * b + y * d + ty;
-                vbuf[index++] = z;
-                uintbuf[index++] = color;
-                vbuf[index++] = lastx ? data[4].u : data[0].u;
-                vbuf[index++] = lasty ? data[4].v : data[0].v;
+                vbuf[vertexOffset++] = x * a + y * c + tx;
+                vbuf[vertexOffset++] = x * b + y * d + ty;
+                vbuf[vertexOffset++] = z;
+                uintbuf[vertexOffset++] = color;
+                vbuf[vertexOffset++] = lastx ? data[4].u : data[0].u;
+                vbuf[vertexOffset++] = lasty ? data[4].v : data[0].v;
 
                 // rb
-                vbuf[index++] = x1 * a + y * c + tx;
-                vbuf[index++] = x1 * b + y * d + ty;
-                vbuf[index++] = z;
-                uintbuf[index++] = color;
-                vbuf[index++] = lastx ? data[5].u : data[1].u;
-                vbuf[index++] = lasty ? data[5].v : data[1].v;
+                vbuf[vertexOffset++] = x1 * a + y * c + tx;
+                vbuf[vertexOffset++] = x1 * b + y * d + ty;
+                vbuf[vertexOffset++] = z;
+                uintbuf[vertexOffset++] = color;
+                vbuf[vertexOffset++] = lastx ? data[5].u : data[1].u;
+                vbuf[vertexOffset++] = lasty ? data[5].v : data[1].v;
 
                 // lt
-                vbuf[index++] = x * a + y1 * c + tx;
-                vbuf[index++] = x * b + y1 * d + ty;
-                vbuf[index++] = z;
-                uintbuf[index++] = color;
-                vbuf[index++] = lastx ? data[6].u : data[2].u;
-                vbuf[index++] = lasty ? data[6].v : data[2].v;
+                vbuf[vertexOffset++] = x * a + y1 * c + tx;
+                vbuf[vertexOffset++] = x * b + y1 * d + ty;
+                vbuf[vertexOffset++] = z;
+                uintbuf[vertexOffset++] = color;
+                vbuf[vertexOffset++] = lastx ? data[6].u : data[2].u;
+                vbuf[vertexOffset++] = lasty ? data[6].v : data[2].v;
 
                 // rt
-                vbuf[index++] = x1 * a + y1 * c + tx;
-                vbuf[index++] = x1 * b + y1 * d + ty;
-                vbuf[index++] = z;
-                uintbuf[index++] = color;
-                vbuf[index++] = lastx ? data[7].u : data[3].u;
-                vbuf[index++] = lasty ? data[7].v : data[3].v;
+                vbuf[vertexOffset++] = x1 * a + y1 * c + tx;
+                vbuf[vertexOffset++] = x1 * b + y1 * d + ty;
+                vbuf[vertexOffset++] = z;
+                uintbuf[vertexOffset++] = color;
+                vbuf[vertexOffset++] = lastx ? data[7].u : data[3].u;
+                vbuf[vertexOffset++] = lasty ? data[7].v : data[3].v;
             }
         }
-    },
-    
-    fillIndexBuffer (sprite, offset, vertexId, ibuf) {
-        let renderData = sprite._renderData;
+
+        // update indices
         let length = renderData.indiceCount;
         for (let i = 0; i < length; i+=6) {
-            ibuf[offset++] = vertexId;
-            ibuf[offset++] = vertexId+1;
-            ibuf[offset++] = vertexId+2;
-            ibuf[offset++] = vertexId+1;
-            ibuf[offset++] = vertexId+3;
-            ibuf[offset++] = vertexId+2;
+            ibuf[indiceOffset++] = vertexId;
+            ibuf[indiceOffset++] = vertexId+1;
+            ibuf[indiceOffset++] = vertexId+2;
+            ibuf[indiceOffset++] = vertexId+1;
+            ibuf[indiceOffset++] = vertexId+3;
+            ibuf[indiceOffset++] = vertexId+2;
             vertexId += 4;
         }
     }


### PR DESCRIPTION
Re: cocos-creator/fireball#7088

Changelog:
 * 记录 node 的 world matrix 到 render data 上，避免每次都重新计算所有顶点
 * 将 batchQueue 逻辑放到 walk 中，不用再维护一个 queue 和 省掉一个大循环
 * 避免每次绘制 sprite assembler 中的 switch
