### PR TITLE
destroy audio element when stop

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -41,6 +41,7 @@ var getAudioFromPath = function (path) {
         var oldId = list.shift();
         var oldAudio = id2audio[oldId];
         oldAudio.stop();
+        oldAudio.destroy();
     }
 
     audio = new Audio(path);
@@ -365,6 +366,8 @@ var audioEngine = {
             return false;
         audio.off('load', audio.__callback);
         audio.stop();
+        audio.destroy();
+
         return true;
     },
 
@@ -380,6 +383,7 @@ var audioEngine = {
             var audio = id2audio[id];
             if (audio && audio.stop) {
                 audio.stop();
+                audio.destroy();
                 audio.off('load', audio.__callback);
             }
         }

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -231,6 +231,7 @@ var AudioSource = cc.Class({
 
     onDestroy: function () {
         this.stop();
+        this.audio.destroy();
         cc.audioEngine.uncache(this._clip);
     },
 


### PR DESCRIPTION
Re: #2409 

Changelog:
 * 
音频再设置setMaxAudioInstance(1) 的时候，频繁播放，
会频繁调用  stop  play，，，stop的时候没有 destroy掉，导致内存泄漏
多次play 之后就无法播放了