### PR TITLE
fixed the wechat platform can't idenitfy the ttf problem

### DIFF
--- a/cocos2d/core/label/CCSGLabel.js
+++ b/cocos2d/core/label/CCSGLabel.js
@@ -490,13 +490,23 @@ _ccsg.Label = _ccsg.Node.extend({
 
     _loadTTFFont: function(fontHandle) {
         var self = this;
-
-        var fontFamilyName = cc.CustomFontLoader._getFontFamily(fontHandle);
         var callback = function () {
             self._notifyLabelSkinDirty();
             self.emit('load');
         };
-        cc.CustomFontLoader.loadTTF(fontHandle, callback);
+
+        var fontFamilyName = "";
+        if (CC_WECHATGAME) {
+            fontFamilyName = wx.loadFont(fontHandle);        
+            //avoid the error in wechat devtool platform
+            if (!fontFamilyName) {
+                fontFamilyName = cc.CustomFontLoader._getFontFamily(fontHandle);
+            }
+            callback();
+        } else {
+            fontFamilyName = cc.CustomFontLoader._getFontFamily(fontHandle);
+            cc.CustomFontLoader.loadTTF(fontHandle, callback);
+        }
 
         return fontFamilyName;
     },

--- a/cocos2d/particle/CCSGParticleSystem.js
+++ b/cocos2d/particle/CCSGParticleSystem.js
@@ -349,6 +349,7 @@ _ccsg.ParticleSystem = _ccsg.Node.extend({
         this.scheduleUpdateWithPriority(1);
         _ccsg.Node.prototype.onEnter.call(this);
     },
+    
     /**
      * This is a hack function for performance, it's only available on Canvas mode. <br/>
      * It's very expensive to change color on Canvas mode, so if set it to true, particle system will ignore the changing color operation.


### PR DESCRIPTION
fixed WeChat playform can't identify the ttf font format problem 


fixed WeChat playform can't identify the ttf font format problem

fix #2456 cocos-creator/fireball#7066

Changelog:
 * 支持在微信小游戏中使用 TTF 字体

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->