### PR TITLE
not support loading sprite frame in atlas via loadRes

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1751,6 +1751,10 @@ Load image ( %s ) failed
 
 Download Uuid: can not find type of raw asset[ %s ]: %s
 
+### 4932
+
+Since v1.10, for any atlas ("%s") in the "resources" directory, it is not possible to find the contained SpriteFrames via `loadRes`, `getRes` or `releaseRes`. Load the SpriteAtlas first and then use `spriteAtlas.getSpriteFrame(name)` instead please.
+
 ### 5000
 
 object already destroyed

--- a/cocos2d/core/platform/CCAssetLibrary.js
+++ b/cocos2d/core/platform/CCAssetLibrary.js
@@ -298,7 +298,6 @@ var AssetLibrary = {
         resources.reset();
         var rawAssets = options.rawAssets;
         if (rawAssets) {
-            var RES_DIR = 'resources/';
             for (var mountPoint in rawAssets) {
                 var assets = rawAssets[mountPoint];
                 for (var uuid in assets) {
@@ -312,20 +311,11 @@ var AssetLibrary = {
                     }
                     _uuidToRawAsset[uuid] = new RawAssetEntry(mountPoint + '/' + url, type);
                     // init resources
-                    if (mountPoint === 'assets' && url.startsWith(RES_DIR)) {
-                        if (cc.isChildClassOf(type, Asset)) {
-                            var ext = cc.path.extname(url);
-                            if (ext) {
-                                // trim base dir and extname
-                                url = url.slice(RES_DIR.length, - ext.length);
-                            }
-                            else {
-                                // trim base dir
-                                url = url.slice(RES_DIR.length);
-                            }
-                        }
-                        else {
-                            url = url.slice(RES_DIR.length);
+                    if (mountPoint === 'assets') {
+                        var ext = cc.path.extname(url);
+                        if (ext) {
+                            // trim base dir and extname
+                            url = url.slice(0, - ext.length);
                         }
                         var isSubAsset = info[2] === 1;
                         // register


### PR DESCRIPTION
Changelog:
 * 避免 resources 下的碎图过多引起的 settings.js 过大

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->