### PR TITLE
fix wx cc.RenderTexture.create for engine/issues/2549

### DIFF
--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -803,7 +803,7 @@ game.once(game.EVENT_RENDERER_INITED, function () {
             var gl = this._gl;
             gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultiplyAlpha);
             if (
-                sys.platform === sys.WECHAT_GAME ||
+                (sys.platform === sys.WECHAT_GAME && !(img instanceof Uint8Array)) ||
                 sys.platform === sys.QQ_PLAY ||
                 img instanceof HTMLCanvasElement ||
                 img instanceof HTMLImageElement ||


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/2549

Changelog:
 * 修复使用 cc.RenderTexture.create，导出微信小游戏的工程后会报 gl.texImage2D 的错误