### PR TITLE
fix audioSource destroy bug

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -177,7 +177,7 @@ Audio.State = {
 
     proto.destroy = function () {
         if (CC_WECHATGAME) {
-            this._element.destroy();
+            this._element && this._element.destroy();
         }
     };
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

audioSource 组件在没有play 之前就进行销毁操作，这时候 _element === null
直接调用 this.element.destroy()  会报错。这里加多一个判断

@jareguo 