### PR TITLE
Correct the MotionStreak rotation

### DIFF
--- a/cocos2d/motion-streak/CCMotionStreak.js
+++ b/cocos2d/motion-streak/CCMotionStreak.js
@@ -282,7 +282,11 @@ var MotionStreak = cc.Class({
         if (this._motionStreak) {
             // add root for let the global coordinates effective
             var node = this.node;
+            //correct the motionStreak rotation
+            const angle = cc.degreesToRadians(-this.node.rotation);
             var worldMt = node.getNodeToWorldTransform();
+            var correct = cc.affineTransformMake(Math.cos(angle), -Math.sin(angle), Math.sin(angle), Math.cos(angle), 0, 0);
+            worldMy = cc.affineTransformConcatIn(worldMt, correct);
             // calculation anchor coordinates
             var tx = worldMt.tx - (node.width / 2 + node.anchorX * node.width);
             var ty = worldMt.ty - (node.height / 2 + node.anchorY * node.height);


### PR DESCRIPTION
MotionStreak Rotation should always keep the same with the action path

Re: cocos-creator/engine#2604

Changelog:
 * 修复 MotionStreak 因绑定节点旋转角度改变引起的位置错误，具体表现为未按照运动路径进行运动显示。

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->