### PR TITLE
fix _id in editor

### DIFF
--- a/cocos2d/core/platform/deserialize.js
+++ b/cocos2d/core/platform/deserialize.js
@@ -570,14 +570,25 @@ var _Deserializer = (function () {
             sources.push('}');
         }
         if (cc.js.isChildClassOf(klass, cc._BaseNode) || cc.js.isChildClassOf(klass, cc.Component)) {
+            let overwriteId = false;
             if (CC_PREVIEW || (CC_EDITOR && self._ignoreEditorOnly)) {
                 var mayUsedInPersistRoot = js.isChildClassOf(klass, cc.Node);
-                if (mayUsedInPersistRoot) {
-                    sources.push('d._id&&(o._id=d._id);');
-                }
+                overwriteId = mayUsedInPersistRoot;
             }
             else {
-                sources.push('d._id&&(o._id=d._id);');
+                overwriteId = true;
+            }
+            if (overwriteId) {
+                if (CC_EDITOR && cc.engine) {
+                    sources.push('if (d._id) {' +
+                                     'delete cc.engine.attachedObjsForEditor[o._id];' +
+                                     'o._id=d._id;' +
+                                     'cc.engine.attachedObjsForEditor[d._id] = o;' +
+                                 '}');
+                }
+                else {
+                    sources.push('d._id&&(o._id=d._id);');
+                }
             }
         }
         if (props[props.length - 1] === '_$erialized') {


### PR DESCRIPTION
Fix issue caused by #2627

Related cocos-creator/fireball#7256

Changelog:
 * 修复编辑器里 id 索引失败的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->