### PR TITLE
Fix Sprite fail to render when texture remain unchanged in sprite frame setter

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -218,9 +218,10 @@ var Sprite = cc.Class({
                 if ((lastSprite && lastSprite.getTexture()) !== (value && value.getTexture())) {
                     // Drop previous material, because texture have changed
                     this._material = null;
+                    this.node._renderFlag &= ~RenderFlow.FLAG_RENDER;
                 }
                 // render & update render data flag will be triggered while applying new sprite frame
-                this.node._renderFlag &= ~(RenderFlow.FLAG_RENDER | RenderFlow.FLAG_UPDATE_RENDER_DATA);
+                this.node._renderFlag &= ~RenderFlow.FLAG_UPDATE_RENDER_DATA;
                 this._applySpriteFrame(lastSprite);
                 if (CC_EDITOR) {
                     this.node.emit('spriteframe-changed', this);


### PR DESCRIPTION
Re: cocos-creator/fireball#7086

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->