### PR TITLE
fix CCMotionStreak color error for fireball/issues/7286

### DIFF
--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -220,7 +220,7 @@ var MotionStreak = cc.Class({
         let material = new SpriteMaterial();
         // TODO: old texture in material have been released by loader
         material.texture = this._texture;
-
+        material.useColor = false;
         this.setMaterial(material);
     },
 
@@ -241,8 +241,8 @@ var MotionStreak = cc.Class({
      * !#zh 删除当前所有的拖尾片段。
      * @method reset
      * @example
-     * // stop particle system.
-     * myParticleSystem.stopSystem();
+     * // Remove all living segments of the ribbon.
+     * myMotionStreak.reset();
      */
     reset: function () {
         this._points.length = 0;

--- a/cocos2d/core/renderer/assemblers/motion-streak.js
+++ b/cocos2d/core/renderer/assemblers/motion-streak.js
@@ -30,10 +30,12 @@ const renderEngine = require('../../renderer/render-engine');
 const MotionStreak = require('../../components/CCMotionStreak');
 const RenderFlow = require('../render-flow');
 
+const vfmtPosColorUv = require('../vertex-format').vfmtPosColorUv;
+
 function Point (point, dir) {
     this.point = point || cc.v2();
     this.dir = dir || cc.v2();
-    this.distance = 0
+    this.distance = 0;
     this.time = 0;
 }
 
@@ -197,10 +199,11 @@ var motionStreakAssembler = js.addon({
         let node = comp.node,
             renderData = comp._renderData,
             data = renderData._data;
-    
-        let buffer = renderer._meshBuffer,
+
+        let buffer = renderer.getBuffer('mesh', vfmtPosColorUv),
             vertexOffset = buffer.byteOffset >> 2,
             vbuf = buffer._vData,
+            uintbuf = buffer._uintVData,
             vertexCount = renderData.vertexCount;
         
         let ibuf = buffer._iData,
@@ -217,6 +220,7 @@ var motionStreakAssembler = js.addon({
             vbuf[vertexOffset++] = vert.y;
             vbuf[vertexOffset++] = vert.u;
             vbuf[vertexOffset++] = vert.v;
+            uintbuf[vertexOffset++] = vert.color;
         }
         
         // index buffer


### PR DESCRIPTION
Re: cocos-creator/fireball#7286

Changelog:
 *将 MotionStreak 改为使用 fmtPosColorUv，修复范例中切换贴图效果显示错误的 bug

错误效果：
![image](https://user-images.githubusercontent.com/7564028/40032888-895d0388-5828-11e8-9d84-95ea9ad94180.png)

目前效果：

![image](https://user-images.githubusercontent.com/7564028/40032973-f2cd80fe-5828-11e8-96ca-46ecf2a7a802.png)


@2youyou2 @pandamicro 