### PR TITLE
Reverts HTMLCanvasElement change in PR #2684.

### DIFF
--- a/jsb/builtin/jsb-adapter/HTMLCanvasElement.js
+++ b/jsb/builtin/jsb-adapter/HTMLCanvasElement.js
@@ -56,8 +56,8 @@ class HTMLCanvasElement extends HTMLElement {
 
         this.top = 0;
         this.left = 0;
-        this._width = width ? Math.ceil(width) : 1;
-        this._height = height ? Math.ceil(height) : 1;
+        this._width = width ? Math.ceil(width) : 0;
+        this._height = height ? Math.ceil(height) : 0;
         this._context2D = null;
         this._data = null;
         this._alignment = 4; // Canvas is used for rendering text only and we make sure the data format is RGBA.

--- a/jsb/builtin/jsb-adapter/HTMLCanvasElement.js
+++ b/jsb/builtin/jsb-adapter/HTMLCanvasElement.js
@@ -56,16 +56,11 @@ class HTMLCanvasElement extends HTMLElement {
 
         this.top = 0;
         this.left = 0;
-        this._width = width ? width : 0;
-        this._height = height ? height : 0;
-        var w = Math.ceil(this._width);
-        var h = Math.ceil(this._height);
-        w = w <= 0 ? 1 : w;
-        h = h <= 0 ? 1 : h;
-        this._bufferWidth = w % 2 === 0 ? w : ++w;
-        this._bufferHeight = h % 2 === 0 ? h : ++h;
+        this._width = width ? Math.ceil(width) : 1;
+        this._height = height ? Math.ceil(height) : 1;
         this._context2D = null;
         this._data = null;
+        this._alignment = 4; // Canvas is used for rendering text only and we make sure the data format is RGBA.
     }
 
     //TODO: implement opts.
@@ -76,12 +71,13 @@ class HTMLCanvasElement extends HTMLElement {
             return window.__ccgl;
         } else if (name === '2d') {
             if (!this._context2D) {
-                this._context2D = new CanvasRenderingContext2D(this._bufferWidth, this._bufferHeight);
+                this._context2D = new CanvasRenderingContext2D(this._width, this._height);
                 this._context2D._canvas = this;
                 this._context2D._setCanvasBufferUpdatedCallback(function(data) {
-                    // Canvas's data will take 2x memory size, one in C++, another is obtained by Uint8Array here.
-                    // HOW TO FIX ?
-                    self._data = new ImageData(data, self._bufferWidth, self._bufferHeight);
+                    // FIXME: Canvas's data will take 2x memory size, one in C++, another is obtained by Uint8Array here.
+                    self._data = new ImageData(data, self._width, self._height);
+                    // If the width of canvas could be divided by 2, it means that the bytes per row could be divided by 8.
+                    self._alignment = self._width % 2 === 0 ? 8 : 4;
                 });
             }
             return this._context2D;
@@ -97,13 +93,9 @@ class HTMLCanvasElement extends HTMLElement {
     }
 
     set width(width) {
-        this._width = width;
         width = Math.ceil(width);
-        // console.log(`==> HTMLCanvasElement.width = ${width}`);
-        // Make sure width could be divided by 2, otherwise text display may be wrong.
-        width = width % 2 === 0 ? width : ++width;
-        if (this._bufferWidth !== width) {
-            this._bufferWidth = width;
+        if (this._width !== width) {
+            this._width = width;
             if (this._context2D) {
                 this._context2D._width = width;
             }
@@ -115,13 +107,9 @@ class HTMLCanvasElement extends HTMLElement {
     }
 
     set height(height) {
-        this._height = height;
         height = Math.ceil(height);
-        // console.log(`==> HTMLCanvasElement.height = ${height}`);
-        // Make sure height could be divided by 2, otherwise text display may be wrong.
-        height = height % 2 === 0 ? height : ++height;
-        if (this._bufferHeight !== height) {
-            this._bufferHeight = height;
+        if (this._height !== height) {
+            this._height = height;
             if (this._context2D) {
                 this._context2D._height = height;
             }

--- a/jsb/builtin/jsb_opengl.js
+++ b/jsb/builtin/jsb_opengl.js
@@ -83,7 +83,8 @@ gl.texImage2D = function(target, level, internalformat, width, height, border, f
             if (image._data) {
                 data = image._data._data;
             }
-            _glTexImage2D(target, level, internalformat, image._bufferWidth, image._bufferHeight, 0, format, type, data);
+            _glPixelStorei(gl.UNPACK_ALIGNMENT, image._alignment);
+            _glTexImage2D(target, level, internalformat, image.width, image.height, 0, format, type, data);
         }
         else if (image instanceof ImageData) {
             _glTexImage2D(target, level, internalformat, image.width, image.height, 0, format, type, image._data);
@@ -127,7 +128,8 @@ gl.texSubImage2D = function(target, level, xoffset, yoffset, width, height, form
             if (image._data) {
                 data = image._data._data;
             }
-            _glTexSubImage2D(target, level, xoffset, yoffset, image._bufferWidth, image._bufferHeight, format, type, data);
+            _glPixelStorei(gl.UNPACK_ALIGNMENT, image._alignment);
+            _glTexSubImage2D(target, level, xoffset, yoffset, image.width, image.height, format, type, data);
         }
         else if (image instanceof ImageData) {
             _glTexSubImage2D(target, level, xoffset, yoffset, image.width, image.height, format, type, image._data);

--- a/jsb/builtin/jsb_opengl.js
+++ b/jsb/builtin/jsb_opengl.js
@@ -54,7 +54,6 @@ const HTMLCanvasElement = require('./jsb-adapter/HTMLCanvasElement');
 const HTMLImageElement = require('./jsb-adapter/HTMLImageElement');
 const ImageData = require('./jsb-adapter/ImageData');
 
-const _glPixelStorei = gl.pixelStorei;
 const _glTexImage2D = gl.texImage2D;
 
 /*
@@ -75,26 +74,24 @@ gl.texImage2D = function(target, level, internalformat, width, height, border, f
         format = width;
 
         if (image instanceof HTMLImageElement) {
-            _glPixelStorei(gl.UNPACK_ALIGNMENT, image._alignment);
-            _glTexImage2D(target, level, image._glInternalFormat, image.width, image.height, 0, image._glFormat, image._glType, image._data);
+            _glTexImage2D(target, level, image._glInternalFormat, image.width, image.height, 0, image._glFormat, image._glType, image._data, image._alignment);
         }
         else if (image instanceof HTMLCanvasElement) {
             var data = null;
             if (image._data) {
                 data = image._data._data;
             }
-            _glPixelStorei(gl.UNPACK_ALIGNMENT, image._alignment);
-            _glTexImage2D(target, level, internalformat, image.width, image.height, 0, format, type, data);
+            _glTexImage2D(target, level, internalformat, image.width, image.height, 0, format, type, data, image._alignment);
         }
         else if (image instanceof ImageData) {
-            _glTexImage2D(target, level, internalformat, image.width, image.height, 0, format, type, image._data);
+            _glTexImage2D(target, level, internalformat, image.width, image.height, 0, format, type, image._data, 0);
         }
         else {
             console.error("Invalid pixel argument passed to gl.texImage2D!");
         } 
     }
     else if (argCount == 9) {
-        _glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+        _glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels, 0);
     }
     else {
         console.error("gl.texImage2D: invalid argument count!");
@@ -120,26 +117,24 @@ gl.texSubImage2D = function(target, level, xoffset, yoffset, width, height, form
         format = width;
 
         if (image instanceof HTMLImageElement) {
-            _glPixelStorei(gl.UNPACK_ALIGNMENT, image._alignment);
-            _glTexSubImage2D(target, level, xoffset, yoffset, image.width, image.height, image._glFormat, image._glType, image._data);
+            _glTexSubImage2D(target, level, xoffset, yoffset, image.width, image.height, image._glFormat, image._glType, image._data, image._alignment);
         }
         else if (image instanceof HTMLCanvasElement) {
             var data = null;
             if (image._data) {
                 data = image._data._data;
             }
-            _glPixelStorei(gl.UNPACK_ALIGNMENT, image._alignment);
-            _glTexSubImage2D(target, level, xoffset, yoffset, image.width, image.height, format, type, data);
+            _glTexSubImage2D(target, level, xoffset, yoffset, image.width, image.height, format, type, data, image._alignment);
         }
         else if (image instanceof ImageData) {
-            _glTexSubImage2D(target, level, xoffset, yoffset, image.width, image.height, format, type, image._data);
+            _glTexSubImage2D(target, level, xoffset, yoffset, image.width, image.height, format, type, image._data, 0);
         }
         else {
             console.error("Invalid pixel argument passed to gl.texImage2D!");
         }
     }
     else if (argCount == 9) {
-        _glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+        _glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels, 0);
     }
     else {
         console.error((new Error("gl.texImage2D: invalid argument count!").stack));

--- a/jsb/gfx.js
+++ b/jsb/gfx.js
@@ -130,8 +130,8 @@ _p.update = function(options) {
 _p.updateSubImage = function(option) {
     var images = [option.image];
     convertImages(images);
-    var data = new Uint16Array(8 + 
-                               (images[0].length + 1) / 2);
+    var data = new Uint32Array(8 + 
+                               (images[0].length + 3) / 4);
 
     data[0] = option.x;
     data[1] = option.y;
@@ -140,11 +140,9 @@ _p.updateSubImage = function(option) {
     data[4] = option.level;
     data[5] = option.flipY;
     data[6] = false;
-
-    
     data[7] = images[0].length;
     var imageData = new Uint8Array(data.buffer);
-    imageData.set(images[0], 16);
+    imageData.set(images[0], 32);
 
     this.updateSubImageNative(data);
 };


### PR DESCRIPTION
Reverts PR #2684.
It's a bug of alignment value while reading texture. Adds _alignment variable in HTMLCanvasElement.

Depends on https://github.com/cocos-creator/cocos2d-x-lite/pull/1249