### PR TITLE
fix fireball/issues/7323, loading image should return an image resource

### DIFF
--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -407,7 +407,8 @@ var Texture2D = cc.Class({
         // load image
         var self = this;
         cc.loader.load({
-            url: this.url
+            url: this.url,
+            _owner: this
         }, function (err, image) {
             if (image) {
                 if (CC_DEBUG && image instanceof cc.Texture2D) {


### PR DESCRIPTION
Re: cocos-creator/fireball#7323

Changelog:
 * 这里的 load image，想要得到的是 image 资源，所以加了 _owner，使 loadimage 不处理创建 texture2d 的阶段