### PR TITLE
Improve checking whether is a subdomain method

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -576,7 +576,7 @@ else if (CC_WECHATGAME) {
     sys.osVersion = version[0];
     sys.osMainVersion = parseInt(sys.osVersion);
     // wechagame subdomain
-    if (wx.getGroupCloudStorage && wx.getFriendCloudStorage) {
+    if (!wx.getFileSystemManager) {
         sys.browserType = sys.BROWSER_TYPE_WECHAT_GAME_SUB;
     }
     else {


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 在某些版本下，主域中还是有包含 wx.getGroupCloudStorage && wx.getFriendCloudStorage api 的，所以改为检查 wx.getFileSystemManager 是否可用来确定是否是子域