### PR TITLE
Cache supported extensions and support to get compressed texture extension object.

### DIFF
--- a/jsb/builtin/jsb-adapter/EventTarget.js
+++ b/jsb/builtin/jsb-adapter/EventTarget.js
@@ -285,9 +285,12 @@ jsb.onTouchCancel = touchEventHandlerFactory('touchcancel');
 function mouseEventHandlerFactory(type) {
     return (event) => {
         const mouseEvent = new MouseEvent(type);
+        var button = event.button;
+        mouseEvent.button = button;
+        mouseEvent.which = button + 1;
         mouseEvent.wheelDelta = event.wheelDeltaY;
-        mouseEvent.clientX = mouseEvent.screenX = event.x;
-        mouseEvent.clientY = mouseEvent.screenY = event.y;
+        mouseEvent.clientX = mouseEvent.screenX = mouseEvent.pageX = event.x;
+        mouseEvent.clientY = mouseEvent.screenY = mouseEvent.pageY = event.y;
 
         var target;
         for (let key in __listenMouseEventMap) {

--- a/jsb/builtin/jsb-adapter/HTMLElement.js
+++ b/jsb/builtin/jsb-adapter/HTMLElement.js
@@ -39,8 +39,6 @@ class HTMLElement extends Element {
       height: `${window.innerHeight}px`
     }
 
-    this.insertBefore = noop
-
     this.innerHTML = ''
     this.parentElement = window.__cccanvas
   }

--- a/jsb/builtin/jsb-adapter/Node.js
+++ b/jsb/builtin/jsb-adapter/Node.js
@@ -40,6 +40,16 @@ class Node extends EventTarget {
     }
   }
 
+  insertBefore(newNode, referenceNode) {
+    //TODO:
+    return newNode;
+  }
+
+  replaceChild(newChild, oldChild) {
+    //TODO:
+    return oldChild;
+  }
+
   cloneNode() {
     const copyNode = Object.create(this)
 

--- a/jsb/builtin/jsb_opengl.js
+++ b/jsb/builtin/jsb_opengl.js
@@ -37,16 +37,58 @@ gl.drawingBufferHeight = window.innerHeight;
 //
 // Extensions
 //
+
+const WebGLCompressedTextureS3TC = {
+    COMPRESSED_RGB_S3TC_DXT1_EXT: 0x83F0, // A DXT1-compressed image in an RGB image format.
+    COMPRESSED_RGBA_S3TC_DXT1_EXT: 0x83F1,// A DXT1-compressed image in an RGB image format with a simple on/off alpha value.
+    COMPRESSED_RGBA_S3TC_DXT3_EXT: 0x83F2,// A DXT3-compressed image in an RGBA image format. Compared to a 32-bit RGBA texture, it offers 4:1 compression.
+    COMPRESSED_RGBA_S3TC_DXT5_EXT: 0x83F3 // A DXT5-compressed image in an RGBA image format. It also provides a 4:1 compression, but differs to the DXT3 compression in how the alpha compression is done.
+};
+
+const WebGLCompressedTextureETC1 = {
+    COMPRESSED_RGB_ETC1_WEBGL: 0x8D64 // Compresses 24-bit RGB data with no alpha channel.
+};
+
+const WebGLCompressedTexturePVRTC = {
+    COMPRESSED_RGB_PVRTC_4BPPV1_IMG: 0x8C00, //  RGB compression in 4-bit mode. One block for each 4×4 pixels.
+    COMPRESSED_RGBA_PVRTC_4BPPV1_IMG: 0x8C02,//  RGBA compression in 4-bit mode. One block for each 4×4 pixels.
+    COMPRESSED_RGB_PVRTC_2BPPV1_IMG: 0x8C01, //  RGB compression in 2-bit mode. One block for each 8×4 pixels.
+    COMPRESSED_RGBA_PVRTC_2BPPV1_IMG: 0x8C03 //  RGBA compression in 2-bit mode. One block for each 8×4 pixe
+};
+
+var extensionPrefixArr = ['MOZ_', 'WEBKIT_'];
+
+var extensionMap = {
+    WEBGL_compressed_texture_s3tc: WebGLCompressedTextureS3TC,
+    WEBGL_compressed_texture_pvrtc: WebGLCompressedTexturePVRTC,
+    WEBGL_compressed_texture_etc1: WebGLCompressedTextureETC1
+};
+
 // From the WebGL spec:
 // Returns an object if, and only if, name is an ASCII case-insensitive match [HTML] for one of the names returned from getSupportedExtensions;
 // otherwise, returns null. The object returned from getExtension contains any constants or functions provided by the extension.
 // A returned object may have no constants or functions if the extension does not define any, but a unique object must still be returned.
 // That object is used to indicate that the extension has been enabled.
 // XXX: The returned object must return the functions and constants.
+
+var supportedExtensions = gl.getSupportedExtensions();
+
 gl.getExtension = function(extension) {
-    var extensions = gl.getSupportedExtensions();
-    if (extensions.indexOf(extension) > -1)
-        return {};
+    var prefix;
+    for (var i = 0, len = extensionPrefixArr.length; i < len; ++i) {
+        prefix = extensionPrefixArr[i];
+        if (extension.startsWith(prefix)) {
+            extension = extension.substring(prefix.length);
+            break;
+        }
+    }
+
+    if (supportedExtensions.indexOf(extension) > -1) {
+        if (extension in extensionMap) {
+            return extensionMap[extension];
+        }
+    }
+
     return null;
 };
 

--- a/jsb/builtin/jsb_opengl.js
+++ b/jsb/builtin/jsb_opengl.js
@@ -87,6 +87,7 @@ gl.getExtension = function(extension) {
         if (extension in extensionMap) {
             return extensionMap[extension];
         }
+        return {}; //TODO: Return an empty object to indicate this platform supports the extension. But we should not return an empty object actually.
     }
 
     return null;


### PR DESCRIPTION
And:
* Empty implementation for Node.insertBefore and Node.replaceChild.
* Mouse event should contain `button` & `which` & pageX & pageY properties.
* Removes insertBefore assignment in HTMLElement.js.