### PR TITLE
修正Fixture对象没有被正确Destroy问题

### DIFF
--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -1045,6 +1045,15 @@ var BaseNode = cc.Class({
     _disableChildComps () {
         // leave this._activeInHierarchy unmodified
         var i, len = this._components.length;
+
+        // disable fixture first
+        for (i = 0; i < len; ++i) {
+            var component = this._components[i];
+            if (component._fixtures && component._fixtures.length >= 0) {
+                component._enabled && cc.director._compScheduler.disableComp(component);
+            }
+        }
+
         for (i = 0; i < len; ++i) {
             var component = this._components[i];
             if (component._enabled) {


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 当游戏系统使用了碰撞系统后，在调用_disableChildComps时，由于数组遍历的顺序，有可能先销毁body再销毁其fixture，这就导致了cc.PhysicsCollider 的__destroy 在执行 DestroyFixture时，其body不存在。故这里通过调整调用顺序来确保正确。

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->