### PR TITLE
sync showLabels and resize view on input blur on mobile platform

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -242,15 +242,26 @@ let EditBoxImpl = cc.Class({
     },
     
     _endEditing () {
-        if (!this._alwaysOnTop) {
-            this._edTxt.style.display = 'none';
-        }
-        if (cc.sys.isMobile && this._editing) {
-            let self = this;
-            // Delay end editing adaptation to ensure virtual keyboard is disapeared
-            setTimeout(function () {
-                self._endEditingOnMobile();
-            }, DELAY_TIME);
+        let self = this;
+        let hideDomInputAndShowLabel = function () {
+            if (!self._alwaysOnTop) {
+                self._edTxt.style.display = 'none';
+            }
+            if (self._delegate && self._delegate.editBoxEditingDidEnded) {
+                self._delegate.editBoxEditingDidEnded();
+            }
+        };
+        if (this._editing) {
+            if (cc.sys.isMobile) {
+                // Delay end editing adaptation to ensure virtual keyboard is disapeared
+                setTimeout(function () {
+                    self._endEditingOnMobile();
+                    hideDomInputAndShowLabel();
+                }, DELAY_TIME);
+            }
+            else {
+                hideDomInputAndShowLabel();
+            }
         }
         this._editing = false;
     },
@@ -444,23 +455,18 @@ function registrationInputEventListener (tmpEdTxt, editBoxImpl, isTextarea) {
         if (e.keyCode === macro.KEY.enter) {
             e.stopPropagation();
 
+            if (editBoxImpl._delegate && editBoxImpl._delegate.editBoxEditingReturn) {
+                editBoxImpl._delegate.editBoxEditingReturn();
+            }
             if (!isTextarea) {
                 editBoxImpl._text = this.value;
                 editBoxImpl._endEditing();
                 cc.game.canvas.focus();
             }
-            if (editBoxImpl._delegate && editBoxImpl._delegate.editBoxEditingReturn) {
-                editBoxImpl._delegate.editBoxEditingReturn();
-            }
         }
     });
     tmpEdTxt.addEventListener('blur', function () {
         editBoxImpl._text = this.value;
-
-        if (editBoxImpl._delegate && editBoxImpl._delegate.editBoxEditingDidEnded) {
-            editBoxImpl._delegate.editBoxEditingDidEnded();
-        }
-
         editBoxImpl._endEditing();
     });
 


### PR DESCRIPTION
Re: cocos-creator/fireball#7286

修复问题：
mobile 平台在隐藏输入键盘的时候进行了resizeView, 这里的resize操作设定了一个延时
但是label 的显示控制 没有同步做延时操作，导致editBox 错位问题

![](https://user-images.githubusercontent.com/14326991/39920735-b375b65a-554a-11e8-9ccd-880fbfecb83d.png)