### PR TITLE
fix fireball/issues/7368

### DIFF
--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -1245,8 +1245,8 @@ var ScrollView = cc.Class({
             this._autoScrolling = false;
         }
 
-        var contentPos = cc.pSub(newPosition, this.getContentPosition());
-        this._moveContent(contentPos, reachedEnd);
+        var deltaMove = cc.pSub(newPosition, this.getContentPosition());
+        this._moveContent(this._clampDelta(deltaMove), reachedEnd);
         this._dispatchEvent('scrolling');
 
         if (!this._autoScrolling) {
@@ -1334,7 +1334,6 @@ var ScrollView = cc.Class({
                 this._autoScrollBraking = true;
             }
         }
-
     },
 
     _calculateTouchMoveVelocity: function() {
@@ -1365,7 +1364,6 @@ var ScrollView = cc.Class({
 
     _moveContent: function(deltaMove, canStartBounceBack) {
         var adjustedMove = this._flattenVectorByDirection(deltaMove);
-
         var newPosition = cc.pAdd(this.getContentPosition(), adjustedMove);
 
         this.setContentPosition(newPosition);
@@ -1376,9 +1374,7 @@ var ScrollView = cc.Class({
         if (this.elastic && canStartBounceBack) {
             this._startBounceBackIfNeeded();
         }
-
     },
-
 
     _getContentLeftBoundary: function() {
         var contentPos = this.getContentPosition();


### PR DESCRIPTION
Re: cocos-creator/fireball#7368

Changelog:
 * ScrollView 在特定操作下，调用了 _processAutoScrolling，但是在 _moveContent 传入的参数没有进行 _clampDelta 判断，导致 7368 的 bug 出现

_clampDelta 这里是判断 ScrollView 的 contentSize 有没有大于 scrollViewSize，如果没有要进行限制