### PR TITLE
new instantiated nodes should clean it's fileId before adding to other prefabs

### DIFF
--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -1107,8 +1107,11 @@ var BaseNode = cc.Class({
             var myPrefabInfo = this._prefab;
             if (myPrefabInfo) {
                 if (newPrefabRoot) {
-                    // change prefab
-                    _Scene.PrefabUtils.linkPrefab(newPrefabRoot._prefab.asset, newPrefabRoot, this);
+                    if (myPrefabInfo.root !== newPrefabRoot) {
+                        // change prefab
+                        _Scene.PrefabUtils.unlinkPrefab(this);
+                        _Scene.PrefabUtils.linkPrefab(newPrefabRoot._prefab.asset, newPrefabRoot, this);
+                    }
                 }
                 else if (myPrefabInfo.root !== this) {
                     // detach from prefab


### PR DESCRIPTION
修复多次拖到同一个 prefab 作为其它 prefab 的子节点会报错的问题