### PR TITLE
fix AudioSources error to JSB

### DIFF
--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -24,7 +24,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-const Audio = require('../../audio/CCAudio');
+const Audio = CC_JSB ? cc.Audio : require('../../audio/CCAudio');
 const AudioClip = require('../assets/CCAudioClip');
 
 /**


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 修复在 JSB 中不支持 'Audio' 