### PR TITLE
Revert "move inputManger into _cc namespace"

### DIFF
--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -604,6 +604,9 @@ var inputManager = {
     }
 };
 
-_cc.inputManager = inputManager;
+js.get(cc, 'inputManager', function () {
+    cc.warnID(1405, 'cc.inputManager', 'cc.systemEvent');
+    return inputManager;
+});
 
 module.exports = inputManager;

--- a/index.js
+++ b/index.js
@@ -37,9 +37,6 @@
 cc = {};
 _ccsg = {};
 
-// For internal usage
-_cc = {};
-
 require('./predefine');
 require('./CCDebugger');
 


### PR DESCRIPTION
Reverts cocos-creator/engine#2832