### PR TITLE
fix dragonbones texturedata clear error

### DIFF
--- a/extensions/dragonbones/CCTextureData.js
+++ b/extensions/dragonbones/CCTextureData.js
@@ -57,7 +57,6 @@ dragonBones.CCTextureData = cc.Class({
     _onClear : function() {
         dragonBones.TextureData.prototype._onClear.call(this);
         if (this.texture) {
-            this.texture.dispose();
             this.texture = null;
         }
     }


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 手动调用 dragonbones texturedata clear 会报错，因为 texture 是 spriteframe 不是 texture2d