### PR TITLE
fixed editorbox stayOnTop exTxt value error

### DIFF
--- a/cocos2d/core/editbox/CCSGEditBox.js
+++ b/cocos2d/core/editbox/CCSGEditBox.js
@@ -1049,6 +1049,9 @@ _ccsg.EditBox.KeyboardReturnType = KeyboardReturnType;
         else if (inputFlag === InputFlag.INITIAL_CAPS_SENTENCE) {
             this._editBox._text = capitalizeFirstLetter(this._editBox._text);
         }
+        if (this._edTxt) {
+            this._edTxt.value = this._editBox._text;
+        }
     };
 
     proto._updateLabelStringStyle = function() {


### PR DESCRIPTION
Re: cocos-creator/fireball#7727

Changelog:
 * 修复 EditorBox 勾选 stayOnTop 时，InputFlag 无效的 bug