### PR TITLE
Fix stop audio unable to call onended

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -206,6 +206,7 @@ Audio.State = {
             this._element.currentTime = 0;
         } catch (error) {}
         this._element.pause();
+        this._onended && this._onended();
         // remove touchPlayList
         for (var i=0; i<touchPlayList.length; i++) {
             if (touchPlayList[i].instance === this) {
@@ -213,8 +214,8 @@ Audio.State = {
                 break;
             }
         }
-        this._unbindEnded();
         this.emit('stop');
+        this._unbindEnded();
         this._state = Audio.State.PAUSED;
     };
 

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -107,7 +107,7 @@ var audioEngine = {
         var audio = getAudioFromPath(filePath);
         var callback = function () {
             audio.setLoop(loop || false);
-            if (typeof volume != 'number' || isNaN(volume)) {
+            if (typeof volume !== 'number' || isNaN(volume)) {
                 volume = 1;
             }
             audio.setVolume(volume);


### PR DESCRIPTION
Re: cocos-creator/fireball#7722

Changelog:
 * 修复暂停 audio 时无法触发 onended 事件，导致 cc.audioEngine.setFinishCallback 无效