### PR TITLE
fix _unregisterAccelerometerEvent err

### DIFF
--- a/cocos2d/core/platform/CCInputExtension.js
+++ b/cocos2d/core/platform/CCInputExtension.js
@@ -32,6 +32,8 @@ var inputManager = require("./CCInputManager");
 
 inputManager.__instanceId = cc.ClassManager.getNewInstanceId();
 
+var _didAccelerateFun;
+
 /**
  * whether enable accelerometer event
  * @method setAccelerometerEnabled
@@ -92,7 +94,8 @@ inputManager._registerAccelerometerEvent = function(){
         _t._minus = -1;
     }
 
-    w.addEventListener(_deviceEventType, _t.didAccelerate.bind(_t), false);
+    _didAccelerateFun = _t.didAccelerate.bind(_t);
+    w.addEventListener(_deviceEventType, _didAccelerateFun, false);
 };
 
 inputManager._unregisterAccelerometerEvent = function () {

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -610,6 +610,5 @@ js.get(cc, 'inputManager', function () {
     cc.warnID(1405, 'cc.inputManager', 'cc.systemEvent');
     return inputManager;
 });
-_cc.inputManager = inputManager;
 
-module.exports = inputManager;
+module.exports = _cc.inputManager = inputManager;


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 之前同步 _unregisterAccelerometerEvent 没有定义内部使用的对象 _didAccelerateFun 现在补上