### PR TITLE
fix particleSystem load bug

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -940,7 +940,7 @@ var ParticleSystem = cc.Class({
     },
 
     _initTextureWithDictionary: function (dict) {
-        var imgPath = cc.path.changeBasename(this._plistFile, dict["textureFileName"]);
+        var imgPath = cc.path.changeBasename(this._plistFile, dict["textureFileName"] || '');
         // texture
         if (dict["textureFileName"]) {
             // Try to get the texture from the cache


### PR DESCRIPTION
Re: cocos-creator/fireball#7751

有些粒子资源不带有 textureFileName 字段，导致粒子资源解析 报错