### PR TITLE
Bug: canvas measureText function would return undefined

### DIFF
--- a/cocos2d/core/label/CCSGLabelCanvasRenderCmd.js
+++ b/cocos2d/core/label/CCSGLabelCanvasRenderCmd.js
@@ -118,6 +118,11 @@
         return fontDesc;
     };
 
+    proto._safeMeasureText = function (ctx, string) {
+        var metric = ctx.measureText(string);
+        return metric && metric.width || 0;
+    };
+
     proto._measureText = function (ctx) {
         return function(string) {
             return ctx.measureText(string).width;
@@ -176,13 +181,13 @@
                     totalHeight = 0;
                     for (i = 0; i < paragraphedStrings.length; ++i) {
                         var j = 0;
-                        var allWidth = this._labelContext.measureText(paragraphedStrings[i]).width;
+                        var allWidth = this._safeMeasureText(this._labelContext, paragraphedStrings[i]);
                         textFragment = cc.TextUtils.fragmentText(paragraphedStrings[i],
                                                                  allWidth,
                                                                  canvasWidthNoMargin,
                                                                  this._measureText(this._labelContext));
                         while(j < textFragment.length) {
-                            var measureWidth = this._labelContext.measureText(textFragment[j]).width;
+                            var measureWidth = this._safeMeasureText(this._labelContext, textFragment[j]);
                             maxLength = measureWidth;
                             totalHeight += this._getLineHeight();
                             ++j;
@@ -228,8 +233,7 @@
         var paragraphLength = [];
 
         for (var i = 0; i < paragraphedStrings.length; ++i) {
-            var textMetric = ctx.measureText(paragraphedStrings[i]);
-            paragraphLength.push(textMetric.width);
+            paragraphLength.push(this._safeMeasureText(ctx, paragraphedStrings[i]));
         }
 
         return paragraphLength;
@@ -255,7 +259,7 @@
             this._splitedStrings = [];
             var canvasWidthNoMargin = this._canvasSize.width - 2 * this._getMargin();
             for (i = 0; i < paragraphedStrings.length; ++i) {
-                var allWidth = this._labelContext.measureText(paragraphedStrings[i]).width;
+                var allWidth = this._safeMeasureText(this._labelContext, paragraphedStrings[i]);
                 var textFragment = cc.TextUtils.fragmentText(paragraphedStrings[i],
                                                              allWidth,
                                                              canvasWidthNoMargin,
@@ -284,7 +288,7 @@
             var canvasSizeX = 0;
             var canvasSizeY = 0;
             for (i = 0; i < paragraphedStrings.length; ++i) {
-                var paraLength = ctx.measureText(paragraphedStrings[i]).width;
+                var paraLength = this._safeMeasureText(ctx, paragraphedStrings[i]);
                 canvasSizeX = canvasSizeX > paraLength ? canvasSizeX : paraLength;
             }
             canvasSizeY = this._splitedStrings.length * this._getLineHeight();


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 
微信后台之后，label 下的 measureText 方法会返回 undefined 引起了一些错误。
此处做了一些保护

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->