### PR TITLE
fix audio bug to wechatgame for fireball/issues/7775

### DIFF
--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -38,7 +38,7 @@ function loadDomAudio (item, callback) {
 
     if (sys.platform === sys.WECHAT_GAME) {
         item.element = dom;
-        callback(null, item.url);
+        callback(null, item.id);
         return;
     }
 


### PR DESCRIPTION
Re: cocos-creator/fireball#7775

Changelog:
 * 修复在微信小游戏下， 通过 loadRes 加载后存储资源的 key 错误，应该是 raw 路径才对