### PR TITLE
Fix bug when font is null and useSystemFont is false

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -418,6 +418,12 @@ let Label = cc.Class({
                 this._isSystemFontUsed = !!value;
                 if (value) {
                     this.font = null;
+                    this._updateAssembler();
+                    this._updateRenderData();
+                    this._checkStringEmpty();
+                }
+                else if (!this._userDefinedFont) {
+                    this.disableRender();
                 }
 
             },


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 修复 font 为 null 时，并且 useSystemFont 为 false，报错的 bug