### PR TITLE
fix Build unchecked md5 will report an error for issues/7845

### DIFF
--- a/cocos2d/core/platform/CCAssetLibrary.js
+++ b/cocos2d/core/platform/CCAssetLibrary.js
@@ -285,7 +285,7 @@ var AssetLibrary = {
         _rawAssetsBase = options.rawAssetsBase;
 
         var md5AssetsMap = options.md5AssetsMap;
-        if (md5AssetsMap) {
+        if (md5AssetsMap && md5AssetsMap.import) {
             // decode uuid
             for (var folder in md5AssetsMap) {
                 var md5Map = js.createMap(true);


### PR DESCRIPTION
Re: cocos-creator/fireball#7845

Changelog:
 * 修复 QQPlay 平台构建面板不勾选 MD5 时，运行后显示黑屏