### PR TITLE
fixed isMobile value error to wxgame devtools

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -609,6 +609,7 @@ function initSys () {
             sys.os = sys.OS_IOS;
         }
         else if (env.platform === 'devtools') {
+            sys.isMobile = false;
             if (system.indexOf('android') > -1) {
                 sys.os = sys.OS_ANDROID;
             }


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 修复在微信工具中 isMobile 的数值