### PR TITLE
set  _renderComponent is null in mask disable

### DIFF
--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -375,6 +375,7 @@ let Mask = cc.Class({
     },
 
     onDisable () {
+        this._super();
         this.node._renderFlag &= ~(RenderFlow.FLAG_POST_RENDER | RenderFlow.FLAG_POST_UPDATE_RENDER_DATA);
     },
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 当 Mask 被 disable 当时候应该要把 _renderComponent 赋值为 null 才行