### PR TITLE
fix videoplay unable to trigger EventType.COMPLETED event

### DIFF
--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -69,7 +69,7 @@ let VideoPlayerImpl = cc.Class({
             self._dispatchEvent(VideoPlayerImpl.EventType.META_LOADED);
         };
         cbs.ended = function () {
-            if (this._video !== video) return;
+            if (self._video !== video) return;
             self._playing = false;
             self._dispatchEvent(VideoPlayerImpl.EventType.COMPLETED);
         };


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 修复 videoplay 无法触发 COMPLETED 事件的 bug