### PR TITLE
componentEventHandler serialize compId instead of compName

### DIFF
--- a/cocos2d/core/components/CCComponentEventHandler.js
+++ b/cocos2d/core/components/CCComponentEventHandler.js
@@ -63,8 +63,18 @@ cc.Component.EventHandler = cc.Class({
          * @type {String}
          * @default ''
          */
-        component: {
-            default: '',
+        // only for deserializing old project component field
+        component: '',
+        _componentId: '',
+        _componentName: {
+            get () {
+                this._genCompIdIfNeeded();
+
+                return this._compId2Name(this._componentId);
+            },
+            set (value) {
+                this._componentId = this._compName2Id(value);
+            },
         },
         /**
          * !#en Event handler
@@ -131,7 +141,10 @@ cc.Component.EventHandler = cc.Class({
         var target = this.target;
         if (!cc.isValid(target)) return;
 
-        var comp = target.getComponent(this.component);
+        this._genCompIdIfNeeded();
+        var compType = cc.js._getClassById(this._componentId);
+        
+        var comp = target.getComponent(compType);
         if (!cc.isValid(comp)) return;
 
         var handler = comp[this.handler];
@@ -143,5 +156,23 @@ cc.Component.EventHandler = cc.Class({
         }
 
         handler.apply(comp, params);
-    }
+    },
+
+    _compName2Id (compName) {
+        let comp = cc.js.getClassByName(compName);
+        return cc.js._getClassId(comp);
+    },
+
+    _compId2Name (compId) {
+        let comp = cc.js._getClassById(compId);
+        return cc.js.getClassName(comp);
+    },
+
+    // to be deprecated in the future
+    _genCompIdIfNeeded () {
+        if (!this._componentId) {
+            this._componentName = this.component;
+            this.component = '';
+        }
+    },
 });


### PR DESCRIPTION
Re: cocos-creator/fireball#1816

component 是准备废弃的字段，目前用来兼容旧项目
clickEventHandler 现在存储 _compnentId，防止脚本名字修改后就丢失了 component 引用
_componentName 在每次 get/set 时候进行 compId2Name / compName2Id 操作

关联pr:
https://github.com/cocos-creator/fireball/pull/7916

@cocos-creator/admins 