### PR TITLE
fix get texture value for particle system

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -255,7 +255,7 @@ var properties = {
      */
     texture: {
         get: function () {
-            return this._texture ? this._texture.url : "";
+            return this._texture;
         },
         set: function (value) {
             cc.warnID(6017);


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 修复粒子系统返回的 texture 数值错误