### PR TITLE
cut debug info when build project

### DIFF
--- a/gulp/tasks/engine.js
+++ b/gulp/tasks/engine.js
@@ -148,7 +148,7 @@ exports.buildCocosJsMin = function (sourceFile, outputFile, excludes, opt_macroF
         bundler.ignore(file);
     });
 
-    bundler.ignore('./DebugInfos.json');
+    bundler.ignore(Path.resolve(__dirname, '../../DebugInfos.json'));
 
     var Size = null;
     try {
@@ -306,7 +306,7 @@ exports.buildJsbMin = function (sourceFile, outputFile, excludes, opt_macroFlags
         bundler.ignore(require.resolve(module));
     });
 
-    bundler.ignore('../../DebugInfos.json');
+    bundler.ignore(Path.resolve(__dirname, '../../DebugInfos.json'));
 
     bundler.bundle()
         .on('error', HandleErrors.handler)


### PR DESCRIPTION
Log: 
- 补充 bundler.ignore 编辑器 DebugInfo.json 相对路径
- 补充 cocos2d-jsb-min.js 忽略 DebugInfo.json

@cocos-creator/admins 