### PR TITLE
fix editbox setting string will not be updated immediately for fireball/issues/7890

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -479,6 +479,7 @@ let EditBox = cc.Class({
 
         textLabel.string = displayText;
         this._impl.setString(text);
+        this._showLabels();
     },
 
     _updateLabelStringStyle (text, ignorePassword) {


### PR DESCRIPTION
Re: cocos-creator/fireball#7890

Changelog:
 * 修复 Editbox 用代码设置 string 不会立即更新