### PR TITLE
return spriteAtlas-related spriteFrames when loadResDir

### DIFF
--- a/cocos2d/core/assets/CCSpriteAtlas.js
+++ b/cocos2d/core/assets/CCSpriteAtlas.js
@@ -62,7 +62,14 @@ var SpriteAtlas = cc.Class({
      * @returns {SpriteFrame}
      */
     getSpriteFrame: function (key) {
-        return this._spriteFrames[key];
+        let sf = this._spriteFrames[key];
+        if (!sf) {
+            return null;
+        } 
+        if (!sf.name) {
+            sf.name = key;
+        }
+        return sf;
     },
 
     /**
@@ -75,7 +82,7 @@ var SpriteAtlas = cc.Class({
         var spriteFrames = this._spriteFrames;
 
         for (var key in spriteFrames) {
-            frames.push(spriteFrames[key]);
+            frames.push(this.getSpriteFrame(key));
         }
 
         return frames;

--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -639,7 +639,24 @@ proto.loadResDir = function (url, type, progressCallback, completeCallback) {
 
     var urls = [];
     var uuids = resources.getUuidArray(url, type, urls);
-    this._loadResUuids(uuids, progressCallback, completeCallback, urls);
+    this._loadResUuids(uuids, progressCallback, function (errors, assetRes, urlRes) {
+        // The spriteFrame url in spriteAtlas will be removed after build project
+        // To show users the exact structure in asset panel, we need to return the spriteFrame assets in spriteAtlas
+        let assetResLength = assetRes.length;
+        for (let i = 0; i < assetResLength; ++i) {
+            if (assetRes[i] instanceof cc.SpriteAtlas) {
+                let spriteFrames = assetRes[i].getSpriteFrames();
+                for (let k in spriteFrames) {
+                    let sf = spriteFrames[k];
+                    assetRes.push(sf);
+                    if (urlRes) {
+                        urlRes.push(`${urlRes[i]}/${sf.name}`);
+                    }
+                }
+            }
+        }
+        completeCallback(errors, assetRes, urlRes);
+    }, urls);
 };
 
 /**


### PR DESCRIPTION
Re: cocos-creator/fireball#6757

loadResDir 时候没有返回 atlas 相关的 spriteFrames
导致 release 资源的时候，textures 释放了，spriteFrames 没有释放
再次加载 atlas 时 textures 无法加载，显示出错

@cocos-creator/admins 