### PR TITLE
rm globalCompositeOperation for ttf

### DIFF
--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -263,7 +263,6 @@ module.exports = {
         for (let i = 0; i < _splitedStrings.length; ++i) {
             if (_isOutlined) {
                 let strokeColor = _outlineColor || WHITE;
-                _context.globalCompositeOperation = 'source-over';
                 _context.strokeStyle = `rgba(${strokeColor.r}, ${strokeColor.g}, ${strokeColor.b}, ${strokeColor.a / 255})`;
                 _context.lineWidth = _outlineWidth * 2;
                 _context.strokeText(_splitedStrings[i], startPosition.x, startPosition.y + i * lineHeight);


### PR DESCRIPTION
fix set_globalCompositeOperation isn't implemented error

Re: cocos-creator/fireball#

Changelog:
 * 移除设置 globalCompositeOperation 属性
