### PR TITLE
fix loadResDir completeCallback absent issue

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -655,7 +655,7 @@ proto.loadResDir = function (url, type, progressCallback, completeCallback) {
                 }
             }
         }
-        completeCallback(errors, assetRes, urlRes);
+        completeCallback && completeCallback(errors, assetRes, urlRes);
     }, urls);
 };
 


### PR DESCRIPTION
修复一个小问题 loadResDir 传入的 completeCallback 没有检测是否存在