### PR TITLE
fix editbox show multi labels when editing

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -482,7 +482,9 @@ let EditBox = cc.Class({
 
         textLabel.string = displayText;
         this._impl.setString(text);
-        this._showLabels();
+        if (!this._impl._editing) {
+            this._showLabels();
+        }
     },
 
     _updateLabelStringStyle (text, ignorePassword) {


### PR DESCRIPTION
Re: cocos-creator/fireball#7944

之前用户反馈 editBox 给 string 赋值时，没有显示 label
这里 _showLabel() 的时候再加多一个 _editing 判断

@cocos-creator/admins 