### PR TITLE
Button allow enableAutoGrayEffect when COLOR transition being choosed

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -502,7 +502,7 @@ function _doDispatchEvent (owner, event) {
         }
     }
     _cachedArray.length = 0;
-};
+}
 
 /**
  * !#en

--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -661,14 +661,15 @@ let Button = cc.Class({
 
     _updateDisabledState () {
         if (this._sprite) {
-            this._sprite.setState(cc.Sprite.State.NORMAL);
-        }
-        if (this.enableAutoGrayEffect && this.transition !== Transition.COLOR) {
-            if (!(this.transition === Transition.SPRITE && this.disabledSprite)) {
-                if (this._sprite && !this.interactable) {
-                    this._sprite.setState(cc.Sprite.State.GRAY);
+            if (this.enableAutoGrayEffect) {
+                if (!(this.transition === Transition.SPRITE && this.disabledSprite)) {
+                    if (!this.interactable) {
+                        this._sprite.setState(cc.Sprite.State.GRAY);
+                        return;
+                    }
                 }
             }
+            this._sprite.setState(cc.Sprite.State.NORMAL);
         }
     }
 });


### PR DESCRIPTION
Re: https://github.com/cocos-creator/creator-docs/issues/519

Changelog:
 * 允许 Button 在选择 COLOR 动态效果并且被禁用时变灰

现在按钮 disable 时是这个效果
![image](https://user-images.githubusercontent.com/1503156/43318739-8c3bc018-91d4-11e8-8666-c67479070632.png)
如果我把 enableAutoGrayEffect 的限制去掉，启用 enableAutoGrayEffect 的同时 disable 是这个效果
![image](https://user-images.githubusercontent.com/1503156/43318749-968cecea-91d4-11e8-9885-878ce797c1fb.png)
应该后面这个才是正确的效果

之前的 PR：https://github.com/cocos-creator/fireball/pull/5019/files
PR 里没写这么改的原因，就写了 fix button color transition disabled color issue，看不懂 issue 在哪…… 所以就改回来吧



<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->