### PR TITLE
fix hex tilemap display error for fireball/issues/8053

### DIFF
--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -521,7 +521,7 @@ let TiledLayer = cc.Class({
         // offset (after layer orientation is set);
         this._offset = this._calculateLayerOffset(layerInfo.offset);
 
-        if (this.layerOrientation === cc.TiledMap.Orientation.HEX) {
+        if (this._layerOrientation === cc.TiledMap.Orientation.HEX) {
             let width = 0, height = 0;
             if (this._staggerAxis === cc.TiledMap.StaggerAxis.STAGGERAXIS_X) {
                 height = mapInfo._tileSize.height * (this._layerSize.height + 0.5);
@@ -543,7 +543,7 @@ let TiledLayer = cc.Class({
 
     _calculateLayerOffset (pos) {
         let ret = cc.v2(0,0);
-        switch (this.layerOrientation) {
+        switch (this._layerOrientation) {
             case cc.TiledMap.Orientation.ORTHO:
                 ret = cc.v2(pos.x * this._mapTileSize.width, -pos.y * this._mapTileSize.height);
                 break;

--- a/cocos2d/tilemap/CCTiledMapAsset.js
+++ b/cocos2d/tilemap/CCTiledMapAsset.js
@@ -60,7 +60,6 @@ let TiledMapAsset = cc.Class({
 
     createNode: CC_EDITOR && function (callback) {
         let node = new cc.Node(this.name);
-        node.setAnchorPoint(0,0);
         let tiledMap = node.addComponent(cc.TiledMap);
         tiledMap.tmxAsset = this;
 

--- a/cocos2d/tilemap/tmx-layer-assembler.js
+++ b/cocos2d/tilemap/tmx-layer-assembler.js
@@ -136,18 +136,18 @@ let tmxAssembler = {
             cols = comp._layerSize.width,
             grids = comp._texGrids,
             tiledTiles = comp._tiledTiles,
-            ox = node._position.x + comp._offset.x,
-            oy = node._position.y + comp._offset.y,
-            mapx = ox * a + oy * c + tx,
-            mapy = ox * b + oy * d + ty,
+            ox = comp._offset.x,
+            oy = comp._offset.y,
             w = tilew * a, h = tileh * d;
 
+        tx += ox * a + oy * c;
+        ty += ox * b + oy * d;
         // Culling
         let startCol = 0, startRow = 0,
             maxCol = cols, maxRow = rows;
 
-        let cullingA = a, cullingD = d, 
-            cullingMapx = mapx, cullingMapy = mapy,
+        let cullingA = a, cullingD = d,
+            cullingMapx = tx, cullingMapy = ty,
             cullingW = w, cullingH = h;
         let enabledCulling = cc.macro.ENABLE_TILEDMAP_CULLING;
         
@@ -168,7 +168,7 @@ let tmxAssembler = {
                 mat4.invert(_mat4_temp, _mat4_temp);
 
                 let rect = cc.visibleRect;
-                let a = _mat4_temp.m00, b = _mat4_temp.m01, c = _mat4_temp.m04, d = _mat4_temp.m05, 
+                let a = _mat4_temp.m00, b = _mat4_temp.m01, c = _mat4_temp.m04, d = _mat4_temp.m05,
                     tx = _mat4_temp.m12, ty = _mat4_temp.m13;
                 let v0x = rect.topLeft.x * a + rect.topLeft.y * c + tx;
                 let v0y = rect.topLeft.x * b + rect.topLeft.y * d + ty;


### PR DESCRIPTION
Re: cocos-creator/fireball#8053

Changelog:
 * 修复六边形的 TiledMap 显示错误