### PR TITLE
fix isloop value error in audioengine

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -161,9 +161,9 @@ var audioEngine = {
      */
     isLoop: function (audioID) {
         var audio = getAudioFromId(audioID);
-        if (!audio || !audio.isLoop)
+        if (!audio || !audio.getLoop)
             return false;
-        return audio.isLoop();
+        return audio.getLoop();
     },
 
     /**


### PR DESCRIPTION
Re: cocos-creator/fireball#

https://github.com/cocos-creator/engine/issues/2998

Changelog:
 * audio 中并没有 isLoop 函数，导致获取 loop 一直为 false