### PR TITLE
fix isloop value error in audioengine

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -178,9 +178,9 @@ var audioEngine = {
      */
     isLoop: function (audioID) {
         var audio = getAudioFromId(audioID);
-        if (!audio || !audio.isLoop)
+        if (!audio || !audio.getLoop)
             return false;
-        return audio.isLoop();
+        return audio.getLoop();
     },
 
     /**


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 *修复 audioengine 获取 loop 错误的 bug