### PR TITLE
Fix load font asset error in runtime

### DIFF
--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -185,6 +185,38 @@ module.exports = {
                     return false;
                 }
             }
+            else if (CC_RUNTIME) {
+                // load from font cache
+                if (CustomFontLoader._fontCache[url]) {
+                    _fontFamily = CustomFontLoader._fontCache[url];
+                    return true;
+                }
+                // load from local font
+                _fontFamily = jsb.loadFont(url);
+                if (_fontFamily) {
+                    CustomFontLoader._fontCache[url] = _fontFamily;
+                }
+                else {
+                    // load from remote font
+                    let item = url;
+                    if (md5Pipe) {
+                        item = {
+                            url: url,
+                            skips: [md5Pipe.id]
+                        };
+                    }                    
+                    cc.loader.load(item, function (err) {
+                        let localPath = loadRuntime().env.USER_DATA_PATH + '/' + url;
+                        _fontFamily = jsb.loadFont(localPath);
+                        if (!_fontFamily) {
+                            _fontFamily = 'Arial';
+                        }
+                        CustomFontLoader._fontCache[url] = _fontFamily;
+                        comp._updateRenderData();
+                    });
+                    return false;
+                }
+            }
             else {
                 _fontFamily = CustomFontLoader._getFontFamily(url);
                 let fontDescriptor = CustomFontLoader._fontCache[_fontFamily];


### PR DESCRIPTION
Changelog:

- 修复在 runtime 中加载远程字体文件失败的问题。

@pandamicro