### PR TITLE
fix editbox font color

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -236,6 +236,7 @@ let EditBox = cc.Class({
             notify () {
                 if (this._placeholderLabel) {
                     this._placeholderLabel.node.color = this.placeholderFontColor;
+                    this._placeholderLabel.node.opacity = this.placeholderFontColor.a;
                 }
             }
         },

--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -479,7 +479,7 @@ function registerInputEventListener (tmpEdTxt, editBoxImpl, isTextarea) {
 
     cbs.focus = function () {
         this.style.fontSize = editBoxImpl._edFontSize + 'px';
-        this.style.color = editBoxImpl._textColor.toHEX();
+        this.style.color = editBoxImpl._textColor.toCSS('#rrggbbaa');
 
         if (cc.sys.isMobile) {
             editBoxImpl._onFocusOnMobile();

--- a/cocos2d/core/value-types/color.js
+++ b/cocos2d/core/value-types/color.js
@@ -522,7 +522,7 @@ var Color = (function () {
         r *= 255;
         g *= 255;
         b *= 255;
-        this._val = ((r << 24) >>> 0) + (g << 16) + (b << 8) + this.a;
+        this._val = ((this.a<<24) >>> 0) + (b<<16) + (g<<8) + r;
         return this;
     };
 


### PR DESCRIPTION
Re: cocos-creator/fireball#8135

- 修复 editBox 字体颜色设置 失效
- 修复 color fromHSV() 计算失误

@cocos-creator/admins 