### PR TITLE
fix editBox input swallow touch event

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -480,6 +480,10 @@ function registerInputEventListener (tmpEdTxt, editBoxImpl, isTextarea) {
     cbs.focus = function () {
         this.style.fontSize = editBoxImpl._edFontSize + 'px';
         this.style.color = editBoxImpl._textColor.toCSS('#rrggbbaa');
+        // When stayOnTop, input will swallow touch event
+        if (editBoxImpl._alwaysOnTop) {
+            editBoxImpl._editing = true;
+        }
 
         if (cc.sys.isMobile) {
             editBoxImpl._onFocusOnMobile();


### PR DESCRIPTION
Re: cocos-creator/fireball#8137

editBox stayOnTop  时，input  会覆盖触摸事件，导致 _editing 一直为 false

@cocos-creator/admins 