### PR TITLE
modify ScrollView calculateBoundary add widget bound update

### DIFF
--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -887,6 +887,11 @@ var ScrollView = cc.Class({
             if(layout && layout.enabledInHierarchy) {
                 layout.updateLayout();
             }
+            var widget = this.node.getComponent(cc.Widget);
+            if (widget && widget.enabledInHierarchy) {
+                widget.updateAlignment();
+            }
+
             var scrollViewSize = this.node.getContentSize();
 
             var leftBottomPosition = this._convertToContentParentSpace(cc.p(0, 0));
@@ -906,6 +911,10 @@ var ScrollView = cc.Class({
     _convertToContentParentSpace: function(position) {
         var scrollViewPositionInWorldSpace = this.node.convertToWorldSpace(position);
         var contentParent = this.content.parent;
+        var widget = contentParent.getComponent(cc.Widget);
+        if (widget && widget.enabledInHierarchy) {
+            widget.updateAlignment();
+        }
         return contentParent.convertToNodeSpaceAR(scrollViewPositionInWorldSpace);
     },
 


### PR DESCRIPTION
http://forum.cocos.com/t/cocos-creator-1-10-0-canvas-fit-width-scrollview-widget-content/64488/7
相关论坛帖。
修复 ScrollView 因为 widget 计算边界延迟，导致边界设置错误从而滑动区域偏移问题。