### PR TITLE
cc.Audio.stop logic fix, pause should be invoked before set currentTime = 0

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -190,10 +190,10 @@ Audio.State = {
 
     proto.stop = function () {
         if (!this._element) return;
+        this._element.pause();
         try {
             this._element.currentTime = 0;
         } catch (error) {}
-        this._element.pause();
         // remove touchPlayList
         for (let i = 0; i < touchPlayList.length; i++) {
             if (touchPlayList[i].instance === this) {


### PR DESCRIPTION
If `currentTime = 0` is set before `pause`, audio may be played from beginning at a very short time before `pause` since audio API is asynchronous.