### PR TITLE
fix uninteractable transition color

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -401,7 +401,7 @@ let Button = cc.Class({
         // // Restore button status
         let target = this.target;
         let transition = this.transition;
-        if (transition === Transition.COLOR) {
+        if (transition === Transition.COLOR && this.interactable) {
             target.color = this.normalColor;
         } else if (transition === Transition.SCALE) {
             target.scale = this._originalScale;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/399

修复问题：
- disable 按钮时，初始化了按钮的颜色，导致 uninteractable 的颜色显示不正确
- 对 按钮 禁用 interactable 时，颜色显示不正确