### PR TITLE
remove cc.info

### DIFF
--- a/cocos2d/core/CCDebug.js
+++ b/cocos2d/core/CCDebug.js
@@ -93,7 +93,7 @@ let resetDebugSetting = function (mode) {
             };
         }
         if (mode === DebugMode.INFO_FOR_WEB_PAGE) {
-            cc.log = cc.info = function () {
+            cc.log = function () {
                 logToWebPage(cc.js.formatStr.apply(null, arguments));
             };
         }
@@ -177,7 +177,6 @@ let resetDebugSetting = function (mode) {
     }
     if (CC_EDITOR) {
         cc.log = Editor.log;
-        cc.info = Editor.info;
     }
     else if (mode === DebugMode.INFO) {
         /**
@@ -204,29 +203,6 @@ let resetDebugSetting = function (mode) {
         else {
             cc.log = function () {
                 return console.log.apply(console, arguments);
-            };
-        }
-        /**
-         * !#en
-         * Outputs an informational message to the Cocos Creator Console (editor) or Web Console (runtime).
-         * - In Cocos Creator, info is blue.
-         * - In Firefox and Chrome, a small "i" icon is displayed next to these items in the Web Console's log.
-         * !#zh
-         * 输出一条信息消息到 Cocos Creator 编辑器的 Console 或运行时 Web 端的 Console 中。
-         * - 在 Cocos Creator 中，Info 信息显示是蓝色的。<br/>
-         * - 在 Firefox 和  Chrome 中，Info 信息有着小 “i” 图标。
-         * @method info
-         * @param {any} msg - A JavaScript string containing zero or more substitution strings.
-         * @param {any} ...subst - JavaScript objects with which to replace substitution strings within msg. This gives you additional control over the format of the output.
-         */
-        if (CC_JSB) {
-            cc.info = (scriptEngineType === "JavaScriptCore") ? function () {
-                (console.info || console.log).apply(console, arguments);
-            } : (console.info || console.log);
-        }
-        else {
-            cc.info = function () {
-                (console.info || console.log).apply(console, arguments);
             };
         }
     }

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -26,7 +26,7 @@
 
 var js = cc.js;
 
-if (CC_DEV) {
+if (CC_DEBUG) {
 
     function deprecateEnum (obj, oldPath, newPath, hasTypePrefixBefore) {
         if (!CC_SUPPORT_JIT) {
@@ -143,7 +143,11 @@ if (CC_DEV) {
             })();
         }
     }
-
+    // remove cc.info
+    js.get(cc, 'info', function () {
+        cc.warnID(1400, 'cc.info', 'cc.log');
+        return cc.log;
+    });
     // cc.spriteFrameCache
     js.get(cc, "spriteFrameCache", function () {
         cc.errorID(1404);

--- a/extensions/dragonbones/lib/dragonBones.js
+++ b/extensions/dragonbones/lib/dragonBones.js
@@ -46,7 +46,7 @@ var dragonBones;
             this._objects = [];
             this._eventManager = null;
             this._eventManager = eventManager;
-            console.info("DragonBones: " + DragonBones.VERSION + "\nWebsite: http://dragonbones.com/\nSource and Demos: https://github.com/DragonBones/");
+            console.log("DragonBones: " + DragonBones.VERSION + "\nWebsite: http://dragonbones.com/\nSource and Demos: https://github.com/DragonBones/");
         }
         DragonBones.prototype.advanceTime = function (passedTime) {
             if (this._objects.length > 0) {

--- a/test/qunit/unit-es5/_init.js
+++ b/test/qunit/unit-es5/_init.js
@@ -156,7 +156,6 @@ cc.engine = new (cc.Class({
 Editor.log = cc.log;
 Editor.warn = cc.warn;
 Editor.error = cc.error;
-Editor.info = cc.info;
 Editor.Utils = Editor.Utils || {};
 Editor.Utils.UuidCache = {};
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/3097
remove cc.info 
清除 cc.info 按照 obsolete 这个修改之后，现在在构建 HelloWorld 的项目后桌面，手机浏览器和微信开发工具会直接报错，其他平台都是 android， 预览会正常显示。
![image](https://user-images.githubusercontent.com/35832931/44380714-7a68a080-a53f-11e8-9955-8c3499e20708.png)
报错内容应该属于正常范围吧