### PR TITLE
hide editbox input onDisable when stayOnTop

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -577,6 +577,14 @@ let EditBox = cc.Class({
         this._impl.clear();
     },
 
+    onEnable () {
+        this._impl && this._impl.onEnable();
+    },
+
+    onDisable () {
+        this._impl && this._impl.onDisable();
+    },
+
     __preload () {
         if (!CC_EDITOR) {
             this._registerEvent();

--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -93,6 +93,25 @@ let EditBoxImpl = cc.Class({
         this.__orientationChanged = null;
     },
 
+    onEnable () {
+        if (!this._edTxt) {
+            return;
+        }
+        if (this._alwaysOnTop) {
+            this._edTxt.style.display = '';
+        } 
+        else {
+            this._edTxt.style.display = 'none';
+        }
+    },
+
+    onDisable () {
+        if (!this._edTxt) {
+            return;
+        }
+        this._edTxt.style.display = 'none';
+    },
+
     setTabIndex (index) {
         if (this._edTxt) {
             this._edTxt.tabIndex = index;


### PR DESCRIPTION
修复问题：
禁用 editbox 时，stayOnTop 情况下，没有隐藏 dom input

@pandamicro @jareguo 