### PR TITLE
Fix _resizeWithBrowserSize naming issue

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -274,8 +274,8 @@ cc.js.mixin(View.prototype, {
             }
         } else {
             //disable
-            if (this.__resizeWithBrowserSize) {
-                this.__resizeWithBrowserSize = false;
+            if (this._resizeWithBrowserSize) {
+                this._resizeWithBrowserSize = false;
                 window.removeEventListener('resize', this._resizeEvent);
                 window.removeEventListener('orientationchange', this._orientationChange);
             }


### PR DESCRIPTION
this.__resizeWithBrowserSize 参数错误
应为 this._resizeWithBrowserSize

Re: cocos-creator/fireball#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->