### PR TITLE
fix video-player fullscreen invalid in ios for fireball/issues/8239

### DIFF
--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -347,10 +347,22 @@ let VideoPlayerImpl = cc.Class({
         let video = this._video;
         if (!video) return;
 
-        if (enable)
-            cc.screen.requestFullScreen(video);
-        else
-            cc.screen.exitFullScreen(video);
+        if (sys.os === sys.OS_IOS && sys.isBrowser) {
+            if (enable) {
+                video['webkitEnterFullscreen'] && video['webkitEnterFullscreen']();
+            }
+            else {
+                video['webkitExitFullscreen'] && video['webkitExitFullscreen']();
+            }
+        }
+        else {
+            if (enable) {
+                cc.screen.requestFullScreen(video);
+            }
+            else {
+                cc.screen.exitFullScreen(video);
+            }
+        }
 
     },
 

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -349,10 +349,10 @@ let VideoPlayerImpl = cc.Class({
 
         if (sys.os === sys.OS_IOS && sys.isBrowser) {
             if (enable) {
-                video['webkitEnterFullscreen'] && video['webkitEnterFullscreen']();
+                video.webkitEnterFullscreen && video.webkitEnterFullscreen();
             }
             else {
-                video['webkitExitFullscreen'] && video['webkitExitFullscreen']();
+                video.webkitExitFullscreen && video.webkitExitFullscreen();
             }
         }
         else {


### PR DESCRIPTION
Re: cocos-creator/fireball#8239

Changelog:
 * 由于 ios 浏览器的全屏只作用于 video 组件，所以在 video 组件上单独对开启全屏进行处理