### PR TITLE
fix alignOnce widget not restore after editing animation

### DIFF
--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -270,8 +270,9 @@ function refreshScene () {
     // check animation editor
     if (CC_EDITOR && !Editor.isBuilder) {
         var AnimUtils = Editor.require('scene://utils/animation');
-        if (AnimUtils) {
-            var nowPreviewing = !!AnimUtils.Cache.animation;
+        var EditMode = Editor.require('scene://edit-mode');
+        if (AnimUtils && EditMode) {
+            var nowPreviewing = (EditMode.curMode().name === 'animation' && !!AnimUtils.Cache.animation);
             if (nowPreviewing !== animationState.previewing) {
                 animationState.previewing = nowPreviewing;
                 if (nowPreviewing) {


### PR DESCRIPTION
Re: cocos-creator/fireball#8265

Changelog:
 * 修复退出动画编辑模式后，Widget.enabled 未正确还原的问题。

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->