### PR TITLE
Fix load null resources issue in cc.loader

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -230,8 +230,12 @@ proto.load = function(resources, progressCallback, completeCallback) {
     var singleRes = false;
     var res;
     if (!(resources instanceof Array)) {
-        singleRes = true;
-        resources = resources ? [resources] : [];
+        if (resources) {
+            singleRes = true;
+            resources = [resources];
+        } else { 
+            resources = [];
+        }
     }
 
     _sharedResources.length = 0;


### PR DESCRIPTION
开发中碰到一个问题，在258行res会有undefined的异常。
res赋值在for循环247行（var resource = resources[i];），根据234行（resources = resources ? [resources] : [];）的情况，当resources = [ ]时，下面的for循环是进不去的，res是不会敷值的，为undefined，此时258行（let id = res.url;）调用res属性时就会有undefined。
目前解决方法当resources = []时singleRes为默认值false

Re: cocos-creator/fireball#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->