### PR TITLE
modify the path.baseName()

### DIFF
--- a/cocos2d/core/utils/CCPath.js
+++ b/cocos2d/core/utils/CCPath.js
@@ -95,8 +95,8 @@ cc.path = /** @lends cc.path# */{
     basename: function (pathStr, extname) {
         var index = pathStr.indexOf("?");
         if (index > 0) pathStr = pathStr.substring(0, index);
-        var reg = /(\/|\\\\)([^(\/|\\\\)]+)$/g;
-        var result = reg.exec(pathStr.replace(/(\/|\\\\)$/, ""));
+        var reg = /(\/|\\)([^\/\\]+)$/g;
+        var result = reg.exec(pathStr.replace(/(\/|\\)$/, ""));
         if (!result) return null;
         var baseName = result[2];
         if (extname && pathStr.substring(pathStr.length - extname.length).toLowerCase() === extname.toLowerCase())

--- a/test/qunit/unit-es5/test-path.js
+++ b/test/qunit/unit-es5/test-path.js
@@ -10,3 +10,18 @@ test('dirname', function () {
     ok(cc.path.dirname('aa/bb/.github/.gitignore') === 'aa/bb/.github', 'get success');
 
 });
+
+test('basename', function () {
+    
+    ok(cc.path.basename('aa/bb/cc.js', '.js') === 'cc', 'get success');
+    ok(cc.path.basename('aa/bb/cc_cc.js','.js') === 'cc_cc', 'get success');
+    ok(cc.path.basename('aa/bb/cc/') === 'cc', 'get success');
+    ok(cc.path.basename('D:\\aa\\bb\\cc') === 'cc', 'get success');
+    ok(cc.path.basename('aa/bb/cc(cc).js', '.js') === 'cc(cc)', 'get success');
+    ok(cc.path.basename('aa/bb/cc[cc].js', '.js') === 'cc[cc]', 'get success');
+    ok(cc.path.basename('aa/bb/cc.js/ee.js', '.js') === 'ee', 'get success');
+    ok(cc.path.basename('aa/bb/.github') === '.github', 'get success');
+    // ios only, and linux not suggest
+    ok(cc.path.basename('aa/bb/cc|cc.js', '.js') === 'cc|cc', 'get success');
+
+});


### PR DESCRIPTION
1. [] 内写入 '()' 导致带有 ‘()‘ 的场景名称无法正确识别， '()' 被当做一般符号列入不识别的范围内：
![image](https://user-images.githubusercontent.com/35832931/44572227-cc1a6080-a7b5-11e8-84af-0aea6836cc59.png)

2.由于我们去掉了 '()' ,旧的写法中对于 \\\\ 的操作就显得不够简洁，reg 的前半部分 (\/|\\\\) 已经加 path 限制在由 / 或者 \\ 起始那么关于后半部分中不识别符号的操作就显得多余。因为 baseName 如果有包含 / 或者 \\ 内容，名称就已经被识别中断并且破坏，所以应该删去后半部分的内容。
__对比建议__：
![image](https://user-images.githubusercontent.com/35832931/44572249-db011300-a7b5-11e8-935f-879292d228d5.png)

这种改法仍然不识别的场景名称为 sceneName 包含 \ 符号。这个部分因为 [] 的特性我暂时改不过来，如果要考虑这种命名方式，
__我建议的匹配方案为: [\w(){}\[\]~`!@#$%^&*.]+__
![image](https://user-images.githubusercontent.com/35832931/44577436-ad22cb00-a7c3-11e8-89bf-be9cade8bb13.png)

以及附上各个系统文件命名规则：
![image](https://user-images.githubusercontent.com/35832931/44576938-6680a100-a7c2-11e8-8c0f-e9b7a8f33bec.png)
