### PR TITLE
修复粒子系统的两个问题。

### DIFF
--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -294,7 +294,13 @@ Simulator.prototype.step = function (dt) {
 
         this.elapsed += dt;
         if (psys.duration !== -1 && psys.duration < this.elapsed)
+        {
             psys.stopSystem();
+            if (particles.length === 0) {
+                this.finished = true;
+                psys._finishedSimulation();
+            }
+        }
     }
 
     // Request buffer for particles
@@ -315,10 +321,11 @@ Simulator.prototype.step = function (dt) {
         _tpa.x = _tpa.y = _tpb.x = _tpb.y = _tpc.x = _tpc.y = 0;
 
         let particle = particles[particleIdx];
-        // life
-        particle.timeToLive -= dt;
 
         if (particle.timeToLive > 0) {
+            // life
+            particle.timeToLive -= dt;
+
             // Mode A: gravity, direction, tangential accel & radial accel
             if (psys.emitterMode === cc.ParticleSystem.EmitterMode.GRAVITY) {
                 let tmp = _tpc, radial = _tpa, tangential = _tpb;
@@ -402,7 +409,7 @@ Simulator.prototype.step = function (dt) {
             pool.put(deadParticle);
             particles.length--;
 
-            if (particles.length === 0) {
+            if (particles.length === 0 && !this.active ) {
                 this.finished = true;
                 psys._finishedSimulation();
             }


### PR DESCRIPTION
1. 配置粒子的属性如下 duration=-1，emissionRate=1，totalParticles=1，粒子错误的只会发射一次。
2. 编辑器粒子消亡后存在残影问题，因为时间有残余，粒子的表现没有计算到最后，就消亡了，而导致顶点数据没有被刷新。