### PR TITLE
fix button sprite material onEnable

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -433,6 +433,8 @@ let Button = cc.Class({
                 }
             }.bind(this));
         }
+
+        this._sprite && this._sprite._activateMaterial();
     },
 
     onDisable () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/8234

修复问题：
按钮 非交互状态 + 禁用状态下，开启交互状态，后续 onEnable 时候没有更新按钮灰度状态