### PR TITLE
fix _finishCallback did not clean up bug

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -35,6 +35,7 @@ let _url2id = {};
 let _audioPool = [];
 
 let recycleAudio = function (audio) {
+    audio._finishCallback = null;
     if (_audioPool.length < 32) {
         audio.off('ended');
         audio.off('stop');


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
不管什么音效，最后一个设置setFinishCallback方法，再播放音效后，会执行前面的回调
 用户反馈 http://forum.cocos.com/t/rc2-cocos-creator-v2-0-1/64731/243