### PR TITLE
fix actionManager can't remove all actions

### DIFF
--- a/cocos2d/actions/CCActionManager.js
+++ b/cocos2d/actions/CCActionManager.js
@@ -145,11 +145,16 @@ cc.ActionManager.prototype = {
      */
     removeAllActions:function () {
         var locTargets = this._arrayTargets;
-        for (var i = 0; i < locTargets.length; i++) {
-            var element = locTargets[i];
+
+        // RemoveAllActionsFromTarget changes the length of array _arrayTargets.
+        // So we iterate on the locTargets_clone instead of locTargets.
+        var locTargets_clone = cc.js.array.copy(locTargets);
+        for (var i = 0; i < locTargets_clone.length; i++) {
+            var element = locTargets_clone[i];
             if (element)
                 this.removeAllActionsFromTarget(element.target, true);
         }
+        locTargets_clone.length = 0;
     },
     /**
      * !#en


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/8244

actionManager  removeAllActions 不能全部移除，原因是在for 循环中 removeAllActionsFromTarget 修改了 locTargets 数组的长度
