### PR TITLE
modify touch event listener clear touches preTouchPool

### DIFF
--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -102,7 +102,7 @@ let inputManager = {
         let selTouch, index, curTouch, touchID,
             handleTouches = [], locTouchIntDict = this._touchesIntegerDict,
             now = sys.now();
-        for (let i = 0, len = touches.length; i< len; i ++) {
+        for (let i = 0, len = touches.length; i < len; i ++) {
             selTouch = touches[i];
             touchID = selTouch.getID();
             index = locTouchIntDict[touchID];
@@ -173,6 +173,7 @@ let inputManager = {
             touchEvent._eventCode = cc.Event.EventTouch.ENDED;
             eventManager.dispatchEvent(touchEvent);
         }
+        this._preTouchPool.length = 0;
     },
 
     /**
@@ -187,6 +188,7 @@ let inputManager = {
             touchEvent._eventCode = cc.Event.EventTouch.CANCELLED;
             eventManager.dispatchEvent(touchEvent);
         }
+        this._preTouchPool.length = 0;
     },
 
     /**


### PR DESCRIPTION
fix: http://forum.cocos.com/t/touchstart/65198

内容修复：
_preTouchesPool 数组在 handleTouchesEnd 状态时没有清空，导致下一次点击时上一次点击事件的 preLoaction 残留，引起 PreviourLoaction 错误。
