### PR TITLE
fix convertToLocationInView calculation bug for fireball/issues/8300

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -963,7 +963,7 @@ cc.js.mixin(View.prototype, {
         let x = this._devicePixelRatio * (tx - relatedPos.left);
         let y = this._devicePixelRatio * (relatedPos.top + relatedPos.height - ty);
         if (this._isRotated) {
-            result.x = this._viewportRect.width - y;
+            result.x = cc.game.canvas.width - y;
             result.y = x;
         }
         else {


### PR DESCRIPTION
Re: cocos-creator/fireball#8300

Changelog:
 * 修复使用 iphone x  大屏幕手机时， convertToLocationInView 计算 x 轴坐标有误