### PR TITLE
only trigger finishCallback after audio ended

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -62,10 +62,6 @@ let getAudioFromPath = function (path) {
 
     var audio = _audioPool.pop() || new Audio();
     var callback = function () {
-        if (audio._finishCallback) {
-            audio._finishCallback();
-        }
-
         var audioInList = getAudioFromId(this.id);
         if (audioInList) {
             delete _id2audio[this.id];
@@ -74,7 +70,14 @@ let getAudioFromPath = function (path) {
         }
         recycleAudio(this);
     };
-    audio.on('ended', callback, audio);
+
+    audio.on('ended', function () {
+        if (audio._finishCallback) {
+            audio._finishCallback();
+        }
+        callback();
+    }, audio);
+
     audio.on('stop', callback, audio);
     audio.id = id;
     _id2audio[id] = audio;


### PR DESCRIPTION
Re: cocos-creator/fireball#8217

Changelog:
 * 更改为在音频 ended 后才触发 finishCallback
