### PR TITLE
fix infinite length in editbox

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -74,7 +74,7 @@ let EditBox = cc.Class({
                 return this._string;
             },
             set(value) {
-                if (value.length >= this.maxLength) {
+                if (this.maxLength >= 0 && value.length >= this.maxLength) {
                     value = value.slice(0, this.maxLength);
                 }
 


### PR DESCRIPTION
有用户反馈，editbox maxLength 填写 -1出现问题
主要是因为在做截取的时候 出错了  slice(0, -1) 返回错误结果