### PR TITLE
create sprite material onEnable

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -444,7 +444,7 @@ var Sprite = cc.Class({
         }
         
         this._updateAssembler();
-        this.markForUpdateRenderData(true);
+        this._activateMaterial();
 
         this.node.on(NodeEvent.SIZE_CHANGED, this._onNodeSizeDirty, this);
         this.node.on(NodeEvent.ANCHOR_CHANGED, this._onNodeSizeDirty, this);
@@ -478,22 +478,11 @@ var Sprite = cc.Class({
     },
 
     _activateMaterial: function () {
-        if (!this.enabledInHierarchy) {
-            this.disableRender();
-            return;
-        }
-
         let spriteFrame = this._spriteFrame;
-        // cannot be activated if texture not loaded yet
-        if (!spriteFrame || !spriteFrame.textureLoaded()) {
-            this.disableRender();
-            return;
-        }
 
         // WebGL
         if (cc.game.renderType !== cc.game.RENDER_TYPE_CANVAS) {
             // Get material
-            let texture = spriteFrame.getTexture();
             let material;
             if (this._state === State.GRAY) {
                 if (!this._graySpriteMaterial) {
@@ -509,21 +498,26 @@ var Sprite = cc.Class({
                 }
                 material = this._spriteMaterial;
             }
-            // TODO: old texture in material have been released by loader
-            if (material.texture !== texture) {
-                material.texture = texture;
-                this._updateMaterial(material);
+            // Set texture
+            if (spriteFrame && spriteFrame.textureLoaded()) {
+                let texture = spriteFrame.getTexture();
+                if (material.texture !== texture) {
+                    material.texture = texture;
+                    this._updateMaterial(material);
+                }
+                else if (material !== this._material) {
+                    this._updateMaterial(material);
+                }
+                if (this._renderData) {
+                    this._renderData.material = material;
+                }
+                this.markForUpdateRenderData(true);
+                this.markForRender(true);
             }
-            else if (material !== this._material) {
-                this._updateMaterial(material);
-            }
-            if (this._renderData) {
-                this._renderData.material = material;
+            else {
+                this.disableRender();
             }
         }
-        
-        this.markForUpdateRenderData(true);
-        this.markForRender(true);
     },
 
     _applyAtlas: CC_EDITOR && function (spriteFrame) {

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/bar-filled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/bar-filled.js
@@ -39,7 +39,7 @@ module.exports = {
             if (!frame._original && dynamicAtlasManager) {
                 dynamicAtlasManager.insertSpriteFrame(frame);
             }
-            if (!sprite._material || sprite._material._texture !== frame._texture) {
+            if (sprite._material._texture !== frame._texture) {
                 sprite._activateMaterial();
             }
         }

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/mesh.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/mesh.js
@@ -41,7 +41,7 @@ const dynamicAtlasManager = require('../../../utils/dynamic-atlas/manager');
             if (!frame._original && dynamicAtlasManager) {
                 dynamicAtlasManager.insertSpriteFrame(frame);
             }
-            if (!sprite._material || sprite._material._texture !== frame._texture) {
+            if (sprite._material._texture !== frame._texture) {
                 sprite._activateMaterial();
             }
         }

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/radial-filled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/radial-filled.js
@@ -51,7 +51,7 @@ module.exports = {
             if (!frame._original && dynamicAtlasManager) {
                 dynamicAtlasManager.insertSpriteFrame(frame);
             }
-            if (!sprite._material || sprite._material._texture !== frame._texture) {
+            if (sprite._material._texture !== frame._texture) {
                 sprite._activateMaterial();
             }
         }

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/simple.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/simple.js
@@ -37,7 +37,7 @@ module.exports = {
             if (!frame._original && dynamicAtlasManager) {
                 dynamicAtlasManager.insertSpriteFrame(frame);
             }
-            if (!sprite._material || sprite._material._texture !== frame._texture) {
+            if (sprite._material._texture !== frame._texture) {
                 sprite._activateMaterial();
             }
         }

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/sliced.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/sliced.js
@@ -48,7 +48,7 @@ module.exports = {
             if (!frame._original && dynamicAtlasManager) {
                 dynamicAtlasManager.insertSpriteFrame(frame);
             }
-            if (!sprite._material || sprite._material._texture !== frame._texture) {
+            if (sprite._material._texture !== frame._texture) {
                 sprite._activateMaterial();
             }
         }

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/tiled.js
@@ -41,7 +41,7 @@ module.exports = {
             if (!frame._original && dynamicAtlasManager) {
                 dynamicAtlasManager.insertSpriteFrame(frame);
             }
-            if (!sprite._material || sprite._material._texture !== frame._texture) {
+            if (sprite._material._texture !== frame._texture) {
                 sprite._activateMaterial();
             }
         }


### PR DESCRIPTION
Re: 
https://github.com/cocos-creator/fireball/issues/8285
https://github.com/cocos-creator/2d-tasks/issues/399

修改：
- sprite 在 onEnable 时候就创建材质
- sprite assembler 忽略 material 判断


具体修复了 按钮 在 onEnable 的时候，没有更新材质的问题

@cocos-creator/admins 