### PR TITLE
Problem that color type cannot be recognized

### DIFF
--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -190,6 +190,7 @@ var MotionStreak = cc.Class({
             set (value) {
                 this._color = value;
             },
+            type: cc.Color,
             tooltip: CC_DEV && 'i18n:COMPONENT.motionStreak.color'
         },
 


### PR DESCRIPTION
修复 MotionStreak 内的 color 类型无法识别的问题

https://github.com/cocos-creator/fireball/issues/8162