### PR TITLE
fix _renderFlags after scene restored

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -2978,7 +2978,7 @@ var Node = cc.Class({
         }
     },
 
-    _restoreProperties () {
+    _restoreProperties: CC_EDITOR && function () {
         /*
          * TODO: Refine this code after completing undo/redo 2.0.
          * The node will be destroyed when deleting in the editor,
@@ -3003,6 +3003,10 @@ var Node = cc.Class({
             else {
                 this._renderComponent.disableRender();
             }
+        }
+
+        if (this._children.length > 0) {
+            this._renderFlag |= RenderFlow.FLAG_CHILDREN;
         }
     },
 


### PR DESCRIPTION
Re: cocos-creator/fireball#8293

Changelog:
 * 修复 Prefab 编辑界面下重编译脚本导致原先场景无法渲染的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->