### PR TITLE
fix setting the spriteframe sliced with code is invalid for fireball/…

### DIFF
--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -28,12 +28,12 @@
 const EventTarget = require("../event/event-target");
 const textureUtil = require('../utils/texture-util');
 
-let temp_uvs = [{u: 0, v: 0}, {u: 0, v: 0}, {u: 0, v: 0}, {u: 0, v: 0}];
+const INSET_LEFT = 0;
+const INSET_TOP = 1;
+const INSET_RIGHT = 2;
+const INSET_BOTTOM = 3;
 
-let INSETLEFT = 0;
-let INSETTOP = 1;
-let INSETRIGHT = 2;
-let INSETBOTTOM = 3;
+let temp_uvs = [{u: 0, v: 0}, {u: 0, v: 0}, {u: 0, v: 0}, {u: 0, v: 0}];
 
 /**
  * !#en
@@ -105,10 +105,10 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
          */
         insetTop: {
             get: function () {
-                return this._capInsets[INSETTOP];
+                return this._capInsets[INSET_TOP];
             },
             set: function (value) {
-                this._capInsets[INSETTOP] = value;
+                this._capInsets[INSET_TOP] = value;
                 if (this._texture) {
                     this._calculateSlicedUV();
                 }
@@ -124,10 +124,10 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
          */
         insetBottom: {
             get: function () {
-                return this._capInsets[INSETBOTTOM];
+                return this._capInsets[INSET_BOTTOM];
             },
             set: function (value) {
-                this._capInsets[INSETBOTTOM] = value;
+                this._capInsets[INSET_BOTTOM] = value;
                 if (this._texture) {
                     this._calculateSlicedUV();
                 }
@@ -143,10 +143,10 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
          */
         insetLeft: {
             get: function () {
-                return this._capInsets[INSETLEFT];
+                return this._capInsets[INSET_LEFT];
             },
             set: function (value) {
-                this._capInsets[INSETLEFT] = value;
+                this._capInsets[INSET_LEFT] = value;
                 if (this._texture) {
                     this._calculateSlicedUV();
                 }
@@ -162,10 +162,10 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
          */
         insetRight: {
             get: function () {
-                return this._capInsets[INSETRIGHT];
+                return this._capInsets[INSET_RIGHT];
             },
             set: function (value) {
-                this._capInsets[INSETRIGHT] = value;
+                this._capInsets[INSET_RIGHT] = value;
                 if (this._texture) {
                     this._calculateSlicedUV();
                 }
@@ -528,11 +528,11 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         let rect = this._rect;
         let atlasWidth = this._texture.width;
         let atlasHeight = this._texture.height;
-        let leftWidth = this._capInsets[INSETLEFT];
-        let rightWidth = this._capInsets[INSETRIGHT];
+        let leftWidth = this._capInsets[INSET_LEFT];
+        let rightWidth = this._capInsets[INSET_RIGHT];
         let centerWidth = rect.width - leftWidth - rightWidth;
-        let topHeight = this._capInsets[INSETTOP];
-        let bottomHeight = this._capInsets[INSETBOTTOM];
+        let topHeight = this._capInsets[INSET_TOP];
+        let bottomHeight = this._capInsets[INSET_BOTTOM];
         let centerHeight = rect.height - topHeight - bottomHeight;
 
         let uvSliced = this.uvSliced;
@@ -691,7 +691,10 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
 
         let capInsets = data.capInsets;
         if (capInsets) {
-            this._capInsets = capInsets;
+            this._capInsets[INSET_LEFT] = capInsets[INSET_LEFT];
+            this._capInsets[INSET_TOP] = capInsets[INSET_TOP];
+            this._capInsets[INSET_RIGHT] = capInsets[INSET_RIGHT];
+            this._capInsets[INSET_BOTTOM] = capInsets[INSET_BOTTOM];
         }
 
         if (CC_EDITOR) {

--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -30,6 +30,11 @@ const textureUtil = require('../utils/texture-util');
 
 let temp_uvs = [{u: 0, v: 0}, {u: 0, v: 0}, {u: 0, v: 0}, {u: 0, v: 0}];
 
+let INSETLEFT = 0;
+let INSETTOP = 1;
+let INSETRIGHT = 2;
+let INSETBOTTOM = 3;
+
 /**
  * !#en
  * A cc.SpriteFrame has:<br/>
@@ -86,7 +91,86 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         //         let texture = cc.textureCache.addImage(url);
         //         this._refreshTexture(texture);
         //     }
-        // }
+        // },
+
+        // insetLeft, insetTop, insetRight, insetBottom
+        _capInsets: [0, 0, 0, 0],
+
+        /**
+         * !#en Top border of the sprite
+         * !#zh sprite 的顶部边框
+         * @property insetTop
+         * @type {Number}
+         * @default 0
+         */
+        insetTop: {
+            get: function () {
+                return this._capInsets[INSETTOP];
+            },
+            set: function (value) {
+                this._capInsets[INSETTOP] = value;
+                if (this._texture) {
+                    this._calculateSlicedUV();
+                }
+            }
+        },
+
+        /**
+         * !#en Bottom border of the sprite
+         * !#zh sprite 的底部边框
+         * @property insetBottom
+         * @type {Number}
+         * @default 0
+         */
+        insetBottom: {
+            get: function () {
+                return this._capInsets[INSETBOTTOM];
+            },
+            set: function (value) {
+                this._capInsets[INSETBOTTOM] = value;
+                if (this._texture) {
+                    this._calculateSlicedUV();
+                }
+            }
+        },
+
+        /**
+         * !#en Left border of the sprite
+         * !#zh sprite 的左边边框
+         * @property insetLeft
+         * @type {Number}
+         * @default 0
+         */
+        insetLeft: {
+            get: function () {
+                return this._capInsets[INSETLEFT];
+            },
+            set: function (value) {
+                this._capInsets[INSETLEFT] = value;
+                if (this._texture) {
+                    this._calculateSlicedUV();
+                }
+            }
+        },
+
+        /**
+         * !#en Right border of the sprite
+         * !#zh sprite 的左边边框
+         * @property insetRight
+         * @type {Number}
+         * @default 0
+         */
+        insetRight: {
+            get: function () {
+                return this._capInsets[INSETRIGHT];
+            },
+            set: function (value) {
+                this._capInsets[INSETRIGHT] = value;
+                if (this._texture) {
+                    this._calculateSlicedUV();
+                }
+            }
+        },
     },
 
     /**
@@ -122,43 +206,9 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
 
         this._rotated = false;
 
-        /**
-         * !#en Top border of the sprite
-         * !#zh sprite 的顶部边框
-         * @property insetTop
-         * @type {Number}
-         * @default 0
-         */
-        this.insetTop = 0;
-
-        /**
-         * !#en Bottom border of the sprite
-         * !#zh sprite 的底部边框
-         * @property insetBottom
-         * @type {Number}
-         * @default 0
-         */
-        this.insetBottom = 0;
-
-        /**
-         * !#en Left border of the sprite
-         * !#zh sprite 的左边边框
-         * @property insetLeft
-         * @type {Number}
-         * @default 0
-         */
-        this.insetLeft = 0;
-
-        /**
-         * !#en Right border of the sprite
-         * !#zh sprite 的左边边框
-         * @property insetRight
-         * @type {Number}
-         * @default 0
-         */
-        this.insetRight = 0;
-
         this.vertices = null;
+
+        this._capInsets = [0, 0, 0, 0];
 
         this.uv = [];
         this.uvSliced = [];
@@ -478,11 +528,11 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         let rect = this._rect;
         let atlasWidth = this._texture.width;
         let atlasHeight = this._texture.height;
-        let leftWidth = this.insetLeft;
-        let rightWidth = this.insetRight;
+        let leftWidth = this._capInsets[INSETLEFT];
+        let rightWidth = this._capInsets[INSETRIGHT];
         let centerWidth = rect.width - leftWidth - rightWidth;
-        let topHeight = this.insetTop;
-        let bottomHeight = this.insetBottom;
+        let topHeight = this._capInsets[INSETTOP];
+        let bottomHeight = this._capInsets[INSETBOTTOM];
         let centerHeight = rect.height - topHeight - bottomHeight;
 
         let uvSliced = this.uvSliced;
@@ -600,13 +650,6 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         if (uuid && exporting) {
             uuid = Editor.Utils.UuidUtils.compressUuid(uuid, true);
         }
-        let capInsets;
-        if (this.insetLeft !== 0 ||
-            this.insetTop !== 0 ||
-            this.insetRight !== 0 ||
-            this.insetBottom !== 0) {
-            capInsets = [this.insetLeft, this.insetTop, this.insetRight, this.insetBottom];
-        }
 
         let vertices;
         if (this.vertices) {
@@ -627,7 +670,7 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
             offset: offset ? [offset.x, offset.y] : undefined,
             originalSize: size ? [size.width, size.height] : undefined,
             rotated: this._rotated ? 1 : undefined,
-            capInsets: capInsets,
+            capInsets: this._capInsets,
             vertices: vertices
         };
     },
@@ -645,13 +688,12 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         }
         this._rotated = data.rotated === 1;
         this._name = data.name;
+
         let capInsets = data.capInsets;
         if (capInsets) {
-            this.insetLeft = capInsets[0];
-            this.insetTop = capInsets[1];
-            this.insetRight = capInsets[2];
-            this.insetBottom = capInsets[3];
+            this._capInsets = capInsets;
         }
+
         if (CC_EDITOR) {
             this._atlasUuid = data.atlas;
         }

--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -93,9 +93,6 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         //     }
         // },
 
-        // insetLeft, insetTop, insetRight, insetBottom
-        _capInsets: [0, 0, 0, 0],
-
         /**
          * !#en Top border of the sprite
          * !#zh sprite 的顶部边框


### PR DESCRIPTION
…issues/8340

Re: cocos-creator/fireball#8340

Changelog:
 * 修复使用代码设置 SpriteFrame 九宫格无效

相关代码设置调用：

![image](https://user-images.githubusercontent.com/7564028/45067938-cf87e300-b0f7-11e8-8cf0-7aeff6c78f62.png)


使用代码前：

![image](https://user-images.githubusercontent.com/7564028/45067930-c565e480-b0f7-11e8-9b7f-db3e2e7e5494.png)


使用代码后：

![image](https://user-images.githubusercontent.com/7564028/45067920-bf700380-b0f7-11e8-89ce-5ee9af6ddc38.png)
