### PR TITLE
fix loading avatar can't be rendered in canvas for fireball/issues/8354

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -511,12 +511,17 @@ var Sprite = cc.Class({
                 if (this._renderData) {
                     this._renderData.material = material;
                 }
+
                 this.markForUpdateRenderData(true);
                 this.markForRender(true);
             }
             else {
                 this.disableRender();
             }
+        }
+        else {
+            this.markForUpdateRenderData(true);
+            this.markForRender(true);
         }
     },
 


### PR DESCRIPTION
Re: cocos-creator/fireball#8354

Changelog:
 * 修复在 Canvas 渲染模式下加载远程图片，赋值给 Sprite 渲染无效的 bug