### PR TITLE
improve editBox setFocus behavior on Web

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -639,9 +639,8 @@ let EditBox = cc.Class({
     },
 
     /**
-     * !#en Let the EditBox get focus, only valid when stayOnTop is true.
-     * !#zh 让当前 EditBox 获得焦点，只有在 stayOnTop 为 true 的时候设置有效
-     * Note: only available on Web at the moment.
+     * !#en Let the EditBox get focus
+     * !#zh 让当前 EditBox 获得焦点
      * @method setFocus
      */
     setFocus () {

--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -120,9 +120,7 @@ let EditBoxImpl = cc.Class({
     },
 
     setFocus () {
-        if (this._edTxt) {
-            this._edTxt.focus();
-        }
+        this._beginEditing();
     },
 
     isFocused() {
@@ -256,24 +254,22 @@ let EditBoxImpl = cc.Class({
     },
 
     _beginEditing () {
-        if (!this._alwaysOnTop) {
-            if (this._edTxt && (this._edTxt.style.display === 'none')) {
-                this._edTxt.style.display = '';
-    
-                let self = this;
-                function startFocus () {
-                    self._edTxt.focus();
-                }
-    
-                if (cc.sys.browserType === cc.sys.BROWSER_TYPE_UC) {
-                    setTimeout(startFocus, FOCUS_DELAY_UC);
-                }
-                else if (cc.sys.browserType === cc.sys.BROWSER_TYPE_FIREFOX) {
-                    setTimeout(startFocus, FOCUS_DELAY_FIREFOX);
-                }
-                else {
-                    startFocus();
-                }
+        if (this._edTxt) {
+            this._edTxt.style.display = '';
+
+            let self = this;
+            function startFocus () {
+                self._edTxt.focus();
+            }
+
+            if (cc.sys.browserType === cc.sys.BROWSER_TYPE_UC) {
+                setTimeout(startFocus, FOCUS_DELAY_UC);
+            }
+            else if (cc.sys.browserType === cc.sys.BROWSER_TYPE_FIREFOX) {
+                setTimeout(startFocus, FOCUS_DELAY_FIREFOX);
+            }
+            else {
+                startFocus();
             }
         }
     


### PR DESCRIPTION
优化 editBox setFocus 在 web 上的表现

之前是只有在 stayOnTop 情况下，setFocus 才有效，
现在的做法相当 setFocus 就执行 _beginEditing 的工作

关联：
https://github.com/cocos-creator-packages/weapp-adapter/pull/42