### PR TITLE
fix asyncLoadAssets causes color to fail for fireball/issues/8360 and …

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -487,14 +487,12 @@ var Sprite = cc.Class({
             if (this._state === State.GRAY) {
                 if (!this._graySpriteMaterial) {
                     this._graySpriteMaterial = new GraySpriteMaterial();
-                    this.node._renderFlag |= RenderFlow.FLAG_COLOR;
                 }
                 material = this._graySpriteMaterial;
             }
             else {
                 if (!this._spriteMaterial) {
                     this._spriteMaterial = new SpriteMaterial();
-                    this.node._renderFlag |= RenderFlow.FLAG_COLOR;
                 }
                 material = this._spriteMaterial;
             }
@@ -512,6 +510,7 @@ var Sprite = cc.Class({
                     this._renderData.material = material;
                 }
 
+                this.node._renderFlag |= RenderFlow.FLAG_COLOR;
                 this.markForUpdateRenderData(true);
                 this.markForRender(true);
             }


### PR DESCRIPTION
…8288

Re: cocos-creator/fireball#8360 
      cocos-creator/fireball#8288

Changelog:
 * 修复勾选延迟加载导致 sprite 的 color 失效