### PR TITLE
fix canvas transform bug

### DIFF
--- a/cocos2d/core/renderer/canvas/canvas-render-walker.js
+++ b/cocos2d/core/renderer/canvas/canvas-render-walker.js
@@ -50,6 +50,7 @@ RenderComponentWalker.prototype = {
         let ctx = this._device._ctx;
         let cam = this._camera;
         ctx.setTransform(cam.a, cam.b, cam.c, cam.d, cam.tx, cam.ty);
+        ctx.scale(1, -1);
         assembler.draw(ctx, comp);
     },
 

--- a/cocos2d/core/renderer/canvas/renderers/graphics/index.js
+++ b/cocos2d/core/renderer/canvas/renderers/graphics/index.js
@@ -36,10 +36,8 @@ module.exports = {
         let matrix = node._worldMatrix;
         let a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
             tx = matrix.m12, ty = matrix.m13;
-        ctx.transform(a, b, c, d, tx, -ty);
-
+        ctx.transform(a, b, c, d, tx, ty);
         ctx.save();
-        ctx.scale(1, -1);
 
         // TODO: handle blend function
 

--- a/cocos2d/core/renderer/canvas/renderers/label/bmfont.js
+++ b/cocos2d/core/renderer/canvas/renderers/label/bmfont.js
@@ -79,7 +79,8 @@ module.exports = js.addon({
         let matrix = node._worldMatrix;
         let a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
             tx = matrix.m12, ty = matrix.m13;
-        ctx.transform(a, b, c, d, tx, -ty);
+        ctx.transform(a, b, c, d, tx, ty);
+        ctx.scale(1, -1);
 
         // TODO: handle blend function
 

--- a/cocos2d/core/renderer/canvas/renderers/label/ttf.js
+++ b/cocos2d/core/renderer/canvas/renderers/label/ttf.js
@@ -62,7 +62,8 @@ module.exports = js.addon({
         let matrix = node._worldMatrix;
         let a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
             tx = matrix.m12, ty = matrix.m13;
-        ctx.transform(a, b, c, d, tx, -ty);
+        ctx.transform(a, b, c, d, tx, ty);
+        ctx.scale(1, -1);
 
         // TODO: handle blend function
 

--- a/cocos2d/core/renderer/canvas/renderers/mask.js
+++ b/cocos2d/core/renderer/canvas/renderers/mask.js
@@ -30,12 +30,6 @@ let beforeHandler = {
     updateRenderData (comp) {},
 
     draw (ctx, mask) {
-        let node = mask.node;
-        // Transform
-        let matrix = node._worldMatrix;
-        let a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
-            tx = matrix.m12, ty = matrix.m13;
-
         ctx.save();
 
         // draw stencil

--- a/cocos2d/core/renderer/canvas/renderers/sprite/simple.js
+++ b/cocos2d/core/renderer/canvas/renderers/sprite/simple.js
@@ -123,7 +123,8 @@ let renderer = {
         let matrix = node._worldMatrix;
         let a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
             tx = matrix.m12, ty = matrix.m13;
-        ctx.transform(a, b, c, d, tx, -ty);
+        ctx.transform(a, b, c, d, tx, ty);
+        ctx.scale(1, -1);
 
         // TODO: handle blend function
 

--- a/cocos2d/core/renderer/canvas/renderers/sprite/sliced.js
+++ b/cocos2d/core/renderer/canvas/renderers/sprite/sliced.js
@@ -116,7 +116,8 @@ let renderer = {
         let matrix = node._worldMatrix;
         let a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
             tx = matrix.m12, ty = matrix.m13;
-        ctx.transform(a, b, c, d, tx, -ty);
+        ctx.transform(a, b, c, d, tx, ty);
+        ctx.scale(1, -1);
 
         // TODO: handle blend function
 

--- a/cocos2d/core/renderer/canvas/renderers/sprite/tiled.js
+++ b/cocos2d/core/renderer/canvas/renderers/sprite/tiled.js
@@ -44,7 +44,8 @@ let renderer = {
         let matrix = node._worldMatrix;
         let a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
             tx = matrix.m12, ty = matrix.m13;
-        ctx.transform(a, b, c, d, tx, -ty);
+        ctx.transform(a, b, c, d, tx, ty);
+        ctx.scale(1, -1);
 
         // TODO: handle blend function
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 修复在 Canvas 渲染模式中坐标转换的 bug，导致子域中的 rotation 是反的