### PR TITLE
fix editbox domInput hidden when view rotated

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -348,6 +348,15 @@ cc.js.mixin(View.prototype, {
             cc.game.container.style['-webkit-transform-origin'] = '0px 0px 0px';
             cc.game.container.style.transformOrigin = '0px 0px 0px';
             this._isRotated = true;
+
+            // Fix for issue: https://github.com/cocos-creator/fireball/issues/8365
+            // Reference: https://www.douban.com/note/343402554/
+            // For Chrome, z-index not working after container transform rotate 90deg.
+            // Because 'transform' style adds canvas (the top-element of container) to a new stack context.
+            // That causes the DOM Input was hidden under canvas.
+            // This should be done after container rotated, instead of in style-mobile.css.
+            cc.game.canvas.style['-webkit-transform'] = 'translateZ(0px)';
+            cc.game.canvas.style.transform = 'translateZ(0px)';
         }
         if (this._orientationChanging) {
             setTimeout(function () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/8365

Chrome 浏览器里，
container 在 rotate 90度之后，canvas 的 z-index 会不起作用，且一直处于最顶层，导致 DOM input 显示不出来。 

参考：
https://www.douban.com/note/343402554/