### PR TITLE
fix get layer properties is null

### DIFF
--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -821,14 +821,8 @@ cc.TMXMapInfo.prototype = {
         }
 
         // The parent element is the last layer
-        let layerProps = getPropertyList(selLayer);
-        if (layerProps) {
-            let layerProp = {};
-            for (let j = 0; j < layerProps.length; j++) {
-                layerProp[layerProps[j].getAttribute('name')] = layerProps[j].getAttribute('value');
-            }
-            layer.properties = layerProp;
-        }
+        layer.properties = getPropertyList(selLayer);
+
         return layer;
     },
 


### PR DESCRIPTION
Re: cocos-creator/fireball#

Changelog:
 * 之前漏改了，导致用户获取 layer properties 是空的