### PR TITLE
fix scrollView manually scroll

### DIFF
--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -819,7 +819,7 @@ let ScrollView = cc.Class({
 
         anchor = anchor.clampf(cc.v2(0, 0), cc.v2(1, 1));
 
-        let scrollSize = this.node.getContentSize();
+        let scrollSize = this.content.parent.getContentSize();
         let contentSize = this.content.getContentSize();
         let bottomDeta = this._getContentBottomBoundary() - this._bottomBoundary;
         bottomDeta = -bottomDeta;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/7694

修复问题描述：
scrollView  跟 mask 大小不一致时候，scrollTo* 位置会有偏差

原因是 _calculateMovePercentDelta 里是以 scrollView 的 contentSize 为 scrollSize,
这里应该是以 mask 的 contentSize 为 scrollSize，因为在计算 outOfBoundaryAmount 的时候都是以这个为参考边界的