### PR TITLE
scene-graph migration

### DIFF
--- a/cocos/scene-graph/base-node.js
+++ b/cocos/scene-graph/base-node.js
@@ -26,7 +26,6 @@
 
 import * as js from '../core/utils/js';
 import IdGenerater from '../core/utils/id-generater';
-import eventManager from '../core/platform/event-manager/CCEventManager';
 import CCObject from '../core/data/object';
 import _decorator from '../core/data/class-decorator';
 const { ccclass, property } = _decorator;
@@ -341,6 +340,9 @@ export default class BaseNode extends CCObject {
     getParent () {
         return this._parent;
     }
+    get parent() {
+        return this._parent;
+    }
 
     /**
      * !#en Set parent of the node.
@@ -365,14 +367,13 @@ export default class BaseNode extends CCObject {
         }
         this._parent = value || null;
 
-        this._onSetParent(value);
+        this._onSetParent(oldParent);
 
         if (value) {
             if (CC_DEBUG && (value._objFlags & Deactivating)) {
                 cc.errorID(3821);
             }
             this._level = value._level + 1;
-            eventManager._setDirtyForNode(this);
             value._children.push(this);
             value.emit && value.emit(CHILD_ADDED, this);
         }
@@ -384,12 +385,12 @@ export default class BaseNode extends CCObject {
                 }
                 oldParent._children.splice(removeAt, 1);
                 oldParent.emit && oldParent.emit(CHILD_REMOVED, this);
-                this._onHierarchyChanged(oldParent);
             }
         }
-        else if (value) {
-            this._onHierarchyChanged(null);
-        }
+        this._onHierarchyChanged(oldParent);
+    }
+    set parent(value) {
+        this.setParent(value);
     }
 
     // ABSTRACT INTERFACES
@@ -648,10 +649,6 @@ export default class BaseNode extends CCObject {
         }
         stack.length = 0;
         BaseNode._stackId--;
-    }
-
-    cleanup () {
-
     }
 
     /**
@@ -1034,7 +1031,8 @@ export default class BaseNode extends CCObject {
         }
     }
 
-    _onSetParent (/*value*/) {}
+    cleanup () {}
+    _onSetParent (/*oldParent*/) {}
     _onPostActivated () {}
     _onBatchRestored () {}
     _onBatchCreated () {}
@@ -1263,6 +1261,18 @@ if (CC_EDITOR) {
             cc.director._nodeActivator.activateNode(this, shouldActiveNow);
         }
     };
+
+    BaseNode.prototype._onPreDestroy = function () {
+        var destroyByParent = this._onPreDestroyBase();
+        if (!destroyByParent) {
+            // ensure this node can reattach to scene by undo system
+            // (simulate some destruct logic to make undo system work correctly)
+            this._parent = null;
+        }
+        return destroyByParent;
+    };
+
+    BaseNode.prototype._onRestoreBase = BaseNode.prototype.onRestore;
 }
 
 if (CC_EDITOR || CC_TEST) {
@@ -1292,32 +1302,6 @@ if (CC_EDITOR || CC_TEST) {
     };
 }
 
-
-BaseNode.idGenerater = idGenerater;
-
-// For walk
-BaseNode._stacks = [[]];
-BaseNode._stackId = 0;
-
-BaseNode.prototype._onPreDestroyBase = BaseNode.prototype._onPreDestroy;
-if (CC_EDITOR) {
-    BaseNode.prototype._onPreDestroy = function () {
-       var destroyByParent = this._onPreDestroyBase();
-       if (!destroyByParent) {
-           // ensure this node can reattach to scene by undo system
-           // (simulate some destruct logic to make undo system work correctly)
-           this._parent = null;
-       }
-       return destroyByParent;
-   };
-}
-
-BaseNode.prototype._onHierarchyChangedBase = BaseNode.prototype._onHierarchyChanged;
-
-if(CC_EDITOR) {
-    BaseNode.prototype._onRestoreBase = BaseNode.prototype.onRestore;
-}
-
 if (CC_DEV) {
     // promote debug info
     js.get(BaseNode.prototype, ' INFO ', function () {
@@ -1335,6 +1319,16 @@ if (CC_DEV) {
         return this.name + ', path: ' + path;
     });
 }
+
+BaseNode.idGenerater = idGenerater;
+
+// For walk
+BaseNode._stacks = [[]];
+BaseNode._stackId = 0;
+
+BaseNode.prototype._onPreDestroyBase = BaseNode.prototype._onPreDestroy;
+
+BaseNode.prototype._onHierarchyChangedBase = BaseNode.prototype._onHierarchyChanged;
 
 /**
  * !#en

--- a/cocos/scene-graph/component-scheduler.js
+++ b/cocos/scene-graph/component-scheduler.js
@@ -26,8 +26,6 @@
 
 import CCObject from '../core/data/object';
 import { array } from '../core/utils/js';
-import _decorator from '../core/data/class-decorator';
-const { ccclass } = _decorator;
 
 var IsStartCalled = CCObject.Flags.IsStartCalled;
 var IsOnEnableCalled = CCObject.Flags.IsOnEnableCalled;

--- a/cocos/scene-graph/index.js
+++ b/cocos/scene-graph/index.js
@@ -27,6 +27,5 @@
 export { default as BaseNode } from './base-node';
 export { default as Node } from './node';
 export { default as NodeActivator } from './node-activator';
-export { default as PrivateNode } from './private-node';
 export { default as Scene } from './scene';
 export { default as find } from './find';

--- a/cocos/scene-graph/node-2d.js
+++ b/cocos/scene-graph/node-2d.js
@@ -1253,19 +1253,6 @@ export default class Node extends BaseNode {
 
     // INTERNAL
 
-    _syncEulerAngles () {
-        let quat = this._quat;
-        let rotx = quat.getRoll();
-        let roty = quat.getPitch();
-        if (rotx === 0 && roty === 0) {
-            this._rotationX = this._rotationY = -quat.getYaw();
-        }
-        else {
-            this._rotationX = rotx;
-            this._rotationY = roty;
-        }
-    }
-
     _upgrade_1x_to_2x () {
         // Upgrade scaleX, scaleY from v1.x
         // TODO: remove in future version, 3.0 ?
@@ -1285,19 +1272,25 @@ export default class Node extends BaseNode {
         // TODO: remove _rotationX & _rotationY in future version, 3.0 ?
         // Update quaternion from rotation, when upgrade from 1.x to 2.0
         // If rotation x & y is 0 in old version, then update rotation from default quaternion is ok too
-        let quat = this._quat;
-        if ((this._rotationX !== 0 || this._rotationY !== 0) && 
-            (quat.x === 0 && quat.y === 0 && quat.z === 0 && quat.w === 1)) {
+        if (this._rotationX !== 0 || this._rotationY !== 0) {
             if (this._rotationX === this._rotationY) {
-                math.quat.fromEuler(quat, 0, 0, -this._rotationX);
+                math.quat.fromEuler(this._quat, 0, 0, -this._rotationX);
             }
             else {
-                math.quat.fromEuler(quat, this._rotationX, this._rotationY, 0);
+                math.quat.fromEuler(this._quat, this._rotationX, this._rotationY, 0);
             }
         }
         // Update rotation from quaternion
         else {
-            this._syncEulerAngles();
+            let rotx = this._quat.getRoll();
+            let roty = this._quat.getPitch();
+            if (rotx === 0 && roty === 0) {
+                this._rotationX = this._rotationY = -this._quat.getYaw();
+            }
+            else {
+                this._rotationX = rotx;
+                this._rotationY = roty;
+            }
         }
 
         // Upgrade from 2.0.0 preview 4 & earlier versions
@@ -1982,33 +1975,18 @@ export default class Node extends BaseNode {
     }
 
     /**
-     * !#en Get rotation of node (along z axi).
-     * !#zh 获取该节点以局部坐标系 Z 轴为轴进行旋转的角度。
-     * @method getRotation
-     * @param {Number} rotation Degree rotation value
-     */
-    getRotation () {
-        return this._rotationX;
-    }
-
-    /**
      * !#en Set rotation of node (along z axi).
      * !#zh 设置该节点以局部坐标系 Z 轴为轴进行旋转的角度。
      * @method setRotation
      * @param {Number} rotation Degree rotation value
      */
-    setRotation (value) {
-        if (this._rotationX !== value || this._rotationY !== value) {
-            this._rotationX = this._rotationY = value;
-            // Update quaternion from rotation
-            math.quat.fromEuler(this._quat, 0, 0, -value);
-            this.setLocalDirty(LocalDirtyFlag.ROTATION);
 
-            if (this._eventMask & ROTATION_ON) {
-                this.emit(EventType.ROTATION_CHANGED);
-            }
-        }
-    }
+    /**
+     * !#en Get rotation of node (along z axi).
+     * !#zh 获取该节点以局部坐标系 Z 轴为轴进行旋转的角度。
+     * @method getRotation
+     * @param {Number} rotation Degree rotation value
+     */
 
     /**
      * !#en
@@ -2186,7 +2164,7 @@ export default class Node extends BaseNode {
      * Set world position.
      * This is not a public API yet, its usage could be updated
      * @method setWorldPos
-     * @param {Vec3} pos
+     * @param {vec3} pos
      */
     setWorldPos (pos) {
         // NOTE: this is faster than invert world matrix and transform the point
@@ -3039,7 +3017,6 @@ if (CC_EDITOR) {
 
 let _p = Node.prototype;
 js.getset(_p, 'rotation', _p.getRotation, _p.setRotation);
-js.getset(_p, 'parent', _p.getParent, _p.setParent);
 js.getset(_p, 'position', _p.getPosition, _p.setPosition, false, true);
 js.getset(_p, 'scale', _p.getScale, _p.setScale, false, true);
 

--- a/cocos/scene-graph/node-activator.js
+++ b/cocos/scene-graph/node-activator.js
@@ -28,8 +28,6 @@ import CompScheduler from './component-scheduler';
 import CCObject from '../core/data/object';
 import { Pool, array } from '../core/utils/js';
 import { tryCatchFunctor_EDITOR } from '../core/utils/misc';
-import _decorator from '../core/data/class-decorator';
-const { ccclass } = _decorator;
 
 var MAX_POOL_SIZE = 4;
 


### PR DESCRIPTION
Put 2D Node aside for now.
3D Node inherits BaseNode.
Use mixin for EventTarget.
No breaking change for any part of 2D infrastructures.

### TODOs for other parts
* reset the `_hasChanged` flag for all nodes every frame in director.
* adapt the following minor API changes:

| Creator Node 	| engine-3d Entity (deprecated) |
|:------------:	|:----------------:|
|uuid		|id|
|insertChild	|insertAt|
|addChild	|append|
|set active	|activate|
|set active	|deactivate|
|getComponent	|getComp|
|getComponents	|getComps|
|getComponentsInChildren	|getCompsInChildren|
|addComponent	|addComp|