### PR TITLE
fix getExtension expires on WeChat 6.6.5 and below

### DIFF
--- a/cocos2d/core/renderer/render-engine.js
+++ b/cocos2d/core/renderer/render-engine.js
@@ -8418,7 +8418,7 @@ var Texture2D = (function (Texture$$1) {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, this._wrapT);
 
     var ext = this._device.ext('EXT_texture_filter_anisotropic');
-    if (ext) {
+    if (ext && ext.TEXTURE_MAX_ANISOTROPY_EXT) {
       gl.texParameteri(gl.TEXTURE_2D, ext.TEXTURE_MAX_ANISOTROPY_EXT, this._anisotropy);
     }
   };
@@ -8748,7 +8748,7 @@ var TextureCube = (function (Texture$$1) {
     // gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_R, this._wrapR);
 
     var ext = this._device.ext('EXT_texture_filter_anisotropic');
-    if (ext) {
+    if (ext && ext.TEXTURE_MAX_ANISOTROPY_EXT) {
       gl.texParameteri(gl.TEXTURE_CUBE_MAP, ext.TEXTURE_MAX_ANISOTROPY_EXT, this._anisotropy);
     }
   };


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复子龙反馈的 getExtension 的判断在微信 6.6.5 及以下版本失效，会导致黑屏