### PR TITLE
fix the cc not defined problem in subdomain

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,13 +37,10 @@ var _global = typeof window === 'undefined' ? global : window;
  * @module cc
  * @main cc
  */
-cc = _global.cc || {};
+_global.cc = _global.cc || {};
 
 // For internal usage
-_cc = _global._cc || {};
-
-// For internal usage
-_cc = {};
+_global._cc = _global._cc || {};
 
 require('./predefine');
 
@@ -74,4 +71,4 @@ if (CC_EDITOR) {
     }
 }
 
-module.exports = cc;
+module.exports = _global.cc;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/426
Re: https://github.com/cocos-creator/2d-tasks/issues/609
1. 和之前的 API 修复不同这次属于新的错误类型。 ES6 转 ES5 在子域脚本非调试模式下会因为子域的严格模式导致 cc module 不被 cocos-min-js 识别为全局变量。
这个调整是通过 _global 定义 cc 为全局变量。

微信开发工具测试通过