### PR TITLE
export decorators in mode 3

### DIFF
--- a/cocos/assets/CCAsset.js
+++ b/cocos/assets/CCAsset.js
@@ -24,10 +24,8 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-import _decorator from '../core/data/class-decorator';
+import { ccclass, property } from '../core/data/class-decorator';
 import RawAsset from './CCRawAsset';
-
-const {ccclass, property} = _decorator;
 
 /**
  * !#en

--- a/cocos/assets/CCBitmapFont.js
+++ b/cocos/assets/CCBitmapFont.js
@@ -26,8 +26,7 @@
 
 import Font from './CCFont';
 import SpriteFrame from './CCSpriteFrame';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 /**
  * @module cc

--- a/cocos/assets/CCFont.js
+++ b/cocos/assets/CCFont.js
@@ -25,8 +25,7 @@
  ****************************************************************************/
 
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass} = _decorator;
+import {ccclass} from '../core/data/class-decorator';
 
 /**
  * !#en Class for Font handling.

--- a/cocos/assets/CCJsonAsset.js
+++ b/cocos/assets/CCJsonAsset.js
@@ -24,8 +24,7 @@
  ****************************************************************************/
 
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 /**
  * !#en

--- a/cocos/assets/CCPrefab.js
+++ b/cocos/assets/CCPrefab.js
@@ -28,8 +28,7 @@ import {compile} from '../core/data/instantiate-jit';
 import Enum from '../core/value-types/enum';
 import {obsolete} from '../core/utils/js';
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 /**
  * !#zh

--- a/cocos/assets/CCRawAsset.js
+++ b/cocos/assets/CCRawAsset.js
@@ -26,8 +26,7 @@
 
 import {isChildClassOf} from '../core/utils/js';
 import CCObject from '../core/data/object';
-import _decorator from '../core/data/class-decorator';
-const {ccclass} = _decorator;
+import {ccclass} from '../core/data/class-decorator';
 
 /**
  * !#en

--- a/cocos/assets/CCSceneAsset.js
+++ b/cocos/assets/CCSceneAsset.js
@@ -25,8 +25,7 @@
  ****************************************************************************/
 
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 /**
  * !#en Class for scene handling.

--- a/cocos/assets/CCScripts.js
+++ b/cocos/assets/CCScripts.js
@@ -25,8 +25,7 @@
  ****************************************************************************/
 
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass} = _decorator;
+import {ccclass} from '../core/data/class-decorator';
 
 /**
  * !#en Class for script handling.

--- a/cocos/assets/CCSpriteAtlas.js
+++ b/cocos/assets/CCSpriteAtlas.js
@@ -25,8 +25,7 @@
  ****************************************************************************/
 
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 /**
  * !#en Class for sprite atlas handling.

--- a/cocos/assets/CCSpriteFrame.js
+++ b/cocos/assets/CCSpriteFrame.js
@@ -29,8 +29,7 @@ import EventTarget from '../core/event/event-target';
 import textureUtil from './texture-util';
 import {addon} from '../core/utils/js';
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 
 const INSET_LEFT = 0;

--- a/cocos/assets/CCTTFFont.js
+++ b/cocos/assets/CCTTFFont.js
@@ -25,8 +25,7 @@
  ****************************************************************************/
 
 import Font from './CCFont';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 /**
  * @module cc

--- a/cocos/assets/CCTextAsset.js
+++ b/cocos/assets/CCTextAsset.js
@@ -25,8 +25,7 @@
  ****************************************************************************/
 
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 /**
  * !#en Class for text file.

--- a/cocos/assets/CCTexture2D.js
+++ b/cocos/assets/CCTexture2D.js
@@ -31,8 +31,7 @@ import Enum from '../core/value-types/enum';
 import {addon} from '../core/utils/js';
 import {enums} from '../renderer/gfx/enums';
 import Asset from './CCAsset';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 const GL_NEAREST = 9728;                // gl.NEAREST
 const GL_LINEAR = 9729;                 // gl.LINEAR

--- a/cocos/camera/CCCamera.js
+++ b/cocos/camera/CCCamera.js
@@ -33,8 +33,7 @@ import Component from '../components/CCComponent';
 // TODO fix import from renderer
 import {default as Renderer_Camera} from '../renderer/scene/camera';
 import {default as Renderer_View} from '../renderer/core/view';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property, executeInEditMode, menu, inspector} = _decorator;
+import {ccclass, property, executeInEditMode, menu, inspector} from '../core/data/class-decorator';
 
 let _mat4_temp_1 = mat4.create();
 let _mat4_temp_2 = mat4.create();

--- a/cocos/components/CCCanvas.js
+++ b/cocos/components/CCCanvas.js
@@ -26,8 +26,7 @@
 
 import Camera from '../camera/CCCamera';
 import Component from './CCComponent';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property, executeInEditMode, menu, help, disallowMultiple} = _decorator;
+import {ccclass, property, executeInEditMode, menu, help, disallowMultiple} from '../core/data/class-decorator';
 
 /**
  * !#zh: 作为 UI 根节点，为所有子节点提供视窗四边的位置信息以供对齐，另外提供屏幕适配策略接口，方便从编辑器设置。

--- a/cocos/components/CCComponent.js
+++ b/cocos/components/CCComponent.js
@@ -27,8 +27,7 @@
 import CCObject from '../core/data/object';
 import {getClassName, value} from '../core/utils/js';
 import IDGenerator from '../core/utils/id-generator';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 let idGenerator = new IDGenerator('Comp');
 const IsOnEnableCalled = CCObject.Flags.IsOnEnableCalled;

--- a/cocos/components/CCComponentEventHandler.js
+++ b/cocos/components/CCComponentEventHandler.js
@@ -26,8 +26,7 @@ import { CCClass } from "../core/data";
  THE SOFTWARE.
  ****************************************************************************/
 
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property} = _decorator;
+import {ccclass, property} from '../core/data/class-decorator';
 
 /**
  * !#en

--- a/cocos/components/missing-script.js
+++ b/cocos/components/missing-script.js
@@ -27,8 +27,7 @@
 import {_getClassById} from '../core/utils/js';
 import {BUILTIN_CLASSID_RE} from '../core/utils/misc';
 import Component from './CCComponent';
-import _decorator from '../core/data/class-decorator';
-const {ccclass, property, inspector} = _decorator;
+import {ccclass, property, inspector} from '../core/data/class-decorator';
 
 /*
  * A temp fallback to contain the original serialized data which can not be loaded.

--- a/cocos/core/data/class-decorator.js
+++ b/cocos/core/data/class-decorator.js
@@ -703,7 +703,7 @@ function mixins () {
     };
 }
 
-let _decorator = cc._decorator = {
+cc._decorator = {
     ccclass,
     property,
     executeInEditMode,
@@ -718,4 +718,17 @@ let _decorator = cc._decorator = {
     mixins,
 };
 
-export default _decorator;
+export {
+    ccclass,
+    property,
+    executeInEditMode,
+    requireComponent,
+    menu,
+    executionOrder,
+    disallowMultiple,
+    playOnFocus,
+    inspector,
+    icon,
+    help,
+    mixins
+};

--- a/cocos/core/data/index.js
+++ b/cocos/core/data/index.js
@@ -23,7 +23,8 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-export { default as _decorator} from './class-decorator';
+import * as _decorator from './class-decorator';
+export { _decorator };
 export { default as CCClass } from './class';
 export { default as CCObject } from './object';
 export { default as deserialize } from './deserialize';

--- a/cocos/scene-graph/base-node.js
+++ b/cocos/scene-graph/base-node.js
@@ -27,8 +27,7 @@
 import * as js from '../core/utils/js';
 import IdGenerator from '../core/utils/id-generator';
 import CCObject from '../core/data/object';
-import _decorator from '../core/data/class-decorator';
-const { ccclass, property } = _decorator;
+import { ccclass, property } from '../core/data/class-decorator';
 
 const Destroying = CCObject.Flags.Destroying;
 const DontDestroy = CCObject.Flags.DontDestroy;

--- a/cocos/scene-graph/node-2d.js
+++ b/cocos/scene-graph/node-2d.js
@@ -33,8 +33,7 @@ import macro from '../core/platform/CCMacro';
 import * as js from '../core/utils/js';
 import EventTarget from '../core/event/event-target';
 import BaseNode from './base-node';
-import _decorator from '../core/data/class-decorator';
-const { ccclass, property } = _decorator;
+import { ccclass, property } from '../core/data/class-decorator';
 
 const Flags = cc.Object.Flags;
 const Destroying = Flags.Destroying;

--- a/cocos/scene-graph/node.js
+++ b/cocos/scene-graph/node.js
@@ -2,8 +2,7 @@ import { vec3, mat4, quat } from '../core/vmath';
 import BaseNode from './base-node';
 import Layers from './layers';
 import { EventTarget } from "../core/event";
-import _decorator from '../core/data/class-decorator';
-const { ccclass, property, mixins } = _decorator;
+import { ccclass, property, mixins } from '../core/data/class-decorator';
 
 let v3_a = cc.v3();
 let q_a = cc.quat();

--- a/cocos/scene-graph/private-node.js
+++ b/cocos/scene-graph/private-node.js
@@ -26,8 +26,7 @@
 'use strict';
 
 import Node from './node';
-import _decorator from '../core/data/class-decorator';
-const { ccclass, property } = _decorator;
+import { ccclass, property } from '../core/data/class-decorator';
 
 const LocalDirtyFlag = Node._LocalDirtyFlag;
 const POSITION_ON = 1 << 0;

--- a/cocos/scene-graph/scene.js
+++ b/cocos/scene-graph/scene.js
@@ -24,8 +24,7 @@
  ****************************************************************************/
 
 import Node from './node';
-import _decorator from '../core/data/class-decorator';
-const { ccclass, property } = _decorator;
+import { ccclass, property } from '../core/data/class-decorator';
 
 /**
  * !#en


### PR DESCRIPTION
to save the awkwardness of:
```js
import _decorator from '../core/data/class-decorator';
const { ccclass, property, mixins } = _decorator;
```
now just do:
```js
import { ccclass, property, mixins } from '../core/data/class-decorator';
```