### PR TITLE
fix when the tilemap has no texture, TiledLayer will always report an error.

### DIFF
--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -571,6 +571,10 @@ let TiledLayer = cc.Class({
 
     _fillTextureGrids (tileset, texId) {
         let tex = this._textures[texId];
+        if (!tex) {
+            return;
+        }
+
         if (!tex.loaded) {
             tex.once('load', function () {
                 this._fillTextureGrids(tileset, texId);


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 当前 tilemap 没有 texture 时，TiledLayer 会一直报没有 offset x 错误信息，从而在 TiledLayer 中对 texture 为 null 时进行处理