### PR TITLE
fix cc.BlockInputEvents can't receive touch move, end, cancel events

### DIFF
--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -515,6 +515,19 @@ var eventManager = {
                     listener._claimedTouches.splice(removedIdx, 1);
             }
         }
+        else if (listener._target) {
+            // cc.BlockInputEvents component should receive all touch events, then stop propagating them.
+            // In case it doesn't receive touchBegan event, the other touch events are ignored.
+            if (listener._target.getComponent(cc.BlockInputEvents)) {
+                if (getCode === EventTouch.MOVED && listener.onTouchMoved) {
+                    listener.onTouchMoved(selTouch, event);
+                } else if (getCode === EventTouch.ENDED && listener.onTouchEnded) {
+                    listener.onTouchEnded(selTouch, event);
+                } else if (getCode === EventTouch.CANCELLED && listener.onTouchCancelled) {
+                    listener.onTouchCancelled(selTouch, event);
+                }
+            }
+        }
 
         // If the event was stopped, return directly.
         if (event.isStopped()) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/316

修复问题：
blockInputEvent 组件在没有收到 touchBegan 事件时，后续也不会收到 touchMove touchEnd 和 touchCancel 事件，这样不能达到阻塞事件的目的

不过这样修改可能会增加事件判断的成本