### PR TITLE
cc.loader.loadResArray type supports Array

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -388,7 +388,7 @@ proto._urlNotFound = function (url, type, completeCallback) {
  */
 proto._parseLoadResArgs = function (type, onProgress, onComplete) {
     if (onComplete === undefined) {
-        var isValidType = js.isChildClassOf(type, cc.RawAsset);
+        var isValidType = (type instanceof Array) || js.isChildClassOf(type, cc.RawAsset);
         if (onProgress) {
             onComplete = onProgress;
             if (isValidType) {
@@ -581,12 +581,13 @@ proto.loadResArray = function (urls, type, progressCallback, completeCallback) {
     var uuids = [];
     for (var i = 0; i < urls.length; i++) {
         var url = urls[i];
-        var uuid = this._getResUuid(url, type);
+        var assetType = (type instanceof Array) ? type[i] : type;
+        var uuid = this._getResUuid(url, assetType);
         if (uuid) {
             uuids.push(uuid);
         }
         else {
-            this._urlNotFound(url, type, completeCallback);
+            this._urlNotFound(url, assetType, completeCallback);
             return;
         }
     }

--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -571,6 +571,7 @@ proto._loadResUuids = function (uuids, progressCallback, completeCallback, urls)
  * loadResArray(url: string[], progressCallback: (completedCount: number, totalCount: number, item: any) => void, completeCallback: ((error: Error, resource: any[]) => void)|null): void
  * loadResArray(url: string[], completeCallback: (error: Error, resource: any[]) => void): void
  * loadResArray(url: string[]): void
+ * loadResArray(url: string[], type: typeof cc.Asset[]): void
  */
 proto.loadResArray = function (urls, type, progressCallback, completeCallback) {
     var args = this._parseLoadResArgs(type, progressCallback, completeCallback);
@@ -579,9 +580,10 @@ proto.loadResArray = function (urls, type, progressCallback, completeCallback) {
     completeCallback = args.onComplete;
 
     var uuids = [];
+    var isTypesArray = type instanceof Array;
     for (var i = 0; i < urls.length; i++) {
         var url = urls[i];
-        var assetType = (type instanceof Array) ? type[i] : type;
+        var assetType = isTypesArray ? type[i] : type;
         var uuid = this._getResUuid(url, assetType);
         if (uuid) {
             uuids.push(uuid);


### PR DESCRIPTION
如图所示
![image](https://user-images.githubusercontent.com/1911170/46062266-d3a99c80-c19b-11e8-941b-cf767d0d53cc.png)

从resources目录动态加载龙骨资源时，因为导出文件中其中两个名字相同，仅仅是后缀类型不同。且由于loadResArray第2个参数资源类型Type只能传一个，导致没法批量加载。建议loadResArray第2个参数能传入类型数组。