### PR TITLE
fix ccNode touchEndHandler when touchCanceled

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -321,12 +321,37 @@ var _touchEndHandler = function (touch, event) {
     var pos = touch.getLocation();
     var node = this.owner;
 
-    if (node._hitTest(pos, this)) {
-        event.type = EventType.TOUCH_END;
+    // get sceneGraphListeners
+    let listeners;
+    let touchOneByOne;
+    if (touchOneByOne = eventManager._listenersMap[cc.EventListener.ListenerID.TOUCH_ONE_BY_ONE]) {
+        listeners = touchOneByOne._sceneGraphListeners;
+    }
+    
+    if (listeners && listeners.includes(this)) {
+        for (let i = 0; i < listeners.length; ++i) {
+            let listener = listeners[i];
+            let target = listener._target;
+            if (target._hitTest(pos, listener)) {
+                if (target === node) {
+                    event.type = EventType.TOUCH_END;
+                }
+                else {
+                    event.type = EventType.TOUCH_CANCEL;
+                }
+                break;
+            }
+        }
     }
     else {
-        event.type = EventType.TOUCH_CANCEL;
+        if (node._hitTest(pos, this)) {
+            event.type = EventType.TOUCH_END;
+        }
+        else {
+            event.type = EventType.TOUCH_CANCEL;
+        }
     }
+
     event.touch = touch;
     event.bubbles = true;
     node.dispatchEvent(event);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/316

完善节点在 touchEndHandler 里对 touchEnd / touchCancel 的判断
当触摸结束时，按钮上方覆盖了新的 button 、 BlockInputEvent 或者注册了 touch 事件的节点，则本次 touch 事件应该是 touchCancel，而不是 touchEnd

目前的做法是：
获取 eventManager 下的 sceneGraphListeners，  
sceneGraphListeners 是经过场景优先级排序的，所以可以按照从上到下的顺序遍历所有 listener._target 并对其进行 hitTest   
判断第一次 hit 的 target 是否等于 当前 event.target, 从而确定当前 touch 是 touchEnd 还是 touchCancel