### PR TITLE
fix scrollView bug for 1.10-release

### DIFF
--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -815,7 +815,7 @@ var ScrollView = cc.Class({
 
         anchor = cc.pClamp(anchor, cc.p(0, 0), cc.p(1, 1));
 
-        var scrollSize = this.node.getContentSize();
+        var scrollSize = this.content.parent.getContentSize();
         var contentSize = this.content.getContentSize();
         var bottomDeta = this._getContentBottomBoundary() - this._bottomBoundary;
         bottomDeta = -bottomDeta;
@@ -1329,11 +1329,6 @@ var ScrollView = cc.Class({
         var currentOutOfBoundary = this._getHowMuchOutOfBoundary();
         if (!cc.pFuzzyEqual(currentOutOfBoundary, cc.p(0, 0), EPSILON)) {
             this._autoScrollCurrentlyOutOfBoundary = true;
-            var afterOutOfBoundary = this._getHowMuchOutOfBoundary(adjustedDeltaMove);
-            if (currentOutOfBoundary.x * afterOutOfBoundary.x > 0 ||
-                currentOutOfBoundary.y * afterOutOfBoundary.y > 0) {
-                this._autoScrollBraking = true;
-            }
         }
     },
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/623

修复问题：
- scrollView 跟 mask 大小不一致时候，调用 scrollTo* 位置会有偏差
- scrollView 向右下角或左上角滑动时，概率性出现滚轮显示异常

关联：
https://github.com/cocos-creator/engine/pull/3242
https://github.com/cocos-creator/engine/pull/2939