### PR TITLE
 fix motion streak index count error.

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/motion-streak.js
+++ b/cocos2d/core/renderer/webgl/assemblers/motion-streak.js
@@ -187,7 +187,7 @@ var motionStreakAssembler = {
         }
 
         renderData.vertexCount = renderData.dataLength;
-        renderData.indiceCount = (renderData.vertexCount - 2)*3;
+        renderData.indiceCount = renderData.indiceCount == 0 ? 0 : (renderData.vertexCount - 2)*3;
     },
 
     fillBuffers (comp, renderer) {


### PR DESCRIPTION
it can cause output error:

[.WebGL-0x7ff4a600ba00]GL ERROR :GL_INVALID_OPERATION : glDrawElements: range out of bounds for buffer