### PR TITLE
should raise an exception if failed to initialize shaders

### DIFF
--- a/cocos2d/shaders/CCGLProgram.js
+++ b/cocos2d/shaders/CCGLProgram.js
@@ -94,7 +94,7 @@ cc.GLProgram = cc._Class.extend(/** @lends cc.GLProgram# */{
         var status = this._glContext.getShaderParameter(shader, this._glContext.COMPILE_STATUS);
 
         if (!status) {
-            cc.logID(8100, this._glContext.getShaderSource(shader));
+            cc.warnID(8100, this._glContext.getShaderSource(shader));
             if (type === this._glContext.VERTEX_SHADER)
                 cc.log("cocos2d: \n" + this.vertexShaderLog());
             else
@@ -150,7 +150,7 @@ cc.GLProgram = cc._Class.extend(/** @lends cc.GLProgram# */{
         if (vertShaderStr) {
             this._vertShader = locGL.createShader(locGL.VERTEX_SHADER);
             if (!this._compileShader(this._vertShader, locGL.VERTEX_SHADER, vertShaderStr)) {
-                cc.logID(8101);
+                cc.warnID(8101);
             }
         }
 
@@ -158,7 +158,7 @@ cc.GLProgram = cc._Class.extend(/** @lends cc.GLProgram# */{
         if (fragShaderStr) {
             this._fragShader = locGL.createShader(locGL.FRAGMENT_SHADER);
             if (!this._compileShader(this._fragShader, locGL.FRAGMENT_SHADER, fragShaderStr)) {
-                cc.logID(8102);
+                cc.warnID(8102);
             }
         }
 


### PR DESCRIPTION
避免用户漏掉关键的报错信息，导致沟通效率低下
![image](https://user-images.githubusercontent.com/1503156/46131139-8138b080-c26d-11e8-8bca-941094b3c749.png)

这里的 log 其实是 error，但是用户看不出来的话反馈问题的时候就会跳过。