### PR TITLE
fix deviceMotionEvent when view rotated

### DIFF
--- a/cocos2d/core/platform/CCInputExtension.js
+++ b/cocos2d/core/platform/CCInputExtension.js
@@ -128,6 +128,12 @@ inputManager.didAccelerate = function (eventData) {
         y = -(eventData["beta"] / 90) * 0.981;
         z = (eventData["alpha"] / 90) * 0.981;
     }
+    
+    if (cc.view._isRotated) {
+        let tmp = x;
+        x = -y;
+        y = tmp;
+    }
 
     mAcceleration.x = x;
     mAcceleration.y = y;


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/628

修复 web-mobile 横屏时，重力感应方向错误问题。

其实这个 问题在 2.0 已经修复过
https://github.com/cocos-creator/engine/pull/2788