### PR TITLE
call jsb.device.setMotion when set setAccelerometer on native

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -38,7 +38,7 @@ const dynamicAtlasManager = require('../core/renderer/utils/dynamic-atlas/manage
 /**
  * !#en An object to boot the game.
  * !#zh 包含游戏主体信息并负责驱动游戏的游戏对象。
- * @class game
+ * @class Game
  * @static
  * @extends EventTarget
  */
@@ -879,6 +879,12 @@ EventTarget.call(game);
 cc.js.addon(game, EventTarget.prototype);
 
 /**
+ * @module cc
+ */
+
+/**
+ * !#en This is a Game instance.
+ * !#zh 这是一个 Game 类的实例，包含游戏主体信息并负责驱动游戏的游戏对象。。
  * @property game
  * @type Game
  */

--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -121,7 +121,11 @@ var SizeMode = cc.Enum({
      */
     RAW: 2
 });
-
+/**
+ * !#en Sprite state can choice the normal or grayscale.
+ * !#zh 精灵颜色通道模式。
+ * @enum Sprite.State
+ */
 var State = cc.Enum({
     /**
      * !#en The normal state

--- a/cocos2d/core/event/system-event.js
+++ b/cocos2d/core/event/system-event.js
@@ -88,9 +88,6 @@ var SystemEvent = cc.Class({
      */
     setAccelerometerEnabled: function (isEnable) {
         inputManger.setAccelerometerEnabled(isEnable);
-        if (CC_JSB) {
-            jsb.device.setMotionEnabled(isEnable);
-        }
     },
 
     /**
@@ -101,9 +98,6 @@ var SystemEvent = cc.Class({
      */
     setAccelerometerInterval: function(interval) {
         inputManger.setAccelerometerInterval(interval);
-        if (CC_JSB) {
-            jsb.device.setMotionInterval(interval);
-        }
     },
 
     on: function (type, callback, target) {

--- a/cocos2d/core/event/system-event.js
+++ b/cocos2d/core/event/system-event.js
@@ -88,6 +88,9 @@ var SystemEvent = cc.Class({
      */
     setAccelerometerEnabled: function (isEnable) {
         inputManger.setAccelerometerEnabled(isEnable);
+        if (CC_JSB) {
+            jsb.device.setMotionEnabled(isEnable);
+        }
     },
 
     /**
@@ -98,6 +101,9 @@ var SystemEvent = cc.Class({
      */
     setAccelerometerInterval: function(interval) {
         inputManger.setAccelerometerInterval(interval);
+        if (CC_JSB) {
+            jsb.device.setMotionInterval(interval);
+        }
     },
 
     on: function (type, callback, target) {

--- a/cocos2d/core/platform/CCInputExtension.js
+++ b/cocos2d/core/platform/CCInputExtension.js
@@ -73,6 +73,10 @@ inputManager.setAccelerometerEnabled = function (isEnable) {
         _t._accelCurTime = 0;
         scheduler.unscheduleUpdate(_t);
     }
+
+    if (CC_JSB) {
+        jsb.device.setMotionEnabled(isEnable);
+    }
 };
 
 /**
@@ -83,6 +87,10 @@ inputManager.setAccelerometerEnabled = function (isEnable) {
 inputManager.setAccelerometerInterval = function (interval) {
     if (this._accelInterval !== interval) {
         this._accelInterval = interval;
+
+        if (CC_JSB) {
+            jsb.device.setMotionInterval(interval);
+        }
     }
 };
 


### PR DESCRIPTION
修复：https://github.com/cocos-creator/2d-tasks/issues/351

配合：https://github.com/cocos-creator/cocos2d-x-lite/pull/1523

重力感应的方法已经在 jsb-adapter 中实现过，只是没被调用。修复在文件：cocos2d/core/event/system-event.js

> PR 的额外工作，同步分支的小差异。