### PR TITLE
fix button bug for 2.1-release

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -60,6 +60,7 @@ const SCALE_ON = 1 << 1;
 const ROTATION_ON = 1 << 2;
 const SIZE_ON = 1 << 3;
 const ANCHOR_ON = 1 << 4;
+const COLOR_ON = 1 << 5;
 
 
 let BuiltinGroupIndex = cc.Enum({
@@ -249,6 +250,16 @@ var EventType = cc.Enum({
      * @static
      */
     ANCHOR_CHANGED: 'anchor-changed',
+    /**
+    * !#en The event type for color change events.
+    * Performance note, this event will be triggered every time corresponding properties being changed,
+    * if the event callback have heavy logic it may have great performance impact, try to avoid such scenario.
+    * !#zh 当节点颜色改变时触发的事件。
+    * 性能警告：这个事件会在每次对应的属性被修改时触发，如果事件回调损耗较高，有可能对性能有很大的负面影响，请尽量避免这种情况。
+    * @property {String} COLOR_CHANGED
+    * @static
+    */
+    COLOR_CHANGED: 'color-changed',
     /**
      * !#en The event type for new child added events.
      * !#zh 当新的子节点被添加时触发的事件。
@@ -944,6 +955,10 @@ var Node = cc.Class({
                     if (this._renderComponent) {
                         this._renderFlag |= RenderFlow.FLAG_COLOR;
                     }
+
+                    if (this._eventMask & COLOR_ON) {
+                        this.emit(EventType.COLOR_CHANGED, value);
+                    }
                 }
             },
         },
@@ -1450,6 +1465,7 @@ var Node = cc.Class({
      * node.on(cc.Node.EventType.TOUCH_END, callback, this);
      * node.on(cc.Node.EventType.TOUCH_CANCEL, callback, this);
      * node.on(cc.Node.EventType.ANCHOR_CHANGED, callback);
+     * node.on(cc.Node.EventType.COLOR_CHANGED, callback);
      */
     on (type, callback, target, useCapture) {
         let forDispatch = this._checknSetupSysEvent(type);
@@ -1472,6 +1488,9 @@ var Node = cc.Class({
                 break;
                 case EventType.ANCHOR_CHANGED:
                 this._eventMask |= ANCHOR_ON;
+                break;
+                case EventType.COLOR_CHANGED:
+                this._eventMask |= COLOR_ON;
                 break;
             }
             if (!this._bubblingListeners) {
@@ -1614,6 +1633,9 @@ var Node = cc.Class({
                     case EventType.ANCHOR_CHANGED:
                     this._eventMask &= ~ANCHOR_ON;
                     break;
+                    case EventType.COLOR_CHANGED:
+                    this._eventMask &= ~COLOR_ON;
+                    break;
                 }
             }
         }
@@ -1671,6 +1693,9 @@ var Node = cc.Class({
             }
             if ((this._eventMask & ANCHOR_ON) && !listeners.hasEventListener(EventType.ANCHOR_CHANGED)) {
                 this._eventMask &= ~ANCHOR_ON;
+            }
+            if ((this._eventMask & COLOR_ON) && !listeners.hasEventListener(EventType.COLOR_CHANGED)) {
+                this._eventMask &= ~COLOR_ON;
             }
         }
         if (this._capturingListeners) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/399

改动：
创建 State 枚举
添加 node  COLOR_CHANGED 事件

修复问题：
禁用 interactable， normalSprite 会设置成 diabledSprite (修复同时 reset 了之前的一个提交 https://github.com/cocos-creator/engine/pull/808)
按钮 color 模式下，设置透明度无效
优化编辑器修改 button  transition 的体验
- transition 从 color 改成其他模式，node 上的颜色应该再初始化（或者变灰度状态）
- transition 从 sprite 改成其他模式，spriteFrame 应该设置为 Normal 状态
- 灰度状态下 改成 color 模式，node 上的颜色改成 disbaled 状态的颜色
- 灰度状态下 改成 sprite 模式，spriteFrame 应该设置为 disabled 状态（如果存在）
