### PR TITLE
fixed the DistanceJoint api name

### DIFF
--- a/cocos2d/core/physics/joint/CCDistanceJoint.js
+++ b/cocos2d/core/physics/joint/CCDistanceJoint.js
@@ -98,7 +98,6 @@ var DistanceJoint = cc.Class({
          * !#zh
          * 阻尼，表示关节变形后，恢复到初始状态受到的阻力。
          * @property {Number} dampingRatio
-         * @property 0
          */
         dampingRatio: {
             tooltip: CC_DEV && 'i18n:COMPONENT.physics.physics_collider.dampingRatio',            


### PR DESCRIPTION
Re: https://github.com/cocos-creator/creator-api-docs/issues/93
修复 api 名称显示错误
![image](https://user-images.githubusercontent.com/35832931/46590816-02ebd200-cae9-11e8-86c6-ac206e896119.png)
![image](https://user-images.githubusercontent.com/35832931/46590846-3a5a7e80-cae9-11e8-9e84-2e8db07884d0.png)

