### PR TITLE
fix button bug in engine for 2.1-release

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -419,7 +419,7 @@ let Button = cc.Class({
         let target = this.target;
         let transition = this.transition;
         if (transition === Transition.COLOR && this.interactable) {
-            target.color = this.normalColor;
+            this._setTargetColor(this.normalColor);
         } else if (transition === Transition.SCALE) {
             target.scale = this._originalScale;
         }
@@ -455,6 +455,15 @@ let Button = cc.Class({
                 }
             }.bind(this));
         }
+    },
+
+    _setTargetColor(color) {
+        let target = this.target;
+        if (!target) {
+            return;
+        }
+        target.color = color;
+        target.opacity = color.a;
     },
 
     _getStateColor (state) {
@@ -550,8 +559,8 @@ let Button = cc.Class({
         }
 
         if (this.transition === Transition.COLOR) {
-            target.color = this._fromColor.lerp(this._toColor, ratio);
-            target.opacity = target.color.a;
+            let color = this._fromColor.lerp(this._toColor, ratio);
+            this._setTargetColor(color);
         } else if (this.transition === Transition.SCALE) {
             target.scale = misc.lerp(this._fromScale, this._toScale, ratio);
         }
@@ -681,15 +690,18 @@ let Button = cc.Class({
         return state;
     },
 
-    _updateColorTransition (state) {
+    _updateColorTransitionImmediately (state) {
         let color = this._getStateColor(state);
-        let target = this.target;
+        this._setTargetColor(color);
+    },
 
-        if (CC_EDITOR) {
-            target.color = color;
-            target.opacity = color.a;
+    _updateColorTransition (state) {
+        if (CC_EDITOR || state === State.DISABLED) {
+            this._updateColorTransitionImmediately(state);
         }
         else {
+            let color = this._getStateColor(state);
+            let target = this.target;
             this._fromColor = target.color.clone();
             this._toColor = color;
             this.time = 0;
@@ -729,7 +741,7 @@ let Button = cc.Class({
     _updateTransition (oldTransition) {
         // Reset to normal data when change transition.
         if (oldTransition === Transition.COLOR) {
-            this._updateColorTransition(State.NORMAL);
+            this._updateColorTransitionImmediately(State.NORMAL);
         }
         else if (oldTransition === Transition.SPRITE) {
             this._updateSpriteTransition(State.NORMAL);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/399

修复问题：
运行时，color模式下，button.interactable = false， 颜色显示不正确

改动：
- 将 target.color 的设置，统一为 _setTargetColor( color ) 接口，避免冗余的 opacity 设置
- 增加 _updateColorTransitionImmediately()，立即更新 button 颜色  


需要立即更新 button 颜色的情况：
- button.interactable = false 的时候进行了 resetState，_transitionFinished = true,这时没办法通过 update() 来更新按钮颜色
- button 在编辑器情况下，或者 _updateTransition 的时候，需要立即更新 button 颜色