### PR TITLE
Fix rendering residue for transparent images on Chrome69.

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -775,7 +775,7 @@ var game = {
             this._renderContext = renderer.device._gl;
             
             // Enable dynamic atlas manager by default
-            if (!cc.macro.CLEANUP_IMAGE_CACHE && dynamicAtlasManager) {
+            if (!cc.macro.CLEANUP_IMAGE_CACHE && dynamicAtlasManager && !(cc.sys.browserType == cc.sys.BROWSER_TYPE_CHROME && parseFloat(cc.sys.browserVersion) >= 69.0)) {
                 dynamicAtlasManager.enabled = true;
             }
         }

--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -775,8 +775,12 @@ var game = {
             this._renderContext = renderer.device._gl;
             
             // Enable dynamic atlas manager by default
-            if (!cc.macro.CLEANUP_IMAGE_CACHE && dynamicAtlasManager && !(cc.sys.browserType == cc.sys.BROWSER_TYPE_CHROME && parseFloat(cc.sys.browserVersion) >= 69.0)) {
+            if (!cc.macro.CLEANUP_IMAGE_CACHE && dynamicAtlasManager) {
                 dynamicAtlasManager.enabled = true;
+            }
+            // Disable dynamicAtlasManager to fix rendering residue for transparent images on Chrome69.
+            if (cc.sys.browserType == cc.sys.BROWSER_TYPE_CHROME && parseFloat(cc.sys.browserVersion) >= 69.0) {
+                dynamicAtlasManager.enabled = false;
             }
         }
         if (!this._renderContext) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#645

Changes:
Disable dynamicAtlasManager by determining the browser version to fix rendering residue for transparent images on Chrome69.
