### PR TITLE
open DragonBones API CCFactory.getInstance()

### DIFF
--- a/extensions/dragonbones/CCFactory.js
+++ b/extensions/dragonbones/CCFactory.js
@@ -24,11 +24,21 @@
  ****************************************************************************/
 
 let BaseObject = dragonBones.BaseObject;
-
+/**
+ * @class CCFactory
+ * @extends BaseFactory
+ * @namespace dragonBones
+*/
 var CCFactory = dragonBones.CCFactory = cc.Class({
     name: 'dragonBones.CCFactory',
     extends: dragonBones.BaseFactory,
-
+    /**
+     * @method getInstance
+     * @return {CCFactory}
+     * @static
+     * @example
+     * let factory = dragonBones.CCFactory.getInstance();
+    */
     statics: {
         _factory: null,
         getInstance () {


### PR DESCRIPTION
按照我们技术支持的需求开放一个 dragonBone 原有的 API 接口在 dragonBone.t.ds
![image](https://user-images.githubusercontent.com/35832931/46654509-97cef800-cbdb-11e8-9e61-1ee8cce5fbc1.png)
除了 getInstance API 之外的 API 函数都是 abstructor 函数，写上避免报错。

下次版本需要重新更新一下 tsd