### PR TITLE
modify the initView API

### DIFF
--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -193,9 +193,6 @@ let ScrollView = cc.Class({
         this._scrollEventEmitMask = 0;
         this._isBouncing = false;
         this._scrolling = false;
-        
-        // content parent object 
-        this._view = undefined;
     },
 
     properties: {
@@ -342,6 +339,15 @@ let ScrollView = cc.Class({
             default: true,
             animatable: false,
             tooltip: CC_DEV && 'i18n:COMPONENT.scrollview.cancelInnerEvents'
+        },
+
+        // private object
+        _view: {
+            get: function () {
+                if (this.content) {
+                    return this.content.parent;
+                }
+            }
         }
     },
 
@@ -1536,7 +1542,6 @@ let ScrollView = cc.Class({
 
     onEnable () {
         if (!CC_EDITOR) {
-            this._initView();
             this._registerEvent();
             this.node.on(NodeEvent.SIZE_CHANGED, this._calculateBoundary, this);
             this.node.on(NodeEvent.SCALE_CHANGED, this._calculateBoundary, this);
@@ -1556,12 +1561,6 @@ let ScrollView = cc.Class({
     update (dt) {
         if (this._autoScrolling) {
             this._processAutoScrolling(dt);
-        }
-    },
-
-    _initView () {
-        if (this.content) {
-            this._view = this.content.parent;
         }
     }
 });


### PR DESCRIPTION
修复 example-case pageView 场景崩溃问题
因为脚本生命周期 onLoad 先于 onEable 为了避免用户以后会有类似在 onLoad 针对 pageView 或者 scrollView 的操作，所以把 view 的初始化过程提前到 onLoad