### PR TITLE
open DragonBones API CCFactory.getInstance()

### DIFF
--- a/extensions/dragonbones/CCFactory.js
+++ b/extensions/dragonbones/CCFactory.js
@@ -24,10 +24,14 @@
  ****************************************************************************/
 
 let BaseObject = dragonBones.BaseObject;
+
+/**
+ * @module dragonBones
+*/
+
 /**
  * @class CCFactory
  * @extends BaseFactory
- * @namespace dragonBones
 */
 var CCFactory = dragonBones.CCFactory = cc.Class({
     name: 'dragonBones.CCFactory',


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/pull/3358
之前的 pr 没修好，重新提一个。。。我下回注意。
顺便一提，我发现咱们注释内容中是不包含 @namespace 这个注释含义的，dragonBones 和 spine 才有 namespace，但是生成的原理不同。
因此上个修复是错误的因为 CCFactory 不能包含到 namespace dragonBones 中