### PR TITLE
make webview add listenerEvent befor load

### DIFF
--- a/cocos2d/webview/CCWebView.js
+++ b/cocos2d/webview/CCWebView.js
@@ -123,13 +123,13 @@ let WebView = cc.Class({
     onEnable () {
         let impl = this._impl;
         impl.createDomElementIfNeeded(this.node.width, this.node.height);
-        impl.loadURL(this._url);
-        impl.setVisible(true);
         if (!CC_EDITOR) {
             impl.setEventListener(EventType.LOADED, this._onWebViewLoaded.bind(this));
             impl.setEventListener(EventType.LOADING, this._onWebViewLoading.bind(this));
             impl.setEventListener(EventType.ERROR, this._onWebViewLoadError.bind(this));
         }
+        impl.loadURL(this._url);
+        impl.setVisible(true);
     },
 
     onDisable () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/example-cases/issues/608
调整 webView 脚本内容执行流程。
![gif](https://user-images.githubusercontent.com/35832931/46855116-66e9ff80-ce35-11e8-8214-581aab99b5a7.gif)

修复了 cc.webView 在读取 default 页面不触发 load 事件监听的 bug