### PR TITLE
Modify the node with opacity 0 to skip rendering.

### DIFF
--- a/cocos2d/core/renderer/render-flow.js
+++ b/cocos2d/core/renderer/render-flow.js
@@ -97,7 +97,7 @@ _proto._children = function (node) {
     let children = node._children;
     for (let i = 0, l = children.length; i < l; i++) {
         let c = children[i];
-        if (!c._activeInHierarchy || c.opacity === 0) continue;
+        if (!c._activeInHierarchy || c._opacity === 0) continue;
         _cullingMask = c._cullingMask = c.groupIndex === 0 ? cullingMask : 1 << c.groupIndex;
         c._renderFlag |= worldTransformFlag | worldOpacityFlag;
 

--- a/cocos2d/core/renderer/render-flow.js
+++ b/cocos2d/core/renderer/render-flow.js
@@ -97,7 +97,7 @@ _proto._children = function (node) {
     let children = node._children;
     for (let i = 0, l = children.length; i < l; i++) {
         let c = children[i];
-        if (!c._activeInHierarchy) continue;
+        if (!c._activeInHierarchy || c.opacity === 0) continue;
         _cullingMask = c._cullingMask = c.groupIndex === 0 ? cullingMask : 1 << c.groupIndex;
         c._renderFlag |= worldTransformFlag | worldOpacityFlag;
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#381

Changes:
Add opacity judgment in render-flow to make the node with opacity 0 skip rendering.
