### PR TITLE
fix life value is 0, emissionRate value calculation error

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -993,7 +993,7 @@ var ParticleSystem = cc.Class({
         this.lifeVar = parseFloat(dict["particleLifespanVariance"] || 0);
 
         // emission Rate
-        this.emissionRate = this.totalParticles / this.life;
+        this.emissionRate = Math.min(this.totalParticles / this.life, Number.MAX_VALUE);
 
         // duration
         this.duration = parseFloat(dict["duration"] || 0);


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 life 值为0，emitRate 值计算错误

由于 ipc 消息会把 Infinity 转换为 0，所以通过 min，当 emitRate 为 Infinity 时取 Number.MAX_VALUE