### PR TITLE
fix outline color invalid

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/label/ttf.js
+++ b/cocos2d/core/renderer/webgl/assemblers/label/ttf.js
@@ -26,6 +26,8 @@
 const js = require('../../../../platform/js');
 const ttfUtls = require('../../../utils/label/ttf');
 
+const WHITE = cc.color(255, 255, 255, 255);
+
 module.exports = js.addon({
     createData (comp) {
         let renderData = comp.requestRenderData();
@@ -49,7 +51,7 @@ module.exports = js.addon({
     fillBuffers (comp, renderer) {
         let data = comp._renderData._data,
             node = comp.node,
-            color = node._color._val,
+            color = WHITE._val,
             matrix = node._worldMatrix,
             a = matrix.m00, b = matrix.m01, c = matrix.m04, d = matrix.m05,
             tx = matrix.m12, ty = matrix.m13;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 outline 设置 color 无效
 * 设置 label material.useColor 为 false 的时候，label fillBuffers 不应该使用节点的 color 来渲染