### PR TITLE
gizmos adaptation

### DIFF
--- a/cocos/3d/builtin/effects/gizmo.json
+++ b/cocos/3d/builtin/effects/gizmo.json
@@ -27,12 +27,12 @@
       "passes": [
        {
          "program": "unlit",
-         "cullMode": "back",
-         "depthTest": true,
+         "cullMode": "none",
+         "depthTest": false,
          "depthWrite": false,
          "blend": true,
          "blendEq": "add",
-         "blendSrc": "srcAlpha",
+         "blendSrc": "one",
          "blendDst": "oneMinusSrcAlpha",
          "blendAlphaEq": "add",
          "blendSrcAlpha": "one",

--- a/cocos/3d/framework/model-component.js
+++ b/cocos/3d/framework/model-component.js
@@ -25,7 +25,7 @@
 // @ts-check
 import RenderSystemActor from './renderSystemActor';
 import renderer from '../../renderer/index';
-import { ccclass, property, menu } from '../../core/data/class-decorator';
+import { ccclass, property, menu, executeInEditMode } from '../../core/data/class-decorator';
 import Mesh from '../assets/mesh';
 import Enum from '../../core/value-types/enum';
 import RenderableComponent from './renderable-component';
@@ -88,6 +88,7 @@ let ModelShadowCastingMode = Enum({
  */
 @ccclass('cc.ModelComponent')
 @menu('Components/ModelComponent')
+@executeInEditMode
 export default class ModelComponent extends RenderableComponent {
     @property
     _materials = [];

--- a/cocos/3d/geom-utils/intersect.js
+++ b/cocos/3d/geom-utils/intersect.js
@@ -40,6 +40,7 @@ let line_plane = (function () {
 
 /**
  * ray-triangle intersect
+ * based on http://fileadmin.cs.lth.se/cs/Personal/Tomas_Akenine-Moller/raytri/
  *
  * @param {ray} ray
  * @param {triangle} triangle
@@ -52,32 +53,26 @@ let ray_triangle = (function () {
   let tvec = vec3.create(0, 0, 0);
   let qvec = vec3.create(0, 0, 0);
 
-  return function (ray, triangle) {
+  return function (ray, triangle, doubleSided) {
     vec3.sub(ab, triangle.b, triangle.a);
     vec3.sub(ac, triangle.c, triangle.a);
 
     vec3.cross(pvec, ray.d, ac);
     let det = vec3.dot(ab, pvec);
+    if (det < Number.EPSILON && (!doubleSided || det > -Number.EPSILON)) return 0;
 
-    if (det <= 0) {
-      return 0;
-    }
+    let inv_det = 1 / det;
 
     vec3.sub(tvec, ray.o, triangle.a);
-    let u = vec3.dot(tvec, pvec);
-    if (u < 0 || u > det) {
-      return 0;
-    }
+    let u = vec3.dot(tvec, pvec) * inv_det;
+    if (u < 0 || u > 1) return 0;
 
     vec3.cross(qvec, tvec, ab);
-    let v = vec3.dot(ray.d, qvec);
-    if (v < 0 || u + v > det) {
-      return 0;
-    }
+    let v = vec3.dot(ray.d, qvec) * inv_det;
+    if (v < 0 || u + v > 1) return 0;
 
-    let t = vec3.dot(ac, qvec) / det;
-    if (t < 0) return 0;
-    return t;
+    let t = vec3.dot(ac, qvec) * inv_det;
+    return t < 0 ? 0 : t;
   };
 })();
 

--- a/cocos/core/event/callbacks-invoker.js
+++ b/cocos/core/event/callbacks-invoker.js
@@ -212,7 +212,7 @@ CallbacksHandler.prototype = {
             }
         }
     }
-}
+};
 
 /**
  * !#en The callbacks invoker to handle and invoke callbacks by key.
@@ -273,4 +273,4 @@ if (CC_TEST) {
 export {
     CallbacksHandler,
     CallbacksInvoker
-}
+};

--- a/cocos/core/event/event-target.js
+++ b/cocos/core/event/event-target.js
@@ -213,6 +213,19 @@ js.mixin(EventTarget.prototype, {
      * eventTarget.emit('fire', event);
      * eventTarget.emit('fire', message, emitter);
      */
+
+    /**
+     * !#en
+     * Send an event with the event object.
+     * !#zh
+     * 通过事件对象派发事件
+     *
+     * @method dispatchEvent
+     * @param {Event} event
+     */
+    dispatchEvent (event) {
+        this.invoke(event.type, event);
+    }
 });
 
 cc.EventTarget = EventTarget;

--- a/cocos/core/event/event-target.js
+++ b/cocos/core/event/event-target.js
@@ -213,19 +213,6 @@ js.mixin(EventTarget.prototype, {
      * eventTarget.emit('fire', event);
      * eventTarget.emit('fire', message, emitter);
      */
-
-    /**
-     * !#en
-     * Send an event with the event object.
-     * !#zh
-     * 通过事件对象派发事件
-     *
-     * @method dispatchEvent
-     * @param {Event} event
-     */
-    dispatchEvent (event) {
-        this.invoke(event.type, event);
-    }
 });
 
 cc.EventTarget = EventTarget;

--- a/cocos/core/value-types/color.js
+++ b/cocos/core/value-types/color.js
@@ -543,6 +543,15 @@ export default class Color extends ValueType {
             this.a = color.a;
         }
     }
+
+    to01(out) {
+      out = out || cc.vmath.color4.create();
+      out.r = this.r / 255;
+      out.g = this.g / 255;
+      out.b = this.b / 255;
+      out.a = this.a / 255;
+      return out;
+    }
 }
 
 CCClass.fastDefine('cc.Color', Color, {r: 0, g: 0, b: 0, a: 255});

--- a/cocos/core/value-types/quat.js
+++ b/cocos/core/value-types/quat.js
@@ -128,6 +128,14 @@ export default class Quat extends ValueType {
         var cosy = 1.0 - 2.0 * (this.y * this.y + this.z * this.z);  
         return 180 * Math.atan2(siny, cosy) / Math.PI;
     }
+    
+    getEulerAngles (out) {
+        out = out || cc.v3();
+        out.x = this.getRoll();
+        out.y = this.getPitch();
+        out.z = this.getYaw();
+        return out;
+    }
 
     lerp (to, ratio, out) {
         out = out || new cc.Quat();

--- a/cocos/renderer/scene/scene.js
+++ b/cocos/renderer/scene/scene.js
@@ -195,21 +195,11 @@ class Scene {
 
 if (CC_EDITOR) {
   /**
-   * create a raycast result array
-   * @return {RecyclePool}
-   */
-  Scene.createRaycastResult = function() {
-    return new RecyclePool(() => {
-      return { node: null, distance: Infinity };
-    }, 16);
-  };
-
-  /**
    * Cast a ray into the scene, record all the intersected models in the result array
    * @param {Ray} worldRay the testing ray
-   * @param {RecyclePool} results the result array
+   * @param {Object[]} results the results array
    * @param {number} mask the layer mask to filter the models
-   * @return {boolean} does the ray hit any models?
+   * @return {Object[]} the results array
    */
   Scene.prototype.raycast = (function() {
     let modelRay = ray.create();
@@ -217,40 +207,46 @@ if (CC_EDITOR) {
     let m4 = mat4.create();
     let distance = Infinity;
     let tri = triangle.create();
-    return function(worldRay, results, mask = Layers.RaycastMask) {
-      results.reset();
+    let pool = new RecyclePool(() => {
+      return { node: null, distance: Infinity };
+    }, 8);
+    let results = [];
+    return function(worldRay, mask = Layers.RaycastMask) {
+      pool.reset();
       for (let i = 0; i < this._models.length; i++) {
         let m = this._models.data[i], node = m._node;
-        if (!cc.Layers.check(node._layer, mask)) continue;
+        if (!cc.Layers.check(node._layer, mask) || !m._bsModelSpace) continue;
         // transform ray back to model space
         mat4.invert(m4, node.getWorldMatrix(m4));
         vec3.transformMat4(modelRay.o, worldRay.o, m4);
         vec3.normalize(modelRay.d, vec3.transformMat4Normal(modelRay.d, worldRay.d, m4));
         // broadphase
-        if (!m._bsModelSpace || (distance = intersect
-          .ray_aabb(modelRay, m._bsModelSpace)) <= 0) continue;
-        if (m._inputAssembler._primitiveType == gfx.PT_TRIANGLES) {
+        if ((distance = intersect.ray_aabb(modelRay, m._bsModelSpace)) <= 0) continue;
+        let ia = m._inputAssembler;
+        if (ia._primitiveType == gfx.PT_TRIANGLES) {
           // narrowphase
           distance = Infinity;
-          let vb = m._inputAssembler._vertexBuffer[gfx.ATTR_POSITION];
-          let ib = m._inputAssembler._indexBuffer._data;
+          let vb = ia._vertexBuffer[gfx.ATTR_POSITION];
+          let ib = ia._indexBuffer._data, sides = ia.doubleSided;
           for (let j = 0; j < ib.length; j += 3) {
             let i0 = ib[j] * 3, i1 = ib[j + 1] * 3, i2 = ib[j + 2] * 3;
             vec3.set(tri.a, vb[i0], vb[i0 + 1], vb[i0 + 2]);
             vec3.set(tri.b, vb[i1], vb[i1 + 1], vb[i1 + 2]);
             vec3.set(tri.c, vb[i2], vb[i2 + 1], vb[i2 + 2]);
-            let dist = intersect.ray_triangle(modelRay, tri);
+            let dist = intersect.ray_triangle(modelRay, tri, sides);
             if (dist <= 0 || dist > distance) continue;
             distance = dist;
           }
         }
         if (distance < Infinity) {
-          let res = results.add();
-          res.node = node;
-          res.distance = distance * vec3.mag(vec3.mul(v3, modelRay.d, node._scale));
+          let r = pool.add();
+          r.node = node;
+          r.distance = distance * vec3.magnitude(vec3.mul(v3, modelRay.d, node._scale));
+          results[pool.length - 1] = r;
         }
       }
-      return results.length;
+      results.length = pool.length;
+      return results;
     };
   })();
 }

--- a/cocos/renderer/scene/scene.js
+++ b/cocos/renderer/scene/scene.js
@@ -213,38 +213,41 @@ if (CC_EDITOR) {
    */
   Scene.prototype.raycast = (function() {
     let modelRay = ray.create();
+    let v3 = vec3.create();
     let m4 = mat4.create();
     let distance = Infinity;
     let tri = triangle.create();
     return function(worldRay, results, mask = Layers.RaycastMask) {
       results.reset();
       for (let i = 0; i < this._models.length; i++) {
-        let m = this._models.data[i];
-        if ((m._node._layer & mask) === 0 ||
-          m._inputAssembler._primitiveType !== gfx.PT_TRIANGLES) continue;
+        let m = this._models.data[i], node = m._node;
+        if (!cc.Layers.check(node._layer, mask)) continue;
         // transform ray back to model space
-        mat4.invert(m4, m._node.getWorldMatrix(m4));
+        mat4.invert(m4, node.getWorldMatrix(m4));
         vec3.transformMat4(modelRay.o, worldRay.o, m4);
         vec3.normalize(modelRay.d, vec3.transformMat4Normal(modelRay.d, worldRay.d, m4));
         // broadphase
-        if (intersect.ray_aabb(modelRay, m._bsModelSpace) <= 0) continue;
-        // narrowphase
-        distance = Infinity;
-        let vb = m._inputAssembler._vertexBuffer[gfx.ATTR_POSITION];
-        let ib = m._inputAssembler._indexBuffer._data;
-        for (let j = 0; j < ib.length; j += 3) {
-          let i0 = ib[j] * 3, i1 = ib[j + 1] * 3, i2 = ib[j + 2] * 3;
-          vec3.set(tri.a, vb[i0], vb[i0 + 1], vb[i0 + 2]);
-          vec3.set(tri.b, vb[i1], vb[i1 + 1], vb[i1 + 2]);
-          vec3.set(tri.c, vb[i2], vb[i2 + 1], vb[i2 + 2]);
-          let dist = intersect.ray_triangle(modelRay, tri);
-          if (dist <= 0 || dist > distance) continue;
-          distance = dist;
+        if (!m._bsModelSpace || (distance = intersect
+          .ray_aabb(modelRay, m._bsModelSpace)) <= 0) continue;
+        if (m._inputAssembler._primitiveType == gfx.PT_TRIANGLES) {
+          // narrowphase
+          distance = Infinity;
+          let vb = m._inputAssembler._vertexBuffer[gfx.ATTR_POSITION];
+          let ib = m._inputAssembler._indexBuffer._data;
+          for (let j = 0; j < ib.length; j += 3) {
+            let i0 = ib[j] * 3, i1 = ib[j + 1] * 3, i2 = ib[j + 2] * 3;
+            vec3.set(tri.a, vb[i0], vb[i0 + 1], vb[i0 + 2]);
+            vec3.set(tri.b, vb[i1], vb[i1 + 1], vb[i1 + 2]);
+            vec3.set(tri.c, vb[i2], vb[i2 + 1], vb[i2 + 2]);
+            let dist = intersect.ray_triangle(modelRay, tri);
+            if (dist <= 0 || dist > distance) continue;
+            distance = dist;
+          }
         }
         if (distance < Infinity) {
           let res = results.add();
-          res.node = m._node;
-          res.distance = distance;
+          res.node = node;
+          res.distance = distance * vec3.mag(vec3.mul(v3, modelRay.d, node._scale));
         }
       }
       return results.length;

--- a/cocos/scene-graph/base-node.js
+++ b/cocos/scene-graph/base-node.js
@@ -40,7 +40,7 @@ var idGenerator = new IdGenerator('Node');
 
 function getConstructor(typeOrClassName) {
     if (!typeOrClassName) {
-        // cc.errorID(3804);
+        cc.errorID(3804);
         return null;
     }
     if (typeof typeOrClassName === 'string') {

--- a/cocos/scene-graph/base-node.js
+++ b/cocos/scene-graph/base-node.js
@@ -40,7 +40,7 @@ var idGenerator = new IdGenerator('Node');
 
 function getConstructor(typeOrClassName) {
     if (!typeOrClassName) {
-        cc.errorID(3804);
+        // cc.errorID(3804);
         return null;
     }
     if (typeof typeOrClassName === 'string') {

--- a/cocos/scene-graph/layers.js
+++ b/cocos/scene-graph/layers.js
@@ -52,9 +52,11 @@ Layers._nextAvailable = 8;
 // built-in layers, reserved up to (1 << 7)
 Layers.Default = (1 << 0);
 Layers.IgnoreRaycast = (1 << 1);
+Layers.Gizmos = (1 << 2);
 
 // masks
-Layers.All = ~0;
-Layers.RaycastMask = Layers.makeExclusiveMask([Layers.IgnoreRaycast]);
+Layers.All = Layers.makeExclusiveMask([Layers.Gizmos]);
+Layers.RaycastMask = Layers.makeExclusiveMask([Layers.Gizmos, Layers.IgnoreRaycast]);
 
 export default Layers;
+cc.Layers = Layers;


### PR DESCRIPTION
for cocos-creator/3d-tasks#123.
migrated the gizmos project into 3d branch.

engine specific approaches during the migration:

* a standalone effect for gizmos(using unlit shader), which makes it look nicer and settles the depth problem.
* extended the `ray_triangle` test to work for both single and double sided triangles, depends on the flag being passed in.

also, fixed `worldToScreen` transform.