### PR TITLE
Fix image blurry caused by camera parameter problems.

### DIFF
--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -525,7 +525,7 @@ let Camera = cc.Class({
         _vec3_temp_1.y = node._worldMatrix.m13;
         _vec3_temp_1.z = 0;
 
-        node.z = height / 1.1566;
+        node.z = height / (Math.tan(this._fov/2) * 2);
         node.lookAt(_vec3_temp_1);
 
         this._matrixDirty = false;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
Fix image blurry caused by camera's eyeZ parameter setting error.