### PR TITLE
add a new API to judge the spriteFrame texture if it insert to dynamic

### DIFF
--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -304,6 +304,19 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
     },
 
     /**
+     * !#en Returns whether the sprite frame has been add to dynamic atlas.
+     * !#zh 判断贴图是否加入图集
+     * @method 
+     * @return {Boolean}
+    */
+    isInsertToDynamicAtlas: function () {
+        if (!this._original) {
+            return false;
+        }
+        return true;
+    },
+
+    /**
      * !#en Returns the texture of the frame.
      * !#zh 获取使用的纹理实例
      * @method getTexture


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/696
Re: http://forum.cocos.com/t/2-0-spriteframe-setrect/63764/9

根据实际使用情况来看，听取建议增加了一个新的 API 用于判断当前 SpriteFrame 中 texture 是否加入到了 dynamic atlas 中。
同时比较希望能够添加一次关于 UV 的计算在 setRect API 中。因为在 setRect 调用时并没有任何处理 updateRenderData 在添加目标 Texture 进入 atlas 之后如果设置 Rect 并不会自动的更新纹理，这似乎导致 setRect 这个 API 的实用性大大降低以及使用范围的限制。
@pandamicro @2youyou2 