### PR TITLE
fixed cc.dynamicAtlasManager class lost

### DIFF
--- a/docs/apisrc.json
+++ b/docs/apisrc.json
@@ -53,6 +53,7 @@
     "!./cocos2d/core/platform/id-generater.js",
 
     "./cocos2d/core/renderer/index.js",
+    "./cocos2d/core/renderer/utils/dynamic-atlas/*",
 
     "./cocos2d/core/utils/affine-transform.js",
     "./cocos2d/core/utils/base-node.js",


### PR DESCRIPTION
Re: http://forum.cocos.com/t/2-0-1-drawcall/65161/19

cc.dynamicAtlasManager 类型缺失
因为 apisrc.json 没有更新对应的文件夹， api-docs 生成的时候没有拷贝对应的文件信息。
修复截图：
![image](https://user-images.githubusercontent.com/35832931/47204197-585f9300-d3b5-11e8-81ab-97e4328a0ad0.png)
