### PR TITLE
fixed the setRect useless problem

### DIFF
--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -256,6 +256,8 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
      */
     setRotated: function (bRotated) {
         this._rotated = bRotated;
+        if (this._texture)
+            this._calculateUV();
     },
 
     /**
@@ -276,6 +278,8 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
      */
     setRect: function (rect) {
         this._rect = rect;
+        if (this._texture)
+            this._calculateUV();
     },
 
     /**
@@ -328,14 +332,14 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
             self._rotated = false;
             w = self._texture.width;
             h = self._texture.height;
-            self.setRect(cc.rect(0, 0, w, h));
+            self._rect = cc.rect(0, 0, w, h);
         }
 
         if (self._rect) {
             self._checkRect(self._texture);
         }
         else {
-            self.setRect(cc.rect(0, 0, w, h));
+            self._rect = cc.rect(0, 0, w, h);
         }
 
         if (!self._originalSize) {
@@ -411,7 +415,7 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
      */
     setTexture: function (textureOrTextureFile, rect, rotated, offset, originalSize) {
         if (rect) {
-            this.setRect(rect);
+            this._rect = rect;
         }
         else {
             this._rect = null;
@@ -675,7 +679,7 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
     _deserialize: function (data, handle) {
         let rect = data.rect;
         if (rect) {
-            this.setRect(new cc.Rect(rect[0], rect[1], rect[2], rect[3]));
+            this._rect = new cc.Rect(rect[0], rect[1], rect[2], rect[3]);
         }
         if (data.offset) {
             this.setOffset(new cc.Vec2(data.offset[0], data.offset[1]));


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/696
为 setRect 增加即时纹理计算
![1](https://user-images.githubusercontent.com/35832931/47331989-7e847c00-d6b0-11e8-9282-bfa79a3cc0c3.gif)

现在超出 atlas 尺寸的 Texture 也能够设置剪裁显示区域