### PR TITLE
Fix rendering errors for pre-multiplied images using dynamicAtlas.

### DIFF
--- a/cocos2d/core/assets/CCRenderTexture.js
+++ b/cocos2d/core/assets/CCRenderTexture.js
@@ -38,8 +38,8 @@ let RenderTexture = cc.Class({
         opts.wrapS = this._wrapS;
         opts.wrapT = this._wrapT;
         opts.premultiplyAlpha = this._premultiplyAlpha;
-        opts.minFilter = Texture2D.FilterIndex[this._minFilter];
-        opts.magFilter = Texture2D.FilterIndex[this._magFilter];
+        opts.minFilter = Texture2D._FilterIndex[this._minFilter];
+        opts.magFilter = Texture2D._FilterIndex[this._magFilter];
 
         if (!this._texture) {
             this._texture = new renderer.Texture2D(renderer.device, opts);

--- a/cocos2d/core/assets/CCRenderTexture.js
+++ b/cocos2d/core/assets/CCRenderTexture.js
@@ -37,6 +37,9 @@ let RenderTexture = cc.Class({
         opts.images = undefined;
         opts.wrapS = this._wrapS;
         opts.wrapT = this._wrapT;
+        opts.premultiplyAlpha = this._premultiplyAlpha;
+        opts.minFilter = Texture2D.FilterIndex[this._minFilter];
+        opts.magFilter = Texture2D.FilterIndex[this._magFilter];
 
         if (!this._texture) {
             this._texture = new renderer.Texture2D(renderer.device, opts);

--- a/cocos2d/core/assets/CCRenderTexture.js
+++ b/cocos2d/core/assets/CCRenderTexture.js
@@ -86,7 +86,8 @@ let RenderTexture = cc.Class({
             width: texture.width,
             height: texture.height,
             level: 0,
-            flipY: false
+            flipY: false,
+            premultiplyAlpha: texture._premultiplyAlpha
         })
     },
 

--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -276,6 +276,8 @@ var Texture2D = cc.Class({
         PixelFormat: PixelFormat,
         WrapMode: WrapMode,
         Filter: Filter,
+        FilterIndex: FilterIndex,
+
         // predefined most common extnames
         extnames: ['.png', '.jpg', '.jpeg', '.bmp', '.webp', '.pvr', '.etc'],
 

--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -276,7 +276,7 @@ var Texture2D = cc.Class({
         PixelFormat: PixelFormat,
         WrapMode: WrapMode,
         Filter: Filter,
-        FilterIndex: FilterIndex,
+        _FilterIndex: FilterIndex,
 
         // predefined most common extnames
         extnames: ['.png', '.jpg', '.jpeg', '.bmp', '.webp', '.pvr', '.etc'],


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#437

Changes:
 Fix rendering errors for pre-multiplied images using dynamicAtlas.
