### PR TITLE
fix editBox bug when can't find camera

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -349,6 +349,16 @@ let EditBoxImpl = cc.Class({
 
     _updateMatrix () {
         if (!this._edTxt) return;
+
+        let camera;
+        // can't find camera in editor
+        if (CC_EDITOR) {
+            camera = cc.Camera.main;
+        }
+        else {
+            camera = cc.Camera.findCamera(this._node);
+        }
+        if (!camera) return;
     
         let node = this._node, 
             scaleX = cc.view._scaleX, scaleY = cc.view._scaleY,
@@ -361,15 +371,6 @@ let EditBoxImpl = cc.Class({
         _vec3.y = -node._anchorPoint.y * contentSize.height;
     
         math.mat4.translate(_matrix, _matrix, _vec3);
-
-        let camera;
-        // can't find camera in editor
-        if (CC_EDITOR) {
-            camera = cc.Camera.main;
-        }
-        else {
-            camera = cc.Camera.findCamera(node);
-        }
         
         camera.getWorldToCameraMatrix(_matrix_temp);
         math.mat4.mul(_matrix_temp, _matrix_temp, _matrix);


### PR DESCRIPTION
修复问题：
editBox 没有 camera 渲染的时候，会报错

![image](https://user-images.githubusercontent.com/17872773/47340422-c0bdb580-d6d0-11e8-874e-b0d17c3648cc.png)
