### PR TITLE
resolve spine ‘pause’ property  invalid problem and export cc.StencilManager for native spine adapter

### DIFF
--- a/cocos2d/core/renderer/webgl/stencil-manager.js
+++ b/cocos2d/core/renderer/webgl/stencil-manager.js
@@ -172,4 +172,4 @@ StencilManager.prototype = {
 StencilManager.sharedManager = new StencilManager();
 StencilManager.Stage = Stage;
 
-module.exports = StencilManager;
+module.exports = cc.StencilManager = StencilManager;

--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -381,6 +381,7 @@ sp.Skeleton = cc.Class({
     },
 
     update (dt) {
+        if (this.paused) return;
         if (CC_EDITOR) return;
         let skeleton = this._skeleton;
         let state = this._state;

--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -381,8 +381,8 @@ sp.Skeleton = cc.Class({
     },
 
     update (dt) {
-        if (this.paused) return;
         if (CC_EDITOR) return;
+        if (this.paused) return;
         let skeleton = this._skeleton;
         let state = this._state;
         if (skeleton) {


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/250

related to:
[cocos-creator/cocos2d-x-lite#1558](https://github.com/cocos-creator/cocos2d-x-lite/pull/1558)
[cocos-creator-packages/jsb-adapter#58](https://github.com/cocos-creator-packages/jsb-adapter/pull/58)
[cocos-creator/bindings-generator#29](https://github.com/cocos-creator/bindings-generator/pull/29)