### PR TITLE
should not invoke component if destroy() called before node activating

### DIFF
--- a/cocos2d/core/node-activator.js
+++ b/cocos2d/core/node-activator.js
@@ -247,6 +247,10 @@ var NodeActivator = cc.Class({
     },
 
     activateComp: CC_EDITOR ? function (comp, preloadInvoker, onLoadInvoker, onEnableInvoker) {
+        if (!cc.isValid(comp, true)) {
+            // destroied before activating
+            return;
+        }
         if (cc.engine._isPlaying || comp.constructor._executeInEditMode) {
             if (!(comp._objFlags & IsPreloadStarted)) {
                 comp._objFlags |= IsPreloadStarted;
@@ -283,6 +287,10 @@ var NodeActivator = cc.Class({
             cc.director._compScheduler.enableComp(comp, onEnableInvoker);
         }
     } : function (comp, preloadInvoker, onLoadInvoker, onEnableInvoker) {
+        if (!cc.isValid(comp, true)) {
+            // destroied before activating
+            return;
+        }
         if (!(comp._objFlags & IsPreloadStarted)) {
             comp._objFlags |= IsPreloadStarted;
             if (comp.__preload) {

--- a/test/qunit/unit-es5/test-component-scheduler.js
+++ b/test/qunit/unit-es5/test-component-scheduler.js
@@ -544,6 +544,18 @@ test('set sibling index during onDisable', function () {
         compOfChild.onEnable.once('child component should be re-enabled');
     });
 
+    test('component might be destroied when destroy() called before node activating', function () {
+        var node = new cc.Node();
+        var comp = createDisabledComp(node, 'destroied');
+        comp.onDestroy = new Callback().disable('onDestroy should not be called');
+        comp.destroy();
+        
+        cc.director.getScene().addChild(node);
+
+        cc.game.step();
+        strictEqual(comp.isValid, false, 'component should be destroied');
+    });
+
     // test('could deactivate parent in onLoad', function () {
     //     strictEqual(StillInvokeRestCompsOnSameNode, false, 'test cases not implemented if "StillInvokeRestCompsOnSameNode"');
     //     strictEqual(StillInvokeOnEnableOnSameComp, false, 'test cases not implemented if "StillInvokeOnEnableOnSameComp"');


### PR DESCRIPTION
Changes:
 * 修复了当组件被 destroy() 时，如果所在节点还未添加到场景，组件可能仍然会被激活的问题。

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](http://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
