### PR TITLE
Optimize the render flow of renderComponent when the active state of …

### DIFF
--- a/cocos2d/core/components/CCRenderComponent.js
+++ b/cocos2d/core/components/CCRenderComponent.js
@@ -130,12 +130,12 @@ let RenderComponent = cc.Class({
     },
     
     _canRender () {
-        return this._enabled;
+        // When the node is activated, it will execute onEnable and the renderflag will also be reset.
+        return this._enabled && this.node._activeInHierarchy;
     },
 
     markForUpdateRenderData (enable) {
-        // When the node is activated, it will execute onEnable and the renderflag will also be reset.
-        if (enable && this._canRender() && this.node._activeInHierarchy) {
+        if (enable && this._canRender()) {
             this.node._renderFlag |= RenderFlow.FLAG_UPDATE_RENDER_DATA;
         }
         else if (!enable) {
@@ -144,8 +144,7 @@ let RenderComponent = cc.Class({
     },
 
     markForRender (enable) {
-        // When the node is activated, it will execute onEnable and the renderflag will also be reset.
-        if (enable && this._canRender() && this.node._activeInHierarchy) {
+        if (enable && this._canRender()) {
             this.node._renderFlag |= RenderFlow.FLAG_RENDER;
         }
         else if (!enable) {

--- a/cocos2d/core/components/CCRenderComponent.js
+++ b/cocos2d/core/components/CCRenderComponent.js
@@ -134,7 +134,8 @@ let RenderComponent = cc.Class({
     },
 
     markForUpdateRenderData (enable) {
-        if (enable && this._canRender()) {
+        // When the node is activated, it will execute onEnable and the renderflag will also be reset.
+        if (enable && this._canRender() && this.node._activeInHierarchy) {
             this.node._renderFlag |= RenderFlow.FLAG_UPDATE_RENDER_DATA;
         }
         else if (!enable) {
@@ -143,7 +144,8 @@ let RenderComponent = cc.Class({
     },
 
     markForRender (enable) {
-        if (enable && this._canRender()) {
+        // When the node is activated, it will execute onEnable and the renderflag will also be reset.
+        if (enable && this._canRender() && this.node._activeInHierarchy) {
             this.node._renderFlag |= RenderFlow.FLAG_RENDER;
         }
         else if (!enable) {

--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -545,7 +545,7 @@ var Sprite = cc.Class({
             if (!this._enabled) return false;
         }
         else {
-            if (!this._enabled || !this._material) return false;
+            if (!this._enabled || !this._material || !this.node._activeInHierarchy) return false;
         }
 
         let spriteFrame = this._spriteFrame;


### PR DESCRIPTION
…the node is false.

Re: cocos-creator/2d-tasks#

Changes:
When the node is activated, it will execute onEnable and the render-flag will also be reset. So it's not have to update the render-flag when the node is not active.


