### PR TITLE
implement Object.getOwnPropertyDescriptors polyfill for Baidu browser

### DIFF
--- a/polyfill/object.js
+++ b/polyfill/object.js
@@ -5,3 +5,19 @@ if (!Object.assign) {
         cc.js.mixin(target, source);
     }
 }
+
+// for Baidu browser
+// Implementation reference to: 
+// http://2ality.com/2016/02/object-getownpropertydescriptors.html
+// http://docs.w3cub.com/javascript/global_objects/reflect/ownkeys/
+if (!Object.getOwnPropertyDescriptors) {
+    Object.getOwnPropertyDescriptors = function (obj) {
+        let descriptors = {};
+        let ownKeys = Object.getOwnPropertyNames(obj).concat(Object.getOwnPropertySymbols(obj));  // equals to Reflect.ownKeys(obj) in ES6
+        for(let i = 0; i < ownKeys.length; ++i){
+            let key = ownKeys[i];
+            descriptors[key] = Object.getOwnPropertyDescriptor(obj, key);
+        }
+        return descriptors;
+    }
+}


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/721


修复 pr https://github.com/cocos-creator/engine/pull/3340 里用到了 es6 的 getOwnPropertyDescriptors，百度浏览器不支持，造成报错