### PR TITLE
fix set isChecked value invaild bug

### DIFF
--- a/cocos2d/core/components/CCToggle.js
+++ b/cocos2d/core/components/CCToggle.js
@@ -52,6 +52,13 @@ var Toggle = cc.Class({
             tooltip: CC_DEV && 'i18n:COMPONENT.toggle.isChecked',
             notify: function () {
                 this._updateCheckMark();
+
+                var group = this.toggleGroup || this._toggleContainer;
+                if (group && group.enabled) {
+                    group.updateToggles(this);
+                }
+
+                this._emitToggleEvents();
             }
         },
 
@@ -164,7 +171,7 @@ var Toggle = cc.Class({
             group.updateToggles(this);
         }
 
-        this._emitToggleEvents(event);
+        this._emitToggleEvents();
     },
 
     _emitToggleEvents: function () {


### PR DESCRIPTION
Re: https://forum.cocos.com/t/toggle/68232

Changes:
 * 修复用户设置 isChecked 无效的 bug

正常情况下，用户设置 isChecked 为 true 的时候，应该触发 toggle 事件与更新 group 的  updateToggles。