### PR TITLE
fixed the richText signal content can't disappear problem

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -449,6 +449,7 @@ let RichText = cc.Class({
         }
         labelSegment._styleIndex = styleIndex;
         labelSegment._lineCount = this._lineCount;
+        labelSegment.active = this.node.active;
 
         labelSegment.setAnchorPoint(0, 0);
         this._applyTextAttribute(labelSegment);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/pull/3039

修复 cc.RichText 部分文本内容不显示问题。
![image](https://user-images.githubusercontent.com/35832931/47627482-31e6e800-db6b-11e8-9d01-4a269c1ac861.png)

修复效果：
![image](https://user-images.githubusercontent.com/35832931/47627470-20054500-db6b-11e8-82dd-1e168cdc5c4d.png)
