### PR TITLE
fix different editbox blur behaviour in iOS and Android

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -495,6 +495,7 @@ function _inputValueHandle (input, editBoxImpl) {
 
 function registerInputEventListener (tmpEdTxt, editBoxImpl, isTextarea) {
     let inputLock = false;
+    let blurWhenComposition = false;
     let cbs = editBoxImpl.__eventListeners;
     cbs.compositionstart = function () {
         inputLock = true;
@@ -503,6 +504,11 @@ function registerInputEventListener (tmpEdTxt, editBoxImpl, isTextarea) {
 
     cbs.compositionend = function () {
         inputLock = false;
+        if (blurWhenComposition) {
+            // restore input value when composition not complete and blur input
+            this.value = editBoxImpl._text;
+            blurWhenComposition = false;
+        }
         _inputValueHandle(this, editBoxImpl);
     };
     tmpEdTxt.addEventListener('compositionend', cbs.compositionend);
@@ -551,7 +557,12 @@ function registerInputEventListener (tmpEdTxt, editBoxImpl, isTextarea) {
     tmpEdTxt.addEventListener('keypress', cbs.keypress);
 
     cbs.blur = function () {
-        editBoxImpl._text = this.value;
+        if (inputLock) {
+            blurWhenComposition = true;
+        }
+        else {
+            editBoxImpl._text = this.value;
+        }
         editBoxImpl._endEditing();
     };
     tmpEdTxt.addEventListener('blur', cbs.blur);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/711

ChangeLog：
- 修复 iOS 上拼音输入问题

修改日志：
在输入拼音时， iOS 跟 Android 平台 blur 的行为不同，
- iOS 会保存输入还没完成的拼音到 input
- Android 不保存

这里统一行为，不保存