### PR TITLE
Add label API to update contentSize immediately.

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -467,8 +467,7 @@ let Label = cc.Class({
         this.node.on(cc.Node.EventType.ANCHOR_CHANGED, this._updateRenderData, this);
 
         this._checkStringEmpty();
-        this._updateAssembler();
-        this._activateMaterial();
+        this._updateRenderData(true);
     },
 
     onDisable () {
@@ -485,6 +484,18 @@ let Label = cc.Class({
             this._ttfTexture = null;
         }
         this._super();
+    },
+
+    /**
+     * !#en Update the label content immediately.
+     * !#zh 立即更新渲染 label 内容, 以便获得最新的 contentSize。
+     * @method updateContentImmediately
+     */
+    updateImmediately () {
+        if (!this._canRender()) return;
+        this._updateAssembler();
+        this._activateMaterial(true);
+        this._assembler.updateRenderData(this);
     },
 
     _canRender () {

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -489,7 +489,7 @@ let Label = cc.Class({
     /**
      * !#en Update the label content immediately.
      * !#zh 立即更新渲染 label 内容, 以便获得最新的 contentSize。
-     * @method updateContentImmediately
+     * @method updateImmediately
      */
     updateImmediately () {
         if (!this._canRender()) return;

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -485,19 +485,7 @@ let Label = cc.Class({
         }
         this._super();
     },
-
-    /**
-     * !#en Update the label content immediately.
-     * !#zh 立即更新渲染 label 内容, 以便获得最新的 contentSize。
-     * @method updateImmediately
-     */
-    updateImmediately () {
-        if (!this._canRender()) return;
-        this._updateAssembler();
-        this._activateMaterial(true);
-        this._assembler.updateRenderData(this);
-    },
-
+    
     _canRender () {
         let result = this._super();
         let font = this.font;

--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -418,7 +418,6 @@ module.exports = {
             let paragraphedStrings = _string.split('\n');
             let paragraphLength = this._calculateParagraphLength(paragraphedStrings, _context);
         
-            //_splitedStrings = paragraphedStrings;
             let i = 0;
             let totalHeight = 0;
             let maxLength = 0;
@@ -453,7 +452,6 @@ module.exports = {
                     _fontDesc = this._getFontDesc();
                     _context.font = _fontDesc;
 
-                    //_splitedStrings = [];
                     totalHeight = 0;
                     for (i = 0; i < paragraphedStrings.length; ++i) {
                         let j = 0;
@@ -468,7 +466,6 @@ module.exports = {
                             totalHeight += this._getLineHeight();
                             ++j;
                         }
-                        //_splitedStrings = _splitedStrings.concat(textFragment);
                     }
 
                     if (tryDivideByTwo) {

--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -118,7 +118,7 @@ module.exports = {
     updateRenderData (comp) {
         if (!comp._renderData.vertDirty) return;
 
-        this._updateFontFamly(comp);
+        this._updateFontFamily(comp);
         this._updateProperties(comp);
         this._calculateLabelFont();
         this._calculateSplitedStrings();
@@ -141,7 +141,7 @@ module.exports = {
     _updateVerts () {
     },
 
-    _updateFontFamly (comp) {
+    _updateFontFamily (comp) {
         if (!comp.useSystemFont) {
             if (comp.font) {
                 if (comp.font._nativeAsset) {
@@ -418,7 +418,7 @@ module.exports = {
             let paragraphedStrings = _string.split('\n');
             let paragraphLength = this._calculateParagraphLength(paragraphedStrings, _context);
         
-            _splitedStrings = paragraphedStrings;
+            //_splitedStrings = paragraphedStrings;
             let i = 0;
             let totalHeight = 0;
             let maxLength = 0;
@@ -453,7 +453,7 @@ module.exports = {
                     _fontDesc = this._getFontDesc();
                     _context.font = _fontDesc;
 
-                    _splitedStrings = [];
+                    //_splitedStrings = [];
                     totalHeight = 0;
                     for (i = 0; i < paragraphedStrings.length; ++i) {
                         let j = 0;
@@ -468,7 +468,7 @@ module.exports = {
                             totalHeight += this._getLineHeight();
                             ++j;
                         }
-                        _splitedStrings = _splitedStrings.concat(textFragment);
+                        //_splitedStrings = _splitedStrings.concat(textFragment);
                     }
 
                     if (tryDivideByTwo) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#406

[旧的修改记录](https://github.com/cocos-creator/engine/pull/3360)

尝试将 contentSize 的计算独立并提前，在 label 相关属性发生变化时立即计算更新 contentSize ，渲染时不再进行 contentSize 的计算。采取这种立即更新的方式，势必会在一系列属性修改时进行多次的 contentSize 计算，并且需要在属性修改上遵循一定的顺序，不管在性能还是使用方式上都不友好。故修改为：
1. label 节点首次加载时立即渲染，对于新创建节点进行的一系列修改，开发者不需进行额外操作。
2. 增加 updateImmediately 接口，在修改label相关属性之后，如需立即获得最新的 contentSize ，则手动调用该 API 。
