### PR TITLE
fix bmFontOriginalSize unable to display in prefab

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -343,7 +343,6 @@ let Label = cc.Class({
                 }
 
                 this._N$file = value;
-                this._bmFontOriginalSize = -1;
                 if (value && this._isSystemFontUsed)
                     this._isSystemFontUsed = false;
 
@@ -412,9 +411,14 @@ let Label = cc.Class({
 
         _bmFontOriginalSize: {
             displayName: 'BMFont Original Size',
-            default: -1,
-            serializable: false,
-            readonly: true,
+            get () {
+                if (this._N$file instanceof cc.BitmapFont) {
+                    return this._N$file.fontSize || -1;
+                }
+                else {
+                    return -1;
+                }
+            },
             visible: true,
             animatable: false
         },

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -350,10 +350,6 @@ let Label = cc.Class({
                     cc.warnID(4000);
                 }
 
-                if (value instanceof cc.BitmapFont) {
-                    this._bmFontOriginalSize = value.fontSize;
-                }
-
                 if (this._renderData) {
                     this.destroyRenderData(this._renderData);
                     this._renderData = null;    

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -413,7 +413,7 @@ let Label = cc.Class({
             displayName: 'BMFont Original Size',
             get () {
                 if (this._N$file instanceof cc.BitmapFont) {
-                    return this._N$file.fontSize || -1;
+                    return this._N$file.fontSize;
                 }
                 else {
                     return -1;


### PR DESCRIPTION
Re: https://forum.cocos.com/t/cocos-creator-v2-0-5-1030-rc-2/68353/121

Changes:
 * 由于 _bmFontOriginalSize 没有序列化无法报错到 prefab 中，所以导致双击 prefab _bmFontOriginalSize 无法显示