### PR TITLE
remove __orientationChanged listener on editbox destroyed

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -245,6 +245,10 @@ let EditBoxImpl = cc.Class({
         this._node = null;
         this.setDelegate(null);
         this.removeDom();
+        if (this.__orientationChanged) {
+            window.removeEventListener('orientationchange', this.__orientationChanged);
+            this.__orientationChanged = null;
+        }
     },
 
     _onTouchBegan (touch) {
@@ -433,10 +437,12 @@ _p.createInput = function() {
 // Called before editbox focus to register cc.view status
 _p._beginEditingOnMobile = function () {
     let self = this;
-    this.__orientationChanged = function () {
-        self._adjustEditBoxPosition();
-    };
-    window.addEventListener('orientationchange', this.__orientationChanged);
+    if (!this.__orientationChanged) {
+        this.__orientationChanged = function () {
+            self._adjustEditBoxPosition();
+        };
+        window.addEventListener('orientationchange', this.__orientationChanged);
+    }
 
     if (cc.view.isAutoFullScreenEnabled()) {
         this.__fullscreen = true;
@@ -465,7 +471,10 @@ _p._endEditingOnMobile = function () {
         this.__rotateScreen = false;
     }
 
-    window.removeEventListener('orientationchange', this.__orientationChanged);
+    if (this.__orientationChanged) {
+        window.removeEventListener('orientationchange', this.__orientationChanged);
+        this.__orientationChanged = null;
+    }
 
     if(this.__fullscreen) {
         cc.view.enableAutoFullScreen(true);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/747

修复 __orientationChanged 监听没有移除，导致切换场景后，改变朝向会报错的问题