### PR TITLE
add scale calculate in layout when child scale changed

### DIFF
--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -462,6 +462,7 @@ var Layout = cc.Class({
             child.on(NodeEvent.SIZE_CHANGED, this._doLayoutDirty, this);
             child.on(NodeEvent.POSITION_CHANGED, this._doLayoutDirty, this);
             child.on(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
+            child.on(NodeEvent.SCALE_CHANGED, this._doLayoutDirty, this);
             child.on('active-in-hierarchy-changed', this._doLayoutDirty, this);
         }
     },
@@ -473,6 +474,7 @@ var Layout = cc.Class({
             child.off(NodeEvent.SIZE_CHANGED, this._doLayoutDirty, this);
             child.off(NodeEvent.POSITION_CHANGED, this._doLayoutDirty, this);
             child.off(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
+            child.off(NodeEvent.SCALE_CHANGED, this._doLayoutDirty, this);
             child.off('active-in-hierarchy-changed', this._doLayoutDirty, this);
         }
     },
@@ -481,6 +483,7 @@ var Layout = cc.Class({
         child.on(NodeEvent.SIZE_CHANGED, this._doLayoutDirty, this);
         child.on(NodeEvent.POSITION_CHANGED, this._doLayoutDirty, this);
         child.on(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
+        child.on(NodeEvent.SCALE_CHANGED, this._doLayoutDirty, this);
         child.on('active-in-hierarchy-changed', this._doLayoutDirty, this);
 
         this._doLayoutDirty();
@@ -490,6 +493,7 @@ var Layout = cc.Class({
         child.off(NodeEvent.SIZE_CHANGED, this._doLayoutDirty, this);
         child.off(NodeEvent.POSITION_CHANGED, this._doLayoutDirty, this);
         child.off(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
+        child.off(NodeEvent.SCALE_CHANGED, this._doLayoutDirty, this);
         child.off('active-in-hierarchy-changed', this._doLayoutDirty, this);
 
         this._doLayoutDirty();


### PR DESCRIPTION
添加 layout 在 Container resize mode 情况下，子节点 scale 变化会同步修正 layout size
建议同步修正文档内容：
https://docs.cocos.com/creator/manual/zh/components/layout.html?h=layout
![image](https://user-images.githubusercontent.com/35832931/47992173-283f2080-e127-11e8-91d7-4cc523a8f8b8.png)
