### PR TITLE
fixed game creator.t.ds decorator

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -39,7 +39,6 @@ const dynamicAtlasManager = require('../core/renderer/utils/dynamic-atlas/manage
  * !#en An object to boot the game.
  * !#zh 包含游戏主体信息并负责驱动游戏的游戏对象。
  * @class Game
- * @static
  * @extends EventTarget
  */
 var game = {


### PR DESCRIPTION
Re: https://forum.cocos.com/t/cc-game-cc-game/68852
修复 ts 脚本引用 cc.game 单例对象引用 Game 方法报错问题。

![image](https://user-images.githubusercontent.com/35832931/48126125-5a818700-e2bb-11e8-8b73-28aee472a555.png)

实际上我们没有 Game 这个类，只有 game 对象