### PR TITLE
fix button _resetState error, the isvalid of the button target must b…

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -420,7 +420,7 @@ let Button = cc.Class({
         this._hovered = false;
         // // Restore button status
         let target = this.target;
-        if (!target) {
+        if (!target || !target.isValid) {
             return;
         }
         let transition = this.transition;


### PR DESCRIPTION
…e true

Re: cocos-creator/2d-tasks#

Changes:
 * 修复当在 onDisable 中调用了 _resetState，node 当 x,y, scale 属性已经被销毁了，所以必须要判断 isValid 必须为 true，才行，不然会报错