### PR TITLE
fixed the FbPlayableAd make the sys.platform mislead error

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -757,7 +757,7 @@ else {
          * Indicate the running platform
          * @property {Number} platform
          */
-        if (typeof FbPlayableAd !== undefined) {
+        if (typeof FbPlayableAd !== "undefined") {
             sys.platform = sys.FB_PLAYABLE_ADS;
         }
         else {


### PR DESCRIPTION
Re: https://forum.cocos.com/t/cocos-creator-v2-0-5-1030-rc-2/68353/182
MDN: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/typeof

修复 cc.sys 浏览器平台状态判断错误