### PR TITLE
fix delay load ttf font bug

### DIFF
--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -150,6 +150,7 @@ module.exports = {
                 else {
                     cc.loader.load(comp.font.nativeUrl, function (err, fontFamily) {
                         _fontFamily = fontFamily || 'Arial';
+                        comp.font._nativeAsset = fontFamily;
                         comp._updateRenderData(true);
                     });
                 }


### PR DESCRIPTION
Changes:
 - 修复延时加载 ttf 字体，会导致加载死循环的问题

原因是 font._nativeAsset 一直为 null 