### PR TITLE
fix bug #334 spine use premultipliedAlpha,set opacity zero, but still show

### DIFF
--- a/cocos2d/core/renderer/render-flow.js
+++ b/cocos2d/core/renderer/render-flow.js
@@ -118,7 +118,7 @@ _proto._children = function (node) {
     let children = node._children;
     for (let i = 0, l = children.length; i < l; i++) {
         let c = children[i];
-        if (!c._activeInHierarchy) continue;
+        if (!c._activeInHierarchy || c._opacity === 0) continue;
         _cullingMask = c._cullingMask = c.groupIndex === 0 ? cullingMask : 1 << c.groupIndex;
         c._renderFlag |= worldTransformFlag | worldOpacityFlag;
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/334

