### PR TITLE
update particle system for 2d-tasks/issues/783

### DIFF
--- a/cocos2d/particle/CCParticleAsset.js
+++ b/cocos2d/particle/CCParticleAsset.js
@@ -25,7 +25,7 @@
  ****************************************************************************/
 
 const Asset = require('../core/assets/CCAsset');
-const Texture2D = require('../core/assets/CCTexture2D');
+const CCSpriteFrame = require('../core/assets/CCSpriteFrame');
 
 /**
  * Class for particle asset handling.
@@ -37,9 +37,9 @@ var ParticleAsset = cc.Class({
     extends: Asset,
 
     properties: {
-        texture: {
+        spriteFrame: {
             default: null,
-            type: Texture2D
+            type: CCSpriteFrame
         }
     }
 });

--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -193,10 +193,10 @@ Simulator.prototype.emitParticle = function (pos) {
 
 Simulator.prototype.updateUVs = function (force) {
     let particleCount = this.particles.length;
-    if (this.sys._buffer && this.sys._spriteFrame) {
+    if (this.sys._buffer && this.sys._renderSpriteFrame) {
         const FLOAT_PER_PARTICLE = 4 * this.sys._vertexFormat._bytes / 4;
         let vbuf = this.sys._buffer._vData;
-        let uv = this.sys._spriteFrame.uv;
+        let uv = this.sys._renderSpriteFrame.uv;
 
         let start = force ? 0 : this._uvFilled;
         for (let i = start; i < particleCount; i++) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#783 cocos-creator/2d-tasks/issues/358

引擎：
- [x] 添加一个 _renderSpriteFrame 用于粒子贴图的渲染，原生的 _spriteFrame 只会存储能能序列化的贴图数据
