### PR TITLE
fix set -webkit-transform style failed in wechat sub domain

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -362,8 +362,10 @@ var View = cc._Class.extend({
             // Because 'transform' style adds canvas (the top-element of container) to a new stack context.
             // That causes the DOM Input was hidden under canvas.
             // This should be done after container rotated, instead of in style-mobile.css.
-            cc.game.canvas.style['-webkit-transform'] = 'translateZ(0px)';
-            cc.game.canvas.style.transform = 'translateZ(0px)';
+            if (cc.game.canvas.style) {
+                cc.game.canvas.style['-webkit-transform'] = 'translateZ(0px)';
+                cc.game.canvas.style.transform = 'translateZ(0px)';
+            }
         }
         if (this._orientationChanging) {
             setTimeout(function () {


### PR DESCRIPTION
Changelog:
- 修复小游戏子域设置 -webkit-transform 报错

相关论坛反馈：
https://forum.cocos.com/t/cannot-set-property-webkit-transform-of-undefined/69075

原因是 子域 sharedCanvas.style 未定义