### PR TITLE
adapter wx.onShow params

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -821,10 +821,11 @@ var game = {
                 game.emit(game.EVENT_HIDE);
             }
         }
-        function onShown () {
+        // In order to adapt the most of platforms the onshow API.
+        function onShown (arg0, arg1, arg2, arg3, arg4) {
             if (hidden) {
                 hidden = false;
-                game.emit(game.EVENT_SHOW);
+                game.emit(game.EVENT_SHOW, arg0, arg1, arg2, arg3, arg4);
             }
         }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/786
增加针对 微信小游戏平台 onShow 函数的参数适配

![image](https://user-images.githubusercontent.com/35832931/48526704-94f2b180-e8c3-11e8-99ab-bbf4a0d8daf1.png)

因为 shareTicket 以及 referrerInfo 需要分享之后才会有参数传递，因此无法进行测试。