### PR TITLE
fix audio resume failed when game back to foreground

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -264,7 +264,7 @@ Audio.State = {
     };
 
     proto.getState = function () {
-        if (!CC_WECHATGAME) {
+        if (!CC_WECHATGAME && !CC_QQPLAY) {
             let elem = this._element;
             if (elem && Audio.State.PLAYING === this._state && elem.paused) {
                 this._state = Audio.State.PAUSED;

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -168,7 +168,7 @@ Audio.State = {
     };
 
     proto.destroy = function () {
-        if (CC_WECHATGAME) {
+        if (CC_WECHATGAME || CC_QQPLAY) {
             this._element && this._element.destroy();
         }
         this._element = null;

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -209,7 +209,7 @@ var AudioSource = cc.Class({
 
     _pausedCallback: function () {
         var state = this.audio.getState();
-        if (state == cc.Audio.State.PLAYING) {
+        if (state === cc.Audio.State.PLAYING) {
             this.audio.pause();
             this._pausedFlag = true;
         }

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -208,10 +208,11 @@ var AudioSource = cc.Class({
     },
 
     _pausedCallback: function () {
-        var audio = this.audio;
-        if (audio.paused) return;
-        this.audio.pause();
-        this._pausedFlag = true;
+        var state = this.audio.getState();
+        if (state == cc.Audio.State.PLAYING) {
+            this.audio.pause();
+            this._pausedFlag = true;
+        }
     },
 
     _restoreCallback: function () {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#802 cocos-creator/2d-tasks#799

Changes:
 * 修复 音频在播放时，锁屏和切换前后台后，返回工程声音无法重现播放（QQPlay）