### PR TITLE
when node hasColor and material useColor false, material will still updateHash 

### DIFF
--- a/cocos2d/core/components/CCRenderComponent.js
+++ b/cocos2d/core/components/CCRenderComponent.js
@@ -182,8 +182,11 @@ let RenderComponent = cc.Class({
     _updateColor () {
         let material = this._material;
         if (material) {
-            material.color = this.node.color;
-            material.updateHash();
+            // For batch rendering, update the color only when useColor is set to true.
+            if (material.useColor) {
+                material.color = this.node.color;
+                material.updateHash();
+            }
 
             // reset flag when set color to material successfully
             this.node._renderFlag &= ~RenderFlow.FLAG_COLOR;


### PR DESCRIPTION
当节点颜色改变时，会调用CCRenderComponent的_updateColor方法，该方法会重置material的color，哪怕Material已经设置了useColor=false，进而重新计算hash值。