### PR TITLE
setting DragonBones properties don't support animation

### DIFF
--- a/extensions/dragonbones/ArmatureDisplay.js
+++ b/extensions/dragonbones/ArmatureDisplay.js
@@ -206,6 +206,7 @@ let ArmatureDisplay = cc.Class({
             type: DefaultArmaturesEnum,
             visible: true,
             editorOnly: true,
+            animatable: false,
             displayName: "Armature",
             tooltip: CC_DEV && 'i18n:COMPONENT.dragon_bones.armature_name'
         },
@@ -239,6 +240,7 @@ let ArmatureDisplay = cc.Class({
             type: DefaultAnimsEnum,
             visible: true,
             editorOnly: true,
+            animatable: false,
             displayName: 'Animation',
             tooltip: CC_DEV && 'i18n:COMPONENT.dragon_bones.animation_name'
         },


### PR DESCRIPTION


Re: cocos-creator/2d-tasks#

Changes:
 * 添加龙骨的 _animationIndex and _defaultArmatureIndex 不支持动画编辑