### PR TITLE
widget align only supports parent nodes not null

### DIFF
--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -433,7 +433,7 @@ function updateAlignment (node) {
     }
     var widget = node._widget ||
                  node.getComponent(cc.Widget);  // node._widget will be null when widget is disabled
-    if (widget) {
+    if (widget && parent) {
         align(node, widget);
     }
 }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * widget 只在有父节点才去 align