### PR TITLE
restore webview/videoplayer support at creator 2.0.x

### DIFF
--- a/cocos2d/videoplayer/CCVideoPlayer.js
+++ b/cocos2d/videoplayer/CCVideoPlayer.js
@@ -270,7 +270,8 @@ let VideoPlayer = cc.Class({
 
     statics: {
         EventType: EventType,
-        ResourceType: ResourceType
+        ResourceType: ResourceType,
+        Impl: VideoPlayerImpl
     },
 
     ctor () {

--- a/cocos2d/webview/CCWebView.js
+++ b/cocos2d/webview/CCWebView.js
@@ -107,6 +107,7 @@ let WebView = cc.Class({
 
     statics: {
         EventType: EventType,
+        Impl: WebViewImpl
     },
 
 


### PR DESCRIPTION
在 creator 2.0.x 支持 webview/videoplayer ,原因：https://github.com/cocos-creator/cocos2d-x-lite/pull/1599#issue-231462296

合并 2.1 适配时相关的改动 https://github.com/cocos-creator/engine/pull/3359 https://github.com/cocos-creator/engine/pull/3341 到 2.0 分支. please merge @pandamicro 