### PR TITLE
fix when the particle system can't play

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -929,7 +929,7 @@ var ParticleSystem = cc.Class({
                 if (!self._custom) {
                     self._initWithDictionary(content);
                 }
-                if (!self.spriteFrame) {
+                if (!self.spriteFrame || !self._renderSpriteFrame) {
                     if (file.spriteFrame) {
                         self.spriteFrame = file.spriteFrame;
                     }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 判断 _renderSpriteFrame 是否为 null，如果为 null，还需要重新去赋值一次，否则会导致运行时无法播放粒子特效
