### PR TITLE
fix particle rendering texture for reset bug

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -231,7 +231,7 @@ var properties = {
             }
             this._renderSpriteFrame = value;
 
-            if (value._uuid) {
+            if (!value || value._uuid) {
                 this._spriteFrame = value;
             }
 
@@ -259,7 +259,9 @@ var properties = {
             return this._texture;
         },
         set: function (value) {
-            cc.warnID(6017);
+            if (value) {
+                cc.warnID(6017);
+            }
         },
         type: cc.Texture2D,
         tooltip: CC_DEV && 'i18n:COMPONENT.particle_system.texture',
@@ -804,6 +806,9 @@ var ParticleSystem = cc.Class({
             else {
                 this._applyFile();
             }
+        }
+        else if (this._custom && this.spriteFrame && !this._renderSpriteFrame) {
+            this._applySpriteFrame(this.spriteFrame);
         }
         // auto play
         if (!CC_EDITOR || cc.engine.isPlaying) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复无法把 spriteFrame 制空
 * 修复导入 ccb 资源设置粒子为 custom 模式，_renderSpriteFrame 没有重新被赋值