### PR TITLE
RichText support node color settings

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -60,7 +60,7 @@ const SCALE_ON = 1 << 1;
 const ROTATION_ON = 1 << 2;
 const SIZE_ON = 1 << 3;
 const ANCHOR_ON = 1 << 4;
-
+const COLOR_ON = 1 << 5;
 
 let BuiltinGroupIndex = cc.Enum({
     DEBUG: 31
@@ -250,6 +250,16 @@ var EventType = cc.Enum({
      * @static
      */
     ANCHOR_CHANGED: 'anchor-changed',
+    /**
+     * !#en The event type for color change events.
+     * Performance note, this event will be triggered every time corresponding properties being changed,
+     * if the event callback have heavy logic it may have great performance impact, try to avoid such scenario.
+     * !#zh 当节点颜色改变时触发的事件。
+     * 性能警告：这个事件会在每次对应的属性被修改时触发，如果事件回调损耗较高，有可能对性能有很大的负面影响，请尽量避免这种情况。
+     * @property {String} COLOR_CHANGED
+     * @static
+     */
+    COLOR_CHANGED: 'color-changed',
     /**
      * !#en The event type for new child added events.
      * !#zh 当新的子节点被添加时触发的事件。
@@ -941,6 +951,10 @@ var Node = cc.Class({
                     if (this._renderComponent) {
                         this._renderFlag |= RenderFlow.FLAG_COLOR;
                     }
+
+                    if (this._eventMask & COLOR_ON) {
+                        this.emit(EventType.COLOR_CHANGED, value);
+                    }
                 }
             },
         },
@@ -1436,6 +1450,7 @@ var Node = cc.Class({
      * node.on(cc.Node.EventType.TOUCH_END, callback, this);
      * node.on(cc.Node.EventType.TOUCH_CANCEL, callback, this);
      * node.on(cc.Node.EventType.ANCHOR_CHANGED, callback);
+     * node.on(cc.Node.EventType.COLOR_CHANGED, callback);
      */
     on (type, callback, target, useCapture) {
         let forDispatch = this._checknSetupSysEvent(type);
@@ -1459,6 +1474,10 @@ var Node = cc.Class({
                 case EventType.ANCHOR_CHANGED:
                 this._eventMask |= ANCHOR_ON;
                 break;
+                case EventType.COLOR_CHANGED:
+                this._eventMask |= COLOR_ON;
+                break;
+
             }
             if (!this._bubblingListeners) {
                 this._bubblingListeners = new EventTarget();
@@ -1600,6 +1619,9 @@ var Node = cc.Class({
                     case EventType.ANCHOR_CHANGED:
                     this._eventMask &= ~ANCHOR_ON;
                     break;
+                    case EventType.COLOR_CHANGED:
+                    this._eventMask &= ~COLOR_ON;
+                    break;
                 }
             }
         }
@@ -1657,6 +1679,9 @@ var Node = cc.Class({
             }
             if ((this._eventMask & ANCHOR_ON) && !listeners.hasEventListener(EventType.ANCHOR_CHANGED)) {
                 this._eventMask &= ~ANCHOR_ON;
+            }
+            if ((this._eventMask & COLOR_ON) && !listeners.hasEventListener(EventType.COLOR_CHANGED)) {
+                this._eventMask &= ~COLOR_ON;
             }
         }
         if (this._capturingListeners) {

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -314,7 +314,7 @@ let RichText = cc.Class({
 
     _onSynChildColor (parentColor) {
         let children = this.node.children;
-        children.forEach((childNode) => {
+        children.forEach(function (childNode) {
             childNode.color = getDisplayedColor(childNode._displayColor, parentColor);
             let outline = childNode.getComponent(cc.LabelOutline);
             if (outline && childNode._outlineDisplayColor) {

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -108,6 +108,10 @@ pool.get = function (string, fontAsset, fontSize) {
     labelComponent._enableItalics(false);
     labelComponent._enableUnderline(false);
 
+
+    labelNode._displayColor = cc.Color.WHITE;
+    labelNode._outlineDisplayColor = cc.Color.WHITE;
+
     return labelNode;
 };
 
@@ -312,12 +316,12 @@ let RichText = cc.Class({
         this._onTTFLoaded();
     },
 
-    _onSynChildColor (parentColor) {
+    _onColorChanged (parentColor) {
         let children = this.node.children;
         children.forEach(function (childNode) {
             childNode.color = getDisplayedColor(childNode._displayColor, parentColor);
             let outline = childNode.getComponent(cc.LabelOutline);
-            if (outline && childNode._outlineDisplayColor) {
+            if (outline) {
                 outline.color = getDisplayedColor(childNode._outlineDisplayColor, parentColor);
             }
         });
@@ -325,12 +329,12 @@ let RichText = cc.Class({
 
     _addEventListeners () {
         this.node.on(cc.Node.EventType.TOUCH_END, this._onTouchEnded, this);
-        this.node.on(cc.Node.EventType.COLOR_CHANGED, this._onSynChildColor, this);
+        this.node.on(cc.Node.EventType.COLOR_CHANGED, this._onColorChanged, this);
     },
 
     _removeEventListeners () {
         this.node.off(cc.Node.EventType.TOUCH_END, this._onTouchEnded, this);
-        this.node.off(cc.Node.EventType.COLOR_CHANGED, this._onSynChildColor, this);
+        this.node.off(cc.Node.EventType.COLOR_CHANGED, this._onColorChanged, this);
     },
 
     _updateLabelSegmentTextAttributes () {

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -107,21 +107,8 @@ pool.get = function (string, fontAsset, fontSize) {
     labelComponent._enableBold(false);
     labelComponent._enableItalics(false);
     labelComponent._enableUnderline(false);
-
-
-    labelNode._displayColor = cc.Color.WHITE;
-    labelNode._outlineDisplayColor = cc.Color.WHITE;
-
     return labelNode;
 };
-
-function getDisplayedColor (color, parentColor) {
-    let newColor = new cc.Color();
-    newColor.r = color.r * parentColor.r / 255;
-    newColor.g = color.g * parentColor.g / 255;
-    newColor.b = color.b * parentColor.b / 255;
-    return newColor;
-}
 
 /**
  * !#en The RichText Component.
@@ -319,11 +306,7 @@ let RichText = cc.Class({
     _onColorChanged (parentColor) {
         let children = this.node.children;
         children.forEach(function (childNode) {
-            childNode.color = getDisplayedColor(childNode._displayColor, parentColor);
-            let outline = childNode.getComponent(cc.LabelOutline);
-            if (outline) {
-                outline.color = getDisplayedColor(childNode._outlineDisplayColor, parentColor);
-            }
+            childNode.color = parentColor;
         });
     },
 
@@ -839,8 +822,6 @@ let RichText = cc.Class({
             labelNode.color = this._convertLiteralColorValue("white");
         }
 
-        labelNode._displayColor = labelNode.color;
-
         labelComponent._enableBold(textStyle && textStyle.bold);
 
         labelComponent._enableItalics(textStyle && textStyle.italic);
@@ -858,8 +839,6 @@ let RichText = cc.Class({
             }
             labelOutlineComponent.color = this._convertLiteralColorValue(textStyle.outline.color);
             labelOutlineComponent.width = textStyle.outline.width;
-
-            labelNode._outlineDisplayColor = labelOutlineComponent.color;
         }
 
         if (textStyle && textStyle.size) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#393

目前没有进行重构为独立渲染，只是做了支持节点颜色的设置

Changes:
 * 同步了 2.1 的节点 color change 事件
 * RichText 支持节点 color 设置， 