### PR TITLE
fix outline enable and disable invaild / rm label updateRenderData CC_EDITOR

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -527,7 +527,7 @@ let Label = cc.Class({
                 self._texture = spriteFrame._texture;
                 self._activateMaterial(force);
 
-                if (CC_EDITOR || force) {
+                if (force) {
                     this._assembler && this._assembler.updateRenderData(this);
                 }
             };
@@ -557,7 +557,7 @@ let Label = cc.Class({
             this._texture = this._ttfTexture;
             this._activateMaterial(force);
 
-            if (CC_EDITOR || force) {
+            if (force) {
                 this._assembler && this._assembler.updateRenderData(this);
             }
         }
@@ -612,7 +612,7 @@ let Label = cc.Class({
             this.markForUpdateRenderData(true);
         }
 
-        if (CC_EDITOR || force) {
+        if (force) {
             this._updateAssembler();
             this._applyFontTexture(force);
         }

--- a/cocos2d/core/components/CCLabelOutline.js
+++ b/cocos2d/core/components/CCLabelOutline.js
@@ -87,10 +87,18 @@ let LabelOutline = cc.Class({
         }
     },
 
+    onEnable () {
+        this._updateRenderData();
+    },
+
+    onDisable () {
+        this._updateRenderData();
+    },
+
     _updateRenderData () {
         let label = this.node.getComponent(cc.Label);
         if (label) {
-            label._updateRenderData(true);
+            label._updateRenderData();
         }
     }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 outline 组件开启与关闭无效
 * 移除了 CC_EDITOR，label 在编辑器中不需要立即获取 label 计算后的大小，如果想要立即获取的话，通过 label._updateRenderData(true) 强制调用 this._assembler.updateRenderData