### PR TITLE
set playOnFocus decorate default value to true

### DIFF
--- a/cocos2d/core/platform/CCClassDecorator.js
+++ b/cocos2d/core/platform/CCClassDecorator.js
@@ -587,7 +587,7 @@ var disallowMultiple = (CC_DEV ? createEditorDecorator : createDummyDecorator)(c
  * playOnFocus(): Function
  * playOnFocus(_class: Function): void
  */
-var playOnFocus = (CC_DEV ? createEditorDecorator : createDummyDecorator)(checkCtorArgument, 'playOnFocus');
+var playOnFocus = (CC_DEV ? createEditorDecorator : createDummyDecorator)(checkCtorArgument, 'playOnFocus', true);
 
 /**
  * !#en


### PR DESCRIPTION
`@playOnFocus` decorate not set `Component._playOnFocus` to true  as desired.
`@playOnFocus(true)` works correct, but creator.d.ts  type info does not match.
So i think this decorate should has a default `true` value.

Re: cocos-creator/2d-tasks#

Changes:
 * set `@playOnFocus` decorate default value to true

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
