### PR TITLE
Fix rendering residue for transparent images on Chrome69. (#3357)

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -776,6 +776,10 @@ var game = {
             if (!cc.macro.CLEANUP_IMAGE_CACHE && dynamicAtlasManager) {
                 dynamicAtlasManager.enabled = true;
             }
+            // Disable dynamicAtlasManager to fix rendering residue for transparent images on Chrome69.
+            if (cc.sys.browserType == cc.sys.BROWSER_TYPE_CHROME && parseFloat(cc.sys.browserVersion) >= 69.0) {
+                dynamicAtlasManager.enabled = false;
+            }
         }
         if (!this._renderContext) {
             this.renderType = this.RENDER_TYPE_CANVAS;


### PR DESCRIPTION
* Fix rendering residue for transparent images on Chrome69.

* Disable dynamicAtlasManager to fix rendering residue for transparent images on Chrome69.


