### PR TITLE
Fix failed to update particle system _renderSpriteFrame

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -156,12 +156,9 @@ var properties = {
             }
             if (this._custom !== value) {
                 this._custom = value;
-                if (!value) {
-                    this._applyFile();
-                }
+                this._applyFile();
                 if (CC_EDITOR) {
                     cc.engine.repaintInEditMode();
-                //    self.preview = self.preview;
                 }
             }
         },
@@ -190,7 +187,6 @@ var properties = {
                     this._applyFile();
                     if (CC_EDITOR) {
                         cc.engine.repaintInEditMode();
-                        //self.preview = self.preview;
                     }
                 }
                 else {
@@ -934,13 +930,17 @@ var ParticleSystem = cc.Class({
                 if (!self._custom) {
                     self._initWithDictionary(content);
                 }
-                if (!self.spriteFrame || !self._renderSpriteFrame) {
+
+                if (!self._spriteFrame) {
                     if (file.spriteFrame) {
                         self.spriteFrame = file.spriteFrame;
                     }
                     else if (self._custom) {
                         self._initTextureWithDictionary(content);
                     }
+                }
+                else if (!self._renderSpriteFrame && self._spriteFrame) {
+                    self._applySpriteFrame(self.spriteFrame);
                 }
             });
         }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 当存在 spriteFrame 并且 _renderSpriteFrame 不存在当时候应该同步 spriteFrame 到 _renderSpriteFrame

同时修复了，用户反馈的，设置粒子 spriteframe 后，在重新实例化一个粒子贴图效果显示还是原来的

范例：

[ParticleTestDemo.zip](https://github.com/cocos-creator/engine/files/2637841/ParticleTestDemo.zip)

