### PR TITLE
add platform differ on baiduGame, vivoGame and oppoGame

### DIFF
--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -35,7 +35,8 @@ function loadDomAudio (item, callback) {
     var dom = document.createElement('audio');
     dom.src = item.url;
 
-    if (CC_WECHATGAME) {
+    const isBaiduGame = (cc.sys.platform === cc.sys.BAIDU_GAME);
+    if (CC_WECHATGAME || isBaiduGame) {
         callback(null, dom);
         return;
     }

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -24,6 +24,14 @@
  THE SOFTWARE.
  ****************************************************************************/
 
+let settingPlatform;
+ if (!CC_EDITOR) {
+    settingPlatform = window._CCSettings ? _CCSettings.platform: undefined;
+ }
+const isBaiduGame = (settingPlatform === 'baidugame');
+const isVivoGame = (settingPlatform === 'vivogame');
+const isOppoGame = (settingPlatform === 'oppogame');
+ 
 function initSys () {
     /**
      * System variables
@@ -354,6 +362,24 @@ function initSys () {
      */
     sys.FB_PLAYABLE_ADS = 106;
     /**
+     * @property {Number} BAIDU_GAME
+     * @readOnly
+     * @default 107
+     */
+    sys.BAIDU_GAME = 107;
+    /**
+     * @property {Number} VIVO_GAME
+     * @readOnly
+     * @default 108
+     */
+    sys.VIVO_GAME = 108;
+    /**
+     * @property {Number} OPPO_GAME
+     * @readOnly
+     * @default 109
+     */
+    sys.OPPO_GAME = 109;
+    /**
      * BROWSER_TYPE_WECHAT
      * @property {String} BROWSER_TYPE_WECHAT
      * @readOnly
@@ -374,6 +400,20 @@ function initSys () {
      * @default "wechatgamesub"
      */
     sys.BROWSER_TYPE_WECHAT_GAME_SUB = "wechatgamesub";
+    /**
+     * BROWSER_TYPE_BAIDU_GAME
+     * @property {String} BROWSER_TYPE_BAIDU_GAME
+     * @readOnly
+     * @default "baidugame"
+     */
+    sys.BROWSER_TYPE_BAIDU_GAME = "baidugame";
+    /**
+     * BROWSER_TYPE_BAIDU_GAME_SUB
+     * @property {String} BROWSER_TYPE_BAIDU_GAME_SUB
+     * @readOnly
+     * @default "baidugamesub"
+     */
+    sys.BROWSER_TYPE_BAIDU_GAME_SUB = "baidugamesub";
     /**
      * BROWSER_TYPE_QQ_PLAY
      * @property {String} BROWSER_TYPE_QQ_PLAY
@@ -533,8 +573,8 @@ function initSys () {
      * Is web browser ?
      * @property {Boolean} isBrowser
      */
-    sys.isBrowser = typeof window === 'object' && typeof document === 'object' && !CC_WECHATGAME && !CC_QQPLAY && !CC_JSB;
-
+    sys.isBrowser = typeof window === 'object' && typeof document === 'object' && !CC_WECHATGAME && !CC_QQPLAY && !CC_JSB && !isBaiduGame;
+    
     if (CC_EDITOR && Editor.isMainProcess) {
         sys.isMobile = false;
         sys.platform = sys.EDITOR_CORE;
@@ -553,13 +593,25 @@ function initSys () {
         sys.__audioSupport = {};
     }
     else if (CC_JSB) {
-        var platform = sys.platform = __getPlatform();
+        let platform;
+        if (isVivoGame) {
+            platform = sys.VIVO_GAME;
+        }
+        else if (isOppoGame) {
+            platform = sys.OPPO_GAME;
+        }
+        else {
+            platform = __getPlatform();
+        }
+        sys.platform = platform;
         sys.isMobile = (platform === sys.ANDROID ||
                         platform === sys.IPAD ||
                         platform === sys.IPHONE ||
                         platform === sys.WP8 ||
                         platform === sys.TIZEN ||
-                        platform === sys.BLACKBERRY);
+                        platform === sys.BLACKBERRY ||
+                        platform === sys.VIVO_GAME ||
+                        platform === sys.OPPO_GAME);
 
         sys.os = __getOS();
         sys.language = __getCurrentLanguage();
@@ -703,6 +755,21 @@ function initSys () {
             DELAY_CREATE_CTX: false,
             format: ['.mp3']
         };
+    }
+    else if (isBaiduGame) {
+        let env = device.getSystemInfo();
+        sys.platform = env.platform;
+        sys.browserType = env.browserType;
+        sys.isMobile = env.isMobile;
+        sys.language = env.language;
+        sys.os = env.os;
+        sys.osVersion = env.osVersion;
+        sys.osMainVersion = env.osMainVersion;
+        sys.browserVersion = env.browserVersion;
+        sys.windowPixelResolution = env.windowPixelResolution;
+        sys.localStorage = env.localStorage;
+        sys.capabilities = env.capabilities;
+        sys.__audioSupport = env.audioSupport;
     }
     else {
         // browser or runtime

--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -30,9 +30,11 @@ const js = require('../platform/js');
 const renderer = require('../renderer');
 require('../platform/CCClass');
 
+const isBaiduGame = (cc.sys.platform === cc.sys.BAIDU_GAME);
+
 var __BrowserGetter = {
     init: function(){
-        if (!CC_WECHATGAME && !CC_QQPLAY) {
+        if (!CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame) {
             this.html = document.getElementsByTagName("html")[0];
         }
     },
@@ -56,6 +58,15 @@ var __BrowserGetter = {
 
 if (cc.sys.os === cc.sys.OS_IOS) // All browsers are WebView
     __BrowserGetter.adaptationType = cc.sys.BROWSER_TYPE_SAFARI;
+
+if (isBaiduGame) {
+    if (cc.sys.browserType === cc.sys.BROWSER_TYPE_BAIDU_GAME_SUB) {
+        __BrowserGetter.adaptationType = cc.sys.BROWSER_TYPE_BAIDU_GAME_SUB;
+    }
+    else {
+        __BrowserGetter.adaptationType = cc.sys.BROWSER_TYPE_BAIDU_GAME;
+    }
+}
 
 if (CC_WECHATGAME) {
     if (cc.sys.browserType === cc.sys.BROWSER_TYPE_WECHAT_GAME_SUB) {
@@ -401,7 +412,7 @@ cc.js.mixin(View.prototype, {
     },
 
     _adjustViewportMeta: function () {
-        if (this._isAdjustViewport && !CC_JSB && !CC_WECHATGAME && !CC_QQPLAY) {
+        if (this._isAdjustViewport && !CC_JSB && !CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame) {
             this._setViewportMeta(__BrowserGetter.meta, false);
             this._isAdjustViewport = false;
         }
@@ -802,7 +813,7 @@ cc.js.mixin(View.prototype, {
      * @param {ResolutionPolicy|Number} resolutionPolicy The resolution policy desired
      */
     setRealPixelResolution: function (width, height, resolutionPolicy) {
-        if (!CC_JSB && !CC_WECHATGAME && !CC_QQPLAY) {
+        if (!CC_JSB && !CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame) {
             // Set viewport's width
             this._setViewportMeta({"width": width}, true);
 
@@ -1060,7 +1071,7 @@ cc.ContainerStrategy = cc.Class({
     _setupContainer: function (view, w, h) {
         var locCanvas = cc.game.canvas, locContainer = cc.game.container;
 
-        if (!CC_WECHATGAME) {
+        if (!CC_WECHATGAME && !isBaiduGame) {
             if (cc.sys.os === cc.sys.OS_ANDROID) {
                 document.body.style.width = (view._isRotated ? h : w) + 'px';
                 document.body.style.height = (view._isRotated ? w : h) + 'px';

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -545,8 +545,9 @@ VideoPlayerImpl._polyfill = {
  * But native does not support this encode,
  * so it is best to provide mp4 and webm or ogv file
  */
+const isBaiduGame = (cc.sys.platform === cc.sys.BAIDU_GAME);
 let dom = document.createElement("video");
-if (!CC_WECHATGAME) {
+if (!CC_WECHATGAME && !isBaiduGame) {
     if (dom.canPlayType("video/ogg")) {
         VideoPlayerImpl._polyfill.canPlayType.push(".ogg");
         VideoPlayerImpl._polyfill.canPlayType.push(".ogv");


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/856
relative pr: https://github.com/cocos-creator-packages/baidu-adapter/pull/1

改动：
- CCSys 增加 baiduGame vivoGame oppoGame 的相关平台判断。还需要配合编辑器构建时修改 setting.js 的输出，这里主要通过 window._CCSetting.platform 来做平台判断
- 适配 百度 runtime 的需求，在需要 CC_WECHATGAME 判断的地方，增加 isBaiduGame 的判断。这几个地方没办法写进 百度 adapter 里边