### PR TITLE
add stopAnimation/startAnimation to game pasue/resume

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -286,6 +286,8 @@ var game = {
         if (cc.audioEngine) {
             cc.audioEngine._break();
         }
+        // Pause animation
+        cc.director.stopAnimation();
         // Pause main loop
         if (this._intervalId)
             window.cancelAnimFrame(this._intervalId);
@@ -305,6 +307,8 @@ var game = {
         if (cc.audioEngine) {
             cc.audioEngine._restore();
         }
+        // Resume animation
+        cc.director.startAnimation();
         // Resume main loop
         this._runMainLoop();
     },


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 cc.game.pause 后在 cc.game.resume 后，计算 dt 的 _lastUpdate 没有重制赋值 performance.now(); 导致 dt 变大，出现了 animation 闪现的错误效果