### PR TITLE
fixed issue that errors is empty array

### DIFF
--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -727,7 +727,7 @@ proto.destroy = function () {
     this._appending = false;
     this._pipeline = null;
     this._ownerQueue = null;
-    this._errorUrls.length = 0;
+    this._errorUrls = [];
     this.onProgress = null;
     this.onComplete = null;
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 
fixed https://github.com/cocos-creator/engine/issues/3580

下载时如果发生错误，回调里的err为空数组，原因是因为回调是在callInNextFrame中执行的，而此时发生错误的loading-items已经被destroy了，_errorUrls被清空，导致返回的err也空了，所以修改为将[]赋给_errorUrls

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
