### PR TITLE
fixed issue that error is empty array

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -268,7 +268,7 @@ proto.load = function(resources, progressCallback, completeCallback) {
             if (completeCallback) {
                 if (singleRes) {
                     let id = res.url;
-                    completeCallback.call(self, items.getError(id), items.getContent(id));
+                    completeCallback.call(self, errors, items.getContent(id));
                 }
                 else {
                     completeCallback.call(self, errors, items);

--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -167,7 +167,7 @@ var LoadingItems = function (pipeline, urlList, onProgress, onComplete) {
 
     this._pipeline = pipeline;
 
-    this._errorUrls = [];
+    this._errorUrls = js.createMap(true);
 
     this._appending = false;
 
@@ -523,7 +523,7 @@ proto._childOnProgress = function (item) {
  * @method allComplete
  */
 proto.allComplete = function () {
-    var errors = this._errorUrls.length === 0 ? null : this._errorUrls;
+    var errors = js.isEmptyObject(this._errorUrls) === true ? null : this._errorUrls;
     if (this.onComplete) {
         this.onComplete(errors, this);
     }
@@ -690,12 +690,16 @@ proto.itemComplete = function (id) {
     }
 
     // Register or unregister errors
-    var errorListId = this._errorUrls.indexOf(id);
-    if (item.error && errorListId === -1) {
-        this._errorUrls.push(id);
+    
+    var errorListId = id in this._errorUrls;
+    if (item.error instanceof Error || js.isString(item.error)) {
+        this._errorUrls[id] = item.error;
     }
-    else if (!item.error && errorListId !== -1) {
-        this._errorUrls.splice(errorListId, 1);
+    else if (item.error) {
+        js.mixin(this._errorUrls, item.error);
+    }
+    else if (!item.error && errorListId) {
+        delete this._errorUrls[id] 
     }
 
     this.completed[id] = item;
@@ -727,7 +731,7 @@ proto.destroy = function () {
     this._appending = false;
     this._pipeline = null;
     this._ownerQueue = null;
-    this._errorUrls.length = 0;
+    js.clear(this._errorUrls);
     this.onProgress = null;
     this.onComplete = null;
 

--- a/cocos2d/core/platform/js.js
+++ b/cocos2d/core/platform/js.js
@@ -222,6 +222,18 @@ var js = {
     },
 
     /**
+     * Checks whether obj is an empty object
+     * @method isEmptyObject
+     * @param {any} obj 
+     */
+    isEmptyObject: function (obj) {
+        for (var key in obj) {
+            return false;
+        }
+        return true;
+    },
+
+    /**
      * Get property descriptor in object and all its ancestors
      * @method getPropertyDescriptor
      * @param {Object} obj

--- a/test/qunit/unit-es5/test-pipeline.js
+++ b/test/qunit/unit-es5/test-pipeline.js
@@ -99,8 +99,7 @@ test('pipeline flow', function () {
     ]);
 
     var onComplete = new Callback(function (error, items) {
-        ok(error instanceof Array, 'should return error array in onComplete when error happened');
-        strictEqual(error[0], 'res/role', 'should contains correct errored url in error array');
+        strictEqual('res/role' in error, true, 'should contains correct errored url in error object');
         ok(items.getError('res/role') !== null, 'should set error property in errored item.');
     }).enable();
     var onProgress = new Callback().enable();


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * fix https://github.com/cocos-creator/engine/issues/3580
   修复返回err为空数组的情况，将errorUrl改为对象实现

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
