### PR TITLE
Fix screen adaptation is invalid to close EditorBox

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/CCEditBoxImpl.js
@@ -245,10 +245,7 @@ let EditBoxImpl = cc.Class({
         this._node = null;
         this.setDelegate(null);
         this.removeDom();
-        if (this.__orientationChanged) {
-            window.removeEventListener('orientationchange', this.__orientationChanged);
-            this.__orientationChanged = null;
-        }
+        this.removeOrientationchangeEvent();
     },
 
     _onTouchBegan (touch) {
@@ -261,8 +258,8 @@ let EditBoxImpl = cc.Class({
 
     _beginEditing () {
         if (cc.sys.isMobile && !this._editing) {
-            // Pre adaptation
-            this._beginEditingOnMobile();
+            // Pre adaptation add orientationchange event
+            this.addOrientationchangeEvent();
         }
 
         if (this._edTxt) {
@@ -436,13 +433,8 @@ _p.createInput = function() {
 
 // Called before editbox focus to register cc.view status
 _p._beginEditingOnMobile = function () {
-    let self = this;
-    if (!this.__orientationChanged) {
-        this.__orientationChanged = function () {
-            self._adjustEditBoxPosition();
-        };
-        window.addEventListener('orientationchange', this.__orientationChanged);
-    }
+    // add orientationchange event
+    this.addOrientationchangeEvent();
 
     if (cc.view.isAutoFullScreenEnabled()) {
         this.__fullscreen = true;
@@ -471,10 +463,8 @@ _p._endEditingOnMobile = function () {
         this.__rotateScreen = false;
     }
 
-    if (this.__orientationChanged) {
-        window.removeEventListener('orientationchange', this.__orientationChanged);
-        this.__orientationChanged = null;
-    }
+    // remove orientationchange event
+    this.removeOrientationchangeEvent();
 
     if(this.__fullscreen) {
         cc.view.enableAutoFullScreen(true);
@@ -652,6 +642,23 @@ _p.removeDom = function () {
         }
     }
     this._edTxt = null;
+};
+
+_p.addOrientationchangeEvent = function () {
+    let self = this;
+    if (!self.__orientationChanged) {
+        self.__orientationChanged = function () {
+            self._adjustEditBoxPosition();
+        };
+    }
+    window.addEventListener('orientationchange', self.__orientationChanged);
+};
+
+_p.removeOrientationchangeEvent = function () {
+    if (this.__orientationChanged) {
+        window.removeEventListener('orientationchange', this.__orientationChanged);
+        this.__orientationChanged = null;
+    }
 };
 
 module.exports = EditBoxImpl;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复输入框键盘收起来后就屏幕无法自动适配的 bug