### PR TITLE
modified isPlainEmptyObj_DEV to use js.isEmptyObject

### DIFF
--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -523,7 +523,8 @@ proto._childOnProgress = function (item) {
  * @method allComplete
  */
 proto.allComplete = function () {
-    var errors = js.isEmptyObject(this._errorUrls) === true ? null : this._errorUrls;
+    var errors = js.isEmptyObject(this._errorUrls) ? null : this._errorUrls;
+
     if (this.onComplete) {
         this.onComplete(errors, this);
     }

--- a/cocos2d/core/platform/utils.js
+++ b/cocos2d/core/platform/utils.js
@@ -25,6 +25,7 @@
  ****************************************************************************/
 
 // TODO - merge with misc.js
+const js = require('./js');
 
 module.exports = {
     contains: function (refNode, otherNode) {
@@ -91,12 +92,8 @@ if (CC_DEV) {
         if (!obj || obj.constructor !== Object) {
             return false;
         }
-        // jshint ignore: start
-        for (var k in obj) {
-            return false;
-        }
-        // jshint ignore: end
-        return true;
+       
+        return js.isEmptyObject(obj);
     };
     module.exports.cloneable_DEV = function (obj) {
         return obj &&


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#3580
补充 https://github.com/cocos-creator/engine/pull/3590

Changes:
 * 修改isPlainEmptyObj_DEV内部使用js.isEmptyObject

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
