### PR TITLE
修改AssetLibrary初始化

### DIFF
--- a/cocos/assets/CCAssetLibrary.js
+++ b/cocos/assets/CCAssetLibrary.js
@@ -347,13 +347,8 @@ let AssetLibrary = {
                     // backward compatibility since 1.10
                     _uuidToRawAsset[uuid] = new RawAssetEntry(mountPoint + '/' + url, type);
                     // init resources
-                    var ext = cc.path.extname(url);
-                    if (ext) {
-                        // trim base dir and extname
-                        url = url.slice(0, - ext.length);
-                    }
-
                     var isSubAsset = info[2] === 1;
+                    
                     if (!assetTables[mountPoint]) {
                         assetTables[mountPoint] = new AssetTable();
                     } 

--- a/cocos/load-pipeline/asset-table.js
+++ b/cocos/load-pipeline/asset-table.js
@@ -35,7 +35,7 @@ function Entry (uuid, type) {
 function isMatchByWord (path, test) {
     if (path.length > test.length) {
         var nextAscii = path.charCodeAt(test.length);
-        return (nextAscii === 46 || nextAscii === 47); // '.' or '/'
+        return (nextAscii === 47); // '/'
     }
     return true;
 }
@@ -159,7 +159,7 @@ export default class AssetTable {
     add (path, uuid, type, isMainAsset) {
         // remove extname
         // (can not use path.slice because length of extname maybe 0)
-        path = path.substring(0, path.length - cc.path.extname(path).length);
+        isMainAsset && (path = path.substring(0, path.length - cc.path.extname(path).length));
         var newEntry = new Entry(uuid, type);
         pushToMap(this._pathToUuid, path, newEntry, isMainAsset);
     }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/231

Changes:
 *修改后缀处理
  核心问题是目前系统在打包导出资源时，资源和子资源的路径除了后缀之外一模一样，引擎处理的时候会统一把后缀删除，通过资源类型来匹配对应资源，但是像Texture这种资源是没有后缀名的，当遇到environment.hdr这种类型的texture时，把hdr当作后缀删除了，导致匹配资源不正确。目前的修改方式是子资源不做后缀名删除。（貌似我们的子资源都没有后缀吧？）2D引擎目前也存在这个问题，看下未来是否所有资源都有对应后缀，比如Texture资源后缀为tex，SpriteFrame后缀spf？

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
