### PR TITLE
fixed the issue that deferred loading makes cc.Mask throw exceptions 

### DIFF
--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -273,6 +273,7 @@ let Mask = cc.Class({
                 // Do not render when sprite frame is not ready
                 this.markForRender(false);
                 if (this._spriteFrame) {
+                    this.markForUpdateRenderData(false);
                     this._spriteFrame.once('load', this._onTextureLoaded, this);
                     this._spriteFrame.ensureLoadTexture();
                 }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/928

Changes:
 * 延迟加载SpriteFrame时，应该把mask的updateRenderData的flag设置一下，否则会在更新渲染数据时报错

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
