### PR TITLE
Change argument of clickEvents for consistency

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -635,7 +635,7 @@ let Button = cc.Class({
         if (!this.interactable || !this.enabledInHierarchy) return;
 
         if (this._pressed) {
-            cc.Component.EventHandler.emitEvents(this.clickEvents, this);
+            cc.Component.EventHandler.emitEvents(this.clickEvents, event, this);
             this.node.emit('click', this);
         }
         this._pressed = false;

--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -635,7 +635,7 @@ let Button = cc.Class({
         if (!this.interactable || !this.enabledInHierarchy) return;
 
         if (this._pressed) {
-            cc.Component.EventHandler.emitEvents(this.clickEvents, event);
+            cc.Component.EventHandler.emitEvents(this.clickEvents, this);
             this.node.emit('click', this);
         }
         this._pressed = false;


### PR DESCRIPTION
All UI component events should pass `this` to event handler instead of `event` for consistency.

Re: cocos-creator/2d-tasks#

Changes:
 *  pass `this` instead of `event` to `clickEvents` handler

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [x] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
