### PR TITLE
fix nested scroll view reset capturing targets

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -53,11 +53,7 @@ var _vec3_temp = math.vec3.create();
 var _quat_temp = math.quat.create();
 var _globalOrderOfArrival = 1;
 
-var _cachedArrayPool = new Array(3);
-_cachedArrayPool.length = 0;
-
-_cachedArrayPool.push(new Array(16));
-_cachedArrayPool.push(new Array(16));
+var _cachedArrayPool = [new Array(16)];
 
 function _getCachedArray(){
     if(_cachedArrayPool.length === 0){

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -52,8 +52,24 @@ var _mat4_temp = math.mat4.create();
 var _vec3_temp = math.vec3.create();
 var _quat_temp = math.quat.create();
 var _globalOrderOfArrival = 1;
-var _cachedArray = new Array(16);
-_cachedArray.length = 0;
+
+var _cachedArrayPool = new Array(3);
+_cachedArrayPool.length = 0;
+
+_cachedArrayPool.push(new Array(16));
+_cachedArrayPool.push(new Array(16));
+
+function _getCachedArray(){
+    if(_cachedArrayPool.length === 0){
+        _cachedArrayPool.push(new Array(16));
+    }
+    return _cachedArrayPool.pop();
+}
+
+function _releaseCachedArray(array){
+    array.length = 0;
+    _cachedArrayPool.push(array);
+}
 
 const POSITION_ON = 1 << 0;
 const SCALE_ON = 1 << 1;
@@ -458,7 +474,7 @@ function _checkListeners (node, events) {
     return true;
 }
 
-function _doDispatchEvent (owner, event) {
+function _doDispatchEvent (owner, event, _cachedArray) {
     var target, i;
     event.target = owner;
 
@@ -1767,8 +1783,9 @@ var Node = cc.Class({
      * @param {Event} event - The Event object that is dispatched into the event flow
      */
     dispatchEvent (event) {
-        _doDispatchEvent(this, event);
-        _cachedArray.length = 0;
+        let _cachedArray = _getCachedArray();
+        _doDispatchEvent(this, event, _cachedArray);
+        _releaseCachedArray(_cachedArray);
     },
 
     /**


### PR DESCRIPTION
`_doDispatchEvent` will be invoked recursively when a button in a multiple nested ScrollView did dispatch a touchMove event, and we should keep capturing targets cache in stack.

Re: cocos-creator/2d-tasks#

Changes:
 * CCNode.js,  track capturing target list in stack using an array pool instead of a singleton array, then we can dispatch event recursively.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [x ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ x] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [x ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
