### PR TITLE
RichText component change to the default color as the color of the node

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -871,7 +871,7 @@ let RichText = cc.Class({
         if (textStyle && textStyle.color) {
             labelNode.color = this._convertLiteralColorValue(textStyle.color);
         }else {
-            labelNode.color = this._convertLiteralColorValue("white");
+            labelNode.color = this.node.color;
         }
 
         labelComponent._enableBold(textStyle && textStyle.bold);


### PR DESCRIPTION
Re: https://forum.cocos.com/t/cc-2-x-richtext/71354

Changes:
 * 调整一下 RichText 中没有颜色设置时，默认颜色为节点的颜色