### PR TITLE
component menu

### DIFF
--- a/cocos/camera/CCCamera.js
+++ b/cocos/camera/CCCamera.js
@@ -77,7 +77,7 @@ let ClearFlags = cc.Enum({
  * @extends Component
  */
 @ccclass('cc.Camera')
-@menu('i18n:MAIN_MENU.component.others/Camera')
+@menu('Render/Camera(deprecated)')
 @inspector('packages://inspector/inspectors/comps/camera.js')
 @executeInEditMode
 export default class Camera extends Component {

--- a/cocos/components/CCCanvas.js
+++ b/cocos/components/CCCanvas.js
@@ -36,7 +36,7 @@ import {ccclass, property, executeInEditMode, menu, help, disallowMultiple} from
  * @extends Component
  */
 @ccclass('cc.Canvas')
-@menu('i18n:MAIN_MENU.component.ui/Canvas')
+@menu('UI/Canvas')
 @help('i18n:COMPONENT.help_url.canvas')
 @executeInEditMode
 @disallowMultiple

--- a/cocos/core/data/class.js
+++ b/cocos/core/data/class.js
@@ -364,7 +364,7 @@ function define (className, baseClass, mixins, options) {
             if (uuid) {
                 js._setClassId(uuid, cls);
                 if (CC_EDITOR) {
-                    Component._addMenuItem(cls, 'i18n:MAIN_MENU.component.scripts/' + className, -1);
+                    // Component._addMenuItem(cls, 'i18n:MAIN_MENU.component.scripts/' + className, -1);
                     cls.prototype.__scriptUuid = Editor.Utils.UuidUtils.decompressUuid(uuid);
                 }
             }


### PR DESCRIPTION
这里允许用户脚本可以使用
```
@cc._decorator.menu('')
```
自己指定菜单路径。

然后取消了I18N这个东西。