### PR TITLE
fix editBox exitFullScreen bug

### DIFF
--- a/cocos2d/core/platform/CCScreen.js
+++ b/cocos2d/core/platform/CCScreen.js
@@ -150,7 +150,7 @@ cc.screen = /** @lends cc.screen# */{
      * @return {Boolean}
      */
     exitFullScreen: function (element) {
-        if (element.tagName.toLowerCase() === "video") {
+        if (element && element.tagName.toLowerCase() === "video") {
             if (cc.sys.os === cc.sys.OS_IOS && cc.sys.isBrowser) {
                 element.webkitExitFullscreen && element.webkitExitFullscreen();
                 return;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/940

web 平台 editbox 调用 cc.Scene.exitFullScreen 没传入 element，只有 videoPlayer 会传入。这里应该做多个判断