### PR TITLE
update audio state onEnded

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -48,6 +48,7 @@ let Audio = function (src) {
     this._state = Audio.State.INITIALZING;
 
     this._onended = function () {
+        this._state = Audio.State.STOPPED;
         this.emit('ended');
     }.bind(this);
 };
@@ -236,6 +237,8 @@ Audio.State = {
         }
 
         if (!(CC_QQPLAY || CC_WECHATGAME)) {
+            // setCurrentTime would fire 'ended' event
+            // so we need to change the callback to rebind ended callback after setCurrentTime
             this._unbindEnded();
             this._bindEnded(function () {
                 this._bindEnded();
@@ -265,9 +268,11 @@ Audio.State = {
 
     proto.getState = function () {
         if (!CC_WECHATGAME && !CC_QQPLAY) {
+            // HACK: in some browser, audio may not fire 'ended' event
+            // so we need to force updating the Audio state
             let elem = this._element;
             if (elem && Audio.State.PLAYING === this._state && elem.paused) {
-                this._state = Audio.State.PAUSED;
+                this._state = Audio.State.STOPPED;
             }
         }
         return this._state;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/932

changeLog:
- 修复 小游戏 上 audioSource 播放完之后，从后台切回来，会重新播放的问题

顺便加了点注释