### PR TITLE
fix mask no spriteframe alway reprot error

### DIFF
--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -265,6 +265,9 @@ let Mask = cc.Class({
         if (this._type !== MaskType.IMAGE_STENCIL) {
             this._updateGraphics();
         }
+        else {
+            this._applySpriteFrame();
+        }
     },
 
     onEnable () {
@@ -344,6 +347,9 @@ let Mask = cc.Class({
                 spriteFrame.once('load', this._onTextureLoaded, this);
                 spriteFrame.ensureLoadTexture();
             }
+        }
+        else {
+            this.disableRender();
         }
     },
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
1.修复当 mask IMAGE_STENCIL 模式没有 spriteFrame 时会无限报错
2.修复回退当时候重现赋值 spriteFrame，mask 不会有效果的 bug
