### PR TITLE
refine fullScreen code and fix videoPlayer exitFullScreen error

### DIFF
--- a/cocos2d/core/platform/CCScreen.js
+++ b/cocos2d/core/platform/CCScreen.js
@@ -102,11 +102,13 @@ cc.screen = /** @lends cc.screen# */{
      * @returns {Boolean}
      */
     fullScreen: function () {
-        if(!this._supportsFullScreen) return false;
-        else if( document[this._fn.fullscreenElement] === undefined || document[this._fn.fullscreenElement] === null )
+        if (!this._supportsFullScreen) return false;
+        else if (!document[this._fn.fullscreenElement] && !document[this._fn.webkitFullscreenElement] && !document[this._fn.mozFullScreenElement]) {
             return false;
-        else
+        }
+        else {
             return true;
+        }
     },
     
     /**

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -79,7 +79,7 @@ let VideoPlayerImpl = cc.Class({
             if (self._fullScreenEnabled) {
                 cc.screen.requestFullScreen(video);
             }
-            else {
+            else if (cc.screen.fullScreen()) {
                 cc.screen.exitFullScreen(video);
             }
             self._dispatchEvent(VideoPlayerImpl.EventType.META_LOADED);
@@ -368,7 +368,7 @@ let VideoPlayerImpl = cc.Class({
         if (enable) {
             cc.screen.requestFullScreen(video);
         }
-        else {
+        else if (cc.screen.fullScreen()) {
             cc.screen.exitFullScreen(video);
         }
     },


### PR DESCRIPTION
Re: 
https://forum.cocos.com/t/2-1-0/71108/6
https://forum.cocos.com/t/cocoscretor/71699/6

Changes:
 * 修复当没有使用 fullscreenElement 时，调用了 exitFullScreen 会导致报错
 * 完善一下 CCScreen 中的 fullScreen 代码