### PR TITLE
fix deviceMotion opposite direction on android 9

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -829,7 +829,7 @@ function initSys () {
 
         // Get the os of system
         var isAndroid = false, iOS = false, osVersion = '', osMainVersion = 0;
-        var uaResult = /android (\d+(?:\.\d+)+)/i.exec(ua) || /android (\d+(?:\.\d+)+)/i.exec(nav.platform);
+        var uaResult = /android (\d+(?:\.\d+)*)/i.exec(ua) || /android (\d+(?:\.\d+)*)/i.exec(nav.platform);
         if (uaResult) {
             isAndroid = true;
             osVersion = uaResult[1] || '';


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/972

changeLog: 
- 修复 android 9 系统重力感应方向相反的问题

补充：
导致的原因是 正则没有匹配到 android 9 的版本号，导致系统判断错误。
导致 之前的修复 https://github.com/cocos-creator/engine/commit/004abc3b66e1caa786cc4be24940fbd036f243b2 无效了