### PR TITLE
fix load mp3 as audioClip

### DIFF
--- a/cocos2d/core/assets/CCAudioClip.js
+++ b/cocos2d/core/assets/CCAudioClip.js
@@ -61,8 +61,15 @@ var AudioClip = cc.Class({
                 return this._audio;
             },
             set (value) {
-                this._audio = value;
-                if (value) {
+                // HACK: fix load mp3 as audioClip, _nativeAsset is set as audioClip.
+                // Should load mp3 as audioBuffer indeed.
+                if (value instanceof cc.AudioClip) {
+                    this._audio = value._nativeAsset;
+                }
+                else {
+                    this._audio = value;
+                }
+                if (this._audio) {
                     this.loaded = true;
                     this.emit('load');
                 }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/994

changeLog:
- 修复重复加载 audioClip 导致音频无法播放的问题