### PR TITLE
remove x5 adaption for videoplayer

### DIFF
--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -170,13 +170,6 @@ let VideoPlayerImpl = cc.Class({
         video.setAttribute('webkit-playsinline', '');
         video.setAttribute('playsinline', '');
 
-        // Stupid tencent x5 adaptation
-        video.setAttribute("x5-playsinline", "");
-        video.setAttribute("x5-video-player-type", "h5");
-        video.setAttribute("x5-video-player-fullscreen", this._fullScreenEnabled ? "true" : "false");
-        let orientation = cc.winSize.width > cc.winSize.height ? "landscape" : "portrait";
-        video.setAttribute("x5-video-orientation", orientation);
-
         this._video = video;
         cc.game.container.appendChild(video);
     },


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#977

Changes:
 * 测试了一下在安卓上，x5 的 videoplayer 的效果很差，会出现一些莫名其妙的 bug，从而移除对 x5 的适配