### PR TITLE
fix EngineErrorMap scheduleSelector log

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -276,7 +276,7 @@ warning: you CANNOT change update priority in scheduled function
 
 ### 1507
 
-CCScheduler#scheduleSelector. Selector already scheduled. Updating interval from: %.4f to %.4f
+CCScheduler#scheduleSelector. Selector already scheduled. Updating interval from: %s to %s"
 
 ### 1508
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 EngineErrorMap scheduleSelector  log 写法