### PR TITLE
Forbid using setResizeCallback in editor

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -307,6 +307,7 @@ cc.js.mixin(View.prototype, {
      * @param {Function|Null} callback - The callback function
      */
     setResizeCallback: function (callback) {
+        if (CC_EDITOR) return;
         if (typeof callback === 'function' || callback == null) {
             this._resizeCallback = callback;
         }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * setResizeCallback 不支持在编辑器下使用