### PR TITLE
fix call onDestroy twice on fireball

### DIFF
--- a/cocos2d/core/node-activator.js
+++ b/cocos2d/core/node-activator.js
@@ -333,6 +333,7 @@ var NodeActivator = cc.Class({
         if (comp.onDestroy && (comp._objFlags & IsOnLoadCalled)) {
             if (cc.engine._isPlaying || comp.constructor._executeInEditMode) {
                 callOnDestroyInTryCatch(comp);
+                comp._objFlags &= ~IsOnLoadCalled;  // In case call onDestroy twice in undo operation
             }
         }
     } : function (comp) {


### PR DESCRIPTION
changeLog:
- 修复编辑器销毁节点时，重复调用 onDestroy 的问题

关联：
https://github.com/cocos-creator/fireball/pull/8678