### PR TITLE
move _childArrivalOrder to Ctor

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -574,7 +574,7 @@ var Node = cc.Class({
             default: 0,
             serializable: false
         },
-        _childArrivalOrder: 1,
+    
 
         // internal properties
 
@@ -1161,6 +1161,7 @@ var Node = cc.Class({
 
         this._eventMask = 0;
         this._cullingMask = 1;
+        this._childArrivalOrder = 1;
     },
 
     statics: {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1014

Changes:
 * 防止_childArrivalOrder被序列化，移到构造函数里面

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
