### PR TITLE
fix dragonBones eventManager undefined for 2d-tasks/issues/1034

### DIFF
--- a/extensions/dragonbones/CCFactory.js
+++ b/extensions/dragonbones/CCFactory.js
@@ -55,7 +55,8 @@ var CCFactory = dragonBones.CCFactory = cc.Class({
     },
 
     ctor () {
-        this._dragonBones = new dragonBones.DragonBones();
+        let eventManager = new dragonBones.CCArmatureDisplay();
+        this._dragonBones = new dragonBones.DragonBones(eventManager);
 
         if (!CC_JSB && !CC_EDITOR && cc.director._scheduler) {
             cc.game.on(cc.game.EVENT_RESTART, this.initUpdate, this);


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1034

Changes:
 * 修复龙骨创建时未传入 eventManager 对象，导致播放动画包含音频事件时，出现 eventManager undefined 的报错