### PR TITLE
remove redundant right shift for bitwise operation

### DIFF
--- a/cocos2d/core/value-types/color.js
+++ b/cocos2d/core/value-types/color.js
@@ -336,12 +336,12 @@ var Color = (function () {
      */
     proto.setA = function (alpha) {
         alpha = ~~cc.misc.clampf(alpha, 0, 255);
-        this._val = ((this._val & 0x00ffffff) | ((alpha << 24) >>> 0)) >>> 0;
+        this._val = ((this._val & 0x00ffffff) | (alpha << 24)) >>> 0;
         return this;
     };
 
     proto._fastSetA = function (alpha) {
-        this._val = ((this._val & 0x00ffffff) | ((alpha << 24) >>> 0)) >>> 0;
+        this._val = ((this._val & 0x00ffffff) | (alpha << 24)) >>> 0;
     };
 
     js.getset(proto, 'r', proto.getR, proto.setR, true);

--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -60,7 +60,7 @@ let Particle = function () {
 let pool = new js.Pool(function (par) {
     par.pos.set(ZERO_VEC2);
     par.startPos.set(ZERO_VEC2);
-    par.color._val = ((255<<24) >>> 0);
+    par.color._val = 0xFF000000;
     par.deltaColor.r = par.deltaColor.g = par.deltaColor.b = 0;
     par.deltaColor.a = 255;
     par.size = 0;

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -153,7 +153,7 @@ let TileFlag = cc.Enum({
      * @type {Number}
      * @static
      */
-    FLIPPED_MASK: (~((0x80000000 | 0x40000000 | 0x20000000) >>> 0)) >>> 0
+    FLIPPED_MASK: (~(0x80000000 | 0x40000000 | 0x20000000)) >>> 0
 });
 
 /*


### PR DESCRIPTION
Changes:
 * 移除多余的 >>> 0（转成正整数只需要发生在位运算的最后一步）

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
