### PR TITLE
Fix sp.Skeleton asset migration

### DIFF
--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -311,6 +311,7 @@ sp.Skeleton = cc.Class({
          */
         premultipliedAlpha: {
             default: true,
+            formerlySerializedAs: "_premultipliedAlpha",
             tooltip: CC_DEV && 'i18n:COMPONENT.skeleton.premultipliedAlpha'
         },
 


### PR DESCRIPTION
Version 1.10 used to serialize this property as `_premultipliedAlpha`

Re: cocos-creator/2d-tasks#

Changes:
 * Fix migration of sp.Skeleton asset from 1.10

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
