### PR TITLE
wx open data context no need to load builtins

### DIFF
--- a/cocos2d/core/platform/CCAssetLibrary.js
+++ b/cocos2d/core/platform/CCAssetLibrary.js
@@ -414,6 +414,10 @@ function loadBuiltins (name, type, cb) {
 }
 
 AssetLibrary._loadBuiltins = function (cb) {
+    if (cc.game.renderType === cc.game.RENDER_TYPE_CANVAS) {
+        return cb && cb();
+    }
+
     loadBuiltins('effect', cc.EffectAsset, () => {
         loadBuiltins('material', cc.Material, cb);
     });


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1050

Changes:
 * 旧版本子域不支持 webgl 所以不需要去加载 builtins 