### PR TITLE
fixed the native texture hash fault problem

### DIFF
--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -731,6 +731,11 @@ var Texture2D = cc.Class({
         let wrapS = this._wrapS === WrapMode.REPEAT ? 1 : (this._wrapS === WrapMode.CLAMP_TO_EDGE ? 2 : 3);
         let wrapT = this._wrapT === WrapMode.REPEAT ? 1 : (this._wrapT === WrapMode.CLAMP_TO_EDGE ? 2 : 3);
         let pixelFormat = this._format;
+        // native platform use the image data straightly
+        let gl = window.__gl;
+        if (CC_JSB && this._image && this._image.glFormat !== gl.RGBA) {
+            pixelFormat = 0;
+        }
 
         this._hash = parseInt(`${minFilter}${magFilter}${pixelFormat}${wrapS}${wrapT}${hasMipmap}${premultiplyAlpha}${flipY}`);
         this._hashDirty = false;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/834

1. 增加关于 hash 生成时针对 native 的特殊处理
2. 暂时手动关联 2dx-lite 中手动适配 png 特殊 format 为 RGBA 的 pr