### PR TITLE
Fix the problem that the button display error when it is grayed out after changing the color.

### DIFF
--- a/cocos2d/core/renderer/render-engine.js
+++ b/cocos2d/core/renderer/render-engine.js
@@ -14392,7 +14392,7 @@ var GraySpriteMaterial = (function (Material$$1) {
         'color': this._color
       },
       [
-        { name: 'useColor', value: true },
+        { name: 'useColor', value: false }
       ]
     );
     

--- a/cocos2d/core/renderer/render-engine.js
+++ b/cocos2d/core/renderer/render-engine.js
@@ -13703,9 +13703,10 @@ var chunks = {
 var templates = [
   {
     name: 'gray_sprite',
-    vert: '\n \nuniform mat4 viewProj;\nattribute vec3 a_position;\nattribute mediump vec2 a_uv0;\nvarying mediump vec2 uv0;\nvoid main () {\n  vec4 pos = viewProj * vec4(a_position, 1);\n  gl_Position = pos;\n  uv0 = a_uv0;\n}',
-    frag: '\n \nuniform sampler2D texture;\nvarying mediump vec2 uv0;\nuniform lowp vec4 color;\nvoid main () {\n  vec4 c = color * texture2D(texture, uv0);\n  float gray = 0.2126*c.r + 0.7152*c.g + 0.0722*c.b;\n  gl_FragColor = vec4(gray, gray, gray, c.a);\n}',
+    vert: '\n \nuniform mat4 viewProj;\nattribute vec3 a_position;\nattribute mediump vec2 a_uv0;\nvarying mediump vec2 uv0;\n#ifndef useColor\nattribute lowp vec4 a_color;\nvarying lowp vec4 v_fragmentColor;\n#endif\nvoid main () {\n  vec4 pos = viewProj * vec4(a_position, 1);\n  gl_Position = pos;\n  uv0 = a_uv0;\n #ifndef useColor\n  v_fragmentColor = a_color;\n #endif\n}',
+    frag: '\n \nuniform sampler2D texture;\nvarying mediump vec2 uv0;\n#ifdef useColor\n  uniform lowp vec4 color;\n#else\n  varying lowp vec4 v_fragmentColor;\n#endif\nvoid main () {\n  #ifdef useColor\n    vec4 o = color;\n  #else\n    vec4 o = v_fragmentColor;\n  #endif\n  vec4 c = o * texture2D(texture, uv0);\n  float gray = 0.2126*c.r + 0.7152*c.g + 0.0722*c.b;\n  gl_FragColor = vec4(gray, gray, gray, c.a);\n}',
     defines: [
+      { name: 'useColor', }
     ],
   },
   {
@@ -14390,7 +14391,9 @@ var GraySpriteMaterial = (function (Material$$1) {
       {
         'color': this._color
       },
-      []
+      [
+        { name: 'useColor', value: true },
+      ]
     );
     
     this._mainTech = mainTech;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#
问题描述：
Button使用白色底图修改颜色作为按钮图片然后再置灰时仍然会显示为白色，因为之前修改批处理时把Sprite的useColor给关闭了，GraySpriteMaterial中的uniform color没有传递。

Changes:
增加GraySpriteMaterial中useColor的动态配置，这个问题也可以简单的把GraySpriteMaterial的useColor设置为true，看使用哪种解决方式，现在看怎么修改都可以。

修改之后的shader：
Vertex:
precision highp float;
uniform mat4 viewProj;
attribute vec3 a_position;
attribute mediump vec2 a_uv0;
varying mediump vec2 uv0;
**#ifndef useColor
    attribute lowp vec4 a_color;
    varying lowp vec4 v_fragmentColor;
#endif**
void main () {
    vec4 pos = viewProj * vec4(a_position, 1);
    gl_Position = pos;
    uv0 = a_uv0;
    **#ifndef useColor
        v_fragmentColor = a_color;
    #endif**
}

Fragment:
precision highp float;
uniform sampler2D texture;
varying mediump vec2 uv0;
**#ifdef useColor
    uniform lowp vec4 color;
#else
    varying lowp vec4 v_fragmentColor;
#endif**
void main () {
    **#ifdef useColor
        vec4 o = color;
    #else
        vec4 o = v_fragmentColor;
    #endif**
    vec4 c = o * texture2D(texture, uv0);
    float gray = 0.2126*c.r + 0.7152*c.g + 0.0722*c.b;
    gl_FragColor = vec4(gray, gray, gray, c.a);
}

