### PR TITLE
Fix short audio after mute will result in 1 frame of sound

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -467,7 +467,7 @@ let WebAudioElement = function (buffer, audio) {
     proto.__defineSetter__('volume', function (num) {
         this._volume = num;
         if (this._gainObj['gain'].setTargetAtTime) {
-            this._gainObj['gain'].setTargetAtTime(this._volume, this._context.currentTime, 0.01);
+            this._gainObj['gain'].setTargetAtTime(this._volume, this._context.currentTime, 0.001);
         } else {
             this._volume['gain'].value = num;
         }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复静音后，使用较短的音频，会出现一帧的音效

demo：[xiaoyouxi.zip](https://github.com/cocos-creator/engine/files/2806262/xiaoyouxi.zip)
