### PR TITLE
Fix: Spine blinks after instantiation

### DIFF
--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -907,8 +907,8 @@ sp.Skeleton = cc.Class({
                 var res = this._state.setAnimationWith(trackIndex, animation, loop);
                 if (CC_EDITOR && !cc.engine.isPlaying) {
                     this._state.update(0);
-                    this._state.apply(this._skeleton);
                 }
+                this._state.apply(this._skeleton);
                 return res;
             }
         }
@@ -1200,10 +1200,6 @@ sp.Skeleton = cc.Class({
                 this._skeletonCache = SkeletonCache.sharedCache;
             } else if (this.renderMode === RenderModeEnum.PRIVATE_CACHE) {
                 this._skeletonCache = new SkeletonCache;
-                
-                // validate skeleton state
-                // as render may happen before `update`
-                this._state.apply(this._skeleton);
             }
         }
 

--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -905,9 +905,6 @@ sp.Skeleton = cc.Class({
                     return null;
                 }
                 var res = this._state.setAnimationWith(trackIndex, animation, loop);
-                if (CC_EDITOR && !cc.engine.isPlaying) {
-                    this._state.update(0);
-                }
                 this._state.apply(this._skeleton);
                 return res;
             }

--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -1200,6 +1200,10 @@ sp.Skeleton = cc.Class({
                 this._skeletonCache = SkeletonCache.sharedCache;
             } else if (this.renderMode === RenderModeEnum.PRIVATE_CACHE) {
                 this._skeletonCache = new SkeletonCache;
+                
+                // validate skeleton state
+                // as render may happen before `update`
+                this._state.apply(this._skeleton);
             }
         }
 


### PR DESCRIPTION
If prefab containing spine animation is instantiated from `update` of some other component then it will be rendered in 'setup' pos for one frame. I've experienced problem and verified fix using CocosCreator 2.0.7 but I see no relevant diffs with current state of the fille.

My understanding is that in described case newly created animation will be rendered before `update` on `sp.Skeleton`. Not sure about changes to skeleton data beside instantiation though. 

Is my understanding correct and problem should be fixed like that?

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
