### PR TITLE
add notify object to support reset data

### DIFF
--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -1187,6 +1187,8 @@ function parseAttributes (cls, attrs, className, propName, usedInGetter) {
     parseSimpleAttr('formerlySerializedAs', 'string');
 
     if (CC_EDITOR) {
+        parseSimpleAttr('notifyFor', 'string');
+
         if ('animatable' in attrs && !attrs.animatable) {
             (attrsProto || getAttrsProto())[attrsProtoKey + 'animatable'] = false;
         }

--- a/cocos2d/core/platform/preprocess-class.js
+++ b/cocos2d/core/platform/preprocess-class.js
@@ -67,6 +67,10 @@ function parseNotify (val, propName, notify, properties) {
             notify.call(this, oldValue);
         };
 
+        if (CC_EDITOR) {
+            val.notifyFor = newKey;
+        }
+
         var newValue = {};
         properties[newKey] = newValue;
         // 将不能用于get方法中的属性移动到newValue中


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 让定义 notify 的对象，支持 reset 