### PR TITLE
check button._originalScale validity &&  distinguish target and node events

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -137,7 +137,7 @@ let Button = cc.Class({
         // init _originalScale in __preload()
         this._fromScale = cc.Vec2.ZERO;
         this._toScale = cc.Vec2.ZERO;
-        this._originalScale = cc.Vec2.ZERO;
+        this._originalScale = null;
 
         this._sprite = null;
     },
@@ -423,7 +423,8 @@ let Button = cc.Class({
         let transition = this.transition;
         if (transition === Transition.COLOR && this.interactable) {
             this._setTargetColor(this.normalColor);
-        } else if (transition === Transition.SCALE) {
+        }
+        else if (transition === Transition.SCALE && this._originalScale) {
             target.scaleX = this._originalScale.x;
             target.scaleY = this._originalScale.y;
         }
@@ -566,7 +567,9 @@ let Button = cc.Class({
         if (this.transition === Transition.COLOR) {
             let color = this._fromColor.lerp(this._toColor, ratio);
             this._setTargetColor(color);
-        } else if (this.transition === Transition.SCALE) {
+        }
+        // Skip if _originalScale is invalid
+        else if (this.transition === Transition.SCALE && this._originalScale) {
             target.scale = this._fromScale.lerp(this._toScale, ratio);
         }
 
@@ -593,6 +596,9 @@ let Button = cc.Class({
     _applyTarget () {
         let target = this._getTarget();
         this._sprite = this._getTargetSprite(target);
+        if (!this._originalScale) {
+            this._originalScale = cc.Vec2.ZERO;
+        }
         this._originalScale.x = target.scaleX;
         this._originalScale.y = target.scaleY;
     },
@@ -614,7 +620,7 @@ let Button = cc.Class({
         let hit = this.node._hitTest(touch.getLocation());
         let target = this._getTarget();
 
-        if (this.transition === Transition.SCALE) {
+        if (this.transition === Transition.SCALE && this._originalScale) {
             if (hit) {
                 this._fromScale.x = this._originalScale.x;
                 this._fromScale.y = this._originalScale.y;
@@ -734,6 +740,11 @@ let Button = cc.Class({
     },
 
     _zoomUp () {
+        // skip before __preload()
+        if (!this._originalScale) {
+            return;
+        }
+
         this._fromScale.x = this._originalScale.x;
         this._fromScale.y = this._originalScale.y;
         this._toScale.x = this._originalScale.x * this.zoomScale;
@@ -743,6 +754,11 @@ let Button = cc.Class({
     },
 
     _zoomBack () {
+        // skip before __preload()
+        if (!this._originalScale) {
+            return;
+        }
+
         let target = this._getTarget();
         this._fromScale.x = target.scaleX;
         this._fromScale.y = target.scaleY;

--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -137,7 +137,7 @@ let Button = cc.Class({
         // init _originalScale in __preload()
         this._fromScale = cc.Vec2.ZERO;
         this._toScale = cc.Vec2.ZERO;
-        this._originalScale = null;
+        this._originalScale = cc.Vec2.ZERO;
 
         this._sprite = null;
     },
@@ -389,13 +389,8 @@ let Button = cc.Class({
             default: null,
             type: cc.Node,
             tooltip: CC_DEV && "i18n:COMPONENT.button.target",
-            notify (oldValue) {
-                if (oldValue !== this.target) {
-                    this._applyTarget();
-                    if (oldValue) {
-                        this._unregisterNodeEvent(oldValue);
-                    }
-                }
+            notify () {
+                this._applyTarget();
             }
         },
 
@@ -428,7 +423,7 @@ let Button = cc.Class({
         let transition = this.transition;
         if (transition === Transition.COLOR && this.interactable) {
             this._setTargetColor(this.normalColor);
-        } else if (transition === Transition.SCALE && this._originalScale) {
+        } else if (transition === Transition.SCALE) {
             target.scaleX = this._originalScale.x;
             target.scaleY = this._originalScale.y;
         }
@@ -448,6 +443,21 @@ let Button = cc.Class({
         }
         if (this.disabledSprite) {
             this.disabledSprite.ensureLoadTexture();
+        }
+        //
+        if (!CC_EDITOR) {
+            this._registerEvent();
+        } else {
+            this.node.on('spriteframe-changed', function (comp) {
+                if (this.transition === Transition.SPRITE) {
+                    this._setCurrentStateSprite(comp.spriteFrame);
+                }
+            }.bind(this));
+            this.node.on('color-changed', function (color) {
+                if (this.transition === Transition.COLOR) {
+                    this._setCurrentStateColor(color);
+                }
+            }.bind(this));
         }
     },
 
@@ -523,12 +533,18 @@ let Button = cc.Class({
 
     onDisable () {
         this._resetState();
-    },
 
-    onDestroy () {
-        let target = this._getTarget();
-        this._unregisterNodeEvent(target);
-        this._originalScale = null;
+        if (!CC_EDITOR) {
+            this.node.off(cc.Node.EventType.TOUCH_START, this._onTouchBegan, this);
+            this.node.off(cc.Node.EventType.TOUCH_MOVE, this._onTouchMove, this);
+            this.node.off(cc.Node.EventType.TOUCH_END, this._onTouchEnded, this);
+            this.node.off(cc.Node.EventType.TOUCH_CANCEL, this._onTouchCancel, this);
+
+            this.node.off(cc.Node.EventType.MOUSE_ENTER, this._onMouseMoveIn, this);
+            this.node.off(cc.Node.EventType.MOUSE_LEAVE, this._onMouseMoveOut, this);
+        } else {
+            this.node.off('spriteframe-changed');
+        }
     },
 
     update (dt) {
@@ -542,81 +558,28 @@ let Button = cc.Class({
             ratio = this.time / this.duration;
         }
 
-        // clamp ratio
         if (ratio >= 1) {
             ratio = 1;
+            this._transitionFinished = true;
         }
 
         if (this.transition === Transition.COLOR) {
             let color = this._fromColor.lerp(this._toColor, ratio);
             this._setTargetColor(color);
-        }
-        // Skip if _originalScale is invalid
-        else if (this.transition === Transition.SCALE && this._originalScale) {
+        } else if (this.transition === Transition.SCALE) {
             target.scale = this._fromScale.lerp(this._toScale, ratio);
         }
 
-        if (ratio === 1) {
-            this._transitionFinished = true;
-        }
-
     },
 
-    _registerNodeEvent (node) {        
-        if (CC_EDITOR) {
-            node.on('spriteframe-changed', this._onNodeSpriteFrameChanged, this);
-            node.on(cc.Node.EventType.COLOR_CHANGED, this._onNodeColorChanged, this);
-            node.on(cc.Node.EventType.SCALE_CHANGED, this._onNodeScaleChanged, this);
-        }
-        else {
-            node.on(cc.Node.EventType.TOUCH_START, this._onTouchBegan, this);
-            node.on(cc.Node.EventType.TOUCH_MOVE, this._onTouchMove, this);
-            node.on(cc.Node.EventType.TOUCH_END, this._onTouchEnded, this);
-            node.on(cc.Node.EventType.TOUCH_CANCEL, this._onTouchCancel, this);
-    
-            node.on(cc.Node.EventType.MOUSE_ENTER, this._onMouseMoveIn, this);
-            node.on(cc.Node.EventType.MOUSE_LEAVE, this._onMouseMoveOut, this);
-        }
-    },
+    _registerEvent () {
+        this.node.on(cc.Node.EventType.TOUCH_START, this._onTouchBegan, this);
+        this.node.on(cc.Node.EventType.TOUCH_MOVE, this._onTouchMove, this);
+        this.node.on(cc.Node.EventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.on(cc.Node.EventType.TOUCH_CANCEL, this._onTouchCancel, this);
 
-    _unregisterNodeEvent (node) {
-        if (CC_EDITOR) {
-            node.off('spriteframe-changed', this._onNodeSpriteFrameChanged, this);
-            node.off(cc.Node.EventType.COLOR_CHANGED, this._onNodeColorChanged, this);
-            node.off(cc.Node.EventType.SCALE_CHANGED, this._onNodeScaleChanged, this);
-        }
-        else {
-            node.off(cc.Node.EventType.TOUCH_START, this._onTouchBegan, this);
-            node.off(cc.Node.EventType.TOUCH_MOVE, this._onTouchMove, this);
-            node.off(cc.Node.EventType.TOUCH_END, this._onTouchEnded, this);
-            node.off(cc.Node.EventType.TOUCH_CANCEL, this._onTouchCancel, this);
-
-            node.off(cc.Node.EventType.MOUSE_ENTER, this._onMouseMoveIn, this);
-            node.off(cc.Node.EventType.MOUSE_LEAVE, this._onMouseMoveOut, this);
-        }
-    },
-
-    _onNodeScaleChanged () {
-        let target = this._getTarget();
-        // update _originalScale if target scale changed
-        if (this._originalScale) {
-            if (this.transition !== Transition.SCALE || this._transitionFinished) {
-                this._originalScale.x = target.scaleX;
-                this._originalScale.y = target.scaleY;
-            }
-        }
-    },
-
-    _onNodeSpriteFrameChanged (comp) {
-        if (this.transition === Transition.SPRITE) {
-            this._setCurrentStateSprite(comp.spriteFrame);
-        }
-    },
-
-    _onNodeColorChanged (color) {
-        if (this.transition === Transition.COLOR) {
-            this._setCurrentStateColor(color);
-        }
+        this.node.on(cc.Node.EventType.MOUSE_ENTER, this._onMouseMoveIn, this);
+        this.node.on(cc.Node.EventType.MOUSE_LEAVE, this._onMouseMoveOut, this);
     },
 
     _getTargetSprite (target) {
@@ -630,12 +593,8 @@ let Button = cc.Class({
     _applyTarget () {
         let target = this._getTarget();
         this._sprite = this._getTargetSprite(target);
-        if (!this._originalScale) {
-            this._originalScale = cc.Vec2.ZERO;
-        }
         this._originalScale.x = target.scaleX;
         this._originalScale.y = target.scaleY;
-        this._registerNodeEvent(target);
     },
 
     // touch event handler
@@ -649,12 +608,13 @@ let Button = cc.Class({
 
     _onTouchMove (event) {
         if (!this.interactable || !this.enabledInHierarchy || !this._pressed) return;
-        let target = this._getTarget();
         // mobile phone will not emit _onMouseMoveOut,
         // so we have to do hit test when touch moving
         let touch = event.touch;
-        let hit = target._hitTest(touch.getLocation());
-        if (this.transition === Transition.SCALE && this._originalScale) {
+        let hit = this.node._hitTest(touch.getLocation());
+        let target = this._getTarget();
+
+        if (this.transition === Transition.SCALE) {
             if (hit) {
                 this._fromScale.x = this._originalScale.x;
                 this._fromScale.y = this._originalScale.y;
@@ -683,9 +643,8 @@ let Button = cc.Class({
         if (!this.interactable || !this.enabledInHierarchy) return;
 
         if (this._pressed) {
-            let target = this._getTarget();
             cc.Component.EventHandler.emitEvents(this.clickEvents, event);
-            target.emit('click', this);
+            this.node.emit('click', this);
         }
         this._pressed = false;
         this._updateState();
@@ -775,10 +734,6 @@ let Button = cc.Class({
     },
 
     _zoomUp () {
-        // skip before __preload()
-        if (!this._originalScale) {
-            return;
-        }
         this._fromScale.x = this._originalScale.x;
         this._fromScale.y = this._originalScale.y;
         this._toScale.x = this._originalScale.x * this.zoomScale;
@@ -788,10 +743,6 @@ let Button = cc.Class({
     },
 
     _zoomBack () {
-        // skip before __preload()
-        if (!this._originalScale) {
-            return;
-        }
         let target = this._getTarget();
         this._fromScale.x = target.scaleX;
         this._fromScale.y = target.scaleY;

--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -297,9 +297,7 @@ let Button = cc.Class({
         /**
          * !#en  When user press the button, the button will zoom to a scale.
          * The final scale of the button  equals (button original scale * zoomScale)
-         * Setting zoomScale less than 1 is not adviced, which could fire the touchCancel event if the touch point is out of touch area after scaling. 
          * !#zh 当用户点击按钮后，按钮会缩放到一个值，这个值等于 Button 原始 scale * zoomScale
-         * 不建议 zoomScale 的值小于 1, 否则缩放后如果触摸点在触摸区域外, 则会触发 touchCancel 事件。
          * @property {Number} zoomScale
          */
         zoomScale: {

--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -72,7 +72,7 @@ module.exports = {
             "hover_color": "Button color when the mouse hovers over it",
             "disabled_color": "Button color when disabled",
             "duration": "How long until the button color/scale transitions to a new color?",
-            "zoom_scale": "When user press the button, the button will zoom to a scale.The final scale of the button  equals (button original scale * zoomScale). Setting zoomScale less than 1 is not adviced, which could fire the touchCancel event if the touch point is out of touch area after scaling.",
+            "zoom_scale": "When user press the button, the button will zoom to a scale.The final scale of the button  equals (button original scale * zoomScale).",
             "auto_gray_effect": "When this flag is true, Button target sprite will turn gray when interactable is false.",
             "normal_sprite": "The Sprite that is used when the button is in a normal sate.",
             "pressed_sprite": "The Sprite that is used when the button is in a pressed sate.",

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -75,7 +75,7 @@ module.exports = {
             'hover_color': '悬停状态的按钮背景颜色',
             'disabled_color': '禁用状态的按钮背景颜色',
             'duration': '按钮颜色变化或者缩放变化的过渡时间',
-            'zoom_scale': '当用户点击按钮后，按钮会缩放到一个值，这个值等于 Button 原始 scale * zoomScale。不建议 zoomScale 的值小于 1, 否则缩放后如果触摸点在触摸区域外, 则会触发 touchCancel 事件',
+            'zoom_scale': '当用户点击按钮后，按钮会缩放到一个值，这个值等于 Button 原始 scale * zoomScale。',
             'auto_gray_effect': "如果这个标记为 true，当 button 的 interactable 属性为 false 的时候，会使用内置 shader 让 button 的 target 节点的 sprite 组件变灰",
             'normal_sprite': '普通状态的按钮背景图资源',
             'pressed_sprite': '按下状态的按钮背景图资源',


### PR DESCRIPTION
Re: 
https://github.com/cocos-creator/2d-tasks/issues/1074
https://github.com/cocos-creator/2d-tasks/issues/1076
https://github.com/cocos-creator/2d-tasks/issues/1080
https://github.com/cocos-creator/2d-tasks/issues/1083

- 修复在激活 button 之前设置 interactable 导致报错，因为访问了无效的 _originalScale
- 修复 toggle 不能点击的问题，原因是 button 的点击事件注册在 target 上了，应该注册在 node 上
- 移除 button scale 小于 1 的警告，相关编辑器修改：https://github.com/cocos-creator/fireball/pull/8746

顺带整理了下，点击事件应该注册在 button 组件的 node 上，而 spriteFrame-changed, color-changed, scale-changed 事件应该注册在 target 上