### PR TITLE
Improve the use of imported particle system data

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -1010,7 +1010,13 @@ var ParticleSystem = cc.Class({
         this.lifeVar = parseFloat(dict["particleLifespanVariance"] || 0);
 
         // emission Rate
-        this.emissionRate = Math.min(this.totalParticles / this.life, Number.MAX_VALUE);
+        var _tempEmissionRate = dict["emissionRate"];
+        if (_tempEmissionRate) {
+            this.emissionRate = _tempEmissionRate;
+        }
+        else {
+            this.emissionRate = Math.min(this.totalParticles / this.life, Number.MAX_VALUE);
+        }
 
         // duration
         this.duration = parseFloat(dict["duration"] || 0);


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 完善粒子导入数据，当 plist 字段中 emissionRate 时应该使用该字段的数值