### PR TITLE
add max value to label font size

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -249,7 +249,7 @@ let Label = cc.Class({
                 this._fontSize = value;
                 this._updateRenderData();
             },
-            range: [0, 2048],
+            range: [0, 512],
             tooltip: CC_DEV && 'i18n:COMPONENT.label.font_size',
         },
 

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -249,6 +249,7 @@ let Label = cc.Class({
                 this._fontSize = value;
                 this._updateRenderData();
             },
+            range: [0, 2048],
             tooltip: CC_DEV && 'i18n:COMPONENT.label.font_size',
         },
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
哲锋: 测试过程遇到的问题：label组件选择SHRINK模式时，如果fontsize输入一个较大的值，比如5000，编辑器直接卡死，然后无法操作。

设置限制 fontSize 最大值为 2048

