### PR TITLE
fix video player event only fire once for 2d-tasks/issues/1075

### DIFF
--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -34,7 +34,7 @@ const READY_STATE = {
     HAVE_CURRENT_DATA: 2,
     HAVE_FUTURE_DATA: 3,
     HAVE_ENOUGH_DATA: 4
-}
+};
 
 let _mat4_temp = math.mat4.create();
 
@@ -168,6 +168,8 @@ let VideoPlayerImpl = cc.Class({
         video.className = "cocosVideo";
         video.setAttribute('preload', 'auto');
         video.setAttribute('webkit-playsinline', '');
+        // This x5-playsinline tag must be added, otherwise the play, pause events will only fire once, in the qq browser.
+        video.setAttribute("x5-playsinline", '');
         video.setAttribute('playsinline', '');
 
         this._video = video;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1075

Changes:
 * video play 在 qq 浏览器上必须要加上 x5-playsinline 标签，否则注册过的 play、pause 事件只会触发一次，而且还会出现删除该 dom 节点无效的各种不知名 bug