### PR TITLE
fix event failed to reorder after modifying zIndex for 2d-tasks/issue…

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1123,7 +1123,7 @@ var Node = cc.Class({
                     this._localZOrder = (this._localZOrder & 0x0000ffff) | (value << 16);
 
                     if (this._parent) {
-                        this._parent._delaySort();
+                        this._onSiblingIndexChanged();
                     }
                 }
             }


### PR DESCRIPTION
…s/1130

Re: cocos-creator/2d-tasks#1130

Changes:
 * 两个节点A，B,A的zIndex变换渲染在B的上层，此时A节点的scrollview滑动区会有部分失效，失效范围为之前A，B重叠的部分。