### PR TITLE
fix label rendering in open data context

### DIFF
--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -255,7 +255,12 @@ module.exports = {
         let lineHeight = this._getLineHeight();
         //use round for line join to avoid sharp intersect point
         _context.lineJoin = 'round';
-        _context.fillStyle = 'white';
+        if (cc.game.renderType === cc.game.RENDER_TYPE_CANVAS) {
+            _context.fillStyle = `rgba(${_color.r}, ${_color.g}, ${_color.b}, ${_color.a / 255})`;
+        }
+        else {
+            _context.fillStyle = 'white';
+        }
         let underlineStartPosition;
 
         //do real rendering


### PR DESCRIPTION
修复开放域canvas 渲染 label 默认为白色的问题
<img width="187" alt="1" src="https://user-images.githubusercontent.com/17872773/53380807-94c97e00-39a9-11e9-9a35-89dd59ca52dd.png">
