### PR TITLE
fixed failed to render the alpha equal 0 'png' with the tiled model

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/sprite/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/tiled.js
@@ -54,9 +54,9 @@ module.exports = {
             appy = node.anchorY * contentHeight;
 
         let rectWidth = rect.width,
-            rectHeight = rect.height,
-            hRepeat = contentWidth / rectWidth,
-            vRepeat = contentHeight / rectHeight,
+            rectHeight = rect.height;
+        let hRepeat = rectWidth === 0 ? 0 : contentWidth / rectWidth,
+            vRepeat = rectHeight === 0 ? 0 : contentHeight / rectHeight,
             row = Math.ceil(vRepeat), 
             col = Math.ceil(hRepeat);
 
@@ -101,8 +101,8 @@ module.exports = {
         let rect = sprite.spriteFrame._rect;
         let contentWidth = Math.abs(node.width);
         let contentHeight = Math.abs(node.height);
-        let hRepeat = contentWidth / rect.width;
-        let vRepeat = contentHeight / rect.height;
+        let hRepeat = rect.width === 0 ? 0 : contentWidth / rect.width;
+        let vRepeat = rect.height === 0 ? 0 : contentHeight / rect.height;
         let row = Math.ceil(vRepeat), 
             col = Math.ceil(hRepeat);
         


### PR DESCRIPTION
修复渲染平铺模式下全透明图片报错问题。

重现操作：
![1](https://user-images.githubusercontent.com/35832931/53398663-22768f00-39e5-11e9-83e4-ea6a2c90cf22.png) （这是一张图）
2.0.9 beta3 场景安放上图，重新加载场景或者开启编辑器，编辑器报错无法渲染错误。