### PR TITLE
Fix spine premultipliedAlpha serialize bug

### DIFF
--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -310,7 +310,6 @@ sp.Skeleton = cc.Class({
          */
         premultipliedAlpha: {
             default: true,
-            formerlySerializedAs: "_premultipliedAlpha",
             tooltip: CC_DEV && 'i18n:COMPONENT.skeleton.premultipliedAlpha'
         },
 


### PR DESCRIPTION
由于历史版本有带下划线和不带下划线两种版本，所以使用 formerlySerializedAs: "_premultipliedAlpha", 无法兼容，改由编辑器场景序列化时进行兼容，编辑器部分由@know进行处理。