### PR TITLE
cancel disable dynamic atlas on chrome.

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -796,10 +796,6 @@ var game = {
             if (!cc.macro.CLEANUP_IMAGE_CACHE && dynamicAtlasManager) {
                 dynamicAtlasManager.enabled = true;
             }
-            // Disable dynamicAtlasManager to fix rendering residue for transparent images on Chrome69.
-            if (cc.sys.browserType === cc.sys.BROWSER_TYPE_CHROME && parseFloat(cc.sys.browserVersion) >= 69.0) {
-                dynamicAtlasManager.enabled = false;
-            }
         }
         if (!this._renderContext) {
             this.renderType = this.RENDER_TYPE_CANVAS;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
自定义引擎测试了一下最新的2.0-release没重现了，取消这个没什么必要的屏蔽吧。
