### PR TITLE
fix label blur when using dark font color

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1177,7 +1177,7 @@ var Node = cc.Class({
 
     // OVERRIDES
 
-    _onSiblingIndexChanged (index) {
+    _onSiblingIndexChanged () {
         // update rendering scene graph, sort them by arrivalOrder
         var parent = this._parent;
         var siblings = parent._children;

--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -51,7 +51,7 @@ let _color = null;
 let _fontFamily = '';
 let _overflow = Overflow.NONE;
 let _isWrapText = false;
-let _backgroundStyle = 'rgba(255, 255, 255, 0.005)';
+const _invisibleAlpha = (1 / 255).toFixed(3);
 
 // outline
 let _isOutlined = false;
@@ -210,7 +210,7 @@ module.exports = {
         _context.clearRect(0, 0, _canvas.width, _canvas.height);
         //Add a white background to avoid black edges.
         //TODO: it is best to add alphaTest to filter out the background color.
-        _context.fillStyle = _backgroundStyle;
+        _context.fillStyle = `rgba(${_color.r}, ${_color.g}, ${_color.b}, ${_invisibleAlpha})`;
         _context.fillRect(0, 0, _canvas.width, _canvas.height);
         _context.font = _fontDesc;
 
@@ -218,7 +218,7 @@ module.exports = {
         let lineHeight = this._getLineHeight();
         //use round for line join to avoid sharp intersect point
         _context.lineJoin = 'round';
-        _context.fillStyle = `rgba(${_color.r}, ${_color.g}, ${_color.b}, ${1})`;
+        _context.fillStyle = `rgba(${_color.r}, ${_color.g}, ${_color.b}, 1)`;
 
         let underlineStartPosition;
         //do real rendering


### PR DESCRIPTION
修复深色本文渲染时的模糊问题

修复前，深色文本边缘会有白边，导致 filter 之后呈现模糊（要文本有拉伸比较清楚）

![image](https://user-images.githubusercontent.com/1503156/53678475-96bd7500-3cfa-11e9-97e6-45139f196df3.png)

修复后

![image](https://user-images.githubusercontent.com/1503156/53678480-accb3580-3cfa-11e9-8c6e-8f05b699acee.png)

