### PR TITLE
use image.src to release image cache on native platform

### DIFF
--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -736,9 +736,10 @@ var Texture2D = cc.Class({
     _clearImage () {
         // wechat game platform will cache image parsed data, 
         // so image will consume much more memory than web, releasing it
-        this._image.src = "";
         // Release image in loader cache
-        cc.loader.removeItem(this._image.id);
+        // native image element has not image.id, release by image.src.
+        cc.loader.removeItem(this._image.id || this._image.src);
+        this._image.src = "";
     }
 });
 


### PR DESCRIPTION
native上没有image.id 所以用image.src释放图片资源
https://github.com/cocos-creator/2d-tasks/issues/1168
https://github.com/cocos-creator/2d-tasks/issues/1214