### PR TITLE
Fix change to edit prefab and back, will throw error

### DIFF
--- a/extensions/dragonbones/ArmatureDisplay.js
+++ b/extensions/dragonbones/ArmatureDisplay.js
@@ -454,7 +454,7 @@ let ArmatureDisplay = cc.Class({
     onRestore () {
         // Destroyed and restored in Editor
         if (!this._material) {
-	        this._material = new SpriteMaterial();
+            this._material = new SpriteMaterial();
             this._materialCache = {};
         }
     },

--- a/extensions/dragonbones/ArmatureDisplay.js
+++ b/extensions/dragonbones/ArmatureDisplay.js
@@ -451,6 +451,14 @@ let ArmatureDisplay = cc.Class({
         this._updateDebugDraw();
     },
 
+    onRestore () {
+        // Destroyed and restored in Editor
+        if (!this._material) {
+	        this._material = new SpriteMaterial();
+            this._materialCache = {};
+        }
+    },
+
     /**
      * !#en
      * It's best to set cache mode before set property 'dragonAsset', or will waste some cpu time.


### PR DESCRIPTION
论坛:https://forum.cocos.com/t/2-0-9-prefab/74662/22
修复如果场景中有dragonbones，此时去编辑prefab，然后关闭prefab，回到场景，会报_material为空的问题。
因为回到场景只会反序列化，不会再调用场景中节点的构造函数，而此时_material已为空，没有重新创建，所以报错了。