### PR TITLE
Fix create dragonbones or spine asset by manual, uuid is empty bug

### DIFF
--- a/extensions/dragonbones/CCFactory.js
+++ b/extensions/dragonbones/CCFactory.js
@@ -73,15 +73,15 @@ var CCFactory = dragonBones.CCFactory = cc.Class({
         this._dragonBones.advanceTime(dt);
     },
 
+    getDragonBonesDataByRawData (rawData) {
+        var dataParser = rawData instanceof ArrayBuffer ? BaseFactory._binaryParser : this._dataParser;
+        return dataParser.parseDragonBonesData(rawData, 1.0);
+    },
+
     // Build new aramture with a new display.
     buildArmatureDisplay (armatureName, dragonBonesName, skinName, textureAtlasName) {
         let armature = this.buildArmature(armatureName, dragonBonesName, skinName, textureAtlasName);
         return armature && armature._display;
-    },
-
-    parseTextureAtlasData (jsonString, texture, atlasUUID) {
-        var atlasJsonObj = JSON.parse(jsonString);
-        return this._super(atlasJsonObj, texture, atlasUUID);
     },
 
     // Build sub armature from an exist armature component.

--- a/extensions/dragonbones/DragonBonesAsset.js
+++ b/extensions/dragonbones/DragonBonesAsset.js
@@ -99,16 +99,27 @@ var DragonBonesAsset = cc.Class({
             this._factory = factory;
         }
 
-        let armatureKey = this._uuid + "#" + atlasUUID;
-        let dragonBonesData = this._factory.getDragonBonesData(armatureKey);
-        if (dragonBonesData) return armatureKey;
-
         let rawData = null;
         if (this.dragonBonesJson) {
             rawData = JSON.parse(this.dragonBonesJson);
         } else {
             rawData = this._nativeAsset;
         }
+
+        // If create by manual, uuid is empty.
+        if (!this._uuid) {
+            let dbData = this._factory.getDragonBonesDataByRawData(rawData);
+            if (dbData) {
+                this._uuid = dbData.name;
+            } else {
+                cc.warn('dragonbones name is empty');
+            }
+        }
+
+        let armatureKey = this._uuid + "#" + atlasUUID;
+        let dragonBonesData = this._factory.getDragonBonesData(armatureKey);
+        if (dragonBonesData) return armatureKey;
+
         this._factory.parseDragonBonesData(rawData, armatureKey);
         return armatureKey;
     },

--- a/extensions/dragonbones/DragonBonesAtlasAsset.js
+++ b/extensions/dragonbones/DragonBonesAtlasAsset.js
@@ -95,11 +95,17 @@ var DragonBonesAtlasAsset = cc.Class({
 
     init (factory) {
         this._factory = factory;
+
+        let atlasJsonObj = JSON.parse(this.atlasJson);
+
+        // If create by manual, uuid is empty.
+        this._uuid = this._uuid || atlasJsonObj.name;
+
         if (this._textureAtlasData) {
             factory.addTextureAtlasData(this._textureAtlasData, this._uuid);
         }
         else {
-            this._textureAtlasData = factory.parseTextureAtlasData(this.atlasJson, this.texture, this._uuid);
+            this._textureAtlasData = factory.parseTextureAtlasData(atlasJsonObj, this.texture, this._uuid);
         }
     },
 

--- a/extensions/spine/skeleton-data.js
+++ b/extensions/spine/skeleton-data.js
@@ -61,6 +61,8 @@ var SkeletonData = cc.Class({
                 this._skeletonJson = value;
                 // If dynamic set skeletonJson field, auto update skeletonJsonStr field.
                 this.skeletonJsonStr = JSON.stringify(value);
+                // If create by manual, uuid is empty.
+                this._uuid = this._uuid || value.skeleton.hash;
                 this.reset();
             }
         },


### PR DESCRIPTION
修复 远程加载dragonbones 或 spine资源时，手动创建asset，导致asset的uuid为空的问题。
forum：https://forum.cocos.com/t/2-0-9-p1-spine/74724