### PR TITLE
Fix spine config has no skeleton field will throw error

### DIFF
--- a/extensions/spine/skeleton-data.js
+++ b/extensions/spine/skeleton-data.js
@@ -62,7 +62,9 @@ var SkeletonData = cc.Class({
                 // If dynamic set skeletonJson field, auto update skeletonJsonStr field.
                 this.skeletonJsonStr = JSON.stringify(value);
                 // If create by manual, uuid is empty.
-                this._uuid = this._uuid || value.skeleton.hash;
+                if (!this._uuid && value.skeleton) {
+                    this._uuid = value.skeleton.hash;
+                }
                 this.reset();
             }
         },


### PR DESCRIPTION
修复当spine json文件没有skeleton字段时，会报错的问题。