### PR TITLE
fix performance drop down on release mode

### DIFF
--- a/gulp/util/utils.js
+++ b/gulp/util/utils.js
@@ -59,6 +59,7 @@ exports.getUglifyOptions = function (platform, flags) {
                 keep_infinity: true,    // reduce jsc file size
                 typeofs: false,
                 inline: 1,              // workaround mishoo/UglifyJS2#2842
+                reduce_funcs: false,
             },
             output: {
                 beautify: true,         // really preserve_lines
@@ -77,6 +78,7 @@ exports.getUglifyOptions = function (platform, flags) {
                 global_defs: global_defs,
                 negate_iife: false,
                 inline: 1,              // workaround mishoo/UglifyJS2#2842
+                reduce_funcs: false,    // keep single-use functions being cached
             },
             output: {
                 ascii_only: true,


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1211

Changes:
 * 修复 release 版引擎性能比 debug 版低的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
