### PR TITLE
Prevents an onLoaded error from causing a callback not to be executed

### DIFF
--- a/cocos/load-pipeline/uuid-loader.js
+++ b/cocos/load-pipeline/uuid-loader.js
@@ -290,7 +290,13 @@ export function loadUuid (item, callback) {
     cc.deserialize.Details.pool.put(tdInfo);
 
     var wrappedCallback = function(err, asset) {
-        if (!err && asset.onLoaded) asset.onLoaded();
+        if (!err && asset.onLoaded) {
+            try {
+                asset.onLoaded();
+            } catch(error) {
+                err = error;
+            }
+        }
         callback(err, asset);
     };
 


### PR DESCRIPTION
加载资源的时候 onLoaded 报错会导致 callback 用户执行不到