### PR TITLE
optimize reordering event code to fix problems with setting zIndex

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1185,7 +1185,6 @@ var Node = cc.Class({
         for (; i < len; i++) {
             sibling = siblings[i];
             sibling._updateOrderOfArrival();
-            eventManager._setDirtyForNode(sibling);
         }
         parent._delaySort();
     },
@@ -3011,6 +3010,10 @@ var Node = cc.Class({
      */
     sortAllChildren () {
         if (this._reorderChildDirty) {
+            // Optimize reordering event code to fix problems with setting zindex
+            // https://github.com/cocos-creator/2d-tasks/issues/1186
+            eventManager._setDirtyForNode(this);
+
             this._reorderChildDirty = false;
             var _children = this._children;
             if (_children.length > 1) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1186

Changes:
 * 优化对平级节点的 zIndex 刷新操作

优化前：

![image](https://user-images.githubusercontent.com/7564028/54517739-81547600-499d-11e9-92d7-35b9b2b50d29.png)


优化后：

![image](https://user-images.githubusercontent.com/7564028/54517593-1c991b80-499d-11e9-9f8a-dbfa5b6e30ae.png)

