### PR TITLE
Added <video muted> attribute on video muted or volume = 0

### DIFF
--- a/cocos2d/videoplayer/CCVideoPlayer.js
+++ b/cocos2d/videoplayer/CCVideoPlayer.js
@@ -297,13 +297,13 @@ let VideoPlayer = cc.Class({
         if (url && cc.loader.md5Pipe) {
             url = cc.loader.md5Pipe.transformURL(url);
         }
-        this._impl.setURL(url, this._mute, this._volume);
+        this._impl.setURL(url, this._mute || this._volume === 0);
     },
 
     onLoad () {
         let impl = this._impl;
         if (impl) {
-            impl.createDomElementIfNeeded(this._mute, this._volume);
+            impl.createDomElementIfNeeded(this._mute || this._volume === 0);
             this._updateVideoSource();
 
             impl.seekTo(this.currentTime);

--- a/cocos2d/videoplayer/CCVideoPlayer.js
+++ b/cocos2d/videoplayer/CCVideoPlayer.js
@@ -297,13 +297,13 @@ let VideoPlayer = cc.Class({
         if (url && cc.loader.md5Pipe) {
             url = cc.loader.md5Pipe.transformURL(url);
         }
-        this._impl.setURL(url);
+        this._impl.setURL(url, this._mute, this._volume);
     },
 
     onLoad () {
         let impl = this._impl;
         if (impl) {
-            impl.createDomElementIfNeeded();
+            impl.createDomElementIfNeeded(this._mute, this._volume);
             this._updateVideoSource();
 
             impl.seekTo(this.currentTime);

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -166,7 +166,6 @@ let VideoPlayerImpl = cc.Class({
         video.className = "cocosVideo";
         video.setAttribute('preload', 'auto');
         video.setAttribute('webkit-playsinline', '');
-        // This x5-playsinline tag must be added, otherwise the play, pause events will only fire once, in the qq browser.	
         video.setAttribute("x5-playsinline", '');
         video.setAttribute('playsinline', '');
         if (muted) {

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -158,7 +158,7 @@ let VideoPlayerImpl = cc.Class({
         video.style.height = height + 'px';
     },
 
-    _createDom () {
+    _createDom (mute, volume) {
         let video = document.createElement('video');
         video.style.position = "absolute";
         video.style.bottom = "0px";
@@ -166,15 +166,16 @@ let VideoPlayerImpl = cc.Class({
         video.className = "cocosVideo";
         video.setAttribute('preload', 'auto');
         video.setAttribute('webkit-playsinline', '');
-        // This x5-playsinline tag must be added, otherwise the play, pause events will only fire once, in the qq browser.
-        video.setAttribute("x5-playsinline", '');
         video.setAttribute('playsinline', '');
+        if (mute || volume === 0) {
+            video.setAttribute('muted', '');
+        }
 
         this._video = video;
         cc.game.container.appendChild(video);
     },
 
-    createDomElementIfNeeded: function () {
+    createDomElementIfNeeded: function (mute, volume) {
         if (!this._video) {
             this._createDom();
         }
@@ -208,7 +209,7 @@ let VideoPlayerImpl = cc.Class({
         this._url = "";
     },
 
-    setURL (path) {
+    setURL (path, mute, volume) {
         let source, extname;
 
         if (this._url === path) {
@@ -217,7 +218,7 @@ let VideoPlayerImpl = cc.Class({
 
         this._url = path;
         this.removeDom();
-        this.createDomElementIfNeeded();
+        this.createDomElementIfNeeded(mute, volume);
         this._bindEvent();
 
         let video = this._video;

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -166,8 +166,9 @@ let VideoPlayerImpl = cc.Class({
         video.className = "cocosVideo";
         video.setAttribute('preload', 'auto');
         video.setAttribute('webkit-playsinline', '');
-        video.setAttribute('playsinline', '');
+        // This x5-playsinline tag must be added, otherwise the play, pause events will only fire once, in the qq browser.	
         video.setAttribute("x5-playsinline", '');
+        video.setAttribute('playsinline', '');
         if (muted) {
             video.setAttribute('muted', '');
         }

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -166,6 +166,7 @@ let VideoPlayerImpl = cc.Class({
         video.className = "cocosVideo";
         video.setAttribute('preload', 'auto');
         video.setAttribute('webkit-playsinline', '');
+        // This x5-playsinline tag must be added, otherwise the play, pause events will only fire once, in the qq browser.
         video.setAttribute("x5-playsinline", '');
         video.setAttribute('playsinline', '');
         if (muted) {

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -158,7 +158,7 @@ let VideoPlayerImpl = cc.Class({
         video.style.height = height + 'px';
     },
 
-    _createDom (mute, volume) {
+    _createDom (muted) {
         let video = document.createElement('video');
         video.style.position = "absolute";
         video.style.bottom = "0px";
@@ -167,7 +167,8 @@ let VideoPlayerImpl = cc.Class({
         video.setAttribute('preload', 'auto');
         video.setAttribute('webkit-playsinline', '');
         video.setAttribute('playsinline', '');
-        if (mute || volume === 0) {
+        video.setAttribute("x5-playsinline", '');
+        if (muted) {
             video.setAttribute('muted', '');
         }
 
@@ -175,9 +176,9 @@ let VideoPlayerImpl = cc.Class({
         cc.game.container.appendChild(video);
     },
 
-    createDomElementIfNeeded: function (mute, volume) {
+    createDomElementIfNeeded: function (muted) {
         if (!this._video) {
-            this._createDom();
+            this._createDom(muted);
         }
     },
 
@@ -209,7 +210,7 @@ let VideoPlayerImpl = cc.Class({
         this._url = "";
     },
 
-    setURL (path, mute, volume) {
+    setURL (path, muted) {
         let source, extname;
 
         if (this._url === path) {
@@ -218,7 +219,7 @@ let VideoPlayerImpl = cc.Class({
 
         this._url = path;
         this.removeDom();
-        this.createDomElementIfNeeded(mute, volume);
+        this.createDomElementIfNeeded(muted);
         this._bindEvent();
 
         let video = this._video;


### PR DESCRIPTION
Changes:
 * Due to playback issues on Apple IOS devices where automatic Video playback needs a user gesture to start playing if it contains sound. If **<video muted> elements will also be allowed to autoplay without a user gesture**. More can be read on https://webkit.org/blog/6784/new-video-policies-for-ios/

* The error you can get if you start playing a video without a user gesture on a IOS device is:
![image](https://user-images.githubusercontent.com/7983358/54696591-c6f77700-4b34-11e9-90d3-e9d23d2d5376.png)
It's all about the permissions set by Apple on IOS.

* This PR fixes this autoplay issues when you run videos with Volume = 0 or mute = true. It simply adds an attribute **muted** to the <video> element, like so: **<video muted>**

* I've tested that it works and fixes the permission problem with video playback on IOS.