### PR TITLE
Fix remove tile map layer and recover will throw error

### DIFF
--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -630,6 +630,11 @@ let TiledLayer = cc.Class({
         }
     },
 
+    onEnable () {
+        this._super();
+        this._activateMaterial();
+    },
+
     _activateMaterial () {
         let material = this._material;
         if (!material) {


### PR DESCRIPTION
issue:https://github.com/cocos-creator/2d-tasks/issues/1232
修复删除TiledLayer节点，再恢复，报材质为空的问题。