### PR TITLE
fix tile layer material missing for 2d-tasks/issues/1232

### DIFF
--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -649,6 +649,11 @@ let TiledLayer = cc.Class({
         
         this._updateMaterial(material);
     },
+
+    onEnable () {
+        this._super();
+        this._activateMaterial();
+    }
 });
 
 cc.TiledLayer = module.exports = TiledLayer;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1232

Changes:
 * 修复在 TileMap 父节点，如果删除带有 TiledLayer 的子节点，撤销后还原的话会报错的 bug