### PR TITLE
fix scrollViewSize

### DIFF
--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -1281,7 +1281,7 @@ let ScrollView = cc.Class({
 
         let targetDelta = deltaMove.normalize();
         let contentSize = this.content.getContentSize();
-        let scrollviewSize = this.node.getContentSize();
+        let scrollviewSize = this._view.getContentSize();
 
         let totalMoveWidth = (contentSize.width - scrollviewSize.width);
         let totalMoveHeight = (contentSize.height - scrollviewSize.height);

--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -1106,7 +1106,7 @@ let ScrollView = cc.Class({
 
     _clampDelta (delta) {
         let contentSize = this.content.getContentSize();
-        let scrollViewSize = this.node.getContentSize();
+        let scrollViewSize = this._view.getContentSize();
         if (contentSize.width < scrollViewSize.width) {
             delta.x = 0;
         }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
滚动视图里面的大小应该取 `this._view.getContentSize()` 而不是`this.node.getContentSize()`。
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
