### PR TITLE
Add a warning by detecting  the maximum texture size in device

### DIFF
--- a/cocos2d/renderer/gfx/texture-2d.js
+++ b/cocos2d/renderer/gfx/texture-2d.js
@@ -77,6 +77,11 @@ export default class Texture2D extends Texture {
         genMipmap = options.mipmap;
       }
 
+      let maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+      let textureMaxSize = (options.width && options.height) ? Math.max(options.width, options.height) : 0;
+      if (maxSize < textureMaxSize)
+        console.warn(`The current texture size ${textureMaxSize} exceeds the maximum size [${maxSize}] supported on the device.`);
+
       if (options.images !== undefined) {
         if (options.images.length > 1) {
           genMipmap = false;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1223

添加当前设备最大支持纹理尺寸检测与警告
