### PR TITLE
Fix db set slot name throw error

### DIFF
--- a/extensions/dragonbones/CCFactory.js
+++ b/extensions/dragonbones/CCFactory.js
@@ -159,7 +159,6 @@ var CCFactory = dragonBones.CCFactory = cc.Class({
 
     _buildSlot (dataPackage, slotData, displays) {
         let slot = BaseObject.borrowObject(dragonBones.CCSlot);
-        slot.name = slotData.name;
         let display = slot;
         slot.init(slotData, displays, display, display);
         return slot;


### PR DESCRIPTION
issue:https://github.com/cocos-creator/2d-tasks/issues/1280
修复由于db库升级，导致历史遗留代码报错的问题。
slot 的 name属性变成只读，会从slotdata中读取name属性，无需赋值。