### PR TITLE
remove editbox.stayOnTop tooltip

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -413,7 +413,6 @@ let EditBox = cc.Class({
          * @deprecated since 2.0.8
          */
         stayOnTop: {
-            tooltip: CC_DEV && 'i18n:COMPONENT.editbox.stay_on_top',
             default: false,
             notify () {
                 cc.warn('editBox.stayOnTop is removed since v2.1.');


### PR DESCRIPTION
去掉 editbox.stayOnTop 属性的警告
<img width="830" alt="WechatIMG3" src="https://user-images.githubusercontent.com/17872773/55701159-ad936d80-5a04-11e9-8c3e-ea916061e85f.png">
