### PR TITLE
setting the anchor point causes the slider to display an error

### DIFF
--- a/cocos2d/core/components/CCSlider.js
+++ b/cocos2d/core/components/CCSlider.js
@@ -203,12 +203,12 @@ var Slider = cc.Class({
 
     _updateProgress: function (touch) {
         if (!this.handle) { return; }
-        var localTouchPos = this.node.convertToNodeSpaceAR(touch.getLocation());
+        var localTouchPos = this.node.convertToNodeSpace(touch.getLocation());
         if (this.direction === Direction.Horizontal) {
-            this.progress = misc.clamp01(0.5 + (localTouchPos.x - this._offset.x) / this.node.width);
+            this.progress = misc.clamp01((localTouchPos.x - this._offset.x) / this.node.width);
         }
         else {
-            this.progress = misc.clamp01(0.5 + (localTouchPos.y - this._offset.y) / this.node.height);
+            this.progress = misc.clamp01((localTouchPos.y - this._offset.y) / this.node.height);
         }
     },
 


### PR DESCRIPTION
Re: https://forum.cocos.com/t/bug-slider-creator-v2-1-0/76125

Changes:
 * 修复当 slider 的节点锚点会导致显示错误

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
