### PR TITLE
Construct a rigid body should be before the user script 'onLoad'

### DIFF
--- a/cocos/3d/framework/physics/detail/physics-based-component.ts
+++ b/cocos/3d/framework/physics/detail/physics-based-component.ts
@@ -22,11 +22,14 @@ export class PhysicsBasedComponent extends Component {
         super();
     }
 
+    public __preload () {
+        this._refSharedBody();
+    }
+
     public onLoad () {
     }
 
     public start () {
-        this._refSharedBody();
     }
 
     public destroy () {

--- a/cocos/3d/framework/physics/rigid-body-component.ts
+++ b/cocos/3d/framework/physics/rigid-body-component.ts
@@ -198,8 +198,8 @@ export class RigidBodyComponent extends PhysicsBasedComponent {
         this._body!.applyForce(force, position);
     }
 
-    public applyImpulse (impulse: Vec3) {
-        this._body!.applyImpulse(impulse);
+    public applyImpulse (impulse: Vec3, position?: Vec3) {
+        this._body!.applyImpulse(impulse, position);
     }
 
     public setCollisionFilter (group: number, mask: number) {

--- a/cocos/3d/physics/api.d.ts
+++ b/cocos/3d/physics/api.d.ts
@@ -74,7 +74,7 @@ export class RigidBodyBase {
 
     applyForce (force: Vec3, position?: Vec3): void;
 
-    applyImpulse (impulse: Vec3): void;
+    applyImpulse (impulse: Vec3, position?: Vec3): void;
 
     getIsKinematic (): boolean;
 

--- a/cocos/3d/physics/instance.ts
+++ b/cocos/3d/physics/instance.ts
@@ -6,7 +6,7 @@ import { RaycastResult } from './raycast-result';
 export enum ERigidBodyType {
     DYNAMIC = 1,
     STATIC = 2,
-    KINEMATIC = 4
+    KINEMATIC = 4,
 }
 
 export function createPhysicsWorld (): PhysicsWorldBase {


### PR DESCRIPTION
Construct a rigid body should be before the user script function 'onLoad'

 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
