### PR TITLE
fixed the particleSystem positionType bugs

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -542,9 +542,21 @@ var properties = {
      * @property {ParticleSystem.PositionType} positionType
      * @default ParticleSystem.PositionType.FREE
      */
-    positionType: {
+    _positionType: {
         default: PositionType.FREE,
-        type: PositionType
+        formerlySerializedAs: "positionType"
+    },
+
+    positionType: {
+        type: PositionType,
+        get () {
+            return this._positionType;
+        },
+        set (val) {
+            if (this.sharedMaterials[0])
+                this.sharedMaterials[0].define('_USE_MODEL', val !== PositionType.FREE);
+            this._positionType = val;
+        }
     },
 
     /**
@@ -1108,6 +1120,8 @@ var ParticleSystem = cc.Class({
         this.endSizeVar = parseFloat(dict["finishParticleSizeVariance"] || 0);
 
         // position
+        // Make empty positionType value and old version compatible
+        this.positionType = parseFloat(dict['positionType'] || PositionType.RELATIVE);
         // for 
         this.sourcePos.x = 0;
         this.sourcePos.y = 0;
@@ -1208,7 +1222,8 @@ var ParticleSystem = cc.Class({
         if (!material) {
             material = Material.getInstantiatedBuiltinMaterial('sprite', this);
             material.define('USE_TEXTURE', true);
-            material.define('_USE_MODEL', true);
+            // In case the plist lost positionType
+            material.define('_USE_MODEL', this._positionType !== PositionType.FREE);
         }
         else {
             material = Material.getInstantiatedMaterial(material, this);

--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -162,7 +162,9 @@ Simulator.prototype.emitParticle = function (pos) {
     particle.startPos.y = pos.y;
 
     // direction
-    let a = misc.degreesToRadians(psys.angle + psys.angleVar * (Math.random() - 0.5) * 2); 
+    let worldRotation = getWorldRotation(psys.node);
+    let relAngle = psys.positionType === cc.ParticleSystem.PositionType.FREE ? psys.angle + worldRotation : psys.angle;
+    let a = misc.degreesToRadians(relAngle + psys.angleVar * (Math.random() - 0.5) * 2);
     // Mode Gravity: A
     if (psys.emitterMode === cc.ParticleSystem.EmitterMode.GRAVITY) {
         let s = psys.speed + psys.speedVar * (Math.random() - 0.5) * 2;
@@ -190,6 +192,16 @@ Simulator.prototype.emitParticle = function (pos) {
         particle.degreesPerSecond = misc.degreesToRadians(psys.rotatePerS + psys.rotatePerSVar * (Math.random() - 0.5) * 2);
     }
 };
+// In the Free mode to get emit real rotation in the world coordinate.
+function getWorldRotation (node) {
+    let rotation = 0;
+    let tempNode = node;
+    while (tempNode) {
+        rotation += tempNode.angle;
+        tempNode = tempNode.parent;
+    }
+    return rotation;
+}
 
 Simulator.prototype.updateUVs = function (force) {
     let particleCount = this.particles.length;
@@ -268,10 +280,16 @@ Simulator.prototype.step = function (dt) {
 
     // Calculate pos
     node._updateWorldMatrix();
-    AffineTrans.fromMat4(_trans, node._worldMatrix);
+    _trans = AffineTrans.identity();
     if (psys.positionType === cc.ParticleSystem.PositionType.FREE) {
+        _trans.tx = node._worldMatrix.m12;
+        _trans.ty = node._worldMatrix.m13;
         AffineTrans.transformVec2(_pos, ZERO_VEC2, _trans);
     } else if (psys.positionType === cc.ParticleSystem.PositionType.RELATIVE) {
+        let angle = misc.degreesToRadians(-node.angle);
+        let cos = Math.cos(angle);
+        let sin = Math.sin(angle);
+        _trans = AffineTrans.create(cos, -sin, sin, cos, 0, 0);
         _pos.x = node._position.x;
         _pos.y = node._position.y;
     }
@@ -376,8 +394,14 @@ Simulator.prototype.step = function (dt) {
 
             // update values in quad buffer
             let newPos = _tpa;
-            if (psys.positionType === cc.ParticleSystem.PositionType.FREE || psys.positionType === cc.ParticleSystem.PositionType.RELATIVE) {
-                let diff = _tpb, startPos = _tpc;
+            let diff = _tpb;
+            if (psys.positionType === cc.ParticleSystem.PositionType.FREE) {
+                diff.subSelf(particle.startPos);
+                newPos.set(particle.pos);
+                newPos.subSelf(diff);
+            }
+            else if (psys.positionType === cc.ParticleSystem.PositionType.RELATIVE) {
+                let startPos = _tpc;
                 // current Position convert To Node Space
                 AffineTrans.transformVec2(diff, _pos, worldToNodeTrans);
                 // start Position convert To Node Space


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/3579

1. 修复 particleSystem.positionType.Free 模式效果错误问题。
2. 增加了对于旧项目的数据兼容。（效果兼容的 pr 在 fireball 的关联 pr 中）
3. 修复了 relative 旋转后粒子移动错位的 bug