### PR TITLE
fix incorrect types path

### DIFF
--- a/scripts/generate-declarations/generate-declarations.js
+++ b/scripts/generate-declarations/generate-declarations.js
@@ -1,5 +1,5 @@
 const { spawnSync } = require('child_process');
-const { join, extname, basename, dirname } = require('path');
+const { join, extname, basename, dirname, isAbsolute } = require('path');
 const { copyFileSync, existsSync, readFileSync, unlinkSync, writeFileSync, ensureDirSync } = require('fs-extra');
 const ts = require('typescript');
 
@@ -71,7 +71,9 @@ function generate (options) {
 
     const types = tsConfig.config.compilerOptions.types.map((typeFile) => `${typeFile}.d.ts`);
     (types.concat(extraDestFiles)).forEach((file) => {
-        copyFileSync(file, join(outDir, basename(file)));
+        const destPath = join(outDir, isAbsolute(file) ? basename(file) : file);
+        ensureDirSync(dirname(destPath));
+        copyFileSync(file, destPath);
     });
     return true;
 }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
