### PR TITLE
create the docs-3d build workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ DebugInfos.json
 /package-lock.json
 playground/library
 /declarations
+docs-3d

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:min": "uglifyjs ./bin/cocos-3d.dev.js --mangle --source-map -o ./bin/cocos-3d.min.js",
     "build-rollup": "tsc --build rollup/tsconfig.json",
     "dev": "rollup -w -c ./rollup/config.js",
-    "postinstall": "npm run build-rollup"
+    "postinstall": "npm run build-rollup",
+    "buildDocs": "node ./scripts/build-docs"
   },
   "repository": {
     "type": "git",
@@ -71,6 +72,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-watch": "^4.3.1",
     "tslint": "^5.12.0",
+    "typedoc": "github:cocos-creator/typedoc#master",
     "typescript": "^3.2.2",
     "uglify-js": "^3.4.9",
     "vconsole": "^3.3.0",

--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -1,0 +1,42 @@
+(function buildingDocs () {
+    let [index, out] = process.argv.slice(3);
+    const { spawn } = require('child_process');
+
+    let options = {
+        indexPath: index || `${process.cwd()}\\index.ts`,
+        mode: 'modules',
+        out: out || `${process.cwd()}\\docs-3d`,
+        name: 'Creator-3D-Docs'
+    };
+
+    // typedoc command
+    let command = [
+        options.indexPath,
+        '--mode', options.mode,
+        '--ignoreCompilerErrors',
+        '--disableOutputCheck',
+        '--includeDeclarations',
+        '--name',
+        options.name,
+        '--out',
+        options.out];
+
+    let child = spawn('typedoc', command, {
+        shell: true,
+        env: process.env,
+    });
+
+    child.stdout.on('data', function (data) {
+        console.log(data.toString());
+    });
+    child.stderr.on('data', function (data) {
+        console.error(`${data}`);
+    });
+    child.on('close', (code) => {
+        if (code !== 0) {
+            console.log('Building Failed!');
+            return;
+        }
+        console.log('Building Success!');
+    });
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
       "lib": ["es2015", "es2017", "dom"],
       "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
       // "lib": [],                             /* Specify library files to be included in the compilation. */
-      "allowJs": false,                         /* Allow javascript files to be compiled. */
+      "allowJs": true,                         /* Allow javascript files to be compiled. */
       // "checkJs": true,                       /* Report errors in .js files. */
       // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
       // "declaration": true,                   /* Generates corresponding '.d.ts' file. */


### PR DESCRIPTION
issue: https://github.com/cocos-creator/3d-tasks/issues/371
Re: https://github.com/cocos-creator/typedoc/pull/4 关联 typedoc 的更新构建 pr
创建 3D 引擎文档构件流程
1. 目前遗留了一个 typedoc 的使用问题，通过 npm run 执行 buildDocs，会影响 typdocs 扫描 class ，最后导致无法获取正确的（declaration）对象，forEach 函数报错。这个问题并不影响最终文档的内容，因为无法定位原因，规避了。（我暂时没什么想法）

![image](https://user-images.githubusercontent.com/35832931/56200397-4e230680-6071-11e9-9253-455595dae27b.png)
