### PR TITLE
support separate alpha atlas for pvr texture format

### DIFF
--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -144,7 +144,9 @@ const PixelFormat = cc.Enum({
      */
     RGBA_PVRTC_2BPPV1: gfx.TEXTURE_FMT_RGBA_PVRTC_2BPPV1,
     /**
-     * rgb a 2 bpp pvrtc
+     * rgb separate a 2 bpp pvrtc
+     * RGB_A_PVRTC_2BPPV1 texture is a 2x height RGB_PVRTC_2BPPV1 format texture.
+     * It separate the origin alpha channel to the bottom half atlas, the origin rgb channel to the top half atlas
      * @property RGB_A_PVRTC_2BPPV1
      * @readonly
      * @type {Number}
@@ -166,6 +168,8 @@ const PixelFormat = cc.Enum({
     RGBA_PVRTC_4BPPV1: gfx.TEXTURE_FMT_RGBA_PVRTC_4BPPV1,
     /**
      * rgb a 4 bpp pvrtc
+     * RGB_A_PVRTC_4BPPV1 texture is a 2x height RGB_PVRTC_4BPPV1 format texture.
+     * It separate the origin alpha channel to the bottom half atlas, the origin rgb channel to the top half atlas
      * @property RGB_A_PVRTC_4BPPV1
      * @readonly
      * @type {Number}

--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -55,6 +55,9 @@ var idGenerater = new (require('../platform/id-generater'))('Tex');
  * @extends Asset
  */
 
+// define a specified number for the pixel format which gfx do not have a standard definition.
+let CUSTOM_PIXEL_FORMAT = 1024;
+
 /**
  * The texture pixel format, default value is RGBA8888, 
  * you should note that textures loaded by normal image files (png, jpg) can only support RGBA8888 format,
@@ -141,6 +144,13 @@ const PixelFormat = cc.Enum({
      */
     RGBA_PVRTC_2BPPV1: gfx.TEXTURE_FMT_RGBA_PVRTC_2BPPV1,
     /**
+     * rgb a 2 bpp pvrtc
+     * @property RGB_A_PVRTC_2BPPV1
+     * @readonly
+     * @type {Number}
+     */
+    RGB_A_PVRTC_2BPPV1: CUSTOM_PIXEL_FORMAT++,
+    /**
      * rgb 4 bpp pvrtc
      * @property RGB_PVRTC_4BPPV1
      * @readonly
@@ -155,6 +165,13 @@ const PixelFormat = cc.Enum({
      */
     RGBA_PVRTC_4BPPV1: gfx.TEXTURE_FMT_RGBA_PVRTC_4BPPV1,
     /**
+     * rgb a 4 bpp pvrtc
+     * @property RGB_A_PVRTC_4BPPV1
+     * @readonly
+     * @type {Number}
+     */
+    RGB_A_PVRTC_4BPPV1: CUSTOM_PIXEL_FORMAT++,
+    /**
      * rgb etc1
      * @property RGB_ETC1
      * @readonly
@@ -167,8 +184,7 @@ const PixelFormat = cc.Enum({
      * @readonly
      * @type {Number}
      */
-    // gfx do not have a standard definition for RGBA_ETC1, need define a specified number for it.
-    RGBA_ETC1: 1024,
+    RGBA_ETC1: CUSTOM_PIXEL_FORMAT++,
 
     /**
      * rgb etc2
@@ -518,10 +534,7 @@ var Texture2D = cc.Class({
         opts.magFilter = FilterIndex[this._magFilter];
         opts.wrapS = this._wrapS;
         opts.wrapT = this._wrapT;
-        opts.format = pixelFormat;
-        if (pixelFormat === PixelFormat.RGBA_ETC1) {
-            opts.format = PixelFormat.RGB_ETC1;
-        }
+        opts.format = this._getGFXPixelFormat(pixelFormat);
         opts.width = pixelsWidth;
         opts.height = pixelsHeight;
         if (!this._texture) {
@@ -622,10 +635,7 @@ var Texture2D = cc.Class({
         opts.width = this.width;
         opts.height = this.height;
         opts.hasMipmap = this._hasMipmap;
-        opts.format = this._format;
-        if (this._format === PixelFormat.RGBA_ETC1) {
-            opts.format = PixelFormat.RGB_ETC1;
-        }
+        opts.format = this._getGFXPixelFormat(this._format);
         opts.premultiplyAlpha = this._premultiplyAlpha;
         opts.flipY = this._flipY;
         opts.minFilter = FilterIndex[this._minFilter];
@@ -766,6 +776,19 @@ var Texture2D = cc.Class({
         opts.wrapS = this._wrapS;
         opts.wrapT = this._wrapT;
         return opts;
+    },
+
+    _getGFXPixelFormat (format) {
+        if (format === PixelFormat.RGBA_ETC1) {
+            format = PixelFormat.RGB_ETC1;
+        }
+        else if (format === PixelFormat.RGB_A_PVRTC_4BPPV1) {
+            format = PixelFormat.RGB_PVRTC_4BPPV1;
+        }
+        else if (format === PixelFormat.RGB_A_PVRTC_2BPPV1) {
+            format = PixelFormat.RGB_PVRTC_2BPPV1;
+        }
+        return format;
     },
 
     _resetUnderlyingMipmaps(mipmapSources) {

--- a/cocos2d/core/assets/material/CCMaterial.js
+++ b/cocos2d/core/assets/material/CCMaterial.js
@@ -151,8 +151,11 @@ let Material = cc.Class({
         if (this._effect) {
             if (val instanceof Texture) {
                 this._effect.setProperty(name, val.getImpl());
-                if (val.getPixelFormat() === PixelFormat.RGBA_ETC1) {
-                    this.define('_USE_ETC1_' + name.toUpperCase(), true);
+                let format = val.getPixelFormat();
+                if (format === PixelFormat.RGBA_ETC1 ||
+                    format === PixelFormat.RGB_A_PVRTC_4BPPV1 ||
+                    format === PixelFormat.RGB_A_PVRTC_2BPPV1) {
+                    this.define('_USE_ALPHA_ATLAS_' + name.toUpperCase(), true);
                 }
             }
             else {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1319

Changes:
 * support separate alpha atlas for pvr texture format
