### PR TITLE
fix label top align error for 2d-tasks/issues/1328

### DIFF
--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -237,7 +237,7 @@ module.exports = {
         let lineHeight = this._getLineHeight();
         let drawStartY = lineHeight * (_splitedStrings.length - 1);
         if (_vAlign === macro.VerticalTextAlignment.TOP) {
-            firstLinelabelY = lineHeight;
+            firstLinelabelY = _fontSize;
         }
         else if (_vAlign === macro.VerticalTextAlignment.CENTER) {
             firstLinelabelY = (_canvasSize.height - drawStartY) * 0.5 + _fontSize * textUtils.MIDDLE_RATIO - _canvasPadding.height / 2;

--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -25,12 +25,12 @@
  ****************************************************************************/
 
 // Draw text the textBaseline ratio (Can adjust the appropriate baseline ratio based on the platform)
-let _BASELINE_RATIO = 0.25;
+let _BASELINE_RATIO = 0.26;
 if (CC_JSB) {
     _BASELINE_RATIO = -0.05;
 }
 else if (CC_RUNTIME) {
-    _BASELINE_RATIO = -0.25;
+    _BASELINE_RATIO = -0.2;
 }
 
 var textUtils = {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1328 cocos-creator/2d-tasks/issues/1338

Changes:
 * 调整 label 在 runtime 中的 _BASELINE_RATIO 数值
 * 修复 label top align 需要根据 font size 来做 label start position 的计算