### PR TITLE
Fix bug with residue particles for 2d-tasks/issues/1339

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -1224,6 +1224,8 @@ var ParticleSystem = cc.Class({
             }
             return;
         }
+        this.resetSystem();
+        this.stopSystem();
         this.disableRender();
         if (this.autoRemoveOnFinish && this._stopped) {
             this.node.destroy();


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1339

Changes:
 * 修复粒子播放完后，隐藏再显示会莫名的出现残留粒子的情况
