### PR TITLE
fix particle life error.

### DIFF
--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -402,6 +402,10 @@ Simulator.prototype.step = function (dt) {
             }
             pool.put(deadParticle);
             particles.length--;
+
+            if (particles.length <= 0) {
+                psys._ia._count = 0;
+            }
         }
     }
 


### PR DESCRIPTION
when particles was stop，it alway has this value, _renderData.ia._count=6, and when the cc.ParticleSystem node active, it will draw one particle!

issue：
https://github.com/cocos-creator/2d-tasks/issues/1339
