### PR TITLE
fix particle system leak

### DIFF
--- a/cocos2d/core/renderer/webgl/mesh-buffer.js
+++ b/cocos2d/core/renderer/webgl/mesh-buffer.js
@@ -215,16 +215,16 @@ let MeshBuffer = cc.Class({
             let vb = this._vbArr[i];
             vb.destroy();
         }
-        this._vbArr = undefined;
+        this._vbArr = null;
 
         for (let i = 0; i < this._ibArr.length; i++) {
             let ib = this._ibArr[i];
             ib.destroy();
         }
-        this._ibArr = undefined;
+        this._ibArr = null;
 
-        this._ib = undefined;
-        this._vb = undefined;
+        this._ib = null;
+        this._vb = null;
     }
 });
 

--- a/cocos2d/core/renderer/webgl/mesh-buffer.js
+++ b/cocos2d/core/renderer/webgl/mesh-buffer.js
@@ -211,14 +211,14 @@ let MeshBuffer = cc.Class({
     },
 
     destroy () {
-        for (let key in this._vbArr) {
-            let vb = this._vbArr[key];
+        for (let i = 0; i <  this._vbArr.length; i++) {
+            let vb = this._vbArr[i];
             vb.destroy();
         }
         this._vbArr = undefined;
 
-        for (let key in this._ibArr) {
-            let ib = this._ibArr[key];
+        for (let i = 0; i < this._ibArr.length; i++) {
+            let ib = this._ibArr[i];
             ib.destroy();
         }
         this._ibArr = undefined;

--- a/cocos2d/core/renderer/webgl/mesh-buffer.js
+++ b/cocos2d/core/renderer/webgl/mesh-buffer.js
@@ -70,44 +70,48 @@ let MeshBuffer = cc.Class({
         this._dirty = false;
     },
 
+    switchBuffer () {
+        let offset = ++this._arrOffset;
+
+        this.byteStart = 0;
+        this.byteOffset = 0;
+        this.vertexStart = 0;
+        this.vertexOffset = 0;
+        this.indiceStart = 0;
+        this.indiceOffset = 0;
+
+        if (offset < this._vbArr.length) {
+            this._vb = this._vbArr[offset];
+            this._ib = this._ibArr[offset];
+        } else {
+
+            this._vb = new gfx.VertexBuffer(
+                this._batcher._device,
+                this._vertexFormat,
+                gfx.USAGE_DYNAMIC,
+                new ArrayBuffer(),
+                0
+            );
+            this._vbArr[offset] = this._vb;
+            this._vb._bytes = this._vData.byteLength;
+
+            this._ib = new gfx.IndexBuffer(
+                this._batcher._device,
+                gfx.INDEX_FMT_UINT16,
+                gfx.USAGE_STATIC,
+                new ArrayBuffer(),
+                0
+            );
+            this._ibArr[offset] = this._ib;
+            this._ib._bytes = this._iData.byteLength;
+        }
+    },
+
     checkAndSwitchBuffer (vertexCount) {
         if (this.vertexOffset + vertexCount > 65535) {
             this.uploadData();
             this._batcher._flush();
-            let offset = ++this._arrOffset;
-
-            this.byteStart = 0;
-            this.byteOffset = 0;
-            this.vertexStart = 0;
-            this.vertexOffset = 0;
-            this.indiceStart = 0;
-            this.indiceOffset = 0;
-
-            if (offset < this._vbArr.length) {
-                this._vb = this._vbArr[offset];
-                this._ib = this._ibArr[offset];
-            } else {
-
-                this._vb = new gfx.VertexBuffer(
-                    this._batcher._device,
-                    this._vertexFormat,
-                    gfx.USAGE_DYNAMIC,
-                    new ArrayBuffer(),
-                    0
-                );
-                this._vbArr[offset] = this._vb;
-                this._vb._bytes = this._vData.byteLength;
-
-                this._ib = new gfx.IndexBuffer(
-                    this._batcher._device,
-                    gfx.INDEX_FMT_UINT16,
-                    gfx.USAGE_STATIC,
-                    new ArrayBuffer(),
-                    0
-                );
-                this._ibArr[offset] = this._ib;
-                this._ib._bytes = this._iData.byteLength;
-            }
+            this.switchBuffer();
         }
     },
 

--- a/cocos2d/core/renderer/webgl/quad-buffer.js
+++ b/cocos2d/core/renderer/webgl/quad-buffer.js
@@ -16,6 +16,30 @@ let QuadBuffer = cc.Class({
             buffer[idx++] = vertextID+3;
             buffer[idx++] = vertextID+2;
         }
+
+        let indicesData = new Uint16Array(this._iData.buffer, 0, count * 6 );
+        this._ib.update(0, indicesData);
+    },
+
+    uploadData () {
+        if (this.byteOffset === 0 || !this._dirty) {
+            return;
+        }
+
+        // update vertext data
+        let vertexsData = new Float32Array(this._vData.buffer, 0, this.byteOffset >> 2);
+        this._vb.update(0, vertexsData);
+
+        this._dirty = false;
+    },
+
+    switchBuffer () {
+        // upload index buffer data
+        if (this.indiceOffset > 0) {
+            let indicesData = new Uint16Array(this._iData.buffer, 0, this.indiceOffset);
+            this._ib.update(0, indicesData);
+        }
+        this._super();
     },
 
     _reallocBuffer () {

--- a/cocos2d/core/renderer/webgl/quad-buffer.js
+++ b/cocos2d/core/renderer/webgl/quad-buffer.js
@@ -34,12 +34,12 @@ let QuadBuffer = cc.Class({
     },
 
     switchBuffer () {
+        this._super();
         // upload index buffer data
         if (this.indiceOffset > 0) {
             let indicesData = new Uint16Array(this._iData.buffer, 0, this.indiceOffset);
             this._ib.update(0, indicesData);
         }
-        this._super();
     },
 
     _reallocBuffer () {

--- a/cocos2d/core/renderer/webgl/quad-buffer.js
+++ b/cocos2d/core/renderer/webgl/quad-buffer.js
@@ -16,21 +16,6 @@ let QuadBuffer = cc.Class({
             buffer[idx++] = vertextID+3;
             buffer[idx++] = vertextID+2;
         }
-
-        let indicesData = new Uint16Array(this._iData.buffer, 0, count * 6 );
-        this._ib.update(0, indicesData);
-    },
-
-    uploadData () {
-        if (this.byteOffset === 0 || !this._dirty) {
-            return;
-        }
-
-        // update vertext data
-        let vertexsData = new Float32Array(this._vData.buffer, 0, this.byteOffset >> 2);
-        this._vb.update(0, vertexsData);
-
-        this._dirty = false;
     },
 
     _reallocBuffer () {

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -883,6 +883,10 @@ var ParticleSystem = cc.Class({
         if (this.autoRemoveOnFinish) {
             this.autoRemoveOnFinish = false;    // already removed
         }
+        if (this._buffer) {
+            this._buffer.destroy();
+            this._buffer = null;
+        }
         this._super();
     },
     


### PR DESCRIPTION
Fix particle quad buffer leak.
Fix quad buffer if exceed 65535 size, index buffer may not upload bug.
Change the way of mesh buffer traverse array when it’s destroyed. 