### PR TITLE
fix bug: "Collider priority must be higher than RigidBody"

### DIFF
--- a/cocos/3d/framework/physics/collider-component.ts
+++ b/cocos/3d/framework/physics/collider-component.ts
@@ -57,12 +57,16 @@ export class ColliderComponentBase extends PhysicsBasedComponent {
 
     public __preload () {
         super.__preload();
+    }
+
+    public onLoad () {
         if (this.sharedBody) {
             this.sharedBody.transfromSource = ETransformSource.SCENE;
+            // useGravity属性默认是为true的
             this.sharedBody.body.setUseGravity(false);
+            this.center = this._center;
+            this.isTrigger = this._triggered;
         }
-        this.center = this._center;
-        this.isTrigger = this._triggered;
     }
 
     // public lateUpdate () {
@@ -95,7 +99,7 @@ export class ColliderComponentBase extends PhysicsBasedComponent {
 }
 
 @ccclass('cc.BoxColliderComponent')
-@executionOrder(100)
+@executionOrder(98)
 @menu('Components/BoxColliderComponent')
 @executeInEditMode
 export class BoxColliderComponent extends ColliderComponentBase {
@@ -140,7 +144,7 @@ export class BoxColliderComponent extends ColliderComponentBase {
 }
 
 @ccclass('cc.SphereColliderComponent')
-@executionOrder(100)
+@executionOrder(98)
 @menu('Components/SphereColliderComponent')
 @executeInEditMode
 export class SphereColliderComponent extends ColliderComponentBase {

--- a/cocos/3d/framework/physics/rigid-body-component.ts
+++ b/cocos/3d/framework/physics/rigid-body-component.ts
@@ -20,7 +20,7 @@ const NonRigidBodyProperties = {
 };
 
 @ccclass('cc.RigidBodyComponent')
-@executionOrder(101)
+@executionOrder(99)
 @menu('Components/RigidBodyComponent')
 @executeInEditMode
 export class RigidBodyComponent extends PhysicsBasedComponent {
@@ -56,8 +56,15 @@ export class RigidBodyComponent extends PhysicsBasedComponent {
 
     public __preload () {
         super.__preload();
-        this.sharedBody!.transfromSource = ETransformSource.PHYSIC;
+    }
+
+    public onLoad () {
+        /**
+         * 此处设置刚体属性是因为__preload不受executionOrder的顺序影响，
+         * 从而导致ColliderComponent后添加会导致刚体的某些属性被重写
+         */
         if (this.sharedBody) {
+            this.sharedBody.transfromSource = ETransformSource.PHYSIC;
             this.mass = this._mass;
             this.linearDamping = this._linearDamping;
             this.angularDamping = this._angularDamping;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#520

Changes:
 * 将属性设置从__preload移动到了onLoad，因为__preload不受executionOrder的顺序影响，从而导致Collider后添加会导致RididBody的某些属性被重写。

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
