### PR TITLE
fix error on adding toggle component

### DIFF
--- a/cocos2d/core/components/CCToggle.js
+++ b/cocos2d/core/components/CCToggle.js
@@ -181,14 +181,10 @@ let Toggle = cc.Class({
     _updateDisabledState: function () {
         this._super();
 
-        let useGrayMaterial = false;
-        if (this.enableAutoGrayEffect) {
-            if (this.checkMark && !this.interactable) {
-                useGrayMaterial = true;
-            }
+        if (this.enableAutoGrayEffect && this.checkMark) {
+            let useGrayMaterial = !this.interactable;
+            this._switchGrayMaterial(useGrayMaterial, this.checkMark);
         }
-
-        this._switchGrayMaterial(useGrayMaterial, this.checkMark);
     },
 
     _registerToggleEvent: function () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1370

修复 toggle.checkMark 不存在时，setMaterial 会报错的问题