### PR TITLE
Extract enum to avoid circular reference

### DIFF
--- a/cocos/3d/physics/cannon-impl.ts
+++ b/cocos/3d/physics/cannon-impl.ts
@@ -12,7 +12,7 @@ import {
     IRaycastOptions, LockConstraintBase, PhysicsWorldBase,
     PointToPointConstraintBase, RigidBodyBase, ShapeBase, SphereShapeBase,
 } from './api';
-import { ERigidBodyType } from './physic-enum';
+import { ERigidBodyType, ETransformSource } from './physic-enum';
 import { RaycastResult } from './raycast-result';
 import { stringfyQuat, stringfyVec3 } from './util';
 
@@ -166,11 +166,6 @@ function fillRaycastResult (result: RaycastResult, cannonResult: CANNON.RaycastR
     );
 }
 
-enum ETransformSource {
-    Scene,
-    Physics,
-}
-
 export class CannonRigidBody implements RigidBodyBase {
 
     get impl (): CANNON.Body {
@@ -185,7 +180,7 @@ export class CannonRigidBody implements RigidBodyBase {
     private _onWorldPostStepListener: (event: CANNON.ICollisionEvent) => any;
     private _collisionCallbacks: ICollisionCallback[] = [];
     private _shapes: CannonShape[] = [];
-    private _transformSource: ETransformSource = ETransformSource.Scene;
+    private _transformSource: ETransformSource = ETransformSource.SCENE;
     private _userData: any;
     private _world: CannonWorld | null = null;
     private _name: string;
@@ -377,7 +372,7 @@ export class CannonRigidBody implements RigidBodyBase {
     }
 
     public isPhysicsManagedTransform (): boolean {
-        return this._transformSource === ETransformSource.Physics;
+        return this._transformSource === ETransformSource.PHYSIC;
     }
 
     public getPosition (out: Vec3) {
@@ -443,9 +438,9 @@ export class CannonRigidBody implements RigidBodyBase {
     private _onBodyTypeUpdated () {
         if (this._cannonBody) {
             if (this._cannonBody.type === CANNON.Body.STATIC) {
-                this._transformSource = ETransformSource.Scene;
+                this._transformSource = ETransformSource.SCENE;
             } else {
-                this._transformSource = ETransformSource.Physics;
+                this._transformSource = ETransformSource.PHYSIC;
             }
         }
     }

--- a/cocos/assets/asset-enum.ts
+++ b/cocos/assets/asset-enum.ts
@@ -1,0 +1,113 @@
+import { GFXAddress, GFXFilter, GFXFormat } from '../gfx/define';
+
+/**
+ * The texture pixel format, default value is RGBA8888,
+ * you should note that textures loaded by normal image files (png, jpg) can only support RGBA8888 format,
+ * other formats are supported by compressed file types or raw data.
+ * @enum {number}
+ */
+export enum PixelFormat {
+    /**
+     * 16-bit texture without Alpha channel
+     */
+    RGB565 = GFXFormat.R5G6B5,
+    /**
+     * 16-bit textures: RGB5A1
+     */
+    RGB5A1 = GFXFormat.RGB5A1,
+    /**
+     * 16-bit textures: RGBA4444
+     */
+    RGBA4444 = GFXFormat.RGBA4,
+    /**
+     * 24-bit texture: RGB888
+     */
+    RGB888 = GFXFormat.RGB8,
+    /**
+     * 32-bit texture: RGBA8888
+     */
+    RGBA8888 = GFXFormat.RGBA8,
+    /**
+     * 32-bit float texture: RGBA32F
+     */
+    RGBA32F = GFXFormat.RGBA32F,
+    /**
+     * 8-bit textures used as masks
+     */
+    A8 = GFXFormat.A8,
+    /**
+     * 8-bit intensity texture
+     */
+    I8 = GFXFormat.L8,
+    /**
+     * 16-bit textures used as masks
+     */
+    AI8 = GFXFormat.LA8,
+    /**
+     * rgb 2 bpp pvrtc
+     */
+    RGB_PVRTC_2BPPV1 = GFXFormat.PVRTC_RGB2,
+    /**
+     * rgba 2 bpp pvrtc
+     */
+    RGBA_PVRTC_2BPPV1 = GFXFormat.PVRTC_RGBA2,
+    /**
+     * rgb 4 bpp pvrtc
+     */
+    RGB_PVRTC_4BPPV1 = GFXFormat.PVRTC_RGB4,
+    /**
+     * rgba 4 bpp pvrtc
+     */
+    RGBA_PVRTC_4BPPV1 = GFXFormat.PVRTC_RGBA4,
+    /**
+     * rgb etc1
+     */
+    RGB_ETC1 = GFXFormat.ETC_RGB8,
+    /**
+     * rgb etc2
+     */
+    RGB_ETC2 = GFXFormat.ETC2_RGB8,
+    /**
+     * rgba etc2
+     */
+    RGBA_ETC2 = GFXFormat.ETC2_RGBA8,
+}
+
+/**
+ * The texture wrap mode.
+ * @enum {number}
+ */
+export enum WrapMode {
+    /**
+     * Specifies that the repeat warp mode will be used.
+     */
+    REPEAT = GFXAddress.WRAP,
+    /**
+     * Specifies that the clamp to edge warp mode will be used.
+     */
+    CLAMP_TO_EDGE = GFXAddress.CLAMP,
+    /**
+     * Specifies that the mirrored repeat warp mode will be used.
+     */
+    MIRRORED_REPEAT = GFXAddress.MIRROR,
+    /**
+     * Specifies that the  clamp to border wrap mode will be used.
+     */
+    CLAMP_TO_BORDER = GFXAddress.BORDER,
+}
+
+/**
+ * The texture filter mode
+ * @enum {number}
+ */
+export enum Filter {
+    NONE = GFXFilter.NONE,
+    /**
+     * Specifies linear filtering.
+     */
+    LINEAR = GFXFilter.LINEAR,
+    /**
+     * Specifies nearest filtering.
+     */
+    NEAREST = GFXFilter.POINT,
+}

--- a/cocos/assets/image-asset.ts
+++ b/cocos/assets/image-asset.ts
@@ -24,10 +24,11 @@
  ****************************************************************************/
 // @ts-check
 import {ccclass, property} from '../core/data/class-decorator';
-// import {addon} from '../core/utils/js';
-import { Asset } from './asset';
 import { EventTargetFactory } from '../core/event/event-target-factory';
 import { GFXDevice, GFXFeature } from '../gfx/device';
+// import {addon} from '../core/utils/js';
+import { Asset } from './asset';
+import { PixelFormat } from './asset-enum';
 
 export interface IMemoryImageSource {
     _data: ArrayBufferView | null;
@@ -187,7 +188,7 @@ export class ImageAsset extends EventTargetFactory(Asset) {
         let format = this._format;
         let ext = '';
         const SupportTextureFormats = cc.macro.SUPPORT_TEXTURE_FORMATS as string[];
-        const PixelFormat = cc.TextureBase.PixelFormat;
+        // const PixelFormat = cc.TextureBase.PixelFormat;
         for (const extensionID of extensionIDs) {
             const extFormat = extensionID.split('@');
 

--- a/cocos/assets/texture-base.ts
+++ b/cocos/assets/texture-base.ts
@@ -27,130 +27,18 @@
 import {ccclass, property} from '../core/data/class-decorator';
 import { EventTargetFactory } from '../core/event/event-target-factory';
 import IDGenerator from '../core/utils/id-generator';
-import { GFXAddress, GFXBufferTextureCopy, GFXFilter, GFXFormat,
-    GFXTextureFlagBit, GFXTextureType, GFXTextureUsageBit, GFXTextureViewType } from '../gfx/define';
+import { GFXBufferTextureCopy, GFXTextureFlagBit, GFXTextureType, GFXTextureUsageBit, GFXTextureViewType } from '../gfx/define';
 import { GFXDevice } from '../gfx/device';
 import { GFXTexture, IGFXTextureInfo } from '../gfx/texture';
 import { GFXTextureView, IGFXTextureViewInfo } from '../gfx/texture-view';
 import { SamplerInfoIndex } from '../renderer/core/sampler-lib';
 import { Asset } from './asset';
+import { Filter, PixelFormat, WrapMode } from './asset-enum';
 import { ImageAsset } from './image-asset';
 
 const CHAR_CODE_1 = 49;    // '1'
 
 const idGenerator = new IDGenerator('Tex');
-
-/**
- * The texture pixel format, default value is RGBA8888,
- * you should note that textures loaded by normal image files (png, jpg) can only support RGBA8888 format,
- * other formats are supported by compressed file types or raw data.
- * @enum {number}
- */
-export enum PixelFormat {
-    /**
-     * 16-bit texture without Alpha channel
-     */
-    RGB565 = GFXFormat.R5G6B5,
-    /**
-     * 16-bit textures: RGB5A1
-     */
-    RGB5A1 = GFXFormat.RGB5A1,
-    /**
-     * 16-bit textures: RGBA4444
-     */
-    RGBA4444 = GFXFormat.RGBA4,
-    /**
-     * 24-bit texture: RGB888
-     */
-    RGB888 = GFXFormat.RGB8,
-    /**
-     * 32-bit texture: RGBA8888
-     */
-    RGBA8888 = GFXFormat.RGBA8,
-    /**
-     * 32-bit float texture: RGBA32F
-     */
-    RGBA32F = GFXFormat.RGBA32F,
-    /**
-     * 8-bit textures used as masks
-     */
-    A8 = GFXFormat.A8,
-    /**
-     * 8-bit intensity texture
-     */
-    I8 = GFXFormat.L8,
-    /**
-     * 16-bit textures used as masks
-     */
-    AI8 = GFXFormat.LA8,
-    /**
-     * rgb 2 bpp pvrtc
-     */
-    RGB_PVRTC_2BPPV1 = GFXFormat.PVRTC_RGB2,
-    /**
-     * rgba 2 bpp pvrtc
-     */
-    RGBA_PVRTC_2BPPV1 = GFXFormat.PVRTC_RGBA2,
-    /**
-     * rgb 4 bpp pvrtc
-     */
-    RGB_PVRTC_4BPPV1 = GFXFormat.PVRTC_RGB4,
-    /**
-     * rgba 4 bpp pvrtc
-     */
-    RGBA_PVRTC_4BPPV1 = GFXFormat.PVRTC_RGBA4,
-    /**
-     * rgb etc1
-     */
-    RGB_ETC1 = GFXFormat.ETC_RGB8,
-    /**
-     * rgb etc2
-     */
-    RGB_ETC2 = GFXFormat.ETC2_RGB8,
-    /**
-     * rgba etc2
-     */
-    RGBA_ETC2 = GFXFormat.ETC2_RGBA8,
-}
-
-/**
- * The texture wrap mode.
- * @enum {number}
- */
-export enum WrapMode {
-    /**
-     * Specifies that the repeat warp mode will be used.
-     */
-    REPEAT = GFXAddress.WRAP,
-    /**
-     * Specifies that the clamp to edge warp mode will be used.
-     */
-    CLAMP_TO_EDGE = GFXAddress.CLAMP,
-    /**
-     * Specifies that the mirrored repeat warp mode will be used.
-     */
-    MIRRORED_REPEAT = GFXAddress.MIRROR,
-    /**
-     * Specifies that the  clamp to border wrap mode will be used.
-     */
-    CLAMP_TO_BORDER = GFXAddress.BORDER,
-}
-
-/**
- * The texture filter mode
- * @enum {number}
- */
-export enum Filter {
-    NONE = GFXFilter.NONE,
-    /**
-     * Specifies linear filtering.
-     */
-    LINEAR = GFXFilter.LINEAR,
-    /**
-     * Specifies nearest filtering.
-     */
-    NEAREST = GFXFilter.POINT,
-}
 
 @ccclass('cc.TextureBase')
 export class TextureBase extends EventTargetFactory(Asset) {

--- a/cocos/renderer/models/skinning-model.ts
+++ b/cocos/renderer/models/skinning-model.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 
 import Skeleton from '../../3d/assets/skeleton';
+import { Filter, PixelFormat, WrapMode } from '../../assets/asset-enum';
 import { Texture2D } from '../../assets/texture-2d';
-import { Filter, PixelFormat, WrapMode } from '../../assets/texture-base';
 import { mat4, vec3, vec4 } from '../../core/vmath';
 import { GFXBuffer } from '../../gfx/buffer';
 import { GFXBufferUsageBit, GFXMemoryUsageBit } from '../../gfx/define';


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#549

Changes:
 * 移除了texture-base.ts文件中定义的enum，为了使其它模块需要引用的同时去避免循环引用问题
 * 增加asset-enum.ts文件，里面定义了PixelFormat、WrapMode、Filter三个enum
 * 去除了物理模块中重复声明的ETransformSource enum类型
 * 将物理模块使用的ETransformSource类型引用到了physics-enum.ts文件中定义的ETransformSource

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
