### PR TITLE
remove compressed texture format's header from array buffer

### DIFF
--- a/cocos/load-pipeline/loader.js
+++ b/cocos/load-pipeline/loader.js
@@ -135,7 +135,9 @@ function loadPVRTex (item) {
         let width = header[PVR_HEADER_WIDTH];
         let height = header[PVR_HEADER_HEIGHT];
         let dataOffset = header[PVR_HEADER_METADATA] + 52;
-        let pvrtcData = new Uint8Array(buffer, dataOffset);
+        // todo: use new Uint8Array(buffer, dataOffset) instead
+        buffer = buffer.slice(dataOffset, buffer.byteLength);
+        let pvrtcData = new Uint8Array(buffer);
         let pvrAsset = {
             _data: pvrtcData,
             _compressed: true,
@@ -148,7 +150,9 @@ function loadPVRTex (item) {
         var headerLength = header[0],
 		height = header[1],
         width = header[2]
-        let pvrtcData = new Uint8Array(buffer, headerLength);
+        // todo: use new Uint8Array(buffer, headerLength) instead
+        buffer = buffer.slice(headerLength, buffer.byteLength);
+        let pvrtcData = new Uint8Array(buffer);
         let pvrAsset = {
             _data: pvrtcData,
             _compressed: true,
@@ -193,7 +197,10 @@ function loadPKMTex(item) {
     let height = readBEUint16(header, ETC_PKM_HEIGHT_OFFSET);
     let encodedWidth = readBEUint16(header, ETC_PKM_ENCODED_WIDTH_OFFSET);
     let encodedHeight = readBEUint16(header, ETC_PKM_ENCODED_HEIGHT_OFFSET);
-    let etcData = new Uint8Array(buffer, ETC_PKM_HEADER_SIZE);
+    // todo: use new Uint8Array(buffer, ETC_PKM_HEADER_SIZE) instead
+    buffer = buffer.slice(ETC_PKM_HEADER_SIZE, buffer.byteLength);
+    let etcData = new Uint8Array(buffer);
+    
     let etcAsset = {
         _data: etcData,
         _compressed: true,


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changes:
 * 切割arraybuffer，删除压缩格式纹理的头部

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
