### PR TITLE
Fix physics component destory bug

### DIFF
--- a/cocos/3d/framework/physics/detail/physics-based-component.ts
+++ b/cocos/3d/framework/physics/detail/physics-based-component.ts
@@ -33,7 +33,9 @@ export class PhysicsBasedComponent extends Component {
     }
 
     public onDisable () {
-        this.sharedBody!.disable();
+        if (this.sharedBody) {
+            this.sharedBody!.disable();
+        }
     }
 
     public destroy () {
@@ -41,6 +43,7 @@ export class PhysicsBasedComponent extends Component {
             this._sharedBody.deref();
             this._sharedBody = null;
         }
+        super.destroy();
     }
 
     private _refSharedBody () {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changes:
 * 修复物理相关组件无法删除成功，原因是继承类未调用基类Component的destroy方法

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
