### PR TITLE
fix device motion bug

### DIFF
--- a/cocos2d/core/platform/CCInputExtension.js
+++ b/cocos2d/core/platform/CCInputExtension.js
@@ -176,8 +176,8 @@ inputManager.didAccelerate = function (eventData) {
         mAcceleration.x = -mAcceleration.x;
         mAcceleration.y = -mAcceleration.y;
     }
-    // fix android acc values are opposite
-    if (cc.sys.os === cc.sys.OS_ANDROID &&
+    // fix android acc values are opposite on Browser or Native platform
+    if ((cc.sys.isBrowser || cc.sys.isNative) && cc.sys.os === cc.sys.OS_ANDROID &&
         cc.sys.browserType !== cc.sys.BROWSER_TYPE_MOBILE_QQ) {
         mAcceleration.x = -mAcceleration.x;
         mAcceleration.y = -mAcceleration.y;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1088

之前的一个 bug 修复在安卓平台将重力方向取反了。
这个修复应该是针对 web 和 native 平台的，不应该影响小游戏平台，小游戏平台不论是 Android 还是 iOS 返回的数值都是一样的

修复完这个问题后，适配层的方向都应该取反，关联适配：
https://github.com/cocos-creator-packages/weapp-adapter/pull/88
https://github.com/cocos-creator-packages/baidu-adapter/pull/16

同时，编辑器构建微信小游戏平台，支持选择 `landscapeLeft` `landscapeRight`, 解决横屏下重力感应翻转的问题, 关联 pr:
https://github.com/cocos-creator/fireball/pull/8884

微信上的 `wx.onDeviceOrientationChange` 接口不能准确地判断屏幕翻转，所以目前的处理是固定屏幕方向为左横屏，或右横屏
