### PR TITLE
fix error when node.position.sub(x, vec2) on some browser

### DIFF
--- a/cocos2d/core/value-types/vec2.js
+++ b/cocos2d/core/value-types/vec2.js
@@ -70,7 +70,7 @@ CCClass.fastDefine('cc.Vec2', Vec2, { x: 0, y: 0 });
 var proto = Vec2.prototype;
 
 // compatible with vec3
-js.value(proto, 'z', 0);
+js.value(proto, 'z', 0, true);
 
 /**
  * !#en clone a Vec2 object


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复在某些浏览器上无法对 vec2.z 进行赋值导致的报错。调整 writable 属性后，将会允许赋值给 vec2 的实例。其它 vec2 的 z 仍默认是 0

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
