### PR TITLE
Collision events are subdivided into ' Enter ', ' Stay ', ' Exit ' three states

### DIFF
--- a/cocos/3d/framework/physics/detail/physics-based-component.ts
+++ b/cocos/3d/framework/physics/detail/physics-based-component.ts
@@ -3,7 +3,7 @@ import { ccclass } from '../../../../core/data/class-decorator';
 import { Quat, Vec3 } from '../../../../core/value-types';
 import { quat, vec3 } from '../../../../core/vmath';
 import { Node } from '../../../../scene-graph/node';
-import { AfterStepCallback, BeforeStepCallback, ICollisionCallback, ICollisionEvent, PhysicsWorldBase, RigidBodyBase } from '../../../physics/api';
+import { AfterStepCallback, BeforeStepCallback, ICollisionCallback, ICollisionEvent, ICollisionType, PhysicsWorldBase, RigidBodyBase } from '../../../physics/api';
 import { createRigidBody } from '../../../physics/instance';
 import { ERigidBodyType, ETransformSource } from '../../../physics/physic-enum';
 import { stringfyQuat, stringfyVec3 } from '../../../physics/util';
@@ -203,11 +203,11 @@ class SharedRigidBody {
         this._body.setWorld(null);
     }
 
-    private _onCollided (event: ICollisionEvent) {
+    private _onCollided (type: ICollisionType, event: ICollisionEvent) {
         if (!this._node) {
             return;
         }
-        this._node.emit('collided', {
+        this._node.emit(type, {
             source: event.source.getUserData() as Node,
             target: event.target.getUserData() as Node,
         });

--- a/cocos/3d/physics/api.ts
+++ b/cocos/3d/physics/api.ts
@@ -21,7 +21,9 @@ export interface ICollisionEvent {
     target: RigidBodyBase;
 }
 
-export type ICollisionCallback = (event: ICollisionEvent) => void;
+export type ICollisionType = 'onCollisionEnter' | 'onCollisionStay' | 'onCollisionExit';
+
+export type ICollisionCallback = (type: ICollisionType, event: ICollisionEvent) => void;
 
 export type BeforeStepCallback = () => void;
 
@@ -248,9 +250,4 @@ export interface LockConstraintBase extends ConstraintBase {
      * @param options Options.
      */
     // constructor (first: RigidBodyBase, second: RigidBodyBase, options?: ILockConstraintOptions);
-}
-
-export enum TransformSource {
-    Scene,
-    Phycis,
 }

--- a/cocos/3d/physics/cannon-impl.ts
+++ b/cocos/3d/physics/cannon-impl.ts
@@ -451,7 +451,8 @@ export class CannonRigidBody implements RigidBodyBase {
             target: getWrap<RigidBodyBase>((event as any).target),
         };
         for (const callback of this._collisionCallbacks) {
-            callback(evt);
+            // TODO : 目前的Canon无法支持Enter\Stay\Exit，目前碰撞仅触发两次Stay
+            callback('onCollisionStay', evt);
         }
     }
 

--- a/cocos/3d/physics/cocos/built-in-body.ts
+++ b/cocos/3d/physics/cocos/built-in-body.ts
@@ -1,6 +1,6 @@
 import { Quat, Vec3 } from '../../../core/value-types';
 import { intersect } from '../../geom-utils';
-import { ICollisionCallback, ICollisionEvent, PhysicsWorldBase, RigidBodyBase } from '../api';
+import { ICollisionCallback, ICollisionEvent, ICollisionType as ICollisionEventType, PhysicsWorldBase, RigidBodyBase } from '../api';
 import { ERigidBodyType } from '../physic-enum';
 import { BuiltInShape } from './built-in-shape';
 import { BuiltInWorld } from './built-in-world';
@@ -25,7 +25,12 @@ export class BuiltInBody implements RigidBodyBase {
     /** 检测的组 */
     private _collisionFilterMask: number = 1;
     /** 碰撞回调 */
-    private _collisionCallbacks: ICollisionCallback[] = [];
+    /** Enter */
+    private _collisionEnterCB: ICollisionCallback[] = [];
+    /** Stay */
+    private _collisionStayCB: ICollisionCallback[] = [];
+    /** Exit */
+    private _collisionExitCB: ICollisionCallback[] = [];
     /** 物理世界 */
     private _world!: BuiltInWorld | null;
     /** Body拥有的现状 */
@@ -51,25 +56,15 @@ export class BuiltInBody implements RigidBodyBase {
         }
         return false;
     }
-    public onCollisionEnter (event: ICollisionEvent) {
-        // TODO : Enter事件
-    }
-    public onCollisionStay (event: ICollisionEvent) {
-        // TODO : Stay事件
-    }
-    public onCollisionExit (event: ICollisionEvent) {
-        // TODO : Exit事件
-    }
-    public onTriggerEnter (event: ICollisionEvent) {
-        for (const callback of this._collisionCallbacks) {
-            callback(event);
+    public onCollision (type: ICollisionEventType, event: ICollisionEvent) {
+        for (const callback of this._collisionStayCB) {
+            callback(type, event);
         }
     }
-    public onTriggerStay (event: ICollisionEvent) {
-        // TODO : Stay事件
-    }
-    public onTriggerExit (event: ICollisionEvent) {
-        // TODO : Exit事件
+    public onTrigger (type: ICollisionEventType, event: ICollisionEvent) {
+        for (const callback of this._collisionStayCB) {
+            callback(type, event);
+        }
     }
     public getType (): ERigidBodyType {
         return this.type;
@@ -190,12 +185,12 @@ export class BuiltInBody implements RigidBodyBase {
         }
     }
     public addCollisionCallback (callback: ICollisionCallback): void {
-        this._collisionCallbacks.push(callback);
+        this._collisionStayCB.push(callback);
     }
     public removeCollisionCllback (callback: ICollisionCallback): void {
-        const i = this._collisionCallbacks.indexOf(callback);
+        const i = this._collisionStayCB.indexOf(callback);
         if (i >= 0) {
-            this._collisionCallbacks.splice(i, 1);
+            this._collisionStayCB.splice(i, 1);
         }
     }
     public getUserData () {

--- a/cocos/3d/physics/cocos/built-in-world.ts
+++ b/cocos/3d/physics/cocos/built-in-world.ts
@@ -46,13 +46,13 @@ export class BuiltInWorld implements PhysicsWorldBase {
           };
           if (this._collisionMatrix.get(bodyA.id, bodyB.id)) {
             // TODO: 触发Stay
-            bodyA.onTriggerStay(event);
-            bodyB.onTriggerStay(event);
+            bodyA.onTrigger('onCollisionStay', event);
+            bodyB.onTrigger('onCollisionStay', event);
           } else {
             this._collisionMatrix.set(bodyA.id, bodyB.id, true);
             /** 是第一次 */ // TODO: 触发Enter
-            bodyA.onTriggerEnter(event);
-            bodyB.onTriggerEnter(event);
+            bodyA.onTrigger('onCollisionEnter', event);
+            bodyB.onTrigger('onCollisionEnter', event);
           }
         } else {
           if (this._collisionMatrix.get(bodyA.id, bodyB.id)) {
@@ -61,8 +61,8 @@ export class BuiltInWorld implements PhysicsWorldBase {
               source: bodyA,
               target: bodyB,
             };
-            bodyA.onTriggerExit(event);
-            bodyB.onTriggerExit(event);
+            bodyA.onTrigger('onCollisionExit', event);
+            bodyB.onTrigger('onCollisionExit', event);
           }
 
           this._collisionMatrix.set(bodyA.id, bodyB.id, false);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#536

Changes:
 * 新增碰撞事件的数值类型 ： `export type ICollisionType = 'onCollisionEnter' | 'onCollisionStay' | 'onCollisionExit';`
 * 碰撞事件分为**Enter**、**Stay**、**Exit**三个状态，目前仅**Built-in**物理系统实现了
 * 由于Cannon还未实现，目前Cannon碰撞事件的实现机制是碰撞时只有两次Stay调用

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
