### PR TITLE
compatible with old webgl

### DIFF
--- a/cocos2d/renderer/gfx/device.js
+++ b/cocos2d/renderer/gfx/device.js
@@ -591,7 +591,10 @@ export default class Device {
     }
 
     try {
-      gl = canvasEL.getContext('webgl', opts);
+      gl = canvasEL.getContext('webgl', opts)
+        || canvasEL.getContext('experimental-webgl', opts)
+        || canvasEL.getContext('webkit-3d', opts)
+        || canvasEL.getContext('moz-webgl', opts);
     } catch (err) {
       console.error(err);
       return;


### PR DESCRIPTION
2.1.1 移除了 experimental-webgl，在一些浏览器上或者 webview 内核上会有报错

`This device does not support webgl`