### PR TITLE
add build-declaration task

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "module": "index.js",
   "scripts": {
     "server": "http-server . -p 8002",
-    "build": "npm run build:dev && npm run build:min",
+    "build": "npm run build:dev && npm run build:min && npm run build-declaration",
     "build:dev": "node ./rollup/out/build-engine-cli.js --sourcemap --platform=any --destination=./bin/cocos-3d.dev.js",
     "build:min": "uglifyjs ./bin/cocos-3d.dev.js --mangle --source-map -o ./bin/cocos-3d.min.js",
+    "build-declaration": "node ./scripts/generate-declarations/generate-declarations-cli.js",
     "build-rollup": "tsc --build rollup/tsconfig.json",
     "postinstall": "npm run build-rollup",
     "build-api-json": "gulp build-api-json -i index.ts -o ./3d-api-docs/tempJson",


### PR DESCRIPTION
增加生成引擎 api 提示的 d.ts 到 declarations 目录

生成任务直接下放到引擎的任务里，和编辑器开发的工作流没有直接关联了，作为 engine package.json 里面 build 任务的子任务

https://github.com/cocos-creator/3d-tasks/issues/587
