### PR TITLE
partially revert #3935

### DIFF
--- a/cocos2d/core/load-pipeline/CCLoader.js
+++ b/cocos2d/core/load-pipeline/CCLoader.js
@@ -655,7 +655,30 @@ proto.loadResDir = function (url, type, progressCallback, completeCallback) {
 
     var urls = [];
     var uuids = resources.getUuidArray(url, type, urls);
-    this._loadResUuids(uuids, progressCallback, completeCallback, urls);
+    if (!type || cc.Class.isChildClassOf(type, cc.SpriteFrame)) {
+        // The spriteFrame url in spriteAtlas will be removed after build project.
+        // To show users the exact structure in asset panel (and match the behavior of other assets),
+        // we need to add them back.
+        this._loadResUuids(uuids, progressCallback, function (errors, assetRes, urlRes) {
+            // let assetResLength = ;
+            for (let i = 0; i < assetRes.length; ++i) {
+                if (assetRes[i] instanceof cc.SpriteAtlas) {
+                    let spriteFrames = assetRes[i].getSpriteFrames();
+                    for (let k in spriteFrames) {
+                        let sf = spriteFrames[k];
+                        assetRes.push(sf);
+                        if (urlRes) {
+                            urlRes.push(`${urlRes[i]}/${sf.name}`);
+                        }
+                    }
+                }
+            }
+            completeCallback && completeCallback(errors, assetRes, urlRes);
+        }, urls);
+    }
+    else {
+        this._loadResUuids(uuids, progressCallback, completeCallback, urls);
+    }
 };
 
 /**


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 loadResDir 无法返回图集中的 SpriteFrame 的问题

保持统一，loadResDir 可以返回其它类型资源的 sub asset

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
