### PR TITLE
sync repair EventTarget once listener can't off

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -963,11 +963,11 @@ cc.Director.prototype = {
     },
 
     __fastOn: function (type, callback, target) {
-        this.add(type, callback, target);
+        this.on(type, callback, target);
     },
 
     __fastOff: function (type, callback, target) {
-        this.remove(type, callback, target);
+        this.off(type, callback, target);
     },
 };
 

--- a/cocos2d/core/event/event-listeners.js
+++ b/cocos2d/core/event/event-listeners.js
@@ -24,29 +24,27 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-var js = cc.js;
-var CallbacksHandler = require('../platform/callbacks-invoker').CallbacksHandler;
+const js = cc.js;
+const CallbacksInvoker = require('../platform/callbacks-invoker');
 
-// Extends CallbacksHandler to handle and invoke event callbacks.
+// Extends CallbacksInvoker to handle and invoke event callbacks.
 function EventListeners () {
-    CallbacksHandler.call(this);
+    CallbacksInvoker.call(this);
 }
-js.extend(EventListeners, CallbacksHandler);
+js.extend(EventListeners, CallbacksInvoker);
 
-EventListeners.prototype.invoke = function (event, captureListeners) {
-    var key = event.type;
-    var list = this._callbackTable[key];
+EventListeners.prototype.emit = function (event, captureListeners) {
+    let key = event.type;
+    const list = this._callbackTable[key];
     if (list) {
-        var rootInvoker = !list.isInvoking;
+        let rootInvoker = !list.isInvoking;
         list.isInvoking = true;
 
-        var callbacks = list.callbacks;
-        var targets = list.targets;
-        for (var i = 0, len = callbacks.length; i < len; ++i) {
-            var callback = callbacks[i];
-            if (callback) {
-                var target = targets[i] || event.currentTarget;
-                callback.call(target, event, captureListeners);
+        const infos = list.callbackInfos;
+        for (let i = 0, len = infos.length; i < len; ++i) {
+            const info = infos[i];
+            if (info && info.callback) {
+                info.callback.call(info.target, event, captureListeners);
                 if (event._propagationImmediateStopped) {
                     break;
                 }

--- a/cocos2d/core/load-pipeline/loading-items.js
+++ b/cocos2d/core/load-pipeline/loading-items.js
@@ -614,7 +614,7 @@ proto.getError = function (id) {
  * @param {Object} target - can be null
  * @return {Boolean} whether the key is new
  */
-proto.addListener = CallbacksInvoker.prototype.add;
+proto.addListener = CallbacksInvoker.prototype.on;
 
 /**
  * !#en
@@ -629,7 +629,7 @@ proto.addListener = CallbacksInvoker.prototype.add;
  * @param {Object} [target]
  * @return {Boolean}
  */
-proto.hasListener = CallbacksInvoker.prototype.has;
+proto.hasListener = CallbacksInvoker.prototype.hasEventListener;
 
 /**
  * !#en
@@ -644,7 +644,7 @@ proto.hasListener = CallbacksInvoker.prototype.has;
  * @param {Object} target
  * @return {Boolean} removed
  */
-proto.removeListener = CallbacksInvoker.prototype.remove;
+proto.removeListener = CallbacksInvoker.prototype.off;
 
 /**
  * !#en
@@ -712,7 +712,7 @@ proto.itemComplete = function (id) {
         this.onProgress(dep ? dep.completed.length : this.completedCount, dep ? dep.deps.length : this.totalCount, item);
     }
 
-    this.invoke(id, item);
+    this.emit(id, item);
     this.removeAll(id);
 
     // All completed

--- a/cocos2d/core/platform/callbacks-invoker.js
+++ b/cocos2d/core/platform/callbacks-invoker.js
@@ -331,14 +331,15 @@ proto.emit = function (key, arg1, arg2, arg3, arg4, arg5) {
         for (let i = 0, len = infos.length; i < len; ++i) {
             const info = infos[i];
             if (info) {
+                if (info.once) {
+                    this.off(key, info.callback, info.target);
+                }
+
                 if (info.target) {
                     info.callback.call(info.target, arg1, arg2, arg3, arg4, arg5);
                 }
                 else {
                     info.callback(arg1, arg2, arg3, arg4, arg5);
-                }
-                if (info.once) {
-                    this.off(key, info.callback, info.target);
                 }
             }
         }

--- a/cocos2d/core/platform/callbacks-invoker.js
+++ b/cocos2d/core/platform/callbacks-invoker.js
@@ -27,88 +27,170 @@
 const js = require('./js');
 const fastRemoveAt = js.array.fastRemoveAt;
 
+function empty () {}
+
+function CallbackInfo () {
+    this.callback = empty;
+    this.target = undefined;
+    this.once = false;
+}
+
+CallbackInfo.prototype.set = function (callback, target, once) {
+    this.callback = callback;
+    this.target = target;
+    this.once = !!once;
+};
+
+let callbackInfoPool = new js.Pool(function (info) {
+    info.callback = empty;
+    info.target = undefined;
+    info.once = false;
+    return true;
+}, 32);
+
+callbackInfoPool.get = function () {
+    return this._get() || new CallbackInfo();
+};
+
 function CallbackList () {
-    this.callbacks = [];
-    this.targets = [];      // same length with callbacks, nullable
+    this.callbackInfos = [];
     this.isInvoking = false;
     this.containCanceled = false;
 }
-var proto = CallbackList.prototype;
 
-proto.removeBy = function (array, value) {
-    var callbacks = this.callbacks;
-    var targets = this.targets;
-    for (var i = 0; i < array.length; ++i) {
-        if (array[i] === value) {
-            fastRemoveAt(callbacks, i);
-            fastRemoveAt(targets, i);
+let proto = CallbackList.prototype;
+
+/**
+ * !#zh
+ * 从列表中移除与指定目标相同回调函数的事件。
+ * @param cb
+ */
+proto.removeByCallback = function (cb) {
+    for (let i = 0; i < this.callbackInfos.length; ++i) {
+        let info = this.callbackInfos[i];
+        if (info && info.callback === cb) {
+            callbackInfoPool.put(info);
+            fastRemoveAt(this.callbackInfos, i);
             --i;
         }
     }
 };
 
+/**
+ * !#zh
+ * 从列表中移除与指定目标相同调用者的事件。
+ * @param target
+ */
+proto.removeByTarget = function (target) {
+    for (let i = 0; i < this.callbackInfos.length; ++i) {
+        const info = this.callbackInfos[i];
+        if (info && info.target === target) {
+            callbackInfoPool.put(info);
+            fastRemoveAt(this.callbackInfos, i);
+            --i;
+        }
+    }
+};
+
+/**
+ * !#zh
+ * 移除指定编号事件。
+ *
+ * @param index
+ */
 proto.cancel = function (index) {
-    this.callbacks[index] = this.targets[index] = null;
+    const info = this.callbackInfos[index];
+    if (info) {
+        callbackInfoPool.put(info);
+        this.callbackInfos[index] = null;
+    }
     this.containCanceled = true;
 };
 
+/**
+ * !#zh
+ * 注销所有事件。
+ */
 proto.cancelAll = function () {
-    let callbacks = this.callbacks;
-    let targets = this.targets;
-    for (let i = 0; i < callbacks.length; i++) {
-        callbacks[i] = targets[i] = null;
+    for (let i = 0; i < this.callbackInfos.length; i++) {
+        const info = this.callbackInfos[i];
+        if (info) {
+            callbackInfoPool.put(info);
+            this.callbackInfos[i] = null;
+        }
     }
     this.containCanceled = true;
 };
 
 // filter all removed callbacks and compact array
 proto.purgeCanceled = function () {
-    this.removeBy(this.callbacks, null);
+    for (let i = this.callbackInfos.length - 1; i >= 0; --i) {
+        const info = this.callbackInfos[i];
+        if (!info) {
+            fastRemoveAt(this.callbackInfos, i);
+        }
+    }
     this.containCanceled = false;
 };
 
+proto.clear = function () {
+    this.cancelAll();
+    this.callbackInfos.length = 0;
+    this.isInvoking = false;
+    this.containCanceled = false;
+};
 
 const MAX_SIZE = 16;
-const callbackListPool = new js.Pool(function (list) {
-    list.callbacks.length = 0;
-    list.targets.length = 0;
-    list.isInvoking = false;
-    list.containCanceled = false;
+let callbackListPool = new js.Pool(function (info) {
+    info.callback = empty;
+    info.target = undefined;
+    info.once = false;
+    return true;
 }, MAX_SIZE);
+
 callbackListPool.get = function () {
     return this._get() || new CallbackList();
 };
 
 /**
- * The CallbacksHandler is an abstract class that can register and unregister callbacks by key.
- * Subclasses should implement their own methods about how to invoke the callbacks.
- * @class _CallbacksHandler
- *
- * @private
+ * !#en The callbacks invoker to handle and invoke callbacks by key.
+ * !#zh CallbacksInvoker 用来根据 Key 管理并调用回调方法。
+ * @class CallbacksInvoker
  */
-function CallbacksHandler () {
+function CallbacksInvoker () {
     this._callbackTable = js.createMap(true);
 }
-proto = CallbacksHandler.prototype;
+
+proto = CallbacksInvoker.prototype;
 
 /**
- * @method add
- * @param {String} key
- * @param {Function} callback
- * @param {Object} [target] - can be null
+ * !#zh
+ * 事件添加管理
+ *
+ * @param key
+ * @param callback
+ * @param target
+ * @param once
  */
-proto.add = function (key, callback, target) {
-    var list = this._callbackTable[key];
+proto.on = function (key, callback, target, once) {
+    let list = this._callbackTable[key];
     if (!list) {
         list = this._callbackTable[key] = callbackListPool.get();
     }
-    list.callbacks.push(callback);
-    list.targets.push(target || null);
+    let info = callbackInfoPool.get();
+    info.set(callback, target, once);
+    list.callbackInfos.push(info);
 };
 
 /**
+ *
+ * !#zh
+ * 检查指定事件是否已注册回调。
+ *
+ * !#en
  * Check if the specified key has any registered callback. If a callback is also specified,
  * it will only return true if the callback is registered.
+ *
  * @method hasEventListener
  * @param {String} key
  * @param {Function} [callback]
@@ -116,32 +198,31 @@ proto.add = function (key, callback, target) {
  * @return {Boolean}
  */
 proto.hasEventListener = function (key, callback, target) {
-    var list = this._callbackTable[key];
+    const list = this._callbackTable[key];
     if (!list) {
         return false;
     }
 
     // check any valid callback
-    var callbacks = list.callbacks;
+    const infos = list.callbackInfos;
     if (!callback) {
         // Make sure no cancelled callbacks
         if (list.isInvoking) {
-            for (let i = 0; i < callbacks.length; i++) {
-                if (callbacks[i]) {
+            for (let i = 0; i < infos.length; ++i) {
+                if (infos[i]) {
                     return true;
                 }
             }
             return false;
         }
         else {
-            return callbacks.length > 0;
+            return infos.length > 0;
         }
     }
 
-    target = target || null;
-    var targets = list.targets;
-    for (let i = 0; i < callbacks.length; ++i) {
-        if (callbacks[i] === callback && targets[i] === target) {
+    for (let i = 0; i < infos.length; ++i) {
+        const info = infos[i];
+        if (info && info.callback === callback && info.target === target) {
             return true;
         }
     }
@@ -149,6 +230,10 @@ proto.hasEventListener = function (key, callback, target) {
 };
 
 /**
+ * !#zh
+ * 移除在特定事件类型中注册的所有回调或在某个目标中注册的所有回调。
+ *
+ * !#en
  * Removes all callbacks registered in a certain event type or all callbacks registered with a certain target
  * @method removeAll
  * @param {String|Object} keyOrTarget - The event key to be removed or the target to be removed
@@ -156,12 +241,13 @@ proto.hasEventListener = function (key, callback, target) {
 proto.removeAll = function (keyOrTarget) {
     if (typeof keyOrTarget === 'string') {
         // remove by key
-        let list = this._callbackTable[keyOrTarget];
+        const list = this._callbackTable[keyOrTarget];
         if (list) {
             if (list.isInvoking) {
                 list.cancelAll();
             }
             else {
+                list.clear();
                 callbackListPool.put(list);
                 delete this._callbackTable[keyOrTarget];
             }
@@ -169,43 +255,46 @@ proto.removeAll = function (keyOrTarget) {
     }
     else if (keyOrTarget) {
         // remove by target
-        for (let key in this._callbackTable) {
-            let list = this._callbackTable[key];
+        for (const key in this._callbackTable) {
+            const list = this._callbackTable[key];
             if (list.isInvoking) {
-                let targets = list.targets;
-                for (let i = 0; i < targets.length; ++i) {
-                    if (targets[i] === keyOrTarget) {
+                const infos = list.callbackInfos;
+                for (let i = 0; i < infos.length; ++i) {
+                    const info = infos[i];
+                    if (info && info.target === keyOrTarget) {
                         list.cancel(i);
                     }
                 }
             }
             else {
-                list.removeBy(list.targets, keyOrTarget);
+                list.removeByTarget(keyOrTarget);
             }
         }
     }
 };
 
 /**
- * @method remove
+ * !#zh
+ * 删除之前与同类型，回调，目标注册的回调。
+ *
+ * @method off
  * @param {String} key
  * @param {Function} callback
  * @param {Object} [target]
  */
-proto.remove = function (key, callback, target) {
-    var list = this._callbackTable[key];
+proto.off = function (key, callback, target) {
+    const list = this._callbackTable[key];
     if (list) {
-        target = target || null;
-        var callbacks = list.callbacks;
-        var targets = list.targets;
-        for (var i = 0; i < callbacks.length; ++i) {
-            if (callbacks[i] === callback && targets[i] === target) {
+        const infos = list.callbackInfos;
+        for (let i = 0; i < infos.length; ++i) {
+            const info = infos[i];
+            if (info && info.callback === callback && info.target === target) {
                 if (list.isInvoking) {
                     list.cancel(i);
                 }
                 else {
-                    fastRemoveAt(callbacks, i);
-                    fastRemoveAt(targets, i);
+                    fastRemoveAt(infos, i);
+                    callbackInfoPool.put(info);
                 }
                 break;
             }
@@ -215,47 +304,41 @@ proto.remove = function (key, callback, target) {
 
 
 /**
- * !#en The callbacks invoker to handle and invoke callbacks by key.
- * !#zh CallbacksInvoker 用来根据 Key 管理并调用回调方法。
- * @class CallbacksInvoker
+ * !#en
+ * Trigger an event directly with the event name and necessary arguments.
+ * !#zh
+ * 通过事件名发送自定义事件
  *
- * @extends _CallbacksHandler
+ * @method emit
+ * @param {String} key - event type
+ * @param {*} [arg1] - First argument
+ * @param {*} [arg2] - Second argument
+ * @param {*} [arg3] - Third argument
+ * @param {*} [arg4] - Fourth argument
+ * @param {*} [arg5] - Fifth argument
+ * @example
+ *
+ * eventTarget.emit('fire', event);
+ * eventTarget.emit('fire', message, emitter);
  */
-var CallbacksInvoker = function () {
-    CallbacksHandler.call(this);
-};
-js.extend(CallbacksInvoker, CallbacksHandler);
-
-if (CC_TEST) {
-    cc._Test.CallbacksInvoker = CallbacksInvoker;
-}
-
-/**
- * @method invoke
- * @param {String} key
- * @param {any} [p1]
- * @param {any} [p2]
- * @param {any} [p3]
- * @param {any} [p4]
- * @param {any} [p5]
- */
-CallbacksInvoker.prototype.invoke = function (key, p1, p2, p3, p4, p5) {
-    var list = this._callbackTable[key];
+proto.emit = function (key, arg1, arg2, arg3, arg4, arg5) {
+    const list = this._callbackTable[key];
     if (list) {
-        var rootInvoker = !list.isInvoking;
+        const rootInvoker = !list.isInvoking;
         list.isInvoking = true;
 
-        var callbacks = list.callbacks;
-        var targets = list.targets;
-        for (var i = 0, len = callbacks.length; i < len; ++i) {
-            var callback = callbacks[i];
-            if (callback) {
-                var target = targets[i];
-                if (target) {
-                    callback.call(target, p1, p2, p3, p4, p5);
+        const infos = list.callbackInfos;
+        for (let i = 0, len = infos.length; i < len; ++i) {
+            const info = infos[i];
+            if (info) {
+                if (info.target) {
+                    info.callback.call(info.target, arg1, arg2, arg3, arg4, arg5);
                 }
                 else {
-                    callback(p1, p2, p3, p4, p5);
+                    info.callback(arg1, arg2, arg3, arg4, arg5);
+                }
+                if (info.once) {
+                    this.off(key, info.callback, info.target);
                 }
             }
         }
@@ -269,5 +352,8 @@ CallbacksInvoker.prototype.invoke = function (key, p1, p2, p3, p4, p5) {
     }
 };
 
-CallbacksInvoker.CallbacksHandler = CallbacksHandler;
+if (CC_TEST) {
+    cc._Test.CallbacksInvoker = CallbacksInvoker;
+}
+
 module.exports = CallbacksInvoker;

--- a/cocos2d/core/platform/callbacks-invoker.js
+++ b/cocos2d/core/platform/callbacks-invoker.js
@@ -331,15 +331,17 @@ proto.emit = function (key, arg1, arg2, arg3, arg4, arg5) {
         for (let i = 0, len = infos.length; i < len; ++i) {
             const info = infos[i];
             if (info) {
+                let target = info.target;
+                let callback = info.callback;
                 if (info.once) {
-                    this.off(key, info.callback, info.target);
+                    this.off(key, callback, target);
                 }
 
-                if (info.target) {
-                    info.callback.call(info.target, arg1, arg2, arg3, arg4, arg5);
+                if (target) {
+                    callback.call(target, arg1, arg2, arg3, arg4, arg5);
                 }
                 else {
-                    info.callback(arg1, arg2, arg3, arg4, arg5);
+                    callback(arg1, arg2, arg3, arg4, arg5);
                 }
             }
         }

--- a/test/qunit/unit-es5/test-callbacks-invoker.js
+++ b/test/qunit/unit-es5/test-callbacks-invoker.js
@@ -6,81 +6,81 @@ test('test', function () {
     var cb1 = Callback();
     var cb2 = Callback();
     var cb3 = Callback();
-    ci.add('a', cb1);
+    ci.on('a', cb1);
     strictEqual(ci.hasEventListener('a', function () {}), false, '`has` should return false if the callback not exists');
     strictEqual(ci.hasEventListener('a', cb1), true, '`has` should return true if the callback exists');
-    ci.add('a', cb2);
-    ci.add('b', cb3);
-    ci.add('nil', undefined);
+    ci.on('a', cb2);
+    ci.on('b', cb3);
+    ci.on('nil', undefined);
 
     cb1.enable();
     cb2.enable();
-    ci.invoke('a');
+    ci.emit('a');
     cb1.once('1 should be called');
     cb2.once('2 should be called');
 
     cb3.enable();
-    ci.invoke('b');
+    ci.emit('b');
     cb3.once('3 should be called');
 
-    ci.remove('a', cb2);
+    ci.off('a', cb2);
     cb2.setDisabledMessage('callback should not be invoked after removed');
     cb1.enable();
-    ci.invoke('a');
+    ci.emit('a');
     cb1.once('callback should still be invoked if not excatly the one being removed');
 
-    ci.add('a', cb2);
+    ci.on('a', cb2);
     strictEqual(ci.hasEventListener('a'), true, '`has` should return true if has any callback');
     ci.removeAll('a');
     strictEqual(ci.hasEventListener('a'), false, '`has` should return false if all callbacks removed');
     cb1.setDisabledMessage('should not be called after all removed');
     cb2.setDisabledMessage('should not be called after all removed');
-    ci.invoke('a');
+    ci.emit('a');
 });
 
 test('remove self during invoking', function () {
     var ci = new cc._Test.CallbacksInvoker();
     var cb1 = Callback(function () {
-        ci.remove('eve', cb1);
+        ci.off('eve', cb1);
     }).enable();
     var cb2 = Callback().enable();
 
-    ci.add('eve', cb1);
-    ci.add('eve', cb2);
-    ci.invoke('eve');
+    ci.on('eve', cb1);
+    ci.on('eve', cb2);
+    ci.emit('eve');
     cb2.once('it should be called correctly if previous callback deregistered itself');
 
     cb1.disable('should not call after removed');
-    ci.invoke('eve');
+    ci.emit('eve');
 });
 
 test('remove self with target during invoking', function () {
     var ci = new cc._Test.CallbacksInvoker();
     var cb1 = Callback(function () {
-        ci.remove('eve', cb1, target);
+        ci.off('eve', cb1, target);
     }).enable();
     var cb2 = Callback().enable();
     var target = {};
 
-    ci.add('eve', cb1, target);
-    ci.add('eve', cb2, target);
-    ci.invoke('eve');
+    ci.on('eve', cb1, target);
+    ci.on('eve', cb2, target);
+    ci.emit('eve');
     cb2.once('it should be called correctly if previous callback deregistered itself');
 
     cb1.disable('should not call after removed');
-    ci.invoke('eve');
+    ci.emit('eve');
 });
 
 test('remove previous during invoking', function () {
     var ci = new cc._Test.CallbacksInvoker();
     var cb1 = Callback().enable();
     var cb2 = Callback(function () {
-        ci.remove('eve', cb1);
+        ci.off('eve', cb1);
     }).enable();
 
-    ci.add('eve', cb1);
-    ci.add('eve', cb2);
-    ci.invoke('eve');
+    ci.on('eve', cb1);
+    ci.on('eve', cb2);
+    ci.emit('eve');
 
     strictEqual(ci.hasEventListener('eve', cb1), false, 'previous callback should be removed');
     strictEqual(ci.hasEventListener('eve', cb2), true, 'self callback should not be removed');
@@ -90,13 +90,13 @@ test('remove previous with target during invoking', function () {
     var ci = new cc._Test.CallbacksInvoker();
     var cb1 = Callback().enable();
     var cb2 = Callback(function () {
-        ci.remove('eve', cb1, target);
+        ci.off('eve', cb1, target);
     }).enable();
     var target = {};
 
-    ci.add('eve', cb1, target);
-    ci.add('eve', cb2, target);
-    ci.invoke('eve');
+    ci.on('eve', cb1, target);
+    ci.on('eve', cb2, target);
+    ci.emit('eve');
 
     strictEqual(ci.hasEventListener('eve', cb1, target), false, 'previous callback should be removed');
     strictEqual(ci.hasEventListener('eve', cb2, target), true, 'self callback should not be removed');
@@ -106,12 +106,12 @@ test('remove last during invoking', function () {
     var ci = new cc._Test.CallbacksInvoker();
     var cb1 = Callback().enable();
     var cb2 = Callback(function () {
-        ci.remove('eve', cb2);
+        ci.off('eve', cb2);
     }).enable();
 
-    ci.add('eve', cb1);
-    ci.add('eve', cb2);
-    ci.invoke('eve');
+    ci.on('eve', cb1);
+    ci.on('eve', cb2);
+    ci.emit('eve');
 
     strictEqual(ci.hasEventListener('eve', cb1), true, 'previous callback should not be removed');
     strictEqual(ci.hasEventListener('eve', cb2), false, 'self callback should be removed');
@@ -121,12 +121,12 @@ test('remove last with target during invoking', function () {
     var ci = new cc._Test.CallbacksInvoker();
     var cb1 = Callback().enable();
     var cb2 = Callback(function () {
-        ci.remove('eve', cb2, target);
+        ci.off('eve', cb2, target);
     }).enable();
     var target = {};
-    ci.add('eve', cb1, target);
-    ci.add('eve', cb2, target);
-    ci.invoke('eve');
+    ci.on('eve', cb1, target);
+    ci.on('eve', cb2, target);
+    ci.emit('eve');
 
     strictEqual(ci.hasEventListener('eve', cb1, target), true, 'previous callback should not be removed');
     strictEqual(ci.hasEventListener('eve', cb2, target), false, 'self callback should be removed');
@@ -136,19 +136,19 @@ test('remove multiple callbacks during invoking', function () {
     var ci = new cc._Test.CallbacksInvoker();
     var cb1 = Callback().enable();
     var cb2 = Callback(function () {
-        ci.remove('eve', cb1);
-        ci.remove('eve', cb3, target);
+        ci.off('eve', cb1);
+        ci.off('eve', cb3, target);
     }).enable();
     var cb3 = Callback(function () {
-        ci.remove('eve', cb2, target);
+        ci.off('eve', cb2, target);
     }).enable();
     var target = {};
-    ci.add('eve', cb1);
-    ci.add('eve', cb1, target);
-    ci.add('eve', cb2, target);
-    ci.add('eve', cb3);
-    ci.add('eve', cb3, target);
-    ci.invoke('eve');
+    ci.on('eve', cb1);
+    ci.on('eve', cb1, target);
+    ci.on('eve', cb2, target);
+    ci.on('eve', cb3);
+    ci.on('eve', cb3, target);
+    ci.emit('eve');
 
     cb1.expect(2, 'first callback should be invoked twice');
     cb2.expect(1, 'second callback should be invoked once');
@@ -166,15 +166,15 @@ test('remove all callbacks during invoking', function () {
         ci.removeAll('eve');
     }).enable();
     var cb3 = Callback(function () {
-        ci.remove('eve', cb2, target);
+        ci.off('eve', cb2, target);
     }).enable();
     var target = {};
-    ci.add('eve', cb1);
-    ci.add('eve', cb1, target);
-    ci.add('eve', cb2, target);
-    ci.add('eve', cb3);
-    ci.add('eve', cb3, target);
-    ci.invoke('eve');
+    ci.on('eve', cb1);
+    ci.on('eve', cb1, target);
+    ci.on('eve', cb2, target);
+    ci.on('eve', cb3);
+    ci.on('eve', cb3, target);
+    ci.emit('eve');
 
     cb1.expect(2, 'first callback should be invoked twice');
     cb2.expect(1, 'second callback should be invoked once');
@@ -187,43 +187,43 @@ test('remove and add again during invoking', function () {
     var ci = new cc._Test.EventListeners();
 
     var cb1 = function () {
-        ci.remove('eve', cb1, target);
-        ci.add('eve', cb1, target);
+        ci.off('eve', cb1, target);
+        ci.on('eve', cb1, target);
     };
 
-    ci.add('eve', cb1, target);
-    ci.invoke(new cc.Event.EventCustom('eve'));
+    ci.on('eve', cb1, target);
+    ci.emit(new cc.Event.EventCustom('eve'));
 
     strictEqual(ci.hasEventListener('eve', cb1, target), true, 'first callback should be added back');
 });
 
 test('remove twice and add again during invoking', function () {
-   var target = new Object();
-   var ci = new cc._Test.EventListeners();
+    var target = new Object();
+    var ci = new cc._Test.EventListeners();
 
-   var cb1 = function () {
-       ci.remove('eve', cb1, target);
-       ci.remove('eve', cb1, target);
-       ci.add('eve', cb1, target);
-   };
+    var cb1 = function () {
+        ci.off('eve', cb1, target);
+        ci.off('eve', cb1, target);
+        ci.on('eve', cb1, target);
+    };
 
-   ci.add('eve', cb1, target);
-   ci.invoke(new cc.Event.EventCustom('eve'));
+    ci.on('eve', cb1, target);
+    ci.emit(new cc.Event.EventCustom('eve'));
 
-   strictEqual(ci.hasEventListener('eve', cb1, target), true, 'first callback should be added back');
+    strictEqual(ci.hasEventListener('eve', cb1, target), true, 'first callback should be added back');
 });
 
 test('remove and check has during invoking', function () {
-   var target = new Object();
-   var ci = new cc._Test.EventListeners();
+    var target = new Object();
+    var ci = new cc._Test.EventListeners();
 
-   var cb1 = function () {
-       ci.remove('eve', cb1, target);
-       strictEqual(ci.hasEventListener('eve', cb1, target), false, 'first callback should be removed');
-   };
+    var cb1 = function () {
+        ci.off('eve', cb1, target);
+        strictEqual(ci.hasEventListener('eve', cb1, target), false, 'first callback should be removed');
+    };
 
-   ci.add('eve', cb1, target);
-   ci.invoke(new cc.Event.EventCustom('eve'));
+    ci.on('eve', cb1, target);
+    ci.emit(new cc.Event.EventCustom('eve'));
 });
 
 test('CallbacksInvoker support target', function () {
@@ -246,16 +246,16 @@ test('CallbacksInvoker support target', function () {
         count: 0
     };
 
-    ci.add('a', cb1);
-    ci.add('a', cb1, target1);
-    ci.add('a', cb1);
-    ci.add('a', cb1, target2);
-    ci.add('a', cb1, target2);
-    ci.add('a', cb2, target2);
-    ci.add('a', cb2, target1);
-    ci.add('a', cb3);
-    ci.add('a', cb3, target1);
-    ci.add('b', cb1, target1);
+    ci.on('a', cb1);
+    ci.on('a', cb1, target1);
+    ci.on('a', cb1);
+    ci.on('a', cb1, target2);
+    ci.on('a', cb1, target2);
+    ci.on('a', cb2, target2);
+    ci.on('a', cb2, target1);
+    ci.on('a', cb3);
+    ci.on('a', cb3, target1);
+    ci.on('b', cb1, target1);
 
     strictEqual(ci.hasEventListener('a', cb2), false, '`has` should return false if the callback without target not exists');
     strictEqual(ci.hasEventListener('a', cb2, target1), true, '`has` should return true if the callback with correct target exists');
@@ -263,7 +263,7 @@ test('CallbacksInvoker support target', function () {
 
     cb2.enable();
     cb3.enable();
-    ci.invoke('a');
+    ci.emit('a');
     strictEqual(cb1.count, 5, 'callback1 should be invoked five times');
     strictEqual(target1.count, 1, 'callback1 should be invoked one time with target1');
     strictEqual(target2.count, 2, 'callback2 should be invoked two times with target2');
@@ -273,10 +273,10 @@ test('CallbacksInvoker support target', function () {
 
     strictEqual(ci.hasEventListener('a', target1), false, '`has` should return false if the target is given');
 
-    ci.remove('b', cb1);
-    ci.remove('b', cb1, target2);
+    ci.off('b', cb1);
+    ci.off('b', cb1, target2);
     strictEqual(ci.hasEventListener('b', cb1, target1), true, 'remove callback without the correct target should fail');
-    ci.remove('b', cb1, target1);
+    ci.off('b', cb1, target1);
     strictEqual(ci.hasEventListener('b', cb1, target1), false, 'remove callback with the correct callback and target should succeed');
 
     cb1.count = 0;
@@ -284,11 +284,11 @@ test('CallbacksInvoker support target', function () {
     target2.count = 0;
     cb2.calledCount = 0;
     cb3.calledCount = 0;
-    ci.remove('a', cb1, target2);
-    ci.remove('a', cb1, target1);
-    ci.remove('a', cb2, target2);
-    ci.remove('a', cb3, target2);
-    ci.invoke('a');
+    ci.off('a', cb1, target2);
+    ci.off('a', cb1, target1);
+    ci.off('a', cb2, target2);
+    ci.off('a', cb3, target2);
+    ci.emit('a');
     strictEqual(target1.count, 0, 'callback1 with target1 should not be invoked after remove');
     strictEqual(target2.count, 1, 'callback1 with target2 should be invoked only once after remove one');
 
@@ -312,21 +312,21 @@ test('CallbacksInvoker remove target', function () {
         count: 0
     };
 
-    ci.add('a', cb1);
-    ci.add('a', cb1, target1);
-    ci.add('a', cb1);
-    ci.add('a', cb1, target2);
-    ci.add('a', cb1, target2);
-    ci.add('a', cb2, target2);
-    ci.add('a', cb2, target1);
-    ci.add('a', cb3);
-    ci.add('a', cb3, target1);
+    ci.on('a', cb1);
+    ci.on('a', cb1, target1);
+    ci.on('a', cb1);
+    ci.on('a', cb1, target2);
+    ci.on('a', cb1, target2);
+    ci.on('a', cb2, target2);
+    ci.on('a', cb2, target1);
+    ci.on('a', cb3);
+    ci.on('a', cb3, target1);
 
     cb1.enable();
     cb2.enable();
     cb3.enable();
 
-    ci.invoke('a');
+    ci.emit('a');
     cb1.expect(5, 'callback1 should be called five times');
     cb2.expect(2, 'callback2 should be called twice');
     cb3.expect(2, 'callback3 should be called twice');
@@ -337,7 +337,7 @@ test('CallbacksInvoker remove target', function () {
     cb2.calledCount = 0;
     cb3.calledCount = 0;
 
-    ci.invoke('a');
+    ci.emit('a');
     cb1.expect(4, 'removed one, callback1 should be called four times');
     cb2.expect(1, 'removed one, callback2 should be called once');
     cb3.expect(1, 'removed one, callback3 should be called once');
@@ -348,7 +348,7 @@ test('CallbacksInvoker remove target', function () {
     cb2.calledCount = 0;
     cb3.calledCount = 0;
 
-    ci.invoke('a');
+    ci.emit('a');
     cb1.expect(2, 'removed two, callback1 should be called twice');
     cb2.expect(0, 'removed one, callback2 should not be called');
     cb3.expect(1, 'callback3 should be called once');
@@ -357,17 +357,17 @@ test('CallbacksInvoker remove target', function () {
 test('event type conflict with object prototype', function () {
     var ci = new cc._Test.CallbacksInvoker();
     var cb1 = Callback(function () {
-        ci.remove('toString', cb1);
+        ci.off('toString', cb1);
     }).enable();
     var cb2 = Callback().enable();
 
-    ci.add('toString', cb1);
-    ci.add('toString', cb2);
-    ci.invoke('toString');
+    ci.on('toString', cb1);
+    ci.on('toString', cb2);
+    ci.emit('toString');
     cb2.once('it should be called correctly if previous callback deregistered itself');
 
     cb1.disable('should not call after removed');
-    ci.invoke('toString');
+    ci.emit('toString');
 });
 
 test('nest invoke', function () {
@@ -380,16 +380,16 @@ test('nest invoke', function () {
         actualSequence.push(cb1);
         if (isParentLoop) {
             isParentLoop = false;
-            ci.invoke('visit');
+            ci.emit('visit');
         }
     };
     var cb2 = function () {
         actualSequence.push(cb2);
     };
 
-    ci.add('visit', cb1);
-    ci.add('visit', cb2);
-    ci.invoke('visit');
+    ci.on('visit', cb1);
+    ci.on('visit', cb2);
+    ci.emit('visit');
 
     deepEqual(actualSequence, [cb1, cb1, cb2, cb2], 'support nest invoke');
 });
@@ -404,16 +404,16 @@ test('remove during nest invoke', function () {
         actualSequence.push(cb1);
         if (isParentLoop) {
             isParentLoop = false;
-            ci.invoke('visit');
+            ci.emit('visit');
         }
         else {
-            ci.remove('visit', cb1);
+            ci.off('visit', cb1);
             strictEqual(ci.hasEventListener('visit'), false, 'all callbacks removed');
         }
     };
 
-    ci.add('visit', cb1);
-    ci.invoke('visit');
+    ci.on('visit', cb1);
+    ci.emit('visit');
 
     deepEqual(actualSequence, [cb1, cb1], 'invoke sequence');
 });
@@ -431,21 +431,21 @@ test('remove many during nest invoke', function () {
         actualSequence.push(cb2);
         if (isParentLoop) {
             isParentLoop = false;
-            ci.invoke('visit');
+            ci.emit('visit');
         }
         else {
-            ci.remove('visit', cb1);
-            ci.remove('visit', cb2);
+            ci.off('visit', cb1);
+            ci.off('visit', cb2);
         }
     };
     var cb3 = function () {
         actualSequence.push(cb3);
     };
 
-    ci.add('visit', cb1);
-    ci.add('visit', cb2);
-    ci.add('visit', cb3);
-    ci.invoke('visit');
+    ci.on('visit', cb1);
+    ci.on('visit', cb2);
+    ci.on('visit', cb3);
+    ci.emit('visit');
 
     deepEqual(actualSequence, [cb1, cb2, cb1, cb2, cb3, cb3], 'invoke sequence');
 });


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 同步 3d 修复 EventTarget once 监听器无法 off 代码

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
