### PR TITLE
fix _histTest ignore scale bug

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1829,7 +1829,10 @@ var Node = cc.Class({
         }
 
         this._updateWorldMatrix();
-        math.mat4.invert(_mat4_temp, this._worldMatrix);
+        // If scale is 0, it can't be hit.
+        if (!math.mat4.invert(_mat4_temp, this._worldMatrix)) {
+            return false;
+        }
         math.vec2.transformMat4(testPt, cameraPt, _mat4_temp);
         testPt.x += this._anchorPoint.x * w;
         testPt.y += this._anchorPoint.y * h;

--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -462,7 +462,10 @@ let Mask = cc.Class({
             testPt = _vec2_temp;
         
         node._updateWorldMatrix();
-        math.mat4.invert(_mat4_temp, node._worldMatrix);
+        // If scale is 0, it can't be hit.
+        if (!math.mat4.invert(_mat4_temp, node._worldMatrix)) {
+            return false;
+        }
         math.vec2.transformMat4(testPt, cameraPt, _mat4_temp);
         testPt.x += node._anchorPoint.x * w;
         testPt.y += node._anchorPoint.y * h;


### PR DESCRIPTION
Re: scrollview 的 sclaeY 设置为 0 时，button 无响应，button 与 scrollview 都是同一个父节点节点下的

Changes:
 * 修复 _hitTest 忽略了 scale 的计算，导致 scale 为 0 还是会显示 hit

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
