### PR TITLE
remove the collider body from world When the collider has shape only

### DIFF
--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -39,6 +39,10 @@ declare const CC_SUPPORT_JIT: boolean;
 
 declare const jsb: any;
 
+declare const CC_PHYISCS_CANNON: boolean;
+declare const CC_PHYISCS_AMMO: boolean;
+declare const CC_PHYISCS_BUILT_IN: boolean;
+
 interface Window {
     mozRequestAnimationFrame (callback: any, element?: any): any;
     oRequestAnimationFrame (callback: any, element?: any): any;
@@ -77,7 +81,7 @@ interface ActiveXObject {
 }
 declare var ActiveXObject: ActiveXObject;
 
-declare const cc : {
+declare const cc: {
     // polyfills: {
     //     destroyObject? (object: any): void;
     // };
@@ -101,7 +105,7 @@ declare namespace Editor {
     function log (message?: any, ...optionalParams: any[]): void;
     function error (message?: any, ...optionalParams: any[]): void;
     function warn (message?: any, ...optionalParams: any[]): void;
-    function require(str:String): any;
+    function require (str: String): any;
     const isMainProcess: boolean | undefined;
     const Ipc: any;
     const Utils: any;

--- a/cocos/3d/framework/physics/collider-component.ts
+++ b/cocos/3d/framework/physics/collider-component.ts
@@ -78,8 +78,8 @@ export class ColliderComponentBase extends PhysicsBasedComponent {
     // }
 
     public onEnable () {
+        super.onEnable();
         if (this.sharedBody) {
-            super.onEnable();
             this.sharedBody.body.addShape(this._shapeBase!);
         }
     }
@@ -87,7 +87,10 @@ export class ColliderComponentBase extends PhysicsBasedComponent {
     public onDisable () {
         if (this.sharedBody) {
             this.sharedBody.body.removeShape(this._shapeBase!);
-            // collider只需要从刚体中移除shape即可, 因为可能存在有rigidBody组件
+
+            if (this.sharedBody.isShapeOnly) {
+                super.onDisable();
+            }
         }
     }
 

--- a/cocos/3d/framework/physics/detail/physics-based-component.ts
+++ b/cocos/3d/framework/physics/detail/physics-based-component.ts
@@ -29,8 +29,9 @@ export class PhysicsBasedComponent extends Component {
     }
 
     public onEnable () {
-        // collider和rigidbody都需要激活刚体
-        this.sharedBody!.enable();
+        if (this.sharedBody) {
+            this.sharedBody!.enable();
+        }
     }
 
     public onDisable () {
@@ -123,8 +124,11 @@ class SharedRigidBody {
     private _onCollidedCallback: ICollisionCallback;
 
     private _transformInitialized: boolean = false;
+
     /** 是否只有Collider组件 */
     private _isShapeOnly: boolean = true;
+    public get isShapeOnly (): boolean { return this._isShapeOnly; }
+
     /** 上一次的缩放 */
     private _prevScale: Vec3 = new Vec3();
 

--- a/cocos/3d/physics/cannon-impl.ts
+++ b/cocos/3d/physics/cannon-impl.ts
@@ -172,8 +172,7 @@ export class CannonRigidBody implements RigidBodyBase {
         return this._cannonBody;
     }
 
-    private _group: number = 0;
-    private _mask: number = 0;
+    private _group: number = 1;
     private _cannonBody: CANNON.Body;
     private _velocityResult: Vec3 = new Vec3();
     private _useGravity = true;

--- a/cocos/3d/physics/cocos/built-in-body.ts
+++ b/cocos/3d/physics/cocos/built-in-body.ts
@@ -22,7 +22,7 @@ export class BuiltInBody implements RigidBodyBase {
 
     private _type: ERigidBodyType = ERigidBodyType.DYNAMIC;
 
-    private _group: number = 0;
+    private _group: number = 1;
     private _collisionFilterGroup: number = 1 << 0;
     private _collisionFilterMask: number = 1 << 0;
 

--- a/cocos/3d/physics/impl-selector.ts
+++ b/cocos/3d/physics/impl-selector.ts
@@ -1,7 +1,4 @@
 
-declare const CC_PHYISCS_CANNON: boolean;
-declare const CC_PHYISCS_AMMO: boolean;
-declare const CC_PHYISCS_BUILT_IN: boolean;
 declare const global: any;
 const _global = typeof window === 'undefined' ? global : window;
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#536

Changes:
 * remove the collider body from world When the collider has shape only;
 * set body group default value to 1;

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
