### PR TITLE
Fix opacity cascading of labelOutLine.

### DIFF
--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -169,8 +169,6 @@ module.exports = {
             _isOutlined = true;
             _margin = _outlineWidth = outline.width;
             _outlineColor = cc.color(outline.color);
-            // TODO: temporary solution, cascade opacity for outline color
-            _outlineColor.a = _outlineColor.a * comp.node.color.a / 255.0;
         }
         else {
             _isOutlined = false;


### PR DESCRIPTION
描边透明度在绘制时确定，在这里作的跟节点的透明度级联就不需要了，节点透明度会在最终绘制时对整个文字纹理控制。

