### PR TITLE
fix IE exception when output log/warn before engine initialization

### DIFF
--- a/cocos2d/core/CCDebug.js
+++ b/cocos2d/core/CCDebug.js
@@ -33,7 +33,7 @@ let logList;
  * @module cc
  */
 
-cc.log = cc.warn = cc.error = cc.assert = console.log;
+cc.log = cc.warn = cc.error = cc.assert = console.log.bind(console);
 
 let resetDebugSetting = function (mode) {
     // reset


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复初始化过程中输出日志会导致 IE/Edge 出错的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
