### PR TITLE
fix editBox bug on web

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -432,9 +432,11 @@ let EditBox = cc.Class({
                 return this._tabIndex;
             },
             set (value) {
-                this._tabIndex = value;
-                if (this._impl) {
-                    this._impl.setTabIndex(value);
+                if (this._tabIndex !== value) {
+                    this._tabIndex = value;
+                    if (this._impl) {
+                        this._impl.setTabIndex(value);
+                    }
                 }
             }
         },

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -555,7 +555,7 @@ Object.assign(WebEditBoxImpl.prototype, {
             && this._placeholderLabelFontSize === placeholderLabel.fontSize
             && this._placeholderLabelFontColor === placeholderLabel.fontColor
             && this._placeholderLabelAlign === placeholderLabel.horizontalAlign
-            && this._placeholderLineHeight === placeholderLabel.lineHeight) {
+            && this._placeholderLineHeight === placeholderLabel.fontSize) {
                 return;
         }
 
@@ -564,7 +564,7 @@ Object.assign(WebEditBoxImpl.prototype, {
         this._placeholderLabelFontSize = placeholderLabel.fontSize;
         this._placeholderLabelFontColor = placeholderLabel.fontColor;
         this._placeholderLabelAlign = placeholderLabel.horizontalAlign;
-        this._placeholderLineHeight = placeholderLabel.lineHeight;
+        this._placeholderLineHeight = placeholderLabel.fontSize;
 
         let styleEl = this._placeholderStyleSheet;
         // font size
@@ -572,7 +572,7 @@ Object.assign(WebEditBoxImpl.prototype, {
         // font color
         let fontColor = placeholderLabel.node.color.toCSS('rgba');
         // line height
-        let lineHeight = placeholderLabel.lineHeight;
+        let lineHeight = placeholderLabel.fontSize;  // top vertical align by default
         // horizontal align
         let horizontalAlign;
         switch (placeholderLabel.horizontalAlign) {

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -273,12 +273,18 @@ Object.assign(WebEditBoxImpl.prototype, {
 
     _hideDomOnMobile () {
         if (cc.sys.os === cc.sys.OS_ANDROID) {
-            if (_fullscreen) {
-                cc.view.enableAutoFullScreen(true);
-            }
-            if (_autoResize) {
-                cc.view.resizeWithBrowserSize(true);
-            }
+            // Closing soft keyboard on mobile will fire 'resize' event
+            // So we need to set a timeout to enable resizeWithBrowserSize
+            setTimeout(function () {
+                if (!_currentEditBoxImpl) {
+                    if (_fullscreen) {
+                        cc.view.enableAutoFullScreen(true);
+                    }
+                    if (_autoResize) {
+                        cc.view.resizeWithBrowserSize(true);
+                    }
+                }
+            }, DELAY_TIME);
         }
         
         // Some browser like wechat on iOS need to mannully scroll back window

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -287,6 +287,16 @@ Object.assign(WebEditBoxImpl.prototype, {
 
     _scrollBackWindow () {
         setTimeout(function () {
+            // FIX: wechat browser bug on iOS
+            // If gameContainer is included in iframe,
+            // Need to scroll the top window, not the one in the iframe
+            // Reference: https://developer.mozilla.org/en-US/docs/Web/API/Window/top
+            let sys = cc.sys;
+            if (sys.browserType === sys.BROWSER_TYPE_WECHAT && sys.os === sys.OS_IOS) {
+                window.top && window.top.scrollTo(0, 0);
+                return;
+            }
+
             window.scrollTo(0, 0);
         }, DELAY_TIME);
     },

--- a/cocos2d/core/components/editbox/tabIndexUtil.js
+++ b/cocos2d/core/components/editbox/tabIndexUtil.js
@@ -1,0 +1,39 @@
+const tabIndexUtil = {
+    _tabIndexList: [],
+
+    add (editBoxImpl) {
+        let list = this._tabIndexList;
+        let index = list.indexOf(editBoxImpl);
+        if (index === -1){
+            list.push(editBoxImpl);
+        }
+    },
+
+    remove (editBoxImpl) {
+        let list = this._tabIndexList;
+        let index = list.indexOf(editBoxImpl);
+        if (index !== -1) {
+            list.splice(index, 1);
+        }
+    },
+
+    resort () {
+        this._tabIndexList.sort(function(a, b) {
+            return a._delegate._tabIndex - b._delegate._tabIndex;
+        });
+    },
+
+    next (editBoxImpl) {
+        let list = this._tabIndexList;
+        let index = list.indexOf(editBoxImpl);
+        editBoxImpl.setFocus(false);
+        if (index !== -1) {
+            let nextImpl = list[index+1];
+            if (nextImpl && nextImpl._delegate._tabIndex >= 0) {
+                nextImpl.setFocus(true);
+            }
+        }
+    },
+}
+
+module.exports = tabIndexUtil;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1400

changeLog:
- 修复 web 平台 editBox 遮挡其他 UI 控件触摸事件的 bug **（把默认的 stayOnTop 改为 unStayOnTop）**
- 修复 iOS 微信浏览器上，将 gameContainer 内置在 iframe 里，导致收起软键盘后触摸区域错位的问题
- 修复 web-mobile 上收起软键盘时，多次适配 canvas 尺寸的 bug
- 修复 web 平台 editBox 多行输入 placeholder 显示不正确的 bug

<img width="579" alt="WechatIMG2" src="https://user-images.githubusercontent.com/17872773/59183473-acb2bf80-8b9e-11e9-96f4-66cb2a85e77a.png">
<img width="580" alt="WechatIMG3" src="https://user-images.githubusercontent.com/17872773/59183481-b1777380-8b9e-11e9-94a9-0018b7d2216f.png">

补充说明：
- 移动端上收起软键盘会多次触发 resize 事件，所以需要延迟开启 `resizeWithBrowserSize`
- 现在 editBox 是 unStayOnTop 状态，需要实现一个 tabIndexUtil 来支持 tab 功能