### PR TITLE
Fix component enable property decorator

### DIFF
--- a/cocos/components/component.ts
+++ b/cocos/components/component.ts
@@ -122,9 +122,7 @@ class Component extends CCObject {
      * cc.log(comp.enabled);
      * ```
      */
-    @property({
-        visible: false,
-    })
+    @property
     get enabled () {
         return this._enabled;
     }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#840

Changes:
 * Fix component enable property decorator

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
