### PR TITLE
Optimize memory issues of BMFont.

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -367,7 +367,8 @@ let Label = cc.Class({
                 if (CC_EDITOR && value) {
                     this._userDefinedFont = value;
                 }
-
+                // release reference
+                cc.Label.FontAtlasManager.releaseFontAtlas(this.font, this.node._id);
                 this._N$file = value;
                 if (value && this._isSystemFontUsed)
                     this._isSystemFontUsed = false;
@@ -380,7 +381,6 @@ let Label = cc.Class({
                     this.destroyRenderData(this._renderData);
                     this._renderData = null;    
                 }
-                this._fontAtlas = null;
                 this._updateAssembler();
                 this._applyFontTexture(true);
                 this._updateRenderData();
@@ -556,6 +556,8 @@ let Label = cc.Class({
             this._ttfTexture.destroy();
             this._ttfTexture = null;
         }
+        // release reference
+        cc.Label.FontAtlasManager.releaseFontAtlas(this.font, this.node._id);
         this._super();
     },
 

--- a/cocos2d/core/renderer/utils/label/bmfont.js
+++ b/cocos2d/core/renderer/utils/label/bmfont.js
@@ -130,11 +130,12 @@ FontAtlasManager.prototype.releaseFontAtlas = function (font, id) {
         for (let i = reference.length - 1; i >= 0; i--) {
             if (reference[i] === id) {
                 reference.splice(i, 1);
+                break;
             }
         }
     }
 
-    if (reference.length === 0) {
+    if (!reference || reference.length === 0) {
         delete this._fontAtlas[name];
     }
 }

--- a/cocos2d/core/renderer/utils/label/bmfont.js
+++ b/cocos2d/core/renderer/utils/label/bmfont.js
@@ -42,8 +42,9 @@ let FontLetterDefinition = function() {
     this._xAdvance = 0;
 };
 
-cc.FontAtlas = function (fntConfig) {
+cc.FontAtlas = function (texture) {
     this._letterDefinitions = {};
+    this._texture = texture;
 };
 
 cc.FontAtlas.prototype = {
@@ -88,6 +89,88 @@ cc.FontAtlas.prototype = {
         return letterDefinition;
     }
 };
+
+let FontAtlasManager = function () {
+    this._fontAtlas = {};
+    this._references = {};
+
+    cc.director.on(cc.Director.EVENT_BEFORE_SCENE_LAUNCH, this.clear, this);
+}
+
+FontAtlasManager.prototype.getFontAtlas = function (comp) {
+    let fontAsset = comp.font;
+    let fntConfig = fontAsset._fntConfig;
+    let name = fntConfig.atlasName
+    let atlas = this._fontAtlas[name];
+    if (!atlas) {
+        atlas = this.createFontAtlas(fontAsset);
+        this._fontAtlas[name] = atlas;
+    }
+
+    if (!this._references[name]) {
+        this._references[name] = [];
+    }
+    
+    if (this._references[name].indexOf(comp.node._id) === -1) {
+        this._references[name].push(comp.node._id);
+    }
+    
+    return this._fontAtlas[name];
+}
+
+FontAtlasManager.prototype.releaseFontAtlas = function (font, id) {
+    if (font === null) return
+    if (!(font instanceof cc.BitmapFont)) return
+    if (!font._fntConfig) return
+    
+    let fntConfig = font._fntConfig;
+    let name = fntConfig.atlasName;
+    let reference = this._references[name];
+    if (reference !== null) {
+        for (let i = reference.length - 1; i >= 0; i--) {
+            if (reference[i] === id) {
+                reference.splice(i, 1);
+            }
+        }
+    }
+
+    if (reference.length === 0) {
+        delete this._fontAtlas[name];
+    }
+}
+
+FontAtlasManager.prototype.createFontAtlas = function (fontAsset) {
+    let spriteFrame = fontAsset.spriteFrame;
+    let fntConfig = fontAsset._fntConfig;
+    let atlas = new cc.FontAtlas(spriteFrame.texture);
+    let fontDict = fntConfig.fontDefDictionary;
+    for (let fontDef in fontDict) {
+        let letterDefinition = new FontLetterDefinition();
+
+        let rect = fontDict[fontDef].rect;
+        letterDefinition._offsetX = fontDict[fontDef].xOffset;
+        letterDefinition._offsetY = fontDict[fontDef].yOffset;
+        letterDefinition._width = rect.width;
+        letterDefinition._height = rect.height;
+        letterDefinition._u = rect.x;
+        letterDefinition._v = rect.y;
+        //FIXME: only one texture supported for now
+        letterDefinition._textureID = 0;
+        letterDefinition._validDefinition = true;
+        letterDefinition._xAdvance = fontDict[fontDef].xAdvance;
+
+        atlas.addLetterDefinitions(fontDef, letterDefinition);
+    }
+
+    return atlas;
+}
+
+FontAtlasManager.prototype.clear = function () {
+    this._fontAtlas = {};
+    this._references = {};
+}
+
+cc.Label.FontAtlasManager = new FontAtlasManager();
 
 let LetterInfo = function() {
     this._char = '';
@@ -160,34 +243,7 @@ module.exports = {
         let fontAsset = _comp.font;
         _spriteFrame = fontAsset.spriteFrame;
         _fntConfig = fontAsset._fntConfig;
-
-        _fontAtlas = _comp._fontAtlas;
-        if (!_fontAtlas) {
-            _fontAtlas = new cc.FontAtlas(_fntConfig);
-            
-            let fontDict = _fntConfig.fontDefDictionary;
-
-            for (let fontDef in fontDict) {
-                let letterDefinition = new FontLetterDefinition();
-
-                let rect = fontDict[fontDef].rect;
-
-                letterDefinition._offsetX = fontDict[fontDef].xOffset;
-                letterDefinition._offsetY = fontDict[fontDef].yOffset;
-                letterDefinition._width = rect.width;
-                letterDefinition._height = rect.height;
-                letterDefinition._u = rect.x;
-                letterDefinition._v = rect.y;
-                //FIXME: only one texture supported for now
-                letterDefinition._textureID = 0;
-                letterDefinition._validDefinition = true;
-                letterDefinition._xAdvance = fontDict[fontDef].xAdvance;
-
-                _fontAtlas.addLetterDefinitions(fontDef, letterDefinition);
-            }
-
-            _comp._fontAtlas = _fontAtlas;
-        }
+        _fontAtlas = cc.Label.FontAtlasManager.getFontAtlas(_comp);
 
         _string = _comp.string.toString();
         _fontSize = _comp.fontSize;
@@ -591,7 +647,6 @@ module.exports = {
 
     _updateQuads () {
         let letterDefinitions = _fontAtlas._letterDefinitions;
-        
         let texture = _spriteFrame._texture;
 
         let node = _comp.node;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

**问题说明：**

反馈自论坛开发者： https://forum.cocos.com/t/bmfont-demo/79336
用户使用2048*2048的BMFont图片记录大约2800个文字，当创建多个使用该BMFont资源的Label时，会创建多份记录2800个FontLetterDefinition对象数据的FontAtlas，导致占用大量的内存。

**解决方案:**

1. 增加FontAtlas的缓存机制，避免多个Label使用相同的BMFont时，仍然会创建多份存储大量FontLetterDefinition数据的FontAtlas对象，保证使用相同的BMFont资源只会存在一份FontAtlas对象数据。

2. FontAtlas的缓存会进行引用记录，当引用该数据的所有节点组件全部销毁时会清除该FontAtlas对象数据，避免内存占用。另外在场景切换的时候，会去重置掉所有组件使用的对象数据，为了保证不会存在冗余数据，在场景切换时也会清空掉所有缓存的FontAtlas。再次使用BMFont时，如果没有缓存会重新创建FontAtlas。
