### PR TITLE
add physics macro to global in publish, set cannon to default

### DIFF
--- a/cocos/3d/physics/impl-selector.ts
+++ b/cocos/3d/physics/impl-selector.ts
@@ -4,7 +4,7 @@ const _global = typeof window === 'undefined' ? global : window;
 
 // tslint:disable: no-string-literal;
 if (typeof _global.CC_PHYSICS_CANNON === 'undefined') {
-    _global.CC_PHYSICS_CANNON = false;
+    _global.CC_PHYSICS_CANNON = true;
 }
 
 if (typeof _global.CC_PHYSICS_AMMO === 'undefined') {
@@ -12,7 +12,7 @@ if (typeof _global.CC_PHYSICS_AMMO === 'undefined') {
 }
 
 if (typeof _global.CC_PHYSICS_BUILT_IN === 'undefined') {
-    _global.CC_PHYSICS_BUILT_IN = true;
+    _global.CC_PHYSICS_BUILT_IN = false;
 }
 
 // Cannon

--- a/predefine.js
+++ b/predefine.js
@@ -164,6 +164,9 @@ if (CC_BUILD) {
     _global.CC_QQPLAY = CC_QQPLAY;
     _global.CC_RUNTIME = CC_RUNTIME;
     _global.CC_SUPPORT_JIT = CC_SUPPORT_JIT;
+    _global.CC_PHYSICS_BUILT_IN = CC_PHYSICS_BUILT_IN;
+    _global.CC_PHYSICS_CANNON = CC_PHYSICS_CANNON;
+    _global.CC_PHYSICS_AMMO = CC_PHYSICS_AMMO;
 }
 else {
     defineMacro('CC_TEST', defined('tap') || defined('QUnit'));


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changes:
 * add physics macro to global in publish
 * set cannon to default

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
