### PR TITLE
ccclass: fix default value when using cc.String

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1355,24 +1355,24 @@ Default value must be initialized at their declaration:
   type: cc.Integer
   default: 0  // <--
 })
-value;
+myProp;
 // After:
 @property({
   type: cc.Integer
 })
-value = 0;    // <--
+myProp = 0;    // <--
 ```
 
 ### 3654
 
-Please specifiy a default value for "%s" property at its declaration:
+Please specifiy a default value for "%s.%s" at its declaration:
 ```
 // Before:
 @property(...)
-value; 
+myProp;
 // After:
 @property(...)
-value = 0
+myProp = 0;
 ```
 
 ### 3655
@@ -1912,7 +1912,7 @@ The 'type' attribute of '%s.%s' must be child class of cc.Asset, otherwise you s
 
 ### 5510
 
-The 'type' attribute of '%s.%s' can not be 'Number', use 'Float' or 'Integer' instead please.
+The 'type' attribute of '%s.%s' can not be 'Number', use cc.Float or cc.Integer instead please.
 
 ### 5511
 

--- a/cocos2d/animation/animation-clip.js
+++ b/cocos2d/animation/animation-clip.js
@@ -41,7 +41,7 @@ var AnimationClip = cc.Class({
     properties: {
         _duration: {
             default: 0,
-            type: 'Float',
+            type: cc.Float,
         },
 
         /**

--- a/cocos2d/core/components/CCProgressBar.js
+++ b/cocos2d/core/components/CCProgressBar.js
@@ -261,7 +261,7 @@ var ProgressBar = cc.Class({
          */
         progress: {
             default: 1,
-            type: 'Float',
+            type: cc.Float,
             range: [0, 1, 0.1],
             slide: true,
             tooltip: CC_DEV && 'i18n:COMPONENT.progress.progress',

--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -253,7 +253,7 @@ let ScrollView = cc.Class({
          */
         brake: {
             default: 0.5,
-            type: 'Float',
+            type: cc.Float,
             range: [0, 1, 0.1],
             tooltip: CC_DEV && 'i18n:COMPONENT.scrollview.brake',
         },

--- a/cocos2d/core/components/CCStudioComponent.js
+++ b/cocos2d/core/components/CCStudioComponent.js
@@ -244,7 +244,7 @@ var StudioComponent = cc.Class({
         sliderProgress: {
             default: 0.5,
             readonly: true,
-            type: 'Float',
+            type: cc.Float,
             range: [0, 1, 0.1]
         },
 

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -904,7 +904,7 @@ function declareProperties (cls, className, properties, baseClass, mixins, es6) 
      properties {
          width: {
              default: 128,
-             type: 'Integer',
+             type: cc.Integer,
              tooltip: 'The width of sprite'
          },
          height: 128,

--- a/cocos2d/core/platform/attribute.js
+++ b/cocos2d/core/platform/attribute.js
@@ -164,7 +164,12 @@ function setClassAttr (ctor, propName, key, value) {
  * })
  * member = [];
  */
-cc.Integer = 'Integer';
+cc.Integer = {
+    default: 0,
+    toString () {
+        return 'Integer';
+    }
+};
 
 /**
  * Indicates that the elements in array should be type double.
@@ -182,7 +187,12 @@ cc.Integer = 'Integer';
  * })
  * member = [];
  */
-cc.Float = 'Float';
+cc.Float = {
+    default: 0,
+    toString () {
+        return 'Float';
+    }
+};
 
 if (CC_EDITOR) {
     js.get(cc, 'Number', function () {
@@ -207,7 +217,12 @@ if (CC_EDITOR) {
  * })
  * member = [];
  */
-cc.Boolean = 'Boolean';
+cc.Boolean = {
+    default: false,
+    toString () {
+        return 'Boolean';
+    }
+};
 
 /**
  * Indicates that the elements in array should be type string.
@@ -225,7 +240,12 @@ cc.Boolean = 'Boolean';
  * })
  * member = [];
  */
-cc.String = 'String';
+cc.String = {
+    default: '',
+    toString () {
+        return 'String';
+    }
+};
 
 /*
 BuiltinAttributes: {
@@ -244,7 +264,7 @@ Callbacks: {
  */
 
 function getTypeChecker (type, attrName) {
-    if (CC_DEV) {
+    if (CC_EDITOR || CC_TEST) {
         return function (constructor, mainPropName) {
             var propInfo = '"' + js.getClassName(constructor) + '.' + mainPropName + '"';
             var mainPropAttrs = attr(constructor, mainPropName);
@@ -252,6 +272,9 @@ function getTypeChecker (type, attrName) {
                 var mainPropAttrsType = mainPropAttrs.type;
                 if (mainPropAttrsType === cc.Integer || mainPropAttrsType === cc.Float) {
                     mainPropAttrsType = 'Number';
+                }
+                else if (mainPropAttrsType === cc.String || mainPropAttrsType === cc.Boolean) {
+                    mainPropAttrsType = '' + mainPropAttrsType;
                 }
                 if (mainPropAttrsType !== type) {
                     cc.warnID(3604, propInfo);

--- a/cocos2d/core/platform/preprocess-class.js
+++ b/cocos2d/core/platform/preprocess-class.js
@@ -190,11 +190,27 @@ function parseType (val, type, className, propName) {
                     js.getClassName(type));
             }
         }
-        else if (type === 'Number') {
-            cc.warnID(5510, className, propName);
-        }
-        else if (type == null) {
-            cc.warnID(5511, className, propName);
+        else {
+            switch (type) {
+            case 'Number':
+                cc.warnID(5510, className, propName);
+                break;
+            case 'String':
+                cc.warn(`The type of "${className}.${propName}" must be cc.String, not "String".`);
+                break;
+            case 'Boolean':
+                cc.warn(`The type of "${className}.${propName}" must be cc.Boolean, not "Boolean".`);
+                break;
+            case 'Float':
+                cc.warn(`The type of "${className}.${propName}" must be cc.Float, not "Float".`);
+                break;
+            case 'Integer':
+                cc.warn(`The type of "${className}.${propName}" must be cc.Integer, not "Integer".`);
+                break;
+            case null:
+                cc.warnID(5511, className, propName);
+                break;
+            }
         }
     }
 }
@@ -294,6 +310,12 @@ exports.getFullFormOfProperty = function (options, propname_dev, classname_dev) 
             return {
                 default: '',
                 url: type,
+                _short: true
+            };
+        }
+        else if (options === cc.String || options === cc.Integer || options === cc.Float || options === cc.Boolean) {
+            return {
+                default: options.default,
                 _short: true
             };
         }

--- a/test/qunit/unit-es5/_init.js
+++ b/test/qunit/unit-es5/_init.js
@@ -39,7 +39,7 @@ var TestTexture = cc.Class({
          */
         width: {
             default: 0,
-            type: 'Integer',
+            type: cc.Integer,
             readonly: true
         },
 
@@ -49,7 +49,7 @@ var TestTexture = cc.Class({
          */
         height: {
             default: 0,
-            type: 'Integer',
+            type: cc.Integer,
             readonly: true
         },
     }

--- a/test/qunit/unit-es5/test-class.js
+++ b/test/qunit/unit-es5/test-class.js
@@ -24,7 +24,7 @@ test('test', function () {
                 serializable: false
             },
             weight10: {
-                type: 'Integer',
+                type: cc.Integer,
                 set: function (value) {
                     this.weight = Math.floor(value / 10);
                 },
@@ -33,7 +33,7 @@ test('test', function () {
                 }
             },
             weight5x: {
-                type: 'Integer',
+                type: cc.Integer,
                 get: function () {
                     return this.weight * 5;
                 },
@@ -722,10 +722,6 @@ test('simplified properties define', function () {
     var ArrayType = cc.Class({
         properties: {
             empty: [],
-            bool: [cc.Boolean],
-            string: [cc.String],
-            float: [cc.Float],
-            int: [cc.Integer],
             valueType: [cc.Vec2],
             node: [cc.Node],
             rawAsset: [cc.RawAsset],
@@ -738,7 +734,6 @@ test('simplified properties define', function () {
 
     var arrayObj = new ArrayType();
 
-    strictEqual(cc.Class.attr(ArrayType, 'bool').type, cc.Boolean, 'checking array of bool type');
     strictEqual(cc.Class.attr(ArrayType, 'valueType').type, 'Object', 'checking array of vec2 type');
     strictEqual(cc.Class.attr(ArrayType, 'valueType').ctor, cc.Vec2, 'checking array of vec2 ctor');
     strictEqual(cc.Class.attr(ArrayType, 'node').type, 'Object', 'checking array of node type');
@@ -747,13 +742,62 @@ test('simplified properties define', function () {
     strictEqual(cc.Class.attr(ArrayType, 'rawAsset').ctor, cc.RawAsset, 'checking array of raw asset ctor');
 
     deepEqual(arrayObj.empty, [], 'checking array of empty');
-    deepEqual(arrayObj.bool, [], 'checking array of bool');
-    deepEqual(arrayObj.string, [], 'checking array of string');
     deepEqual(arrayObj.valueType, [], 'checking array of valueType');
     deepEqual(arrayObj.node, [], 'checking array of node');
     deepEqual(arrayObj.rawAsset, [], 'checking array of rawAsset');
     deepEqual(arrayObj.asset, [], 'checking array of asset');
 });
+
+test('simplified properties define using cc.xxxType', function () {
+    var Type = cc.Class({
+        properties: {
+            string: cc.String,
+            bool: cc.Boolean,
+            float: cc.Float,
+            int: cc.Integer,
+        }
+    });
+    var ArrayType = cc.Class({
+        properties: {
+            string: [cc.String],
+            bool: [cc.Boolean],
+            float: [cc.Float],
+            int: [cc.Integer],
+        }
+    });
+
+    strictEqual(cc.Class.attr(Type, 'string').type, undefined, 'checking string type');
+    strictEqual(cc.Class.attr(Type, 'string').ctor, undefined, 'checking string ctor');
+    strictEqual(cc.Class.attr(Type, 'bool').type, undefined, 'checking bool type');
+    strictEqual(cc.Class.attr(Type, 'bool').ctor, undefined, 'checking bool ctor');
+    strictEqual(cc.Class.attr(Type, 'float').type, undefined, 'checking float type');
+    strictEqual(cc.Class.attr(Type, 'float').ctor, undefined, 'checking float ctor');
+    strictEqual(cc.Class.attr(Type, 'int').type, undefined, 'checking int type');
+    strictEqual(cc.Class.attr(Type, 'int').ctor, undefined, 'checking int ctor');
+
+    strictEqual(cc.Class.attr(ArrayType, 'string').type, cc.String, 'checking array of string type');
+    strictEqual(cc.Class.attr(ArrayType, 'string').ctor, undefined, 'checking array of string ctor');
+    strictEqual(cc.Class.attr(ArrayType, 'bool').type, cc.Boolean, 'checking array of bool type');
+    strictEqual(cc.Class.attr(ArrayType, 'bool').ctor, undefined, 'checking array of bool ctor');
+    strictEqual(cc.Class.attr(ArrayType, 'float').type, cc.Float, 'checking array of float type');
+    strictEqual(cc.Class.attr(ArrayType, 'float').ctor, undefined, 'checking array of float ctor');
+    strictEqual(cc.Class.attr(ArrayType, 'int').type, cc.Integer, 'checking array of int type');
+    strictEqual(cc.Class.attr(ArrayType, 'int').ctor, undefined, 'checking array of int ctor');
+
+    var obj = new Type();
+    var arrayObj = new ArrayType();
+
+    strictEqual(obj.string, '', 'checking default value of string');
+    strictEqual(obj.bool, false, 'checking default value of bool');
+    strictEqual(obj.float, 0, 'checking default value of float');
+    strictEqual(obj.int, 0, 'checking default value of int');
+
+    deepEqual(arrayObj.bool, [], 'checking array of bool');
+    deepEqual(arrayObj.string, [], 'checking array of string');
+    deepEqual(arrayObj.float, [], 'checking array of float');
+    deepEqual(arrayObj.int, [], 'checking array of int');
+});
+
 
 // test('call CCClass', function () {
 //     var Husky = cc.Class({

--- a/test/qunit/unit/test-class.js
+++ b/test/qunit/unit/test-class.js
@@ -830,6 +830,62 @@ largeModule('Class ES6');
         deepEqual(arrayObj.asset, [], 'checking array of asset');
     });
 
+    test('simplified properties define using cc.xxxType', function () {
+        @ccclass
+        class Type {
+            @property(cc.String)
+            string = '';
+            @property(cc.Boolean)
+            bool = false;
+            @property(cc.Float)
+            float = 0;
+            @property(cc.Integer)
+            int = 0;
+        }
+        @ccclass
+        class ArrayType {
+            @property([cc.String])
+            string = [];
+            @property([cc.Boolean])
+            bool = [];
+            @property([cc.Float])
+            float = [];
+            @property([cc.Integer])
+            int = [];
+        }
+
+        strictEqual(cc.Class.attr(Type, 'string').type, undefined, 'checking string type');
+        strictEqual(cc.Class.attr(Type, 'string').ctor, undefined, 'checking string ctor');
+        strictEqual(cc.Class.attr(Type, 'bool').type, undefined, 'checking bool type');
+        strictEqual(cc.Class.attr(Type, 'bool').ctor, undefined, 'checking bool ctor');
+        strictEqual(cc.Class.attr(Type, 'float').type, undefined, 'checking float type');
+        strictEqual(cc.Class.attr(Type, 'float').ctor, undefined, 'checking float ctor');
+        strictEqual(cc.Class.attr(Type, 'int').type, undefined, 'checking int type');
+        strictEqual(cc.Class.attr(Type, 'int').ctor, undefined, 'checking int ctor');
+
+        strictEqual(cc.Class.attr(ArrayType, 'string').type, cc.String, 'checking array of string type');
+        strictEqual(cc.Class.attr(ArrayType, 'string').ctor, undefined, 'checking array of string ctor');
+        strictEqual(cc.Class.attr(ArrayType, 'bool').type, cc.Boolean, 'checking array of bool type');
+        strictEqual(cc.Class.attr(ArrayType, 'bool').ctor, undefined, 'checking array of bool ctor');
+        strictEqual(cc.Class.attr(ArrayType, 'float').type, cc.Float, 'checking array of float type');
+        strictEqual(cc.Class.attr(ArrayType, 'float').ctor, undefined, 'checking array of float ctor');
+        strictEqual(cc.Class.attr(ArrayType, 'int').type, cc.Integer, 'checking array of int type');
+        strictEqual(cc.Class.attr(ArrayType, 'int').ctor, undefined, 'checking array of int ctor');
+
+        var obj = new Type();
+        var arrayObj = new ArrayType();
+
+        strictEqual(obj.string, '', 'checking default value of string');
+        strictEqual(obj.bool, false, 'checking default value of bool');
+        strictEqual(obj.float, 0, 'checking default value of float');
+        strictEqual(obj.int, 0, 'checking default value of int');
+
+        deepEqual(arrayObj.bool, [], 'checking array of bool');
+        deepEqual(arrayObj.string, [], 'checking array of string');
+        deepEqual(arrayObj.float, [], 'checking array of float');
+        deepEqual(arrayObj.int, [], 'checking array of int');
+    });
+
     // test('property', function () {
     //     @ccclass
     //     class Foo {
@@ -850,7 +906,7 @@ largeModule('Class ES6');
     //             return this.bar;
     //         };
     //
-    //         // @property('Integer')
+    //         // @property(cc.Integer)
     //         set bbb (value) {
     //             this.bar = value;
     //         }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/766

先修复一丢丢现有问题

Changes:
 * 将 cc.Boolean/Float 等类型改为 Object，防止 Creator 2D 版本在未提供默认值的情况下，将默认值视为 "Boolean" 字符串

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
