### PR TITLE
fix warn after subContextView modules are excluded

### DIFF
--- a/cocos2d/core/components/index.js
+++ b/cocos2d/core/components/index.js
@@ -28,6 +28,24 @@ require('./CCComponent');
 require('./CCComponentEventHandler');
 require('./missing-script');
 
+// In case subContextView modules are excluded
+let WXSubContextView = require('./WXSubContextView');
+let SwanSubContextView = require('./SwanSubContextView');
+
+if (!WXSubContextView) {
+    WXSubContextView = cc.Class({
+        name: 'cc.WXSubContextView',
+        extends: cc.Component,
+    });
+}
+
+if (!SwanSubContextView) {
+    SwanSubContextView = cc.Class({
+        name: 'cc.SwanSubContextView',
+        extends: cc.Component,
+    });
+}
+
 var components = [
     require('./CCSprite'),
     require('./CCWidget'),
@@ -53,8 +71,8 @@ var components = [
     require('./CCToggle'),
     require('./CCBlockInputEvents'),
     require('./CCMotionStreak'),
-    require('./WXSubContextView'),
-    require('./SwanSubContextView'),
+    WXSubContextView,
+    SwanSubContextView,
 ];
 
 module.exports = components;


### PR DESCRIPTION
changeLog:
- 修复剔除 subContextView 组件后导致找不到组件的问题

关联：https://github.com/cocos-creator/fireball/pull/8968