### PR TITLE
Fix collider sync bug, add shape to body before enable body

### DIFF
--- a/cocos/3d/framework/physics/collider/collider-component.ts
+++ b/cocos/3d/framework/physics/collider/collider-component.ts
@@ -203,6 +203,7 @@ export class ColliderComponent extends PhysicsBasedComponent implements IEventTa
     protected onEnable () {
 
         if (!CC_EDITOR) {
+            super.onEnable();
 
             const rigidBody = this.sharedBody.rigidBody as RigidBodyComponent | null;
             if (rigidBody != null) {
@@ -217,9 +218,9 @@ export class ColliderComponent extends PhysicsBasedComponent implements IEventTa
             if (!CC_PHYSICS_BUILT_IN) {
                 this.sharedBody.body.addCollisionCallback(this._collisionCallBack);
             }
+            // sync after add shape
+            this.sharedBody.syncPhysWithScene();
         }
-
-        super.onEnable();
     }
 
     protected onDisable () {

--- a/cocos/3d/framework/physics/collider/collider-component.ts
+++ b/cocos/3d/framework/physics/collider/collider-component.ts
@@ -201,7 +201,6 @@ export class ColliderComponent extends PhysicsBasedComponent implements IEventTa
     }
 
     protected onEnable () {
-        super.onEnable();
 
         if (!CC_EDITOR) {
 
@@ -219,6 +218,8 @@ export class ColliderComponent extends PhysicsBasedComponent implements IEventTa
                 this.sharedBody.body.addCollisionCallback(this._collisionCallBack);
             }
         }
+
+        super.onEnable();
     }
 
     protected onDisable () {

--- a/cocos/3d/framework/physics/detail/physics-based-component.ts
+++ b/cocos/3d/framework/physics/detail/physics-based-component.ts
@@ -314,7 +314,11 @@ class SharedRigidBody {
         }
     }
 
-    public syncPhysWithScene (node: Node) {
+    public syncPhysWithScene (){
+        this._syncPhysWithScene(this._node);
+    }
+
+    private _syncPhysWithScene (node: Node) {
         // sync position rotation
         node.getWorldMatrix(SharedRigidBody._tempMat4);
         node.getWorldRotation(SharedRigidBody._tempQuat);
@@ -339,7 +343,7 @@ class SharedRigidBody {
 
     private _activeBody () {
         // Sync scenes, no matter how many activations
-        this.syncPhysWithScene(this._node);
+        this._syncPhysWithScene(this._node);
 
         if (this._actived) {
             return;
@@ -378,7 +382,7 @@ class SharedRigidBody {
                 this._body.scaleAllShapes(this._node.worldScale);
                 vec3.copy(this._prevScale, this._node.worldScale);
             }
-            this.syncPhysWithScene(this._node);
+            this._syncPhysWithScene(this._node);
 
             if (!CC_PHYSICS_BUILT_IN) {
                 if (this._body.isSleeping()) {
@@ -397,7 +401,7 @@ class SharedRigidBody {
                 // 对于只有形状组件的节点，需要将Scene中节点的Transform同步到Phyisc。
                 // 这是因为物理计算后可能会改变一些节点，这会导致这些子节点的Transform也发生改变。
                 if (this._node.hasChanged) {
-                    this.syncPhysWithScene(this._node);
+                    this._syncPhysWithScene(this._node);
 
                     if (this._body.isSleeping()) {
                         this._body.wakeUp();

--- a/cocos/3d/framework/physics/detail/physics-based-component.ts
+++ b/cocos/3d/framework/physics/detail/physics-based-component.ts
@@ -247,8 +247,6 @@ class SharedRigidBody {
 
     private _afterStepCallback!: AfterStepCallback;
 
-    private _transformInitialized: boolean = false;
-
     /** 是否只有Collider组件 */
     private _isShapeOnly: boolean = true;
 
@@ -340,11 +338,8 @@ class SharedRigidBody {
     }
 
     private _activeBody () {
-        // 是否为第一次激活
-        if (!this._transformInitialized) {
-            this._transformInitialized = true;
-            this.syncPhysWithScene(this._node);
-        }
+        // Sync scenes, no matter how many activations
+        this.syncPhysWithScene(this._node);
 
         if (this._actived) {
             return;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changes:
 * enable body will sync the body and shape, make sure add shape before enable

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
