### PR TITLE
fix audio stop after answering the phone call

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -875,7 +875,9 @@ var game = {
 
         if (CC_WECHATGAME && cc.sys.browserType !== cc.sys.BROWSER_TYPE_WECHAT_GAME_SUB) {
             wx.onShow && wx.onShow(onShown);
+            wx.onAudioInterruptionEnd && wx.onAudioInterruptionEnd(onShown);
             wx.onHide && wx.onHide(onHidden);
+            wx.onAudioInterruptionBegin && wx.onAudioInterruptionBegin(onHidden);
         }
 
         if ("onpageshow" in window && "onpagehide" in window) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1395

changeLog:
- 修复微信平台，接听语音电话之后，音频不再继续播放的问题

在微信平台，提供了独立的 `wx.onAudioInterruptionBegin` 接口来监听 **闹钟、电话、FaceTime 通话、微信语音聊天、微信视频聊天** 等事件，实际上这些事件在引擎里应该都归为 event_hide 事件