### PR TITLE
fixed get max joint matrix size for skinned mesh renderer

### DIFF
--- a/cocos2d/core/3d/skeleton/CCSkinnedMeshRenderer.js
+++ b/cocos2d/core/3d/skeleton/CCSkinnedMeshRenderer.js
@@ -31,8 +31,6 @@ const mat4 = cc.vmath.mat4;
 let _m4_tmp = mat4.create();
 
 const dummyNode = new cc.Node();
-const JOINT_MATRICES_SIZE = 50;
-const MAX_FLOAT_TEXTURE_SIZE = 64;
 
 /**
  * !#en
@@ -183,7 +181,7 @@ let SkinnedMeshRenderer = cc.Class({
         let customProperties = this._customProperties;
 
         let inited = false;
-        if (jointCount <= JOINT_MATRICES_SIZE) {
+        if (jointCount <= cc.sys.getMaxJointMatrixSize()) {
             inited = true;
 
             this._jointsData = this._jointsFloat32Data = new Float32Array(jointCount * 16);
@@ -191,8 +189,8 @@ let SkinnedMeshRenderer = cc.Class({
             customProperties.define('_USE_JOINTS_TEXTRUE', false);
         }
 
-        let SUPPORT_FLOAT_TEXTURE = !!cc.sys.glExtension('OES_texture_float');
         if (!inited) {
+            let SUPPORT_FLOAT_TEXTURE = !!cc.sys.glExtension('OES_texture_float');
             let size;
             if (jointCount > 256) {
                 size = 64;

--- a/cocos2d/core/3d/skeleton/CCSkinnedMeshRenderer.js
+++ b/cocos2d/core/3d/skeleton/CCSkinnedMeshRenderer.js
@@ -213,7 +213,7 @@ let SkinnedMeshRenderer = cc.Class({
                 pixelFormat = cc.Texture2D.PixelFormat.RGBA8888;
                 width *= 4;
 
-                cc.warn(`SkinnedMeshRenderer [${this.node.name}] has too much joints [${jointCount}] and device do not support float32 texture, fallback to use RGBA8888 texture, which is much slower.`);
+                cc.warn(`SkinnedMeshRenderer [${this.node.name}] has too many joints [${jointCount}] and device do not support float32 texture, fallback to use RGBA8888 texture, which is much slower.`);
             }
 
             let texture = this._jointsTexture || new cc.Texture2D();

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -626,7 +626,13 @@ function initSys () {
             const LEFT_UNIFORM_SIZE = 10;
 
             let gl = cc.game._renderContext;
-            sys._maxJointMatrixSize = Math.min(JOINT_MATRICES_SIZE, gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS) / 4 - LEFT_UNIFORM_SIZE);
+            let maxUniforms = Math.floor(gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS) / 4) - LEFT_UNIFORM_SIZE;
+            if (maxUniforms < JOINT_MATRICES_SIZE) {
+                sys._maxJointMatrixSize = 0;
+            }
+            else {
+                sys._maxJointMatrixSize = JOINT_MATRICES_SIZE;
+            }
         }
         return sys._maxJointMatrixSize;
     }

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -615,6 +615,21 @@ function initSys () {
         }
         return !!cc.renderer.device.ext(name);
     }
+
+    /**
+     * Get max joint matrix size for skinned mesh renderer.
+     * @method getMaxJointMatrixSize
+     */
+    sys.getMaxJointMatrixSize = function () {
+        if (!sys._maxJointMatrixSize) {
+            const JOINT_MATRICES_SIZE = 50;
+            const LEFT_UNIFORM_SIZE = 10;
+
+            let gl = cc.game._renderContext;
+            sys._maxJointMatrixSize = Math.min(JOINT_MATRICES_SIZE, gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS) / 4 - LEFT_UNIFORM_SIZE);
+        }
+        return sys._maxJointMatrixSize;
+    }
     
     if (_global.__platform && _global.__platform.getSystemInfo) {
         let env = _global.__platform.getSystemInfo();


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1578

Changes:
 * fixed get max joint matrix size for skinned mesh renderer
