### PR TITLE
fixed cc.tween

### DIFF
--- a/cocos2d/actions/tween.js
+++ b/cocos2d/actions/tween.js
@@ -22,7 +22,7 @@ let TweenAction = cc.Class({
 
             // property may have custom easing or progress function
             let easing, progress;
-            if (value.value && (value.easing || value.progress)) {
+            if (value.value !== undefined && (value.easing || value.progress)) {
                 if (typeof value.easing === 'string') {
                     easing = cc.easing[value.easing];
                     !easing && cc.warnID(1031, value.easing);


### PR DESCRIPTION
Re: https://forum.cocos.com/t/2-1-1-cc-tween-bug-2-1-2/80081

Changes:
 * fixed `cc.tween().to(1, { scale: 2, x: { value: 0, easing: 'sineOutIn' } })` has no effect
