### PR TITLE
fix repeatly recycle audio

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -40,7 +40,10 @@ let recycleAudio = function (audio) {
         audio.off('ended');
         audio.off('stop');
         audio.src = null;
-        _audioPool.push(audio);
+        // In case repeatly recycle audio
+        if (!_audioPool.includes(audio)) {
+            _audioPool.push(audio);
+        }
     }
     else {
         audio.destroy();


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1581

changeLog:
- audioEngine 无法停止播放背景音乐的问题

主要是因为 audioEngine 播放结束后，回收了 audio 到对象池，用户又手动调用了 uncache，而引擎没有防止重复回收的判断，导致对象池管理混乱