### PR TITLE
update build engine

### DIFF
--- a/rollup/src/build-engine-cli.ts
+++ b/rollup/src/build-engine-cli.ts
@@ -129,10 +129,6 @@ function getGlobalDefs (platform: Platform, physics: Physics, flags?: IFlags): o
             result.CC_PHYSICS_AMMO = false;
             result.CC_PHYSICS_BUILT_IN = true;
             break;
-
-        default:
-            throw new Error(`Unknown physics ${physics}.`);
-            break;
     }
 
     return result;


### PR DESCRIPTION
physics 传参错误时不应在命令行调用的脚本直接抛出错误