### PR TITLE
fix runMainLoop twice in editor

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -623,6 +623,9 @@ var game = {
     },
     //Run game.
     _runMainLoop: function () {
+        if (CC_EDITOR) {
+            return;
+        }
         var self = this, callback, config = self.config,
             director = cc.director,
             skip = true, frameRate = config.frameRate;


### PR DESCRIPTION
编辑器里会通过调用 tickInEditMode 来执行 mainLoop
引擎是不主动执行 mainLoop 的