### PR TITLE
set imageAsset._url when load finished

### DIFF
--- a/cocos/load-pipeline/loader.js
+++ b/cocos/load-pipeline/loader.js
@@ -69,7 +69,7 @@ function loadImage (item) {
     var rawUrl = item.rawUrl;
     var imageAsset = item.imageAsset || new ImageAsset();
     imageAsset._uuid = item.uuid;
-    imageAsset.url = rawUrl;
+    imageAsset._url = rawUrl;
     imageAsset._setRawAsset(rawUrl, false);
     imageAsset._nativeAsset = image;
     return imageAsset;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 加载远程图片之后，设置url

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
