### PR TITLE
fix CCParticleSystem _bytes error

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -901,7 +901,7 @@ var ParticleSystem = cc.Class({
     },
     
     lateUpdate (dt) {
-        if (!this._simulator.finished && this.sharedMaterials[0]) {
+        if (!this._simulator.finished && this.sharedMaterials[0] && this._ia) {
             this._simulator.step(dt);
         }
     },


### PR DESCRIPTION
Re:https://github.com/cocos-creator/2d-tasks/issues/1604 
用户反馈：https://forum.cocos.com/t/cocos-creator-v2-1-2-07-09-rc-4/79255/227


Changes:
 * 修复 CCParticleSystem 渲染时，IA 未创建出现的 _vertexFormat._bytes 为 null 的报错

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
