### PR TITLE
support alipay minigame

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -549,7 +549,6 @@ let Label = cc.Class({
     },
 
     onDestroy () {
-        this._assembler && this._assembler._resetAssemblerData && this._assembler._resetAssemblerData(this._assemblerData);
         this._assemblerData = null;
         this._letterTexture = null;
         if (this._ttfTexture) {
@@ -599,11 +598,11 @@ let Label = cc.Class({
     },
 
     _applyFontTexture (force) {
+        let self = this;
         let font = this.font;
         if (font instanceof cc.BitmapFont) {
             let spriteFrame = font.spriteFrame;
             this._frame = spriteFrame;
-            let self = this;
             let onBMFontTextureLoaded = function () {
                 // TODO: old texture in material have been released by loader
                 self._frame._texture = spriteFrame._texture;
@@ -637,6 +636,9 @@ let Label = cc.Class({
             } else if (!this._ttfTexture) {
                 this._ttfTexture = new cc.Texture2D();
                 this._assemblerData = this._assembler._getAssemblerData();
+                this._ttfTexture.on('load', function () {
+                    self._assembler && self._assembler._resetAssemblerData && self._assembler._resetAssemblerData(self._assemblerData);
+                });
                 this._ttfTexture.initWithElement(this._assemblerData.canvas);
             } 
 

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -636,9 +636,11 @@ let Label = cc.Class({
             } else if (!this._ttfTexture) {
                 this._ttfTexture = new cc.Texture2D();
                 this._assemblerData = this._assembler._getAssemblerData();
-                this._ttfTexture.on('load', function () {
+                function onTextureLoaded () {
                     self._assembler && self._assembler._resetAssemblerData && self._assembler._resetAssemblerData(self._assemblerData);
-                });
+                    self._ttfTexture.off('load', onTextureLoaded);
+                }
+                this._ttfTexture.on('load', onTextureLoaded);
                 this._ttfTexture.initWithElement(this._assemblerData.canvas);
             } 
 

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -402,6 +402,12 @@ function initSys () {
      */
     sys.JKW_GAME = 112;
     /**
+     * @property {Number} ALIPAY_GAME
+     * @readOnly
+     * @default 113
+     */
+    sys.ALIPAY_GAME = 113;
+    /**
      * BROWSER_TYPE_WECHAT
      * @property {String} BROWSER_TYPE_WECHAT
      * @readOnly
@@ -443,6 +449,13 @@ function initSys () {
      * @default "xiaomigame"
      */
     sys.BROWSER_TYPE_XIAOMI_GAME = "xiaomigame";
+    /**
+     * BROWSER_TYPE_ALIPAY_GAME
+     * @property {String} BROWSER_TYPE_ALIPAY_GAME
+     * @readOnly
+     * @default "alipaygame"
+     */
+    sys.BROWSER_TYPE_ALIPAY_GAME = "alipaygame";
     /**
      * BROWSER_TYPE_QQ_PLAY
      * @property {String} BROWSER_TYPE_QQ_PLAY

--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -33,10 +33,12 @@ require('../platform/CCClass');
 // TODO: move into adapter
 const isXiaomiGame = (cc.sys.platform === cc.sys.XIAOMI_GAME);
 const isBaiduGame = (cc.sys.platform === cc.sys.BAIDU_GAME);
+const isAlipayGame = (cc.sys.platform === cc.sys.ALIPAY_GAME);
 
 var __BrowserGetter = {
     init: function(){
-        if (!CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame && !isXiaomiGame) {
+        // NOTE: not merge into v2.2.0, move into Alipay adapter
+        if (!CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame && !isXiaomiGame && !isAlipayGame) {
             this.html = document.getElementsByTagName("html")[0];
         }
     },
@@ -72,6 +74,11 @@ if (isBaiduGame) {
 
 if (isXiaomiGame) {
     __BrowserGetter.adaptationType = cc.sys.BROWSER_TYPE_XIAOMI_GAME;
+}
+
+// NOTE: not merge into v2.2.0, move into Alipay adapter
+if (isAlipayGame) {
+    __BrowserGetter.adaptationType = cc.sys.BROWSER_TYPE_ALIPAY_GAME;
 }
 
 if (CC_WECHATGAME) {
@@ -420,7 +427,8 @@ cc.js.mixin(View.prototype, {
     },
 
     _adjustViewportMeta: function () {
-        if (this._isAdjustViewport && !CC_JSB && !CC_RUNTIME && !CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame && !isXiaomiGame) {
+        // NOTE: not merge into v2.2.0, move into Alipay adapter
+        if (this._isAdjustViewport && !CC_JSB && !CC_RUNTIME && !CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame && !isXiaomiGame && !isAlipayGame) {
             this._setViewportMeta(__BrowserGetter.meta, false);
             this._isAdjustViewport = false;
         }
@@ -822,7 +830,8 @@ cc.js.mixin(View.prototype, {
      * @param {ResolutionPolicy|Number} resolutionPolicy The resolution policy desired
      */
     setRealPixelResolution: function (width, height, resolutionPolicy) {
-        if (!CC_JSB && !CC_RUNTIME && !CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame && !isXiaomiGame) {
+        // NOTE: not merge into v2.2.0, move into Alipay adapter
+        if (!CC_JSB && !CC_RUNTIME && !CC_WECHATGAME && !CC_QQPLAY && !isBaiduGame && !isXiaomiGame && !isAlipayGame) {
             // Set viewport's width
             this._setViewportMeta({"width": width}, true);
 
@@ -1080,7 +1089,8 @@ cc.ContainerStrategy = cc.Class({
     _setupContainer: function (view, w, h) {
         var locCanvas = cc.game.canvas, locContainer = cc.game.container;
 
-        if (!CC_WECHATGAME && !isBaiduGame && !isXiaomiGame) {
+        // NOTE: not merge into v2.2.0, move into Alipay adapter
+        if (!CC_WECHATGAME && !isBaiduGame && !isXiaomiGame && !isAlipayGame) {
             if (cc.sys.os === cc.sys.OS_ANDROID) {
                 document.body.style.width = (view._isRotated ? h : w) + 'px';
                 document.body.style.height = (view._isRotated ? w : h) + 'px';

--- a/cocos2d/core/utils/profiler/CCProfiler.js
+++ b/cocos2d/core/utils/profiler/CCProfiler.js
@@ -79,7 +79,12 @@ function generateAtlas () {
     
     for (let i = 32; i <= 126; i++) {
         let char = String.fromCharCode(i);
-        let width = ctx.measureText(char).width;
+        let measureResult = ctx.measureText(char);
+        let width = measureResult.width;
+        // NOTE: not merge into v2.2.0, move into Alipay adapter
+        if (measureResult.height) {
+            lineHeight = measureResult.height;
+        }
     
         if ((x + width) >= textureWidth) {
             x = space;

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -542,10 +542,8 @@ VideoPlayerImpl._polyfill = {
  * so it is best to provide mp4 and webm or ogv file
  */
 // TODO: move into adapter
-const isXiaomiGame = (cc.sys.platform === cc.sys.XIAOMI_GAME);
-const isBaiduGame = (cc.sys.platform === cc.sys.BAIDU_GAME);
 let dom = document.createElement("video");
-if (!CC_WECHATGAME && !isBaiduGame && !isXiaomiGame) {
+if (dom.canPlayType) {
     if (dom.canPlayType("video/ogg")) {
         VideoPlayerImpl._polyfill.canPlayType.push(".ogg");
         VideoPlayerImpl._polyfill.canPlayType.push(".ogv");


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1615

由于支付宝创建离屏 canvas 的成本较高，测试是创建 30 个 canvas 内存就会崩
目前是尽量回收 canvas，在提交完 texture 之后就回收 canvas，之后优化的方向是尽量使用一个 canvas 来绘制

pr 里还有一些平台相关的代码， 2.2 分支里要移到 adapter 层