### PR TITLE
fix CCParticleSystem set material define wrong operation

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -553,8 +553,10 @@ var properties = {
             return this._positionType;
         },
         set (val) {
-            if (this.sharedMaterials[0])
-                this.sharedMaterials[0].define('_USE_MODEL', val !== PositionType.FREE);
+            let material = this.getMaterial(0);
+            if (material) {
+                material.define('_USE_MODEL', val !== PositionType.FREE);
+            }
             this._positionType = val;
         }
     },


### PR DESCRIPTION
Re: https://forum.cocos.com/t/2-1-2-bug-demo-07-15/80507/6

Changes:
 * 修复粒子中设置 material define  错误操作，导致会影响到 sprite 的渲染