### PR TITLE
remove warning when upgrading editBox compnent

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -297,10 +297,7 @@ let EditBox = cc.Class({
         },
 
         // To be removed in the future
-        _N$fontColor: {
-            default: undefined,
-            type: cc.Color,
-        },
+        _N$fontColor: undefined,
 
         /**
          * !#en The display text of placeholder.
@@ -380,10 +377,7 @@ let EditBox = cc.Class({
         },
 
         // To be removed in the future
-        _N$placeholderFontColor: {
-            default: undefined,
-            type: cc.Color,
-        },
+        _N$placeholderFontColor: undefined,
 
         /**
          * !#en The maximize input length of EditBox.


### PR DESCRIPTION
changeLog:
- 去掉 editBox 相关 fontColor 属性的警告

<img width="932" alt="WechatIMG22" src="https://user-images.githubusercontent.com/17872773/61513955-42a8f800-aa31-11e9-8e38-5ca1c59e3d5d.png">

