### PR TITLE
BUG FIX: audio fail to register touch event listener && fix audio loading

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -158,8 +158,9 @@ Audio.State = {
             if (touchBinded) return;
             touchBinded = true;
 
+            let touchEventName = ('ontouchend' in window) ? 'touchend' : 'mousedown';
             // Listen to the touchstart body event and play the audio when necessary.
-            cc.game.canvas.addEventListener('touchstart', function () {
+            cc.game.canvas.addEventListener(touchEventName, function () {
                 let item;
                 while (item = touchPlayList.pop()) {
                     item.audio.play(item.offset);

--- a/cocos2d/core/load-pipeline/audio-downloader.js
+++ b/cocos2d/core/load-pipeline/audio-downloader.js
@@ -38,7 +38,8 @@ function loadDomAudio (item, callback) {
     // TODO: move into adapter
     const isXiaomiGame = (cc.sys.platform === cc.sys.XIAOMI_GAME);
     const isBaiduGame = (cc.sys.platform === cc.sys.BAIDU_GAME);
-    if (CC_WECHATGAME || isBaiduGame || isXiaomiGame) {
+    const isAlipayGame = (cc.sys.platform === cc.sys.ALIPAY_GAME);
+    if (CC_WECHATGAME || isBaiduGame || isXiaomiGame || isAlipayGame) {
         callback(null, dom);
         return;
     }


### PR DESCRIPTION
changeLog:
- 修复 chrome 和 safari 浏览器上音频不能播放的问题，原因是 pc 浏览器上没有 touch 事件的回调
- 修复支付宝上 domAudio 加载失败问题