### PR TITLE
fix IE11's not supporting to Array.includes

### DIFF
--- a/polyfill/array.js
+++ b/polyfill/array.js
@@ -18,17 +18,9 @@ if (!Array.prototype.find) {
     };
 }
 
+// for ie 11
 if (!Array.prototype.includes) {
-    Array.prototype.includes = function () {       
-        var length = this.length, i = 0;
-        if (arguments.length >= 2) {
-            i = arguments[1];
-        }
-        for(; i < length; i++) {
-            if(this[i] === arguments[0]) {
-                return true;
-            }
-        }
-        return false;
-    };
+   Array.prototype.includes = function (value) {
+       return this.indexOf(value) !== -1;
+   };
 }

--- a/polyfill/array.js
+++ b/polyfill/array.js
@@ -20,7 +20,7 @@ if (!Array.prototype.find) {
 
 // for ie 11
 if (!Array.prototype.includes) {
-   Array.prototype.includes = function (value) {
-       return this.indexOf(value) !== -1;
-   };
+    Array.prototype.includes = function (value) {
+        return this.indexOf(value) !== -1;
+    };
 }

--- a/polyfill/array.js
+++ b/polyfill/array.js
@@ -17,3 +17,19 @@ if (!Array.prototype.find) {
         return undefined;
     };
 }
+
+// 
+if (!Array.prototype.includes) {
+    Array.prototype.includes = function () {       
+        var length = this.length, i = 0;
+        if (arguments.length >= 2) {
+            i = arguments[1];
+        }
+        for(; i < length; i++) {
+            if(this[i] === arguments[0]) {
+                return true;
+            }
+        }
+        return false;
+    };
+}

--- a/polyfill/array.js
+++ b/polyfill/array.js
@@ -18,7 +18,6 @@ if (!Array.prototype.find) {
     };
 }
 
-// 
 if (!Array.prototype.includes) {
     Array.prototype.includes = function () {       
         var length = this.length, i = 0;

--- a/test/qunit/lib/polyfill-for-phantom.js
+++ b/test/qunit/lib/polyfill-for-phantom.js
@@ -58,13 +58,6 @@ if (!Function.prototype.bind) {
     };
 }
 
-//if (!Array.prototype.includes) {
-//    // This will break test-node-serialization.js
-//    Array.prototype.includes = function (value) {
-//        return this.indexOf(value) !== -1;
-//    };
-//}
-
 var isPhantomJS = window.navigator.userAgent.indexOf('PhantomJS') !== -1;
 if (isPhantomJS) {
     QUnit.config.notrycatch = true;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1609

Changes:
 * 完善 ie11 对 Array.includes 的支持

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
