### PR TITLE
V2.1.3 fix for IE11's not supporting to Array.includes

### DIFF
--- a/polyfill/array.js
+++ b/polyfill/array.js
@@ -17,3 +17,10 @@ if (!Array.prototype.find) {
         return undefined;
     };
 }
+
+// for ie 11
+if (!Array.prototype.includes) {
+    Array.prototype.includes = function (value) {
+        return this.indexOf(value) !== -1;
+    };
+}

--- a/test/qunit/lib/polyfill-for-phantom.js
+++ b/test/qunit/lib/polyfill-for-phantom.js
@@ -58,13 +58,6 @@ if (!Function.prototype.bind) {
     };
 }
 
-//if (!Array.prototype.includes) {
-//    // This will break test-node-serialization.js
-//    Array.prototype.includes = function (value) {
-//        return this.indexOf(value) !== -1;
-//    };
-//}
-
 var isPhantomJS = window.navigator.userAgent.indexOf('PhantomJS') !== -1;
 if (isPhantomJS) {
     QUnit.config.notrycatch = true;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1636

Changes:
 * fix for IE11's not supporting to Array.includes

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
