### PR TITLE
fix browser breaking when playing audio on uc browser

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -350,7 +350,8 @@ Audio.State = {
 // TIME_CONSTANT need to be 0 by default, or may fail to set volume at the very beginning of playing audio
 let TIME_CONSTANT;
 if (cc.sys.browserType === cc.sys.BROWSER_TYPE_EDGE || 
-    cc.sys.browserType === cc.sys.BROWSER_TYPE_BAIDU) {
+    cc.sys.browserType === cc.sys.BROWSER_TYPE_BAIDU ||
+    cc.sys.browserType === cc.sys.BROWSER_TYPE_UC) {
     TIME_CONSTANT = 0.01;
 }
 else {

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -995,37 +995,30 @@ function initSys () {
         /* Determine the browser type */
         (function(){
             var typeReg1 = /mqqbrowser|micromessenger|qq|sogou|qzone|liebao|maxthon|ucbs|360 aphone|360browser|baiduboxapp|baidubrowser|maxthon|mxbrowser|miuibrowser/i;
-            var typeReg2 = /qqbrowser|ucbrowser|edge|ubrowser/i;
+            var typeReg2 = /qqbrowser|ucbrowser|ubrowser|edge/i;
             var typeReg3 = /chrome|safari|firefox|trident|opera|opr\/|oupeng/i;
-            var browserTypes = typeReg1.exec(ua);
-            if(!browserTypes) browserTypes = typeReg2.exec(ua);
-            if(!browserTypes) browserTypes = typeReg3.exec(ua);
+            var browserTypes = typeReg1.exec(ua) || typeReg2.exec(ua) || typeReg3.exec(ua);
 
             var browserType = browserTypes ? browserTypes[0].toLowerCase() : sys.BROWSER_TYPE_UNKNOWN;
             if (CC_WECHATGAME)
                 browserType = sys.BROWSER_TYPE_WECHAT_GAME;
             else if (CC_QQPLAY)
                 browserType = sys.BROWSER_TYPE_QQ_PLAY;
-            else if (browserType === 'micromessenger')
-                browserType = sys.BROWSER_TYPE_WECHAT;
             else if (browserType === "safari" && isAndroid)
                 browserType = sys.BROWSER_TYPE_ANDROID;
             else if (browserType === "qq" && ua.match(/android.*applewebkit/i))
                 browserType = sys.BROWSER_TYPE_ANDROID;
-            else if (browserType === "trident")
-                browserType = sys.BROWSER_TYPE_IE;
-            else if (browserType === 'edge')
-                browserType === sys.BROWSER_TYPE_EDGE;
-            else if (browserType === "360 aphone")
-                browserType = sys.BROWSER_TYPE_360;
-            else if (browserType === "mxbrowser")
-                browserType = sys.BROWSER_TYPE_MAXTHON;
-            else if (browserType === "opr/")
-                browserType = sys.BROWSER_TYPE_OPERA;
-            else if (browserType === "ucbrowser" || browserType === 'ubrowser')
-                browserType = sys.BROWSER_TYPE_UC;
-
-            sys.browserType = browserType;
+            let typeMap = {
+                'micromessenger': sys.BROWSER_TYPE_WECHAT,
+                'trident': sys.BROWSER_TYPE_IE,
+                'edge': sys.BROWSER_TYPE_EDGE,
+                '360 aphone': sys.BROWSER_TYPE_360,
+                'mxbrowser': sys.BROWSER_TYPE_MAXTHON,
+                'opr/': sys.BROWSER_TYPE_OPERA,
+                'ubrowser': sys.BROWSER_TYPE_UC
+            };
+            
+            sys.browserType = typeMap[browserType] || browserType;
         })();
 
         /**

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -995,7 +995,7 @@ function initSys () {
         /* Determine the browser type */
         (function(){
             var typeReg1 = /mqqbrowser|micromessenger|qq|sogou|qzone|liebao|maxthon|ucbs|360 aphone|360browser|baiduboxapp|baidubrowser|maxthon|mxbrowser|miuibrowser/i;
-            var typeReg2 = /qqbrowser|ucbrowser|edge/i;
+            var typeReg2 = /qqbrowser|ucbrowser|edge|ubrowser/i;
             var typeReg3 = /chrome|safari|firefox|trident|opera|opr\/|oupeng/i;
             var browserTypes = typeReg1.exec(ua);
             if(!browserTypes) browserTypes = typeReg2.exec(ua);
@@ -1022,6 +1022,8 @@ function initSys () {
                 browserType = sys.BROWSER_TYPE_MAXTHON;
             else if (browserType === "opr/")
                 browserType = sys.BROWSER_TYPE_OPERA;
+            else if (browserType === "ucbrowser" || browserType === 'ubrowser')
+                browserType = sys.BROWSER_TYPE_UC;
 
             sys.browserType = browserType;
         })();


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1636

Changes:
 * now when using uc browser to play audio, the delay time before setting takes effects will be set to 0.01s.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
