### PR TITLE
Fix call node targetOff func has not remove node from target.__eventTargets array

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1739,10 +1739,6 @@ let NodeDefines = {
         if (listeners) {
             listeners.targetOff(target);
 
-            if (target && target.__eventTargets) {
-                js.array.fastRemove(target.__eventTargets, this);
-            }
-
             // Check for event mask reset
             if ((this._eventMask & POSITION_ON) && !listeners.hasEventListener(EventType.POSITION_CHANGED)) {
                 this._eventMask &= ~POSITION_ON;
@@ -1765,6 +1761,10 @@ let NodeDefines = {
         }
         if (this._capturingListeners) {
             this._capturingListeners.targetOff(target);
+        }
+
+        if (target && target.__eventTargets) {
+            js.array.fastRemove(target.__eventTargets, this);
         }
 
         if (this._touchListener && !_checkListeners(this, _touchEvents)) {

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1739,6 +1739,10 @@ let NodeDefines = {
         if (listeners) {
             listeners.targetOff(target);
 
+            if (target && target.__eventTargets) {
+                js.array.fastRemove(target.__eventTargets, this);
+            }
+
             // Check for event mask reset
             if ((this._eventMask & POSITION_ON) && !listeners.hasEventListener(EventType.POSITION_CHANGED)) {
                 this._eventMask &= ~POSITION_ON;

--- a/cocos2d/core/event/event-target.js
+++ b/cocos2d/core/event/event-target.js
@@ -133,11 +133,15 @@ proto.on = function (type, callback, target) {
  */
 proto.off = function (type, callback, target) {
     if (!callback) {
-        this.removeAll(type);
-
-        if (target && target.__eventTargets) {
-            fastRemove(target.__eventTargets, this);
+        let list = this._callbackTable[type];
+        let targets = list.targets;
+        for (let i = 0; i < targets.length; ++i) {
+            let target = targets[i];
+            if (target && target.__eventTargets) {
+                fastRemove(target.__eventTargets, this);
+            }
         }
+        this.removeAll(type);
     }
     else {
         this.remove(type, callback, target);

--- a/cocos2d/core/event/event-target.js
+++ b/cocos2d/core/event/event-target.js
@@ -134,6 +134,10 @@ proto.on = function (type, callback, target) {
 proto.off = function (type, callback, target) {
     if (!callback) {
         this.removeAll(type);
+
+        if (target && target.__eventTargets) {
+            fastRemove(target.__eventTargets, this);
+        }
     }
     else {
         this.remove(type, callback, target);
@@ -155,7 +159,13 @@ proto.off = function (type, callback, target) {
  * @method targetOff
  * @param {Object} target - The target to be searched for all related listeners
  */
-proto.targetOff = proto.removeAll;
+proto.targetOff = function (target) {
+    this.removeAll(target);
+    
+    if (target && target.__eventTargets) {
+        fastRemove(target.__eventTargets, this);
+    }
+};
 
 /**
  * !#en


### PR DESCRIPTION
修复调用node的targetOff方法，但没有将节点从target node的_eventTarget数组中移除的bug
forum:https://forum.cocos.com/t/targetoff/81473