### PR TITLE
bug fix on editBox

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -72,6 +72,7 @@ let EditBox = cc.Class({
                 return this._string;
             },
             set(value) {
+                value = '' + value;
                 if (this.maxLength >= 0 && value.length >= this.maxLength) {
                     value = value.slice(0, this.maxLength);
                 }

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -525,9 +525,12 @@ Object.assign(WebEditBoxImpl.prototype, {
             font = textLabel.fontFamily;
         }
 
+        // get font size
+        let fontSize = textLabel.fontSize * textLabel.node.scaleY;
+
         // whether need to update
         if (this._textLabelFont === font
-            && this._textLabelFontSize === textLabel.fontSize
+            && this._textLabelFontSize === fontSize
             && this._textLabelFontColor === textLabel.fontColor
             && this._textLabelAlign === textLabel.horizontalAlign) {
                 return;
@@ -535,13 +538,13 @@ Object.assign(WebEditBoxImpl.prototype, {
 
         // update cache
         this._textLabelFont = font;
-        this._textLabelFontSize = textLabel.fontSize;
+        this._textLabelFontSize = fontSize;
         this._textLabelFontColor = textLabel.fontColor;
         this._textLabelAlign = textLabel.horizontalAlign;
 
         let elem = this._elem;
         // font size
-        elem.style.fontSize = `${textLabel.fontSize}px`;
+        elem.style.fontSize = `${fontSize}px`;
         // font color
         elem.style.color = textLabel.node.color.toCSS('rgba');
         // font family
@@ -576,9 +579,12 @@ Object.assign(WebEditBoxImpl.prototype, {
             font = placeholderLabel.fontFamily;
         }
 
+        // get font size
+        let fontSize = placeholderLabel.fontSize * placeholderLabel.node.scaleY;
+
         // whether need to update
         if (this._placeholderLabelFont === font
-            && this._placeholderLabelFontSize === placeholderLabel.fontSize
+            && this._placeholderLabelFontSize === fontSize
             && this._placeholderLabelFontColor === placeholderLabel.fontColor
             && this._placeholderLabelAlign === placeholderLabel.horizontalAlign
             && this._placeholderLineHeight === placeholderLabel.fontSize) {
@@ -587,14 +593,13 @@ Object.assign(WebEditBoxImpl.prototype, {
 
         // update cache
         this._placeholderLabelFont = font;
-        this._placeholderLabelFontSize = placeholderLabel.fontSize;
+        this._placeholderLabelFontSize = fontSize;
         this._placeholderLabelFontColor = placeholderLabel.fontColor;
         this._placeholderLabelAlign = placeholderLabel.horizontalAlign;
         this._placeholderLineHeight = placeholderLabel.fontSize;
 
         let styleEl = this._placeholderStyleSheet;
-        // font size
-        let fontSize = placeholderLabel.fontSize;
+        
         // font color
         let fontColor = placeholderLabel.node.color.toCSS('rgba');
         // line height

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -639,6 +639,13 @@ Object.assign(WebEditBoxImpl.prototype, {
                 text-align: ${horizontalAlign};
             }
         `;
+        // EDGE_BUG_FIX: hide clear button, because clearing input box in Edge does not emit input event 
+        // issue refference: https://github.com/angular/angular/issues/26307
+        if (cc.sys.browserType === cc.sys.BROWSER_TYPE_EDGE) {
+            styleEl.innerHTML += `#${this._domId}::-ms-clear{
+                display: none;
+            }`;
+        }
     },
 
     // ===========================================


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1635

changeLog:
- 修复原生平台给 EditBox.string 传 number 类型导致的报错问题
- Edge 浏览器上隐藏 Clear 按钮，因为清除输入内容不会触发 input 事件
- 同步 Label 节点的 scale 到 input.fontSize

![1](https://user-images.githubusercontent.com/17872773/62448238-e6b4d200-b799-11e9-9852-03e505cd120a.png)
![2](https://user-images.githubusercontent.com/17872773/62448257-f207fd80-b799-11e9-8a72-0e266f4455d0.png)
