### PR TITLE
fix event target off && remove target registered on node

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1774,12 +1774,8 @@ let NodeDefines = {
         if ( !listeners.hasEventListener(type, callback, target) ) {
             listeners.on(type, callback, target);
 
-            if (target) {
-                if (target.__eventTargets) {
-                    target.__eventTargets.push(this);
-                } else if (target.node && target.node.__eventTargets) {
-                    target.node.__eventTargets.push(this);
-                }
+            if (target && target.__eventTargets) {
+                target.__eventTargets.push(this);
             }
         }
 
@@ -1866,12 +1862,8 @@ let NodeDefines = {
             if (listeners) {
                 listeners.off(type, callback, target);
 
-                if (target) {
-                    if (target.__eventTargets) {
-                        js.array.fastRemove(target.__eventTargets, this);
-                    } else if (target.node && target.node.__eventTargets) {
-                        js.array.fastRemove(target.node.__eventTargets, this);
-                    }
+                if (target && target.__eventTargets) {
+                    js.array.fastRemove(target.__eventTargets, this);
                 }
             }
 

--- a/cocos2d/core/event/event-target.js
+++ b/cocos2d/core/event/event-target.js
@@ -105,13 +105,8 @@ proto.on = function (type, callback, target, once) {
     if ( !this.hasEventListener(type, callback, target) ) {
         this.__on(type, callback, target, once);
 
-        if (target) {
-            if (target.__eventTargets) {
-                target.__eventTargets.push(this);
-            }
-            else if (target.node && target.node.__eventTargets) {
-                target.node.__eventTargets.push(this);
-            }
+        if (target && target.__eventTargets) {
+            target.__eventTargets.push(this);
         }
     }
     return callback;
@@ -142,9 +137,9 @@ proto.__off = proto.off;
 proto.off = function (type, callback, target) {
     if (!callback) {
         let list = this._callbackTable[type];
-        let targets = list.targets;
-        for (let i = 0; i < targets.length; ++i) {
-            let target = targets[i];
+        let infos = list.callbackInfos;
+        for (let i = 0; i < infos.length; ++i) {
+            let target = infos[i].target;
             if (target && target.__eventTargets) {
                 fastRemove(target.__eventTargets, this);
             }
@@ -154,13 +149,8 @@ proto.off = function (type, callback, target) {
     else {
         this.__off(type, callback, target);
 
-        if (target) {
-            if (target.__eventTargets) {
-                fastRemove(target.__eventTargets, this);
-            }
-            else if (target.node && target.node.__eventTargets) {
-                fastRemove(target.node.__eventTargets, this);
-            }
+        if (target && target.__eventTargets) {
+            fastRemove(target.__eventTargets, this);
         }
     }
 };


### PR DESCRIPTION
Re: 
https://github.com/cocos-creator/2d-tasks/issues/1662
https://github.com/cocos-creator/2d-tasks/issues/1666

changeLog:
- 修复 event target 取消注册事件时的报错
- 移除在 target.node 上注册 __eventTargets，target 是 component，就没必要再注册 __eventTargets 到 node 上了