### PR TITLE
fix deletion of videoplayer will cause an error for 2d-tasks/issues/1680

### DIFF
--- a/cocos2d/videoplayer/CCVideoPlayer.js
+++ b/cocos2d/videoplayer/CCVideoPlayer.js
@@ -241,7 +241,7 @@ let VideoPlayer = cc.Class({
             default: true,
             type: cc.Boolean,
             notify: function () {
-                this._impl.setKeepAspectRatioEnabled(this.keepAspectRatio);
+                this._impl && this._impl.setKeepAspectRatioEnabled(this.keepAspectRatio);
             }
         },
 
@@ -258,12 +258,12 @@ let VideoPlayer = cc.Class({
         },
         isFullscreen: {
             get () {
-                this._isFullscreen = this._impl.isFullScreenEnabled();
+                this._isFullscreen = this._impl && this._impl.isFullScreenEnabled();
                 return this._isFullscreen;
             },
             set (enable) {
                 this._isFullscreen = enable;
-                this._impl.setFullScreenEnabled(enable);
+                this._impl && this._impl.setFullScreenEnabled(enable);
             },
             animatable: false,
             tooltip: CC_DEV && 'i18n:COMPONENT.videoplayer.isFullscreen'


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1680 cocos-creator/2d-tasks/issues/1691

Changes:
 * 修复当删除 videoplayer 会出现 isFullScreenEnabled 未定义的报错，因为删除了以后还会一帧 dump节点，这是获取组件上的 isFullScreenEnabled 数据的时候 _impl 已经是未定义了，才导致报错