### PR TITLE
fix label node size with outLine component

### DIFF
--- a/cocos2d/core/renderer/utils/label/letter-font.js
+++ b/cocos2d/core/renderer/utils/label/letter-font.js
@@ -401,8 +401,16 @@ module.exports = {
             _labelInfo.margin = 0;
         }
 
-        _contentSize.width = _comp.node._contentSize.width + _labelInfo.margin * 2;
-        _contentSize.height = _comp.node._contentSize.height + _labelInfo.margin * 2;
+        _contentSize.width = _comp.node.width;
+        _contentSize.height = _comp.node.height;
+
+        if (_overflow === Overflow.NONE) {
+            _contentSize.width += _labelInfo.margin * 2;
+            _contentSize.height += _labelInfo.margin * 2;
+        }
+        else if (_overflow === Overflow.RESIZE_HEIGHT) {
+            _contentSize.height += _labelInfo.margin * 2;
+        }
 
         _labelInfo.lineHeight = _lineHeight;
         _labelInfo.fontSize = _fontSize;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1665

changeLog:
- 修复带 outline 组件时，label 节点的尺寸更新不正确的 bug

RESIZE_HEIGHT 模式需要运行时自动加上 outline 高度
NONE 模式需要自动加上 outline 宽度和高度

其他的 SHRINK 和 CLAMP 模式，节点宽高都应该忠于用户自己的设置