### PR TITLE
rm rotation to eulerAngle for _upgrade_1x_to_2x code

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1343,22 +1343,6 @@ let NodeDefines = {
             this._zIndex = undefined;
         }
 
-        // TODO: remove _rotationX & _rotationY in future version, 3.0 ?
-        // Update eulerAngles from rotation, when upgrade from 1.x to 2.0
-        // If rotation x & y is 0 in old version, then update rotation from default quaternion is ok too
-        let eulerAngles = this._eulerAngles;
-        if ((this._rotationX || this._rotationY) &&
-            (eulerAngles.x === 0 && eulerAngles.y === 0 && eulerAngles.z === 0)) {
-            if (this._rotationX === this._rotationY) {
-                eulerAngles.z = -this._rotationX;
-            }
-            else {
-                eulerAngles.x = this._rotationX;
-                eulerAngles.y = this._rotationY;
-            }
-            this._rotationX = this._rotationY = undefined;
-        }
-
         this._fromEuler();
 
         // Upgrade from 2.0.0 preview 4 & earlier versions


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

相关联 pr https://github.com/cocos-creator/fireball/pull/9050

Changes:
 * 在场景与 prefab 导入的时候已经把 rotation 转换成 eulerAngle 了，这里的代码可以去掉了
