### PR TITLE
persist sprite's uv need update when dynamic atlas enabled

### DIFF
--- a/cocos2d/core/renderer/assembler-2d.js
+++ b/cocos2d/core/renderer/assembler-2d.js
@@ -125,6 +125,9 @@ export default class Assembler2D extends Assembler {
             if (!material) return;
             
             if (material.getProperty('texture') !== frame._texture) {
+                // texture was packed to dynamic atlas, should update uvs
+                comp._vertsDirty = true;
+
                 comp._activateMaterial();
             }
         }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * persist sprite's uv need update when dynamic atlas enabled
