### PR TITLE
space added when atlas calculates next y position.

### DIFF
--- a/cocos2d/core/renderer/utils/dynamic-atlas/atlas.js
+++ b/cocos2d/core/renderer/utils/dynamic-atlas/atlas.js
@@ -42,7 +42,7 @@ cc.js.mixin(Atlas.prototype, {
                 this._y = this._nexty;
             }
 
-            if ((this._y + height) > this._nexty) {
+            if ((this._y + height + space) > this._nexty) {
                 this._nexty = this._y + height + space;
             }
 


### PR DESCRIPTION
The dynamic atlas sometimes makes some border with scale because there is no y space.

border (scaled and rotated)
![image](https://user-images.githubusercontent.com/7022750/63634015-cf813b80-c605-11e9-838c-28c7357a70c3.png)

debug image of dynamic atlas
![image](https://user-images.githubusercontent.com/7022750/63633985-89c47300-c605-11e9-977c-8ddb9537da97.png)


Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [V] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [V] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
