### PR TITLE
refine engine prepare

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -384,27 +384,16 @@ var game = {
     },
 
     _prepareFinished (cb) {
-
         if (CC_PREVIEW && window.__modular) {
             window.__modular.run();
         }
-
-        this._prepared = true;
-
-        // Init engine
-        this._initEngine();
+        // Log engine version
+        console.log('Cocos Creator v' + cc.ENGINE_VERSION);
         
-        this._setAnimFrame();
-        cc.AssetLibrary._loadBuiltins(() => {
-            // Log engine version
-            console.log('Cocos Creator v' + cc.ENGINE_VERSION);
-
-            this._runMainLoop();
-
-            this.emit(this.EVENT_GAME_INITED);
-
-            if (cb) cb();
-        });
+        this._prepared = true;
+        this._runMainLoop();
+        this.emit(this.EVENT_GAME_INITED);
+        cb && cb();
     },
 
     eventTargetOn: EventTarget.prototype.on,
@@ -482,19 +471,24 @@ var game = {
             if (cb) cb();
             return;
         }
-
-        // Load game scripts
-        let jsList = this.config.jsList;
-        if (jsList && jsList.length > 0) {
-            var self = this;
-            cc.loader.load(jsList, function (err) {
-                if (err) throw new Error(JSON.stringify(err));
+        let self = this;
+        // Init engine
+        this._initEngine();
+        this._setAnimFrame();
+        // Load builtin assets
+        cc.AssetLibrary._loadBuiltins(function () {
+            // Load game scripts
+            let jsList = self.config.jsList;
+            if (jsList && jsList.length > 0) {
+                cc.loader.load(jsList, function (err) {
+                    if (err) throw new Error(JSON.stringify(err));
+                    self._prepareFinished(cb);
+                });
+            }
+            else {
                 self._prepareFinished(cb);
-            });
-        }
-        else {
-            this._prepareFinished(cb);
-        }
+            }
+        });
     },
 
     /**


### PR DESCRIPTION
changeLog:
- 修复在 mac 平台，插件脚本里调用 `cc.game.setFrameRate()` 失败的问题

setFrameRate 会生成 debug 信息的 labelAtlas，在这之前应该先加载完内置资源
所以 prepare 流程应该是 prepare -> loadBuiltins -> loadJsList -> prepareFinished

demo [iOS_frameRate.zip](https://github.com/cocos-creator/engine/files/3546998/iOS_frameRate.zip)
