### PR TITLE
Fixed a display error when Label's string was empty.

### DIFF
--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -598,7 +598,7 @@ var Texture2D = cc.Class({
      * @param {Boolean} [premultiplied]
      */
     handleLoadedTexture () {
-        if (!this._image || !this._image.width || !this._image.height)
+        if (!this._image || this._image.width == null || this._image.height == null)
             return;
         
         this.width = this._image.width;

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -536,7 +536,7 @@ let Label = cc.Class({
         this.node.on(cc.Node.EventType.COLOR_CHANGED, this._updateColor, this);
 
         this._checkStringEmpty();
-        this._updateRenderData(true);
+        this._updateRenderData(!!this.string);
     },
 
     onDisable () {


### PR DESCRIPTION
修复论坛中用户反馈的Label置空之后仍会显示的问题：

https://forum.cocos.com/t/label/81190
https://forum.cocos.com/t/cc-label-string/82642/9