### PR TITLE
Revert "refine engine prepare (#5261)"

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -384,16 +384,27 @@ var game = {
     },
 
     _prepareFinished (cb) {
+
         if (CC_PREVIEW && window.__modular) {
             window.__modular.run();
         }
-        // Log engine version
-        console.log('Cocos Creator v' + cc.ENGINE_VERSION);
-        
+
         this._prepared = true;
-        this._runMainLoop();
-        this.emit(this.EVENT_GAME_INITED);
-        cb && cb();
+
+        // Init engine
+        this._initEngine();
+        
+        this._setAnimFrame();
+        cc.AssetLibrary._loadBuiltins(() => {
+            // Log engine version
+            console.log('Cocos Creator v' + cc.ENGINE_VERSION);
+
+            this._runMainLoop();
+
+            this.emit(this.EVENT_GAME_INITED);
+
+            if (cb) cb();
+        });
     },
 
     eventTargetOn: EventTarget.prototype.on,
@@ -471,24 +482,19 @@ var game = {
             if (cb) cb();
             return;
         }
-        let self = this;
-        // Init engine
-        this._initEngine();
-        this._setAnimFrame();
-        // Load builtin assets
-        cc.AssetLibrary._loadBuiltins(function () {
-            // Load game scripts
-            let jsList = self.config.jsList;
-            if (jsList && jsList.length > 0) {
-                cc.loader.load(jsList, function (err) {
-                    if (err) throw new Error(JSON.stringify(err));
-                    self._prepareFinished(cb);
-                });
-            }
-            else {
+
+        // Load game scripts
+        let jsList = this.config.jsList;
+        if (jsList && jsList.length > 0) {
+            var self = this;
+            cc.loader.load(jsList, function (err) {
+                if (err) throw new Error(JSON.stringify(err));
                 self._prepareFinished(cb);
-            }
-        });
+            });
+        }
+        else {
+            this._prepareFinished(cb);
+        }
     },
 
     /**


### PR DESCRIPTION
revert pr: https://github.com/cocos-creator/engine/pull/5261

之前的问题是用户在插件脚本里 调用里 cc.game.setFrameRate ，这时候内置资源还没加载完。
所以之前的 pr 是调整了加载顺序为： 内置资源 -> 用户脚本

不过[文档](https://docs.cocos.com/creator/manual/zh/release-notes/upgrade-guide-v2.0.html#32-%E5%90%AF%E5%8A%A8%E6%B5%81%E7%A8%8B%E5%8D%87%E7%BA%A7)里，我们的加载流程是 用户脚本 -> 内置资源

用户也不应该在插件脚本里调引擎接口。这个应该在文档里补充说明。 @jareguo 


之前的修复也有一个问题，用户脚本里监听的 Event_ENGINE_INITED 失效了
