### PR TITLE
fix particle pos in worldSpace on Free Mode

### DIFF
--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -396,7 +396,8 @@ Simulator.prototype.step = function (dt) {
             let newPos = _tpa;
             let diff = _tpb;
             if (psys.positionType === cc.ParticleSystem.PositionType.FREE) {
-                diff.subSelf(particle.startPos);
+                diff.set(particle.startPos);
+                diff.negSelf();  // Unify direction with other positionType
                 newPos.set(particle.pos);
                 newPos.subSelf(diff);
             }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1708

changeLog:
- 修复 particleSystem Free 模式下，坐标计算错误的问题