### PR TITLE
Label support blendFunc setting for adapter

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -30,6 +30,7 @@ const Material = require('../assets/material/CCMaterial');
 const LabelFrame = require('../renderer/utils/label/label-frame');
 const RenderFlow = require('../renderer/render-flow');
 const opacityFlag = RenderFlow.FLAG_COLOR | RenderFlow.FLAG_OPACITY;
+const BlendFunc = require('../utils/blend-func');
 
 /**
  * !#en Enum for text alignment.
@@ -163,6 +164,7 @@ const CacheMode = cc.Enum({
 let Label = cc.Class({
     name: 'cc.Label',
     extends: RenderComponent,
+    mixins: [BlendFunc],
 
     ctor () {
         if (CC_EDITOR) {
@@ -521,6 +523,10 @@ let Label = cc.Class({
             this.cacheMode = CacheMode.BITMAP;
             this._batchAsBitmap = false;
         }
+
+        // default blend factor
+        this.srcBlendFactor = cc.macro.BlendFactor.SRC_ALPHA;
+        this.dstBlendFactor = cc.macro.BlendFactor.ONE_MINUS_SRC_ALPHA;
     },
 
     onEnable () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1750

关联 pr:
https://github.com/cocos-creator-packages/alipay-adapter/pull/10
https://github.com/cocos-creator/example-cases/pull/760

changeLog:
- Label 组件支持设置 srcBlendFactor 和 dstBlendFactor

主要是为了修复支付宝上的 label 黑边问题