### PR TITLE
Fix ccgame init order incorrect

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -389,8 +389,6 @@ var game = {
             window.__modular.run();
         }
 
-        this._prepared = true;
-
         // Init engine
         this._initEngine();
         
@@ -398,7 +396,7 @@ var game = {
         cc.AssetLibrary._loadBuiltins(() => {
             // Log engine version
             console.log('Cocos Creator v' + cc.ENGINE_VERSION);
-
+            this._prepared = true;
             this._runMainLoop();
 
             this.emit(this.EVENT_GAME_INITED);
@@ -627,6 +625,8 @@ var game = {
         if (CC_EDITOR) {
             return;
         }
+        if (!this._prepared) return;
+
         var self = this, callback, config = self.config,
             director = cc.director,
             skip = true, frameRate = config.frameRate;


### PR DESCRIPTION
修复profile文本及dragonbones消失的bug
issue: https://github.com/cocos-creator/2d-tasks/issues/1774

在android平台游戏启动时，会调用resume回调，在resume方法中调用了mainLoop方法，而此时引擎未初始化完，导致了一些异常，至于为什么之前没有问题，是因为之前的某一错误的写法导致了resume调用mainLoop方法时报错了，于是就“错错得对”了。