### PR TITLE
Fix the warn "WebGL: INVALID_VALUE: texImage2D: no canvas".

### DIFF
--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -629,7 +629,7 @@ var Texture2D = cc.Class({
      * @param {Boolean} [premultiplied]
      */
     handleLoadedTexture () {
-        if (!this._image || this._image.width == null || this._image.height == null)
+        if (!this._image || !this._image.width || !this._image.height)
             return;
         
         this.width = this._image.width;


### PR DESCRIPTION
修改说明：
这里还原一下，之前置空字符串仍然显示旧文本的BUG已经修复，与这里无关。使用canvas作为image时，提交宽度为0的image在Chrome会出现“WebGL: INVALID_VALUE: texImage2D: no canvas”的警告，然后后续再更新提交该image数据会无法渲染。手机端浏览器无警告，但是仍然会有渲染不出来的问题。