### PR TITLE
open and hide webgl canvas renderer modules by default

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -63,6 +63,8 @@
 
   {
     "name": "Canvas Renderer",
+    "locked": true,
+    "hide": true,
     "entries": [
       "./cocos2d/core/renderer/canvas/index.js"
     ]
@@ -289,6 +291,8 @@
   },
   {
     "name": "WebGL Renderer",
+    "locked": true,
+    "hide": true,
     "entries": [
       "./cocos2d/core/renderer/webgl/model-batcher.js",
       "./cocos2d/core/renderer/webgl/assemblers/index.js",


### PR DESCRIPTION
changeLog:
- 项目设置里，默认开启和隐藏 wengl 和 canvas 渲染模块。构建阶段会按需剔除