### PR TITLE
fix widget target haven't UITransformComponent error

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -2171,6 +2171,10 @@ AssetLibrary has already been initialized!
 
 Widget target must be one of the parent nodes of it
 
+### 6501
+
+%s's widget target must have UITransformComponent, Please add it in target
+
 ### 6600
 
 collider not added or already removed

--- a/cocos/ui/components/widget-component.ts
+++ b/cocos/ui/components/widget-component.ts
@@ -803,9 +803,13 @@ export class WidgetComponent extends Component {
 
     protected _registerTargetEvents () {
         const target = this._target || this.node.parent;
-        if (target){
-            target.on(SystemEventType.TRANSFORM_CHANGED, this._targetChangedOperation, this);
-            target.on(SystemEventType.SIZE_CHANGED, this._targetChangedOperation, this);
+        if (target) {
+            if (target.getComponent(UITransformComponent)) {
+                target.on(SystemEventType.TRANSFORM_CHANGED, this._targetChangedOperation, this);
+                target.on(SystemEventType.SIZE_CHANGED, this._targetChangedOperation, this);
+            } else {
+                cc.warnID(6501, this.node.name);
+            }
         }
     }
 

--- a/cocos/ui/components/widget-manager.ts
+++ b/cocos/ui/components/widget-manager.ts
@@ -40,6 +40,7 @@ import { Node } from '../../core/scene-graph/node';
 import { INode } from '../../core/utils/interfaces';
 import { array } from '../../core/utils/js';
 import { AlignFlags, AlignMode, computeInverseTransForTarget, getReadonlyNodeSize, WidgetComponent } from './widget-component';
+import { UITransformComponent } from '../../core/components';
 
 const _tempPos = new Vec3();
 const _defaultAnchor = new Vec2();
@@ -60,6 +61,9 @@ function align (node: INode, widget: WidgetComponent) {
         computeInverseTransForTarget(node as INode, target, inverseTranslate, inverseScale);
     } else {
         target = node.parent;
+    }
+    if (!target.getComponent (UITransformComponent)) {
+        return;
     }
     const targetSize = getReadonlyNodeSize(target);
     const isScene = target instanceof Scene;
@@ -415,6 +419,11 @@ export const widgetManager = cc._widgetManager = {
             }
 
             if (!e) {
+                return;
+            }
+
+            if (!widgetParent.getComponent(UITransformComponent)) {
+                cc.warnID(6501, widget.node.name);
                 return;
             }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/1276
If widget target haven't UITransformComponent，throw a warn.
add check in _registerTargetEvents() and align()
use cc.warnID
