### PR TITLE
Fixed matrix without restoring 3d nodes

### DIFF
--- a/cocos2d/core/3d/polyfill-3d.js
+++ b/cocos2d/core/3d/polyfill-3d.js
@@ -189,7 +189,6 @@ cc.js.getset(proto, 'position', proto.getPosition, setPosition, false, true);
 cc.js.getset(proto, 'is3DNode', function () {
     return this._is3DNode;
 }, function (v) {
-    if (this._is3DNode === v) return;
     this._is3DNode = v;
     this._update3DFunction();
 });

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -3216,6 +3216,8 @@ let NodeDefines = {
          * The node will be destroyed when deleting in the editor,
          * but it will be reserved and reused for undo.
         */
+        // restore 3d node
+        this.is3DNode = this.is3DNode;
         if (!this._matrix) {
             this._matrix = mathPools.mat4.get();
         }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复进入 prefab 编辑模式下，进行编译脚本后，退出 prefab 编辑模式，导致原来的场景的 3d 节点错乱，变成了 2d 节点
