### PR TITLE
in search of sub asset of image asset when load resource failed

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1806,6 +1806,10 @@ Since v1.10, for any atlas ("%s") in the "resources" directory, it is not possib
 
 Download Font [ %s ] failed, using Arial or system default font instead
 
+### 4934
+
+Please assure that the full path of sub asset is correct!
+
 ### 5000
 
 object already destroyed

--- a/cocos/core/load-pipeline/CCLoader.ts
+++ b/cocos/core/load-pipeline/CCLoader.ts
@@ -1016,18 +1016,7 @@ export class CCLoader extends Pipeline {
         mount = mount || 'assets';
         let uuid = '';
         if (CC_EDITOR) {
-            let info = EditorExtends.Asset.getAssetInfoFromUrl(`db://${mount}/resources/${url}`);
-            if (!info && type) {
-                if (isChildClassOf(type, SpriteFrame)) {
-                    info = EditorExtends.Asset.getAssetInfoFromUrl(`db://${mount}/resources/${url}/spriteFrame`);
-                }
-                else if (isChildClassOf(type, Texture2D)) {
-                    info = EditorExtends.Asset.getAssetInfoFromUrl(`db://${mount}/resources/${url}/texture`);
-                }
-                else if (isChildClassOf(type, TextureCube)) {
-                    info = EditorExtends.Asset.getAssetInfoFromUrl(`db://${mount}/resources/${url}/textureCube`);
-                }
-            }
+            const info = EditorExtends.Asset.getAssetInfoFromUrl(`db://${mount}/resources/${url}`);
             uuid = info ? info.uuid : '';
         }
         else {
@@ -1050,20 +1039,13 @@ export class CCLoader extends Pipeline {
                         }
                     }
                 }
-                if (!uuid && type) {
-                    if (isChildClassOf(type, SpriteFrame)) {
-                        uuid = assetTable.getUuid(url + '/spriteFrame', type);
-                    }
-                    else if (isChildClassOf(type, Texture2D)) {
-                        uuid = assetTable.getUuid(url + '/texture', type);
-                    }
-                    else if (isChildClassOf(type, TextureCube)) {
-                        uuid = assetTable.getUuid(url + '/textureCube', type);
-                    }
-                }
             }
         }
-
+        if (!uuid && type) {
+            if (isChildClassOf(type, SpriteFrame) || isChildClassOf(type, Texture2D) || isChildClassOf(type, TextureCube)) {
+                cc.warnID(4934);
+            }
+        }
         return uuid;
     }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 考虑到开发者的使用习惯还是 2d 那边的习惯，loadRes现在同时支持通过全名查找图片的子资源以及通过父资源名称加类型来查找图片子资源。目前只对图片资源做了这个兼容，其他的资源比如gltf，还是按照全名来查找

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
