### PR TITLE
V2.2.0 optimize group change event

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -579,7 +579,9 @@ function _getActualGroupIndex (node) {
 function _updateCullingMask (node) {
     let index = _getActualGroupIndex(node);
     node._cullingMask = 1 << index;
-    node.emit(EventType.GROUP_CHANGED, node);
+    if (CC_JSB && CC_NATIVERENDERER) {
+        node._proxy && node._proxy.updateCullingMask();
+    };
     for (let i = 0; i < node._children.length; i++) {
         _updateCullingMask(node._children[i]);
     }
@@ -644,6 +646,7 @@ let NodeDefines = {
             },
             set (value) {
                 this._groupIndex = value;
+                this.emit(EventType.GROUP_CHANGED, this);
                 _updateCullingMask(this);
             }
         },

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -646,8 +646,8 @@ let NodeDefines = {
             },
             set (value) {
                 this._groupIndex = value;
-                this.emit(EventType.GROUP_CHANGED, this);
                 _updateCullingMask(this);
+                this.emit(EventType.GROUP_CHANGED, this);
             }
         },
 


### PR DESCRIPTION
forum: https://forum.cocos.com/t/creator-2-2-0/83939
优化GroupChange事件，无需向子节点广播。
之前这么改是因为原生层需要知道cullingmask的值发生变更，现在改为cullingmask改变时，直接调用jsb接口，而不是监听GroupChange事件。
GroupChange只关心GroupIndex改变即可，无需关心CullingMask改变。