### PR TITLE
refine font setting both in Label and RichText component

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -164,7 +164,7 @@ let Label = cc.Class({
 
     ctor () {
         if (CC_EDITOR) {
-            this._userDefinedFont = null;
+            this._fontCache = null;
         }
 
         this._actualFontSize = 0;
@@ -368,18 +368,7 @@ let Label = cc.Class({
             },
             set (value) {
                 if (this.font === value) return;
-                
-                //if delete the font, we should change isSystemFontUsed to true
-                if (!value) {
-                    this._isSystemFontUsed = true;
-                }
-
-                if (CC_EDITOR && value) {
-                    this._userDefinedFont = value;
-                }
                 this._N$file = value;
-                if (value && this._isSystemFontUsed)
-                    this._isSystemFontUsed = false;
 
                 if ( typeof value === 'string' ) {
                     cc.warnID(4000);
@@ -389,6 +378,8 @@ let Label = cc.Class({
                 this._resetAssembler();
                 this._applyFontTexture(true);
                 this._lazyUpdateRenderData();
+
+                this.useSystemFont = value ? false : true;
             },
             type: cc.Font,
             tooltip: CC_DEV && 'i18n:COMPONENT.label.font',
@@ -408,26 +399,28 @@ let Label = cc.Class({
             },
             set (value) {
                 if (this._isSystemFontUsed === value) return;
-               
+                this._isSystemFontUsed = !!value;
+
                 if (CC_EDITOR) {
-                    if (!value && this._isSystemFontUsed && this._userDefinedFont) {
-                        this.font = this._userDefinedFont;
+                    if (value) {
+                        this._fontCache = this.font;
+                    }
+                    else if (this._fontCache) {
+                        this.font = this._fontCache;
                         this.spacingX = this._spacingX;
                         return;
                     }
                 }
 
-                this._isSystemFontUsed = !!value;
                 if (value) {
                     this.font = null;
                     this._resetAssembler();
                     this._lazyUpdateRenderData();
                     this._checkStringEmpty();
                 }
-                else if (!this._userDefinedFont) {
+                else if (!this.font) {
                     this.disableRender();
                 }
-
             },
             animatable: false,
             tooltip: CC_DEV && 'i18n:COMPONENT.label.system_font',

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -127,6 +127,7 @@ let RichText = cc.Class({
         this._linesWidth = [];
 
         if (CC_EDITOR) {
+            this._fontCache = null;
             this._updateRichTextStatus = debounce(this._updateRichText, 200);
         }
         else {
@@ -245,12 +246,34 @@ let RichText = cc.Class({
                 return this._isSystemFontUsed;
             },
             set (value) {
-                if (!value && !this.font || (this._isSystemFontUsed === value)) {
+                if (this._isSystemFontUsed === value) {
                     return;
                 }
                 this._isSystemFontUsed = value;
                 this._layoutDirty = true;
-                this._updateRichTextStatus();
+
+                if (CC_EDITOR) {
+                    if (value) {
+                        this._fontCache = this.font;
+                    }
+                    else if (this._fontCache) {
+                        this.font = this._fontCache;
+                        return;
+                    }
+                }
+
+                if (value) {
+                    this.font = null;
+                    this._updateRichTextStatus();
+                }
+                else if (!this.font) {
+                    this._labelSegments.forEach(node => {
+                        let comp = node.getComponent(cc.RenderComponent);
+                        if (comp) {
+                            comp.disableRender()
+                        }
+                    });
+                }
             },
             animatable: false,
             tooltip: CC_DEV && 'i18n:COMPONENT.richtext.system_font',


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1699

changeLog:
- 优化编辑器下 Label 和 RichText 的字体设置操作

![test](https://user-images.githubusercontent.com/17872773/65831407-9cf4ed80-e2eb-11e9-8864-752ed5c332ce.gif)

