### PR TITLE
refine font setting both in Label and RichText component

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1629,6 +1629,9 @@ The texture of Font '%s' must be already loaded on JSB. Using system font instea
 
 Sorry, lineHeight of system font not supported on JSB.
 
+### 4014
+You should set a custom font, or use system font by default.
+
 ### 4100
 
 Property padding is deprecated, please use paddingLeft, paddingRight, paddingTop and paddingBottom instead

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -164,7 +164,7 @@ let Label = cc.Class({
 
     ctor () {
         if (CC_EDITOR) {
-            this._userDefinedFont = null;
+            this._fontCache = null;
         }
 
         this._actualFontSize = 0;
@@ -368,18 +368,7 @@ let Label = cc.Class({
             },
             set (value) {
                 if (this.font === value) return;
-                
-                //if delete the font, we should change isSystemFontUsed to true
-                if (!value) {
-                    this._isSystemFontUsed = true;
-                }
-
-                if (CC_EDITOR && value) {
-                    this._userDefinedFont = value;
-                }
                 this._N$file = value;
-                if (value && this._isSystemFontUsed)
-                    this._isSystemFontUsed = false;
 
                 if ( typeof value === 'string' ) {
                     cc.warnID(4000);
@@ -389,6 +378,8 @@ let Label = cc.Class({
                 this._resetAssembler();
                 this._applyFontTexture(true);
                 this._lazyUpdateRenderData();
+
+                this.useSystemFont = value ? false : true;
             },
             type: cc.Font,
             tooltip: CC_DEV && 'i18n:COMPONENT.label.font',
@@ -408,26 +399,29 @@ let Label = cc.Class({
             },
             set (value) {
                 if (this._isSystemFontUsed === value) return;
-               
+                if (!(value || this.font || this._fontCache)) {
+                    cc.warnID(4014);
+                    return;
+                }
+                this._isSystemFontUsed = !!value;
+
                 if (CC_EDITOR) {
-                    if (!value && this._isSystemFontUsed && this._userDefinedFont) {
-                        this.font = this._userDefinedFont;
+                    if (value) {
+                        this._fontCache = this.font;
+                    }
+                    else if (this._fontCache) {
+                        this.font = this._fontCache;
                         this.spacingX = this._spacingX;
                         return;
                     }
                 }
 
-                this._isSystemFontUsed = !!value;
                 if (value) {
                     this.font = null;
-                    this._resetAssembler();
-                    this._lazyUpdateRenderData();
-                    this._checkStringEmpty();
                 }
-                else if (!this._userDefinedFont) {
-                    this.disableRender();
-                }
-
+                this._resetAssembler();
+                this._lazyUpdateRenderData();
+                this._checkStringEmpty();
             },
             animatable: false,
             tooltip: CC_DEV && 'i18n:COMPONENT.label.system_font',

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -127,6 +127,7 @@ let RichText = cc.Class({
         this._linesWidth = [];
 
         if (CC_EDITOR) {
+            this._fontCache = null;
             this._updateRichTextStatus = debounce(this._updateRichText, 200);
         }
         else {
@@ -226,11 +227,11 @@ let RichText = cc.Class({
                 if (this.font) {
                     this.useSystemFont = false;
                     this._onTTFLoaded();
+                    this._updateRichTextStatus();
                 }
                 else {
                     this.useSystemFont = true;
                 }
-                this._updateRichTextStatus();
             }
         },
 
@@ -245,11 +246,29 @@ let RichText = cc.Class({
                 return this._isSystemFontUsed;
             },
             set (value) {
-                if (!value && !this.font || (this._isSystemFontUsed === value)) {
+                if (this._isSystemFontUsed === value) {
+                    return;
+                }
+                if (!(value || this.font || this._fontCache)) {
+                    cc.warnID(4014);
                     return;
                 }
                 this._isSystemFontUsed = value;
-                this._layoutDirty = true;
+
+                if (CC_EDITOR) {
+                    if (value) {
+                        this._fontCache = this.font;
+                    }
+                    else if (this._fontCache) {
+                        this.font = this._fontCache;
+                        return;
+                    }
+                }
+
+                if (value) {
+                    this.font = null;
+                    this._layoutDirty = true;
+                }
                 this._updateRichTextStatus();
             },
             animatable: false,


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1699

changeLog:
- 优化 Label 和 RichText 的字体设置操作，禁止不设置自定义字体也不使用系统字体

![test](https://user-images.githubusercontent.com/17872773/65844481-0cf58900-e369-11e9-8161-8e5ab06b6846.gif)
