### PR TITLE
Fix the problem that Label switch CacheMode is invalid in Editor.

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -488,7 +488,9 @@ let Label = cc.Class({
                 if (oldValue === CacheMode.CHAR) {
                     this._ttfTexture = null;
                 }
-
+                
+                this._resetAssembler();
+                this._applyFontTexture(true);
                 this._lazyUpdateRenderData();
             },
             animatable: false

--- a/cocos2d/core/renderer/webgl/assemblers/label/2d/bmfont.js
+++ b/cocos2d/core/renderer/webgl/assemblers/label/2d/bmfont.js
@@ -58,7 +58,9 @@ export default class WebglBmfontAssembler extends BmfontAssembler {
         _dataOffset = 0;
     }
 
-    updateColor () {}
+    _getColor (comp) {
+        return comp.node._color._val;
+    }
 
     appendQuad (comp, texture, rect, rotated, x, y, scale) {
         let renderData = this._renderData;
@@ -72,7 +74,7 @@ export default class WebglBmfontAssembler extends BmfontAssembler {
             texh = texture.height,
             rectWidth = rect.width,
             rectHeight = rect.height,
-            color = comp.node._color._val;
+            color = this._getColor(comp);
 
         let l, b, r, t;
         let floatsPerVert = this.floatsPerVert;

--- a/cocos2d/core/renderer/webgl/assemblers/label/2d/letter.js
+++ b/cocos2d/core/renderer/webgl/assemblers/label/2d/letter.js
@@ -33,8 +33,13 @@ export default class WebglLetterFontAssembler extends LetterFontAssembler {
         return comp.requestRenderData();
     }
 
+    _getColor (comp) {
+        WHITE._fastSetA(comp.node._color.a);
+        return WHITE._val;
+    }
+
     updateColor (comp) {
-        WHITE._fastSetA(comp.node.color.a);
+        WHITE._fastSetA(comp.node._color.a);
         let color = WHITE._val;
 
         super.updateColor(comp, color);

--- a/cocos2d/core/renderer/webgl/assemblers/label/2d/letter.js
+++ b/cocos2d/core/renderer/webgl/assemblers/label/2d/letter.js
@@ -39,8 +39,7 @@ export default class WebglLetterFontAssembler extends LetterFontAssembler {
     }
 
     updateColor (comp) {
-        WHITE._fastSetA(comp.node._color.a);
-        let color = WHITE._val;
+        let color = this._getColor(comp);
 
         super.updateColor(comp, color);
     }

--- a/cocos2d/core/renderer/webgl/assemblers/label/2d/ttf.js
+++ b/cocos2d/core/renderer/webgl/assemblers/label/2d/ttf.js
@@ -43,7 +43,7 @@ export default class WebglTTFAssembler extends TTFAssembler {
     }
 
     updateColor (comp) {
-        WHITE._fastSetA(comp.node.color.a);
+        WHITE._fastSetA(comp.node._color.a);
         let color = WHITE._val;
 
         super.updateColor(comp, color);


### PR DESCRIPTION
修复几个重构导致的Label问题：
1.编辑器内修改CacheMode无效的问题。
2.BMFont字体修改节点颜色无效的问题。
3.Letter跟TTF访问节点颜色的时候直接使用_color。
4.CHAR模式节点颜色会叠加的问题。