### PR TITLE
Fix the problem of Label's assembler dynamic switching.

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -419,7 +419,7 @@ let Label = cc.Class({
                 this._isSystemFontUsed = !!value;
                 if (value) {
                     this.font = null;
-                    this._frame = null;
+
                     this._resetAssembler();
                     this._applyFontTexture(true);
                     this._lazyUpdateRenderData();
@@ -580,6 +580,12 @@ let Label = cc.Class({
             this._lazyUpdateRenderData();
         }
        RenderComponent.prototype._updateColor.call(this);
+    },
+
+    _resetAssembler () {
+        this._frame = null;
+
+        RenderComponent.prototype._resetAssembler.call(this);
     },
 
     _canRender () {


### PR DESCRIPTION
反馈：https://forum.cocos.com/t/cocos-creator-v2-2-0-09-30-beta-3/82831/467?u=cary

问题说明：
动态切换文本的Font之后，切换Assembler，所使用的SpriteFrame也需要重置，否则texture更新，rect数据没有同步更新。