### PR TITLE
fix animation playing logic

### DIFF
--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -186,7 +186,6 @@ export class AnimationComponent extends Component implements IEventTarget {
     }
 
     public start () {
-        this._crossFade.play();
         if (!CC_EDITOR && this.playOnLoad && this._defaultClip) {
             this.crossFade(this._defaultClip.name, 0);
         }
@@ -232,6 +231,7 @@ export class AnimationComponent extends Component implements IEventTarget {
     public crossFade (name: string, duration = 0.3) {
         const state = this._nameToState[name];
         if (state) {
+            this._crossFade.play();
             this._crossFade.crossFade(state, duration);
         }
     }


### PR DESCRIPTION
Before this PR, `AnimationComponent.crossFade` won't resume `CrossFade` state to `playing`, this leads to mistaken behaviour of any `AnimationComponent.play()` or `AnimationComponent.crossFade()` invocations after call to first `AnimationComponent.stop`.

This PR now invoke `CrossFade.play` everytime `AnimationComponent.crossFade` is called.