### PR TITLE
Limit vertical alignment when BMFont is overframed.

### DIFF
--- a/cocos2d/core/renderer/utils/label/bmfont.js
+++ b/cocos2d/core/renderer/utils/label/bmfont.js
@@ -630,7 +630,7 @@ export default class BmfontAssembler extends Assembler2D {
         // TOP
         _letterOffsetY = (_contentSize.height + _textDesiredHeight) / 2;
         if (_vAlign !== macro.VerticalTextAlignment.TOP) {
-            let blank = (_lineHeight - _originFontSize) * _bmfontScale;
+            let blank = Math.max((_lineHeight - _originFontSize), 0) * _bmfontScale;
             if (_vAlign === macro.VerticalTextAlignment.BOTTOM) {
                 // BOTTOM
                 _letterOffsetY -= blank;


### PR DESCRIPTION
@xunyi0 SHRINK模式下，当LineHeight小于OriginSize的时候，会通过上边缘对齐，下边缘对齐来进行Top和Bottom的垂直布局，表现就是Top下移，Bottom上移，现在限制这种超框情况下固定显示在节点中心区域内。