### PR TITLE
fix detect iPad device on IOS 13.1.1+

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -823,7 +823,7 @@ function initSys () {
             osVersion = uaResult[2] || '';
             osMainVersion = parseInt(osVersion) || 0;
         }
-        else if (/(iPhone|iPad|iPod|MacIntel)/.exec(nav.platform) {
+        else if (/(iPhone|iPad|iPod|MacIntel)/.exec(nav.platform)) {
             iOS = true;
             osVersion = '';
             osMainVersion = 0;

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -823,7 +823,7 @@ function initSys () {
             osVersion = uaResult[2] || '';
             osMainVersion = parseInt(osVersion) || 0;
         }
-        else if (/(iPhone|iPad|iPod)/.exec(nav.platform)) {
+        else if (/(iPhone|iPad|iPod)/.exec(nav.platform)||nav.platform === 'MacIntel') {
             iOS = true;
             osVersion = '';
             osMainVersion = 0;

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -823,7 +823,7 @@ function initSys () {
             osVersion = uaResult[2] || '';
             osMainVersion = parseInt(osVersion) || 0;
         }
-        else if (/(iPhone|iPad|iPod)/.exec(nav.platform)||nav.platform === 'MacIntel') {
+        else if (/(iPhone|iPad|iPod|MacIntel)/.exec(nav.platform) {
             iOS = true;
             osVersion = '';
             osMainVersion = 0;


### PR DESCRIPTION
修复更新ios13.1.1+版本后iPad设备的UA信息的识别=>
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko)"
参考资料：https://stackoverflow.com/questions/58019463

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
