### PR TITLE
align canvas with widget but not itself

### DIFF
--- a/cocos2d/core/components/CCCanvas.js
+++ b/cocos2d/core/components/CCCanvas.js
@@ -194,40 +194,44 @@ var Canvas = cc.Class({
         }
     },
 
-    //
-
+    // align canvas
     alignWithScreen: function () {
-        var designSize, nodeSize;
-        if (CC_EDITOR) {
-            nodeSize = designSize = cc.engine.getDesignResolutionSize();
-            this.node.setPosition(designSize.width * 0.5, designSize.height * 0.5);
+        let widget = this.node.getComponent(cc.Widget);
+        if (widget) {
+            widget.isAlignTop = true;
+            widget.isAlignBottom = true;
+            widget.isAlignLeft = true;
+            widget.isAlignRight = true;
+            widget.left = 0;
+            widget.right = 0;
+            widget.top = 0;
+            widget.bottom = 0;
         }
-        else {
-            var canvasSize = nodeSize = cc.visibleRect;
-            designSize = cc.view.getDesignResolutionSize();
-            var clipTopRight = !this.fitHeight && !this.fitWidth;
-            var offsetX = 0;
-            var offsetY = 0;
-            if (clipTopRight) {
-                // offset the canvas to make it in the center of screen
-                offsetX = (designSize.width - canvasSize.width) * 0.5;
-                offsetY = (designSize.height - canvasSize.height) * 0.5;
-            }
-            this.node.setPosition(canvasSize.width * 0.5 + offsetX, canvasSize.height * 0.5 + offsetY);
-        }
-        this.node.width = nodeSize.width;
-        this.node.height = nodeSize.height;
     },
 
+    // set policy and calculate
     applySettings: function () {
         var ResolutionPolicy = cc.ResolutionPolicy;
         var policy;
+        var hasWidget = this.getComponent(cc.Widget);
 
         if (this.fitHeight && this.fitWidth) {
-            policy = ResolutionPolicy.SHOW_ALL;
+            if (hasWidget) {
+                var designSize = CC_EDITOR ? cc.engine.getDesignResolutionSize() : cc.view.getDesignResolutionSize();
+                var canvasWidth = cc.game.canvas.width, canvasHeight = cc.game.canvas.height;
+                if (canvasWidth / designSize.width > canvasHeight / designSize.height) {
+                    policy = ResolutionPolicy.FIXED_HEIGHT;
+                }
+                else {
+                    policy = ResolutionPolicy.FIXED_WIDTH;
+                }
+            }
+            else {
+                policy = ResolutionPolicy.SHOW_ALL;
+            }
         }
         else if (!this.fitHeight && !this.fitWidth) {
-            policy = ResolutionPolicy.NO_BORDER;
+            policy = hasWidget ? ResolutionPolicy.NO_BORDER : ResolutionPolicy.UNKNOWN;
         }
         else if (this.fitWidth) {
             policy = ResolutionPolicy.FIXED_WIDTH;

--- a/cocos2d/core/components/CCCanvas.js
+++ b/cocos2d/core/components/CCCanvas.js
@@ -196,16 +196,25 @@ var Canvas = cc.Class({
 
     // align canvas
     alignWithScreen: function () {
-        let widget = this.node.getComponent(cc.Widget);
-        if (widget) {
-            widget.isAlignTop = true;
-            widget.isAlignBottom = true;
-            widget.isAlignLeft = true;
-            widget.isAlignRight = true;
-            widget.left = 0;
-            widget.right = 0;
-            widget.top = 0;
-            widget.bottom = 0;
+        // canvas should not be moved to another place but canvas area in editor
+        if (CC_EDITOR) {
+            let designRes = cc.engine.getDesignResolutionSize();
+            this.node.width = designRes.width;
+            this.node.height = designRes.height;
+            this.node.setPosition(designRes.width * 0.5, designRes.height * 0.5);
+        }
+        else {
+            let widget = this.node.getComponent(cc.Widget);
+            if (widget) {
+                widget.isAlignTop = true;
+                widget.isAlignBottom = true;
+                widget.isAlignLeft = true;
+                widget.isAlignRight = true;
+                widget.left = 0;
+                widget.right = 0;
+                widget.top = 0;
+                widget.bottom = 0;
+            }
         }
     },
 


### PR DESCRIPTION
re: cocos-creator/2d-tasks#1894
无 Widget 条件下，关闭 fitWidth 和 fitHeight 时，无论窗口大小如何，保留设计分辨率：

![image](https://user-images.githubusercontent.com/42939682/66993253-d1471700-f0fd-11e9-890f-1d5a0a22251e.png)

![image](https://user-images.githubusercontent.com/42939682/66993306-ea4fc800-f0fd-11e9-9783-1be16ae06098.png)

而单独打开 fitWidth 、单独打开 fitHeight 和两者都打开时会按照设定进行拉伸，保留黑边（下图中是两者都打开时）：

![image](https://user-images.githubusercontent.com/42939682/66993679-92fe2780-f0fe-11e9-81af-12d14ad7494b.png)

在有 Widget 条件下，关闭 fitWidth 和 fitHeight 时，会按照比例进行拉伸来保证屏幕中不存在黑边：

![image](https://user-images.githubusercontent.com/42939682/66993826-d8baf000-f0fe-11e9-8b06-d0c389384df2.png)

单独打开 fitWidth 、单独打开 fitHeight 和两者都打开时也会按照设定进行拉伸，不同的是会延伸覆盖黑边：

![image](https://user-images.githubusercontent.com/42939682/66993983-1fa8e580-f0ff-11e9-8ec0-210c2bb3dda7.png)
