### PR TITLE
allow up to 2^32 shader macro combinations

### DIFF
--- a/cocos/core/pipeline/render-pipeline.ts
+++ b/cocos/core/pipeline/render-pipeline.ts
@@ -1233,8 +1233,8 @@ export abstract class RenderPipeline {
                         model.updateUBOs();
                         this.addVisibleModel(model, camera);
                     }
-                }else{
-                    if ((model.node && (view.visibility & model.node.layer)) ||
+                } else {
+                    if (model.node && ((view.visibility & model.node.layer) === model.node.layer) ||
                         (view.visibility & model.visFlags)) {
                         model.updateTransform();
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#1667

Changelog:
 * allow up to 2^32 shader macro combinations
 * stricter layer check for rendering (to skip rendering grid in preview window)

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->