### PR TITLE
Fix tiledmap order bug

### DIFF
--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -687,6 +687,7 @@ let TiledMap = cc.Class({
                     node.addChild(child);
                 }
 
+                child.zIndex = i;
                 child.active = layerInfo.visible;
 
                 if (layerInfo instanceof cc.TMXLayerInfo) {

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -687,7 +687,7 @@ let TiledMap = cc.Class({
                     node.addChild(child);
                 }
 
-                child.zIndex = i;
+                child.setSiblingIndex(i);
                 child.active = layerInfo.visible;
 
                 if (layerInfo instanceof cc.TMXLayerInfo) {


### PR DESCRIPTION
forum:https://forum.cocos.com/t/creator2-2-tiledmap/84837
为了保存节点上的用户组件，重刷tilemap资源时，判断是否存在同名节点，若有，则直接使用该节点，但此时zIndex有可能不对，所以这里要重新设置