### PR TITLE
add getTotalTime api to CCDirector

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -123,6 +123,7 @@ cc.Director = function () {
     this._totalFrames = 0;
     this._lastUpdate = 0;
     this._deltaTime = 0.0;
+    this._startTime = 0.0;
 
     // Scheduler for user registration update
     this._scheduler = null;
@@ -146,6 +147,7 @@ cc.Director.prototype = {
     init: function () {
         this._totalFrames = 0;
         this._lastUpdate = performance.now();
+        this._startTime = performance.now();
         this._paused = false;
         this._purgeDirectorInNextLoop = false;
         this._winSizeInPoints = cc.size(0, 0);
@@ -778,6 +780,16 @@ cc.Director.prototype = {
      */
     getDeltaTime: function () {
         return this._deltaTime;
+    },
+
+    /**
+     * !#en Returns the total passed time since game start
+     * !#zh 获取从游戏开始到现在总共经过的时间
+     * @method getTotalTime
+     * @return {Number}
+     */
+    getTotalTime: function () {
+        return performance.now() - this._startTime;
     },
 
     /**

--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -147,7 +147,7 @@ cc.Director.prototype = {
     init: function () {
         this._totalFrames = 0;
         this._lastUpdate = performance.now();
-        this._startTime = performance.now();
+        this._startTime = this._lastUpdate;
         this._paused = false;
         this._purgeDirectorInNextLoop = false;
         this._winSizeInPoints = cc.size(0, 0);

--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -783,8 +783,8 @@ cc.Director.prototype = {
     },
 
     /**
-     * !#en Returns the total passed time since game start
-     * !#zh 获取从游戏开始到现在总共经过的时间
+     * !#en Returns the total passed time since game start, unit: ms
+     * !#zh 获取从游戏开始到现在总共经过的时间，单位为 ms
      * @method getTotalTime
      * @return {Number}
      */


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1978
新增一个变量来记录游戏开始时间，然后通过用当前时间减去游戏开始时间获得游戏运行到现在总共经过的时间。这个流程已经被封装进了函数 getTotalTime().
Add a new variable to record game's start time, the passed time can be got by using current time minus the variable. And this progress has been packaged into a new function named getTotalTime in this pr.