### PR TITLE
fix wrong mouse position gotten in qqbrowser and correct wrong ua match order

### DIFF
--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -341,6 +341,12 @@ let inputManager = {
      * @return {Vec2}
      */
     getPointByEvent (event, pos) {
+        // qqbrowser and uc browser can't calculate pageY correctly, need to refresh canvas bounding rect
+        if (cc.sys.browserType === cc.sys.BROWSER_TYPE_QQ 
+            || cc.sys.browserType === cc.sys.BROWSER_TYPE_UC) {
+            this._updateCanvasBoundingRect();
+        }
+        
         if (event.pageX != null)  //not avalable in <= IE8
             return {x: event.pageX, y: event.pageY};
 

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -858,8 +858,8 @@ function initSys () {
         sys.browserType = sys.BROWSER_TYPE_UNKNOWN;
         /* Determine the browser type */
         (function(){
-            var typeReg1 = /mqqbrowser|micromessenger|qq|sogou|qzone|liebao|maxthon|ucbs|360 aphone|360browser|baiduboxapp|baidubrowser|maxthon|mxbrowser|miuibrowser/i;
-            var typeReg2 = /qqbrowser|ucbrowser|ubrowser|edge/i;
+            var typeReg1 = /mqqbrowser|micromessenger|qqbrowser|sogou|qzone|liebao|maxthon|ucbs|360 aphone|360browser|baiduboxapp|baidubrowser|maxthon|mxbrowser|miuibrowser/i;
+            var typeReg2 = /qq|ucbrowser|ubrowser|edge/i;
             var typeReg3 = /chrome|safari|firefox|trident|opera|opr\/|oupeng/i;
             var browserTypes = typeReg1.exec(ua) || typeReg2.exec(ua) || typeReg3.exec(ua);
 
@@ -889,8 +889,8 @@ function initSys () {
         sys.browserVersion = "";
         /* Determine the browser version number */
         (function(){
-            var versionReg1 = /(mqqbrowser|micromessenger|qq|sogou|qzone|liebao|maxthon|uc|ucbs|360 aphone|360|baiduboxapp|baidu|maxthon|mxbrowser|miui(?:.hybrid)?)(mobile)?(browser)?\/?([\d.]+)/i;
-            var versionReg2 = /(qqbrowser|chrome|safari|firefox|trident|opera|opr\/|oupeng)(mobile)?(browser)?\/?([\d.]+)/i;
+            var versionReg1 = /(mqqbrowser|micromessenger|qqbrowser|sogou|qzone|liebao|maxthon|uc|ucbs|360 aphone|360|baiduboxapp|baidu|maxthon|mxbrowser|miui(?:.hybrid)?)(mobile)?(browser)?\/?([\d.]+)/i;
+            var versionReg2 = /(qq|chrome|safari|firefox|trident|opera|opr\/|oupeng)(mobile)?(browser)?\/?([\d.]+)/i;
             var tmp = ua.match(versionReg1);
             if(!tmp) tmp = ua.match(versionReg2);
             sys.browserVersion = tmp ? tmp[4] : "";


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1958
之前的 cc.sys 中正则匹配的第一个表达式中的 qq 会匹配 qqbrowser 字段中的  ‘qq’ 字符串，会导致 qq 浏览器的 cc.sys.browserType 获取成 ‘qq’，这里将 qq 和 qqbrowser 的正则匹配顺序进行了调换。另外针对 qq 浏览器做了处理，现在可以正确获得点击位置了。