### PR TITLE
Fixed a problem of button interactable.

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -757,13 +757,14 @@ let Button = cc.Class({
     _updateColorTransitionImmediately (state) {
         let color = this._getStateColor(state);
         this._setTargetColor(color);
+        this._fromColor = color.clone();
+        this._toColor = color;
     },
 
     _updateColorTransition (state) {
         if (CC_EDITOR || state === State.DISABLED) {
             this._updateColorTransitionImmediately(state);
-        }
-        else {
+        } else {
             let target = this._getTarget();
             let color = this._getStateColor(state);
             this._fromColor = target.color.clone();

--- a/cocos2d/core/utils/gray-sprite-state.js
+++ b/cocos2d/core/utils/gray-sprite-state.js
@@ -26,7 +26,8 @@ GraySpriteState.prototype._switchGrayMaterial = function (useGrayMaterial, rende
     else {
         material = this._spriteMaterial;
         if (!material) {
-            material = renderComp.sharedMaterials[0] || Material.getBuiltinMaterial('2d-sprite', renderComp);
+            let mat = renderComp.sharedMaterials[0];
+            material = mat && mat !== this._graySpriteMaterial ?  mat : Material.getBuiltinMaterial('2d-sprite', renderComp);
         }
         material = this._spriteMaterial = Material.getInstantiatedMaterial(material, renderComp);
     }

--- a/cocos2d/core/utils/gray-sprite-state.js
+++ b/cocos2d/core/utils/gray-sprite-state.js
@@ -26,7 +26,6 @@ let GraySpriteState = cc.Class({
             },
             type: Material,
             tooltip: CC_DEV && 'i18n:COMPONENT.button.normal_material',
-            visible: true,
             animatable: false
         },
 
@@ -49,7 +48,6 @@ let GraySpriteState = cc.Class({
             },
             type: Material,
             tooltip: CC_DEV && 'i18n:COMPONENT.button.gray_material',
-            visible: true,
             animatable: false
         }
     },

--- a/cocos2d/core/utils/gray-sprite-state.js
+++ b/cocos2d/core/utils/gray-sprite-state.js
@@ -4,35 +4,79 @@ const Material = require('../assets/material/CCMaterial');
 /**
  * HelpClass for switching render component's material between normal sprite material and gray sprite material.
  */
-function GraySpriteState () {
-    this._graySpriteMaterial = null;
-    this._spriteMaterial = null;
-}
 
-GraySpriteState.prototype._switchGrayMaterial = function (useGrayMaterial, renderComp) {
+let GraySpriteState = cc.Class({
+    properties: {
+        _normalMaterial: null,
 
-    if (cc.game.renderType === cc.game.RENDER_TYPE_CANVAS) {
-        return;
-    }
+        /**
+         * !#en The normal material.
+         * !#zh 正常状态的材质。
+         * @property normalMaterial
+         * @type {Material}
+         * @default null
+         */
+        normalMaterial: {
+            get () {
+                return this._normalMaterial;
+            },
+            set (val) {
+                this._normalMaterial = val;
+                this._updateDisabledState && this._updateDisabledState();
+            },
+            type: Material,
+            tooltip: CC_DEV && 'i18n:COMPONENT.button.normal_material',
+            visible: true,
+            animatable: false
+        },
 
-    let material;
-    if (useGrayMaterial) {
-        material = this._graySpriteMaterial;
-        if (!material) {
-            material = Material.getBuiltinMaterial('2d-gray-sprite');
+        _grayMaterial: null,
+
+        /**
+         * !#en The gray material.
+         * !#zh 置灰状态的材质。
+         * @property grayMaterial
+         * @type {Material}
+         * @default null
+         */
+        grayMaterial: {
+            get () {
+                return this._grayMaterial;
+            },
+            set (val) {
+                this._grayMaterial = val;
+                this._updateDisabledState && this._updateDisabledState();
+            },
+            type: Material,
+            tooltip: CC_DEV && 'i18n:COMPONENT.button.gray_material',
+            visible: true,
+            animatable: false
         }
-        material = this._graySpriteMaterial = Material.getInstantiatedMaterial(material, renderComp);
-    }
-    else {
-        material = this._spriteMaterial;
-        if (!material) {
-            let mat = renderComp.sharedMaterials[0];
-            material = mat && mat !== this._graySpriteMaterial ?  mat : Material.getBuiltinMaterial('2d-sprite', renderComp);
+    },
+  
+    _switchGrayMaterial (useGrayMaterial, renderComp) {
+        if (cc.game.renderType === cc.game.RENDER_TYPE_CANVAS) {
+            return;
         }
-        material = this._spriteMaterial = Material.getInstantiatedMaterial(material, renderComp);
+    
+        let material;
+        if (useGrayMaterial) {
+            material = this._grayMaterial;
+            if (!material) {
+                material = Material.getBuiltinMaterial('2d-gray-sprite');
+            }
+            material = this._grayMaterial = Material.getInstantiatedMaterial(material, renderComp);
+        }
+        else {
+            material = this._normalMaterial;
+            if (!material) {
+                material = Material.getBuiltinMaterial('2d-sprite', renderComp);
+            }
+            material = this._normalMaterial = Material.getInstantiatedMaterial(material, renderComp);
+        }
+    
+        renderComp.setMaterial(0, material);
     }
-
-    renderComp.setMaterial(0, material);
-};
+})
 
 module.exports = GraySpriteState;

--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -79,6 +79,8 @@ module.exports = {
             "pressed_sprite": "The Sprite that is used when the button is in a pressed sate.",
             "hover_sprite": "The Sprite that is used when the button is hovered over.",
             "disabled_sprite": "The Sprite that is used when the button is in a disabled sate.",
+            'normal_material': 'The material used for the background image specified by the button under normal conditions',
+            'gray_material': 'The material used for the background image specified by the button in the disabled state',
             "target": "reference to the Sprite as button's background. When the state of the button changes the sprite's color or spriteFrame will be updated.",
             "click_events": "What method is called on the click event?"
         },

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -82,6 +82,8 @@ module.exports = {
             'pressed_sprite': '按下状态的按钮背景图资源',
             'hover_sprite': '悬停状态的按钮背景图资源',
             'disabled_sprite': '禁用状态的按钮背景图资源',
+            'normal_material': '正常状态下按钮指定的背景图片所使用的材质',
+            'gray_material': '禁用状态下按钮指定的背景图片所使用的材质',
             'target': '指定 Button 背景节点，Button 状态改变时会修改此节点的 Color 或 Sprite 属性',
             'click_events': '按钮点击事件的列表。先将数量改为1或更多，就可以为每个点击事件设置接受者和处理方法'
         },


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/1985

用户反馈问题说明：

![image](https://user-images.githubusercontent.com/39078800/67450650-af471a80-f650-11e9-8689-ba3582e21ede.png)

用户会对Button下的Sprite设置自定义材质，故要优先使用用户设定的材质，但是如果节点设置为grey状态，然后重新加载场景，则会把grey材质认为是用户设定的材质。
