### PR TITLE
fix ArrayBuffer.isView polyfill

### DIFF
--- a/polyfill/array-buffer.js
+++ b/polyfill/array-buffer.js
@@ -3,7 +3,10 @@ if (!ArrayBuffer.isView) {
     ArrayBuffer.isView = (typeof TypedArray === 'function') ? function (obj) {
         return obj instanceof TypedArray;
     } : function (obj) {
-        // old JSC, phantom
+        // old JSC, phantom, QtWebview
+        if (typeof obj !== 'object') {
+            return false;
+        }
         let ctor = obj.constructor;
         return ctor === Float32Array || ctor === Uint8Array || ctor === Uint32Array || ctor === Int8Array;
     };


### PR DESCRIPTION
changeLog:
- 修复某些浏览器上 ArrayBuffer.isView 没定义造成的报错

传入的 obj 可能为 null