### PR TITLE
Fixed top and bottom alignment of CHAR mode.

### DIFF
--- a/cocos2d/core/renderer/utils/label/bmfont.js
+++ b/cocos2d/core/renderer/utils/label/bmfont.js
@@ -630,13 +630,13 @@ export default class BmfontAssembler extends Assembler2D {
         // TOP
         _letterOffsetY = _contentSize.height;
         if (_vAlign !== macro.VerticalTextAlignment.TOP) {
-            let blank = (_lineHeight - _originFontSize) * _bmfontScale;
+            let blank = _contentSize.height - _textDesiredHeight + (_lineHeight - _originFontSize) * _bmfontScale;
             if (_vAlign === macro.VerticalTextAlignment.BOTTOM) {
                 // BOTTOM
-                _letterOffsetY = _textDesiredHeight - blank;
+                _letterOffsetY -= blank;
             } else {
                 // CENTER:
-                _letterOffsetY = (_contentSize.height + _textDesiredHeight - blank) / 2;
+                _letterOffsetY -= blank / 2;
             }
         }
     }

--- a/cocos2d/core/renderer/utils/label/bmfont.js
+++ b/cocos2d/core/renderer/utils/label/bmfont.js
@@ -630,7 +630,7 @@ export default class BmfontAssembler extends Assembler2D {
         // TOP
         _letterOffsetY = _contentSize.height;
         if (_vAlign !== macro.VerticalTextAlignment.TOP) {
-            let blank = Math.max((_lineHeight - _originFontSize), 0) * _bmfontScale;
+            let blank = (_lineHeight - _originFontSize) * _bmfontScale;
             if (_vAlign === macro.VerticalTextAlignment.BOTTOM) {
                 // BOTTOM
                 _letterOffsetY = _textDesiredHeight - blank;

--- a/cocos2d/core/renderer/utils/label/bmfont.js
+++ b/cocos2d/core/renderer/utils/label/bmfont.js
@@ -628,15 +628,15 @@ export default class BmfontAssembler extends Assembler2D {
         }
 
         // TOP
-        _letterOffsetY = (_contentSize.height + _textDesiredHeight) / 2;
+        _letterOffsetY = _contentSize.height;
         if (_vAlign !== macro.VerticalTextAlignment.TOP) {
             let blank = Math.max((_lineHeight - _originFontSize), 0) * _bmfontScale;
             if (_vAlign === macro.VerticalTextAlignment.BOTTOM) {
                 // BOTTOM
-                _letterOffsetY -= blank;
+                _letterOffsetY = _textDesiredHeight - blank;
             } else {
                 // CENTER:
-                _letterOffsetY -= blank / 2;
+                _letterOffsetY = (_contentSize.height + _textDesiredHeight - blank) / 2;
             }
         }
     }

--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -211,18 +211,20 @@ export default class TTFAssembler extends Assembler2D {
             labelX = (_canvasSize.width - _canvasPadding.width) / 2;
         }
 
-        let firstLinelabelY = 0;
         let lineHeight = this._getLineHeight();
         let drawStartY = lineHeight * (_splitedStrings.length - 1);
-        let blank = _fontSize * textUtils.BASELINE_RATIO;
-        if (_vAlign === macro.VerticalTextAlignment.TOP) {
-            firstLinelabelY = _fontSize - blank / 2;
-        }
-        else if (_vAlign === macro.VerticalTextAlignment.CENTER) {
-            firstLinelabelY = (_canvasSize.height - drawStartY) * 0.5 + _fontSize * textUtils.MIDDLE_RATIO - _canvasPadding.height / 2;
-        }
-        else {
-            firstLinelabelY = _canvasSize.height - drawStartY - blank / 2 - _canvasPadding.height;
+        // TOP
+        let firstLinelabelY = _fontSize * (1 - textUtils.BASELINE_RATIO / 2);
+        if (_vAlign !== macro.VerticalTextAlignment.TOP) {
+            // free space in vertical direction
+            let blank = _canvasSize.height - drawStartY - _canvasPadding.height - _fontSize;
+            if (_vAlign === macro.VerticalTextAlignment.BOTTOM) {
+              // BOTTOM
+              firstLinelabelY += blank;
+            } else {
+              // CENTER
+              firstLinelabelY += blank / 2;
+            }
         }
 
         return cc.v2(labelX + _canvasPadding.x, firstLinelabelY + _canvasPadding.y);

--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -217,13 +217,13 @@ export default class TTFAssembler extends Assembler2D {
         let firstLinelabelY = _fontSize * (1 - textUtils.BASELINE_RATIO / 2);
         if (_vAlign !== macro.VerticalTextAlignment.TOP) {
             // free space in vertical direction
-            let blank = _canvasSize.height - drawStartY - _canvasPadding.height - _fontSize;
+            let blank = drawStartY + _canvasPadding.height + _fontSize - _canvasSize.height;
             if (_vAlign === macro.VerticalTextAlignment.BOTTOM) {
-              // BOTTOM
-              firstLinelabelY += blank;
+                // BOTTOM
+                firstLinelabelY -= blank;
             } else {
-              // CENTER
-              firstLinelabelY += blank / 2;
+                // CENTER
+                firstLinelabelY -= blank / 2;
             }
         }
 

--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -214,14 +214,15 @@ export default class TTFAssembler extends Assembler2D {
         let firstLinelabelY = 0;
         let lineHeight = this._getLineHeight();
         let drawStartY = lineHeight * (_splitedStrings.length - 1);
+        let blank = _fontSize * textUtils.BASELINE_RATIO;
         if (_vAlign === macro.VerticalTextAlignment.TOP) {
-            firstLinelabelY = _fontSize;
+            firstLinelabelY = _fontSize - blank / 2;
         }
         else if (_vAlign === macro.VerticalTextAlignment.CENTER) {
             firstLinelabelY = (_canvasSize.height - drawStartY) * 0.5 + _fontSize * textUtils.MIDDLE_RATIO - _canvasPadding.height / 2;
         }
         else {
-            firstLinelabelY = _canvasSize.height - drawStartY - _fontSize * textUtils.BASELINE_RATIO - _canvasPadding.height;
+            firstLinelabelY = _canvasSize.height - drawStartY - blank / 2 - _canvasPadding.height;
         }
 
         return cc.v2(labelX + _canvasPadding.x, firstLinelabelY + _canvasPadding.y);


### PR DESCRIPTION
**问题反馈：**

https://forum.cocos.com/t/2-2-0-label-cache-mode-char-vertical-align/85052

**问题说明：**

这个问题其实是已知的，目前2.2版本的CHAR模式沿用了BMFont的处理，对齐方式也跟BMFont一致，旧版本的BMFont的居中对齐会在节点空间位置偏下，2.2版本修正了居中对齐的效果，所以旧项目升级上来，居中对齐的BMFont位置会出现偏移。Top 跟 Bottom 对齐只是保持了旧版本的处理，这个问题之前改了几次了，只是做微调，没敢做大的改动，但是一直有用户会有不同使用情况的反馈，现在既然2.2版本已经把居中修正了，Top 跟 Bottom 也一并彻底修改了吧。

居中已经正确，该修改只是修正了 Top 跟 Bottom 的对齐，目前系统字体跟BMFont的所有对齐方式的效果全部一致。

**测试验证：**

这里以SHRINK模式为例：

**修正之前：**

![image](https://user-images.githubusercontent.com/39078800/67541975-73c65200-f71d-11e9-8d38-28d55a3fd4a8.png)


**修正之后：**

居中，顶端对齐，底部对齐分别为

![image](https://user-images.githubusercontent.com/39078800/67541748-ac196080-f71c-11e9-9e6e-976468b10d9d.png)




