### PR TITLE
update @cocos/cannon to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -878,9 +878,9 @@
       }
     },
     "@cocos/cannon": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cocos/cannon/-/cannon-1.0.1.tgz",
-      "integrity": "sha512-D/LQSfW7YM5xV6Si7r5ari1+0nb5HP5aXqBmQmMGBGOq0HPDQgeq8pEQ05DKPIfdCncHz7BHDxP6LJIA9P/cGg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cocos/cannon/-/cannon-1.0.2.tgz",
+      "integrity": "sha512-BMr1vEB+eKC1ZGxX0642uj3C4v6tul/T15ZfBAN9gH4Hp/JcNtFooQjcPcxACKoDcErw4zPnX777cZFec4lZbA=="
     },
     "@jest/console": {
       "version": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "yargs": "^12.0.5"
   },
   "dependencies": {
-    "@cocos/cannon": "^1.0.1"
+    "@cocos/cannon": "^1.0.2"
   }
 }


### PR DESCRIPTION
- fix trigger exit overlap tick may not execute