### PR TITLE
refine font setting

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -407,16 +407,15 @@ let Label = cc.Class({
             },
             set (value) {
                 if (this._isSystemFontUsed === value) return;
-               
+                this._isSystemFontUsed = !!value;
                 if (CC_EDITOR) {
-                    if (!value && this._isSystemFontUsed && this._userDefinedFont) {
+                    if (!value && this._userDefinedFont) {
                         this.font = this._userDefinedFont;
                         this.spacingX = this._spacingX;
                         return;
                     }
                 }
 
-                this._isSystemFontUsed = !!value;
                 if (value) {
                     this.font = null;
 
@@ -425,10 +424,6 @@ let Label = cc.Class({
                     this._lazyUpdateRenderData();
                     this._checkStringEmpty();
                 }
-                else if (!this._userDefinedFont) {
-                    this.disableRender();
-                }
-
             },
             animatable: false,
             tooltip: CC_DEV && 'i18n:COMPONENT.label.system_font',
@@ -540,15 +535,6 @@ let Label = cc.Class({
 
     onEnable () {
         this._super();
-
-        // TODO: Hack for barbarians
-        if (!this.font && !this._isSystemFontUsed) {
-            this.useSystemFont = true;
-        }
-        // Reapply default font family if necessary
-        if (this.useSystemFont && !this.fontFamily) {
-            this.fontFamily = 'Arial';
-        }
 
         // Keep track of Node size
         this.node.on(cc.Node.EventType.SIZE_CHANGED, this._lazyUpdateRenderData, this);

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -127,6 +127,7 @@ let RichText = cc.Class({
         this._linesWidth = [];
 
         if (CC_EDITOR) {
+            this._userDefinedFont = null;
             this._updateRichTextStatus = debounce(this._updateRichText, 200);
         }
         else {
@@ -224,6 +225,9 @@ let RichText = cc.Class({
 
                 this._layoutDirty = true;
                 if (this.font) {
+                    if (CC_EDITOR) {
+                        this._userDefinedFont = this.font;
+                    }
                     this.useSystemFont = false;
                     this._onTTFLoaded();
                 }
@@ -245,10 +249,21 @@ let RichText = cc.Class({
                 return this._isSystemFontUsed;
             },
             set (value) {
-                if (!value && !this.font || (this._isSystemFontUsed === value)) {
+                if (this._isSystemFontUsed === value) {
                     return;
                 }
                 this._isSystemFontUsed = value;
+
+                if (CC_EDITOR) {
+                    if (value) {
+                        this.font = null;
+                    }
+                    else if (this._userDefinedFont) {
+                        this.font = this._userDefinedFont;
+                        return;
+                    }
+                }
+
                 this._layoutDirty = true;
                 this._updateRichTextStatus();
             },

--- a/cocos2d/core/renderer/utils/utils.js
+++ b/cocos2d/core/renderer/utils/utils.js
@@ -44,7 +44,7 @@ module.exports = {
             return 'Arial';
         }
         else {
-            return comp.fontFamily;
+            return comp.fontFamily || 'Arial';
         }
     },
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1699

之前的 pr https://github.com/cocos-creator/engine/pull/5490 重新提交

changeLog:
- 优化编辑器下 Label 和 RichText 设置字体的操作体验
- 修复使用系统字体时，Font Family 为空导致的渲染问题

![test](https://user-images.githubusercontent.com/17872773/67631781-9d29de00-f8d5-11e9-9925-0e72a9767a82.gif)
