### PR TITLE
Fix skeleton cache mode error

### DIFF
--- a/extensions/spine/Skeleton.js
+++ b/extensions/spine/Skeleton.js
@@ -828,7 +828,9 @@ sp.Skeleton = cc.Class({
     updateAnimationCache (animName) {
         if (!this.isAnimationCached()) return;
         let uuid = this.skeletonData._uuid;
-        this._skeletonCache.updateAnimationCache(uuid, animName);
+        if (this._skeletonCache) {
+            this._skeletonCache.updateAnimationCache(uuid, animName);
+        }
     },
 
     /**
@@ -840,7 +842,9 @@ sp.Skeleton = cc.Class({
      */
     invalidAnimationCache () {
         if (!this.isAnimationCached()) return;
-        this._skeletonCache.invalidAnimationCache(this.skeletonData._uuid);
+        if (this._skeletonCache) {
+            this._skeletonCache.invalidAnimationCache(this.skeletonData._uuid);
+        }
     },
 
     /**
@@ -991,6 +995,7 @@ sp.Skeleton = cc.Class({
             if (trackIndex !== 0) {
                 cc.warn("Track index can not greater than 0 in cached mode.");
             }
+            if (!this._skeletonCache) return null;
             let cache = this._skeletonCache.getAnimationCache(this.skeletonData._uuid, name);
             if (!cache) {
                 cache = this._skeletonCache.initAnimationCache(this.skeletonData._uuid, name);


### PR DESCRIPTION
修复当spine还未加载，用户调用cache相关接口，会报错的问题。
issue：https://github.com/cocos-creator/2d-tasks/issues/1955#event-2726791387