### PR TITLE
fix tiledmap object texture render error

### DIFF
--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -152,7 +152,7 @@ let TiledLayer = cc.Class({
     addUserNode (node) {
         let dataComp = node.getComponent(TiledUserNodeData);
         if (dataComp) {
-            cc.warn("CCTiledLayer:addUserNode node has add");
+            cc.warn("CCTiledLayer:addUserNode node has added");
             return false;
         }
 

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -152,7 +152,7 @@ let TiledLayer = cc.Class({
     addUserNode (node) {
         let dataComp = node.getComponent(TiledUserNodeData);
         if (dataComp) {
-            cc.warn("CCTiledLayer:insertUserNode node has insert");
+            cc.warn("CCTiledLayer:addUserNode node has add");
             return false;
         }
 
@@ -191,7 +191,8 @@ let TiledLayer = cc.Class({
         node.off(cc.Node.EventType.SIZE_CHANGED, this._userNodeSizeChange, dataComp);
         this._removeUserNodeFromGrid(dataComp);
         delete this._userNodeMap[node._id];
-        node.removeComponent(dataComp);
+        node._removeComponent(dataComp);
+        dataComp.destroy();
         node.removeFromParent(true);
         node._renderFlag &= ~RenderFlow.FLAG_BREAK_FLOW;
         return true;

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -152,7 +152,7 @@ let TiledLayer = cc.Class({
     addUserNode (node) {
         let dataComp = node.getComponent(TiledUserNodeData);
         if (dataComp) {
-            cc.warn("CCTiledLayer:addUserNode node has added");
+            cc.warn("CCTiledLayer:addUserNode node has been added");
             return false;
         }
 

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -224,7 +224,7 @@ let TiledObjectGroup = cc.Class({
                     sp = imgNode.addComponent(cc.Sprite);
                 }
                 sp.spriteFrame = new cc.SpriteFrame();
-                let rect = cc.rect(grid.x, grid.y, grid.width, grid.height);
+                let rect = cc.rect(grid);
                 sp.spriteFrame.setTexture(grid.tileset.sourceImage, rect);
 
                 imgNode.width = object.width;

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -224,7 +224,8 @@ let TiledObjectGroup = cc.Class({
                     sp = imgNode.addComponent(cc.Sprite);
                 }
                 sp.spriteFrame = new cc.SpriteFrame();
-                sp.spriteFrame.setTexture(grid.tileset.sourceImage, grid);
+                let rect = cc.rect(grid.x, grid.y, grid.width, grid.height);
+                sp.spriteFrame.setTexture(grid.tileset.sourceImage, rect);
 
                 imgNode.width = object.width;
                 imgNode.height = object.height;


### PR DESCRIPTION
修复object group纹理坐标不正确的问题。
修复在同一帧插入删除再插入用户节点，会报组件已存在的问题。（因为组件在下一帧才会从node中移除，这里调用了内部的_removeComponent方法，把组件立即从node中移除，然后再手动调用组件destroy方法。）