### PR TITLE
fix wrong particle properties in cpp when callback after load particle file

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -1032,6 +1032,7 @@ var ParticleSystem = cc.Class({
                 else if (!self._renderSpriteFrame && self._spriteFrame) {
                     self._applySpriteFrame(self.spriteFrame);
                 }
+                self._initProperties && self._initProperties();
             });
         }
     },


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1934
这里目前的行为是在异步加载资源之后调用回调才更新 particleSystem 中的粒子数据，但是更新完以后不会将数据传给 jsb-particle，导致 cpp 文件内的相关类维护的粒子数据仍然是初始值。解决方法是在异步回调的方法体结束前将值传给 jsb-particle 保证数据是最新的。

