### PR TITLE
fix a bug about getting deltaTime as negative

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -221,6 +221,13 @@ cc.Director.prototype = {
         if (CC_DEBUG && (this._deltaTime > 1))
             this._deltaTime = 1 / 60.0;
 
+        // avoid delta time from being negative
+        // negative deltaTime would be caused by the precision of now's value, for details please see: https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame
+        if (this._deltaTime < 0) {
+            this.calculateDeltaTime();
+            return;
+        }
+
         this._lastUpdate = now;
     },
 

--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -1215,7 +1215,7 @@ let ScrollView = cc.Class({
             this._isScrollEndedWithThresholdEventFired = true;
         }
 
-        if (this.elastic && !reachedEnd) {
+        if (this.elastic) {
             let brakeOffsetPosition = newPosition.sub(this._autoScrollBrakingStartPosition);
             if (isAutoScrollBrake) {
                 brakeOffsetPosition = brakeOffsetPosition.mul(brakingFactor);


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1555
当获取的 _lastUpdate 值为负数的时候将其更改为 0。

该 bug 会导致 ScrollView 回弹计算有误