### PR TITLE
 add aspect ratio to particle system

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -1210,8 +1210,6 @@ var ParticleSystem = cc.Class({
 
     _onTextureLoaded () {
         this._simulator.updateUVs(true);
-        // Reactivate material
-        this._activateMaterial();
         
         // set aspect ratio
         var spriteFrameWidth = this._renderSpriteFrame._rect.width;

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -347,6 +347,13 @@ var properties = {
     },
 
     /**
+     * !#en Aspect ratio of particle.
+     * !#zh 粒子宽高比。
+     * @property {Number} aspectRatio
+     * @default 1
+     */
+    aspectRatio: 1,
+    /**
      * !#en Maximum particles of the system.
      * !#zh 粒子最大数量。
      * @property {Number} totalParticles
@@ -1216,6 +1223,11 @@ var ParticleSystem = cc.Class({
         this._simulator.updateUVs(true);
         // Reactivate material
         this._activateMaterial();
+        
+        // set aspect ratio
+        var spriteFrameWidth = this._renderSpriteFrame._rect.width;
+        var spriteFrameHeight = this._renderSpriteFrame._rect.height;
+        this.aspectRatio = spriteFrameWidth / spriteFrameHeight;
     },
 
     _applySpriteFrame: function (oldFrame) {

--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -167,7 +167,7 @@ Simulator.prototype.emitParticle = function (pos) {
     particle.startPos.y = pos.y;
 
     // aspect ratio
-    particle.aspectRatio = psys.aspectRatio ? psys.aspectRatio : 1;
+    particle.aspectRatio = psys.aspectRatio || 1;
 
     // direction
     let worldRotation = getWorldRotation(psys.node);

--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -46,6 +46,7 @@ let Particle = function () {
     this.deltaRotation = 0;
     this.timeToLive = 0;
     this.drawPos = cc.v2(0, 0);
+    this.aspectRatio = 1;
     // Mode A
     this.dir = cc.v2(0, 0);
     this.radialAccel = 0;
@@ -69,6 +70,7 @@ let pool = new js.Pool(function (par) {
     par.deltaRotation = 0;
     par.timeToLive = 0;
     par.drawPos.set(ZERO_VEC2);
+    par.aspectRatio = 1;
     // Mode A
     par.dir.set(ZERO_VEC2);
     par.radialAccel = 0;
@@ -161,6 +163,9 @@ Simulator.prototype.emitParticle = function (pos) {
     particle.startPos.x = pos.x;
     particle.startPos.y = pos.y;
 
+    // aspect ratio
+    particle.aspectRatio = psys.aspectRatio ? psys.aspectRatio : 1;
+
     // direction
     let worldRotation = getWorldRotation(psys.node);
     let relAngle = psys.positionType === cc.ParticleSystem.PositionType.FREE ? psys.angle + worldRotation : psys.angle;
@@ -236,11 +241,15 @@ Simulator.prototype.updateParticleBuffer = function (particle, pos, buffer, offs
     let uintbuf = buffer._uintVData;
     
     let x = pos.x, y = pos.y;
-    let size_2 = particle.size / 2;
+    let width = height = particle.size;
+    let aspectRatio = particle.aspectRatio;
+    aspectRatio > 1 ? (height = width / aspectRatio) : (width = height * aspectRatio);
+    let halfWidth = width / 2;
+    let halfHeight = height / 2;
     // pos
     if (particle.rotation) {
-        let x1 = -size_2, y1 = -size_2;
-        let x2 = size_2, y2 = size_2;
+        let x1 = -halfWidth, y1 = -halfHeight;
+        let x2 = halfWidth, y2 = halfHeight;
         let rad = -misc.degreesToRadians(particle.rotation);
         let cr = Math.cos(rad), sr = Math.sin(rad);
         // bl
@@ -258,17 +267,17 @@ Simulator.prototype.updateParticleBuffer = function (particle, pos, buffer, offs
     }
     else {
         // bl
-        vbuf[offset] = x - size_2;
-        vbuf[offset+1] = y - size_2;
+        vbuf[offset] = x - halfWidth;
+        vbuf[offset+1] = y - halfHeight;
         // br
-        vbuf[offset+5] = x + size_2;
-        vbuf[offset+6] = y - size_2;
+        vbuf[offset+5] = x + halfWidth;
+        vbuf[offset+6] = y - halfHeight;
         // tl
-        vbuf[offset+10] = x - size_2;
-        vbuf[offset+11] = y + size_2;
+        vbuf[offset+10] = x - halfWidth;
+        vbuf[offset+11] = y + halfHeight;
         // tr
-        vbuf[offset+15] = x + size_2;
-        vbuf[offset+16] = y + size_2;
+        vbuf[offset+15] = x + halfWidth;
+        vbuf[offset+16] = y + halfHeight;
     }
     // color
     uintbuf[offset+4] = particle.color._val;


### PR DESCRIPTION
re: forum.cocos.org/t/topic/74021

主要改动：
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;在 particleSystem 内新添 aspectRatio 变量，默认为 1。该变量会参与到 particle-simulator 中粒子顶点相关的运算来让每个粒子的宽高比保持和纹理一致。用户也可以通过更改其值在脚本中动态地自定义其宽高拉伸比例。

宽高比 aspectRatio 和尺寸 size 之间的关系：
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;当 aspectRatio > 1 时，保持宽度为 size，缩短高度为 size / aspectRatio；当 aspectRatio < 1 时，保持高度为 size， 缩短宽度为 aspectRatio * size。这样可以保证宽和高二者中最大值为 size，视觉上相对合理。

解决的问题：
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;论坛中用户在引入宽高比不一致的粒子图像的时候，由于之前的粒子尺寸固定为宽高都是 size，所以虽然纹理的宽高不一样，但在具体粒子表现的时候就会被拉伸到正方形。这里的改动主要是让用户导入的纹理在引擎中能够正常地表现出其原本具有的宽高比以防止拉伸，同时若用户需要拉伸只需更改此值而不用去改动资源。
