### PR TITLE
fixed assembler pool

### DIFF
--- a/cocos2d/core/assets/material/material-pool.js
+++ b/cocos2d/core/assets/material/material-pool.js
@@ -53,13 +53,19 @@ class MaterialPool extends Pool {
             pool[uuid][key] = [];
         }
         if (this.count > this.maxSize) return;
+
+        this._clean(mat);
         pool[uuid][key].push(mat);
         this.count++;
     }
-    
+
     clear () {
         this._pool = {};
         this.count = 0;
+    }
+
+    _clean (mat) {
+        mat._owner = null;
     }
 }
 


### PR DESCRIPTION

Changes:
 * 构建 release 后 Assembler 的构造函数都被压缩成 e 了，不能用 assembler.constructor.name 来作为 pool 的 key 值，改为生成 assembler constructor id 来代替
