### PR TITLE
interval's default value should be 0 and assert should not be raised before this

### DIFF
--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -550,9 +550,10 @@ var Component = cc.Class({
      */
     schedule (callback, interval, repeat, delay) {
         cc.assertID(callback, 1619);
-        cc.assertID(interval >= 0, 1620);
 
         interval = interval || 0;
+        cc.assertID(interval >= 0, 1620);
+
         repeat = isNaN(repeat) ? cc.macro.REPEAT_FOREVER : repeat;
         delay = delay || 0;
 


### PR DESCRIPTION
Re:https://forum.cocos.org/t/bug-schedule-callback-interva-asser-t/85535
目前的行为是如果 schedule 这个方法没有传入 interval 参数值的话就会报错，然后再给 interval 赋值 0。
据论坛用户反馈，这里的 interval 默认值是 0，因此在不传值的时候不应该报错，不知道设计上来讲这个参数原本是否可以忽略，用户的反馈是这里不传入 interval 参数的时候默认为 0 而不是报错比较好。
