### PR TITLE
add highp precision check

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -2715,3 +2715,7 @@ LabelAtlas '%s' cannot be loaded, raw texture does not exist.
 ### 9101
 
 LabelAtlas '%s' cannot be loaded, fnt data does not exist.
+
+### 9102
+
+Program not support highp precision, will change to mediump.

--- a/cocos2d/renderer/core/program-lib.js
+++ b/cocos2d/renderer/core/program-lib.js
@@ -284,8 +284,10 @@ export default class ProgramLib {
     let gl = this._device._gl;
     let highpSupported = false;
     if (gl.getShaderPrecisionFormat) {
-        var highp = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT);
-        highpSupported = highp && highp.precision !== 0;
+        let vertHighp = gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.HIGH_FLOAT);
+        let fragHighp = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT);
+        highpSupported = (vertHighp && vertHighp.precision > 0) &&
+          (fragHighp && fragHighp.precision > 0);
     }
     if (!highpSupported) {
       cc.warnID(9102);

--- a/cocos2d/renderer/core/program-lib.js
+++ b/cocos2d/renderer/core/program-lib.js
@@ -64,7 +64,7 @@ function _unrollLoops(string) {
 }
 
 function _replaceHighp(string) {
-  return string.replace(/\bhighp\b/, 'mediump');
+  return string.replace(/\bhighp\b/g, 'mediump');
 }
 
 export default class ProgramLib {

--- a/cocos2d/renderer/core/program-lib.js
+++ b/cocos2d/renderer/core/program-lib.js
@@ -288,7 +288,7 @@ export default class ProgramLib {
         highpSupported = highp && highp.precision !== 0;
     }
     if (!highpSupported) {
-      cc.warn('Program not support highp precision, will change to mediump.');
+      cc.warnID(9102);
     }
     this._highpSupported = highpSupported;
   }

--- a/cocos2d/renderer/core/program-lib.js
+++ b/cocos2d/renderer/core/program-lib.js
@@ -63,6 +63,10 @@ function _unrollLoops(string) {
   return string.replace(pattern, replace);
 }
 
+function _replaceHighp(string) {
+  return string.replace(/\bhighp\b/, 'mediump');
+}
+
 export default class ProgramLib {
   /**
    * @param {gfx.Device} device
@@ -73,6 +77,8 @@ export default class ProgramLib {
     // register templates
     this._templates = {};
     this._cache = {};
+
+    this._checkPrecision();
   }
 
   clear () {
@@ -228,8 +234,15 @@ export default class ProgramLib {
     let customDef = _generateDefines(defineList);
     let vert = _replaceMacroNums(tmpl.vert, defineList);
     vert = customDef + _unrollLoops(vert);
+    if (!this._highpSupported) {
+      vert = _replaceHighp(vert);
+    }
+
     let frag = _replaceMacroNums(tmpl.frag, defineList);
     frag = customDef + _unrollLoops(frag);
+    if (!this._highpSupported) {
+      frag = _replaceHighp(frag);
+    }
 
     program = new gfx.Program(this._device, {
       vert,
@@ -265,5 +278,18 @@ export default class ProgramLib {
         return value;
       }
     }
+  }
+
+  _checkPrecision () {
+    let gl = this._device._gl;
+    let highpSupported = false;
+    if (gl.getShaderPrecisionFormat) {
+        var highp = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT);
+        highpSupported = highp && highp.precision !== 0;
+    }
+    if (!highpSupported) {
+      cc.warn('Program not support highp precision, will change to mediump.');
+    }
+    this._highpSupported = highpSupported;
   }
 }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#844

Changes:
 * add highp precision check

老设备上可能不支持 highp，这里判断如果设备不支持 highp 则替换 shader 中的 highp 为 mediump。

![image](https://user-images.githubusercontent.com/1862402/68185375-5c6c4c00-ffdc-11e9-87bf-2bd2242b509d.png)

