### PR TITLE
matrix and trs precision optimize

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1413,9 +1413,9 @@ let NodeDefines = {
         if (!this._spaceInfo) {
             if (CC_EDITOR || CC_TEST) {
                 this._spaceInfo = {
-                    trs: new Float32Array(10),
-                    localMat: new Float32Array(16),
-                    worldMat: new Float32Array(16),
+                    trs: new Float64Array(10),
+                    localMat: new Float64Array(16),
+                    worldMat: new Float64Array(16),
                 }
             } else {
                 this._spaceInfo = nodeMemPool.pop();            

--- a/cocos2d/core/platform/instantiate-jit.js
+++ b/cocos2d/core/platform/instantiate-jit.js
@@ -55,6 +55,7 @@ const DEFAULT_MODULE_CACHE = {
     'cc.PrefabInfo': false
 };
 
+!Float64Array.name && (Float64Array.name = 'Float64Array');
 !Float32Array.name && (Float32Array.name = 'Float32Array');
 !Uint32Array.name && (Uint32Array.name = 'Uint32Array');
 !Int32Array.name && (Int32Array.name = 'Int32Array');

--- a/cocos2d/core/utils/trans-pool/node-unit.js
+++ b/cocos2d/core/utils/trans-pool/node-unit.js
@@ -23,6 +23,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
+const Float64_Bytes = 8;
 const Float32_Bytes = 4;
 const Uint32_Bytes = 4;
 const Uint8_Bytes = 1;
@@ -33,19 +34,19 @@ const Dirty_Members = 1;
 const Dirty_Stride = Dirty_Members * Uint32_Bytes;
 
 // Space : [TRS]                                    [Size:4 * 10 Float32]
-const TRS_Type = Float32Array;
+let TRS_Type = Float64Array;
 const TRS_Members = 10;
-const TRS_Stride = TRS_Members * Float32_Bytes;
+let TRS_Stride = TRS_Members * Float64_Bytes;
 
 // Space : [LocalMatrix]                            [Size:4 * 16 Float32]
-const LocalMatrix_Type = Float32Array;
+let LocalMatrix_Type = Float64Array;
 const LocalMatrix_Members = 16;
-const LocalMatrix_Stride = LocalMatrix_Members * Float32_Bytes;
+let LocalMatrix_Stride = LocalMatrix_Members * Float64_Bytes;
 
 // Space : [WorldMatrix]                            [Size:4 * 16 Float32]
-const WorldMatrix_Type = Float32Array;
+let WorldMatrix_Type = Float64Array;
 const WorldMatrix_Members = 16;
-const WorldMatrix_Stride = WorldMatrix_Members * Float32_Bytes;
+let WorldMatrix_Stride = WorldMatrix_Members * Float64_Bytes;
 
 // Space : [Parent Unit]                            [Size:4 Uint32]
 // Space : [Parent Index]                           [Size:4 Uint32]
@@ -81,6 +82,17 @@ const Node_Members = 2;
 const Skew_Type = Float32Array;
 const Skew_Members = 2;
 const Skew_Stride = Skew_Members * Float32_Bytes;
+
+if (CC_JSB && CC_NATIVERENDERER) {
+    TRS_Type = Float32Array;
+    TRS_Stride = TRS_Members * Float32_Bytes;
+
+    LocalMatrix_Type = Float32Array;
+    LocalMatrix_Stride = LocalMatrix_Members * Float32_Bytes;
+
+    WorldMatrix_Type = Float32Array;
+    WorldMatrix_Stride = WorldMatrix_Members * Float32_Bytes;
+}
 
 let UnitBase = require('./unit-base');
 let NodeUnit = function (unitID, memPool) {

--- a/cocos2d/core/utils/trans-pool/node-unit.js
+++ b/cocos2d/core/utils/trans-pool/node-unit.js
@@ -23,8 +23,8 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-const Float64_Bytes = 8;
-const Float32_Bytes = 4;
+import { FLOAT_ARRAY_TYPE, FLOAT_BYTES } from '../../vmath/utils';
+
 const Uint32_Bytes = 4;
 const Uint8_Bytes = 1;
 
@@ -33,20 +33,17 @@ const Dirty_Type = Uint32Array;
 const Dirty_Members = 1;
 const Dirty_Stride = Dirty_Members * Uint32_Bytes;
 
-// Space : [TRS]                                    [Size:4 * 10 Float32]
-let TRS_Type = Float64Array;
+// Space : [TRS]                                    [Size:4 * 10 Float32|Float64]
 const TRS_Members = 10;
-let TRS_Stride = TRS_Members * Float64_Bytes;
+const TRS_Stride = TRS_Members * FLOAT_BYTES;
 
-// Space : [LocalMatrix]                            [Size:4 * 16 Float32]
-let LocalMatrix_Type = Float64Array;
+// Space : [LocalMatrix]                            [Size:4 * 16 Float32|Float64]
 const LocalMatrix_Members = 16;
-let LocalMatrix_Stride = LocalMatrix_Members * Float64_Bytes;
+const LocalMatrix_Stride = LocalMatrix_Members * FLOAT_BYTES;
 
-// Space : [WorldMatrix]                            [Size:4 * 16 Float32]
-let WorldMatrix_Type = Float64Array;
+// Space : [WorldMatrix]                            [Size:4 * 16 Float32|Float64]
 const WorldMatrix_Members = 16;
-let WorldMatrix_Stride = WorldMatrix_Members * Float64_Bytes;
+const WorldMatrix_Stride = WorldMatrix_Members * FLOAT_BYTES;
 
 // Space : [Parent Unit]                            [Size:4 Uint32]
 // Space : [Parent Index]                           [Size:4 Uint32]
@@ -79,29 +76,17 @@ const Node_Type = Uint32Array;
 const Node_Members = 2;
 
 // Space : [Skew]                                   [Size:4 * 2 Float32]
-const Skew_Type = Float32Array;
 const Skew_Members = 2;
-const Skew_Stride = Skew_Members * Float32_Bytes;
-
-if (CC_JSB && CC_NATIVERENDERER) {
-    TRS_Type = Float32Array;
-    TRS_Stride = TRS_Members * Float32_Bytes;
-
-    LocalMatrix_Type = Float32Array;
-    LocalMatrix_Stride = LocalMatrix_Members * Float32_Bytes;
-
-    WorldMatrix_Type = Float32Array;
-    WorldMatrix_Stride = WorldMatrix_Members * Float32_Bytes;
-}
+const Skew_Stride = Skew_Members * FLOAT_BYTES;
 
 let UnitBase = require('./unit-base');
 let NodeUnit = function (unitID, memPool) {
     UnitBase.call(this, unitID, memPool);
 
     let contentNum = this._contentNum;
-    this.trsList = new TRS_Type(contentNum * TRS_Members);
-    this.localMatList = new LocalMatrix_Type(contentNum * LocalMatrix_Members);
-    this.worldMatList = new WorldMatrix_Type(contentNum * WorldMatrix_Members);
+    this.trsList = new FLOAT_ARRAY_TYPE(contentNum * TRS_Members);
+    this.localMatList = new FLOAT_ARRAY_TYPE(contentNum * LocalMatrix_Members);
+    this.worldMatList = new FLOAT_ARRAY_TYPE(contentNum * WorldMatrix_Members);
 
     if (CC_JSB && CC_NATIVERENDERER) {
         this.dirtyList = new Dirty_Type(contentNum * Dirty_Members);
@@ -111,7 +96,7 @@ let NodeUnit = function (unitID, memPool) {
         this.opacityList = new Opacity_Type(contentNum * Opacity_Members);
         this.is3DList = new Is3D_Type(contentNum * Is3D_Members);
         this.nodeList = new Node_Type(contentNum * Node_Members);
-        this.skewList = new Skew_Type(contentNum * Skew_Members);
+        this.skewList = new FLOAT_ARRAY_TYPE(contentNum * Skew_Members);
 
         this._memPool._nativeMemPool.updateNodeData(
             unitID,
@@ -132,9 +117,9 @@ let NodeUnit = function (unitID, memPool) {
     for (let i = 0; i < contentNum; i ++) {
         let space = this._spacesData[i];
 
-        space.trs = new TRS_Type(this.trsList.buffer, i * TRS_Stride, TRS_Members);
-        space.localMat = new LocalMatrix_Type(this.localMatList.buffer, i * LocalMatrix_Stride, LocalMatrix_Members);
-        space.worldMat = new WorldMatrix_Type(this.worldMatList.buffer, i * WorldMatrix_Stride, WorldMatrix_Members);
+        space.trs = new FLOAT_ARRAY_TYPE(this.trsList.buffer, i * TRS_Stride, TRS_Members);
+        space.localMat = new FLOAT_ARRAY_TYPE(this.localMatList.buffer, i * LocalMatrix_Stride, LocalMatrix_Members);
+        space.worldMat = new FLOAT_ARRAY_TYPE(this.worldMatList.buffer, i * WorldMatrix_Stride, WorldMatrix_Members);
 
         if (CC_JSB && CC_NATIVERENDERER) {
             space.dirty = new Dirty_Type(this.dirtyList.buffer, i * Dirty_Stride, Dirty_Members);
@@ -143,7 +128,7 @@ let NodeUnit = function (unitID, memPool) {
             space.cullingMask = new CullingMask_Type(this.cullingMaskList.buffer, i * CullingMask_Stride, CullingMask_Members);
             space.opacity = new Opacity_Type(this.opacityList.buffer, i * Opacity_Stride, Opacity_Members);
             space.is3D = new Is3D_Type(this.is3DList.buffer, i * Is3D_Stride, Is3D_Members);
-            space.skew = new Skew_Type(this.skewList.buffer, i * Skew_Stride, Skew_Members);
+            space.skew = new FLOAT_ARRAY_TYPE(this.skewList.buffer, i * Skew_Stride, Skew_Members);
         }
     }
 };

--- a/cocos2d/core/value-types/mat4.js
+++ b/cocos2d/core/value-types/mat4.js
@@ -62,7 +62,11 @@ import { mat4 } from '../vmath';
  * @param {Number} m33 Component in column 3, row 3 position (index 15)
  */
 function Mat4 (m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) {
-    this.m = new Float32Array(16);
+    if (CC_JSB && CC_NATIVERENDERER) {
+        this.m = new Float32Array(16);
+    } else {
+        this.m = new Float64Array(16);
+    }
     let tm = this.m;
     tm[0] = m00;
     tm[1] = m01;

--- a/cocos2d/core/value-types/mat4.js
+++ b/cocos2d/core/value-types/mat4.js
@@ -28,6 +28,7 @@ const js = require('../platform/js');
 const CCClass = require('../platform/CCClass');
 
 import { mat4 } from '../vmath';
+import { FLOAT_ARRAY_TYPE } from '../vmath/utils';
 
 /**
  * !#en Representation of 4*4 matrix.
@@ -62,11 +63,7 @@ import { mat4 } from '../vmath';
  * @param {Number} m33 Component in column 3, row 3 position (index 15)
  */
 function Mat4 (m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) {
-    if (CC_JSB && CC_NATIVERENDERER) {
-        this.m = new Float32Array(16);
-    } else {
-        this.m = new Float64Array(16);
-    }
+    this.m = new FLOAT_ARRAY_TYPE(16);
     let tm = this.m;
     tm[0] = m00;
     tm[1] = m01;

--- a/cocos2d/core/vmath/mat2.js
+++ b/cocos2d/core/vmath/mat2.js
@@ -13,16 +13,20 @@ class mat2 {
    * @param {Number} m03 - Value assigned to element at column 1 row 1.
    */
   constructor(m00 = 1, m01 = 0, m02 = 0, m03 = 1) {
-    if (m00 instanceof Float32Array) {
+    if (ArrayBuffer.isView(m00)) {
         // deep copy
         if (m01) {
-            this.m = new Float32Array(4);
+            this.m = new m00.constructor(4);
             this.m.set(m00);
         } else {
             this.m = m00;
         }
     } else {
-        this.m = new Float32Array(4);
+        if (CC_JSB && CC_NATIVERENDERER) {
+            this.m = new Float32Array(4);
+        } else {
+            this.m = new Float64Array(4);
+        }
         let m = this.m;
         /**
          * The element at column 0 row 0.

--- a/cocos2d/core/vmath/mat2.js
+++ b/cocos2d/core/vmath/mat2.js
@@ -1,4 +1,4 @@
-import { EPSILON } from './utils';
+import { EPSILON, FLOAT_ARRAY_TYPE } from './utils';
 
 /**
  * Mathematical 2x2 matrix.
@@ -7,13 +7,13 @@ class mat2 {
   /**
    * Creates a matrix, with elements specified separately.
    *
-   * @param {Number} m00 - Value assigned to element at column 0 row 0.
-   * @param {Number} m01 - Value assigned to element at column 0 row 1.
+   * @param {Number|Float32Array|Float64Array} m00 - Value assigned to element at column 0 row 0 or array of matrix elements.
+   * @param {Number|Boolean} m01 - Value assigned to element at column 0 row 1 or whether you need a deep copy of the parameter passed in parameter 1.
    * @param {Number} m02 - Value assigned to element at column 1 row 0.
    * @param {Number} m03 - Value assigned to element at column 1 row 1.
    */
   constructor(m00 = 1, m01 = 0, m02 = 0, m03 = 1) {
-    if (ArrayBuffer.isView(m00)) {
+    if (typeof m00 === 'object') {
         // deep copy
         if (m01) {
             this.m = new m00.constructor(4);
@@ -22,11 +22,7 @@ class mat2 {
             this.m = m00;
         }
     } else {
-        if (CC_JSB && CC_NATIVERENDERER) {
-            this.m = new Float32Array(4);
-        } else {
-            this.m = new Float64Array(4);
-        }
+        this.m = new FLOAT_ARRAY_TYPE(4);
         let m = this.m;
         /**
          * The element at column 0 row 0.

--- a/cocos2d/core/vmath/mat23.js
+++ b/cocos2d/core/vmath/mat23.js
@@ -1,4 +1,4 @@
-import { EPSILON } from './utils';
+import { EPSILON, FLOAT_ARRAY_TYPE } from './utils';
 
 /**
  * Mathematical 2x3 matrix.
@@ -28,7 +28,7 @@ class mat23 {
    * @param {Number} m05 -  Value assigned to element ty.
    */
   constructor(m00 = 1, m01 = 0, m02 = 0, m03 = 1, m04 = 0, m05 = 0) {
-    if (ArrayBuffer.isView(m00)) {
+    if (typeof m00 === 'object') {
         // deep copy
         if (m01) {
             this.m = new m00.constructor(6);
@@ -37,11 +37,7 @@ class mat23 {
             this.m = m00;
         }
     } else {
-        if (CC_JSB && CC_NATIVERENDERER) {
-            this.m = new Float32Array(6);
-        } else {
-            this.m = new Float64Array(6);
-        }
+        this.m = new FLOAT_ARRAY_TYPE(6);
         let m = this.m;
         /**
          * The element a.

--- a/cocos2d/core/vmath/mat23.js
+++ b/cocos2d/core/vmath/mat23.js
@@ -28,16 +28,20 @@ class mat23 {
    * @param {Number} m05 -  Value assigned to element ty.
    */
   constructor(m00 = 1, m01 = 0, m02 = 0, m03 = 1, m04 = 0, m05 = 0) {
-    if (m00 instanceof Float32Array) {
+    if (ArrayBuffer.isView(m00)) {
         // deep copy
         if (m01) {
-            this.m = new Float32Array(6);
+            this.m = new m00.constructor(6);
             this.m.set(m00);
         } else {
             this.m = m00;
         }
     } else {
-        this.m = new Float32Array(6);
+        if (CC_JSB && CC_NATIVERENDERER) {
+            this.m = new Float32Array(6);
+        } else {
+            this.m = new Float64Array(6);
+        }
         let m = this.m;
         /**
          * The element a.

--- a/cocos2d/core/vmath/mat3.js
+++ b/cocos2d/core/vmath/mat3.js
@@ -46,16 +46,20 @@ class mat3 {
     m03 = 0, m04 = 1, m05 = 0,
     m06 = 0, m07 = 0, m08 = 1
   ) {
-    if (m00 instanceof Float32Array) {
+    if (ArrayBuffer.isView(m00)) {
         // deep copy
         if (m01) {
-            this.m = new Float32Array(9);
+            this.m = new m00.constructor(9);
             this.m.set(m00);
         } else {
             this.m = m00;
         }
     } else {
-        this.m = new Float32Array(9);
+        if (CC_JSB && CC_NATIVERENDERER) {
+            this.m = new Float32Array(9);
+        } else {
+            this.m = new Float64Array(9);
+        }
         let m = this.m;
         /**
          * The element at column 0 row 0.

--- a/cocos2d/core/vmath/mat3.js
+++ b/cocos2d/core/vmath/mat3.js
@@ -1,4 +1,4 @@
-import { EPSILON } from './utils';
+import { EPSILON, FLOAT_ARRAY_TYPE } from './utils';
 import vec3 from './vec3';
 
 /**
@@ -31,8 +31,8 @@ class mat3 {
   /**
    * Creates a matrix, with elements specified separately.
    *
-   * @param {Number} m00 - Value assigned to element at column 0 row 0.
-   * @param {Number} m01 - Value assigned to element at column 0 row 1.
+   * @param {Number|Float32Array|Float64Array} m00 - Value assigned to element at column 0 row 0 or array of matrix elements.
+   * @param {Number|Boolean} m01 - Value assigned to element at column 0 row 1 or whether you need a deep copy of the parameter passed in parameter 1.
    * @param {Number} m02 - Value assigned to element at column 0 row 2.
    * @param {Number} m03 - Value assigned to element at column 1 row 0.
    * @param {Number} m04 - Value assigned to element at column 1 row 1.
@@ -46,7 +46,7 @@ class mat3 {
     m03 = 0, m04 = 1, m05 = 0,
     m06 = 0, m07 = 0, m08 = 1
   ) {
-    if (ArrayBuffer.isView(m00)) {
+    if (typeof m00 === 'object') {
         // deep copy
         if (m01) {
             this.m = new m00.constructor(9);
@@ -55,11 +55,7 @@ class mat3 {
             this.m = m00;
         }
     } else {
-        if (CC_JSB && CC_NATIVERENDERER) {
-            this.m = new Float32Array(9);
-        } else {
-            this.m = new Float64Array(9);
-        }
+        this.m = new FLOAT_ARRAY_TYPE(9);
         let m = this.m;
         /**
          * The element at column 0 row 0.

--- a/cocos2d/core/vmath/mat4.js
+++ b/cocos2d/core/vmath/mat4.js
@@ -53,16 +53,20 @@ class mat4 {
     m08 = 0, m09 = 0, m10 = 1, m11 = 0,
     m12 = 0, m13 = 0, m14 = 0, m15 = 1
   ) {
-    if (m00 instanceof Float32Array) {
+    if (ArrayBuffer.isView(m00)) {
         // deep copy
         if (m01) {
-            this.m = new Float32Array(16);
+            this.m = new m00.constructor(16);
             this.m.set(m00);
         } else {
             this.m = m00;
         }
     } else {
-        this.m = new Float32Array(16);
+        if (CC_JSB && CC_NATIVERENDERER) {
+            this.m = new Float32Array(16);
+        } else {
+            this.m = new Float64Array(16);
+        }
 
         let m = this.m;
         /**

--- a/cocos2d/core/vmath/mat4.js
+++ b/cocos2d/core/vmath/mat4.js
@@ -1,4 +1,4 @@
-import { EPSILON } from './utils';
+import { EPSILON, FLOAT_ARRAY_TYPE } from './utils';
 
 /**
  * Mathematical 4x4 matrix.
@@ -30,8 +30,8 @@ class mat4 {
   /**
    * Creates a matrix, with elements specified separately.
    *
-   * @param {Number} m00 - Value assigned to element at column 0 row 0.
-   * @param {Number} m01 - Value assigned to element at column 0 row 1.
+   * @param {Number|Float32Array|Float64Array} m00 - Value assigned to element at column 0 row 0 or array of matrix elements.
+   * @param {Number|Boolean} m01 - Value assigned to element at column 0 row 1 or whether you need a deep copy of the parameter passed in parameter 1.
    * @param {Number} m02 - Value assigned to element at column 0 row 2.
    * @param {Number} m03 - Value assigned to element at column 0 row 3.
    * @param {Number} m04 - Value assigned to element at column 1 row 0.
@@ -53,7 +53,7 @@ class mat4 {
     m08 = 0, m09 = 0, m10 = 1, m11 = 0,
     m12 = 0, m13 = 0, m14 = 0, m15 = 1
   ) {
-    if (ArrayBuffer.isView(m00)) {
+    if (typeof m00 === 'object') {
         // deep copy
         if (m01) {
             this.m = new m00.constructor(16);
@@ -62,12 +62,7 @@ class mat4 {
             this.m = m00;
         }
     } else {
-        if (CC_JSB && CC_NATIVERENDERER) {
-            this.m = new Float32Array(16);
-        } else {
-            this.m = new Float64Array(16);
-        }
-
+        this.m = new FLOAT_ARRAY_TYPE(16);
         let m = this.m;
         /**
          * The element at column 0 row 0.

--- a/cocos2d/core/vmath/trs.js
+++ b/cocos2d/core/vmath/trs.js
@@ -7,7 +7,7 @@ export default class trs {
     /**
      * 
      * @param {Quat} out 
-     * @param {Float32Array} a 
+     * @param {Float32Array|Float64Array} a 
      * @return {Quat}
      */
     static toRotation (out, a) {
@@ -20,9 +20,9 @@ export default class trs {
 
     /**
      * 
-     * @param {Float32Array} out 
+     * @param {Float32Array|Float64Array} out 
      * @param {Quat} a 
-     * @return {Float32Array}
+     * @return {Float32Array|Float64Array}
      */
     static fromRotation (out, a) {
         out[3] = a.x;
@@ -35,7 +35,7 @@ export default class trs {
     /**
      * 
      * @param {Vec3} out 
-     * @param {Float32Array} a 
+     * @param {Float32Array|Float64Array} a 
      * @return {Vec3}
      */
     static toEuler (out, a) {
@@ -46,9 +46,9 @@ export default class trs {
 
     /**
      * 
-     * @param {Float32Array} out 
+     * @param {Float32Array|Float64Array} out 
      * @param {Vec3} a 
-     * @return {Float32Array}
+     * @return {Float32Array|Float64Array}
      */
     static fromEuler (out, a) {
         quat.fromEuler(tmp_quat, a.x, a.y, a.z);
@@ -58,11 +58,11 @@ export default class trs {
 
     /**
      * 
-     * @param {Float32Array} out 
+     * @param {Float32Array|Float64Array} out 
      * @param {Number} x 
      * @param {Number} y 
      * @param {Number} z 
-     * @return {Float32Array}
+     * @return {Float32Array|Float64Array}
      */
     static fromEulerNumber (out, x, y, z) {
         quat.fromEuler(tmp_quat, x, y, z);
@@ -73,7 +73,7 @@ export default class trs {
     /**
      * 
      * @param {Vec3} out 
-     * @param {Float32Array} a 
+     * @param {Float32Array|Float64Array} a 
      * @return {Vec3}
      */
     static toScale (out, a) {
@@ -85,9 +85,9 @@ export default class trs {
 
     /**
      * 
-     * @param {Float32Array} out 
+     * @param {Float32Array|Float64Array} out 
      * @param {Vec3} a 
-     * @return {Float32Array}
+     * @return {Float32Array|Float64Array}
      */
     static fromScale (out, a) {
         out[7] = a.x;
@@ -99,7 +99,7 @@ export default class trs {
     /**
      * 
      * @param {Vec3} out 
-     * @param {Float32Array} a 
+     * @param {Float32Array|Float64Array} a 
      * @return {Vec3}
      */
     static toPosition (out, a) {
@@ -111,9 +111,9 @@ export default class trs {
 
     /**
      * 
-     * @param {Float32Array} out 
+     * @param {Float32Array|Float64Array} out 
      * @param {Vec3} a 
-     * @return {Float32Array}
+     * @return {Float32Array|Float64Array}
      */
     static fromPosition (out, a) {
         out[0] = a.x;
@@ -124,7 +124,7 @@ export default class trs {
 
     /**
      * 
-     * @param {Float32Array} out 
+     * @param {Float32Array|Float64Array} out 
      * @param {Number} a 
      */
     static fromAngleZ (out, a) {

--- a/cocos2d/core/vmath/utils.js
+++ b/cocos2d/core/vmath/utils.js
@@ -13,6 +13,13 @@ const _r2d = 180.0 / Math.PI;
 export const EPSILON = 0.000001;
 
 /**
+ * Use single-precision floating point on native platforms to be compatible with native math libraries.
+ * Double precision floating point is used on Web platforms and editors to reduce the overhead of type conversion.
+ */
+export const FLOAT_ARRAY_TYPE = (CC_JSB && CC_NATIVERENDERER) ? Float32Array : Float64Array;
+export const FLOAT_BYTES = (CC_JSB && CC_NATIVERENDERER) ? 4 : 8;
+
+/**
  * Tests whether or not the arguments have approximately the same value, within an absolute
  * or relative tolerance of glMatrix.EPSILON (an absolute tolerance is used for values less
  * than or equal to 1.0, and a relative tolerance is used for larger values)


### PR DESCRIPTION
web使用双精度浮点，解决trs序列化小数位过长的问题。
同时减少web中单精度与双精度类型转化的所造成的不必要的损耗。
native使用单精度浮点，保持与native数学库兼容。
关联pr：https://github.com/cocos-creator/fireball/pull/9212