### PR TITLE
add tip about child node's group being setting to father node's group

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -671,6 +671,7 @@ let NodeDefines = {
          * !#zh
          * 节点的分组。<br/>
          * 节点的分组将关系到节点的碰撞组件可以与哪些碰撞组件相碰撞。<br/>
+         * 子节点在被加入到父节点时 group 会与父节点同步。
          * @property group
          * @type {String}
          */

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -668,10 +668,11 @@ let NodeDefines = {
          * !#en
          * Group of node.<br/>
          * Which Group this node belongs to will resolve that this node's collision components can collide with which other collision componentns.<br/>
+         * When adding a child node to a father node, child node's group will be set same as father node's group.<br/>
          * !#zh
          * 节点的分组。<br/>
          * 节点的分组将关系到节点的碰撞组件可以与哪些碰撞组件相碰撞。<br/>
-         * 子节点在被加入到父节点时 group 会与父节点同步。
+         * 子节点在被加入到父节点时 group 会与父节点同步。<br/>
          * @property group
          * @type {String}
          */


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2045
在 ccNode 的代码注释中添加对被添加的子节点与父节点之间的 group 关系的解释，将会被同步至文档。