### PR TITLE
optimize the setMaterial function

### DIFF
--- a/cocos2d/core/components/CCRenderComponent.js
+++ b/cocos2d/core/components/CCRenderComponent.js
@@ -189,7 +189,14 @@ let RenderComponent = cc.Class({
      * @param {Material} material 
      */
     setMaterial (index, material) {
-        this._materials[index] = material;
+        let temp = material;
+        this._materials.forEach((item)=>{
+          if (item.effect._name == material.effect._name) {
+            let mIndex = this._materials.indexOf(item);
+            this._materials.splice(mIndex, 1, this._materials[index]);
+          }
+        });
+        this._materials[index] = temp;
         if (material) {
             this.markForUpdateRenderData(true);
         }

--- a/cocos2d/core/components/CCRenderComponent.js
+++ b/cocos2d/core/components/CCRenderComponent.js
@@ -191,7 +191,7 @@ let RenderComponent = cc.Class({
     setMaterial (index, material) {
         let temp = material;
         this._materials.forEach((item)=>{
-          if (item.effect._name == material.effect._name) {
+          if (item.effect._name === material.effect._name) {
             let mIndex = this._materials.indexOf(item);
             this._materials.splice(mIndex, 1, this._materials[index]);
           }


### PR DESCRIPTION
RE: https://github.com/cocos-creator/2d-tasks/issues/2057
setMaterial 接口代码：

![image](https://user-images.githubusercontent.com/35944775/68357184-77ab9880-014f-11ea-9c65-da2acb0cd5ea.png)


目前这样的设计不利于用户直接通过调用这个接口来动态切换渲染节点的 material，用户需要自己额外设计数据结构来满足只调用 setMaterials  接口做动态切换 material 的需求。

目前的这样修改的想法是：
如果传入的 material 是 _materials 中已有的，则与用户指定的 index 索引的 materila 置换。如果是新的则插入到指定 index 索引位置。