### PR TITLE
Support node.parent to be Scene type

### DIFF
--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -612,6 +612,8 @@ export class Director extends EventTarget {
         if (onLaunched) {
             onLaunched(null, scene);
         }
+        let node = new Node();
+        node.parent = scene as Scene;
         this.emit(cc.Director.EVENT_AFTER_SCENE_LAUNCH, scene);
     }
 

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -326,7 +326,7 @@ export class Node extends BaseNode implements INode {
     public _onSetParent (oldParent: this | null, keepWorldTransform: boolean) {
         super._onSetParent(oldParent, keepWorldTransform);
         if (keepWorldTransform) {
-            const parent = this._parent;
+            const parent = this._parent as Node;
             if (parent) {
                 parent.updateWorldTransform();
                 Mat4.multiply(m4_1, Mat4.invert(m4_1, parent._mat), this._mat);
@@ -458,7 +458,7 @@ export class Node extends BaseNode implements INode {
         dirtyBit |= TransformDirtyBit.POSITION;
         const len = this._children.length;
         for (let i = 0; i < len; ++i) {
-            this._children[i].invalidateChildren(dirtyBit);
+            (this._children[i] as Node).invalidateChildren(dirtyBit);
         }
     }
 
@@ -470,12 +470,12 @@ export class Node extends BaseNode implements INode {
      */
     public updateWorldTransform () {
         if (!this._dirtyFlags) { return; }
-        let cur: this | null = this;
+        let cur: Node | null = this;
         let i = 0;
         while (cur && cur._dirtyFlags) {
             // top level node
             array_a[i++] = cur;
-            cur = cur._parent;
+            cur = cur._parent as Node;
         }
         let child: this; let dirtyBits = 0;
         while (i) {
@@ -674,10 +674,10 @@ export class Node extends BaseNode implements INode {
 
     public inverseTransformPoint (out: Vec3, p: Vec3) {
         Vec3.copy(out, p);
-        let cur = this; let i = 0;
+        let cur = this as Node; let i = 0;
         while (cur._parent) {
             array_a[i++] = cur;
-            cur = cur._parent;
+            cur = cur._parent as Node;
         }
         while (i >= 0) {
             Vec3.transformInverseRTS(out, out, cur._lrot, cur._lpos, cur._lscale);
@@ -709,7 +709,7 @@ export class Node extends BaseNode implements INode {
         } else {
             Vec3.set(this._pos, val as number, y, z);
         }
-        const parent = this._parent;
+        const parent = this._parent as Node;
         const local = this._lpos;
         if (parent) {
             // TODO: benchmark these approaches
@@ -766,9 +766,10 @@ export class Node extends BaseNode implements INode {
         } else {
             Quat.set(this._rot, val as number, y, z, w);
         }
-        if (this._parent) {
-            this._parent.updateWorldTransform();
-            Quat.multiply(this._lrot, Quat.conjugate(this._lrot, this._parent._rot), this._rot);
+        let parent = this._parent as Node;
+        if (parent) {
+            parent.updateWorldTransform();
+            Quat.multiply(this._lrot, Quat.conjugate(this._lrot, parent._rot), this._rot);
         } else {
             Quat.copy(this._lrot, this._rot);
         }
@@ -789,9 +790,10 @@ export class Node extends BaseNode implements INode {
      */
     public setWorldRotationFromEuler (x: number, y: number, z: number): void {
         Quat.fromEuler(this._rot, x, y, z);
-        if (this._parent) {
-            this._parent.updateWorldTransform();
-            Quat.multiply(this._lrot, Quat.conjugate(this._lrot, this._parent._rot), this._rot);
+        let parent = this._parent as Node;
+        if (parent) {
+            parent.updateWorldTransform();
+            Quat.multiply(this._lrot, Quat.conjugate(this._lrot, parent._rot), this._rot);
         } else {
             Quat.copy(this._lrot, this._rot);
         }
@@ -839,7 +841,7 @@ export class Node extends BaseNode implements INode {
         } else {
             Vec3.set(this._scale, val as number, y, z);
         }
-        const parent = this._parent;
+        const parent = this._parent as Node;
         if (parent) {
             parent.updateWorldTransform();
             Mat3.fromQuat(m3_1, Quat.conjugate(qt_1, parent._rot));

--- a/cocos/core/scene-graph/scene.ts
+++ b/cocos/core/scene-graph/scene.ts
@@ -146,7 +146,7 @@ export class Scene extends BaseNode {
         return null;
     }
 
-    public _onHierarchyChanged () { }
+    protected _onHierarchyChanged () { }
 
     public _onBatchCreated () {
         super._onBatchCreated();

--- a/cocos/core/utils/interfaces.ts
+++ b/cocos/core/utils/interfaces.ts
@@ -89,13 +89,13 @@ export interface IBaseNode {
      * @zh
      * 父节点
      */
-    parent: this | null;
+    parent: IBaseNode | null;
 
     /**
      * @zh
      * 孩子节点数组
      */
-    children: Readonly<this[]>;
+    children: Readonly<IBaseNode[]>;
 
     /**
      * @en
@@ -157,7 +157,7 @@ export interface IBaseNode {
      * var parent = this.node.getParent();
      * ```
      */
-    getParent (): this | null;
+    getParent (): IBaseNode | null;
 
     /**
      * @en Set parent of the node.
@@ -167,7 +167,7 @@ export interface IBaseNode {
      * node.setParent(newNode);
      * ```
      */
-    setParent (value: this | null, keepWorldTransform?: boolean): void;
+    setParent (value: IBaseNode | null, keepWorldTransform?: boolean): void;
 
     /**
      * @en Is this node a child of the given node?
@@ -178,25 +178,25 @@ export interface IBaseNode {
      * node.isChildOf(newNode);
      * ```
      */
-    isChildOf (parent: this | null): boolean;
+    isChildOf (parent: IBaseNode | null): boolean;
 
     /**
      * @zh 增加一个孩子节点
      * @param child 孩子节点
      */
-    addChild (child: this): void;
+    addChild (child: IBaseNode): void;
 
     /**
      * @zh 移除节点中指定的子节点
      * @param child 孩子节点
      */
-    removeChild (child: this, cleanup?: boolean): void;
+    removeChild (child: IBaseNode, cleanup?: boolean): void;
 
     /**
     * @zh 插入子节点到指定位置
     * @param siblingIndex 指定位置
     */
-    insertChild (child: this, siblingIndex: number): void;
+    insertChild (child: IBaseNode, siblingIndex: number): void;
 
     /**
      * @en Returns a child from the container given its uuid.
@@ -208,7 +208,7 @@ export interface IBaseNode {
      * var child = node.getChildByUuid(uuid);
      * ```
      */
-    getChildByUuid (uuid: string): this | null;
+    getChildByUuid (uuid: string): IBaseNode | null;
 
     /**
      * @en Returns a child from the container given its name.
@@ -220,7 +220,7 @@ export interface IBaseNode {
      * var child = node.getChildByName("Test Node");
      * ```
      */
-    getChildByName (name: string): this | null;
+    getChildByName (name: string): IBaseNode | null;
 
     /**
      * @en Returns a child from the container given its path.
@@ -232,7 +232,7 @@ export interface IBaseNode {
      * var child = node.getChildByPath("Test Node");
      * ```
      */
-    getChildByPath (path: string): this | null;
+    getChildByPath (path: string): IBaseNode | null;
 
     /**
      * @en
@@ -246,7 +246,7 @@ export interface IBaseNode {
      * node.insertChild(child, 2);
      * ```
      */
-    insertChild (child: this, siblingIndex: number): void;
+    insertChild (child: IBaseNode, siblingIndex: number): void;
 
     /**
      * @en Get the sibling index.
@@ -294,7 +294,7 @@ export interface IBaseNode {
      * node.removeChild(newNode);
      * ```
      */
-    removeChild (child: this): void;
+    removeChild (child: IBaseNode): void;
 
     /**
      * @en
@@ -424,6 +424,12 @@ export interface IBaseNode {
     dispatchEvent (event: Event): void;
     hasEventListener (type: string): boolean;
     targetOff (target: string | Object): void;
+
+    _onPostActivated (active: boolean);
+
+    _onBatchRestored ();
+
+    _onBatchCreated ();
 
     /**
      * @zh


### PR DESCRIPTION
由于 https://github.com/cocos-creator/3d-tasks/issues/1662 导致下面的代码会被 TS 识别为错误

```
node.parent = scene;
```

如果不做类似的修改，需要强制用户强转 Scene 为 Node

```
node.parent = scene as Node
```

这个解决方案虽然麻烦一些，不过从面向对象角度来说，是正确的做法
可以说说你们的看法