### PR TITLE
fixed copy material

### DIFF
--- a/cocos2d/core/assets/material/CCMaterial.js
+++ b/cocos2d/core/assets/material/CCMaterial.js
@@ -133,7 +133,7 @@ let Material = cc.Class({
      * @param {Material} mat
      */
     copy (mat) {
-        this.effectAsset = mat.effectAsset;
+        this._effect = mat.effect.clone();
 
         for (let name in mat._defines) {
             this.define(name, mat._defines[name]);


### PR DESCRIPTION

Changes:
 * 修复编辑器中 gizmo 显示错误，原因是拷贝材质的时候拷贝的是原始 effect asset 的数据，不是指定材质中 effect 的数据
