### PR TITLE
Support split spine atlas file

### DIFF
--- a/extensions/spine/lib/spine.js
+++ b/extensions/spine/lib/spine.js
@@ -2422,8 +2422,10 @@ var spine;
         }
         AtlasAttachmentLoader.prototype.newRegionAttachment = function (skin, name, path) {
             var region = this.atlas.findRegion(path);
-            if (region == null)
-                throw new Error("Region not found in atlas: " + path + " (region attachment: " + name + ")");
+            if (region == null) {
+                // throw new Error("Region not found in atlas: " + path + " (region attachment: " + name + ")");
+                return null;
+            }
             region.renderObject = region;
             var attachment = new spine.RegionAttachment(name);
             attachment.setRegion(region);
@@ -2431,8 +2433,10 @@ var spine;
         };
         AtlasAttachmentLoader.prototype.newMeshAttachment = function (skin, name, path) {
             var region = this.atlas.findRegion(path);
-            if (region == null)
-                throw new Error("Region not found in atlas: " + path + " (mesh attachment: " + name + ")");
+            if (region == null) {
+                // throw new Error("Region not found in atlas: " + path + " (mesh attachment: " + name + ")");
+                return null;
+            }
             region.renderObject = region;
             var attachment = new spine.MeshAttachment(name);
             attachment.region = region;
@@ -6084,8 +6088,10 @@ var spine;
                         for (var timelineName in slotMap) {
                             var timelineMap = slotMap[timelineName];
                             var attachment = skin.getAttachment(slotIndex, timelineName);
-                            if (attachment == null)
-                                throw new Error("Deform attachment not found: " + timelineMap.name);
+                            if (attachment == null) {
+                                // throw new Error("Deform attachment not found: " + timelineMap.name);
+                                continue;
+                            }
                             var weighted = attachment.bones != null;
                             var vertices = attachment.vertices;
                             var deformLength = weighted ? vertices.length / 3 * 2 : vertices.length;

--- a/extensions/spine/skeleton-data.js
+++ b/extensions/spine/skeleton-data.js
@@ -66,6 +66,7 @@ let SkeletonData = cc.Class({
                 return this._skeletonJson;
             },
             set: function (value) {
+                this.reset();
                 if (typeof(value) == "string") {
                     this._skeletonJson = JSON.parse(value);
                 } else {
@@ -75,7 +76,6 @@ let SkeletonData = cc.Class({
                 if (!this._uuid && value.skeleton) {
                     this._uuid = value.skeleton.hash;
                 }
-                this.reset();
             }
         },
 


### PR DESCRIPTION
支持部件贴图拆分，增强换装功能。
（原spine runtime当缺少某部件贴图时，会报错，这里修改为直接跳过或返回空值，当用户想换装时，可根据需要只提供某个部件的贴图图集）
关联pr：https://github.com/cocos-creator/cocos2d-x-lite/pull/1924