### PR TITLE
fixed cc.RotateTo error

### DIFF
--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -881,6 +881,7 @@ cc.RotateTo = cc.Class({
     extends: cc.ActionInterval,
 
     ctor:function (duration, dstAngle) {
+        dstAngle *= cc.macro.ROTATE_ACTION_CCW ? 1 : -1;
         this._startAngle = 0;
         this._dstAngle = 0;
         this._angle = 0;
@@ -895,7 +896,7 @@ cc.RotateTo = cc.Class({
      */
     initWithDuration:function (duration, dstAngle) {
         if (cc.ActionInterval.prototype.initWithDuration.call(this, duration)) {
-            this._dstAngle = -dstAngle;
+            this._dstAngle = dstAngle;
             return true;
         }
         return false;
@@ -913,7 +914,7 @@ cc.RotateTo = cc.Class({
 
         let startAngle = target.angle % 360;
 
-        let angle = cc.macro.ROTATE_ACTION_CCW ? (this._dstAngle - startAngle) : (this._dstAngle + startAngle);
+        let angle = cc.macro.ROTATE_ACTION_CCW ? (this._dstAngle - startAngle) : (startAngle - this._dstAngle);
         if (angle > 180) angle -= 360;
         if (angle < -180) angle += 360;
 

--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -895,7 +895,7 @@ cc.RotateTo = cc.Class({
      */
     initWithDuration:function (duration, dstAngle) {
         if (cc.ActionInterval.prototype.initWithDuration.call(this, duration)) {
-            this._dstAngle = dstAngle;
+            this._dstAngle = -dstAngle;
             return true;
         }
         return false;
@@ -913,7 +913,7 @@ cc.RotateTo = cc.Class({
 
         let startAngle = target.angle % 360;
 
-        let angle = cc.macro.ROTATE_ACTION_CCW ? (this._dstAngle - startAngle) : (startAngle - this._dstAngle);
+        let angle = cc.macro.ROTATE_ACTION_CCW ? (this._dstAngle - startAngle) : (this._dstAngle + startAngle);
         if (angle > 180) angle -= 360;
         if (angle < -180) angle += 360;
 

--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -881,7 +881,6 @@ cc.RotateTo = cc.Class({
     extends: cc.ActionInterval,
 
     ctor:function (duration, dstAngle) {
-        dstAngle *= cc.macro.ROTATE_ACTION_CCW ? 1 : -1;
         this._startAngle = 0;
         this._dstAngle = 0;
         this._angle = 0;

--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -895,7 +895,7 @@ cc.RotateTo = cc.Class({
      */
     initWithDuration:function (duration, dstAngle) {
         if (cc.ActionInterval.prototype.initWithDuration.call(this, duration)) {
-            this._dstAngle = dstAngle;
+            this._dstAngle = -dstAngle;
             return true;
         }
         return false;

--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -895,7 +895,7 @@ cc.RotateTo = cc.Class({
      */
     initWithDuration:function (duration, dstAngle) {
         if (cc.ActionInterval.prototype.initWithDuration.call(this, duration)) {
-            this._dstAngle = -dstAngle;
+            this._dstAngle = dstAngle;
             return true;
         }
         return false;
@@ -913,7 +913,7 @@ cc.RotateTo = cc.Class({
 
         let startAngle = target.angle % 360;
 
-        let angle = cc.macro.ROTATE_ACTION_CCW ? (this._dstAngle - startAngle) : (this._dstAngle + startAngle);
+        let angle = cc.macro.ROTATE_ACTION_CCW ? (this._dstAngle - startAngle) : (startAngle - this._dstAngle);
         if (angle > 180) angle -= 360;
         if (angle < -180) angle += 360;
 


### PR DESCRIPTION
issues: https://github.com/cocos-creator/2d-tasks/issues/2063

用户传入的是 rotation 的值，而引擎内部使用 rotation 进行旋转变换需要把 rotation 转成 angle 才能正确使用。
之前 cc.RotateTo 内部没有对用户传入的 rotation 转换成 angle。