### PR TITLE
fix error when get builtin materials

### DIFF
--- a/cocos2d/core/asset-manager/builtins.js
+++ b/cocos2d/core/asset-manager/builtins.js
@@ -36,13 +36,11 @@ const finalizer = require('./finalizer');
  */
 var builtins = {
     
-    _assets: new Cache(), // builtin assets
+    _assets: new Cache({ material: new Cache(), effect: new Cache() }), // builtin assets
 
     _loadBuiltins (name, cb) {
         let dirname = name  + 's';
-        let builtin = new Cache();
-        this._assets.add(name, builtin);
-
+        let builtin = this._assets.get(name);
         return cc.assetManager._bundles.get('internal').loadDir(dirname, null, null, (err, assets) => {
             if (err) {
                 cc.error(err);
@@ -125,9 +123,8 @@ var builtins = {
                 finalizer.unlock(asset);
                 finalizer.release(asset, true);
             });
-            assets.destroy();
+            assets.clear();
         })
-        this._assets.clear();
     }
 }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 即使没有加载内置资源，也不应该报错

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
