### PR TITLE
refine editbox begin editing callback

### DIFF
--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -189,11 +189,11 @@ Object.assign(WebEditBoxImpl.prototype, {
         if (_currentEditBoxImpl && _currentEditBoxImpl !== this) {
             _currentEditBoxImpl.setFocus(false);
         }
+        this._delegate.editBoxEditingDidBegan();
         this._editing = true;
         _currentEditBoxImpl = this;
         this._showDom();
         this._elem.focus();  // set focus
-        this._delegate.editBoxEditingDidBegan();  
     },
 
     endEditing () {

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -189,9 +189,9 @@ Object.assign(WebEditBoxImpl.prototype, {
         if (_currentEditBoxImpl && _currentEditBoxImpl !== this) {
             _currentEditBoxImpl.setFocus(false);
         }
-        this._delegate.editBoxEditingDidBegan();
         this._editing = true;
         _currentEditBoxImpl = this;
+        this._delegate.editBoxEditingDidBegan();
         this._showDom();
         this._elem.focus();  // set focus
     },


### PR DESCRIPTION
changeLog:
- 修复 editBox 在 editing-did-began 回调里无法设置 editBox.string 的问题

应该在 showDom 之前执行用户注册的回调，这样用户才能看到他们期望看到的结果