### PR TITLE
Fix button node in the onLoad callback setting scale is invalid

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -424,7 +424,6 @@ let Button = cc.Class({
 
     __preload () {
         this._applyTarget();
-        this._updateState();
     },
 
     _resetState () {
@@ -442,6 +441,10 @@ let Button = cc.Class({
             target.setScale(originalScale.x, originalScale.y);
         }
         this._transitionFinished = true;
+    },
+
+    onLoad () {
+        this._updateState();
     },
 
     onEnable () {

--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -424,6 +424,7 @@ let Button = cc.Class({
 
     __preload () {
         this._applyTarget();
+        this._resetState();
     },
 
     _resetState () {
@@ -441,10 +442,6 @@ let Button = cc.Class({
             target.setScale(originalScale.x, originalScale.y);
         }
         this._transitionFinished = true;
-    },
-
-    onLoad () {
-        this._updateState();
     },
 
     onEnable () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2077
这样修改的原因是因为 button 在 _preload 阶段执行了 this._updateState(); 这时候把 _transitionFinished 改成了 false。这句代码优先于用户代码的 onLoad 回调的执行顺序，所以当用户在脚本 onLoad 回调修改节点 scale 时，因为条件语句：
```
if (this._originalScale && (this.transition !== Transition.SCALE || this._transitionFinished)) {
```
的限制，导致无法执行。
所以现在将 _preload 中的 this._updateState(); 移到 onLoad 回调中，这样就可以解决问题。