### PR TITLE
fixed cc.RotateBy reverse error

### DIFF
--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -1007,9 +1007,10 @@ cc.RotateBy = cc.Class({
     },
 
     reverse:function () {
-        var action = new cc.RotateBy(this._duration, -this._deltaAngle);
+        var action = new cc.RotateBy();
         this._cloneDecoration(action);
         this._reverseEaseList(action);
+        action.initWithDuration(this._duration, -this._deltaAngle);
         return action;
     }
 });

--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -1008,9 +1008,9 @@ cc.RotateBy = cc.Class({
 
     reverse:function () {
         var action = new cc.RotateBy();
+        action.initWithDuration(this._duration, -this._deltaAngle);
         this._cloneDecoration(action);
         this._reverseEaseList(action);
-        action.initWithDuration(this._duration, -this._deltaAngle);
         return action;
     }
 });


### PR DESCRIPTION
Re: https://forum.cocos.org/t/cocos-creator-v2-2-1/85555/267?u=endevil

Changes:
 * 
fixed cc.RotateBy reverse function error code.

cc.RotateBy 的构造函数中有对 this._deltaAngle 进行取反的操作，所以导致调用 
```
new cc.RotateBy(tthis._duration, -this._deltaAngle) 
```
之后，this._deltaAngle 实际上没有发生变化，故导致了问题。
现在不利用 new cc.RotateBy() 来初始化数据，而是使用 
```
action.initWithDuration(this._duration, -this._deltaAngle);
```
这样就没有问题。