### PR TITLE
editbox component add protection code

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -713,14 +713,14 @@ let EditBox = cc.Class({
     },
 
     editBoxEditingDidBegan () {
-        if (this.editingDidBegan) {
+        if (cc.isValid(this)) {
             cc.Component.EventHandler.emitEvents(this.editingDidBegan, this);
             this.node.emit('editing-did-began', this);
         }
     },
 
     editBoxEditingDidEnded () {
-        if (this.editingDidEnded) {
+        if (cc.isValid(this)) {
             cc.Component.EventHandler.emitEvents(this.editingDidEnded, this);
             this.node.emit('editing-did-ended', this);
         }
@@ -729,14 +729,14 @@ let EditBox = cc.Class({
     editBoxTextChanged (text) {
         text = this._updateLabelStringStyle(text, true);
         this.string = text;
-        if (this.textChanged) {
+        if (cc.isValid(this)) {
             cc.Component.EventHandler.emitEvents(this.textChanged, text, this);
             this.node.emit('text-changed', this);
         }
     },
 
     editBoxEditingReturn() {
-        if (this.editingReturn) {
+        if (cc.isValid(this)) {
             cc.Component.EventHandler.emitEvents(this.editingReturn, this);
             this.node.emit('editing-return', this);
         }

--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -713,33 +713,25 @@ let EditBox = cc.Class({
     },
 
     editBoxEditingDidBegan () {
-        if (cc.isValid(this)) {
-            cc.Component.EventHandler.emitEvents(this.editingDidBegan, this);
-            this.node.emit('editing-did-began', this);
-        }
+        cc.Component.EventHandler.emitEvents(this.editingDidBegan, this);
+        this.node.emit('editing-did-began', this);
     },
 
     editBoxEditingDidEnded () {
-        if (cc.isValid(this)) {
-            cc.Component.EventHandler.emitEvents(this.editingDidEnded, this);
-            this.node.emit('editing-did-ended', this);
-        }
+        cc.Component.EventHandler.emitEvents(this.editingDidEnded, this);
+        this.node.emit('editing-did-ended', this);
     },
 
     editBoxTextChanged (text) {
         text = this._updateLabelStringStyle(text, true);
         this.string = text;
-        if (cc.isValid(this)) {
-            cc.Component.EventHandler.emitEvents(this.textChanged, text, this);
-            this.node.emit('text-changed', this);
-        }
+        cc.Component.EventHandler.emitEvents(this.textChanged, text, this);
+        this.node.emit('text-changed', this);
     },
 
     editBoxEditingReturn() {
-        if (cc.isValid(this)) {
-            cc.Component.EventHandler.emitEvents(this.editingReturn, this);
-            this.node.emit('editing-return', this);
-        }
+        cc.Component.EventHandler.emitEvents(this.editingReturn, this);
+        this.node.emit('editing-return', this);
     },
 
     onEnable () {
@@ -761,6 +753,9 @@ let EditBox = cc.Class({
     },
 
     onDestroy () {
+        if (this.isFocused()) {
+            this.blur();
+        }
         if (this._impl) {
             this._impl.clear();
         }

--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -713,25 +713,33 @@ let EditBox = cc.Class({
     },
 
     editBoxEditingDidBegan () {
-        cc.Component.EventHandler.emitEvents(this.editingDidBegan, this);
-        this.node.emit('editing-did-began', this);
+        if (this.editingDidBegan) {
+            cc.Component.EventHandler.emitEvents(this.editingDidBegan, this);
+            this.node.emit('editing-did-began', this);
+        }
     },
 
     editBoxEditingDidEnded () {
-        cc.Component.EventHandler.emitEvents(this.editingDidEnded, this);
-        this.node.emit('editing-did-ended', this);
+        if (this.editingDidEnded) {
+            cc.Component.EventHandler.emitEvents(this.editingDidEnded, this);
+            this.node.emit('editing-did-ended', this);
+        }
     },
 
     editBoxTextChanged (text) {
         text = this._updateLabelStringStyle(text, true);
         this.string = text;
-        cc.Component.EventHandler.emitEvents(this.textChanged, text, this);
-        this.node.emit('text-changed', this);
+        if (this.textChanged) {
+            cc.Component.EventHandler.emitEvents(this.textChanged, text, this);
+            this.node.emit('text-changed', this);
+        }
     },
 
     editBoxEditingReturn() {
-        cc.Component.EventHandler.emitEvents(this.editingReturn, this);
-        this.node.emit('editing-return', this);
+        if (this.editingReturn) {
+            cc.Component.EventHandler.emitEvents(this.editingReturn, this);
+            this.node.emit('editing-return', this);
+        }
     },
 
     onEnable () {


### PR DESCRIPTION
Re: 来自木七七技术支持群反馈的问题
复现视频：
[1573803377131248.mp4.zip](https://github.com/cocos-creator/engine/files/3850567/1573803377131248.mp4.zip)

![image](https://user-images.githubusercontent.com/35944775/68929395-41ad8a80-07c7-11ea-88fe-71a757ad8170.png)

看了下代码，是因为 editbox 组件被销毁之后，存在 editbox 依然能触发事件回调的情况。在这种情况下 editbox 组件 this 对象已经不可用了，所以导致后续代码调用相关属性的时候出现问题。