### PR TITLE
Fix the penetration of click events when Mask nesting.

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -2084,12 +2084,12 @@ let NodeDefines = {
                             }
                         } else {
                             // mask parent no longer exists
-                            mask.splice(j, length - j);
+                            mask.length = j;
                             break
                         }
                     } else if (i > temp.index) {
                         // mask parent no longer exists
-                        mask.splice(j, length - j);
+                        mask.length = j;
                         break
                     }
                 }

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -489,6 +489,8 @@ function _searchMaskInParent (node) {
     var Mask = cc.Mask;
     if (Mask) {
         let index = 0;
+        // Because Mask may be nested, need to find all the Mask components in the parent node. 
+        // The click area must satisfy all Masks to trigger the click.
         let temp = {
             index: -1,
             node: null,
@@ -1406,7 +1408,7 @@ let NodeDefines = {
             cc._widgetManager._nodesOrderDirty = true;
         }
 
-        if (oldParent) {
+        if (oldParent && this._activeInHierarchy) {
             this._checkListenerMask();
         }
         
@@ -1608,8 +1610,6 @@ let NodeDefines = {
 
     // EVENT TARGET
     _checkListenerMask () {
-        if (!this._activeInHierarchy) return;
-
         if (this._touchListener) {
             var mask = this._touchListener.mask = _searchMaskInParent(this);
             if (this._mouseListener) {

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -508,8 +508,9 @@ function _searchMaskInParent (node) {
             }
         }
 
-        return list;
+        return list.next ? list : null;
     }
+    
     return null;
 }
 

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1384,6 +1384,8 @@ let NodeDefines = {
             // ActionManager & EventManager
             actionManager && actionManager.resumeTarget(this);
             eventManager.resumeTarget(this);
+            // Search Mask in parent
+            this._checkListenerMask();
         } else {
             // deactivate
             actionManager && actionManager.pauseTarget(this);
@@ -1404,8 +1406,10 @@ let NodeDefines = {
             cc._widgetManager._nodesOrderDirty = true;
         }
 
-        this._checkListenerMask();
-
+        if (oldParent) {
+            this._checkListenerMask();
+        }
+        
         // Node proxy
         if (CC_JSB && CC_NATIVERENDERER) {
             this._proxy.updateParent();

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1409,6 +1409,7 @@ let NodeDefines = {
         }
 
         if (oldParent && this._activeInHierarchy) {
+            //TODO: It may be necessary to update the listener mask of all child nodes.
             this._checkListenerMask();
         }
         
@@ -2074,7 +2075,7 @@ let NodeDefines = {
                     if (i === mask.next.index) {
                         if (parent === mask.next.node) {
                             let comp = parent.getComponent(cc.Mask);
-                            if (comp && comp.enabledInHierarchy && comp._hitTest(cameraPt)) {
+                            if (comp && comp._enabled && comp._hitTest(cameraPt)) {
                                 mask = mask.next;
                             } else {
                                 hit = false;


### PR DESCRIPTION
**问题说明：**

反馈自论坛：https://forum.cocos.org/t/cocos-creator-v2-2-1/85555/250?u=endevil

在 Mask 嵌套的情况下，因为节点的点击事件只会对第一个 Mask 父节点进行 hitTest，所以会出现 button 不显示的区域也会触发点击事件。

测试Demo：
[scrollview_test 2.zip](https://github.com/cocos-creator/engine/files/3851110/scrollview_test.2.zip)

**修改说明：**

1. 这里对 touchListener 进行父节点的 Mask 查询及缓存的时候，之前只会缓存第一个 Maks节点，现在以单链表的形式缓存所有 Mask 父节点，在进行点击区域判定的时候，会对缓存的链表中的所有 Mask 节点进行 hitTest 判定，必须全部满足才会触发点击。

2. 之前只有在节点 postActive 的时候才会查询记录事件的 mask，在 button 重新设置父节点的时候并没有重置 Mask 的记录，增加在 _onHierarchyChanged 节点层级发生变化时也进行重新查询的记录。

**注意：**

另外有一种情况就是当 button 的父节点层级发生变化，如果没有触发 button 节点的 _onHierarchyChanged 或者 active 状态改变，仍然不会重置事件的 Mask 记录。对于这种情况比较少见，为了不浪费性能，暂时忽略该使用场景，有需要的可以调用 _checkListenerMask 进行更新。

另：非新增问题，可在 v2.2.2 版本更新
