### PR TITLE
fix undefined material on flushMaterial

### DIFF
--- a/cocos2d/core/renderer/webgl/model-batcher.js
+++ b/cocos2d/core/renderer/webgl/model-batcher.js
@@ -117,6 +117,9 @@ ModelBatcher.prototype = {
     },
 
     _flushMaterial (material) {
+        if (!material) {
+            return;
+        }
         this.material = material;
         let effect = material.effect;
         if (!effect) return;


### PR DESCRIPTION
changeLog:
- 修复 flushMaterial 报错的问题

<img width="420" alt="20191119194732" src="https://user-images.githubusercontent.com/17872773/69144154-a2113480-0b05-11ea-9d33-bce8d20059b5.png">
来自支付宝用户线上游戏的报错反馈，这里可能需要判断下 material 是否为空