### PR TITLE
Improved type array to get the name of the code

### DIFF
--- a/cocos2d/core/platform/instantiate-jit.js
+++ b/cocos2d/core/platform/instantiate-jit.js
@@ -72,7 +72,9 @@ function getTypedArrayName (constructor) {
     else if (constructor === Uint32Array) { return 'Uint32Array'; }
     else if (constructor === Int32Array) { return 'Int32Array'; }
     else if (constructor === Uint8Array) { return 'Uint8Array'; }
-    return '';
+    else {
+        throw new Error(`Unknown TypedArray could not be instantiated: ${constructor}`);
+    }
 }
 
 // HELPER CLASSES

--- a/cocos2d/core/platform/instantiate-jit.js
+++ b/cocos2d/core/platform/instantiate-jit.js
@@ -55,6 +55,26 @@ const DEFAULT_MODULE_CACHE = {
     'cc.PrefabInfo': false
 };
 
+try {
+    // compatible for IE
+    !Float64Array.name && (Float64Array.name = 'Float64Array');
+    !Float32Array.name && (Float32Array.name = 'Float32Array');
+    !Uint32Array.name && (Uint32Array.name = 'Uint32Array');
+    !Int32Array.name && (Int32Array.name = 'Int32Array');
+    !Uint8Array.name && (Uint8Array.name = 'Uint8Array');
+}
+catch (e) {}
+
+// compatible for iOS 9
+function getTypedArrayName (constructor) {
+    if (constructor === Float64Array) { return 'Float64Array'; }
+    else if (constructor === Float32Array) { return 'Float32Array'; }
+    else if (constructor === Uint32Array) { return 'Uint32Array'; }
+    else if (constructor === Int32Array) { return 'Int32Array'; }
+    else if (constructor === Uint8Array) { return 'Uint8Array'; }
+    return '';
+}
+
 // HELPER CLASSES
 
 // ('foo', 'bar')
@@ -362,33 +382,8 @@ proto.instantiateArray = function (value) {
     return codeArray;
 };
 
-// 这里为了适配 ios9 与 ie 环境下 TypedArray 的 Name 为空的情况
-let _typedArrayStr2Name;
-function getTypedArrayName (value) {
-    let type = value.constructor.name;
-    if (!type) {
-        try {
-            let constructorStr = value.constructor.toString();
-            type = _typedArrayStr2Name && _typedArrayStr2Name[constructorStr];
-            if (type) return type;
-            if (_typedArrayStr2Name) {
-                _typedArrayStr2Name = {};
-            }
-            // 通过正则提取构造函数中的 name
-            // 例如：function Float32Array() { [native code] } 提出出来的 name 为 Float32Array;
-            const rex = new RegExp(/function (\S*)\b/);
-            type = constructorStr.match(rex)[1];
-            _typedArrayStr2Name[constructorStr] = type;
-        }
-        catch (e) {
-            console.error(e);
-        }
-    }
-    return type;
-}
-
 proto.instantiateTypedArray = function (value) {
-    let type = getTypedArrayName(value);
+    let type = value.constructor.name || getTypedArrayName(value.constructor);
     if (value.length === 0) {
         return 'new ' + type;
     }

--- a/cocos2d/core/platform/instantiate-jit.js
+++ b/cocos2d/core/platform/instantiate-jit.js
@@ -60,12 +60,12 @@ try {
     !Float32Array.name && (Float32Array.name = 'Float32Array');
     !Float64Array.name && (Float64Array.name = 'Float64Array');
 
-    !Int8Array.name && (Float64Array.name = 'Int8Array');
-    !Int16Array.name && (Float64Array.name = 'Int16Array');
+    !Int8Array.name && (Int8Array.name = 'Int8Array');
+    !Int16Array.name && (Int16Array.name = 'Int16Array');
     !Int32Array.name && (Int32Array.name = 'Int32Array');
 
     !Uint8Array.name && (Uint8Array.name = 'Uint8Array');
-    !Uint16Array.name && (Uint8Array.name = 'Uint16Array');
+    !Uint16Array.name && (Uint16Array.name = 'Uint16Array');
     !Uint32Array.name && (Uint32Array.name = 'Uint32Array');
 }
 catch (e) {}

--- a/cocos2d/core/platform/instantiate-jit.js
+++ b/cocos2d/core/platform/instantiate-jit.js
@@ -57,21 +57,31 @@ const DEFAULT_MODULE_CACHE = {
 
 try {
     // compatible for IE
-    !Float64Array.name && (Float64Array.name = 'Float64Array');
     !Float32Array.name && (Float32Array.name = 'Float32Array');
-    !Uint32Array.name && (Uint32Array.name = 'Uint32Array');
+    !Float64Array.name && (Float64Array.name = 'Float64Array');
+
+    !Int8Array.name && (Float64Array.name = 'Int8Array');
+    !Int16Array.name && (Float64Array.name = 'Int16Array');
     !Int32Array.name && (Int32Array.name = 'Int32Array');
+
     !Uint8Array.name && (Uint8Array.name = 'Uint8Array');
+    !Uint16Array.name && (Uint8Array.name = 'Uint16Array');
+    !Uint32Array.name && (Uint32Array.name = 'Uint32Array');
 }
 catch (e) {}
 
 // compatible for iOS 9
 function getTypedArrayName (constructor) {
-    if (constructor === Float64Array) { return 'Float64Array'; }
-    else if (constructor === Float32Array) { return 'Float32Array'; }
-    else if (constructor === Uint32Array) { return 'Uint32Array'; }
+    if (constructor === Float32Array) { return 'Float32Array'; }
+    else if (constructor === Float64Array) { return 'Float64Array'; }
+
+    else if (constructor === Int8Array) { return 'Int8Array'; }
+    else if (constructor === Int16Array) { return 'Int16Array'; }
     else if (constructor === Int32Array) { return 'Int32Array'; }
+
     else if (constructor === Uint8Array) { return 'Uint8Array'; }
+    else if (constructor === Uint16Array) { return 'Uint16Array'; }
+    else if (constructor === Uint32Array) { return 'Uint32Array'; }
     else {
         throw new Error(`Unknown TypedArray could not be instantiated: ${constructor}`);
     }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复跑上 ios9 上崩溃的 bug
原因：由于之前为了处理 ie 上 TypeArray 获取到 name 为空的问题，在代码中设置了 TypeArray 的  name，但是 ios9 系统 name 是只读的属性如果设置的话就会报错，从而导致引擎代码跑在 ios9 系统上会崩溃
