### PR TITLE
change animatable property from  sharedMaterials to materials

### DIFF
--- a/cocos/core/3d/framework/renderable-component.ts
+++ b/cocos/core/3d/framework/renderable-component.ts
@@ -31,6 +31,7 @@ export class RenderableComponent extends Component {
         type: Material,
         displayName: 'Materials',
         tooltip: '源材质',
+        animatable: false,
     })
     get sharedMaterials () {
         // if we don't create an array copy, the editor will modify the original array directly.
@@ -56,6 +57,11 @@ export class RenderableComponent extends Component {
      * @zh 模型材质。
      * @type {Material[]}
      */
+    @property({
+        type: Material,
+        visible: false,
+        animatable: true,
+    })
     get materials () {
         for (let i = 0; i < this._materials.length; i++) {
             this._materials[i] = this.getMaterial(i)!;

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -1248,8 +1248,8 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
     parseSimpleAttribute('formerlySerializedAs', 'string');
 
     if (CC_EDITOR) {
-        if ('animatable' in attributes && !attributes.animatable) {
-            (attrsProto || getAttrsProto())[attrsProtoKey + 'animatable'] = false;
+        if ('animatable' in attributes) {
+            (attrsProto || getAttrsProto())[attrsProtoKey + 'animatable'] = attributes.animatable;
         }
     }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * change animatable property from  sharedMaterials to materials in renderable-component

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
