### PR TITLE
2.2.1 to 2.2.2 vmath compatibility issue

### DIFF
--- a/cocos2d/core/utils/trans-pool/node-unit.js
+++ b/cocos2d/core/utils/trans-pool/node-unit.js
@@ -23,7 +23,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-import { FLOAT_ARRAY_TYPE, FLOAT_BYTES } from '../../vmath/utils';
+import { FLOAT_ARRAY_TYPE, FLOAT_BYTES } from '../../value-types/utils'
 
 const Uint32_Bytes = 4;
 const Uint8_Bytes = 1;


### PR DESCRIPTION
@holycanvas 合并2.2.1 代码时，与2.2.2 数学库目录不一至，导致的报错。