### PR TITLE
fix crash loading scene while editBox is on editing on Mac

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -753,9 +753,6 @@ let EditBox = cc.Class({
     },
 
     onDestroy () {
-        if (this.isFocused()) {
-            this.blur();
-        }
         if (this._impl) {
             this._impl.clear();
         }

--- a/cocos2d/core/components/editbox/EditBoxImplBase.js
+++ b/cocos2d/core/components/editbox/EditBoxImplBase.js
@@ -55,11 +55,11 @@ let EditBoxImplBase = cc.Class({
     },
 
     setTabIndex (index) {
-        // Only support on Web platform
+
     },
 
     setSize (width, height) {
-        // Only support on Web platform
+
     },
 
     setFocus (value) {

--- a/cocos2d/core/components/editbox/EditBoxImplBase.js
+++ b/cocos2d/core/components/editbox/EditBoxImplBase.js
@@ -28,7 +28,8 @@
 
 let EditBoxImplBase = cc.Class({
     ctor () {
-        this._delegate = null;        
+        this._delegate = null;
+        this._editing = false;
     },
 
     init (delegate) {
@@ -40,7 +41,9 @@ let EditBoxImplBase = cc.Class({
     },
 
     disable () {
-
+        if (this._editing) {
+            this.endEditing();
+        }
     },
 
     clear () {
@@ -52,7 +55,7 @@ let EditBoxImplBase = cc.Class({
     },
 
     setTabIndex (index) {
-        // Only support on Web platform  
+        // Only support on Web platform
     },
 
     setSize (width, height) {
@@ -60,11 +63,16 @@ let EditBoxImplBase = cc.Class({
     },
 
     setFocus (value) {
-        
+        if (value) {
+            this.beginEditing();
+        }
+        else {
+            this.endEditing();
+        }
     },
 
     isFocused () {
-
+        return this._editing;
     },
 
     beginEditing () {

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -62,14 +62,15 @@ let _currentEditBoxImpl = null;
 let _fullscreen = false;
 let _autoResize = false;
 
+const BaseClass = EditBox._ImplClass;
  // This is an adapter for EditBoxImpl on web platform.
  // For more adapters on other platforms, please inherit from EditBoxImplBase and implement the interface.
 function WebEditBoxImpl () {
+    BaseClass.call(this);
     this._domId = `EditBoxId_${++_domCount}`;
     this._placeholderStyleSheet = null;
     this._elem = null;
     this._isTextArea = false;
-    this._editing = false;
 
     // matrix
     this._worldMat = math.mat4.create();
@@ -105,7 +106,7 @@ function WebEditBoxImpl () {
     this._placeholderLineHeight = null;
 }
 
-js.extend(WebEditBoxImpl, EditBox._ImplClass);
+js.extend(WebEditBoxImpl, BaseClass);
 EditBox._ImplClass = WebEditBoxImpl;
 
 Object.assign(WebEditBoxImpl.prototype, {
@@ -132,17 +133,6 @@ Object.assign(WebEditBoxImpl.prototype, {
 
         _fullscreen = cc.view.isAutoFullScreenEnabled();
         _autoResize = cc.view._resizeWithBrowserSize;
-    },
-
-    enable () {
-        // Do nothing
-    },
-
-    disable () {
-        // Need to hide dom when disable editBox on editing
-        if (this._editing) {
-            this._elem.blur();
-        }
     },
 
     clear () {
@@ -172,19 +162,6 @@ Object.assign(WebEditBoxImpl.prototype, {
         elem.style.height = height + 'px';
     },
 
-    setFocus (value) {
-        if (value) {
-            this.beginEditing();
-        }
-        else {
-            this._elem.blur();
-        }
-    },
-
-    isFocused () {
-        return this._editing;
-    },
-
     beginEditing () {
         if (_currentEditBoxImpl && _currentEditBoxImpl !== this) {
             _currentEditBoxImpl.setFocus(false);
@@ -197,7 +174,9 @@ Object.assign(WebEditBoxImpl.prototype, {
     },
 
     endEditing () {
-        // Do nothing, handle endEditing on blur callback
+        if (this._elem) {
+            this._elem.blur();
+        }
     },
 
     // ==========================================================================


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2133

changeLog:
- revert pr: https://github.com/cocos-creator/engine/pull/5748
在 OnDestroy 阶段去操作子节点的显示隐藏，这时候子节点已经被销毁了，应该放到 onDisable 这个阶段去做
- 同时把部分 WebEditBoxImpl 的实现移到基类中来， 
关联 pr: 
https://github.com/cocos-creator-packages/adapters/pull/39
https://github.com/cocos-creator-packages/jsb-adapter/pull/214