### PR TITLE
fix setting stayOnBottom bug for video player

### DIFF
--- a/cocos2d/videoplayer/CCVideoPlayer.js
+++ b/cocos2d/videoplayer/CCVideoPlayer.js
@@ -340,6 +340,7 @@ let VideoPlayer = cc.Class({
         let impl = this._impl;
         if (impl) {
             impl.createDomElementIfNeeded(this._mute || this._volume === 0);
+            impl.setStayOnBottom(this._stayOnBottom);
             this._updateVideoSource();
 
             if (!CC_EDITOR) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复初始化 video player 的 stayOnBottom 属性无效