### PR TITLE
fixed RE #2109

### DIFF
--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -753,9 +753,6 @@ let EditBox = cc.Class({
     },
 
     onDestroy () {
-        if (this.isFocused()) {
-            this.blur();
-        }
         if (this._impl) {
             this._impl.clear();
         }

--- a/cocos2d/core/components/editbox/EditBoxImplBase.js
+++ b/cocos2d/core/components/editbox/EditBoxImplBase.js
@@ -28,7 +28,8 @@
 
 let EditBoxImplBase = cc.Class({
     ctor () {
-        this._delegate = null;        
+        this._delegate = null;
+        this._editing = false;
     },
 
     init (delegate) {
@@ -40,7 +41,9 @@ let EditBoxImplBase = cc.Class({
     },
 
     disable () {
-
+        if (this._editing) {
+            this.endEditing();
+        }
     },
 
     clear () {
@@ -52,19 +55,24 @@ let EditBoxImplBase = cc.Class({
     },
 
     setTabIndex (index) {
-        // Only support on Web platform  
+
     },
 
     setSize (width, height) {
-        // Only support on Web platform
+
     },
 
     setFocus (value) {
-        
+        if (value) {
+            this.beginEditing();
+        }
+        else {
+            this.endEditing();
+        }
     },
 
     isFocused () {
-
+        return this._editing;
     },
 
     beginEditing () {

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -62,14 +62,15 @@ let _currentEditBoxImpl = null;
 let _fullscreen = false;
 let _autoResize = false;
 
+const BaseClass = EditBox._ImplClass;
  // This is an adapter for EditBoxImpl on web platform.
  // For more adapters on other platforms, please inherit from EditBoxImplBase and implement the interface.
 function WebEditBoxImpl () {
+    BaseClass.call(this);
     this._domId = `EditBoxId_${++_domCount}`;
     this._placeholderStyleSheet = null;
     this._elem = null;
     this._isTextArea = false;
-    this._editing = false;
 
     // matrix
     this._worldMat = math.mat4.create();
@@ -105,7 +106,7 @@ function WebEditBoxImpl () {
     this._placeholderLineHeight = null;
 }
 
-js.extend(WebEditBoxImpl, EditBox._ImplClass);
+js.extend(WebEditBoxImpl, BaseClass);
 EditBox._ImplClass = WebEditBoxImpl;
 
 Object.assign(WebEditBoxImpl.prototype, {
@@ -132,17 +133,6 @@ Object.assign(WebEditBoxImpl.prototype, {
 
         _fullscreen = cc.view.isAutoFullScreenEnabled();
         _autoResize = cc.view._resizeWithBrowserSize;
-    },
-
-    enable () {
-        // Do nothing
-    },
-
-    disable () {
-        // Need to hide dom when disable editBox on editing
-        if (this._editing) {
-            this._elem.blur();
-        }
     },
 
     clear () {
@@ -172,19 +162,6 @@ Object.assign(WebEditBoxImpl.prototype, {
         elem.style.height = height + 'px';
     },
 
-    setFocus (value) {
-        if (value) {
-            this.beginEditing();
-        }
-        else {
-            this._elem.blur();
-        }
-    },
-
-    isFocused () {
-        return this._editing;
-    },
-
     beginEditing () {
         if (_currentEditBoxImpl && _currentEditBoxImpl !== this) {
             _currentEditBoxImpl.setFocus(false);
@@ -197,7 +174,9 @@ Object.assign(WebEditBoxImpl.prototype, {
     },
 
     endEditing () {
-        // Do nothing, handle endEditing on blur callback
+        if (this._elem) {
+            this._elem.blur();
+        }
     },
 
     // ==========================================================================

--- a/cocos2d/core/platform/CCScreen.js
+++ b/cocos2d/core/platform/CCScreen.js
@@ -165,7 +165,7 @@ cc.screen = /** @lends cc.screen# */{
             document.addEventListener(eventName, onFullScreenError, { once: true });
         }
 
-        element[this._fn.requestFullscreen]();
+        element[this._fn.requestFullscreen] && element[this._fn.requestFullscreen]();
     },
     
     /**
@@ -212,6 +212,7 @@ cc.screen = /** @lends cc.screen# */{
     _ensureFullScreen (element, onFullScreenChange) {
         let self = this;
         let touchTarget = cc.game.canvas || element;
+        if (!element[this._fn.fullscreenerror]) return;
         let fullScreenErrorEventName = this._fn.fullscreenerror;
         let touchEventName = this._touchEvent;
         

--- a/cocos2d/core/platform/CCScreen.js
+++ b/cocos2d/core/platform/CCScreen.js
@@ -165,7 +165,7 @@ cc.screen = /** @lends cc.screen# */{
             document.addEventListener(eventName, onFullScreenError, { once: true });
         }
 
-        element[this._fn.requestFullscreen] && element[this._fn.requestFullscreen]();
+        element[this._fn.requestFullscreen]();
     },
     
     /**
@@ -194,9 +194,10 @@ cc.screen = /** @lends cc.screen# */{
      */
     autoFullScreen: function (element, onFullScreenChange) {
         element = element || document.body;
-
-        this._ensureFullScreen(element, onFullScreenChange);
-        this.requestFullScreen(element, onFullScreenChange);
+        if (element[this._fn.requestFullscreen] && element[this._fn.fullscreenerror]) {
+            this._ensureFullScreen(element, onFullScreenChange);
+            this.requestFullScreen(element, onFullScreenChange);
+        }
     },
 
     disableAutoFullScreen (element) {
@@ -212,7 +213,6 @@ cc.screen = /** @lends cc.screen# */{
     _ensureFullScreen (element, onFullScreenChange) {
         let self = this;
         let touchTarget = cc.game.canvas || element;
-        if (!element[this._fn.fullscreenerror]) return;
         let fullScreenErrorEventName = this._fn.fullscreenerror;
         let touchEventName = this._touchEvent;
         


### PR DESCRIPTION
RE: https://github.com/cocos-creator/2d-tasks/issues/2109

UC浏览器 V12.7.6.1056 ，对应使用的 chrome 内核版本是 57.0.2987.108。经过真机（vivo x7plus）测试 ，它的 web document 支持下列接口：
```
webkitCancelFullScreen、webkitIsFullScreen、webkitCurrentFullScreenElement
```
不支持：
```
webkitRequestFullScreen、webkitfullscreenchange、webkitfullscreenerror
```
所以导致当前异常出现。引擎中需要使用 requestFullscreen 和 fullscreenerror，但是由于该浏览器不支持所以导致问题。
现在是在接口调用的时候加个保护，防止同类事情发生。