### PR TITLE
fix crash on DeviceMotion on wechat

### DIFF
--- a/cocos2d/core/event/system-event.js
+++ b/cocos2d/core/event/system-event.js
@@ -99,7 +99,7 @@ var SystemEvent = cc.Class({
         }
 
         // for iOS 13+
-        if (isEnable && typeof DeviceMotionEvent.requestPermission === 'function') {
+        if (isEnable && window.DeviceMotionEvent && typeof DeviceMotionEvent.requestPermission === 'function') {
             DeviceMotionEvent.requestPermission().then(response => {
                 console.log(`Device Motion Event request permission: ${response}`);
                 inputManger.setAccelerometerEnabled(response === 'granted');


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2141

changeLog:
- 修复微信开启重力感应时的报错