### PR TITLE
fix wrong video matrix after exiting fullscreen on IE

### DIFF
--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -509,7 +509,13 @@ let VideoPlayerImpl = cc.Class({
         this._video.style['-webkit-transform'] = matrix;
         this._video.style['transform-origin'] = '0px 100% 0px';
         this._video.style['-webkit-transform-origin'] = '0px 100% 0px';
-        this._forceUpdate = false;
+
+        // TODO: move into web adapter
+        // video style would change when enter fullscreen on IE
+        // there is no way to add fullscreenchange event listeners on IE so that we can restore the cached video style
+        if (sys.browserType !== sys.BROWSER_TYPE_IE) {
+            this._forceUpdate = false;
+        }
     }
 });
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2143

changeLog:
- 修复 IE 浏览器上 VideoPlayer 在退出全屏后位置计算错误的问题

IE 上 video 全屏会改变样式，IE 上没办法监听 video 退出全屏，暂时只能让他一直强制 updateMatrix