### PR TITLE
Fix the bottom alignment of the system font.

### DIFF
--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -219,6 +219,8 @@ export default class TTFAssembler extends Assembler2D {
             // free space in vertical direction
             let blank = drawStartY + _canvasPadding.height + _fontSize - _canvasSize.height;
             if (_vAlign === macro.VerticalTextAlignment.BOTTOM) {
+                // Unlike BMFont, needs to reserve space below.
+                blank += textUtils.BASELINE_RATIO / 2 * _fontSize;
                 // BOTTOM
                 firstLinelabelY -= blank;
             } else {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2067

Changes:
之前修正BMFont对齐的时候把系统文本这里也修改为一样的计算方式，只是依据2.1.x及之前的版本更改了计算方式，对齐的计算结果是一致的，不过修改的时候Bottom对齐这里相比之前的版本少预留了一个留白的空间，补上。这里跟BMFont不一样的是，在垂直方向额外预留了一部分空间。

修复前：
![image](https://user-images.githubusercontent.com/39078800/70032069-a1899b00-15e7-11ea-9edb-506f35b15e75.png)

修复后：
![image](https://user-images.githubusercontent.com/39078800/70032206-ec0b1780-15e7-11ea-87b2-e6442b39dcfb.png)


