### PR TITLE
fix add function invalid of vec2

### DIFF
--- a/cocos2d/core/value-types/vec2.ts
+++ b/cocos2d/core/value-types/vec2.ts
@@ -751,8 +751,8 @@ export default class Vec2 extends ValueType {
      */
     add (vector: Vec2, out?: Vec2): Vec2 {
         out = out || new Vec2();
-        out.x += vector.x;
-        out.y += vector.y;
+        out.x = this.x + vector.x;
+        out.y = this.y + vector.y;
         return out;
     }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 vec2 加法运算无效的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
