### PR TITLE
Fix the problem of Button material switching.

### DIFF
--- a/cocos2d/core/utils/gray-sprite-state.js
+++ b/cocos2d/core/utils/gray-sprite-state.js
@@ -74,6 +74,7 @@ let GraySpriteState = cc.Class({
         }
     
         renderComp.setMaterial(0, material);
+        renderComp._updateMaterial();
     }
 })
 


### PR DESCRIPTION
这个修改 https://github.com/cocos-creator/engine/pull/5740 会导致初始化之后Button缓存的材质没有指定Texture，然后鼠标移动到Button之后，触发_onMouseMoveIn之后切换材质，没有再更新Texture显示错误。