### PR TITLE
Modify the calculation of drawcall.

### DIFF
--- a/cocos2d/renderer/gfx/device.js
+++ b/cocos2d/renderer/gfx/device.js
@@ -1374,6 +1374,9 @@ export default class Device {
           count
         );
       }
+
+      // update stats
+      this._stats.drawcalls++;
     }
 
     // TODO: autogen mipmap for color buffer
@@ -1381,9 +1384,6 @@ export default class Device {
     //   gl.bindTexture(this._framebuffer.colors[i]._target, colors[i]._glID);
     //   gl.generateMipmap(this._framebuffer.colors[i]._target);
     // }
-
-    // update stats
-    this._stats.drawcalls++;
 
     // reset states
     cur.set(next);


### PR DESCRIPTION
2.2版本之后所有的状态切换都通过材质进行，这里不产生drawElement的调用，就不需要叠加drawcall了，否则如Mask组件的drawcall统计就会出现错误。