### PR TITLE
fix IB stride fallback when uint8 extension not supported

### DIFF
--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -399,20 +399,22 @@ export class Mesh extends Asset {
                 const idxView = prim.indexView;
 
                 let dstStride = idxView.stride;
+                let dstSize = idxView.length;
                 if (dstStride === 4 && !gfxDevice.hasFeature(GFXFeature.ELEMENT_INDEX_UINT)) {
                     const vertexCount = this._struct.vertexBundles[prim.vertexBundelIndices[0]].view.count;
-                    if (vertexCount >= 2 ** 16) {
-                        warnID(10001, vertexCount, 2 ** 16);
+                    if (vertexCount >= 65536) {
+                        warnID(10001, vertexCount, 65536);
                         continue; // Ignore this primitive
                     } else {
-                        dstStride = 2; // Reduce to short.
+                        dstStride >>= 1; // Reduce to short.
+                        dstSize >>= 1;
                     }
                 }
 
                 indexBuffer = gfxDevice.createBuffer({
                     usage: GFXBufferUsageBit.INDEX | GFXBufferUsageBit.TRANSFER_DST,
                     memUsage: GFXMemoryUsageBit.HOST | GFXMemoryUsageBit.DEVICE,
-                    size: idxView.length,
+                    size: dstSize,
                     stride: dstStride,
                 });
                 indexBuffers.push(indexBuffer);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#2018

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->