### PR TITLE
use Mat4.transform instead of Mat4.translate

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -3284,7 +3284,7 @@ let NodeDefines = {
         _vec3_temp.y = -this._anchorPoint.y * contentSize.height;
 
         Mat4.copy(_mat4_temp, this._matrix);
-        Mat4.translate(_mat4_temp, _mat4_temp, _vec3_temp);
+        Mat4.transform(_mat4_temp, _mat4_temp, _vec3_temp);
         return AffineTrans.fromMat4(out, _mat4_temp);
     },
 
@@ -3335,7 +3335,7 @@ let NodeDefines = {
         _vec3_temp.y = -this._anchorPoint.y * contentSize.height;
 
         Mat4.copy(_mat4_temp, this._worldMatrix);
-        Mat4.translate(_mat4_temp, _mat4_temp, _vec3_temp);
+        Mat4.transform(_mat4_temp, _mat4_temp, _vec3_temp);
 
         return AffineTrans.fromMat4(out, _mat4_temp);
     },

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -328,7 +328,7 @@ Object.assign(WebEditBoxImpl.prototype, {
         _vec3.x = -node._anchorPoint.x * this._w;
         _vec3.y = -node._anchorPoint.y * this._h;
     
-        Mat4.translate(worldMat, worldMat, _vec3);
+        Mat4.transform(worldMat, worldMat, _vec3);
 
         // can't find camera in editor
         let cameraMat;

--- a/cocos2d/renderer/scene/camera.js
+++ b/cocos2d/renderer/scene/camera.js
@@ -491,7 +491,7 @@ export default class Camera {
     let halfWidth = width / 2;
     let halfHeight = height / 2;
     Mat4.identity(_tmp_mat4);
-    Mat4.translate(_tmp_mat4, _tmp_mat4, Vec3.set(_tmp_v3, halfWidth, halfHeight, 0));
+    Mat4.transform(_tmp_mat4, _tmp_mat4, Vec3.set(_tmp_v3, halfWidth, halfHeight, 0));
     Mat4.scale(_tmp_mat4, _tmp_mat4, Vec3.set(_tmp_v3, halfWidth, halfHeight, 1));
 
     Mat4.mul(out, _tmp_mat4, out);

--- a/cocos2d/tilemap/tmx-layer-assembler.js
+++ b/cocos2d/tilemap/tmx-layer-assembler.js
@@ -437,7 +437,7 @@ export default class TmxAssembler extends Assembler {
         tiledNode._updateLocalMatrix();
         Mat4.copy(_mat4_temp, tiledNode._matrix);
         Vec3.set(_vec3_temp, -(left + _moveX), -(bottom + _moveY), 0);
-        Mat4.translate(_mat4_temp, _mat4_temp, _vec3_temp);
+        Mat4.transform(_mat4_temp, _mat4_temp, _vec3_temp);
         let m = _mat4_temp.m;
         let a = m[0];
         let b = m[1];


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * use Mat4.transform instead of Mat4.translate

cc.Mat4.transform 跟原来的 cc.vmath.translate 才是一致的行为