### PR TITLE
optimize tiledmap some logic

### DIFF
--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -1037,7 +1037,7 @@ cc.TMXMapInfo.prototype = {
                 let objectProp = {};
 
                 // Set the id of the object
-                objectProp['id'] = selObj.getAttribute('id') || 0;
+                objectProp['id'] = selObj.getAttribute('id') || j;
 
                 // Set the name of the object to the value for "name"
                 objectProp["name"] = selObj.getAttribute('name') || "";

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -1224,33 +1224,37 @@ let TiledLayer = cc.Class({
         this._layerOrientation = mapInfo.orientation;
         this._mapTileSize = mapInfo.getTileSize();
 
+        let maptw = this._mapTileSize.width;
+        let mapth = this._mapTileSize.height;
+        let layerW = this._layerSize.width;
+        let layerH = this._layerSize.height;
+
         if (this._layerOrientation === cc.TiledMap.Orientation.HEX) {
             // handle hex map
             const TiledMap = cc.TiledMap;
             const StaggerAxis = TiledMap.StaggerAxis;
-            const StaggerIndex = TiledMap.StaggerIndex;
-
-            let maptw = this._mapTileSize.width;
-            let mapth = this._mapTileSize.height;
+            const StaggerIndex = TiledMap.StaggerIndex;            
             let width = 0, height = 0;
 
             this._odd_even = (this._staggerIndex === StaggerIndex.STAGGERINDEX_ODD) ? 1 : -1;
-
+            height = tileSize.height * (mapSize.height + 0.5);
             if (this._staggerAxis === StaggerAxis.STAGGERAXIS_X) {
                 this._diffX1 = (maptw - this._hexSideLength) / 2;
                 this._diffY1 = 0;
-                height = mapth * (this._layerSize.height + 0.5);
-                width = (maptw + this._hexSideLength) * Math.floor(this._layerSize.width / 2) + maptw * (this._layerSize.width % 2);
+                height = mapth * (layerH + 0.5);
+                width = (maptw + this._hexSideLength) * Math.floor(layerW / 2) + maptw * (layerW % 2);
             } else {
                 this._diffX1 = 0;
                 this._diffY1 = (mapth - this._hexSideLength) / 2;
-                width = maptw * (this._layerSize.width + 0.5);
-                height = (mapth + this._hexSideLength) * Math.floor(this._layerSize.height / 2) + mapth * (this._layerSize.height % 2);
+                width = maptw * (layerW + 0.5);
+                height = (mapth + this._hexSideLength) * Math.floor(layerH / 2) + mapth * (layerH % 2);
             }
             this.node.setContentSize(width, height);
+        } else if (this._layerOrientation === cc.TiledMap.Orientation.ISO) {
+            let wh = layerW + layerH;
+            this.node.setContentSize(maptw * 0.5 * wh, mapth * 0.5 * wh);
         } else {
-            this.node.setContentSize(this._layerSize.width * this._mapTileSize.width,
-                this._layerSize.height * this._mapTileSize.height);
+            this.node.setContentSize(layerW * maptw, layerH * mapth);
         }
 
         // offset (after layer orientation is set);

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -444,9 +444,19 @@ let TiledLayer = cc.Class({
     },
 
     _positionForIsoAt (x, y) {
+        let offsetX = 0, offsetY = 0;
+        let index = Math.floor(x) + Math.floor(y) * this._layerSize.width;
+        let gid = this._tiles[index];
+        if (gid) {
+            let tileset = this._texGrids[gid].tileset;
+            let offset = tileset.tileOffset;
+            offsetX = offset.x;
+            offsetY = offset.y;
+        }
+
         return cc.v2(
-            this._mapTileSize.width / 2 * ( this._layerSize.width + x - y - 1),
-            this._mapTileSize.height / 2 * (( this._layerSize.height * 2 - x - y) - 2)
+            this._mapTileSize.width * 0.5 * (this._layerSize.height + x - y - 1) + offsetX,
+            this._mapTileSize.height * 0.5 * (this._layerSize.width - x + this._layerSize.height - y - 2) - offsetY
         );
     },
 

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -461,9 +461,19 @@ let TiledLayer = cc.Class({
     },
 
     _positionForOrthoAt (x, y) {
+        let offsetX = 0, offsetY = 0;
+        let index = Math.floor(x) + Math.floor(y) * this._layerSize.width;
+        let gid = this._tiles[index];
+        if (gid) {
+            let tileset = this._texGrids[gid].tileset;
+            let offset = tileset.tileOffset;
+            offsetX = offset.x;
+            offsetY = offset.y;
+        }
+
         return cc.v2(
-            x * this._mapTileSize.width,
-            (this._layerSize.height - y - 1) * this._mapTileSize.height
+            x * this._mapTileSize.width + offsetX,
+            (this._layerSize.height - y - 1) * this._mapTileSize.height - offsetY
         );
     },
 

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -1257,7 +1257,6 @@ let TiledLayer = cc.Class({
             let width = 0, height = 0;
 
             this._odd_even = (this._staggerIndex === StaggerIndex.STAGGERINDEX_ODD) ? 1 : -1;
-            height = tileSize.height * (mapSize.height + 0.5);
             if (this._staggerAxis === StaggerAxis.STAGGERAXIS_X) {
                 this._diffX1 = (maptw - this._hexSideLength) / 2;
                 this._diffY1 = 0;

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -141,6 +141,10 @@ let TiledObjectGroup = cc.Class({
                 width = tileSize.width * (mapSize.width + 0.5);
                 height = (tileSize.height + mapInfo.getHexSideLength()) * Math.floor(mapSize.height / 2) + tileSize.height * (mapSize.height % 2);
             }
+        } else if (mapInfo.orientation === Orientation.ISO) {
+            let wh = mapSize.width + mapSize.height;
+            width = tileSize.width * 0.5 * wh;
+            height = tileSize.height * 0.5 * wh;
         } else {
             width = mapSize.width * tileSize.width; 
             height = mapSize.height * tileSize.height;

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -272,13 +272,11 @@ let TiledObjectGroup = cc.Class({
 
         // destroy useless node
         let children = this.node.children;
-        let imgExp = /^img\d+$/;
-        let txtExp = /^text\d+$/;
+        let uselessExp = /^(?:img|text)\d+$/;
         for (let i = 0, n = children.length; i < n; i++) {
             let c = children[i];
             let cName = c._name;
-            let isUseless = imgExp.test(cName);
-            isUseless = isUseless || txtExp.test(cName);
+            let isUseless = uselessExp.test(cName);
             if (isUseless && !aliveNodes[cName]) c.destroy();
         }
     }

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -166,15 +166,15 @@ let TiledObjectGroup = cc.Class({
                 for (let pi = 0; pi < points.length; pi++) {
                     points[pi].y *= -1;
                 }
-            }
+            }         
 
             if (Orientation.ISO !== mapInfo.orientation) {
                 object.y = height - object.y;
             } else {
                 let posIdxX = object.x / tileSize.width * 2;
                 let posIdxY = object.y / tileSize.height;
-                object.x = tileSize.width / 2 * (mapSize.width + posIdxX - posIdxY);
-                object.y = tileSize.height / 2 * (mapSize.height * 2 - posIdxX - posIdxY);
+                object.x = tileSize.width * 0.5 * (mapSize.height + posIdxX - posIdxY);
+                object.y = tileSize.height * 0.5 * (mapSize.width + mapSize.height - posIdxX - posIdxY);
             }
 
             if (objType === TMXObjectType.TEXT) {
@@ -220,6 +220,10 @@ let TiledObjectGroup = cc.Class({
                 let imgName = "img" + object.id;
                 aliveNodes[imgName] = true;
                 let imgNode = this.node.getChildByName(imgName);
+                let imgWidth = object.width || grid.width;
+                let imgHeight = object.height || grid.height;
+                let tileOffsetX = tileset.tileOffset.x;
+                let tileOffsetY = tileset.tileOffset.y;
 
                 // Delete image nodes implemented as private nodes
                 // Use cc.Node to implement node-level requirements
@@ -234,15 +238,15 @@ let TiledObjectGroup = cc.Class({
                 }
 
                 if (Orientation.ISO == mapInfo.orientation) {
-                    imgNode.anchorX = 0.5;
-                    imgNode.anchorY = 0;
+                    imgNode.anchorX = 0.5 + tileOffsetX / imgWidth;
+                    imgNode.anchorY = tileOffsetY / imgHeight;
                 } else {
-                    imgNode.anchorX = 0;
-                    imgNode.anchorY = 0;
+                    imgNode.anchorX = tileOffsetX / imgWidth;
+                    imgNode.anchorY = tileOffsetY / imgHeight;
                 }
                 imgNode.angle = -object.rotation;
-                imgNode.x = object.x - leftTopX + tileset.tileOffset.x;
-                imgNode.y = object.y - leftTopY + tileset.tileOffset.y;
+                imgNode.x = object.x - leftTopX;
+                imgNode.y = object.y - leftTopY;
                 imgNode.name = imgName;
                 imgNode.parent = this.node;
                 imgNode.opacity = this._opacity;
@@ -252,12 +256,16 @@ let TiledObjectGroup = cc.Class({
                 if (!sp) {
                     sp = imgNode.addComponent(cc.Sprite);
                 }
-                let spf = new cc.SpriteFrame();
+                let spf = sp.spriteFrame;
+                if (!spf) {
+                    spf = new cc.SpriteFrame();
+                }
                 spf.setTexture(grid.tileset.sourceImage, cc.rect(grid));
                 sp.spriteFrame = spf;
 
-                imgNode.width = object.width;
-                imgNode.height = object.height;
+                // object group may has no width or height info
+                imgNode.width = imgWidth;
+                imgNode.height = imgHeight;
             }
         }
         this._objects = objects;


### PR DESCRIPTION
优化tiledmap 代码逻辑
修复斜角地图为非左右对称形状时，包围盒计算不正确的问题
包围盒相关issue: https://github.com/cocos-creator/2d-tasks/issues/2168
