### PR TITLE
fix using the scroll wheel does not trigger the scroll-end event

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -297,8 +297,18 @@ cc.js.mixin(View.prototype, {
 
     _initFrameSize: function () {
         var locFrameSize = this._frameSize;
-        var w = __BrowserGetter.availWidth(cc.game.frame);
-        var h = __BrowserGetter.availHeight(cc.game.frame);
+
+        var w, h;
+        // fix
+        if (cc.sys.browserType === cc.sys.BROWSER_TYPE_SAFARI) {
+            w = window.innerWidth;
+            h = window.innerHeight;
+        }
+        else {
+            w = __BrowserGetter.availWidth(cc.game.frame);
+            h = __BrowserGetter.availHeight(cc.game.frame);
+        }
+
         var isLandscape = w >= h;
 
         if (CC_EDITOR || !cc.sys.isMobile ||


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2179
用户修复的论坛地址：https://forum.cocos.org/t/ios13-safari-bug/86800/7

Changes:
 * 修复 safari 有导航栏视图显示错误