### PR TITLE
sprite tiled type support sliced border

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -2739,7 +2739,3 @@ Program not support highp precision, will change to mediump.
 ### 9107
 
 %s : illegal property: [%s], myabe defined an unused property;
-
-### 9108
-
-Since version 2.3.0 ,tiled type sprite will be influences by spriteFrame sliced border.

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -2739,3 +2739,7 @@ Program not support highp precision, will change to mediump.
 ### 9107
 
 %s : illegal property: [%s], myabe defined an unused property;
+
+### 9108
+
+Since version 2.3.0 ,tiled type sprite will be influences by spriteFrame sliced border.

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -209,22 +209,22 @@ export default class TiledAssembler extends Assembler2D {
 
                 // UV
                 if (rotated) {
-                  // lb
-                  verts[uvOffset] = uv[0];
-                  verts[uvOffset + 1] = uv[1];
-                  uvOffset += floatsPerVert;
-                  // rb
-                  verts[uvOffset] = uv[0];
-                  verts[uvOffset + 1] = uv[1] + (uv[7] - uv[1]) * coefu;
-                  uvOffset += floatsPerVert;
-                  // lt
-                  verts[uvOffset] = uv[0] + (uv[6] - uv[0]) * coefv;
-                  verts[uvOffset + 1] = uv[1];
-                  uvOffset += floatsPerVert;
-                  // rt
-                  verts[uvOffset] = verts[uvOffset - floatsPerVert];
-                  verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
-                  uvOffset += floatsPerVert;
+                    // lb
+                    verts[uvOffset] = uv[0];
+                    verts[uvOffset + 1] = uv[1];
+                    uvOffset += floatsPerVert;
+                    // rb
+                    verts[uvOffset] = uv[0];
+                    verts[uvOffset + 1] = uv[1] + (uv[7] - uv[1]) * coefu;
+                    uvOffset += floatsPerVert;
+                    // lt
+                    verts[uvOffset] = uv[0] + (uv[6] - uv[0]) * coefv;
+                    verts[uvOffset + 1] = uv[1];
+                    uvOffset += floatsPerVert;
+                    // rt
+                    verts[uvOffset] = verts[uvOffset - floatsPerVert];
+                    verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
+                    uvOffset += floatsPerVert;
                 }
                 else {
                     // lb

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -200,6 +200,9 @@ export default class TiledAssembler extends Assembler2D {
 
         let hadTopOrBottomBorder = (sprite.spriteFrame.insetTop > 0 || sprite.spriteFrame.insetBottom > 0);
         let hadLeftOrRightBorder = (sprite.spriteFrame.insetLeft > 0 || sprite.spriteFrame.insetRight > 0);
+        if (hadTopOrBottomBorder || hadLeftOrRightBorder) {
+            cc.warnID(9108);
+        }
         let rotated = sprite.spriteFrame._rotated;
         let floatsPerVert = this.floatsPerVert, uvOffset = this.uvOffset;
         for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -58,151 +58,270 @@ export default class TiledAssembler extends Assembler2D {
     }
 
     updateRenderData (sprite) {
-        let frame = sprite._spriteFrame;
-        this.packToDynamicAtlas(sprite, frame);
+      let frame = sprite._spriteFrame;
+      this.packToDynamicAtlas(sprite, frame);
 
-        let node = sprite.node;
+      let node = sprite.node;
 
-        let contentWidth = this.contentWidth = Math.abs(node.width);
-        let contentHeight = this.contentHeight = Math.abs(node.height);
-        let rect = frame._rect;
-        let rectWidth = this.rectWidth = rect.width;
-        let rectHeight = this.rectHeight = rect.height;
-        let hRepeat = this.hRepeat = contentWidth / rectWidth;
-        let vRepeat = this.vRepeat = contentHeight / rectHeight;
-        let row = this.row = Math.ceil(vRepeat);
-        let col = this.col = Math.ceil(hRepeat);
-
-        // update data property
-        let count = row * col;
-        this.verticesCount = count * 4;
-        this.indicesCount = count * 6;
-
-        let renderData = this._renderData;
-        let flexBuffer = renderData._flexBuffer;
-        if (flexBuffer.reserve(this.verticesCount, this.indicesCount)) {
-            this._updateIndices();
-            this.updateColor(sprite);
+      let contentWidth = this.contentWidth = Math.abs(node.width);
+      let contentHeight = this.contentHeight = Math.abs(node.height);
+      let rect = frame._rect;
+      let rectWidth = this.rectWidth = rect.width;
+      let rectHeight = this.rectHeight = rect.height;
+      let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
+          topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
+      if (frame.insetBottom > 0 || frame.insetTop > 0) {
+        if (contentHeight >= rectHeight) {
+          contentHeight -= topHeight;
+          rectHeight = centerHeight;
         }
-        flexBuffer.used(this.verticesCount, this.indicesCount);
-
-        if (sprite._vertsDirty) {
-            this.updateUVs(sprite);
-            this.updateVerts(sprite);
-            sprite._vertsDirty = false;
+      }
+      if (frame.insetLeft > 0 || frame.insetRight > 0) {
+        if (contentWidth >= rectWidth) {
+          contentWidth -= rightWidth;
+          rectWidth = centerWidth;
         }
+      }
+      let hRepeat = this.hRepeat = contentWidth / rectWidth;
+      let vRepeat = this.vRepeat = contentHeight / rectHeight;
+      let row = this.row = Math.ceil(vRepeat);
+      let col = this.col = Math.ceil(hRepeat);
+
+      // update data property
+      let count = row * col;
+      this.verticesCount = count * 4;
+      this.indicesCount = count * 6;
+
+      let renderData = this._renderData;
+      let flexBuffer = renderData._flexBuffer;
+      if (flexBuffer.reserve(this.verticesCount, this.indicesCount)) {
+        this._updateIndices();
+        this.updateColor(sprite);
+      }
+      flexBuffer.used(this.verticesCount, this.indicesCount);
+
+      if (sprite._vertsDirty) {
+        this.updateUVs(sprite);
+        this.updateVerts(sprite);
+        sprite._vertsDirty = false;
+      }
     }
 
     updateVerts (sprite) {
-        let node = sprite.node,
-            appx = node.anchorX * node.width, appy = node.anchorY * node.height;
+      let frame = sprite._spriteFrame;
+      let rect = frame._rect;
+      let node = sprite.node,
+          appx = node.anchorX * node.width, appy = node.anchorY * node.height;
 
-        let { row, col, rectWidth, rectHeight, contentWidth, contentHeight } = this;
-        let { x, y } = this._local;
-        x.length = y.length = 0;
-        for (let i = 0; i <= col; ++i) {
-            x[i] = Math.min(rectWidth * i, contentWidth) - appx;
-        }
-        for (let i = 0; i <= row; ++i) {
-            y[i] = Math.min(rectHeight * i, contentHeight) - appy;
-        }
+      let { row, col, rectWidth, rectHeight, contentWidth, contentHeight } = this;
+      let { x, y } = this._local;
+      x.length = y.length = 0;
 
-        this.updateWorldVerts(sprite);
+      let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
+          topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
+      for (let i = 0; i <= col; ++i) {
+        if (contentWidth <= rectWidth) {
+            x[i] = Math.min(rectWidth * i , contentWidth) - appx;
+        } else {
+            if (i === 0) {
+              x[i] =  - appx;
+            } else if (i > 0 && i < col){
+              x[i] = Math.min(leftWidth + centerWidth * i, contentWidth) - appx;
+            } else if (i === col) {
+              x[i] = Math.min(leftWidth + centerWidth * i + rightWidth, contentWidth) - appx;
+            }
+        }
+      }
+      for (let _i = 0; _i <= row; ++_i) {
+        if (contentHeight <= rectHeight) {
+            y[_i] = Math.min(rectHeight * _i, contentHeight) - appy;
+        } else {
+            if (_i === 0) {
+              y[_i] = - appy;
+            } else if (_i > 0 && _i < row) {
+              y[_i] = Math.min(bottomHeight + centerHeight * _i, contentHeight) - appy;
+            } else if (_i === row) {
+              y[_i] = Math.min(bottomHeight + centerHeight * _i + topHeight, contentHeight) - appy;
+            }
+        }
+      }
+
+      this.updateWorldVerts(sprite);
     }
     
     updateWorldVerts (sprite) {
-        let renderData = this._renderData;
-        let local = this._local;
-        let localX = local.x, localY = local.y;
-        let world = renderData.vDatas[0];
-        let { row, col } = this;
-        let matrix = sprite.node._worldMatrix;
-        let matrixm = matrix.m;
-        let a = matrixm[0], b = matrixm[1], c = matrixm[4], d = matrixm[5],
-            tx = matrixm[12], ty = matrixm[13];
+      let renderData = this._renderData;
+      let local = this._local;
+      let localX = local.x, localY = local.y;
+      let world = renderData.vDatas[0];
+      let { row, col } = this;
+      let matrix = sprite.node._worldMatrix;
+      let matrixm = matrix.m;
+      let a = matrixm[0], b = matrixm[1], c = matrixm[4], d = matrixm[5],
+          tx = matrixm[12], ty = matrixm[13];
 
-        let x, x1, y, y1;
-        let floatsPerVert = this.floatsPerVert;
-        let vertexOffset = 0;
-        for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
-            y = localY[yindex];
-            y1 = localY[yindex + 1];
-            for (let xindex = 0, xlength = col; xindex < xlength; ++xindex) {
-                x = localX[xindex];
-                x1 = localX[xindex + 1];
+      let x, x1, y, y1;
+      let floatsPerVert = this.floatsPerVert;
+      let vertexOffset = 0;
+      for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
+          y = localY[yindex];
+          y1 = localY[yindex + 1];
+          for (let xindex = 0, xlength = col; xindex < xlength; ++xindex) {
+              x = localX[xindex];
+              x1 = localX[xindex + 1];
 
-                // lb
-                world[vertexOffset] = x * a + y * c + tx;
-                world[vertexOffset + 1] = x * b + y * d + ty;
-                vertexOffset += floatsPerVert;
-                // rb
-                world[vertexOffset] = x1 * a + y * c + tx;
-                world[vertexOffset + 1] = x1 * b + y * d + ty;
-                vertexOffset += floatsPerVert;
-                // lt
-                world[vertexOffset] = x * a + y1 * c + tx;
-                world[vertexOffset + 1] = x * b + y1 * d + ty;
-                vertexOffset += floatsPerVert;
-                // rt
-                world[vertexOffset] = x1 * a + y1 * c + tx;
-                world[vertexOffset + 1] = x1 * b + y1 * d + ty;
-                vertexOffset += floatsPerVert;
-            }
-        }
+              // lb
+              world[vertexOffset] = x * a + y * c + tx;
+              world[vertexOffset + 1] = x * b + y * d + ty;
+              vertexOffset += floatsPerVert;
+              // rb
+              world[vertexOffset] = x1 * a + y * c + tx;
+              world[vertexOffset + 1] = x1 * b + y * d + ty;
+              vertexOffset += floatsPerVert;
+              // lt
+              world[vertexOffset] = x * a + y1 * c + tx;
+              world[vertexOffset + 1] = x * b + y1 * d + ty;
+              vertexOffset += floatsPerVert;
+              // rt
+              world[vertexOffset] = x1 * a + y1 * c + tx;
+              world[vertexOffset + 1] = x1 * b + y1 * d + ty;
+              vertexOffset += floatsPerVert;
+          }
+      }
     }
 
     updateUVs (sprite) {
-        let verts = this._renderData.vDatas[0];
-        if (!verts) return;
+      let verts = this._renderData.vDatas[0];
+      if (!verts) return;
+      
+      let { row, col, hRepeat, vRepeat } = this;
+      let uv = sprite.spriteFrame.uv;
+      let uvSliced = sprite.spriteFrame.uvSliced;
 
-        let { row, col, hRepeat, vRepeat } = this;
-        let uv = sprite.spriteFrame.uv;
-        let rotated = sprite.spriteFrame._rotated;
-        let floatsPerVert = this.floatsPerVert, uvOffset = this.uvOffset;
-        for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
-            let coefv = Math.min(1, vRepeat - yindex);
-            for (let xindex = 0, xlength = col; xindex < xlength; ++xindex) {
-                let coefu = Math.min(1, hRepeat - xindex);
+      let hadTopOrBottomBorder = (sprite.spriteFrame.insetTop > 0 || sprite.spriteFrame.insetBottom > 0);
+      let hadLeftOrRightBorder = (sprite.spriteFrame.insetLeft > 0 || sprite.spriteFrame.insetRight > 0);
+      let rotated = sprite.spriteFrame._rotated;
+      let floatsPerVert = this.floatsPerVert, uvOffset = this.uvOffset;
 
-                // UV
-                if (rotated) {
-                    // lb
-                    verts[uvOffset] = uv[0];
-                    verts[uvOffset + 1] = uv[1];
-                    uvOffset += floatsPerVert;
-                    // rb
-                    verts[uvOffset] = uv[0];
-                    verts[uvOffset + 1] = uv[1] + (uv[7] - uv[1]) * coefu;
-                    uvOffset += floatsPerVert;
-                    // lt
-                    verts[uvOffset] = uv[0] + (uv[6] - uv[0]) * coefv;
-                    verts[uvOffset + 1] = uv[1];
-                    uvOffset += floatsPerVert;
-                    // rt
-                    verts[uvOffset] = verts[uvOffset - floatsPerVert];
-                    verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
-                    uvOffset += floatsPerVert;
-                }
-                else {
-                    // lb
-                    verts[uvOffset] = uv[0];
-                    verts[uvOffset + 1] = uv[1];
-                    uvOffset += floatsPerVert;
-                    // rb
-                    verts[uvOffset] = uv[0] + (uv[6] - uv[0]) * coefu;
-                    verts[uvOffset + 1] = uv[1];
-                    uvOffset += floatsPerVert;
-                    // lt
-                    verts[uvOffset] = uv[0];
-                    verts[uvOffset + 1] = uv[1] + (uv[7] - uv[1]) * coefv;
-                    uvOffset += floatsPerVert;
-                    // rt
-                    verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
-                    verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
-                    uvOffset += floatsPerVert;
-                }
+      for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
+        var coefv = Math.min(1, vRepeat - yindex);
+        for (let xindex = 0, xlength = col; xindex < xlength; ++xindex) {
+          var coefu = Math.min(1, hRepeat - xindex);
+
+          // UV
+          if (rotated) {
+            // lb
+            verts[uvOffset] = uv[0];
+            verts[uvOffset + 1] = uv[1];
+            uvOffset += floatsPerVert;
+            // rb
+            verts[uvOffset] = uv[0];
+            verts[uvOffset + 1] = uv[1] + (uv[7] - uv[1]) * coefu;
+            uvOffset += floatsPerVert;
+            // lt
+            verts[uvOffset] = uv[0] + (uv[6] - uv[0]) * coefv;
+            verts[uvOffset + 1] = uv[1];
+            uvOffset += floatsPerVert;
+            // rt
+            verts[uvOffset] = verts[uvOffset - floatsPerVert];
+            verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
+            uvOffset += floatsPerVert;
+          } else {
+            // lb
+            if (xindex === 0) {
+              verts[uvOffset] = uvSliced[0].u;
+            } else if (xindex > 0 && xindex < (col - 1)) {
+              verts[uvOffset] = uvSliced[1].u;
+            } else if (xindex === (col - 1)) {
+              if (hadLeftOrRightBorder) {
+                verts[uvOffset] = uvSliced[2].u;
+              } else {
+                verts[uvOffset] = uvSliced[0].u;
+              }
             }
+            if (yindex === 0) {
+              verts[uvOffset + 1] = uvSliced[0].v;
+            } else if(yindex > 0 && yindex < (row - 1)) {
+              verts[uvOffset + 1] = uvSliced[4].v;
+            } else if (yindex === (row - 1)){
+              if (hadTopOrBottomBorder) {
+                verts[uvOffset + 1] = uvSliced[8].v;
+              } else {
+                verts[uvOffset + 1] = uvSliced[0].v;
+              }
+            }
+            uvOffset += floatsPerVert;
+            // rb
+            if (xindex === 0) {
+              verts[uvOffset] = uvSliced[0].u + (uvSliced[3].u - uvSliced[0].u) * coefu;
+            } else if(xindex > 0 && xindex < (col - 1)){
+              verts[uvOffset] = uvSliced[0].u + (uvSliced[2].u - uvSliced[0].u) * coefu;
+            } else if (xindex === (col - 1)) {
+              verts[uvOffset - 4 * floatsPerVert * xindex] = uvSliced[2].u;
+              if (hadLeftOrRightBorder) {
+                verts[uvOffset] = uvSliced[3].u;
+              } else {
+                verts[uvOffset] = uvSliced[0].u + (uvSliced[3].u - uvSliced[0].u) * coefu;
+              }
+            }
+            if (yindex === 0) {
+              verts[uvOffset + 1] = uvSliced[0].v;
+            } else if (yindex > 0 && yindex < (row - 1)) {
+              verts[uvOffset + 1] = uvSliced[4].v;
+            } else if (yindex === (row - 1)) {
+              if (hadTopOrBottomBorder) {
+                verts[uvOffset + 1] = uvSliced[8].v;
+              } else {
+                verts[uvOffset + 1] = uvSliced[0].v;
+              }
+            }
+            uvOffset += floatsPerVert;
+            // lt
+            if (xindex === 0) {
+              verts[uvOffset] = uvSliced[0].u;
+            } else if (xindex > 0 && xindex < (col - 1)) {
+              verts[uvOffset] = uvSliced[1].u;
+            } else if (xindex === (col - 1)) {
+              if (hadLeftOrRightBorder) {
+                verts[uvOffset] = uvSliced[2].u;
+              } else {
+                verts[uvOffset] = uvSliced[0].u;
+              }
+            }
+            if (yindex === 0) {
+              verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[12].v - uvSliced[0].v) * coefv;
+            } else if (yindex > 0 && yindex < (row - 1)) {
+              verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[8].v - uvSliced[0].v) * coefv;
+            } else if (yindex === (row - 1)) {
+              verts[uvOffset + 1 - 4 * floatsPerVert * col * yindex] = uvSliced[8].v;
+              if (hadTopOrBottomBorder) {
+                verts[uvOffset + 1] = uvSliced[12].v;
+              } else {
+                verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[12].v - uvSliced[0].v) * coefv;
+              }
+            }
+            uvOffset += floatsPerVert;
+            // rt
+            if (xindex === 0) {
+              verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
+            } else if(xindex > 0 && xindex < (col - 1)){
+              verts[uvOffset] = verts[uvOffset - floatsPerVert * 2]
+            } else if (xindex === (col - 1)) {
+              verts[uvOffset - 4 * floatsPerVert * xindex] = uvSliced[2].u;
+              verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
+            }
+            if (yindex === 0) {
+              verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
+            } else if (yindex > 0 && yindex < (row - 1)) {
+              verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
+            } else if (yindex === (row - 1)) {
+              verts[uvOffset + 1 - 4 * floatsPerVert * col * yindex] = uvSliced[8].v;
+              verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
+            }
+            uvOffset += floatsPerVert;
+          }
         }
+      }
     }
 }
 

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -58,270 +58,270 @@ export default class TiledAssembler extends Assembler2D {
     }
 
     updateRenderData (sprite) {
-      let frame = sprite._spriteFrame;
-      this.packToDynamicAtlas(sprite, frame);
+        let frame = sprite._spriteFrame;
+        this.packToDynamicAtlas(sprite, frame);
 
-      let node = sprite.node;
+        let node = sprite.node;
 
-      let contentWidth = this.contentWidth = Math.abs(node.width);
-      let contentHeight = this.contentHeight = Math.abs(node.height);
-      let rect = frame._rect;
-      let rectWidth = this.rectWidth = rect.width;
-      let rectHeight = this.rectHeight = rect.height;
-      let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
-          topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
-      if (frame.insetBottom > 0 || frame.insetTop > 0) {
-        if (contentHeight >= rectHeight) {
-          contentHeight -= topHeight;
-          rectHeight = centerHeight;
+        let contentWidth = this.contentWidth = Math.abs(node.width);
+        let contentHeight = this.contentHeight = Math.abs(node.height);
+        let rect = frame._rect;
+        let rectWidth = this.rectWidth = rect.width;
+        let rectHeight = this.rectHeight = rect.height;
+        let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
+            topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
+        if (frame.insetBottom > 0 || frame.insetTop > 0) {
+            if (contentHeight >= rectHeight) {
+                contentHeight -= topHeight;
+                rectHeight = centerHeight;
+            }
         }
-      }
-      if (frame.insetLeft > 0 || frame.insetRight > 0) {
-        if (contentWidth >= rectWidth) {
-          contentWidth -= rightWidth;
-          rectWidth = centerWidth;
+        if (frame.insetLeft > 0 || frame.insetRight > 0) {
+            if (contentWidth >= rectWidth) {
+                contentWidth -= rightWidth;
+                rectWidth = centerWidth;
+            }
         }
-      }
-      let hRepeat = this.hRepeat = contentWidth / rectWidth;
-      let vRepeat = this.vRepeat = contentHeight / rectHeight;
-      let row = this.row = Math.ceil(vRepeat);
-      let col = this.col = Math.ceil(hRepeat);
+        let hRepeat = this.hRepeat = contentWidth / rectWidth;
+        let vRepeat = this.vRepeat = contentHeight / rectHeight;
+        let row = this.row = Math.ceil(vRepeat);
+        let col = this.col = Math.ceil(hRepeat);
 
-      // update data property
-      let count = row * col;
-      this.verticesCount = count * 4;
-      this.indicesCount = count * 6;
+        // update data property
+        let count = row * col;
+        this.verticesCount = count * 4;
+        this.indicesCount = count * 6;
 
-      let renderData = this._renderData;
-      let flexBuffer = renderData._flexBuffer;
-      if (flexBuffer.reserve(this.verticesCount, this.indicesCount)) {
-        this._updateIndices();
-        this.updateColor(sprite);
-      }
-      flexBuffer.used(this.verticesCount, this.indicesCount);
+        let renderData = this._renderData;
+        let flexBuffer = renderData._flexBuffer;
+        if (flexBuffer.reserve(this.verticesCount, this.indicesCount)) {
+          this._updateIndices();
+          this.updateColor(sprite);
+        }
+        flexBuffer.used(this.verticesCount, this.indicesCount);
 
-      if (sprite._vertsDirty) {
-        this.updateUVs(sprite);
-        this.updateVerts(sprite);
-        sprite._vertsDirty = false;
-      }
+        if (sprite._vertsDirty) {
+          this.updateUVs(sprite);
+          this.updateVerts(sprite);
+          sprite._vertsDirty = false;
+        }
     }
 
     updateVerts (sprite) {
-      let frame = sprite._spriteFrame;
-      let rect = frame._rect;
-      let node = sprite.node,
-          appx = node.anchorX * node.width, appy = node.anchorY * node.height;
+        let frame = sprite._spriteFrame;
+        let rect = frame._rect;
+        let node = sprite.node,
+            appx = node.anchorX * node.width, appy = node.anchorY * node.height;
 
-      let { row, col, rectWidth, rectHeight, contentWidth, contentHeight } = this;
-      let { x, y } = this._local;
-      x.length = y.length = 0;
+        let { row, col, rectWidth, rectHeight, contentWidth, contentHeight } = this;
+        let { x, y } = this._local;
+        x.length = y.length = 0;
 
-      let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
-          topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
-      for (let i = 0; i <= col; ++i) {
-        if (contentWidth <= rectWidth) {
-            x[i] = Math.min(rectWidth * i , contentWidth) - appx;
-        } else {
-            if (i === 0) {
-              x[i] =  - appx;
-            } else if (i > 0 && i < col){
-              x[i] = Math.min(leftWidth + centerWidth * i, contentWidth) - appx;
-            } else if (i === col) {
-              x[i] = Math.min(leftWidth + centerWidth * i + rightWidth, contentWidth) - appx;
+        let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
+            topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
+        for (let i = 0; i <= col; ++i) {
+            if (contentWidth <= rectWidth) {
+                x[i] = Math.min(rectWidth * i , contentWidth) - appx;
+            } else {
+                if (i === 0) {
+                    x[i] =  - appx;
+                } else if (i > 0 && i < col){
+                    x[i] = Math.min(leftWidth + centerWidth * i, contentWidth) - appx;
+                } else if (i === col) {
+                    x[i] = Math.min(leftWidth + centerWidth * i + rightWidth, contentWidth) - appx;
+                }
             }
         }
-      }
-      for (let _i = 0; _i <= row; ++_i) {
-        if (contentHeight <= rectHeight) {
-            y[_i] = Math.min(rectHeight * _i, contentHeight) - appy;
-        } else {
-            if (_i === 0) {
-              y[_i] = - appy;
-            } else if (_i > 0 && _i < row) {
-              y[_i] = Math.min(bottomHeight + centerHeight * _i, contentHeight) - appy;
-            } else if (_i === row) {
-              y[_i] = Math.min(bottomHeight + centerHeight * _i + topHeight, contentHeight) - appy;
+        for (let _i = 0; _i <= row; ++_i) {
+            if (contentHeight <= rectHeight) {
+                y[_i] = Math.min(rectHeight * _i, contentHeight) - appy;
+            } else {
+                if (_i === 0) {
+                    y[_i] = - appy;
+                } else if (_i > 0 && _i < row) {
+                    y[_i] = Math.min(bottomHeight + centerHeight * _i, contentHeight) - appy;
+                } else if (_i === row) {
+                    y[_i] = Math.min(bottomHeight + centerHeight * _i + topHeight, contentHeight) - appy;
+                }
             }
         }
-      }
 
-      this.updateWorldVerts(sprite);
+        this.updateWorldVerts(sprite);
     }
     
     updateWorldVerts (sprite) {
-      let renderData = this._renderData;
-      let local = this._local;
-      let localX = local.x, localY = local.y;
-      let world = renderData.vDatas[0];
-      let { row, col } = this;
-      let matrix = sprite.node._worldMatrix;
-      let matrixm = matrix.m;
-      let a = matrixm[0], b = matrixm[1], c = matrixm[4], d = matrixm[5],
-          tx = matrixm[12], ty = matrixm[13];
+        let renderData = this._renderData;
+        let local = this._local;
+        let localX = local.x, localY = local.y;
+        let world = renderData.vDatas[0];
+        let { row, col } = this;
+        let matrix = sprite.node._worldMatrix;
+        let matrixm = matrix.m;
+        let a = matrixm[0], b = matrixm[1], c = matrixm[4], d = matrixm[5],
+            tx = matrixm[12], ty = matrixm[13];
 
-      let x, x1, y, y1;
-      let floatsPerVert = this.floatsPerVert;
-      let vertexOffset = 0;
-      for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
-          y = localY[yindex];
-          y1 = localY[yindex + 1];
-          for (let xindex = 0, xlength = col; xindex < xlength; ++xindex) {
-              x = localX[xindex];
-              x1 = localX[xindex + 1];
+        let x, x1, y, y1;
+        let floatsPerVert = this.floatsPerVert;
+        let vertexOffset = 0;
+        for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
+            y = localY[yindex];
+            y1 = localY[yindex + 1];
+            for (let xindex = 0, xlength = col; xindex < xlength; ++xindex) {
+                x = localX[xindex];
+                x1 = localX[xindex + 1];
 
-              // lb
-              world[vertexOffset] = x * a + y * c + tx;
-              world[vertexOffset + 1] = x * b + y * d + ty;
-              vertexOffset += floatsPerVert;
-              // rb
-              world[vertexOffset] = x1 * a + y * c + tx;
-              world[vertexOffset + 1] = x1 * b + y * d + ty;
-              vertexOffset += floatsPerVert;
-              // lt
-              world[vertexOffset] = x * a + y1 * c + tx;
-              world[vertexOffset + 1] = x * b + y1 * d + ty;
-              vertexOffset += floatsPerVert;
-              // rt
-              world[vertexOffset] = x1 * a + y1 * c + tx;
-              world[vertexOffset + 1] = x1 * b + y1 * d + ty;
-              vertexOffset += floatsPerVert;
-          }
-      }
+                // lb
+                world[vertexOffset] = x * a + y * c + tx;
+                world[vertexOffset + 1] = x * b + y * d + ty;
+                vertexOffset += floatsPerVert;
+                // rb
+                world[vertexOffset] = x1 * a + y * c + tx;
+                world[vertexOffset + 1] = x1 * b + y * d + ty;
+                vertexOffset += floatsPerVert;
+                // lt
+                world[vertexOffset] = x * a + y1 * c + tx;
+                world[vertexOffset + 1] = x * b + y1 * d + ty;
+                vertexOffset += floatsPerVert;
+                // rt
+                world[vertexOffset] = x1 * a + y1 * c + tx;
+                world[vertexOffset + 1] = x1 * b + y1 * d + ty;
+                vertexOffset += floatsPerVert;
+            }
+        }
     }
 
     updateUVs (sprite) {
-      let verts = this._renderData.vDatas[0];
-      if (!verts) return;
-      
-      let { row, col, hRepeat, vRepeat } = this;
-      let uv = sprite.spriteFrame.uv;
-      let uvSliced = sprite.spriteFrame.uvSliced;
+        let verts = this._renderData.vDatas[0];
+        if (!verts) return;
+        
+        let { row, col, hRepeat, vRepeat } = this;
+        let uv = sprite.spriteFrame.uv;
+        let uvSliced = sprite.spriteFrame.uvSliced;
 
-      let hadTopOrBottomBorder = (sprite.spriteFrame.insetTop > 0 || sprite.spriteFrame.insetBottom > 0);
-      let hadLeftOrRightBorder = (sprite.spriteFrame.insetLeft > 0 || sprite.spriteFrame.insetRight > 0);
-      let rotated = sprite.spriteFrame._rotated;
-      let floatsPerVert = this.floatsPerVert, uvOffset = this.uvOffset;
+        let hadTopOrBottomBorder = (sprite.spriteFrame.insetTop > 0 || sprite.spriteFrame.insetBottom > 0);
+        let hadLeftOrRightBorder = (sprite.spriteFrame.insetLeft > 0 || sprite.spriteFrame.insetRight > 0);
+        let rotated = sprite.spriteFrame._rotated;
+        let floatsPerVert = this.floatsPerVert, uvOffset = this.uvOffset;
+        for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
+            let coefv = Math.min(1, vRepeat - yindex);
+            for (let xindex = 0, xlength = col; xindex < xlength; ++xindex) {
+                let coefu = Math.min(1, hRepeat - xindex);
 
-      for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
-        var coefv = Math.min(1, vRepeat - yindex);
-        for (let xindex = 0, xlength = col; xindex < xlength; ++xindex) {
-          var coefu = Math.min(1, hRepeat - xindex);
-
-          // UV
-          if (rotated) {
-            // lb
-            verts[uvOffset] = uv[0];
-            verts[uvOffset + 1] = uv[1];
-            uvOffset += floatsPerVert;
-            // rb
-            verts[uvOffset] = uv[0];
-            verts[uvOffset + 1] = uv[1] + (uv[7] - uv[1]) * coefu;
-            uvOffset += floatsPerVert;
-            // lt
-            verts[uvOffset] = uv[0] + (uv[6] - uv[0]) * coefv;
-            verts[uvOffset + 1] = uv[1];
-            uvOffset += floatsPerVert;
-            // rt
-            verts[uvOffset] = verts[uvOffset - floatsPerVert];
-            verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
-            uvOffset += floatsPerVert;
-          } else {
-            // lb
-            if (xindex === 0) {
-              verts[uvOffset] = uvSliced[0].u;
-            } else if (xindex > 0 && xindex < (col - 1)) {
-              verts[uvOffset] = uvSliced[1].u;
-            } else if (xindex === (col - 1)) {
-              if (hadLeftOrRightBorder) {
-                verts[uvOffset] = uvSliced[2].u;
-              } else {
-                verts[uvOffset] = uvSliced[0].u;
-              }
+                // UV
+                if (rotated) {
+                  // lb
+                  verts[uvOffset] = uv[0];
+                  verts[uvOffset + 1] = uv[1];
+                  uvOffset += floatsPerVert;
+                  // rb
+                  verts[uvOffset] = uv[0];
+                  verts[uvOffset + 1] = uv[1] + (uv[7] - uv[1]) * coefu;
+                  uvOffset += floatsPerVert;
+                  // lt
+                  verts[uvOffset] = uv[0] + (uv[6] - uv[0]) * coefv;
+                  verts[uvOffset + 1] = uv[1];
+                  uvOffset += floatsPerVert;
+                  // rt
+                  verts[uvOffset] = verts[uvOffset - floatsPerVert];
+                  verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
+                  uvOffset += floatsPerVert;
+                }
+                else {
+                    // lb
+                    if (xindex === 0) {
+                        verts[uvOffset] = uvSliced[0].u;
+                    } else if (xindex > 0 && xindex < (col - 1)) {
+                        verts[uvOffset] = uvSliced[1].u;
+                    } else if (xindex === (col - 1)) {
+                        if (hadLeftOrRightBorder) {
+                            verts[uvOffset] = uvSliced[2].u;
+                        } else {
+                            verts[uvOffset] = uvSliced[0].u;
+                        }
+                    }
+                    if (yindex === 0) {
+                        verts[uvOffset + 1] = uvSliced[0].v;
+                    } else if(yindex > 0 && yindex < (row - 1)) {
+                        verts[uvOffset + 1] = uvSliced[4].v;
+                    } else if (yindex === (row - 1)){
+                        if (hadTopOrBottomBorder) {
+                            verts[uvOffset + 1] = uvSliced[8].v;
+                        } else {
+                            verts[uvOffset + 1] = uvSliced[0].v;
+                        }
+                    }
+                    uvOffset += floatsPerVert;
+                    // rb
+                    if (xindex === 0) {
+                        verts[uvOffset] = uvSliced[0].u + (uvSliced[3].u - uvSliced[0].u) * coefu;
+                    } else if(xindex > 0 && xindex < (col - 1)){
+                        verts[uvOffset] = uvSliced[0].u + (uvSliced[2].u - uvSliced[0].u) * coefu;
+                    } else if (xindex === (col - 1)) {
+                        verts[uvOffset - 4 * floatsPerVert * xindex] = uvSliced[2].u;
+                        if (hadLeftOrRightBorder) {
+                            verts[uvOffset] = uvSliced[3].u;
+                        } else {
+                            verts[uvOffset] = uvSliced[0].u + (uvSliced[3].u - uvSliced[0].u) * coefu;
+                        }
+                    }
+                    if (yindex === 0) {
+                        verts[uvOffset + 1] = uvSliced[0].v;
+                    } else if (yindex > 0 && yindex < (row - 1)) {
+                        verts[uvOffset + 1] = uvSliced[4].v;
+                    } else if (yindex === (row - 1)) {
+                        if (hadTopOrBottomBorder) {
+                            verts[uvOffset + 1] = uvSliced[8].v;
+                        } else {
+                            verts[uvOffset + 1] = uvSliced[0].v;
+                        }
+                    }
+                    uvOffset += floatsPerVert;
+                    // lt
+                    if (xindex === 0) {
+                        verts[uvOffset] = uvSliced[0].u;
+                    } else if (xindex > 0 && xindex < (col - 1)) {
+                        verts[uvOffset] = uvSliced[1].u;
+                    } else if (xindex === (col - 1)) {
+                        if (hadLeftOrRightBorder) {
+                            verts[uvOffset] = uvSliced[2].u;
+                        } else {
+                            verts[uvOffset] = uvSliced[0].u;
+                        }
+                    }
+                    if (yindex === 0) {
+                        verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[12].v - uvSliced[0].v) * coefv;
+                    } else if (yindex > 0 && yindex < (row - 1)) {
+                        verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[8].v - uvSliced[0].v) * coefv;
+                    } else if (yindex === (row - 1)) {
+                        verts[uvOffset + 1 - 4 * floatsPerVert * col * yindex] = uvSliced[8].v;
+                        if (hadTopOrBottomBorder) {
+                            verts[uvOffset + 1] = uvSliced[12].v;
+                        } else {
+                            verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[12].v - uvSliced[0].v) * coefv;
+                        }
+                    }
+                    uvOffset += floatsPerVert;
+                    // rt
+                    if (xindex === 0) {
+                        verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
+                    } else if(xindex > 0 && xindex < (col - 1)){
+                        verts[uvOffset] = verts[uvOffset - floatsPerVert * 2]
+                    } else if (xindex === (col - 1)) {
+                        verts[uvOffset - 4 * floatsPerVert * xindex] = uvSliced[2].u;
+                        verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
+                    }
+                    if (yindex === 0) {
+                        verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
+                    } else if (yindex > 0 && yindex < (row - 1)) {
+                        verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
+                    } else if (yindex === (row - 1)) {
+                        verts[uvOffset + 1 - 4 * floatsPerVert * col * yindex] = uvSliced[8].v;
+                        verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
+                    }
+                    uvOffset += floatsPerVert;
+                }
             }
-            if (yindex === 0) {
-              verts[uvOffset + 1] = uvSliced[0].v;
-            } else if(yindex > 0 && yindex < (row - 1)) {
-              verts[uvOffset + 1] = uvSliced[4].v;
-            } else if (yindex === (row - 1)){
-              if (hadTopOrBottomBorder) {
-                verts[uvOffset + 1] = uvSliced[8].v;
-              } else {
-                verts[uvOffset + 1] = uvSliced[0].v;
-              }
-            }
-            uvOffset += floatsPerVert;
-            // rb
-            if (xindex === 0) {
-              verts[uvOffset] = uvSliced[0].u + (uvSliced[3].u - uvSliced[0].u) * coefu;
-            } else if(xindex > 0 && xindex < (col - 1)){
-              verts[uvOffset] = uvSliced[0].u + (uvSliced[2].u - uvSliced[0].u) * coefu;
-            } else if (xindex === (col - 1)) {
-              verts[uvOffset - 4 * floatsPerVert * xindex] = uvSliced[2].u;
-              if (hadLeftOrRightBorder) {
-                verts[uvOffset] = uvSliced[3].u;
-              } else {
-                verts[uvOffset] = uvSliced[0].u + (uvSliced[3].u - uvSliced[0].u) * coefu;
-              }
-            }
-            if (yindex === 0) {
-              verts[uvOffset + 1] = uvSliced[0].v;
-            } else if (yindex > 0 && yindex < (row - 1)) {
-              verts[uvOffset + 1] = uvSliced[4].v;
-            } else if (yindex === (row - 1)) {
-              if (hadTopOrBottomBorder) {
-                verts[uvOffset + 1] = uvSliced[8].v;
-              } else {
-                verts[uvOffset + 1] = uvSliced[0].v;
-              }
-            }
-            uvOffset += floatsPerVert;
-            // lt
-            if (xindex === 0) {
-              verts[uvOffset] = uvSliced[0].u;
-            } else if (xindex > 0 && xindex < (col - 1)) {
-              verts[uvOffset] = uvSliced[1].u;
-            } else if (xindex === (col - 1)) {
-              if (hadLeftOrRightBorder) {
-                verts[uvOffset] = uvSliced[2].u;
-              } else {
-                verts[uvOffset] = uvSliced[0].u;
-              }
-            }
-            if (yindex === 0) {
-              verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[12].v - uvSliced[0].v) * coefv;
-            } else if (yindex > 0 && yindex < (row - 1)) {
-              verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[8].v - uvSliced[0].v) * coefv;
-            } else if (yindex === (row - 1)) {
-              verts[uvOffset + 1 - 4 * floatsPerVert * col * yindex] = uvSliced[8].v;
-              if (hadTopOrBottomBorder) {
-                verts[uvOffset + 1] = uvSliced[12].v;
-              } else {
-                verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[12].v - uvSliced[0].v) * coefv;
-              }
-            }
-            uvOffset += floatsPerVert;
-            // rt
-            if (xindex === 0) {
-              verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
-            } else if(xindex > 0 && xindex < (col - 1)){
-              verts[uvOffset] = verts[uvOffset - floatsPerVert * 2]
-            } else if (xindex === (col - 1)) {
-              verts[uvOffset - 4 * floatsPerVert * xindex] = uvSliced[2].u;
-              verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
-            }
-            if (yindex === 0) {
-              verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
-            } else if (yindex > 0 && yindex < (row - 1)) {
-              verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
-            } else if (yindex === (row - 1)) {
-              verts[uvOffset + 1 - 4 * floatsPerVert * col * yindex] = uvSliced[8].v;
-              verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
-            }
-            uvOffset += floatsPerVert;
-          }
         }
-      }
     }
 }
 

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -72,13 +72,13 @@ export default class TiledAssembler extends Assembler2D {
             topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
         if (frame.insetBottom > 0 || frame.insetTop > 0) {
             if (contentHeight >= rectHeight) {
-                contentHeight -= topHeight;
+                contentHeight -= topHeight + bottomHeight;
                 rectHeight = centerHeight;
             }
         }
         if (frame.insetLeft > 0 || frame.insetRight > 0) {
             if (contentWidth >= rectWidth) {
-                contentWidth -= rightWidth;
+                contentWidth -= rightWidth + leftWidth;
                 rectWidth = centerWidth;
             }
         }
@@ -132,16 +132,16 @@ export default class TiledAssembler extends Assembler2D {
                 }
             }
         }
-        for (let _i = 0; _i <= row; ++_i) {
+        for (let i = 0; i <= row; ++i) {
             if (contentHeight <= rectHeight) {
-                y[_i] = Math.min(rectHeight * _i, contentHeight) - appy;
+                y[i] = Math.min(rectHeight * i, contentHeight) - appy;
             } else {
-                if (_i === 0) {
-                    y[_i] = - appy;
-                } else if (_i > 0 && _i < row) {
-                    y[_i] = Math.min(bottomHeight + centerHeight * _i, contentHeight) - appy;
-                } else if (_i === row) {
-                    y[_i] = Math.min(bottomHeight + centerHeight * _i + topHeight, contentHeight) - appy;
+                if (i === 0) {
+                    y[i] = - appy;
+                } else if (i > 0 && i < row) {
+                    y[i] = Math.min(bottomHeight + centerHeight * i, contentHeight) - appy;
+                } else if (i === row) {
+                    y[i] = Math.min(bottomHeight + centerHeight * i + topHeight, contentHeight) - appy;
                 }
             }
         }
@@ -198,11 +198,8 @@ export default class TiledAssembler extends Assembler2D {
         let uv = sprite.spriteFrame.uv;
         let uvSliced = sprite.spriteFrame.uvSliced;
 
-        let hadTopOrBottomBorder = (sprite.spriteFrame.insetTop > 0 || sprite.spriteFrame.insetBottom > 0);
-        let hadLeftOrRightBorder = (sprite.spriteFrame.insetLeft > 0 || sprite.spriteFrame.insetRight > 0);
-        if (hadTopOrBottomBorder || hadLeftOrRightBorder) {
-            cc.warnID(9108);
-        }
+        let hasTopOrBottomBorder = (sprite.spriteFrame.insetTop > 0 || sprite.spriteFrame.insetBottom > 0);
+        let hasLeftOrRightBorder = (sprite.spriteFrame.insetLeft > 0 || sprite.spriteFrame.insetRight > 0);
         let rotated = sprite.spriteFrame._rotated;
         let floatsPerVert = this.floatsPerVert, uvOffset = this.uvOffset;
         for (let yindex = 0, ylength = row; yindex < ylength; ++yindex) {
@@ -236,8 +233,8 @@ export default class TiledAssembler extends Assembler2D {
                     } else if (xindex > 0 && xindex < (col - 1)) {
                         verts[uvOffset] = uvSliced[1].u;
                     } else if (xindex === (col - 1)) {
-                        if (hadLeftOrRightBorder) {
-                            verts[uvOffset] = uvSliced[2].u;
+                        if (hasLeftOrRightBorder) {
+                            verts[uvOffset] = uvSliced[2].u + (uvSliced[1].u - uvSliced[2].u) * coefu;
                         } else {
                             verts[uvOffset] = uvSliced[0].u;
                         }
@@ -247,8 +244,8 @@ export default class TiledAssembler extends Assembler2D {
                     } else if(yindex > 0 && yindex < (row - 1)) {
                         verts[uvOffset + 1] = uvSliced[4].v;
                     } else if (yindex === (row - 1)){
-                        if (hadTopOrBottomBorder) {
-                            verts[uvOffset + 1] = uvSliced[8].v;
+                        if (hasTopOrBottomBorder) {
+                            verts[uvOffset + 1] = uvSliced[8].v + (uvSliced[4].v - uvSliced[8].v) * coefv;
                         } else {
                             verts[uvOffset + 1] = uvSliced[0].v;
                         }
@@ -261,7 +258,7 @@ export default class TiledAssembler extends Assembler2D {
                         verts[uvOffset] = uvSliced[0].u + (uvSliced[2].u - uvSliced[0].u) * coefu;
                     } else if (xindex === (col - 1)) {
                         verts[uvOffset - 4 * floatsPerVert * xindex] = uvSliced[2].u;
-                        if (hadLeftOrRightBorder) {
+                        if (hasLeftOrRightBorder) {
                             verts[uvOffset] = uvSliced[3].u;
                         } else {
                             verts[uvOffset] = uvSliced[0].u + (uvSliced[3].u - uvSliced[0].u) * coefu;
@@ -272,8 +269,8 @@ export default class TiledAssembler extends Assembler2D {
                     } else if (yindex > 0 && yindex < (row - 1)) {
                         verts[uvOffset + 1] = uvSliced[4].v;
                     } else if (yindex === (row - 1)) {
-                        if (hadTopOrBottomBorder) {
-                            verts[uvOffset + 1] = uvSliced[8].v;
+                        if (hasTopOrBottomBorder) {
+                            verts[uvOffset + 1] = uvSliced[8].v + (uvSliced[4].v - uvSliced[8].v) * coefv;
                         } else {
                             verts[uvOffset + 1] = uvSliced[0].v;
                         }
@@ -285,8 +282,8 @@ export default class TiledAssembler extends Assembler2D {
                     } else if (xindex > 0 && xindex < (col - 1)) {
                         verts[uvOffset] = uvSliced[1].u;
                     } else if (xindex === (col - 1)) {
-                        if (hadLeftOrRightBorder) {
-                            verts[uvOffset] = uvSliced[2].u;
+                        if (hasLeftOrRightBorder) {
+                            verts[uvOffset] = uvSliced[2].u + (uvSliced[1].u - uvSliced[2].u) * coefu;
                         } else {
                             verts[uvOffset] = uvSliced[0].u;
                         }
@@ -297,7 +294,7 @@ export default class TiledAssembler extends Assembler2D {
                         verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[8].v - uvSliced[0].v) * coefv;
                     } else if (yindex === (row - 1)) {
                         verts[uvOffset + 1 - 4 * floatsPerVert * col * yindex] = uvSliced[8].v;
-                        if (hadTopOrBottomBorder) {
+                        if (hasTopOrBottomBorder) {
                             verts[uvOffset + 1] = uvSliced[12].v;
                         } else {
                             verts[uvOffset + 1] = uvSliced[0].v + (uvSliced[12].v - uvSliced[0].v) * coefv;

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -95,15 +95,15 @@ export default class TiledAssembler extends Assembler2D {
         let renderData = this._renderData;
         let flexBuffer = renderData._flexBuffer;
         if (flexBuffer.reserve(this.verticesCount, this.indicesCount)) {
-          this._updateIndices();
-          this.updateColor(sprite);
+            this._updateIndices();
+            this.updateColor(sprite);
         }
         flexBuffer.used(this.verticesCount, this.indicesCount);
 
         if (sprite._vertsDirty) {
-          this.updateUVs(sprite);
-          this.updateVerts(sprite);
-          sprite._vertsDirty = false;
+            this.updateUVs(sprite);
+            this.updateVerts(sprite);
+            sprite._vertsDirty = false;
         }
     }
 

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -133,7 +133,7 @@ export default class TiledAssembler extends Assembler2D {
                 x[i] = - appx;
             }
             else if (i > 0 && i < col) {
-                if (i <= 2) {
+                if (i === 1) {
                     x[i] = leftWidth * xScale + Math.min(centerWidth, this.sizableWidth) - appx;
                 }
                 else {
@@ -159,7 +159,7 @@ export default class TiledAssembler extends Assembler2D {
                 y[i] = - appy;
             }
             else if (i > 0 && i < row) {
-                if (i <= 2) {
+                if (i === 1) {
                     y[i] = bottomHeight * yScale + Math.min(centerHeight, this.sizableHeight) - appy;
                 }
                 else {

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -108,8 +108,8 @@ export default class TiledAssembler extends Assembler2D {
         x.length = y.length = 0;
         let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
             topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
-        let xScale = node.width / (leftWidth + rightWidth) > 1 ? 1 : node.width / (leftWidth + rightWidth);
-        let yScale = node.height / (topHeight + bottomHeight) > 1 ? 1 : node.height / (topHeight + bottomHeight);
+        let xScale = (node.width / (leftWidth + rightWidth)) > 1 ? 1 : (node.width / (leftWidth + rightWidth));
+        let yScale = (node.height / (topHeight + bottomHeight)) > 1 ? 1 : (node.height / (topHeight + bottomHeight));
         let offsetWidth = 0, offsetHeight = 0;
         if (centerWidth > 0) {
             /*

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -68,8 +68,8 @@ export default class TiledAssembler extends Assembler2D {
         let rect = frame._rect;
         let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
             topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
-        this.sizableWidth = Math.floor((contentWidth - leftWidth - rightWidth) * 1000) / 1000;
-        this.sizableHeight = Math.floor((contentHeight - topHeight - bottomHeight) * 1000) / 1000;
+        this.sizableWidth = contentWidth - leftWidth - rightWidth;
+        this.sizableHeight = contentHeight - topHeight - bottomHeight;
         this.sizableWidth = this.sizableWidth > 0 ? this.sizableWidth : 0;
         this.sizableHeight = this.sizableHeight > 0 ? this.sizableHeight : 0;
         let hRepeat = this.hRepeat = centerWidth === 0 ? this.sizableWidth : this.sizableWidth / centerWidth;
@@ -112,13 +112,13 @@ export default class TiledAssembler extends Assembler2D {
         let yScale = node.height / (topHeight + bottomHeight) > 1 ? 1 : node.height / (topHeight + bottomHeight);
         let offsetWidth = 0, offsetHeight = 0;
         if (centerWidth > 0) {
-            offsetWidth = this.sizableWidth % centerWidth === 0 ? centerWidth : this.sizableWidth % centerWidth;
+            offsetWidth = Math.floor(this.sizableWidth * 1000) / 1000 % centerWidth === 0 ? centerWidth : this.sizableWidth % centerWidth;
         }
         else {
             offsetWidth = this.sizableWidth;
         }
         if (centerHeight > 0) {
-            offsetHeight = this.sizableHeight % centerHeight === 0 ? centerHeight : this.sizableHeight % centerHeight;
+            offsetHeight = Math.floor(this.sizableHeight * 1000) / 1000 % centerHeight === 0 ? centerHeight : this.sizableHeight % centerHeight;
         }
         else {
             offsetHeight = this.sizableHeight;

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -112,6 +112,9 @@ export default class TiledAssembler extends Assembler2D {
         let yScale = node.height / (topHeight + bottomHeight) > 1 ? 1 : node.height / (topHeight + bottomHeight);
         let offsetWidth = 0, offsetHeight = 0;
         if (centerWidth > 0) {
+            /* Because the float numerical calculation in javascript is not accurate enough, 
+             * there is an expected result of 1.0, but the actual result is 1.000001.
+             */
             offsetWidth = Math.floor(this.sizableWidth * 1000) / 1000 % centerWidth === 0 ? centerWidth : this.sizableWidth % centerWidth;
         }
         else {

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -119,10 +119,12 @@ export default class TiledAssembler extends Assembler2D {
 
         let leftWidth = frame.insetLeft, rightWidth = frame.insetRight, centerWidth = rect.width - leftWidth - rightWidth,
             topHeight = frame.insetTop, bottomHeight = frame.insetBottom, centerHeight = rect.height - topHeight - bottomHeight;
-        for (let i = 0; i <= col; ++i) {
-            if (contentWidth <= rectWidth) {
+        if (contentWidth <= rectWidth) {
+            for (let i = 0; i <= col; ++i) {
                 x[i] = Math.min(rectWidth * i , contentWidth) - appx;
-            } else {
+            }
+        } else {
+            for (let i = 0; i <= col; ++i) {
                 if (i === 0) {
                     x[i] =  - appx;
                 } else if (i > 0 && i < col){
@@ -132,10 +134,12 @@ export default class TiledAssembler extends Assembler2D {
                 }
             }
         }
-        for (let i = 0; i <= row; ++i) {
-            if (contentHeight <= rectHeight) {
+        if (contentHeight <= rectHeight) {
+            for (let i = 0; i <= row; ++i) {
                 y[i] = Math.min(rectHeight * i, contentHeight) - appy;
-            } else {
+            }
+        } else {
+            for (let i = 0; i <= row; ++i) {
                 if (i === 0) {
                     y[i] = - appy;
                 } else if (i > 0 && i < row) {

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -112,7 +112,8 @@ export default class TiledAssembler extends Assembler2D {
         let yScale = node.height / (topHeight + bottomHeight) > 1 ? 1 : node.height / (topHeight + bottomHeight);
         let offsetWidth = 0, offsetHeight = 0;
         if (centerWidth > 0) {
-            /* Because the float numerical calculation in javascript is not accurate enough, 
+            /*
+             * Because the float numerical calculation in javascript is not accurate enough, 
              * there is an expected result of 1.0, but the actual result is 1.000001.
              */
             offsetWidth = Math.floor(this.sizableWidth * 1000) / 1000 % centerWidth === 0 ? centerWidth : this.sizableWidth % centerWidth;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2081

Changes:
 * 
根据 sprite 的 uvSliced 处理 uv 数据，
根据 sprite 九宫格切割之后的 4 个 border 数据处理图片的矩阵数据，
原始效果：
![image](https://user-images.githubusercontent.com/35944775/71087085-4b674b00-21d6-11ea-874a-806493622aa1.png)

处理后的效果：
![image](https://user-images.githubusercontent.com/35944775/71086808-b7957f00-21d5-11ea-8809-e61193dc7226.png)
