### PR TITLE
Fix bug when reset ImageAsset with raw data

### DIFF
--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -165,7 +165,7 @@ export class ImageAsset extends Asset {
         }
 
         if (nativeAsset !== undefined) {
-            this._nativeAsset = nativeAsset;
+            this.reset(nativeAsset);
         }
     }
 
@@ -177,7 +177,7 @@ export class ImageAsset extends Asset {
         if (!(data instanceof HTMLElement)) {
             // this._nativeData = Object.create(data);
             this._nativeData = data;
-            this._nativeData.format = this._format;
+            this._format = data.format;
             this._onDataComplete();
         } else {
             this._nativeData = data;


### PR DESCRIPTION
This PR fixes that the following constructor/setters/methods of `ImageAsset` misbehave when `ImageSource` is 
 not `HTMLElement`:
- `constructor`
- `reset()`
- `set _nativeAsset(value)`
The `format` property in `ImageSource` was erroneously ignored.

Request review from @JoneLau  , @YunHsiao .