### PR TITLE
v1.1 remove the isBuffer condition from the deserialize class

### DIFF
--- a/cocos/core/data/deserialize.ts
+++ b/cocos/core/data/deserialize.ts
@@ -849,11 +849,7 @@ function deserialize (data, details, options) {
     const target = (CC_EDITOR || CC_TEST) && options.target;
     const customEnv = options.customEnv;
     const ignoreEditorOnly = options.ignoreEditorOnly;
-
-    if (CC_EDITOR && Buffer.isBuffer(data)) {
-        data = data.toString();
-    }
-
+    
     if (typeof data === 'string') {
         data = JSON.parse(data);
     }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 
1.remove the isBuffer condition from the cocos/core/data/deserialize class 
2.Convert the buffer to string in editor3d
<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
