### PR TITLE
copyBuffersToTexture using ArrayBufferViews

### DIFF
--- a/cocos/core/3d/framework/batched-skinning-model-component.ts
+++ b/cocos/core/3d/framework/batched-skinning-model-component.ts
@@ -391,7 +391,7 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
     protected cookTextures (target: Texture2D, prop: string, passIdx: number) {
         const texImages: TexImageSource[] = [];
         const texImageRegions: GFXBufferTextureCopy[] = [];
-        const texBuffers: ArrayBuffer[] = [];
+        const texBuffers: ArrayBufferView[] = [];
         const texBufferRegions: GFXBufferTextureCopy[] = [];
         for (const unit of this.units) {
             if (!unit.material) { continue; }
@@ -407,7 +407,7 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
                     texImages.push(data);
                     texImageRegions.push(region);
                 } else {
-                    texBuffers.push((data as ArrayBufferView).buffer);
+                    texBuffers.push(data);
                     texBufferRegions.push(region);
                 }
             }

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -73,8 +73,8 @@ export class ImageAsset extends Asset {
      * 此图像资源的图像数据。
      */
     get data () {
-        let data:any = (this._nativeData as IMemoryImageSource)._data;
-        return (ArrayBuffer.isView(data) || data instanceof ArrayBuffer) ? data : this._nativeData;
+        const data = (this._nativeData as IMemoryImageSource)._data;
+        return ArrayBuffer.isView(data) ? data : this._nativeData as (HTMLCanvasElement | HTMLImageElement);
     }
 
     /**
@@ -119,7 +119,7 @@ export class ImageAsset extends Asset {
 
     get _texture () {
         if (!this._tex) {
-            let tex = new cc.Texture2D();
+            const tex = new cc.Texture2D();
             tex.name = this._url;
             tex.image = this;
             this._tex = tex;

--- a/cocos/core/assets/simple-texture.ts
+++ b/cocos/core/assets/simple-texture.ts
@@ -111,7 +111,7 @@ export class SimpleTexture extends TextureBase {
      * @param level Mipmap 层级。
      * @param arrayIndex 数组索引。
      */
-    public uploadData (source: HTMLCanvasElement | HTMLImageElement | ArrayBuffer, level: number = 0, arrayIndex: number = 0) {
+    public uploadData (source: HTMLCanvasElement | HTMLImageElement | ArrayBufferView, level: number = 0, arrayIndex: number = 0) {
         if (!this._gfxTexture || this._gfxTexture.mipLevel <= level) {
             return;
         }
@@ -136,7 +136,7 @@ export class SimpleTexture extends TextureBase {
             }
         }
 
-        if (source instanceof ArrayBuffer) {
+        if (ArrayBuffer.isView(source)) {
             gfxDevice.copyBuffersToTexture([source], this._gfxTexture, _regions);
         } else {
             gfxDevice.copyTexImagesToTexture([source], this._gfxTexture, _regions);
@@ -149,13 +149,7 @@ export class SimpleTexture extends TextureBase {
             if (!data) {
                 return;
             }
-            let source: HTMLCanvasElement | HTMLImageElement | ArrayBuffer;
-            if (ArrayBuffer.isView(data)) {
-                source = (data as ArrayBufferView).buffer;
-            } else {
-                source = (data as HTMLCanvasElement | HTMLImageElement);
-            }
-            this.uploadData(source, level, arrayIndex);
+            this.uploadData(data, level, arrayIndex);
             this._checkTextureLoaded();
         };
         if (image.loaded) {

--- a/cocos/core/gfx/device.ts
+++ b/cocos/core/gfx/device.ts
@@ -320,11 +320,11 @@ export abstract class GFXDevice {
         return this._memoryStatus;
     }
 
-    get reverseCW(): boolean {
+    get reverseCW (): boolean {
         return this._reverseCW;
     }
 
-    set reverseCW(val: boolean) {
+    set reverseCW (val: boolean) {
         this._reverseCW = val;
     }
 
@@ -506,7 +506,7 @@ export abstract class GFXDevice {
      * @param texture GFX纹理。
      * @param regions GFX缓冲纹理拷贝区域信息。
      */
-    public abstract copyBuffersToTexture (buffers: ArrayBuffer[], texture: GFXTexture, regions: GFXBufferTextureCopy[]);
+    public abstract copyBuffersToTexture (buffers: ArrayBufferView[], texture: GFXTexture, regions: GFXBufferTextureCopy[]);
 
     /**
      * @zh

--- a/cocos/core/gfx/webgl/webgl-buffer.ts
+++ b/cocos/core/gfx/webgl/webgl-buffer.ts
@@ -17,7 +17,7 @@ export class WebGLGFXBuffer extends GFXBuffer {
     }
 
     private _gpuBuffer: WebGLGPUBuffer | null = null;
-    private _uniformBuffer: ArrayBuffer | null = null;
+    private _uniformBuffer: Uint8Array | null = null;
     private _indirectBuffer: IGFXIndirectBuffer | null = null;
 
     constructor (device: GFXDevice) {
@@ -37,7 +37,7 @@ export class WebGLGFXBuffer extends GFXBuffer {
             this._indirectBuffer = { drawInfos: [] };
         } else {
             if ((this._usage & GFXBufferUsageBit.UNIFORM) && this._size > 0) {
-                this._uniformBuffer = new ArrayBuffer(this._size);
+                this._uniformBuffer = new Uint8Array(this._size);
             }
         }
 
@@ -88,7 +88,7 @@ export class WebGLGFXBuffer extends GFXBuffer {
         this._count = this._size / this._stride;
 
         if (this._uniformBuffer) {
-            this._uniformBuffer = new ArrayBuffer(this._size);
+            this._uniformBuffer = new Uint8Array(this._size);
         }
 
         if (this._bufferView && oldSize !== size) {
@@ -96,7 +96,7 @@ export class WebGLGFXBuffer extends GFXBuffer {
             this._bufferView = new Uint8Array(this._size);
             this._bufferView.set(oldView);
             if (this._gpuBuffer) {
-                this._gpuBuffer.buffer = this._bufferView.buffer;
+                this._gpuBuffer.buffer = this._bufferView;
             }
         }
 

--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -630,7 +630,7 @@ export function WebGLCmdFuncCreateBuffer (device: WebGLGFXDevice, gpuBuffer: Web
         gpuBuffer.glTarget = gl.NONE;
 
         if (gpuBuffer.buffer) {
-            gpuBuffer.vf32 = new Float32Array(gpuBuffer.buffer as ArrayBuffer);
+            gpuBuffer.vf32 = new Float32Array(gpuBuffer.buffer.buffer);
         }
     } else if (gpuBuffer.usage & GFXBufferUsageBit.INDIRECT) {
         gpuBuffer.glTarget = gl.NONE;
@@ -698,7 +698,7 @@ export function WebGLCmdFuncResizeBuffer (device: WebGLGFXDevice, gpuBuffer: Web
     } else if (gpuBuffer.usage & GFXBufferUsageBit.UNIFORM) {
         // console.error("WebGL 1.0 doesn't support uniform buffer.");
         if (gpuBuffer.buffer) {
-            gpuBuffer.vf32 = new Float32Array(gpuBuffer.buffer as ArrayBuffer);
+            gpuBuffer.vf32 = new Float32Array(gpuBuffer.buffer.buffer);
         }
     } else if ((gpuBuffer.usage & GFXBufferUsageBit.INDIRECT) ||
             (gpuBuffer.usage & GFXBufferUsageBit.TRANSFER_DST) ||
@@ -2640,7 +2640,7 @@ export function WebGLCmdFuncCopyTexImagesToTexture (
 
 export function WebGLCmdFuncCopyBuffersToTexture (
     device: WebGLGFXDevice,
-    buffers: ArrayBuffer[],
+    buffers: ArrayBufferView[],
     gpuTexture: WebGLGPUTexture,
     regions: GFXBufferTextureCopy[]) {
 
@@ -2668,7 +2668,7 @@ export function WebGLCmdFuncCopyBuffersToTexture (
                 // console.debug('Copying buffer to texture 2D: ' + w + ' x ' + h);
 
                 for (m = region.texSubres.baseMipLevel; m < region.texSubres.levelCount; ++m) {
-                    const pixels = (fmtInfo.type === GFXFormatType.FLOAT && !isCompressed ? new Float32Array(buffers[n++]) : new Uint8Array(buffers[n++]));
+                    const pixels = buffers[n++];
                     if (!isCompressed) {
                         gl.texSubImage2D(gl.TEXTURE_2D, m,
                             region.texOffset.x, region.texOffset.y, w, h,
@@ -2703,7 +2703,7 @@ export function WebGLCmdFuncCopyBuffersToTexture (
 
                     const mcount = region.texSubres.baseMipLevel + region.texSubres.levelCount;
                     for (m = region.texSubres.baseMipLevel; m < mcount; ++m) {
-                        const pixels = (fmtInfo.type === GFXFormatType.FLOAT && !isCompressed ? new Float32Array(buffers[n++]) : new Uint8Array(buffers[n++]));
+                        const pixels = buffers[n++];
                         if (!isCompressed) {
                             gl.texSubImage2D(gl.TEXTURE_CUBE_MAP_POSITIVE_X + f, m,
                                 region.texOffset.x, region.texOffset.y, w, h,

--- a/cocos/core/gfx/webgl/webgl-device.ts
+++ b/cocos/core/gfx/webgl/webgl-device.ts
@@ -620,7 +620,7 @@ export class WebGLGFXDevice extends GFXDevice {
         queue.clear();
     }
 
-    public copyBuffersToTexture (buffers: ArrayBuffer[], texture: GFXTexture, regions: GFXBufferTextureCopy[]) {
+    public copyBuffersToTexture (buffers: ArrayBufferView[], texture: GFXTexture, regions: GFXBufferTextureCopy[]) {
         WebGLCmdFuncCopyBuffersToTexture(
             this,
             buffers,

--- a/cocos/core/gfx/webgl/webgl-gpu-objects.ts
+++ b/cocos/core/gfx/webgl/webgl-gpu-objects.ts
@@ -39,7 +39,7 @@ export class WebGLGPUBuffer {
 
     public glTarget: GLenum = 0;
     public glBuffer: WebGLBuffer | null = null;
-    public buffer: ArrayBuffer | null = null;
+    public buffer: ArrayBufferView | null = null;
     public vf32: Float32Array | null = null;
     public indirects: IGFXDrawInfo[] = [];
 }

--- a/cocos/core/gfx/webgl2/webgl2-buffer.ts
+++ b/cocos/core/gfx/webgl2/webgl2-buffer.ts
@@ -85,7 +85,7 @@ export class WebGL2GFXBuffer extends GFXBuffer {
             this._bufferView = new Uint8Array(this._size);
             this._bufferView.set(oldView);
             if (this._gpuBuffer) {
-                this._gpuBuffer.buffer = this._bufferView.buffer;
+                this._gpuBuffer.buffer = this._bufferView;
             }
         }
 

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -2645,7 +2645,7 @@ export function WebGL2CmdFuncCopyTexImagesToTexture (
 
 export function WebGL2CmdFuncCopyBuffersToTexture (
     device: WebGL2GFXDevice,
-    buffers: ArrayBuffer[],
+    buffers: ArrayBufferView[],
     gpuTexture: WebGL2GPUTexture,
     regions: GFXBufferTextureCopy[]) {
 
@@ -2670,7 +2670,7 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
                 w = region.texExtent.width;
                 h = region.texExtent.height;
                 for (m = region.texSubres.baseMipLevel; m < region.texSubres.levelCount; ++m) {
-                    const pixels = (fmtInfo.type === GFXFormatType.FLOAT && !isCompressed ? new Float32Array(buffers[n++]) : new Uint8Array(buffers[n++]));
+                    const pixels = buffers[n++];
                     if (!isCompressed) {
                         gl.texSubImage2D(gl.TEXTURE_2D, m,
                             region.texOffset.x, region.texOffset.y, w, h,
@@ -2702,7 +2702,7 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
 
                     const mcount = region.texSubres.baseMipLevel + region.texSubres.levelCount;
                     for (m = region.texSubres.baseMipLevel; m < mcount; ++m) {
-                        const pixels = (fmtInfo.type === GFXFormatType.FLOAT && !isCompressed ? new Float32Array(buffers[n++]) : new Uint8Array(buffers[n++]));
+                        const pixels = buffers[n++];
 
                         if (!isCompressed) {
                             gl.texSubImage2D(gl.TEXTURE_CUBE_MAP_POSITIVE_X + f, m,

--- a/cocos/core/gfx/webgl2/webgl2-device.ts
+++ b/cocos/core/gfx/webgl2/webgl2-device.ts
@@ -529,7 +529,7 @@ export class WebGL2GFXDevice extends GFXDevice {
         queue.clear();
     }
 
-    public copyBuffersToTexture (buffers: ArrayBuffer[], texture: GFXTexture, regions: GFXBufferTextureCopy[]) {
+    public copyBuffersToTexture (buffers: ArrayBufferView[], texture: GFXTexture, regions: GFXBufferTextureCopy[]) {
         WebGL2CmdFuncCopyBuffersToTexture(
             this,
             buffers,

--- a/cocos/core/gfx/webgl2/webgl2-gpu-objects.ts
+++ b/cocos/core/gfx/webgl2/webgl2-gpu-objects.ts
@@ -41,7 +41,7 @@ export class WebGL2GPUBuffer {
 
     public glTarget: GLenum = 0;
     public glBuffer: WebGLBuffer | null = null;
-    public buffer: ArrayBuffer | null = null;
+    public buffer: ArrayBufferView | null = null;
     public vf32: Float32Array | null = null;
     public indirects: IGFXDrawInfo[] = [];
 }

--- a/cocos/core/renderer/core/pass.ts
+++ b/cocos/core/renderer/core/pass.ts
@@ -49,7 +49,7 @@ import { Root } from '../../root';
 import { murmurhash2_32_gc } from '../../utils/murmurhash2_gc';
 import { customizeType, getBindingFromHandle, getBindingTypeFromHandle,
     getOffsetFromHandle, getTypeFromHandle, type2default, type2reader, type2writer } from './pass-utils';
-import { IProgramInfo, programLib, IShaderResources } from './program-lib';
+import { IProgramInfo, IShaderResources, programLib } from './program-lib';
 import { samplerLib } from './sampler-lib';
 
 export interface IDefineMap { [name: string]: number | boolean | string; }

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -559,7 +559,7 @@ export class TerrainBlock {
                 weightIndex += 1;
             }
         }
-        this._weightMap.uploadData(weightData.buffer);
+        this._weightMap.uploadData(weightData);
     }
 
     public _updateLightmap(tex: Texture2D|null, uoff: number, voff: number, uscale: number, vscale: number) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#555

Changelog:
 * change copyBuffersToTexture to accept ArrayBufferViews instead of ArrayBuffers

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->