### PR TITLE
fixed calculateDeltaTime error

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -220,16 +220,12 @@ cc.Director.prototype = {
      */
     calculateDeltaTime: function (now) {
         if (!now) now = performance.now();
-        this._deltaTime = (now - this._lastUpdate) / 1000;
-        if (CC_DEBUG && (this._deltaTime > 1))
-            this._deltaTime = 1 / 60.0;
 
         // avoid delta time from being negative
         // negative deltaTime would be caused by the precision of now's value, for details please see: https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame
-        if (this._deltaTime < 0) {
-            this.calculateDeltaTime();
-            return;
-        }
+        this._deltaTime = now > this._lastUpdate ? (now - this._lastUpdate) / 1000 : 0;
+        if (CC_DEBUG && (this._deltaTime > 1))
+            this._deltaTime = 1 / 60.0;
 
         this._lastUpdate = now;
     },


### PR DESCRIPTION
RE：https://forum.cocos.org/t/creator-2-2-1-calculatedeltatime/87187

这个问题其实是因为之前这个 PR 的修复导致的：https://github.com/cocos-creator/engine/pull/5641

之前的代码不能保证在之后 this._deltaTime 不会再小于 0，所以会有一定概率下导致在微信上多帧进入死循环，导致项目进程卡顿，游戏启动黑屏。

现在可以保证 this._deltaTime 不会小于 0 。