### PR TITLE
remove @property of materials

### DIFF
--- a/cocos/core/3d/framework/renderable-component.ts
+++ b/cocos/core/3d/framework/renderable-component.ts
@@ -31,7 +31,6 @@ export class RenderableComponent extends Component {
         type: Material,
         displayName: 'Materials',
         tooltip: '源材质',
-        animatable: false,
     })
     get sharedMaterials () {
         // if we don't create an array copy, the editor will modify the original array directly.
@@ -57,11 +56,6 @@ export class RenderableComponent extends Component {
      * @zh 模型材质。
      * @type {Material[]}
      */
-    @property({
-        type: Material,
-        visible: false,
-        animatable: true,
-    })
     get materials () {
         for (let i = 0; i < this._materials.length; i++) {
             this._materials[i] = this.getMaterial(i)!;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 去掉materials的@property，否则会在编辑器中为所有renderableComponent创建一个材质实例，会打断合批机制，材质动画会在编辑器中处理将sharedMaterials转变为materials。

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
