### PR TITLE
fix CCPageView auto scroll to page bug for 2d-tasks/issues/2205

### DIFF
--- a/cocos2d/core/components/CCPageView.js
+++ b/cocos2d/core/components/CCPageView.js
@@ -566,7 +566,8 @@ var PageView = cc.Class({
         var moveOffset = this._touchBeganPosition.sub(this._touchEndPosition);
         if (bounceBackStarted) {
             var dragDirection = this._getDragDirection(moveOffset);
-            if (dragDirection === 0) {
+            // setting is not allowed until the auto scrolling ends
+            if (dragDirection === 0 || this._autoScrolling) {
                 return;
             }
             if (dragDirection > 0) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2205

Changes:
 * 修复 PageView 在超出边界时进行快速二次拖动，会导致页面跳转错乱