### PR TITLE
Fix the click issue when Mask component is disabled.

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -2320,12 +2320,12 @@ let NodeDefines = {
                     if (i === temp.index) {
                         if (parent === temp.node) {
                             let comp = parent.getComponent(cc.Mask);
-                            if (comp && comp._enabled && comp._hitTest(cameraPt)) {
-                                j++;
-                            } else {
+                            if (comp && comp._enabled && !comp._hitTest(cameraPt)) {
                                 hit = false;
                                 break
-                            }
+                            } 
+
+                            j++;
                         } else {
                             // mask parent no longer exists
                             mask.length = j;


### PR DESCRIPTION
 反馈自论坛：https://forum.cocos.org/t/cocos-creator-v2-3-0/87487/73

**修复说明：**

增加Mask嵌套时 https://github.com/cocos-creator/engine/pull/5749 遗留的问题 

当 Mask 组件禁用时，Mask组件的检测不应该直接返回 false，应该直接通过。