### PR TITLE
Modify deprecated api of Label in RichText.

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -898,14 +898,14 @@ let RichText = cc.Class({
     
         labelComponent.useSystemFont = this._isSystemFontUsed;
         labelComponent.lineHeight = this.lineHeight;
-        labelComponent._enableBold(textStyle && textStyle.bold);
-        labelComponent._enableItalics(textStyle && textStyle.italic);
+        labelComponent.enableBold = textStyle && textStyle.bold;
+        labelComponent.enableItalics = textStyle && textStyle.italic;
         //TODO: temporary implementation, the italic effect should be implemented in the internal of label-assembler.
         if (textStyle && textStyle.italic) {
             labelNode.skewX = 12;
         }
 
-        labelComponent._enableUnderline(textStyle && textStyle.underline);
+        labelComponent.enableUnderline = textStyle && textStyle.underline;
 
         if (textStyle && textStyle.outline) {
             let labelOutlineComponent = labelNode.getComponent(cc.LabelOutline);


### PR DESCRIPTION
Label 的 _enableBold 等API废弃了，引擎 RichText 组件之前忘记同步。