### PR TITLE
fixed component don't off all eventListen when node destroy

### DIFF
--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -502,7 +502,7 @@ var Component = cc.Class({
 
         // Remove all listeners
         var eventTargets = this.__eventTargets;
-        for (var i = 0, l = eventTargets.length; i < l; ++i) {
+        for (var i = eventTargets.length - 1; i >= 0; --i) {
             var target = eventTargets[i];
             target && target.targetOff(this);
         }


### PR DESCRIPTION
Re: https://forum.cocos.org/t/-onpredestroy-target-targetoff-this-bug/87616

由于每次循环时，如果条件满足的话，eventTargets 数组都会剔除一个元素，所以如果使用原来增量遍历的方法会导致 eventTargets[i] 访问不到正确的元素。

这是出现异常时，chrome 的调试信息：
<img width="764" alt="WX20191227-163323@2x" src="https://user-images.githubusercontent.com/35944775/71510967-a0d4e380-28cb-11ea-8db9-dd5df2b06868.png">