### PR TITLE
V2.3.0 tiledmap texture compress

### DIFF
--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -331,7 +331,7 @@ function getPropertyList (node, map) {
  * @param {Object} tsxMap
  * @param {Object} textures
  */
-cc.TMXMapInfo = function (tmxFile, tsxMap, textures, imageLayerTextures) {
+cc.TMXMapInfo = function (tmxFile, tsxMap, textures, textureSizes, imageLayerTextures) {
     this.properties = [];
     this.orientation = null;
     this.parentElement = null;
@@ -364,7 +364,7 @@ cc.TMXMapInfo = function (tmxFile, tsxMap, textures, imageLayerTextures) {
 
     this._imageLayerTextures = null;
 
-    this.initWithXML(tmxFile, tsxMap, textures, imageLayerTextures);
+    this.initWithXML(tmxFile, tsxMap, textures, textureSizes, imageLayerTextures);
 };
 cc.TMXMapInfo.prototype = {
     constructor: cc.TMXMapInfo,
@@ -650,7 +650,7 @@ cc.TMXMapInfo.prototype = {
      * @param {Object} textures
      * @return {Boolean}
      */
-    initWithXML (tmxString, tsxMap, textures, imageLayerTextures) {
+    initWithXML (tmxString, tsxMap, textures, textureSizes, imageLayerTextures) {
         this._tilesets.length = 0;
         this._layers.length = 0;
         this._imageLayers.length = 0;
@@ -658,6 +658,7 @@ cc.TMXMapInfo.prototype = {
         this._tsxMap = tsxMap;
         this._textures = textures;
         this._imageLayerTextures = imageLayerTextures;
+        this._textureSizes = textureSizes;
 
         this._objectGroups.length = 0;
         this._allChildren.length = 0;
@@ -817,6 +818,7 @@ cc.TMXMapInfo.prototype = {
                         tileset._tileSize = tilesetSize;
                         tileset.tileOffset = tileOffset;
                         tileset.sourceImage = this._textures[firstImageName];
+                        tileset.imageSize = this._textureSizes[firstImageName] || tileset.imageSize;
                         if (!tileset.sourceImage) {
                             cc.errorID(7221, firstImageName);
                         }

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -1277,8 +1277,9 @@ let TiledLayer = cc.Class({
 
         let texIdMatIdx = this._texIdToMatIndex = {};
         let textures = this._textures;
+        let matLen = tilesetIndexArr.length;
 
-        for (let i = 0; i < tilesetIndexArr.length; i++) {
+        for (let i = 0; i < matLen; i++) {
             let tilesetIdx = tilesetIndexArr[i];
             let texture = textures[tilesetIdx];
 
@@ -1295,6 +1296,7 @@ let TiledLayer = cc.Class({
             
             texIdMatIdx[tilesetIdx] = i;
         }
+        this._materials.length = matLen;
         this.markForRender(true);
     }
 });

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -536,9 +536,13 @@ let TiledMap = cc.Class({
         if (file) {
             let texValues = file.textures;
             let texKeys = file.textureNames;
+            let texSizes = file.textureSizes;
             let textures = {};
+            let textureSizes = {};
             for (let i = 0; i < texValues.length; ++i) {
-                textures[texKeys[i]] = texValues[i];
+                let texName = texKeys[i];
+                textures[texName] = texValues[i];
+                textureSizes[texName] = texSizes[i];
             }
 
             let imageLayerTextures = {};
@@ -557,7 +561,7 @@ let TiledMap = cc.Class({
                 }
             }
 
-            let mapInfo = new cc.TMXMapInfo(file.tmxXmlStr, tsxMap, textures, imageLayerTextures);
+            let mapInfo = new cc.TMXMapInfo(file.tmxXmlStr, tsxMap, textures, textureSizes, imageLayerTextures);
             let tilesets = mapInfo.getTilesets();
             if(!tilesets || tilesets.length === 0)
                 cc.logID(7241);

--- a/cocos2d/tilemap/CCTiledMapAsset.js
+++ b/cocos2d/tilemap/CCTiledMapAsset.js
@@ -51,6 +51,14 @@ let TiledMapAsset = cc.Class({
         textureNames: [cc.String],
 
         /**
+         * @property {Size[]} textureSizes
+         */
+        textureSizes: {
+            default: [],
+            type: [cc.Size]
+        },
+
+        /**
          * @property {Texture2D[]} imageLayerTextures
          */
         imageLayerTextures: {


### PR DESCRIPTION
压缩纹理后，tiledmap获取纹理宽高错误，需要将压缩前宽高保存在meta中。
相关issue：https://github.com/cocos-creator/2d-tasks/issues/2037