### PR TITLE
V2.3.0 jno graphics stroke  flatten paths

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/graphics/index.js
+++ b/cocos2d/core/renderer/webgl/assemblers/graphics/index.js
@@ -465,7 +465,7 @@ export default class GraphicsAssembler extends Assembler {
             let p0 = pts[pts.length - 1];
             let p1 = pts[0];
     
-            if (pts.length > 2 && p0.equals(p1)) {
+            if (p0.equals(p1)) {
                 path.closed = true;
                 pts.pop();
                 p0 = pts[pts.length - 1];

--- a/cocos2d/core/renderer/webgl/assemblers/graphics/index.js
+++ b/cocos2d/core/renderer/webgl/assemblers/graphics/index.js
@@ -465,7 +465,7 @@ export default class GraphicsAssembler extends Assembler {
             let p0 = pts[pts.length - 1];
             let p1 = pts[0];
     
-            if (p0.equals(p1)) {
+            if (pts.length > 2 && p0.equals(p1)) {
                 path.closed = true;
                 pts.pop();
                 p0 = pts[pts.length - 1];


### PR DESCRIPTION
RE: https://forum.cocos.org/t/graphic-bug/87288
测试demo：
[20191230.zip](https://github.com/cocos-creator/engine/files/4009079/20191230.zip)
changeList：
当 *pts* 的长度只有2时，存在两个元素 *p0* 和 *p1*，并满足 *p0.equals(p1)* ，这段 if 语句中执行体会认为已经绘制完毕，对 *pts* 的元素进行剔除，这时候剩下 *p0*。之后在接下来的绘制中，新增的每组 *points* 都会与之前的 *p0* 参与绘制，所以会出现绘制出多个三角形的异常情况。
![image](https://user-images.githubusercontent.com/35944775/71570529-863f7c00-2b10-11ea-9548-a36f004cb931.png)
所以只要保证 *pts* 的长度大于2就可以解决问题。
