### PR TITLE
fixed wechat uniform

### DIFF
--- a/cocos2d/core/assets/material/effect-parser.ts
+++ b/cocos2d/core/assets/material/effect-parser.ts
@@ -30,12 +30,24 @@ function parseProperties (effectAsset, passJson) {
         let name = u.name,
             prop = properties[name] = Object.assign({}, u),
             propInfo = propertiesJson[name];
+
+        let value = enums2default[u.type];
         if (propInfo) {
-            prop.value = propInfo.type === enums.PARAM_TEXTURE_2D ? null : new Float32Array(propInfo.value);
+            if (propInfo.type === enums.PARAM_TEXTURE_2D) {
+                value = null;
+            }
+            else if (propInfo.type === enums.PARAM_INT || propInfo.type === enums.PARAM_FLOAT) {
+                value = Array.isArray(propInfo.value) ? propInfo.value[0] : propInfo.value;
+            }
+            else {
+                value = new Float32Array(propInfo.value);
+            }
         }
         else {
-            prop.value = enums2default[u.type];
+            value = enums2default[u.type];
         }
+
+        prop.value = value;
     });
 
     return properties;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2246

Changes:
 * fixed wechat uniform value

微信 ios 调用 gl.uniform1f(id, value), 如果 value 传的是 new Float32Array([0.5]) 会失败，需要直接传 number 才行。
