### PR TITLE
improve RichText v-align and support img align feature

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -648,7 +648,18 @@ let RichText = cc.Class({
         if (spriteFrame) {
             let spriteNode = new cc.PrivateNode(RichTextChildImageName);
             let spriteComponent = spriteNode.addComponent(cc.Sprite);
-            spriteNode.setAnchorPoint(0, 0);
+            switch( richTextElement.style.imageAlign )
+            {
+                case 'top':
+                    spriteNode.setAnchorPoint(0, 1);
+                    break;
+                case 'center':
+                    spriteNode.setAnchorPoint(0, 0.5);
+                    break;
+                default:
+                    spriteNode.setAnchorPoint(0, 0);
+                    break;
+            }
             spriteComponent.type = cc.Sprite.Type.SLICED;
             spriteComponent.sizeMode = cc.Sprite.SizeMode.CUSTOM;
             this.node.addChild(spriteNode);
@@ -661,8 +672,7 @@ let RichText = cc.Class({
             let expectWidth = richTextElement.style.imageWidth;
             let expectHeight = richTextElement.style.imageHeight;
 
-            //follow the original rule, expectHeight must less then lineHeight
-            if (expectHeight > 0 && expectHeight < this.lineHeight) {
+            if (expectHeight > 0) {
                 scaleFactor = expectHeight / spriteHeight;
                 spriteWidth = spriteWidth * scaleFactor;
                 spriteHeight = spriteHeight * scaleFactor;
@@ -853,6 +863,30 @@ let RichText = cc.Class({
             if (lineCount === nextLineIndex) {
                 nextTokenX += labelSize.width;
             }
+
+            // adjust img position by anchorY (setting from <img align>)
+            let sprite = label.getComponent( cc.Sprite );
+            if( sprite ) {
+
+                let LineHeight = this.lineHeight;
+                let LineHeightReal = this.lineHeight * 1.26; //我也不懂为什么为什么node高是实际的x1.26, 这值是看编辑器变化算出来的
+                switch( label.anchorY )
+                {
+                    case 1:
+                        label.y += ( LineHeight );
+                        break;
+                    case 0.5:
+                        label.y += ( LineHeightReal / 2 );
+                        break;
+                    default:
+                        label.y += ( ( LineHeightReal - LineHeight ) / 2 );
+                        break;
+                }
+            }
+
+            //adjust y for label with outline
+            let outline = label.getComponent( cc.LabelOutline )
+            if( outline ) label.y = label.y - outline.width;
         }
     },
 

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -648,7 +648,7 @@ let RichText = cc.Class({
         if (spriteFrame) {
             let spriteNode = new cc.PrivateNode(RichTextChildImageName);
             let spriteComponent = spriteNode.addComponent(cc.Sprite);
-            switch( richTextElement.style.imageAlign )
+            switch (richTextElement.style.imageAlign)
             {
                 case 'top':
                     spriteNode.setAnchorPoint(0, 1);
@@ -660,6 +660,7 @@ let RichText = cc.Class({
                     spriteNode.setAnchorPoint(0, 0);
                     break;
             }
+            if (richTextElement.style.imageOffset) spriteNode._imageOffset = richTextElement.style.imageOffset;
             spriteComponent.type = cc.Sprite.Type.SLICED;
             spriteComponent.sizeMode = cc.Sprite.SizeMode.CUSTOM;
             this.node.addChild(spriteNode);
@@ -864,29 +865,45 @@ let RichText = cc.Class({
                 nextTokenX += labelSize.width;
             }
 
-            // adjust img position by anchorY (setting from <img align>)
-            let sprite = label.getComponent( cc.Sprite );
-            if( sprite ) {
-
-                let LineHeight = this.lineHeight;
-                let LineHeightReal = this.lineHeight * 1.26; //我也不懂为什么为什么node高是实际的x1.26, 这值是看编辑器变化算出来的
-                switch( label.anchorY )
+            let sprite = label.getComponent(cc.Sprite);
+            if (sprite) {
+                // adjust img align (from <img align=top|center|bottom>)
+                let lineHeightSet = this.lineHeight;
+                let lineHeightReal = this.lineHeight * (1 + textUtils.BASELINE_RATIO); //single line node height
+                switch (label.anchorY)
                 {
                     case 1:
-                        label.y += ( LineHeight );
+                        label.y += ( lineHeightSet + ( ( lineHeightReal - lineHeightSet) / 2 ) );
                         break;
                     case 0.5:
-                        label.y += ( LineHeightReal / 2 );
+                        label.y += ( lineHeightReal / 2 );
                         break;
                     default:
-                        label.y += ( ( LineHeightReal - LineHeight ) / 2 );
+                        label.y += ( (lineHeightReal - lineHeightSet) / 2 );
                         break;
+                }
+                // adjust img offset (from <img offset=12|12,34>)
+                if (label._imageOffset)
+                {
+                    let offsets = label._imageOffset.split(',');
+                    if (offsets.length === 1 && offsets[0])
+                    {
+                        let offsetY = parseFloat(offsets[0]);
+                        if (Number.isInteger(offsetY)) label.y += offsetY;
+                    }
+                    else if(offsets.length === 2)
+                    {
+                        let offsetX = parseFloat(offsets[0]);
+                        let offsetY = parseFloat(offsets[1]);
+                        if (Number.isInteger(offsetX)) label.x += offsetX;
+                        if (Number.isInteger(offsetY)) label.y += offsetY;
+                    }
                 }
             }
 
             //adjust y for label with outline
-            let outline = label.getComponent( cc.LabelOutline )
-            if( outline ) label.y = label.y - outline.width;
+            let outline = label.getComponent(cc.LabelOutline);
+            if (outline && outline.width) label.y = label.y - outline.width;
         }
     },
 

--- a/cocos2d/core/utils/html-text-parser.js
+++ b/cocos2d/core/utils/html-text-parser.js
@@ -25,7 +25,7 @@
  ****************************************************************************/
 
 var eventRegx = /^(click)(\s)*=|(param)(\s)*=/;
-var imageAttrReg = /(\s)*src(\s)*=|(\s)*height(\s)*=|(\s)*width(\s)*=|(\s)*align(\s)*=|(\s)*click(\s)*=|(\s)*param(\s)*=/;
+var imageAttrReg = /(\s)*src(\s)*=|(\s)*height(\s)*=|(\s)*width(\s)*=|(\s)*align(\s)*=|(\s)*offset(\s)*=|(\s)*click(\s)*=|(\s)*param(\s)*=/;
 /**
  * A utils class for parsing HTML texts. The parsed results will be an object array.
  */
@@ -161,6 +161,8 @@ HtmlTextParser.prototype = {
                         obj.imageWidth = parseInt(tagValue);
                     } else if (tagName === "align") {
                         obj.imageAlign = tagValue.toLocaleLowerCase();
+                    } else if (tagName === "offset") {
+                        obj.imageOffset = tagValue;
                     } else if (tagName === "click") {
                         obj.event = this._processEventHandler(tagName + "=" + tagValue);
                     }

--- a/cocos2d/core/utils/html-text-parser.js
+++ b/cocos2d/core/utils/html-text-parser.js
@@ -25,7 +25,7 @@
  ****************************************************************************/
 
 var eventRegx = /^(click)(\s)*=|(param)(\s)*=/;
-var imageAttrReg = /(\s)*src(\s)*=|(\s)*height(\s)*=|(\s)*width(\s)*=|(\s)*click(\s)*=|(\s)*param(\s)*=/;
+var imageAttrReg = /(\s)*src(\s)*=|(\s)*height(\s)*=|(\s)*width(\s)*=|(\s)*align(\s)*=|(\s)*click(\s)*=|(\s)*param(\s)*=/;
 /**
  * A utils class for parsing HTML texts. The parsed results will be an object array.
  */
@@ -159,6 +159,8 @@ HtmlTextParser.prototype = {
                         obj.imageHeight = parseInt(tagValue);
                     } else if (tagName === "width") {
                         obj.imageWidth = parseInt(tagValue);
+                    } else if (tagName === "align") {
+                        obj.imageAlign = tagValue.toLocaleLowerCase();
                     } else if (tagName === "click") {
                         obj.event = this._processEventHandler(tagName + "=" + tagValue);
                     }


### PR DESCRIPTION
小修正及部份改进，
代码在我的项目已经运行一段时间，没发现什么问题，
各位大神帮忙检视一下这样是否可行，谢谢

### Changes:
- 修正outline的垂直对齐误差
   fix v-align for`<outline width=2>text</outline>`

- 让`<img height=999>`设定值可以设定超过行高
   add`<img>`ability to set size over lineHeight

- 新增`<img align=top>`设定垂直对齐属性，可为top|center|bottom，未设定及预设值为bottom
   add`<img>`align tag like align=top|center|bottom, if not setting use default:bottom

### 未修改时的效果
![image](https://user-images.githubusercontent.com/3889141/71641626-5fcd3c80-2cda-11ea-9c98-7e16dffe2dd3.png)

### 修改后的效果
![image](https://user-images.githubusercontent.com/3889141/71641631-6a87d180-2cda-11ea-9e8b-997602cf0db8.png)

