### PR TITLE
Fixed an issue when the material dynamically switched Texture.

### DIFF
--- a/cocos2d/core/assets/material/CCMaterial.js
+++ b/cocos2d/core/assets/material/CCMaterial.js
@@ -196,11 +196,8 @@ let Material = cc.Class({
 
         if (val instanceof Texture) {
             let format = val.getPixelFormat();
-            if (format === PixelFormat.RGBA_ETC1 ||
-                format === PixelFormat.RGB_A_PVRTC_4BPPV1 ||
-                format === PixelFormat.RGB_A_PVRTC_2BPPV1) {
-                this.define('CC_USE_ALPHA_ATLAS_' + name.toUpperCase(), true);
-            }
+            let val = (format === PixelFormat.RGBA_ETC1 || format === PixelFormat.RGB_A_PVRTC_4BPPV1 || format === PixelFormat.RGB_A_PVRTC_2BPPV1)
+            this.define('CC_USE_ALPHA_ATLAS_' + name.toUpperCase(), val);
 
             function loaded () {
                 this._effect.setProperty(name, val, passIdx);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39078800/71654397-9f446900-2d6c-11ea-9f7e-2d8e465454c8.png)

修复动态切换Texture时，CC_USE_ALPHA_ATLAS_TEXTURE 的 define 值没有重置的问题。
