### PR TITLE
fix resize widget on orientation changed

### DIFF
--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -465,8 +465,9 @@ var widgetManager = cc._widgetManager = module.exports = {
         }
         else {
             if (cc.sys.isMobile) {
-                window.addEventListener('resize', this.onResized.bind(this));
-                window.addEventListener('orientationchange', this.onResized.bind(this));
+                let thisOnResized = this.onResized.bind(this);
+                window.addEventListener('resize', thisOnResized);
+                window.addEventListener('orientationchange', thisOnResized);
             }
             else {
                 cc.view.on('canvas-resize', this.onResized, this);

--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -466,6 +466,7 @@ var widgetManager = cc._widgetManager = module.exports = {
         else {
             if (cc.sys.isMobile) {
                 window.addEventListener('resize', this.onResized.bind(this));
+                window.addEventListener('orientationchange', this.onResized.bind(this));
             }
             else {
                 cc.view.on('canvas-resize', this.onResized, this);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2338

changeLog:
- 修复浏览器自动旋转后， widget 没有正确适配的问题

resize 事件会在刚开始旋转时就触发，这时候适配 widget 是不正确的，应该在 orientationchange 事件里再适配一次，这时候才是旋转结束的时间点