### PR TITLE
Fix the error when Radial data is 0.

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/radial-filled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/radial-filled.js
@@ -214,6 +214,7 @@ export default class RadialFilledAssembler extends Assembler2D {
         let fillEnd = fillStart + fillRange;
         
         let local = this._local;
+        local.length = 0;
 
         let offset = 0;
         let floatsPerTriangle = 3 * this.floatsPerVert;


### PR DESCRIPTION
反馈自论坛：https://forum.cocos.org/t/cocos-creator-v2-3-0-beta-5/87487/243?u=cary

Radial 的参数设置为 0 时，没有设置 local 数据，local 也没有重置 length，导致后续的vertexCount错误。