### PR TITLE
fix safari view adaption when auto rotate to portrait

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -211,6 +211,16 @@ cc.js.mixin(View.prototype, {
     _orientationChange: function () {
         cc.view._orientationChanging = true;
         cc.view._resizeEvent();
+        // HACK: show nav bar on iOS safari
+        // safari will enter fullscreen when rotate to landscape
+        // need to exit fullscreen when rotate back to portrait, scrollTo(0, -60) works.
+        if (cc.sys.browserType === cc.sys.BROWSER_TYPE_SAFARI && cc.sys.isMobile) {
+            setTimeout(() => {
+                if (window.innerHeight > window.innerWidth) {
+                    window.scrollTo(0, -60);
+                }
+            }, 500);
+        }
     },
 
     /**

--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -213,11 +213,11 @@ cc.js.mixin(View.prototype, {
         cc.view._resizeEvent();
         // HACK: show nav bar on iOS safari
         // safari will enter fullscreen when rotate to landscape
-        // need to exit fullscreen when rotate back to portrait, scrollTo(0, -60) works.
+        // need to exit fullscreen when rotate back to portrait, scrollTo(0, 1) works.
         if (cc.sys.browserType === cc.sys.BROWSER_TYPE_SAFARI && cc.sys.isMobile) {
             setTimeout(() => {
                 if (window.innerHeight > window.innerWidth) {
-                    window.scrollTo(0, -60);
+                    window.scrollTo(0, 1);
                 }
             }, 500);
         }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2092

changeLog:
- 修复 iOS safari 自动转屏到竖屏时，底部出现空白区域的问题

原因是 safari 自动隐藏了导航栏，window.innerHeight 又获取不到正确的高度，没办法做适配