### PR TITLE
Fix hash calculation for Texture on native platforms.

### DIFF
--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -957,9 +957,9 @@ var Texture2D = cc.Class({
         let pixelFormat = this._format;
         let image = this._image;
         if (CC_JSB && image) {
-            if (image._glFormat !== GL_RGBA)
+            if (image._glFormat && image._glFormat !== GL_RGBA)
                 pixelFormat = 0;
-            premultiplyAlpha = image._premultiplyAlpha;
+            premultiplyAlpha = image._premultiplyAlpha ? 1 : 0;
         }
 
         this._hash = Number(`${minFilter}${magFilter}${pixelFormat}${wrapS}${wrapT}${genMipmaps}${premultiplyAlpha}${flipY}`);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2293

Changes:
1.原生平台的Hash计算boolean值没有做转换，另外image的glFormat没有初始化值。修复原生平台文本BITMAP不能合批的问题。另外原生平台的cc.macro.CLEANUP_IMAGE_CACHE默认为true，要使用BITMAP合批的话，关闭 cc.macro.CLEANUP_IMAGE_CACHE。

