### PR TITLE
add loadRes-internals to modules.json

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -2,7 +2,18 @@
   {
     "name": "Core",
     "locked": true,
-    "entries": []
+    "entries": [],
+    "loadRes-internals": [
+      "db://internal/resources/effects/builtin-2d-gray-sprite.effect",
+      "db://internal/resources/effects/builtin-2d-sprite.effect",
+      "db://internal/resources/effects/builtin-clear-stencil.effect",
+      "db://internal/resources/effects/builtin-unlit.effect",
+      "db://internal/resources/materials/builtin-2d-base.mtl",
+      "db://internal/resources/materials/builtin-2d-gray-sprite.mtl",
+      "db://internal/resources/materials/builtin-2d-sprite.mtl",
+      "db://internal/resources/materials/builtin-clear-stencil.mtl",
+      "db://internal/resources/materials/builtin-unlit.mtl"
+    ]
   },
   {
     "name": "Canvas",
@@ -244,6 +255,10 @@
     "entries": [
       "./extensions/spine/index.js"
     ],
+    "loadRes-internals": [
+      "db://internal/resources/effects/builtin-2d-spine.effect",
+      "db://internal/resources/materials/builtin-2d-spine.mtl"
+    ],
     "dependencies": ["WebGL Renderer"]
   },
   {
@@ -374,6 +389,12 @@
     "entries": [
       "./cocos2d/core/3d/particle/particle-system-3d.ts",
       "./cocos2d/core/3d/particle/renderer/particle-system-3d-renderer.ts"
+    ],
+    "loadRes-internals": [
+      "db://internal/resources/effects/builtin-particle.effect",
+      "db://internal/resources/effects/builtin-particle-trail.effect",
+      "db://internal/resources/materials/builtin-particle.mtl",
+      "db://internal/resources/materials/builtin-particle-trail.mtl"
     ],
     "dependencies": ["3D"]
   }

--- a/modules.json
+++ b/modules.json
@@ -3,16 +3,12 @@
     "name": "Core",
     "locked": true,
     "entries": [],
-    "loadRes-internals": [
-      "db://internal/resources/effects/builtin-2d-gray-sprite.effect",
-      "db://internal/resources/effects/builtin-2d-sprite.effect",
-      "db://internal/resources/effects/builtin-clear-stencil.effect",
-      "db://internal/resources/effects/builtin-unlit.effect",
-      "db://internal/resources/materials/builtin-2d-base.mtl",
-      "db://internal/resources/materials/builtin-2d-gray-sprite.mtl",
-      "db://internal/resources/materials/builtin-2d-sprite.mtl",
-      "db://internal/resources/materials/builtin-clear-stencil.mtl",
-      "db://internal/resources/materials/builtin-unlit.mtl"
+    "internal/resources": [
+      "builtin-2d-gray-sprite",
+      "builtin-2d-sprite",
+      "builtin-clear-stencil",
+      "builtin-unlit",
+      "builtin-2d-base"
     ]
   },
   {
@@ -255,9 +251,8 @@
     "entries": [
       "./extensions/spine/index.js"
     ],
-    "loadRes-internals": [
-      "db://internal/resources/effects/builtin-2d-spine.effect",
-      "db://internal/resources/materials/builtin-2d-spine.mtl"
+    "internal/resources": [
+      "builtin-2d-spine"
     ],
     "dependencies": ["WebGL Renderer"]
   },
@@ -390,11 +385,9 @@
       "./cocos2d/core/3d/particle/particle-system-3d.ts",
       "./cocos2d/core/3d/particle/renderer/particle-system-3d-renderer.ts"
     ],
-    "loadRes-internals": [
-      "db://internal/resources/effects/builtin-particle.effect",
-      "db://internal/resources/effects/builtin-particle-trail.effect",
-      "db://internal/resources/materials/builtin-particle.mtl",
-      "db://internal/resources/materials/builtin-particle-trail.mtl"
+    "internal/resources": [
+      "builtin-3d-particle",
+      "builtin-3d-particle-trail"
     ],
     "dependencies": ["3D"]
   }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2384

Changes:
 * 添加 modules.json 中模块依赖的内置资源路径，用于剔除资源，减少包体使用
