### PR TITLE
[bug] remove support cc.sys.languageCode defined in  runtime platform

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -717,7 +717,7 @@ function initSys () {
         sys.os = __getOS();
         sys.language = __getCurrentLanguage();
         var languageCode; 
-        if (CC_JSB || CC_RUNTIME) {
+        if (CC_JSB) {
             languageCode = __getCurrentLanguageCode();
         }
         sys.languageCode = languageCode ? languageCode.toLowerCase() : undefined;


### PR DESCRIPTION
这个应该挪到 runtime 适配层，不应该在这里定义。
后面新增 其他 runtime 渠道 如无此方法，会导致运行报错。
原先 pr:https://github.com/cocos-creator/engine/pull/6060
