### PR TITLE
fix: without elastic, the scroll-to-bottom event cannot be triggered

### DIFF
--- a/cocos2d/core/components/CCScrollView.js
+++ b/cocos2d/core/components/CCScrollView.js
@@ -1037,7 +1037,7 @@ let ScrollView = cc.Class({
         if (realMove.y > 0) { //up
             let icBottomPos = this.content.y - this.content.anchorY * this.content.height;
 
-            if (icBottomPos + realMove.y > this._bottomBoundary) {
+            if (icBottomPos + realMove.y >= this._bottomBoundary) {
                 scrollEventType = 'scroll-to-bottom';
             }
         }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2402

Changes:
 * 修复：如果没有弹性，则无法触发 scroll-to-bottom 事件

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
