### PR TITLE
Fix the matrix is incorrect after calling the function of 'getBoundingBoxToWorld'.

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -3548,7 +3548,6 @@ let NodeDefines = {
     },
 
     _getBoundingBoxTo (parentMat) {
-        this._updateLocalMatrix();
         let width = this._contentSize.width;
         let height = this._contentSize.height;
         let rect = cc.rect(

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -3556,9 +3556,9 @@ let NodeDefines = {
             -this._anchorPoint.y * height, 
             width, 
             height);
-
-        var parentMat = Mat4.mul(this._worldMatrix, parentMat, this._matrix);
-        rect.transformMat4(rect, parentMat);
+        
+        this._calculWorldMatrix();
+        rect.transformMat4(rect, this._worldMatrix);
 
         //query child's BoundingBox
         if (!this._children)

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -3540,14 +3540,14 @@ let NodeDefines = {
     getBoundingBoxToWorld () {
         if (this._parent) {
             this._parent._updateWorldMatrix();
-            return this._getBoundingBoxTo(this._parent._worldMatrix);
+            return this._getBoundingBoxTo();
         }
         else {
             return this.getBoundingBox();
         }
     },
 
-    _getBoundingBoxTo (parentMat) {
+    _getBoundingBoxTo () {
         let width = this._contentSize.width;
         let height = this._contentSize.height;
         let rect = cc.rect(
@@ -3567,7 +3567,7 @@ let NodeDefines = {
         for (var i = 0; i < locChildren.length; i++) {
             var child = locChildren[i];
             if (child && child.active) {
-                var childRect = child._getBoundingBoxTo(parentMat);
+                var childRect = child._getBoundingBoxTo();
                 if (childRect)
                     rect.union(rect, childRect);
             }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2401

Changes:

3D节点又嵌套2D节点，调用 getBoundingBoxToWorld 之后会导致节点矩阵不正确，getBoundingBoxToWorld 方法里更新世界矩阵是按照3d的计算方式，没有区分2d和3d，用统一的回调来处理。

