### PR TITLE
fix not resize browser size when editbox end editing

### DIFF
--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -253,17 +253,17 @@ Object.assign(WebEditBoxImpl.prototype, {
 
     _hideDomOnMobile () {
         if (cc.sys.os === cc.sys.OS_ANDROID) {
-            if (!_currentEditBoxImpl) {
-                if (_autoResize) {
-                    cc.view.resizeWithBrowserSize(true);
-                }
-                // In case enter full screen when soft keyboard still showing
-                setTimeout(function () {
+            if (_autoResize) {
+                cc.view.resizeWithBrowserSize(true);
+            }
+            // In case enter full screen when soft keyboard still showing
+            setTimeout(function () {
+                if (!_currentEditBoxImpl) {
                     if (_fullscreen) {
                         cc.view.enableAutoFullScreen(true);
                     }
-                }, DELAY_TIME);
-            }
+                }
+            }, DELAY_TIME);
         }
 
         // Some browser like wechat on iOS need to mannully scroll back window

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -253,20 +253,19 @@ Object.assign(WebEditBoxImpl.prototype, {
 
     _hideDomOnMobile () {
         if (cc.sys.os === cc.sys.OS_ANDROID) {
-            // Closing soft keyboard on mobile will fire 'resize' event
-            // So we need to set a timeout to enable resizeWithBrowserSize
-            setTimeout(function () {
-                if (!_currentEditBoxImpl) {
+            if (!_currentEditBoxImpl) {
+                if (_autoResize) {
+                    cc.view.resizeWithBrowserSize(true);
+                }
+                // In case enter full screen when soft keyboard still showing
+                setTimeout(function () {
                     if (_fullscreen) {
                         cc.view.enableAutoFullScreen(true);
                     }
-                    if (_autoResize) {
-                        cc.view.resizeWithBrowserSize(true);
-                    }
-                }
-            }, DELAY_TIME);
+                }, DELAY_TIME);
+            }
         }
-        
+
         // Some browser like wechat on iOS need to mannully scroll back window
         this._scrollBackWindow();
     },


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2419

changeLog:
- 修复 editBox 结束编辑后，没能及时适配 UI 界面的问题

之前延时做 resizeWithBrowserSize 是为了避免在收起软件盘时，多次触发 resize 事件的问题
现在新的浏览器版本，在收起软件盘时，只会触发一次 resize
所以需要立即开启 resizeWithBrowserSize