### PR TITLE
disable retina in editor for 2d-tasks/issues/2449

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -425,6 +425,10 @@ cc.js.mixin(View.prototype, {
      * @param {Boolean} enabled - Enable or disable retina display
      */
     enableRetina: function(enabled) {
+        if (CC_EDITOR && enabled) {
+            cc.warn('Can not enable retina in Editor.');
+            return;
+        }
         this._retinaEnabled = !!enabled;
     },
 
@@ -438,6 +442,9 @@ cc.js.mixin(View.prototype, {
      * @return {Boolean}
      */
     isRetinaEnabled: function() {
+        if (CC_EDITOR) {
+            return false;
+        }
         return this._retinaEnabled;
     },
 


### PR DESCRIPTION
Re: 

https://github.com/cocos-creator/2d-tasks/issues/2298
https://github.com/cocos-creator/2d-tasks/issues/2449

Changes:
 * 在编辑器中禁用 retina（如果后续想支持的话，需要解决开启后会出现 canvas 布局错乱的问题）
