### PR TITLE
fix: keepAspectRatio invalid when update clip

### DIFF
--- a/cocos2d/videoplayer/CCVideoPlayer.js
+++ b/cocos2d/videoplayer/CCVideoPlayer.js
@@ -334,6 +334,7 @@ let VideoPlayer = cc.Class({
             url = cc.loader.md5Pipe.transformURL(url);
         }
         this._impl.setURL(url, this._mute || this._volume === 0);
+        this._impl.setKeepAspectRatioEnabled(this.keepAspectRatio);
     },
 
     onLoad () {
@@ -345,7 +346,6 @@ let VideoPlayer = cc.Class({
 
             if (!CC_EDITOR) {
                 impl.seekTo(this.currentTime);
-                impl.setKeepAspectRatioEnabled(this.keepAspectRatio);
                 impl.setFullScreenEnabled(this._isFullscreen);
                 this.pause();
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2458

Changes:
 * 修复通过本地下载的视频 url，Keep Aspect Ratio 无效的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
