### PR TITLE
fixed zoom ratio when alignWithScreen is false

### DIFF
--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -782,7 +782,7 @@ let Camera = cc.Class({
             fov = Math.atan(Math.tan(fov / 2) / this.zoomRatio) * 2;
             this._camera.setFov(fov);
 
-            this._camera.setOrthoHeight(this._orthoSize * this.zoomRatio);
+            this._camera.setOrthoHeight(this._orthoSize / this.zoomRatio);
         }
 
         this._camera.dirty = true;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * fixed zoom ratio when alignWithScreen is false, orthoSize should be less when zoomRatio is bigger
