### PR TITLE
Fix a problem of autoplay particles not showing for the first time.

### DIFF
--- a/cocos2d/core/3d/particle/particle-system-3d.ts
+++ b/cocos2d/core/3d/particle/particle-system-3d.ts
@@ -655,7 +655,8 @@ export default class ParticleSystem3D extends RenderComponent {
     onEnable () {
         super.onEnable();
         if (this.playOnAwake) {
-            this.play();
+            // Here must wait until the nodes are aligned, otherwise the first emit will not get the correct world matrix.
+            cc.director.on(cc.Director.EVENT_AFTER_UPDATE, this.play, this);
         }
         this._assembler.onEnable();
         this.trailModule.onEnable();


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2428, cocos-creator/2d-tasks#2432, cocos-creator/2d-tasks#2460

Changes:
 修复部分平台使用世界空间的粒子，自动播放时第一次没有正确显示的问题。

原因是因为在移动平台，节点的align对齐是在LateUpdate之后执行的，在这之前如果获取节点的世界矩阵就不是正确的，需要在align之后才能获取到正确的世界矩阵。所以这里自动播放的粒子改为在LateUpdate之后执行play播放。