### PR TITLE
Fixed animation editor stuck after exit

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -357,7 +357,7 @@ let RichText = cc.Class({
         if (this.handleTouchEvent) {
             this._addEventListeners();
         }
-        this._onTTFLoaded();
+        this._updateRichText();
         this._activateChildren(true);
     },
 
@@ -366,6 +366,10 @@ let RichText = cc.Class({
             this._removeEventListeners();
         }
         this._activateChildren(false);
+    },
+
+    start () {
+        this._onTTFLoaded();
     },
 
     _onColorChanged (parentColor) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2484

Changes:
 * 回退对 CCRichText 的修改，该改动会导致动画编辑器退出后卡死（因为退出时候进行了重置组件，导致 CCRichText 又重新删除跟添加子节点，导致动画编辑器 dump 后的 uuid 无法进行 Instance 从而报错卡死）

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
