### PR TITLE
fix tiledmap image layer load throw error

### DIFF
--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -727,10 +727,7 @@ let TiledMap = cc.Class({
                         image = child.addComponent(cc.Sprite);
                     }
                     
-                    let spf = image.spriteFrame;
-                    if (!spf) {
-                        spf = new cc.SpriteFrame();
-                    }
+                    let spf = image.spriteFrame || new cc.SpriteFrame();
                     spf.setTexture(texture);
                     image.spriteFrame = spf;
 

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -726,8 +726,13 @@ let TiledMap = cc.Class({
                     if (!image) {
                         image = child.addComponent(cc.Sprite);
                     }
-                    image.spriteFrame = new cc.SpriteFrame();
-                    image.spriteFrame.setTexture(texture);
+                    
+                    let spf = image.spriteFrame;
+                    if (!spf) {
+                        spf = new cc.SpriteFrame();
+                    }
+                    spf.setTexture(texture);
+                    image.spriteFrame = spf;
 
                     child.width = texture.width;
                     child.height = texture.height;


### PR DESCRIPTION
由于新版本的CCSprite不允许赋值一个空的CCSpriteFrame，所以得修改写法，否则会报错