### PR TITLE
export eventManager in cc.internal

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -817,7 +817,7 @@ var game = {
 
         // register system events
         if (this.config.registerSystemEvent)
-            _cc.inputManager.registerSystemEvent(this.canvas);
+            cc.internal.inputManager.registerSystemEvent(this.canvas);
 
         if (typeof document.hidden !== 'undefined') {
             hiddenPropName = "hidden";

--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -1058,4 +1058,4 @@ js.get(cc, 'eventManager', function () {
     return eventManager;
 });
 
-module.exports = eventManager;
+module.exports = cc.internal.eventManager = eventManager;

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -567,4 +567,4 @@ let inputManager = {
     }
 };
 
-module.exports = _cc.inputManager = inputManager;
+module.exports = cc.internal.inputManager = inputManager;

--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -767,7 +767,7 @@ cc.js.mixin(View.prototype, {
         cc.visibleRect && cc.visibleRect.init(this._visibleRect);
 
         renderer.updateCameraViewport();
-        _cc.inputManager._updateCanvasBoundingRect();
+        cc.internal.inputManager._updateCanvasBoundingRect();
         this.emit('design-resolution-changed');
     },
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var _global = typeof window === 'undefined' ? global : window;
 _global.cc = _global.cc || {};
 
 // For internal usage
-_global._cc = _global._cc || {};
+cc.internal = cc.internal || {};
 
 require('./predefine');
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2513

changeLog:
- 移除 _cc 全局变量
- 将内部模块放到 cc.internal 里 （同步 3d 的做法）
- 将 eventManager 导出到 cc.internal 

关联： https://github.com/cocos-creator-packages/adapters/pull/87