### PR TITLE
Fix the afterimage problem of particle trail when doing transform animation.

### DIFF
--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -433,6 +433,8 @@ export default class TrailModule {
         if (!trail) {
             trail = this._trailSegments.alloc();
             this._particleTrail.set(p, trail);
+            // Avoid position and trail are one frame apart at the end of the particle animation.
+            return;
         }
         let lastSeg = trail.getElement(trail.end - 1);
         if (this._needTransform) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#1763

Changes:

粒子通过 Animation 进行位移动画时，复位时原点位置的粒子拖尾记录到最后一帧的坐标，从而导致拖尾的 0, 1 两个点显示为错误的残影。

在更新粒子拖尾时，如果当前粒子没有拖尾记录，那就等待下一帧才开始处理拖尾。