### PR TITLE
add tileObjectGroups

### DIFF
--- a/cocos2d/core/3d/primitive/index.ts
+++ b/cocos2d/core/3d/primitive/index.ts
@@ -11,7 +11,8 @@ import { PolyhedronType, polyhedron } from './polyhedron';
 import VertexData from './vertex-data';
 
 /**
- * 一个创建 3D 物体顶点数据的基础模块，你可以通过 "cc.primitive" 来访问这个模块。
+ * !#en A basic module for creating vertex data for 3D objects. You can access this module by `cc.primitive`.
+ * !#zh 一个创建 3D 物体顶点数据的基础模块，你可以通过 `cc.primitive` 来访问这个模块。
  * @module cc.primitive
  * @submodule cc.primitive
  * @main
@@ -144,3 +145,8 @@ cc.primitive = Object.assign({
     PolyhedronType,
     VertexData,
 }, utils);
+
+// fix submodule pollute ...
+/**
+ * @submodule cc
+ */

--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -817,7 +817,7 @@ var game = {
 
         // register system events
         if (this.config.registerSystemEvent)
-            _cc.inputManager.registerSystemEvent(this.canvas);
+            cc.internal.inputManager.registerSystemEvent(this.canvas);
 
         if (typeof document.hidden !== 'undefined') {
             hiddenPropName = "hidden";

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1554,9 +1554,9 @@ let NodeDefines = {
         },
 
         /**
-         * !en
+         * !#en
          * Switch 2D/3D node. The 2D nodes will run faster.
-         * !zh
+         * !#zh
          * 切换 2D/3D 节点，2D 节点会有更高的运行效率
          * @property {Boolean} is3DNode
          * @default false

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -2490,8 +2490,12 @@ let NodeDefines = {
         if (!this.active)
             return;
         cc.assertID(action, 1618);
-        cc.warnID(1639);
-        cc.director.getActionManager().addAction(action, this, false);
+        let am = cc.director.getActionManager();
+        if (!am._suppressDeprecation) {
+            am._suppressDeprecation = true;
+            cc.warnID(1639);
+        }
+        am.addAction(action, this, false);
         return action;
     } : emptyFunc,
 

--- a/cocos2d/core/CCScheduler.js
+++ b/cocos2d/core/CCScheduler.js
@@ -346,9 +346,9 @@ cc.Scheduler.prototype = {
 
     //-----------------------public method-------------------------
     /**
-     * !en This method should be called for any target which needs to schedule tasks, and this method should be called before any scheduler API usage.
+     * !#en This method should be called for any target which needs to schedule tasks, and this method should be called before any scheduler API usage.
      * This method will add a `_id` property if it doesn't exist.
-     * !zh 任何需要用 Scheduler 管理任务的对象主体都应该调用这个方法，并且应该在调用任何 Scheduler API 之前调用这个方法。
+     * !#zh 任何需要用 Scheduler 管理任务的对象主体都应该调用这个方法，并且应该在调用任何 Scheduler API 之前调用这个方法。
      * 这个方法会给对象添加一个 `_id` 属性，如果这个属性不存在的话。
      * @method enableForTarget
      * @param {Object} target

--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -209,6 +209,9 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
 
         this._rotated = false;
 
+        this._flipX = false;
+        this._flipY = false;
+
         this.vertices = null;
 
         this._capInsets = [0, 0, 0, 0];
@@ -272,6 +275,52 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         this._rotated = bRotated;
         if (this._texture)
             this._calculateUV();
+    },
+
+    /**
+     * !#en Returns whether the sprite frame is flip x axis in the texture.
+     * !#zh 获取 SpriteFrame 是否反转 x 轴
+     * @method isFlipX
+     * @return {Boolean}
+     */
+    isFlipX: function () {
+        return this._flipX;
+    },
+
+    /**
+     * !#en Returns whether the sprite frame is flip y axis in the texture.
+     * !#zh 获取 SpriteFrame 是否反转 y 轴
+     * @method isFlipY
+     * @return {Boolean}
+     */
+    isFlipY: function () {
+        return this._flipY;
+    },
+
+    /**
+     * !#en Set whether the sprite frame is flip x axis in the texture.
+     * !#zh 设置 SpriteFrame 是否翻转 x 轴
+     * @method setFlipX
+     * @param {Boolean} flipX
+     */
+    setFlipX: function (flipX) {
+        this._flipX = flipX;
+        if (this._texture) {
+            this._calculateUV();
+        }
+    },
+
+    /**
+     * !#en Set whether the sprite frame is flip y axis in the texture.
+     * !#zh 设置 SpriteFrame 是否翻转 y 轴
+     * @method setFlipY
+     * @param {Boolean} flipY
+     */
+    setFlipY: function (flipY) {
+        this._flipY = flipY;
+        if (this._texture) {
+            this._calculateUV();
+        }
     },
 
     /**
@@ -522,6 +571,28 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         }
     },
 
+    _flipXY (uvs) {
+        if (this._flipX) {
+            let tempVal = uvs[0];
+            uvs[0] = uvs[1];
+            uvs[1] = tempVal;
+
+            tempVal = uvs[2];
+            uvs[2] = uvs[3];
+            uvs[3] = tempVal;
+        }
+
+        if (this._flipY) {
+            let tempVal = uvs[0];
+            uvs[0] = uvs[2];
+            uvs[2] = tempVal;
+
+            tempVal = uvs[1];
+            uvs[1] = uvs[3];
+            uvs[3] = tempVal;
+        }
+    },
+
     _calculateSlicedUV () {
         let rect = this._rect;
         let atlasWidth = this._texture.width;
@@ -545,6 +616,8 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
             temp_uvs[1].v = (rect.y + leftWidth + centerWidth) / atlasHeight;
             temp_uvs[0].v = (rect.y + rect.width) / atlasHeight;
 
+            this._flipXY(temp_uvs);
+
             for (let row = 0; row < 4; ++row) {
                 let rowD = temp_uvs[row];
                 for (let col = 0; col < 4; ++col) {
@@ -565,6 +638,8 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
             temp_uvs[2].v = (rect.y + topHeight) / atlasHeight;
             temp_uvs[1].v = (rect.y + topHeight + centerHeight) / atlasHeight;
             temp_uvs[0].v = (rect.y + rect.height) / atlasHeight;
+
+            this._flipXY(temp_uvs);
 
             for (let row = 0; row < 4; ++row) {
                 let rowD = temp_uvs[row];
@@ -637,6 +712,42 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
             uv[5] = t;
             uv[6] = r;
             uv[7] = t;
+        }
+
+        if (this._flipX) {
+            let tempVal = uv[0];
+            uv[0] = uv[2];
+            uv[2] = tempVal;
+
+            tempVal = uv[1];
+            uv[1] = uv[3];
+            uv[3] = tempVal;
+
+            tempVal = uv[4];
+            uv[4] = uv[6];
+            uv[6] = tempVal;
+
+            tempVal = uv[5];
+            uv[5] = uv[7];
+            uv[7] = tempVal;
+        }
+
+        if (this._flipY) {
+            let tempVal = uv[0];
+            uv[0] = uv[4];
+            uv[4] = tempVal;
+
+            tempVal = uv[1];
+            uv[1] = uv[5];
+            uv[5] = tempVal;
+
+            tempVal = uv[2];
+            uv[2] = uv[6];
+            uv[6] = tempVal;
+
+            tempVal = uv[3];
+            uv[3] = uv[7];
+            uv[7] = tempVal;
         }
 
         let vertices = this.vertices;

--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -234,6 +234,7 @@ var Component = cc.Class({
      * !#zh 如果该组件启用，则每帧调用 LateUpdate。<br/>
      * 该方法为生命周期方法，父类未必会有实现。并且你只能在该方法内部调用父类的实现，不可在其它地方直接调用该方法。
      * @method lateUpdate
+     * @param {Number} dt - the delta time in seconds it took to complete the last frame
      * @protected
      */
     lateUpdate: null,

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -389,9 +389,7 @@ let Label = cc.Class({
                     cc.warnID(4000);
                 }
 
-                this._resetAssembler();
-                this._applyFontTexture();
-                this.setVertsDirty();
+                this._forceUpdateRenderData();
             },
             type: cc.Font,
             tooltip: CC_DEV && 'i18n:COMPONENT.label.font',
@@ -423,9 +421,7 @@ let Label = cc.Class({
                 if (value) {
                     this.font = null;
 
-                    this._resetAssembler();
-                    this.setVertsDirty();
-                    this._applyFontTexture();
+                    this._forceUpdateRenderData();
                 }
                 this.markForValidate();
             },
@@ -488,9 +484,7 @@ let Label = cc.Class({
                     this._ttfTexture = null;
                 }
 
-                this.setVertsDirty();
-                this._resetAssembler();
-                this._applyFontTexture();
+                this._forceUpdateRenderData();
             },
             animatable: false
         },
@@ -750,6 +744,8 @@ let Label = cc.Class({
     },
 
     _forceUpdateRenderData () {
+        if (!this.enabledInHierarchy) return;
+
         this.setVertsDirty();
         this._resetAssembler();
         this._applyFontTexture();

--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -738,7 +738,7 @@ let Label = cc.Class({
 
     _updateMaterialWebgl () {
         if (!this._frame) return;
-        let material = this._materials[0];
+        let material = this.getMaterial(0);
         material && material.setProperty('texture', this._frame._texture);
     },
 

--- a/cocos2d/core/components/CCMask.js
+++ b/cocos2d/core/components/CCMask.js
@@ -219,7 +219,6 @@ let Mask = cc.Class({
             notify: function () {
                 if (cc.game.renderType === cc.game.RENDER_TYPE_CANVAS) {
                     cc.warnID(4202);
-                    return;
                 }
             }
         },
@@ -351,7 +350,7 @@ let Mask = cc.Class({
 
         this.setMaterial(0, material);
 
-        this._graphics._materials[0] = material
+        this._graphics._materials[0] = material;
 
         this._updateMaterial();
     },
@@ -418,6 +417,7 @@ let Mask = cc.Class({
     _removeGraphics () {
         if (this._graphics) {
             this._graphics.destroy();
+            this._graphics._destroyImmediate(); // FIX: cocos-creator/2d-tasks#2511. TODO: cocos-creator/2d-tasks#2516
             this._graphics = null;
         }
     },

--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -25,8 +25,6 @@
  ****************************************************************************/
 
 const RenderComponent = require('../components/CCRenderComponent');
-const Material = require('../assets/material/CCMaterial');
-const textureUtil = require('../utils/texture-util');
 const BlendFunc = require('../../core/utils/blend-func');
 
 /**
@@ -252,7 +250,7 @@ var MotionStreak = cc.Class({
         }
     },
 
-    update (dt) {
+    lateUpdate (dt) {
         this._assembler && this._assembler.update(this, dt);
     }
 });

--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -216,7 +216,7 @@ var MotionStreak = cc.Class({
     },
 
     _updateMaterial () {
-        let material = this._materials[0];
+        let material = this.getMaterial(0);
         material && material.setProperty('texture', this._texture);
 
         BlendFunc.prototype._updateMaterial.call(this);

--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -434,7 +434,7 @@ var Sprite = cc.Class({
         let texture = this._spriteFrame && this._spriteFrame.getTexture();
         
         // make sure material is belong to self.
-        let material = this._materials[0];
+        let material = this.getMaterial(0);
         material && material.setProperty('texture', texture);
 
         BlendFunc.prototype._updateMaterial.call(this);

--- a/cocos2d/core/components/editbox/CCEditBox.js
+++ b/cocos2d/core/components/editbox/CCEditBox.js
@@ -100,8 +100,8 @@ let EditBox = cc.Class({
         },
 
          /**
-         * !en The Label component attached to the node for EditBox's placeholder text label
-         * !zh 输入框占位符节点上挂载的 Label 组件对象
+         * !#en The Label component attached to the node for EditBox's placeholder text label
+         * !#zh 输入框占位符节点上挂载的 Label 组件对象
          * @property {Label} placeholderLabel
          */
         placeholderLabel: {

--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -1058,4 +1058,4 @@ js.get(cc, 'eventManager', function () {
     return eventManager;
 });
 
-module.exports = eventManager;
+module.exports = cc.internal.eventManager = eventManager;

--- a/cocos2d/core/geom-utils/triangle.ts
+++ b/cocos2d/core/geom-utils/triangle.ts
@@ -141,7 +141,7 @@ export default class triangle {
     c: Vec3;
 
     /**
-     * @property geometry type
+     * geometry type
      */
     _type: number;
 

--- a/cocos2d/core/load-pipeline/downloader.js
+++ b/cocos2d/core/load-pipeline/downloader.js
@@ -159,6 +159,7 @@ var defaultMap = {
 
     'tmx' : downloadText,
     'tsx' : downloadText,
+    'tx'  : downloadText,
 
     'json' : downloadText,
     'ExportJson' : downloadText,

--- a/cocos2d/core/load-pipeline/pipeline.js
+++ b/cocos2d/core/load-pipeline/pipeline.js
@@ -194,9 +194,9 @@ proto.insertPipe = function (pipe, index) {
 };
 
 /**
- * !en
+ * !#en
  * Insert a pipe to the end of an existing pipe. The existing pipe must be a valid pipe in the pipeline.
- * !zh
+ * !#zh
  * 在当前 pipeline 的一个已知 pipe 后面插入一个新的 pipe。
  * @method insertPipeAfter
  * @param {Object} refPipe An existing pipe in the pipeline.

--- a/cocos2d/core/mesh/CCMeshRenderer.js
+++ b/cocos2d/core/mesh/CCMeshRenderer.js
@@ -286,14 +286,14 @@ let MeshRenderer = cc.Class({
     },
 
     _updateReceiveShadow () {
-        let materials = this._materials;
+        let materials = this.getMaterials();
         for (let i = 0; i < materials.length; i++) {
             materials[i].define('CC_USE_SHADOW_MAP', this._receiveShadows, undefined, true);
         }
     },
 
     _updateCastShadow () {
-        let materials = this._materials;
+        let materials = this.getMaterials();
         for (let i = 0; i < materials.length; i++) {
             materials[i].define('CC_CASTING_SHADOW', this._shadowCastingMode === ShadowCastingMode.ON, undefined, true);
         }
@@ -303,7 +303,7 @@ let MeshRenderer = cc.Class({
         let subDatas = this._mesh && this._mesh.subDatas;
         if (!subDatas) return;
 
-        let materials = this._materials;
+        let materials = this.getMaterials();
         for (let i = 0; i < materials.length; i++) {
             if (!subDatas[i]) break;
             let vfm = subDatas[i].vfm;

--- a/cocos2d/core/physics/joint/CCRevoluteJoint.js
+++ b/cocos2d/core/physics/joint/CCRevoluteJoint.js
@@ -199,9 +199,9 @@ var RevoluteJoint = cc.Class({
     },
 
     /**
-     * #!en
+     * !#en
      * Set the max and min limit angle.
-     * #!zh
+     * !#zh
      * 设置关节的角度最大和最小角度。
      * @param {Number} lower 
      * @param {Number} upper 

--- a/cocos2d/core/platform/CCClassDecorator.js
+++ b/cocos2d/core/platform/CCClassDecorator.js
@@ -724,3 +724,8 @@ cc._decorator = module.exports = {
     help,
     mixins,
 };
+
+// fix submodule pollute ...
+/**
+ * @submodule cc
+ */

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -567,4 +567,4 @@ let inputManager = {
     }
 };
 
-module.exports = _cc.inputManager = inputManager;
+module.exports = cc.internal.inputManager = inputManager;

--- a/cocos2d/core/platform/CCMacro.js
+++ b/cocos2d/core/platform/CCMacro.js
@@ -326,15 +326,13 @@ cc.macro = {
 
     /**
      * !#en
-     * Whether or not clear dom Image object cache after uploading to gl texture.
-     * Concretely, we are setting image.src to empty string to release the cache.
-     * Normally you don't need to enable this option, because on web the Image object doesn't consume too much memory.
+     * Whether to clear the original image cache after uploaded a texture to GPU. If cleared, [Dynamic Atlas](https://docs.cocos.com/creator/manual/en/advanced-topics/dynamic-atlas.html) will not be supported.
+     * Normally you don't need to enable this option on the web platform, because Image object doesn't consume too much memory.
      * But on WeChat Game platform, the current version cache decoded data in Image object, which has high memory usage.
      * So we enabled this option by default on WeChat, so that we can release Image cache immediately after uploaded to GPU.
      * !#zh
-     * 是否在将贴图上传至 GPU 之后删除 DOM Image 缓存。
-     * 具体来说，我们通过设置 image.src 为空字符串来释放这部分内存。
-     * 正常情况下，你不需要开启这个选项，因为在 web 平台，Image 对象所占用的内存很小。
+     * 是否在将贴图上传至 GPU 之后删除原始图片缓存，删除之后图片将无法进行 [动态合图](https://docs.cocos.com/creator/manual/zh/advanced-topics/dynamic-atlas.html)。
+     * 在 Web 平台，你通常不需要开启这个选项，因为在 Web 平台 Image 对象所占用的内存很小。
      * 但是在微信小游戏平台的当前版本，Image 对象会缓存解码后的图片数据，它所占用的内存空间很大。
      * 所以我们在微信平台默认开启了这个选项，这样我们就可以在上传 GL 贴图之后立即释放 Image 对象的内存，避免过高的内存占用。
      * @property {Boolean} CLEANUP_IMAGE_CACHE
@@ -365,10 +363,10 @@ cc.macro = {
     /**
      * !#en
      * Set cc.RotateTo/cc.RotateBy rotate direction.
-     * If need set rotate positive direction to counterclockwise, please change setting to : cc.macro.ROTATE_ACTION_CCW = true;
+     * If need set rotate positive direction to counterclockwise, please change setting to: `cc.macro.ROTATE_ACTION_CCW = true;`
      * !#zh
      * 设置 cc.RotateTo/cc.RotateBy 的旋转方向。
-     * 如果需要设置旋转的正方向为逆时针方向，请设置选项为： cc.macro.ROTATE_ACTION_CCW = true;
+     * 如果需要设置旋转的正方向为逆时针方向，请设置选项为：`cc.macro.ROTATE_ACTION_CCW = true;`
      * @property {Boolean} ROTATE_ACTION_CCW
      * @default false
      */
@@ -389,13 +387,13 @@ cc.macro = {
 let SUPPORT_TEXTURE_FORMATS = ['.pkm', '.pvr', '.webp', '.jpg', '.jpeg', '.bmp', '.png'];
 
 /**
- * !en
+ * !#en
  * The image format supported by the engine defaults, and the supported formats may differ in different build platforms and device types.
  * Currently all platform and device support ['.webp', '.jpg', '.jpeg', '.bmp', '.png'], The iOS mobile platform also supports the PVR format。
- * !zh
+ * !#zh
  * 引擎默认支持的图片格式，支持的格式可能在不同的构建平台和设备类型上有所差别。
  * 目前所有平台和设备支持的格式有 ['.webp', '.jpg', '.jpeg', '.bmp', '.png']. 另外 Ios 手机平台还额外支持了 PVR 格式。
- * @property {[String]} SUPPORT_TEXTURE_FORMATS
+ * @property {String[]} SUPPORT_TEXTURE_FORMATS
  */
 cc.macro.SUPPORT_TEXTURE_FORMATS = SUPPORT_TEXTURE_FORMATS;
 

--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -1004,16 +1004,16 @@ cc.js.mixin(View.prototype, {
 });
 
 /**
- * !en
+ * !#en
  * Emit when design resolution changed.
- * !zh
+ * !#zh
  * 当设计分辨率改变时发送。
  * @event design-resolution-changed
  */
  /**
- * !en
+ * !#en
  * Emit when canvas resize.
- * !zh
+ * !#zh
  * 当画布大小改变时发送。
  * @event canvas-resize
  */

--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -767,7 +767,7 @@ cc.js.mixin(View.prototype, {
         cc.visibleRect && cc.visibleRect.init(this._visibleRect);
 
         renderer.updateCameraViewport();
-        _cc.inputManager._updateCanvasBoundingRect();
+        cc.internal.inputManager._updateCanvasBoundingRect();
         this.emit('design-resolution-changed');
     },
 

--- a/cocos2d/core/platform/js.js
+++ b/cocos2d/core/platform/js.js
@@ -45,8 +45,8 @@ function _copyprop(name, source, target) {
 }
 
 /**
- * This module provides some JavaScript utilities.
- * All members can be accessed with "cc.js".
+ * !#en This module provides some JavaScript utilities. All members can be accessed with `cc.js`.
+ * !#zh 这个模块封装了 JavaScript 相关的一些实用函数，你可以通过 `cc.js` 来访问这个模块。
  * @submodule js
  * @module js
  */

--- a/cocos2d/core/renderer/utils/dynamic-atlas/manager.js
+++ b/cocos2d/core/renderer/utils/dynamic-atlas/manager.js
@@ -26,16 +26,16 @@ function beforeSceneLoad () {
 let _enabled = false;
 
 /**
- * !#en Manager the dynamic atlas.
- * !#zh 管理动态图集。
+ * !#en Manage Dynamic Atlas Manager. Dynamic Atlas Manager is used for merging textures at runtime, see [Dynamic Atlas](https://docs.cocos.com/creator/manual/en/advanced-topics/dynamic-atlas.html) for details.
+ * !#zh 管理动态图集。动态图集用于在运行时对贴图进行合并，详见 [动态合图](https://docs.cocos.com/creator/manual/zh/advanced-topics/dynamic-atlas.html)。
  * @class DynamicAtlasManager
  */
 let dynamicAtlasManager = {
     Atlas: Atlas,
     
     /**
-     * !#en Enabled or Disabled dynamic atlas.
-     * !#zh 开启或者关闭动态图集。
+     * !#en Enable or disable the dynamic atlas, see [Dynamic Atlas](https://docs.cocos.com/creator/manual/en/advanced-topics/dynamic-atlas.html) for details.
+     * !#zh 开启或者关闭动态图集，详见 [动态合图](https://docs.cocos.com/creator/manual/zh/advanced-topics/dynamic-atlas.html)。
      * @property enabled
      * @type {Boolean}
      */
@@ -220,7 +220,7 @@ let dynamicAtlasManager = {
                     let spriteFrame = new cc.SpriteFrame();
                     spriteFrame.setTexture(_atlases[i]._texture);
 
-                    let sprite = node.addComponent(cc.Sprite)
+                    let sprite = node.addComponent(cc.Sprite);
                     sprite.spriteFrame = spriteFrame;
 
                     node.parent = content;

--- a/cocos2d/core/utils/blend-func.js
+++ b/cocos2d/core/utils/blend-func.js
@@ -82,7 +82,7 @@ let BlendFunc = cc.Class({
         if (this._srcBlendFactor === BlendFactor.SRC_ALPHA && this._dstBlendFactor === BlendFactor.ONE_MINUS_SRC_ALPHA) {
             return;
         }
-        let materials = this._materials;
+        let materials = this.getMaterials();
         for (let i = 0; i < materials.length; i++) {
             let material = materials[i];
             this._updateMaterialBlendFunc(material);

--- a/cocos2d/core/value-types/color.ts
+++ b/cocos2d/core/value-types/color.ts
@@ -161,7 +161,7 @@ export default class Color extends ValueType {
      * Copy content of a color into another.
      * @method copy
      * @typescript
-     * static copy (out: Color, a: Color): Color
+     * copy (out: Color, a: Color): Color
      * @static
      */
     static copy (out: Color, a: Color): Color {
@@ -176,7 +176,7 @@ export default class Color extends ValueType {
      * Clone a new color.
      * @method clone
      * @typescript
-     * static clone (a: Color): Color
+     * clone (a: Color): Color
      * @static
      */
     static clone (a: Color): Color {
@@ -187,7 +187,7 @@ export default class Color extends ValueType {
      * Set the components of a color to the given values.
      * @method set
      * @typescript
-     * static set (out: Color, r = 255, g = 255, b = 255, a = 255): Color
+     * set (out: Color, r = 255, g = 255, b = 255, a = 255): Color
      * @static
      */
     static set (out: Color, r = 255, g = 255, b = 255, a = 255): Color {
@@ -202,7 +202,7 @@ export default class Color extends ValueType {
      * Converts the hexadecimal formal color into rgb formal.
      * @method fromHex
      * @typescript
-     * static fromHex (out: Color, hex: number): Color
+     * fromHex (out: Color, hex: number): Color
      * @static
      */
     static fromHex (out: Color, hex: number): Color {
@@ -222,7 +222,7 @@ export default class Color extends ValueType {
      * Add components of two colors, respectively.
      * @method add
      * @typescript
-     * static add (out: Color, a: Color, b: Color): Color
+     * add (out: Color, a: Color, b: Color): Color
      * @static
      */
     static add (out: Color, a: Color, b: Color): Color {
@@ -237,7 +237,7 @@ export default class Color extends ValueType {
      * Subtract components of color b from components of color a, respectively.
      * @method subtract
      * @typescript
-     * static subtract (out: Color, a: Color, b: Color): Color
+     * subtract (out: Color, a: Color, b: Color): Color
      * @static
      */
     static subtract (out: Color, a: Color, b: Color): Color {
@@ -252,7 +252,7 @@ export default class Color extends ValueType {
      * Multiply components of two colors, respectively.
      * @method multiply
      * @typescript
-     * static multiply (out: Color, a: Color, b: Color): Color
+     * multiply (out: Color, a: Color, b: Color): Color
      * @static
      */
     static multiply (out: Color, a: Color, b: Color): Color {
@@ -267,7 +267,7 @@ export default class Color extends ValueType {
      * Divide components of color a by components of color b, respectively.
      * @method divide
      * @typescript
-     * static divide (out: Color, a: Color, b: Color): Color
+     * divide (out: Color, a: Color, b: Color): Color
      * @static
      */
     static divide (out: Color, a: Color, b: Color): Color {
@@ -282,7 +282,7 @@ export default class Color extends ValueType {
      * Scales a color by a number.
      * @method scale
      * @typescript
-     * static scale (out: Color, a: Color, b: number): Color
+     * scale (out: Color, a: Color, b: number): Color
      * @static
      */
     static scale (out: Color, a: Color, b: number): Color {
@@ -297,7 +297,7 @@ export default class Color extends ValueType {
      * Performs a linear interpolation between two colors.
      * @method lerp
      * @typescript
-     * static lerp (out: Color, a: Color, b: Color, t: number): Color
+     * lerp (out: Color, a: Color, b: Color, t: number): Color
      * @static
      */
     static lerp (out: Color, a: Color, b: Color, t: number): Color {
@@ -317,7 +317,7 @@ export default class Color extends ValueType {
      * !#en Turn an array of colors
      * @method toArray
      * @typescript
-     * static toArray <Out extends IWritableArrayLike<number>> (out: Out, a: IColorLike, ofs = 0)
+     * toArray <Out extends IWritableArrayLike<number>> (out: Out, a: IColorLike, ofs = 0)
      * @param ofs 数组起始偏移量
      * @static
      */
@@ -335,7 +335,7 @@ export default class Color extends ValueType {
      * !#en An array of colors turn
      * @method fromArray
      * @typescript
-     * static fromArray <Out extends IColorLike> (arr: IWritableArrayLike<number>, out: Out, ofs = 0)
+     * fromArray <Out extends IColorLike> (arr: IWritableArrayLike<number>, out: Out, ofs = 0)
      * @param ofs 数组起始偏移量
      * @static
      */

--- a/cocos2d/core/value-types/mat3.ts
+++ b/cocos2d/core/value-types/mat3.ts
@@ -3,7 +3,7 @@ import Vec3 from './vec3';
 import Vec2 from './vec2';
 import Mat4 from './mat4';
 import Quat from './quat';
-import { IMat3Like } from './math';
+import { IMat3Like, IMat4Like, FloatArray } from './math';
 
 /**
  * Mathematical 3x3 matrix.
@@ -799,8 +799,9 @@ export default class Mat3 {
      * !#en Matrix transpose array
      * @method toArray
      * @typescript
-     * static toArray <Out extends IWritableArrayLike<number>> (out: Out, mat: IMat3Like, ofs = 0)
+     * toArray <Out extends IWritableArrayLike<number>> (out: Out, mat: IMat3Like, ofs = 0)
      * @param ofs 数组内的起始偏移量
+     * @static
      */
     static toArray <Out extends IWritableArrayLike<number>> (out: Out, mat: IMat3Like, ofs = 0) {
         let m = mat.m;
@@ -815,8 +816,9 @@ export default class Mat3 {
      * !#en Transfer matrix array
      * @method fromArray
      * @typescript
-     * static fromArray <Out extends IMat3Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
+     * fromArray <Out extends IMat3Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
      * @param ofs 数组起始偏移量
+     * @static
      */
     static fromArray <Out extends IMat3Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0) {
         let m = out.m;
@@ -835,15 +837,9 @@ export default class Mat3 {
 
 
     /**
-     * Creates a matrix, with elements specified separately.
-     *
      * @method constructor
      * @typescript
-     * constructor (
-            m00: number | Float32Array = 1, m01 = 0, m02 = 0,
-            m03 = 0, m04 = 1, m05 = 0,
-            m06 = 0, m07 = 0, m08 = 1
-        )
+     * constructor (m00: number | Float32Array = 1, m01 = 0, m02 = 0, m03 = 0, m04 = 1, m05 = 0, m06 = 0, m07 = 0, m08 = 1)
      */
     constructor (
         m00: number | FloatArray = 1, m01 = 0, m02 = 0,
@@ -859,7 +855,7 @@ export default class Mat3 {
              * The element at column 0 row 0.
              * @type {number}
              * */
-            m[0] = m00;
+            m[0] = m00 as number;
 
             /**
              * The element at column 0 row 1.

--- a/cocos2d/core/value-types/mat4.ts
+++ b/cocos2d/core/value-types/mat4.ts
@@ -29,7 +29,7 @@ import Vec3 from './vec3';
 import Quat from './quat';
 import { EPSILON, FLOAT_ARRAY_TYPE } from './utils';
 import Mat3 from './mat3';
-import { IMat4Like, IVec3Like } from './math';
+import { IMat4Like, IVec3Like, FloatArray } from './math';
 
 let _a00: number = 0; let _a01: number = 0; let _a02: number = 0; let _a03: number = 0;
 let _a10: number = 0; let _a11: number = 0; let _a12: number = 0; let _a13: number = 0;
@@ -46,12 +46,37 @@ let _a30: number = 0; let _a31: number = 0; let _a32: number = 0; let _a33: numb
 export default class Mat4 extends ValueType {
     static mul = Mat4.multiply;
     static sub = Mat4.subtract;
+
+    /**
+     * !#en Multiply the current matrix with another one
+     * !#zh 将当前矩阵与指定矩阵相乘
+     * @method mul
+     * @param {Mat4} other the second operand
+     * @param {Mat4} [out] the receiving matrix, you can pass the same matrix to save result to itself, if not provided, a new matrix will be created
+     * @returns {Mat4} out
+     */
     mul (m: Mat4, out: Mat4): Mat4 {
         return Mat4.multiply(out || new Mat4(), this, m);
     }
+    /**
+     * !#en Multiply each element of the matrix by a scalar.
+     * !#zh 将矩阵的每一个元素都乘以指定的缩放值。
+     * @method mulScalar
+     * @param {Number} number amount to scale the matrix's elements by
+     * @param {Mat4} [out] the receiving matrix, you can pass the same matrix to save result to itself, if not provided, a new matrix will be created
+     * @returns {Mat4} out
+     */
     mulScalar (num: number, out: Mat4) {
         Mat4.multiplyScalar(out || new Mat4(), this, num);
     }
+    /**
+     * !#en Subtracts the current matrix with another one
+     * !#zh 将当前矩阵与指定的矩阵相减
+     * @method sub
+     * @param {Mat4} other the second operand
+     * @param {Mat4} [out] the receiving matrix, you can pass the same matrix to save result to itself, if not provided, a new matrix will be created
+     * @returns {Mat4} out
+     */
     sub (m: Mat4, out: Mat4) {
         Mat4.subtract(out || new Mat4(), this, m);
     }
@@ -68,7 +93,7 @@ export default class Mat4 extends ValueType {
      * !#en Copy of the specified matrix to obtain
      * @method clone
      * @typescript
-     * static clone<Out extends IMat4Like> (a: Out)
+     * clone<Out extends IMat4Like> (a: Out)
      * @static
      */
     static clone<Out extends IMat4Like> (a: Out) {
@@ -86,7 +111,7 @@ export default class Mat4 extends ValueType {
      * !#en Copy the target matrix
      * @method copy
      * @typescript
-     * static copy<Out extends IMat4Like> (out: Out, a: Out)
+     * copy<Out extends IMat4Like> (out: Out, a: Out)
      * @static
      */
     static copy<Out extends IMat4Like> (out: Out, a: Out) {
@@ -135,7 +160,7 @@ export default class Mat4 extends ValueType {
      * !#en The target of an assignment is the identity matrix
      * @method identity
      * @typescript
-     * static identity<Out extends IMat4Like> (out: Out)
+     * identity<Out extends IMat4Like> (out: Out)
      * @static
      */
     static identity<Out extends IMat4Like> (out: Out) {
@@ -164,7 +189,7 @@ export default class Mat4 extends ValueType {
      * !#en Transposed matrix
      * @method transpose
      * @typescript
-     * static transpose<Out extends IMat4Like> (out: Out, a: Out)
+     * transpose<Out extends IMat4Like> (out: Out, a: Out)
      * @static
      */
     static transpose<Out extends IMat4Like> (out: Out, a: Out) {
@@ -210,7 +235,7 @@ export default class Mat4 extends ValueType {
      * !#en Matrix inversion
      * @method invert
      * @typescript
-     * static invert<Out extends IMat4Like> (out: Out, a: Out)
+     * invert<Out extends IMat4Like> (out: Out, a: Out)
      * @static
      */
     static invert<Out extends IMat4Like> (out: Out, a: Out) {
@@ -265,7 +290,7 @@ export default class Mat4 extends ValueType {
      * !#en Matrix determinant
      * @method determinant
      * @typescript
-     * static determinant<Out extends IMat4Like> (a: Out): number
+     * determinant<Out extends IMat4Like> (a: Out): number
      * @static
      */
     static determinant<Out extends IMat4Like> (a: Out): number {
@@ -297,7 +322,7 @@ export default class Mat4 extends ValueType {
      * !#en Matrix Multiplication
      * @method multiply
      * @typescript
-     * static multiply<Out extends IMat4Like> (out: Out, a: Out, b: Out)
+     * multiply<Out extends IMat4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static multiply<Out extends IMat4Like> (out: Out, a: Out, b: Out) {
@@ -339,7 +364,7 @@ export default class Mat4 extends ValueType {
      * !#en Was added in a given transformation matrix transformation on the basis of
      * @method transform
      * @typescript
-     * static transform<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike)
+     * transform<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike)
      * @static
      */
     static transform<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike) {
@@ -373,7 +398,7 @@ export default class Mat4 extends ValueType {
      * !#en Add new displacement transducer in a matrix transformation on the basis of a given
      * @method translate
      * @typescript
-     * static translate<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike)
+     * translate<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike)
      * @static
      */
     static translate<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike) {
@@ -399,7 +424,7 @@ export default class Mat4 extends ValueType {
      * !#en Add new scaling transformation in a given matrix transformation on the basis of
      * @method scale
      * @typescript
-     * static scale<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike)
+     * scale<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike)
      * @static
      */
     static scale<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, v: VecLike) {
@@ -429,7 +454,7 @@ export default class Mat4 extends ValueType {
      * !#en Add a new rotational transform matrix transformation on the basis of a given
      * @method rotate
      * @typescript
-     * static rotate<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, rad: number, axis: VecLike)
+     * rotate<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, a: Out, rad: number, axis: VecLike)
      * @param rad 旋转角度
      * @param axis 旋转轴
      * @static
@@ -493,7 +518,7 @@ export default class Mat4 extends ValueType {
      * !#en Add rotational transformation around the X axis at a given matrix transformation on the basis of
      * @method rotateX
      * @typescript
-     * static rotateX<Out extends IMat4Like> (out: Out, a: Out, rad: number)
+     * rotateX<Out extends IMat4Like> (out: Out, a: Out, rad: number)
      * @param rad 旋转角度
      * @static
      */
@@ -539,7 +564,7 @@ export default class Mat4 extends ValueType {
      * !#en Add about the Y axis rotation transformation in a given matrix transformation on the basis of
      * @method rotateY
      * @typescript
-     * static rotateY<Out extends IMat4Like> (out: Out, a: Out, rad: number)
+     * rotateY<Out extends IMat4Like> (out: Out, a: Out, rad: number)
      * @param rad 旋转角度
      * @static
      */
@@ -585,7 +610,7 @@ export default class Mat4 extends ValueType {
      * !#en Added about the Z axis at a given rotational transformation matrix transformation on the basis of
      * @method rotateZ
      * @typescript
-     * static rotateZ<Out extends IMat4Like> (out: Out, a: Out, rad: number)
+     * rotateZ<Out extends IMat4Like> (out: Out, a: Out, rad: number)
      * @param rad 旋转角度
      * @static
      */
@@ -633,7 +658,7 @@ export default class Mat4 extends ValueType {
      * !#en Displacement matrix calculation
      * @method fromTranslation
      * @typescript
-     * static fromTranslation<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, v: VecLike)
+     * fromTranslation<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, v: VecLike)
      * @static
      */
     static fromTranslation<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, v: VecLike) {
@@ -662,7 +687,7 @@ export default class Mat4 extends ValueType {
      * !#en Scaling matrix calculation
      * @method fromScaling
      * @typescript
-     * static fromScaling<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, v: VecLike)
+     * fromScaling<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, v: VecLike)
      * @static
      */
     static fromScaling<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, v: VecLike) {
@@ -691,7 +716,7 @@ export default class Mat4 extends ValueType {
      * !#en Calculates the rotation matrix
      * @method fromRotation
      * @typescript
-     * static fromRotation<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, rad: number, axis: VecLike)
+     * fromRotation<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, rad: number, axis: VecLike)
      * @static
      */
     static fromRotation<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, rad: number, axis: VecLike) {
@@ -737,7 +762,7 @@ export default class Mat4 extends ValueType {
      * !#en Calculating rotation matrix about the X axis
      * @method fromXRotation
      * @typescript
-     * static fromXRotation<Out extends IMat4Like> (out: Out, rad: number)
+     * fromXRotation<Out extends IMat4Like> (out: Out, rad: number)
      * @static
      */
     static fromXRotation<Out extends IMat4Like> (out: Out, rad: number) {
@@ -769,7 +794,7 @@ export default class Mat4 extends ValueType {
      * !#en Calculating rotation matrix about the Y axis
      * @method fromYRotation
      * @typescript
-     * static fromYRotation<Out extends IMat4Like> (out: Out, rad: number)
+     * fromYRotation<Out extends IMat4Like> (out: Out, rad: number)
      * @static
      */
     static fromYRotation<Out extends IMat4Like> (out: Out, rad: number) {
@@ -801,7 +826,7 @@ export default class Mat4 extends ValueType {
      * !#en Calculating rotation matrix about the Z axis
      * @method fromZRotation
      * @typescript
-     * static fromZRotation<Out extends IMat4Like> (out: Out, rad: number)
+     * fromZRotation<Out extends IMat4Like> (out: Out, rad: number)
      * @static
      */
     static fromZRotation<Out extends IMat4Like> (out: Out, rad: number) {
@@ -833,7 +858,7 @@ export default class Mat4 extends ValueType {
      * !#en The rotation and displacement information calculating matrix
      * @method fromRT
      * @typescript
-     * static fromRT<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike)
+     * fromRT<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike)
      * @static
      */
     static fromRT<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike) {
@@ -878,7 +903,7 @@ export default class Mat4 extends ValueType {
      * !#en Extracting displacement information of the matrix, the matrix transform to the default sequential application S-> R-> T is
      * @method getTranslation
      * @typescript
-     * static getTranslation<Out extends IMat4Like, VecLike extends IVec3Like> (out: VecLike, mat: Out)
+     * getTranslation<Out extends IMat4Like, VecLike extends IVec3Like> (out: VecLike, mat: Out)
      * @static
      */
     static getTranslation<Out extends IMat4Like, VecLike extends IVec3Like> (out: VecLike, mat: Out) {
@@ -895,7 +920,7 @@ export default class Mat4 extends ValueType {
      * !#en Scaling information extraction matrix, the matrix transform to the default sequential application S-> R-> T is
      * @method getScaling
      * @typescript
-     * static getScaling<Out extends IMat4Like, VecLike extends IVec3Like> (out: VecLike, mat: Out)
+     * getScaling<Out extends IMat4Like, VecLike extends IVec3Like> (out: VecLike, mat: Out)
      * @static
      */
     static getScaling<Out extends IMat4Like, VecLike extends IVec3Like> (out: VecLike, mat: Out) {
@@ -923,7 +948,7 @@ export default class Mat4 extends ValueType {
      * !#en Rotation information extraction matrix, the matrix containing no default input scaling information, such as the use of `toRTS` should consider the scaling function.
      * @method getRotation
      * @typescript
-     * static getRotation<Out extends IMat4Like> (out: Quat, mat: Out)
+     * getRotation<Out extends IMat4Like> (out: Quat, mat: Out)
      * @static
      */
     static getRotation<Out extends IMat4Like> (out: Quat, mat: Out) {
@@ -965,7 +990,7 @@ export default class Mat4 extends ValueType {
      * !#en Extracting rotational displacement, zoom information, the default matrix transformation in order S-> R-> T applications
      * @method toRTS
      * @typescript
-     * static toRTS<Out extends IMat4Like, VecLike extends IVec3Like> (mat: Out, q: Quat, v: VecLike, s: VecLike)
+     * toRTS<Out extends IMat4Like, VecLike extends IVec3Like> (mat: Out, q: Quat, v: VecLike, s: VecLike)
      * @static
      */
     static toRTS<Out extends IMat4Like, VecLike extends IVec3Like> (mat: Out, q: Quat, v: VecLike, s: VecLike) {
@@ -994,7 +1019,7 @@ export default class Mat4 extends ValueType {
      * !#en The rotary displacement, the scaling matrix calculation information, the order S-> R-> T applications
      * @method fromRTS
      * @typescript
-     * static fromRTS<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike, s: VecLike)
+     * fromRTS<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike, s: VecLike)
      * @static
      */
     static fromRTS<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike, s: VecLike) {
@@ -1042,7 +1067,7 @@ export default class Mat4 extends ValueType {
      * !#en According to the specified rotation, displacement, and scale conversion matrix calculation information center, order S-> R-> T applications
      * @method fromRTSOrigin
      * @typescript
-     * static fromRTSOrigin<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike, s: VecLike, o: VecLike)
+     * fromRTSOrigin<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike, s: VecLike, o: VecLike)
      * @param q 旋转值
      * @param v 位移值
      * @param s 缩放值
@@ -1099,7 +1124,7 @@ export default class Mat4 extends ValueType {
      * !#en The rotation matrix calculation information specified
      * @method fromQuat
      * @typescript
-     * static fromQuat<Out extends IMat4Like> (out: Out, q: Quat)
+     * fromQuat<Out extends IMat4Like> (out: Out, q: Quat)
      * @static
      */
     static fromQuat<Out extends IMat4Like> (out: Out, q: Quat) {
@@ -1147,7 +1172,7 @@ export default class Mat4 extends ValueType {
      * !#en The matrix calculation information specified frustum
      * @method frustum
      * @typescript
-     * static frustum<Out extends IMat4Like> (out: Out, left: number, right: number, bottom: number, top: number, near: number, far: number)
+     * frustum<Out extends IMat4Like> (out: Out, left: number, right: number, bottom: number, top: number, near: number, far: number)
      * @param left 左平面距离
      * @param right 右平面距离
      * @param bottom 下平面距离
@@ -1186,7 +1211,7 @@ export default class Mat4 extends ValueType {
      * !#en Perspective projection matrix calculation
      * @method perspective
      * @typescript
-     * static perspective<Out extends IMat4Like> (out: Out, fovy: number, aspect: number, near: number, far: number)
+     * perspective<Out extends IMat4Like> (out: Out, fovy: number, aspect: number, near: number, far: number)
      * @param fovy 纵向视角高度
      * @param aspect 长宽比
      * @param near 近平面距离
@@ -1222,7 +1247,7 @@ export default class Mat4 extends ValueType {
      * !#en Computing orthogonal projection matrix
      * @method ortho
      * @typescript
-     * static ortho<Out extends IMat4Like> (out: Out, left: number, right: number, bottom: number, top: number, near: number, far: number)
+     * ortho<Out extends IMat4Like> (out: Out, left: number, right: number, bottom: number, top: number, near: number, far: number)
      * @param left 左平面距离
      * @param right 右平面距离
      * @param bottom 下平面距离
@@ -1260,7 +1285,7 @@ export default class Mat4 extends ValueType {
      * !#en `Up` parallel vector or vector center` not be zero - the matrix calculation according to the viewpoint, note` eye
      * @method lookAt
      * @typescript
-     * static lookAt<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, eye: VecLike, center: VecLike, up: VecLike)
+     * lookAt<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, eye: VecLike, center: VecLike, up: VecLike)
      * @param eye 当前位置
      * @param center 目标视点
      * @param up 视口上方向
@@ -1324,7 +1349,7 @@ export default class Mat4 extends ValueType {
      * !#en Reversal matrix calculation
      * @method inverseTranspose
      * @typescript
-     * static inverseTranspose<Out extends IMat4Like> (out: Out, a: Out)
+     * inverseTranspose<Out extends IMat4Like> (out: Out, a: Out)
      * @static
      */
     static inverseTranspose<Out extends IMat4Like> (out: Out, a: Out) {
@@ -1385,7 +1410,7 @@ export default class Mat4 extends ValueType {
      * !#en Element by element matrix addition
      * @method add
      * @typescript
-     * static add<Out extends IMat4Like> (out: Out, a: Out, b: Out)
+     * add<Out extends IMat4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static add<Out extends IMat4Like> (out: Out, a: Out, b: Out) {
@@ -1414,7 +1439,7 @@ export default class Mat4 extends ValueType {
      * !#en Matrix element by element subtraction
      * @method subtract
      * @typescript
-     * static subtract<Out extends IMat4Like> (out: Out, a: Out, b: Out)
+     * subtract<Out extends IMat4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static subtract<Out extends IMat4Like> (out: Out, a: Out, b: Out) {
@@ -1443,7 +1468,7 @@ export default class Mat4 extends ValueType {
      * !#en Matrix scalar multiplication
      * @method multiplyScalar
      * @typescript
-     * static multiplyScalar<Out extends IMat4Like> (out: Out, a: Out, b: number)
+     * multiplyScalar<Out extends IMat4Like> (out: Out, a: Out, b: number)
      * @static
      */
     static multiplyScalar<Out extends IMat4Like> (out: Out, a: Out, b: number) {
@@ -1472,7 +1497,7 @@ export default class Mat4 extends ValueType {
      * !#en Elements of the matrix by the scalar multiplication and addition: A + B * scale
      * @method multiplyScalarAndAdd
      * @typescript
-     * static multiplyScalarAndAdd<Out extends IMat4Like> (out: Out, a: Out, b: Out, scale: number)
+     * multiplyScalarAndAdd<Out extends IMat4Like> (out: Out, a: Out, b: Out, scale: number)
      * @static
      */
     static multiplyScalarAndAdd<Out extends IMat4Like> (out: Out, a: Out, b: Out, scale: number) {
@@ -1501,7 +1526,7 @@ export default class Mat4 extends ValueType {
      * !#en Analyzing the equivalent matrix
      * @method strictEquals
      * @typescript
-     * static strictEquals<Out extends IMat4Like> (a: Out, b: Out)
+     * strictEquals<Out extends IMat4Like> (a: Out, b: Out)
      * @static
      */
     static strictEquals<Out extends IMat4Like> (a: Out, b: Out) {
@@ -1517,7 +1542,7 @@ export default class Mat4 extends ValueType {
      * !#en Negative floating point error is approximately equivalent to determining a matrix
      * @method equals
      * @typescript
-     * static equals<Out extends IMat4Like> (a: Out, b: Out, epsilon = EPSILON)
+     * equals<Out extends IMat4Like> (a: Out, b: Out, epsilon = EPSILON)
      * @static
      */
     static equals<Out extends IMat4Like> (a: Out, b: Out, epsilon = EPSILON) {
@@ -1581,7 +1606,7 @@ export default class Mat4 extends ValueType {
      * !#en Matrix transpose array
      * @method toArray
      * @typescript
-     * static toArray <Out extends IWritableArrayLike<number>> (out: Out, mat: IMat4Like, ofs = 0)
+     * toArray <Out extends IWritableArrayLike<number>> (out: Out, mat: IMat4Like, ofs = 0)
      * @param ofs 数组内的起始偏移量
      * @static
      */
@@ -1598,7 +1623,7 @@ export default class Mat4 extends ValueType {
      * !#en Transfer matrix array
      * @method fromArray
      * @typescript
-     * static fromArray <Out extends IMat4Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
+     * fromArray <Out extends IMat4Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
      * @param ofs 数组起始偏移量
      * @static
      */
@@ -1626,12 +1651,7 @@ export default class Mat4 extends ValueType {
      * 构造函数，可查看 {{#crossLink "cc/mat4:method"}}cc.mat4{{/crossLink}}
      * @method constructor
      * @typescript
-     * constructor (
-            m00: number = 1, m01: number = 0, m02: number = 0, m03: number = 0,
-            m10: number = 0, m11: number = 1, m12: number = 0, m13: number = 0,
-            m20: number = 0, m21: number = 0, m22: number = 1, m23: number = 0,
-            m30: number = 0, m31: number = 0, m32: number = 0, m33: number = 1
-        )
+     * constructor ( m00: number = 1, m01: number = 0, m02: number = 0, m03: number = 0, m10: number = 0, m11: number = 1, m12: number = 0, m13: number = 0, m20: number = 0, m21: number = 0, m22: number = 1, m23: number = 0, m30: number = 0, m31: number = 0, m32: number = 0, m33: number = 1)
      */
     constructor (
         m00: number | FloatArray = 1, m01: number = 0, m02: number = 0, m03: number = 0,
@@ -1644,7 +1664,7 @@ export default class Mat4 extends ValueType {
         } else {
             this.m = new FLOAT_ARRAY_TYPE(16);
             let tm = this.m;
-            tm[0] = m00;
+            tm[0] = m00 as number;
             tm[1] = m01;
             tm[2] = m02;
             tm[3] = m03;

--- a/cocos2d/core/value-types/math.ts
+++ b/cocos2d/core/value-types/math.ts
@@ -1,5 +1,6 @@
 
-type FloatArray = Float64Array | Float32Array;
+export type FloatArray = Float64Array | Float32Array;
+
 export interface IColorLike {
     r: number;
     g: number;

--- a/cocos2d/core/value-types/quat.ts
+++ b/cocos2d/core/value-types/quat.ts
@@ -60,6 +60,14 @@ export default class Quat extends ValueType {
     static scale = Quat.multiplyScalar;
     static mag = Quat.len;
 
+    /**
+     * !#en Calculate the multiply result between this quaternion and another one
+     * !#zh 计算四元数乘积的结果
+     * @method mul
+     * @param {Quat} other
+     * @param {Quat} [out]
+     * @returns {Quat} out
+     */
     mul (other: Quat, out?: Quat): Quat {
         return Quat.multiply(out || new Quat(), this, other);
     }
@@ -71,7 +79,7 @@ export default class Quat extends ValueType {
      * !#en Obtaining copy specified quaternion
      * @method clone
      * @typescript
-     * static clone<Out extends IQuatLike> (a: Out)
+     * clone<Out extends IQuatLike> (a: Out)
      * @static
      */
     static clone<Out extends IQuatLike> (a: Out) {
@@ -83,7 +91,7 @@ export default class Quat extends ValueType {
      * !#en Copy quaternion target
      * @method copy
      * @typescript
-     * static copy<Out extends IQuatLike, QuatLike extends IQuatLike> (out: Out, a: QuatLike)
+     * copy<Out extends IQuatLike, QuatLike extends IQuatLike> (out: Out, a: QuatLike)
      * @static
      */
     static copy<Out extends IQuatLike, QuatLike extends IQuatLike> (out: Out, a: QuatLike) {
@@ -99,7 +107,7 @@ export default class Quat extends ValueType {
      * !#en Provided Quaternion Value
      * @method set
      * @typescript
-     * static set<Out extends IQuatLike> (out: Out, x: number, y: number, z: number, w: number)
+     * set<Out extends IQuatLike> (out: Out, x: number, y: number, z: number, w: number)
      * @static
      */
     static set<Out extends IQuatLike> (out: Out, x: number, y: number, z: number, w: number) {
@@ -115,7 +123,7 @@ export default class Quat extends ValueType {
      * !#en The target of an assignment as a unit quaternion
      * @method identity
      * @typescript
-     * static identity<Out extends IQuatLike> (out: Out)
+     * identity<Out extends IQuatLike> (out: Out)
      * @static
      */
     static identity<Out extends IQuatLike> (out: Out) {
@@ -131,7 +139,7 @@ export default class Quat extends ValueType {
      * !#en Set quaternion rotation is the shortest path between two vectors, the default two vectors are normalized
      * @method rotationTo
      * @typescript
-     * static rotationTo<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, a: VecLike, b: VecLike)
+     * rotationTo<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, a: VecLike, b: VecLike)
      * @static
      */
     static rotationTo<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, a: VecLike, b: VecLike) {
@@ -165,7 +173,7 @@ export default class Quat extends ValueType {
      * !#en Get the rotary shaft and the arc of rotation quaternion
      * @method getAxisAngle
      * @typescript
-     * static getAxisAngle<Out extends IQuatLike, VecLike extends IVec3Like> (outAxis: VecLike, q: Out)
+     * getAxisAngle<Out extends IQuatLike, VecLike extends IVec3Like> (outAxis: VecLike, q: Out)
      * @param outAxis 旋转轴输出
      * @param q 源四元数
      * @return 旋转弧度
@@ -192,7 +200,7 @@ export default class Quat extends ValueType {
      * !#en Quaternion multiplication
      * @method multiply
      * @typescript
-     * static multiply<Out extends IQuatLike, QuatLike_1 extends IQuatLike, QuatLike_2 extends IQuatLike> (out: Out, a: QuatLike_1, b: QuatLike_2)
+     * multiply<Out extends IQuatLike, QuatLike_1 extends IQuatLike, QuatLike_2 extends IQuatLike> (out: Out, a: QuatLike_1, b: QuatLike_2)
      * @static
      */
     static multiply<Out extends IQuatLike, QuatLike_1 extends IQuatLike, QuatLike_2 extends IQuatLike> (out: Out, a: QuatLike_1, b: QuatLike_2) {
@@ -212,7 +220,7 @@ export default class Quat extends ValueType {
      * !#en Quaternion scalar multiplication
      * @method multiplyScalar
      * @typescript
-     * static multiplyScalar<Out extends IQuatLike> (out: Out, a: Out, b: number)
+     * multiplyScalar<Out extends IQuatLike> (out: Out, a: Out, b: number)
      * @static
      */
     static multiplyScalar<Out extends IQuatLike> (out: Out, a: Out, b: number) {
@@ -228,7 +236,7 @@ export default class Quat extends ValueType {
      * !#en Quaternion multiplication and addition: A + B * scale
      * @method scaleAndAdd
      * @typescript
-     * static scaleAndAdd<Out extends IQuatLike> (out: Out, a: Out, b: Out, scale: number)
+     * scaleAndAdd<Out extends IQuatLike> (out: Out, a: Out, b: Out, scale: number)
      * @static
      */
     static scaleAndAdd<Out extends IQuatLike> (out: Out, a: Out, b: Out, scale: number) {
@@ -244,7 +252,7 @@ export default class Quat extends ValueType {
      * !#en About the X axis specified quaternion
      * @method rotateX
      * @typescript
-     * static rotateX<Out extends IQuatLike> (out: Out, a: Out, rad: number)
+     * rotateX<Out extends IQuatLike> (out: Out, a: Out, rad: number)
      * @param rad 旋转弧度
      * @static
      */
@@ -266,7 +274,7 @@ export default class Quat extends ValueType {
      * !#en Rotation about the Y axis designated quaternion
      * @method rotateY
      * @typescript
-     * static rotateY<Out extends IQuatLike> (out: Out, a: Out, rad: number)
+     * rotateY<Out extends IQuatLike> (out: Out, a: Out, rad: number)
      * @param rad 旋转弧度
      * @static
      */
@@ -288,7 +296,7 @@ export default class Quat extends ValueType {
      * !#en Around the Z axis specified quaternion
      * @method rotateZ
      * @typescript
-     * static rotateZ<Out extends IQuatLike> (out: Out, a: Out, rad: number)
+     * rotateZ<Out extends IQuatLike> (out: Out, a: Out, rad: number)
      * @param rad 旋转弧度
      * @static
      */
@@ -310,7 +318,7 @@ export default class Quat extends ValueType {
      * !#en Space around the world at a given axis of rotation quaternion
      * @method rotateAround
      * @typescript
-     * static rotateAround<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, rot: Out, axis: VecLike, rad: number)
+     * rotateAround<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, rot: Out, axis: VecLike, rad: number)
      * @param axis 旋转轴，默认已归一化
      * @param rad 旋转弧度
      * @static
@@ -330,7 +338,7 @@ export default class Quat extends ValueType {
      * !#en Local space around the specified axis rotation quaternion
      * @method rotateAroundLocal
      * @typescript
-     * static rotateAroundLocal<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, rot: Out, axis: VecLike, rad: number)
+     * rotateAroundLocal<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, rot: Out, axis: VecLike, rad: number)
      * @param axis 旋转轴
      * @param rad 旋转弧度
      * @static
@@ -346,7 +354,7 @@ export default class Quat extends ValueType {
      * !#en The component w xyz components calculated, normalized by default
      * @method calculateW
      * @typescript
-     * static calculateW<Out extends IQuatLike> (out: Out, a: Out)
+     * calculateW<Out extends IQuatLike> (out: Out, a: Out)
      * @static
      */
     static calculateW<Out extends IQuatLike> (out: Out, a: Out) {
@@ -363,7 +371,7 @@ export default class Quat extends ValueType {
      * !#en Quaternion dot product (scalar product)
      * @method dot
      * @typescript
-     * static dot<Out extends IQuatLike> (a: Out, b: Out)
+     * dot<Out extends IQuatLike> (a: Out, b: Out)
      * @static
      */
     static dot<Out extends IQuatLike> (a: Out, b: Out) {
@@ -375,7 +383,7 @@ export default class Quat extends ValueType {
      * !#en Element by element linear interpolation: A + t * (B - A)
      * @method lerp
      * @typescript
-     * static lerp<Out extends IQuatLike> (out: Out, a: Out, b: Out, t: number)
+     * lerp<Out extends IQuatLike> (out: Out, a: Out, b: Out, t: number)
      * @static
      */
     static lerp<Out extends IQuatLike> (out: Out, a: Out, b: Out, t: number) {
@@ -436,7 +444,7 @@ export default class Quat extends ValueType {
      * !#en Quaternion with two spherical interpolation control points
      * @method sqlerp
      * @typescript
-     * static sqlerp<Out extends IQuatLike> (out: Out, a: Out, b: Out, c: Out, d: Out, t: number)
+     * sqlerp<Out extends IQuatLike> (out: Out, a: Out, b: Out, c: Out, d: Out, t: number)
      * @static
      */
     static sqlerp<Out extends IQuatLike> (out: Out, a: Out, b: Out, c: Out, d: Out, t: number) {
@@ -451,7 +459,7 @@ export default class Quat extends ValueType {
      * !#en Quaternion inverse
      * @method invert
      * @typescript
-     * static invert<Out extends IQuatLike, QuatLike extends IQuatLike> (out: Out, a: QuatLike)
+     * invert<Out extends IQuatLike, QuatLike extends IQuatLike> (out: Out, a: QuatLike)
      * @static
      */
     static invert<Out extends IQuatLike, QuatLike extends IQuatLike> (out: Out, a: QuatLike) {
@@ -472,7 +480,7 @@ export default class Quat extends ValueType {
      * !#en Conjugating a quaternion, and the unit quaternion equivalent to inversion, but more efficient
      * @method conjugate
      * @typescript
-     * static conjugate<Out extends IQuatLike> (out: Out, a: Out)
+     * conjugate<Out extends IQuatLike> (out: Out, a: Out)
      * @static
      */
     static conjugate<Out extends IQuatLike> (out: Out, a: Out) {
@@ -488,7 +496,7 @@ export default class Quat extends ValueType {
      * !#en Seek length quaternion
      * @method len
      * @typescript
-     * static len<Out extends IQuatLike> (a: Out)
+     * len<Out extends IQuatLike> (a: Out)
      * @static
      */
     static len<Out extends IQuatLike> (a: Out) {
@@ -500,7 +508,7 @@ export default class Quat extends ValueType {
      * !#en Seeking quaternion square of the length
      * @method lengthSqr
      * @typescript
-     * static lengthSqr<Out extends IQuatLike> (a: Out)
+     * lengthSqr<Out extends IQuatLike> (a: Out)
      * @static
      */
     static lengthSqr<Out extends IQuatLike> (a: Out) {
@@ -512,7 +520,7 @@ export default class Quat extends ValueType {
      * !#en Normalized quaternions
      * @method normalize
      * @typescript
-     * static normalize<Out extends IQuatLike> (out: Out, a: Out)
+     * normalize<Out extends IQuatLike> (out: Out, a: Out)
      * @static
      */
     static normalize<Out extends IQuatLike> (out: Out, a: Out) {
@@ -532,7 +540,7 @@ export default class Quat extends ValueType {
      * !#en Calculated according to the local orientation quaternion coordinate axis, the default three vectors are normalized and mutually perpendicular
      * @method fromAxes
      * @typescript
-     * static fromAxes<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, xAxis: VecLike, yAxis: VecLike, zAxis: VecLike)
+     * fromAxes<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, xAxis: VecLike, yAxis: VecLike, zAxis: VecLike)
      * @static
      */
     static fromAxes<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, xAxis: VecLike, yAxis: VecLike, zAxis: VecLike) {
@@ -549,7 +557,7 @@ export default class Quat extends ValueType {
      * !#en The forward direction and the direction of the viewport computing quaternion
      * @method fromViewUp
      * @typescript
-     * static fromViewUp<Out extends IQuatLike> (out: Out, view: Vec3, up?: Vec3)
+     * fromViewUp<Out extends IQuatLike> (out: Out, view: Vec3, up?: Vec3)
      * @param view 视口面向的前方向，必须归一化
      * @param up 视口的上方向，必须归一化，默认为 (0, 1, 0)
      * @static
@@ -564,7 +572,7 @@ export default class Quat extends ValueType {
      * !#en The quaternion calculated and the arc of rotation of the rotary shaft
      * @method fromAxisAngle
      * @typescript
-     * static fromAxisAngle<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, axis: VecLike, rad: number)
+     * fromAxisAngle<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, axis: VecLike, rad: number)
      * @static
      */
     static fromAxisAngle<Out extends IQuatLike, VecLike extends IVec3Like> (out: Out, axis: VecLike, rad: number) {
@@ -597,7 +605,7 @@ export default class Quat extends ValueType {
      * !#en Calculating the three-dimensional quaternion matrix information, default zoom information input matrix does not contain
      * @method fromMat3
      * @typescript
-     * static fromMat3<Out extends IQuatLike> (out: Out, mat: Mat3)
+     * fromMat3<Out extends IQuatLike> (out: Out, mat: Mat3)
      * @static
      */
     static fromMat3<Out extends IQuatLike> (out: Out, mat: Mat3) {
@@ -649,7 +657,7 @@ export default class Quat extends ValueType {
      * !#en The quaternion calculated Euler angle information, rotation order YZX
      * @method fromEuler
      * @typescript
-     * static fromEuler<Out extends IQuatLike> (out: Out, x: number, y: number, z: number)
+     * fromEuler<Out extends IQuatLike> (out: Out, x: number, y: number, z: number)
      * @static
      */
     static fromEuler<Out extends IQuatLike> (out: Out, x: number, y: number, z: number) {
@@ -677,7 +685,7 @@ export default class Quat extends ValueType {
      * !#en This returns the result of the quaternion coordinate system X-axis vector
      * @method toAxisX
      * @typescript
-     * static toAxisX<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out)
+     * toAxisX<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out)
      * @static
      */
     static toAxisX<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out) {
@@ -695,7 +703,7 @@ export default class Quat extends ValueType {
      * !#en This returns the result of the quaternion coordinate system Y axis vector
      * @method toAxisY
      * @typescript
-     * static toAxisY<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out)
+     * toAxisY<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out)
      * @static
      */
     static toAxisY<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out) {
@@ -714,7 +722,7 @@ export default class Quat extends ValueType {
      * !#en This returns the result of the quaternion coordinate system the Z-axis vector
      * @method toAxisZ
      * @typescript
-     * static toAxisZ<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out)
+     * toAxisZ<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out)
      * @static
      */
     static toAxisZ<Out extends IQuatLike, VecLike extends IVec3Like> (out: VecLike, q: Out) {
@@ -733,7 +741,7 @@ export default class Quat extends ValueType {
      * !#en The quaternion calculated Euler angles, return angle x, y in the [-180, 180] interval, z default the range [-90, 90] interval, the rotation order YZX
      * @method toEuler
      * @typescript
-     * static toEuler<Out extends IVec3Like> (out: Out, q: IQuatLike, outerZ?: boolean)
+     * toEuler<Out extends IVec3Like> (out: Out, q: IQuatLike, outerZ?: boolean)
      * @param outerZ z 取值范围区间改为 [-180, -90] U [90, 180]
      * @static
      */
@@ -773,7 +781,7 @@ export default class Quat extends ValueType {
      * !#en Analyzing quaternion equivalent
      * @method strictEquals
      * @typescript
-     * static strictEquals<Out extends IQuatLike> (a: Out, b: Out)
+     * strictEquals<Out extends IQuatLike> (a: Out, b: Out)
      * @static
      */
     static strictEquals<Out extends IQuatLike> (a: Out, b: Out) {
@@ -785,7 +793,7 @@ export default class Quat extends ValueType {
      * !#en Negative floating point error quaternion approximately equivalent Analyzing
      * @method equals
      * @typescript
-     * static equals<Out extends IQuatLike> (a: Out, b: Out, epsilon = EPSILON)
+     * equals<Out extends IQuatLike> (a: Out, b: Out, epsilon = EPSILON)
      * @static
      */
     static equals<Out extends IQuatLike> (a: Out, b: Out, epsilon = EPSILON) {
@@ -801,7 +809,7 @@ export default class Quat extends ValueType {
      * !#en Quaternion rotation array
      * @method toArray
      * @typescript
-     * static toArray <Out extends IWritableArrayLike<number>> (out: Out, q: IQuatLike, ofs = 0)
+     * toArray <Out extends IWritableArrayLike<number>> (out: Out, q: IQuatLike, ofs = 0)
      * @param ofs 数组内的起始偏移量
      * @static
      */
@@ -818,7 +826,7 @@ export default class Quat extends ValueType {
      * !#en Array to a quaternion
      * @method fromArray
      * @typescript
-     * static fromArray <Out extends IQuatLike> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
+     * fromArray <Out extends IQuatLike> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
      * @param ofs 数组起始偏移量
      * @static
      */

--- a/cocos2d/core/value-types/vec2.ts
+++ b/cocos2d/core/value-types/vec2.ts
@@ -50,25 +50,160 @@ export default class Vec2 extends ValueType {
     static mag   = Vec2.len;
     static squaredMagnitude = Vec2.lengthSqr;
     static div = Vec2.divide;
+    /**
+     * !#en Returns the length of this vector.
+     * !#zh 返回该向量的长度。
+     * @method mag
+     * @return {number} the result
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.mag(); // return 14.142135623730951;
+     */
     mag  = Vec2.prototype.len;
+    /**
+     * !#en Returns the squared length of this vector.
+     * !#zh 返回该向量的长度平方。
+     * @method magSqr
+     * @return {number} the result
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.magSqr(); // return 200;
+     */
     magSqr = Vec2.prototype.lengthSqr;
+    /**
+     * !#en Subtracts one vector from this. If you want to save result to another vector, use sub() instead.
+     * !#zh 向量减法。如果你想保存结果到另一个向量，可使用 sub() 代替。
+     * @method subSelf
+     * @param {Vec2} vector
+     * @return {Vec2} returns this
+     * @chainable
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.subSelf(cc.v2(5, 5));// return Vec2 {x: 5, y: 5};
+     */
     subSelf  = Vec2.prototype.subtract;
+    /**
+     * !#en Subtracts one vector from this, and returns the new result.
+     * !#zh 向量减法，并返回新结果。
+     * @method sub
+     * @param {Vec2} vector
+     * @param {Vec2} [out] - optional, the receiving vector, you can pass the same vec2 to save result to itself, if not provided, a new vec2 will be created
+     * @return {Vec2} the result
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.sub(cc.v2(5, 5));      // return Vec2 {x: 5, y: 5};
+     * var v1;
+     * v.sub(cc.v2(5, 5), v1);  // return Vec2 {x: 5, y: 5};
+     */
     sub (vector: Vec2, out?: Vec2): Vec2 {
         return Vec2.subtract(out || new Vec2(), this, vector);
     }
+    /**
+     * !#en Multiplies this by a number. If you want to save result to another vector, use mul() instead.
+     * !#zh 缩放当前向量。如果你想结果保存到另一个向量，可使用 mul() 代替。
+     * @method mulSelf
+     * @param {number} num
+     * @return {Vec2} returns this
+     * @chainable
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.mulSelf(5);// return Vec2 {x: 50, y: 50};
+     */
     mulSelf  = Vec2.prototype.multiplyScalar;
+    /**
+     * !#en Multiplies by a number, and returns the new result.
+     * !#zh 缩放向量，并返回新结果。
+     * @method mul
+     * @param {number} num
+     * @param {Vec2} [out] - optional, the receiving vector, you can pass the same vec2 to save result to itself, if not provided, a new vec2 will be created
+     * @return {Vec2} the result
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.mul(5);      // return Vec2 {x: 50, y: 50};
+     * var v1;
+     * v.mul(5, v1);  // return Vec2 {x: 50, y: 50};
+     */
     mul (num: number, out?: Vec2): Vec2 {
         return Vec2.multiplyScalar(out || new Vec2(), this, num);
     }
+    /**
+     * !#en Divides by a number. If you want to save result to another vector, use div() instead.
+     * !#zh 向量除法。如果你想结果保存到另一个向量，可使用 div() 代替。
+     * @method divSelf
+     * @param {number} num
+     * @return {Vec2} returns this
+     * @chainable
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.divSelf(5); // return Vec2 {x: 2, y: 2};
+     */
     divSelf  = Vec2.prototype.divide;
+    /**
+     * !#en Divides by a number, and returns the new result.
+     * !#zh 向量除法，并返回新的结果。
+     * @method div
+     * @param {number} num
+     * @param {Vec2} [out] - optional, the receiving vector, you can pass the same vec2 to save result to itself, if not provided, a new vec2 will be created
+     * @return {Vec2} the result
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.div(5);      // return Vec2 {x: 2, y: 2};
+     * var v1;
+     * v.div(5, v1);  // return Vec2 {x: 2, y: 2};
+     */
     div (vector: Vec2, out?: Vec2): Vec2 {
         return Vec2.divide(out || new Vec2(), this, vector);
     }
+    /**
+     * !#en Multiplies two vectors.
+     * !#zh 分量相乘。
+     * @method scaleSelf
+     * @param {Vec2} vector
+     * @return {Vec2} returns this
+     * @chainable
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.scaleSelf(cc.v2(5, 5));// return Vec2 {x: 50, y: 50};
+     */
     scaleSelf = Vec2.prototype.multiply;
+    /**
+     * !#en Multiplies two vectors, and returns the new result.
+     * !#zh 分量相乘，并返回新的结果。
+     * @method scale
+     * @param {Vec2} vector
+     * @param {Vec2} [out] - optional, the receiving vector, you can pass the same vec2 to save result to itself, if not provided, a new vec2 will be created
+     * @return {Vec2} the result
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.scale(cc.v2(5, 5));      // return Vec2 {x: 50, y: 50};
+     * var v1;
+     * v.scale(cc.v2(5, 5), v1);  // return Vec2 {x: 50, y: 50};
+     */
     scale (vector: Vec2, out?: Vec2): Vec2 {
         return Vec2.multiply(out || new Vec2(), this, vector);
     }
+    /**
+     * !#en Negates the components. If you want to save result to another vector, use neg() instead.
+     * !#zh 向量取反。如果你想结果保存到另一个向量，可使用 neg() 代替。
+     * @method negSelf
+     * @return {Vec2} returns this
+     * @chainable
+     * @example
+     * var v = cc.v2(10, 10);
+     * v.negSelf(); // return Vec2 {x: -10, y: -10};
+     */
     negSelf = Vec2.prototype.negate;
+    /**
+     * !#en Negates the components, and returns the new result.
+     * !#zh 返回取反后的新向量。
+     * @method neg
+     * @param {Vec2} [out] - optional, the receiving vector, you can pass the same vec2 to save result to itself, if not provided, a new vec2 will be created
+     * @return {Vec2} the result
+     * @example
+     * var v = cc.v2(10, 10);
+     * var v1;
+     * v.neg(v1);  // return Vec2 {x: -10, y: -10};
+     */
     neg (out?: Vec2): Vec2 {
         return Vec2.negate(out || new Vec2(), this);
     }
@@ -135,7 +270,7 @@ export default class Vec2 extends ValueType {
      * !#zh 获得指定向量的拷贝
      * @method clone
      * @typescript
-     * static clone <Out extends IVec2Like> (a: Out)
+     * clone <Out extends IVec2Like> (a: Out)
      * @static
      */
     static clone <Out extends IVec2Like> (a: Out) {
@@ -146,7 +281,7 @@ export default class Vec2 extends ValueType {
      * !#zh 复制指定向量的值
      * @method copy
      * @typescript
-     * static copy <Out extends IVec2Like> (out: Out, a: Out)
+     * copy <Out extends IVec2Like> (out: Out, a: Out)
      * @static
      */
     static copy <Out extends IVec2Like> (out: Out, a: Out) {
@@ -159,7 +294,7 @@ export default class Vec2 extends ValueType {
      * !#zh  设置向量值
      * @method set
      * @typescript
-     * static set <Out extends IVec2Like> (out: Out, x: number, y: number)
+     * set <Out extends IVec2Like> (out: Out, x: number, y: number)
      * @static
      */
     static set <Out extends IVec2Like> (out: Out, x: number, y: number) {
@@ -172,7 +307,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量加法
      * @method add
      * @typescript
-     * static add <Out extends IVec2Like> (out: Out, a: Out, b: Out)
+     * add <Out extends IVec2Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static add <Out extends IVec2Like> (out: Out, a: Out, b: Out) {
@@ -185,7 +320,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量减法
      * @method subtract
      * @typescript
-     * static subtract <Out extends IVec2Like> (out: Out, a: Out, b: Out)
+     * subtract <Out extends IVec2Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static subtract <Out extends IVec2Like> (out: Out, a: Out, b: Out) {
@@ -198,7 +333,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量乘法
      * @method multiply
      * @typescript
-     * static multiply <Out extends IVec2Like> (out: Out, a: Out, b: Out)
+     * multiply <Out extends IVec2Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static multiply <Out extends IVec2Like> (out: Out, a: Out, b: Out) {
@@ -211,7 +346,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量除法
      * @method divide
      * @typescript
-     * static divide <Out extends IVec2Like> (out: Out, a: Out, b: Out)
+     * divide <Out extends IVec2Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static divide <Out extends IVec2Like> (out: Out, a: Out, b: Out) {
@@ -224,7 +359,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量向上取整
      * @method ceil
      * @typescript
-     * static ceil <Out extends IVec2Like> (out: Out, a: Out)
+     * ceil <Out extends IVec2Like> (out: Out, a: Out)
      * @static
      */
     static ceil <Out extends IVec2Like> (out: Out, a: Out) {
@@ -237,7 +372,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量向下取整
      * @method ceil
      * @typescript
-     * static floor <Out extends IVec2Like> (out: Out, a: Out)
+     * floor <Out extends IVec2Like> (out: Out, a: Out)
      * @static
      */
     static floor <Out extends IVec2Like> (out: Out, a: Out) {
@@ -250,7 +385,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量最小值
      * @method min
      * @typescript
-     * static min <Out extends IVec2Like> (out: Out, a: Out, b: Out)
+     * min <Out extends IVec2Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static min <Out extends IVec2Like> (out: Out, a: Out, b: Out) {
@@ -264,7 +399,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量最大值
      * @method max
      * @typescript
-     * static max <Out extends IVec2Like> (out: Out, a: Out, b: Out)
+     * max <Out extends IVec2Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static max <Out extends IVec2Like> (out: Out, a: Out, b: Out) {
@@ -277,7 +412,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量四舍五入取整
      * @method round
      * @typescript
-     * static round <Out extends IVec2Like> (out: Out, a: Out)
+     * round <Out extends IVec2Like> (out: Out, a: Out)
      * @static
      */
     static round <Out extends IVec2Like> (out: Out, a: Out) {
@@ -290,7 +425,7 @@ export default class Vec2 extends ValueType {
      * !#zh 向量标量乘法
      * @method multiplyScalar
      * @typescript
-     * static multiplyScalar <Out extends IVec2Like> (out: Out, a: Out, b: number)
+     * multiplyScalar <Out extends IVec2Like> (out: Out, a: Out, b: number)
      * @static
      */
     static multiplyScalar <Out extends IVec2Like> (out: Out, a: Out, b: number) {
@@ -303,7 +438,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量乘加: A + B * scale
      * @method scaleAndAdd
      * @typescript
-     * static scaleAndAdd <Out extends IVec2Like> (out: Out, a: Out, b: Out, scale: number)
+     * scaleAndAdd <Out extends IVec2Like> (out: Out, a: Out, b: Out, scale: number)
      * @static
      */
     static scaleAndAdd <Out extends IVec2Like> (out: Out, a: Out, b: Out, scale: number) {
@@ -316,7 +451,7 @@ export default class Vec2 extends ValueType {
      * !#zh 求两向量的欧氏距离
      * @method distance
      * @typescript
-     * static distance <Out extends IVec2Like> (a: Out, b: Out)
+     * distance <Out extends IVec2Like> (a: Out, b: Out)
      * @static
      */
     static distance <Out extends IVec2Like> (a: Out, b: Out) {
@@ -329,7 +464,7 @@ export default class Vec2 extends ValueType {
      * !#zh 求两向量的欧氏距离平方
      * @method squaredDistance
      * @typescript
-     * static squaredDistance <Out extends IVec2Like> (a: Out, b: Out)
+     * squaredDistance <Out extends IVec2Like> (a: Out, b: Out)
      * @static
      */
     static squaredDistance <Out extends IVec2Like> (a: Out, b: Out) {
@@ -342,7 +477,7 @@ export default class Vec2 extends ValueType {
      * !#zh 求向量长度
      * @method len
      * @typescript
-     * static len <Out extends IVec2Like> (a: Out)
+     * len <Out extends IVec2Like> (a: Out)
      * @static
      */
     static len <Out extends IVec2Like> (a: Out) {
@@ -355,7 +490,7 @@ export default class Vec2 extends ValueType {
      * !#zh 求向量长度平方
      * @method lengthSqr
      * @typescript
-     * static lengthSqr <Out extends IVec2Like> (a: Out)
+     * lengthSqr <Out extends IVec2Like> (a: Out)
      * @static
      */
     static lengthSqr <Out extends IVec2Like> (a: Out) {
@@ -368,7 +503,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量取负
      * @method negate
      * @typescript
-     * static negate <Out extends IVec2Like> (out: Out, a: Out)
+     * negate <Out extends IVec2Like> (out: Out, a: Out)
      * @static
      */
     static negate <Out extends IVec2Like> (out: Out, a: Out) {
@@ -381,7 +516,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量取倒数，接近 0 时返回 Infinity
      * @method inverse
      * @typescript
-     * static inverse <Out extends IVec2Like> (out: Out, a: Out)
+     * inverse <Out extends IVec2Like> (out: Out, a: Out)
      * @static
      */
     static inverse <Out extends IVec2Like> (out: Out, a: Out) {
@@ -394,7 +529,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量取倒数，接近 0 时返回 0
      * @method inverseSafe
      * @typescript
-     * static inverseSafe <Out extends IVec2Like> (out: Out, a: Out)
+     * inverseSafe <Out extends IVec2Like> (out: Out, a: Out)
      * @static
      */
     static inverseSafe <Out extends IVec2Like> (out: Out, a: Out) {
@@ -420,7 +555,7 @@ export default class Vec2 extends ValueType {
      * !#zh 归一化向量
      * @method normalize
      * @typescript
-     * static normalize <Out extends IVec2Like, Vec2Like extends IVec2Like> (out: Out, a: Vec2Like)
+     * normalize <Out extends IVec2Like, Vec2Like extends IVec2Like> (out: Out, a: Vec2Like)
      * @static
      */
     static normalize <Out extends IVec2Like, Vec2Like extends IVec2Like> (out: Out, a: Vec2Like) {
@@ -439,7 +574,7 @@ export default class Vec2 extends ValueType {
      * !#zh 向量点积（数量积）
      * @method dot
      * @typescript
-     * static dot <Out extends IVec2Like> (a: Out, b: Out)
+     * dot <Out extends IVec2Like> (a: Out, b: Out)
      * @static
      */
     static dot <Out extends IVec2Like> (a: Out, b: Out) {
@@ -450,7 +585,7 @@ export default class Vec2 extends ValueType {
      * !#zh 向量叉积（向量积），注意二维向量的叉积为与 Z 轴平行的三维向量
      * @method cross
      * @typescript
-     * static cross <Out extends IVec2Like> (out: Vec2, a: Out, b: Out)
+     * cross <Out extends IVec2Like> (out: Vec2, a: Out, b: Out)
      * @static
      */
     static cross <Out extends IVec2Like> (out: Vec2, a: Out, b: Out) {
@@ -463,7 +598,7 @@ export default class Vec2 extends ValueType {
      * !#zh 逐元素向量线性插值： A + t * (B - A)
      * @method lerp
      * @typescript
-     * static lerp <Out extends IVec2Like> (out: Out, a: Out, b: Out, t: number)
+     * lerp <Out extends IVec2Like> (out: Out, a: Out, b: Out, t: number)
      * @static
      */
     static lerp <Out extends IVec2Like> (out: Out, a: Out, b: Out, t: number) {
@@ -478,7 +613,7 @@ export default class Vec2 extends ValueType {
      * !#zh 生成一个在单位圆上均匀分布的随机向量
      * @method random
      * @typescript
-     * static random <Out extends IVec2Like> (out: Out, scale?: number)
+     * random <Out extends IVec2Like> (out: Out, scale?: number)
      * @static
      */
     static random <Out extends IVec2Like> (out: Out, scale?: number) {
@@ -493,7 +628,7 @@ export default class Vec2 extends ValueType {
      * !#zh 向量与三维矩阵乘法，默认向量第三位为 1。
      * @method transformMat3
      * @typescript
-     * static transformMat3 <Out extends IVec2Like, MatLike extends IMat3Like> (out: Out, a: Out, mat: IMat3Like)
+     * transformMat3 <Out extends IVec2Like, MatLike extends IMat3Like> (out: Out, a: Out, mat: IMat3Like)
      * @static
      */
     static transformMat3 <Out extends IVec2Like, MatLike extends IMat3Like> (out: Out, a: Out, mat: MatLike) {
@@ -509,7 +644,7 @@ export default class Vec2 extends ValueType {
      * !#zh 向量与四维矩阵乘法，默认向量第三位为 0，第四位为 1。
      * @method transformMat4
      * @typescript
-     * static transformMat4 <Out extends IVec2Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike)
+     * transformMat4 <Out extends IVec2Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike)
      * @static
      */
     static transformMat4 <Out extends IVec2Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike) {
@@ -525,7 +660,7 @@ export default class Vec2 extends ValueType {
      * !#zh 向量等价判断
      * @method strictEquals
      * @typescript
-     * static strictEquals <Out extends IVec2Like> (a: Out, b: Out)
+     * strictEquals <Out extends IVec2Like> (a: Out, b: Out)
      * @static
      */
     static strictEquals <Out extends IVec2Like> (a: Out, b: Out) {
@@ -536,7 +671,7 @@ export default class Vec2 extends ValueType {
      * !#zh 排除浮点数误差的向量近似等价判断
      * @method equals
      * @typescript
-     * static equals <Out extends IVec2Like> (a: Out, b: Out,  epsilon = EPSILON)
+     * equals <Out extends IVec2Like> (a: Out, b: Out,  epsilon = EPSILON)
      * @static
      */
     static equals <Out extends IVec2Like> (a: Out, b: Out,  epsilon = EPSILON) {
@@ -552,7 +687,7 @@ export default class Vec2 extends ValueType {
      * !#zh 排除浮点数误差的向量近似等价判断
      * @method angle
      * @typescript
-     * static angle <Out extends IVec2Like> (a: Out, b: Out)
+     * angle <Out extends IVec2Like> (a: Out, b: Out)
      * @static
      */
     static angle <Out extends IVec2Like> (a: Out, b: Out) {
@@ -572,7 +707,7 @@ export default class Vec2 extends ValueType {
      * !#zh 向量转数组
      * @method toArray
      * @typescript
-     * static toArray <Out extends IWritableArrayLike<number>> (out: Out, v: IVec2Like, ofs = 0)
+     * toArray <Out extends IWritableArrayLike<number>> (out: Out, v: IVec2Like, ofs = 0)
      * @static
      */
     static toArray <Out extends IWritableArrayLike<number>> (out: Out, v: IVec2Like, ofs = 0) {
@@ -585,7 +720,7 @@ export default class Vec2 extends ValueType {
      * !#zh 数组转向量
      * @method fromArray
      * @typescript
-     * static fromArray <Out extends IVec2Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
+     * fromArray <Out extends IVec2Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
      * @static
      */
     static fromArray <Out extends IVec2Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0) {

--- a/cocos2d/core/value-types/vec2.ts
+++ b/cocos2d/core/value-types/vec2.ts
@@ -151,8 +151,8 @@ export default class Vec2 extends ValueType {
      * var v1;
      * v.div(5, v1);  // return Vec2 {x: 2, y: 2};
      */
-    div (vector: Vec2, out?: Vec2): Vec2 {
-        return Vec2.divide(out || new Vec2(), this, vector);
+    div (num: number, out?: Vec2): Vec2 {
+        return Vec2.multiplyScalar(out || new Vec2(), this, 1/num);
     }
     /**
      * !#en Multiplies two vectors.

--- a/cocos2d/core/value-types/vec2.ts
+++ b/cocos2d/core/value-types/vec2.ts
@@ -370,7 +370,7 @@ export default class Vec2 extends ValueType {
 
     /**
      * !#zh 逐元素向量向下取整
-     * @method ceil
+     * @method floor
      * @typescript
      * floor <Out extends IVec2Like> (out: Out, a: Out)
      * @static
@@ -926,7 +926,7 @@ export default class Vec2 extends ValueType {
     /**
      * !#en Multiplies this by a number.
      * !#zh 缩放当前向量。
-     * @method multiply
+     * @method multiplyScalar
      * @param {number} num
      * @return {Vec2} returns this
      * @chainable

--- a/cocos2d/core/value-types/vec3.ts
+++ b/cocos2d/core/value-types/vec3.ts
@@ -52,25 +52,119 @@ export default class Vec3 extends ValueType {
     static mag   = Vec3.len;
     static squaredMagnitude = Vec3.lengthSqr;
     static div = Vec3.divide;
+
+    /**
+     * !#en Returns the length of this vector.
+     * !#zh 返回该向量的长度。
+     * @method mag
+     * @return {number} the result
+     * @example
+     * var v = cc.v3(10, 10, 10);
+     * v.mag(); // return 17.320508075688775;
+     */
     mag  = Vec3.prototype.len;
+    /**
+     * !#en Returns the squared length of this vector.
+     * !#zh 返回该向量的长度平方。
+     * @method magSqr
+     * @return {number} the result
+     */
     magSqr = Vec3.prototype.lengthSqr;
+    /**
+     * !#en Subtracts one vector from this. If you want to save result to another vector, use sub() instead.
+     * !#zh 向量减法。如果你想保存结果到另一个向量，可使用 sub() 代替。
+     * @method subSelf
+     * @param {Vec3} vector
+     * @return {Vec3} returns this
+     * @chainable
+     */
     subSelf  = Vec3.prototype.subtract;
+    /**
+     * !#en Subtracts one vector from this, and returns the new result.
+     * !#zh 向量减法，并返回新结果。
+     * @method sub
+     * @param {Vec3} vector
+     * @param {Vec3} [out] - optional, the receiving vector, you can pass the same vec3 to save result to itself, if not provided, a new vec3 will be created
+     * @return {Vec3} the result
+     */
     sub (vector: Vec3, out?: Vec3) {
         return Vec3.subtract(out || new Vec3(), this, vector);
     }
+    /**
+     * !#en Multiplies this by a number. If you want to save result to another vector, use mul() instead.
+     * !#zh 缩放当前向量。如果你想结果保存到另一个向量，可使用 mul() 代替。
+     * @method mulSelf
+     * @param {number} num
+     * @return {Vec3} returns this
+     * @chainable
+     */
     mulSelf  = Vec3.prototype.multiplyScalar;
+    /**
+     * !#en Multiplies by a number, and returns the new result.
+     * !#zh 缩放向量，并返回新结果。
+     * @method mul
+     * @param {number} num
+     * @param {Vec3} [out] - optional, the receiving vector, you can pass the same vec3 to save result to itself, if not provided, a new vec3 will be created
+     * @return {Vec3} the result
+     */
     mul (num: number, out?: Vec3) {
         return Vec3.multiplyScalar(out || new Vec3(), this, num);
     }
+    /**
+     * !#en Divides by a number. If you want to save result to another vector, use div() instead.
+     * !#zh 向量除法。如果你想结果保存到另一个向量，可使用 div() 代替。
+     * @method divSelf
+     * @param {number} num
+     * @return {Vec3} returns this
+     * @chainable
+     */
     divSelf  = Vec3.prototype.divide;
+    /**
+     * !#en Divides by a number, and returns the new result.
+     * !#zh 向量除法，并返回新的结果。
+     * @method div
+     * @param {number} num
+     * @param {Vec3} [out] - optional, the receiving vector, you can pass the same vec3 to save result to itself, if not provided, a new vec3 will be created
+     * @return {Vec3} the result
+     */
     div (vector: Vec3, out?: Vec3) {
         return Vec3.divide(out || new Vec3(), this, vector);
     }
+    /**
+     * !#en Multiplies two vectors.
+     * !#zh 分量相乘。
+     * @method scaleSelf
+     * @param {Vec3} vector
+     * @return {Vec3} returns this
+     * @chainable
+     */
     scaleSelf = Vec3.prototype.multiply;
+    /**
+     * !#en Multiplies two vectors, and returns the new result.
+     * !#zh 分量相乘，并返回新的结果。
+     * @method scale
+     * @param {Vec3} vector
+     * @param {Vec3} [out] - optional, the receiving vector, you can pass the same vec3 to save result to itself, if not provided, a new vec3 will be created
+     * @return {Vec3} the result
+     */
     scale (vector: Vec3, out?: Vec3) {
         return Vec3.multiply(out || new Vec3(), this, vector);
     }
+    /**
+     * !#en Negates the components. If you want to save result to another vector, use neg() instead.
+     * !#zh 向量取反。如果你想结果保存到另一个向量，可使用 neg() 代替。
+     * @method negSelf
+     * @return {Vec3} returns this
+     * @chainable
+     */
     negSelf = Vec3.prototype.negate;
+    /**
+     * !#en Negates the components, and returns the new result.
+     * !#zh 返回取反后的新向量。
+     * @method neg
+     * @param {Vec3} [out] - optional, the receiving vector, you can pass the same vec3 to save result to itself, if not provided, a new vec3 will be created
+     * @return {Vec3} the result
+     */
     neg (out?: Vec3) {
         return Vec3.negate(out || new Vec3(), this);
     }
@@ -131,7 +225,7 @@ export default class Vec3 extends ValueType {
      * !#en The target of an assignment zero vector
      * @method zero
      * @typescript
-     * static zero<Out extends IVec3Like> (out: Out)
+     * zero<Out extends IVec3Like> (out: Out)
      * @static
      */
     static zero<Out extends IVec3Like> (out: Out) {
@@ -146,7 +240,7 @@ export default class Vec3 extends ValueType {
      * !#en Obtaining copy vectors designated
      * @method clone
      * @typescript
-     * static clone<Out extends IVec3Like> (a: Out)
+     * clone<Out extends IVec3Like> (a: Out)
      * @static
      */
     static clone<Out extends IVec3Like> (a: Out) {
@@ -158,7 +252,7 @@ export default class Vec3 extends ValueType {
      * !#en Copy the target vector
      * @method copy
      * @typescript
-     * static copy<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like)
+     * copy<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like)
      * @static
      */
     static copy<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like) {
@@ -173,7 +267,7 @@ export default class Vec3 extends ValueType {
      * !#en Set to value
      * @method set
      * @typescript
-     * static set<Out extends IVec3Like> (out: Out, x: number, y: number, z: number)
+     * set<Out extends IVec3Like> (out: Out, x: number, y: number, z: number)
      * @static
      */
     static set<Out extends IVec3Like> (out: Out, x: number, y: number, z: number) {
@@ -188,7 +282,7 @@ export default class Vec3 extends ValueType {
      * !#en Element-wise vector addition
      * @method add
      * @typescript
-     * static add<Out extends IVec3Like> (out: Out, a: Out, b: Out)
+     * add<Out extends IVec3Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static add<Out extends IVec3Like> (out: Out, a: Out, b: Out) {
@@ -203,7 +297,7 @@ export default class Vec3 extends ValueType {
      * !#en Element-wise vector subtraction
      * @method subtract
      * @typescript
-     * static subtract<Out extends IVec3Like> (out: Out, a: Out, b: Out)
+     * subtract<Out extends IVec3Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static subtract<Out extends IVec3Like> (out: Out, a: Out, b: Out) {
@@ -218,7 +312,7 @@ export default class Vec3 extends ValueType {
      * !#en Element-wise vector multiplication (product component)
      * @method multiply
      * @typescript
-     * static multiply<Out extends IVec3Like, Vec3Like_1 extends IVec3Like, Vec3Like_2 extends IVec3Like> (out: Out, a: Vec3Like_1, b: Vec3Like_2)
+     * multiply<Out extends IVec3Like, Vec3Like_1 extends IVec3Like, Vec3Like_2 extends IVec3Like> (out: Out, a: Vec3Like_1, b: Vec3Like_2)
      * @static
      */
     static multiply<Out extends IVec3Like, Vec3Like_1 extends IVec3Like, Vec3Like_2 extends IVec3Like> (out: Out, a: Vec3Like_1, b: Vec3Like_2) {
@@ -233,7 +327,7 @@ export default class Vec3 extends ValueType {
      * !#en Element-wise vector division
      * @method divide
      * @typescript
-     * static divide<Out extends IVec3Like> (out: Out, a: Out, b: Out)
+     * divide<Out extends IVec3Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static divide<Out extends IVec3Like> (out: Out, a: Out, b: Out) {
@@ -248,7 +342,7 @@ export default class Vec3 extends ValueType {
      * !#en Rounding up by elements of the vector
      * @method ceil
      * @typescript
-     * static ceil<Out extends IVec3Like> (out: Out, a: Out)
+     * ceil<Out extends IVec3Like> (out: Out, a: Out)
      * @static
      */
     static ceil<Out extends IVec3Like> (out: Out, a: Out) {
@@ -263,7 +357,7 @@ export default class Vec3 extends ValueType {
      * !#en Element vector by rounding down
      * @method floor
      * @typescript
-     * static floor<Out extends IVec3Like> (out: Out, a: Out)
+     * floor<Out extends IVec3Like> (out: Out, a: Out)
      * @static
      */
     static floor<Out extends IVec3Like> (out: Out, a: Out) {
@@ -278,7 +372,7 @@ export default class Vec3 extends ValueType {
      * !#en The minimum by-element vector
      * @method min
      * @typescript
-     * static min<Out extends IVec3Like> (out: Out, a: Out, b: Out)
+     * min<Out extends IVec3Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static min<Out extends IVec3Like> (out: Out, a: Out, b: Out) {
@@ -293,7 +387,7 @@ export default class Vec3 extends ValueType {
      * !#en The maximum value of the element-wise vector
      * @method max
      * @typescript
-     * static max<Out extends IVec3Like> (out: Out, a: Out, b: Out)
+     * max<Out extends IVec3Like> (out: Out, a: Out, b: Out)
      * @static
      */
     static max<Out extends IVec3Like> (out: Out, a: Out, b: Out) {
@@ -308,7 +402,7 @@ export default class Vec3 extends ValueType {
      * !#en Element-wise vector of rounding to whole
      * @method round
      * @typescript
-     * static round<Out extends IVec3Like> (out: Out, a: Out)
+     * round<Out extends IVec3Like> (out: Out, a: Out)
      * @static
      */
     static round<Out extends IVec3Like> (out: Out, a: Out) {
@@ -323,7 +417,7 @@ export default class Vec3 extends ValueType {
      * !#en Vector scalar multiplication
      * @method multiplyScalar
      * @typescript
-     * static multiplyScalar<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like, b: number)
+     * multiplyScalar<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like, b: number)
      * @static
      */
     static multiplyScalar<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like, b: number) {
@@ -338,7 +432,7 @@ export default class Vec3 extends ValueType {
      * !#en Element-wise vector multiply add: A + B * scale
      * @method scaleAndAdd
      * @typescript
-     * static scaleAndAdd<Out extends IVec3Like> (out: Out, a: Out, b: Out, scale: number)
+     * scaleAndAdd<Out extends IVec3Like> (out: Out, a: Out, b: Out, scale: number)
      * @static
      */
     static scaleAndAdd<Out extends IVec3Like> (out: Out, a: Out, b: Out, scale: number) {
@@ -353,7 +447,7 @@ export default class Vec3 extends ValueType {
      * !#en Seeking two vectors Euclidean distance
      * @method distance
      * @typescript
-     * static distance<Out extends IVec3Like> (a: Out, b: Out)
+     * distance<Out extends IVec3Like> (a: Out, b: Out)
      * @static
      */
     static distance<Out extends IVec3Like> (a: Out, b: Out) {
@@ -368,7 +462,7 @@ export default class Vec3 extends ValueType {
      * !#en Euclidean distance squared seeking two vectors
      * @method squaredDistance
      * @typescript
-     * static squaredDistance<Out extends IVec3Like> (a: Out, b: Out)
+     * squaredDistance<Out extends IVec3Like> (a: Out, b: Out)
      * @static
      */
     static squaredDistance<Out extends IVec3Like> (a: Out, b: Out) {
@@ -383,7 +477,7 @@ export default class Vec3 extends ValueType {
      * !#en Seeking vector length
      * @method len
      * @typescript
-     * static len<Out extends IVec3Like> (a: Out)
+     * len<Out extends IVec3Like> (a: Out)
      * @static
      */
     static len<Out extends IVec3Like> (a: Out) {
@@ -398,7 +492,7 @@ export default class Vec3 extends ValueType {
      * !#en Seeking squared vector length
      * @method lengthSqr
      * @typescript
-     * static lengthSqr<Out extends IVec3Like> (a: Out)
+     * lengthSqr<Out extends IVec3Like> (a: Out)
      * @static
      */
     static lengthSqr<Out extends IVec3Like> (a: Out) {
@@ -413,7 +507,7 @@ export default class Vec3 extends ValueType {
      * !#en By taking the negative elements of the vector
      * @method negate
      * @typescript
-     * static negate<Out extends IVec3Like> (out: Out, a: Out)
+     * negate<Out extends IVec3Like> (out: Out, a: Out)
      * @static
      */
     static negate<Out extends IVec3Like> (out: Out, a: Out) {
@@ -428,7 +522,7 @@ export default class Vec3 extends ValueType {
      * !#en Element vector by taking the inverse, return near 0 Infinity
      * @method inverse
      * @typescript
-     * static inverse<Out extends IVec3Like> (out: Out, a: Out)
+     * inverse<Out extends IVec3Like> (out: Out, a: Out)
      * @static
      */
     static inverse<Out extends IVec3Like> (out: Out, a: Out) {
@@ -443,7 +537,7 @@ export default class Vec3 extends ValueType {
      * !#en Element vector by taking the inverse, return near 0 0
      * @method inverseSafe
      * @typescript
-     * static inverseSafe<Out extends IVec3Like> (out: Out, a: Out)
+     * inverseSafe<Out extends IVec3Like> (out: Out, a: Out)
      * @static
      */
     static inverseSafe<Out extends IVec3Like> (out: Out, a: Out) {
@@ -477,7 +571,7 @@ export default class Vec3 extends ValueType {
      * !#en Normalized vector
      * @method normalize
      * @typescript
-     * static normalize<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like)
+     * normalize<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like)
      * @static
      */
     static normalize<Out extends IVec3Like, Vec3Like extends IVec3Like> (out: Out, a: Vec3Like) {
@@ -500,7 +594,7 @@ export default class Vec3 extends ValueType {
      * !#en Vector dot product (scalar product)
      * @method dot
      * @typescript
-     * static dot<Out extends IVec3Like> (a: Out, b: Out)
+     * dot<Out extends IVec3Like> (a: Out, b: Out)
      * @static
      */
     static dot<Out extends IVec3Like> (a: Out, b: Out) {
@@ -512,7 +606,7 @@ export default class Vec3 extends ValueType {
      * !#en Vector cross product (vector product)
      * @method cross
      * @typescript
-     * static cross<Out extends IVec3Like, Vec3Like_1 extends IVec3Like, Vec3Like_2 extends IVec3Like> (out: Out, a: Vec3Like_1, b: Vec3Like_2)
+     * cross<Out extends IVec3Like, Vec3Like_1 extends IVec3Like, Vec3Like_2 extends IVec3Like> (out: Out, a: Vec3Like_1, b: Vec3Like_2)
      * @static
      */
     static cross<Out extends IVec3Like, Vec3Like_1 extends IVec3Like, Vec3Like_2 extends IVec3Like> (out: Out, a: Vec3Like_1, b: Vec3Like_2) {
@@ -529,7 +623,7 @@ export default class Vec3 extends ValueType {
      * !#en Vector element by element linear interpolation: A + t * (B - A)
      * @method lerp
      * @typescript
-     * static lerp<Out extends IVec3Like> (out: Out, a: Out, b: Out, t: number)
+     * lerp<Out extends IVec3Like> (out: Out, a: Out, b: Out, t: number)
      * @static
      */
     static lerp<Out extends IVec3Like> (out: Out, a: Out, b: Out, t: number) {
@@ -544,7 +638,7 @@ export default class Vec3 extends ValueType {
      * !#en Generates a uniformly distributed random vectors on the unit sphere
      * @method random
      * @typescript
-     * static random<Out extends IVec3Like> (out: Out, scale?: number)
+     * random<Out extends IVec3Like> (out: Out, scale?: number)
      * @param scale 生成的向量长度
      * @static
      */
@@ -566,7 +660,7 @@ export default class Vec3 extends ValueType {
      * !#en Four-dimensional vector and matrix multiplication, the default vectors fourth one.
      * @method transformMat4
      * @typescript
-     * static transformMat4<Out extends IVec3Like, Vec3Like extends IVec3Like, MatLike extends IMat4Like> (out: Out, a: Vec3Like, mat: MatLike)
+     * transformMat4<Out extends IVec3Like, Vec3Like extends IVec3Like, MatLike extends IMat4Like> (out: Out, a: Vec3Like, mat: MatLike)
      * @static
      */
     static transformMat4<Out extends IVec3Like, Vec3Like extends IVec3Like, MatLike extends IMat4Like> (out: Out, a: Vec3Like, mat: MatLike) {
@@ -587,7 +681,7 @@ export default class Vec3 extends ValueType {
      * !#en Four-dimensional vector and matrix multiplication, vector fourth default is 0.
      * @method transformMat4Normal
      * @typescript
-     * static transformMat4Normal<Out extends IVec3Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike)
+     * transformMat4Normal<Out extends IVec3Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike)
      * @static
      */
     static transformMat4Normal<Out extends IVec3Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike) {
@@ -608,7 +702,7 @@ export default class Vec3 extends ValueType {
      * !#en Dimensional vector matrix multiplication
      * @method transformMat3
      * @typescript
-     * static transformMat3<Out extends IVec3Like, MatLike extends IMat3Like> (out: Out, a: Out, mat: MatLike)
+     * transformMat3<Out extends IVec3Like, MatLike extends IMat3Like> (out: Out, a: Out, mat: MatLike)
      * @static
      */
     static transformMat3<Out extends IVec3Like, MatLike extends IMat3Like> (out: Out, a: Out, mat: MatLike) {
@@ -644,7 +738,7 @@ export default class Vec3 extends ValueType {
      * !#en Vector quaternion multiplication
      * @method transformQuat
      * @typescript
-     * static transformQuat<Out extends IVec3Like, VecLike extends IVec3Like, QuatLike extends IQuatLike> (out: Out, a: VecLike, q: QuatLike)
+     * transformQuat<Out extends IVec3Like, VecLike extends IVec3Like, QuatLike extends IQuatLike> (out: Out, a: VecLike, q: QuatLike)
      * @static
      */
     static transformQuat<Out extends IVec3Like, VecLike extends IVec3Like, QuatLike extends IQuatLike> (out: Out, a: VecLike, q: QuatLike) {
@@ -708,7 +802,7 @@ export default class Vec3 extends ValueType {
      * !#en Rotation vector specified angle about the X axis
      * @method rotateX
      * @typescript
-     * static rotateX<Out extends IVec3Like> (out: Out, v: Out, o: Out, a: number)
+     * rotateX<Out extends IVec3Like> (out: Out, v: Out, o: Out, a: number)
      * @param v 待旋转向量
      * @param o 旋转中心
      * @param a 旋转弧度
@@ -740,7 +834,7 @@ export default class Vec3 extends ValueType {
      * !#en Rotation vector specified angle around the Y axis
      * @method rotateY
      * @typescript
-     * static rotateY<Out extends IVec3Like> (out: Out, v: Out, o: Out, a: number)
+     * rotateY<Out extends IVec3Like> (out: Out, v: Out, o: Out, a: number)
      * @param v 待旋转向量
      * @param o 旋转中心
      * @param a 旋转弧度
@@ -772,7 +866,7 @@ export default class Vec3 extends ValueType {
      * !#en Around the Z axis specified angle vector
      * @method rotateZ
      * @typescript
-     * static rotateZ<Out extends IVec3Like> (out: Out, v: Out, o: Out, a: number)
+     * rotateZ<Out extends IVec3Like> (out: Out, v: Out, o: Out, a: number)
      * @param v 待旋转向量
      * @param o 旋转中心
      * @param a 旋转弧度
@@ -804,7 +898,7 @@ export default class Vec3 extends ValueType {
      * !#en Equivalent vectors Analyzing
      * @method strictEquals
      * @typescript
-     * static strictEquals<Out extends IVec3Like> (a: Out, b: Out)
+     * strictEquals<Out extends IVec3Like> (a: Out, b: Out)
      * @static
      */
     static strictEquals<Out extends IVec3Like> (a: Out, b: Out) {
@@ -816,7 +910,7 @@ export default class Vec3 extends ValueType {
      * !#en Negative error vector floating point approximately equivalent Analyzing
      * @method equals
      * @typescript
-     * static equals<Out extends IVec3Like> (a: Out, b: Out, epsilon = EPSILON)
+     * equals<Out extends IVec3Like> (a: Out, b: Out, epsilon = EPSILON)
      * @static
      */
     static equals<Out extends IVec3Like> (a: Out, b: Out, epsilon = EPSILON) {
@@ -837,7 +931,7 @@ export default class Vec3 extends ValueType {
      * !#en Radian angle between two vectors seek
      * @method angle
      * @typescript
-     * static angle<Out extends IVec3Like> (a: Out, b: Out)
+     * angle<Out extends IVec3Like> (a: Out, b: Out)
      * @static
      */
     static angle<Out extends IVec3Like> (a: Out, b: Out) {
@@ -858,7 +952,7 @@ export default class Vec3 extends ValueType {
      * !#en Calculating a projection vector in the specified plane
      * @method projectOnPlane
      * @typescript
-     * static projectOnPlane<Out extends IVec3Like> (out: Out, a: Out, n: Out)
+     * projectOnPlane<Out extends IVec3Like> (out: Out, a: Out, n: Out)
      * @param a 待投影向量
      * @param n 指定平面的法线
      * @static
@@ -872,7 +966,7 @@ export default class Vec3 extends ValueType {
      * !#en Projection vector calculated in the vector designated
      * @method project
      * @typescript
-     * static project<Out extends IVec3Like> (out: Out, a: Out, b: Out)
+     * project<Out extends IVec3Like> (out: Out, a: Out, b: Out)
      * @param a 待投影向量
      * @param n 目标向量
      * @static
@@ -891,7 +985,7 @@ export default class Vec3 extends ValueType {
      * !#en Vector transfer array
      * @method toArray
      * @typescript
-     * static toArray <Out extends IWritableArrayLike<number>> (out: Out, v: IVec3Like, ofs = 0)
+     * toArray <Out extends IWritableArrayLike<number>> (out: Out, v: IVec3Like, ofs = 0)
      * @param ofs 数组起始偏移量
      * @static
      */
@@ -908,7 +1002,7 @@ export default class Vec3 extends ValueType {
      * !#en Array steering amount
      * @method fromArray
      * @typescript
-     * static fromArray <Out extends IVec3Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
+     * fromArray <Out extends IVec3Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
      * @param ofs 数组起始偏移量
      * @static
      */
@@ -1200,8 +1294,8 @@ export default class Vec3 extends ValueType {
      * @method len
      * @return {number} the result
      * @example
-     * var v = cc.v2(10, 10);
-     * v.len(); // return 14.142135623730951;
+     * var v = cc.v3(10, 10, 10);
+     * v.len(); // return 17.320508075688775;
      */
     len (): number {
         return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);

--- a/cocos2d/core/value-types/vec3.ts
+++ b/cocos2d/core/value-types/vec3.ts
@@ -127,8 +127,8 @@ export default class Vec3 extends ValueType {
      * @param {Vec3} [out] - optional, the receiving vector, you can pass the same vec3 to save result to itself, if not provided, a new vec3 will be created
      * @return {Vec3} the result
      */
-    div (vector: Vec3, out?: Vec3) {
-        return Vec3.divide(out || new Vec3(), this, vector);
+    div (num: number, out?: Vec3): Vec3 {
+        return Vec3.multiplyScalar(out || new Vec3(), this, 1/num);
     }
     /**
      * !#en Multiplies two vectors.

--- a/cocos2d/core/value-types/vec4.ts
+++ b/cocos2d/core/value-types/vec4.ts
@@ -52,23 +52,101 @@ export default class Vec4 extends ValueType {
     public static squaredMagnitude = Vec4.lengthSqr;
     mag  = Vec4.prototype.len;
     magSqr = Vec4.prototype.lengthSqr;
+    /**
+     * !#en Subtracts one vector from this. If you want to save result to another vector, use sub() instead.
+     * !#zh 向量减法。如果你想保存结果到另一个向量，可使用 sub() 代替。
+     * @method subSelf
+     * @param {Vec4} vector
+     * @return {Vec4} returns this
+     * @chainable
+     */
     subSelf  = Vec4.prototype.subtract;
+    /**
+     * !#en Subtracts one vector from this, and returns the new result.
+     * !#zh 向量减法，并返回新结果。
+     * @method sub
+     * @param {Vec4} vector
+     * @param {Vec4} [out] - optional, the receiving vector, you can pass the same vec4 to save result to itself, if not provided, a new vec4 will be created
+     * @return {Vec4} the result
+     */
     sub (vector: Vec4, out?: Vec4) {
         return Vec4.subtract(out || new Vec4(), this, vector);
     }
+    /**
+     * !#en Multiplies this by a number. If you want to save result to another vector, use mul() instead.
+     * !#zh 缩放当前向量。如果你想结果保存到另一个向量，可使用 mul() 代替。
+     * @method mulSelf
+     * @param {number} num
+     * @return {Vec4} returns this
+     * @chainable
+     */
     mulSelf  = Vec4.prototype.multiplyScalar;
+    /**
+     * !#en Multiplies by a number, and returns the new result.
+     * !#zh 缩放向量，并返回新结果。
+     * @method mul
+     * @param {number} num
+     * @param {Vec4} [out] - optional, the receiving vector, you can pass the same vec4 to save result to itself, if not provided, a new vec4 will be created
+     * @return {Vec4} the result
+     */
     mul (num: number, out?: Vec4) {
         return Vec4.multiplyScalar(out || new Vec4(), this, num);
     }
+    /**
+     * !#en Divides by a number. If you want to save result to another vector, use div() instead.
+     * !#zh 向量除法。如果你想结果保存到另一个向量，可使用 div() 代替。
+     * @method divSelf
+     * @param {number} num
+     * @return {Vec4} returns this
+     * @chainable
+     */
     divSelf  = Vec4.prototype.divide;
+    /**
+     * !#en Divides by a number, and returns the new result.
+     * !#zh 向量除法，并返回新的结果。
+     * @method div
+     * @param {number} num
+     * @param {Vec4} [out] - optional, the receiving vector, you can pass the same vec4 to save result to itself, if not provided, a new vec4 will be created
+     * @return {Vec4} the result
+     */
     div (vector: Vec4, out?: Vec4) {
         return Vec4.divide(out || new Vec4(), this, vector);
     }
+    /**
+     * !#en Multiplies two vectors.
+     * !#zh 分量相乘。
+     * @method scaleSelf
+     * @param {Vec4} vector
+     * @return {Vec4} returns this
+     * @chainable
+     */
     scaleSelf = Vec4.prototype.multiply;
+    /**
+     * !#en Multiplies two vectors, and returns the new result.
+     * !#zh 分量相乘，并返回新的结果。
+     * @method scale
+     * @param {Vec4} vector
+     * @param {Vec4} [out] - optional, the receiving vector, you can pass the same vec4 to save result to itself, if not provided, a new vec4 will be created
+     * @return {Vec4} the result
+     */
     scale (vector: Vec4, out?: Vec4) {
         return Vec4.multiply(out || new Vec4(), this, vector);
     }
+    /**
+     * !#en Negates the components. If you want to save result to another vector, use neg() instead.
+     * !#zh 向量取反。如果你想结果保存到另一个向量，可使用 neg() 代替。
+     * @method negSelf
+     * @return {Vec4} returns this
+     * @chainable
+     */
     negSelf = Vec4.prototype.negate;
+    /**
+     * !#en Negates the components, and returns the new result.
+     * !#zh 返回取反后的新向量。
+     * @method neg
+     * @param {Vec4} [out] - optional, the receiving vector, you can pass the same vec4 to save result to itself, if not provided, a new vec4 will be created
+     * @return {Vec4} the result
+     */
     neg (out?: Vec4) {
         return Vec4.negate(out || new Vec4(), this);
     }
@@ -87,7 +165,7 @@ export default class Vec4 extends ValueType {
      * !#en Obtaining copy vectors designated
      * @method clone
      * @typescript
-     * public static clone <Out extends IVec4Like> (a: Out)
+     * clone <Out extends IVec4Like> (a: Out)
      * @static
      */
     public static clone <Out extends IVec4Like> (a: Out) {
@@ -99,7 +177,7 @@ export default class Vec4 extends ValueType {
      * !#en Copy the target vector
      * @method copy
      * @typescript
-     * public static copy <Out extends IVec4Like> (out: Out, a: Out)
+     * copy <Out extends IVec4Like> (out: Out, a: Out)
      * @static
      */
     public static copy <Out extends IVec4Like> (out: Out, a: Out) {
@@ -115,7 +193,7 @@ export default class Vec4 extends ValueType {
      * !#en Set to value
      * @method set
      * @typescript
-     * public static set <Out extends IVec4Like> (out: Out, x: number, y: number, z: number, w: number)
+     * set <Out extends IVec4Like> (out: Out, x: number, y: number, z: number, w: number)
      * @static
      */
     public static set <Out extends IVec4Like> (out: Out, x: number, y: number, z: number, w: number) {
@@ -131,7 +209,7 @@ export default class Vec4 extends ValueType {
      * !#en Element-wise vector addition
      * @method add
      * @typescript
-     * public static add <Out extends IVec4Like> (out: Out, a: Out, b: Out)
+     * add <Out extends IVec4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     public static add <Out extends IVec4Like> (out: Out, a: Out, b: Out) {
@@ -147,7 +225,7 @@ export default class Vec4 extends ValueType {
      * !#en Element-wise vector subtraction
      * @method subtract
      * @typescript
-     * public static subtract <Out extends IVec4Like> (out: Out, a: Out, b: Out)
+     * subtract <Out extends IVec4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     public static subtract <Out extends IVec4Like> (out: Out, a: Out, b: Out) {
@@ -163,7 +241,7 @@ export default class Vec4 extends ValueType {
      * !#en Element-wise vector multiplication
      * @method multiply
      * @typescript
-     * public static multiply <Out extends IVec4Like> (out: Out, a: Out, b: Out)
+     * multiply <Out extends IVec4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     public static multiply <Out extends IVec4Like> (out: Out, a: Out, b: Out) {
@@ -179,7 +257,7 @@ export default class Vec4 extends ValueType {
      * !#en Element-wise vector division
      * @method divide
      * @typescript
-     * public static divide <Out extends IVec4Like> (out: Out, a: Out, b: Out)
+     * divide <Out extends IVec4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     public static divide <Out extends IVec4Like> (out: Out, a: Out, b: Out) {
@@ -195,7 +273,7 @@ export default class Vec4 extends ValueType {
      * !#en Rounding up by elements of the vector
      * @method ceil
      * @typescript
-     * public static ceil <Out extends IVec4Like> (out: Out, a: Out)
+     * ceil <Out extends IVec4Like> (out: Out, a: Out)
      * @static
      */
     public static ceil <Out extends IVec4Like> (out: Out, a: Out) {
@@ -211,7 +289,7 @@ export default class Vec4 extends ValueType {
      * !#en Element vector by rounding down
      * @method floor
      * @typescript
-     * public static floor <Out extends IVec4Like> (out: Out, a: Out)
+     * floor <Out extends IVec4Like> (out: Out, a: Out)
      * @static
      */
     public static floor <Out extends IVec4Like> (out: Out, a: Out) {
@@ -227,7 +305,7 @@ export default class Vec4 extends ValueType {
      * !#en The minimum by-element vector
      * @method min
      * @typescript
-     * public static min <Out extends IVec4Like> (out: Out, a: Out, b: Out)
+     * min <Out extends IVec4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     public static min <Out extends IVec4Like> (out: Out, a: Out, b: Out) {
@@ -243,7 +321,7 @@ export default class Vec4 extends ValueType {
      * !#en The maximum value of the element-wise vector
      * @method max
      * @typescript
-     * public static max <Out extends IVec4Like> (out: Out, a: Out, b: Out)
+     * max <Out extends IVec4Like> (out: Out, a: Out, b: Out)
      * @static
      */
     public static max <Out extends IVec4Like> (out: Out, a: Out, b: Out) {
@@ -259,7 +337,7 @@ export default class Vec4 extends ValueType {
      * !#en Element-wise vector of rounding to whole
      * @method round
      * @typescript
-     * public static round <Out extends IVec4Like> (out: Out, a: Out)
+     * round <Out extends IVec4Like> (out: Out, a: Out)
      * @static
      */
     public static round <Out extends IVec4Like> (out: Out, a: Out) {
@@ -275,7 +353,7 @@ export default class Vec4 extends ValueType {
      * !#en Vector scalar multiplication
      * @method multiplyScalar
      * @typescript
-     * public static multiplyScalar <Out extends IVec4Like> (out: Out, a: Out, b: number)
+     * multiplyScalar <Out extends IVec4Like> (out: Out, a: Out, b: number)
      * @static
      */
     public static multiplyScalar <Out extends IVec4Like> (out: Out, a: Out, b: number) {
@@ -291,7 +369,7 @@ export default class Vec4 extends ValueType {
      * !#en Element-wise vector multiply add: A + B * scale
      * @method scaleAndAdd
      * @typescript
-     * public static scaleAndAdd <Out extends IVec4Like> (out: Out, a: Out, b: Out, scale: number)
+     * scaleAndAdd <Out extends IVec4Like> (out: Out, a: Out, b: Out, scale: number)
      * @static
      */
     public static scaleAndAdd <Out extends IVec4Like> (out: Out, a: Out, b: Out, scale: number) {
@@ -307,7 +385,7 @@ export default class Vec4 extends ValueType {
      * !#en Seeking two vectors Euclidean distance
      * @method distance
      * @typescript
-     * public static distance <Out extends IVec4Like> (a: Out, b: Out)
+     * distance <Out extends IVec4Like> (a: Out, b: Out)
      * @static
      */
     public static distance <Out extends IVec4Like> (a: Out, b: Out) {
@@ -323,7 +401,7 @@ export default class Vec4 extends ValueType {
      * !#en Euclidean distance squared seeking two vectors
      * @method squaredDistance
      * @typescript
-     * public static squaredDistance <Out extends IVec4Like> (a: Out, b: Out)
+     * squaredDistance <Out extends IVec4Like> (a: Out, b: Out)
      * @static
      */
     public static squaredDistance <Out extends IVec4Like> (a: Out, b: Out) {
@@ -339,7 +417,7 @@ export default class Vec4 extends ValueType {
      * !#en Seeking vector length
      * @method len
      * @typescript
-     * public static len <Out extends IVec4Like> (a: Out)
+     * len <Out extends IVec4Like> (a: Out)
      * @static
      */
     public static len <Out extends IVec4Like> (a: Out) {
@@ -355,7 +433,7 @@ export default class Vec4 extends ValueType {
      * !#en Seeking squared vector length
      * @method lengthSqr
      * @typescript
-     * public static lengthSqr <Out extends IVec4Like> (a: Out)
+     * lengthSqr <Out extends IVec4Like> (a: Out)
      * @static
      */
     public static lengthSqr <Out extends IVec4Like> (a: Out) {
@@ -371,7 +449,7 @@ export default class Vec4 extends ValueType {
      * !#en By taking the negative elements of the vector
      * @method negate
      * @typescript
-     * public static negate <Out extends IVec4Like> (out: Out, a: Out)
+     * negate <Out extends IVec4Like> (out: Out, a: Out)
      * @static
      */
     public static negate <Out extends IVec4Like> (out: Out, a: Out) {
@@ -387,7 +465,7 @@ export default class Vec4 extends ValueType {
      * !#en Element vector by taking the inverse, return near 0 Infinity
      * @method inverse
      * @typescript
-     * public static inverse <Out extends IVec4Like> (out: Out, a: Out)
+     * inverse <Out extends IVec4Like> (out: Out, a: Out)
      * @static
      */
     public static inverse <Out extends IVec4Like> (out: Out, a: Out) {
@@ -403,7 +481,7 @@ export default class Vec4 extends ValueType {
      * !#en Element vector by taking the inverse, return near 0 0
      * @method inverseSafe
      * @typescript
-     * public static inverseSafe <Out extends IVec4Like> (out: Out, a: Out)
+     * inverseSafe <Out extends IVec4Like> (out: Out, a: Out)
      * @static
      */
     public static inverseSafe <Out extends IVec4Like> (out: Out, a: Out) {
@@ -444,7 +522,7 @@ export default class Vec4 extends ValueType {
      * !#en Normalized vector
      * @method normalize
      * @typescript
-     * public static normalize <Out extends IVec4Like> (out: Out, a: Out)
+     * normalize <Out extends IVec4Like> (out: Out, a: Out)
      * @static
      */
     public static normalize <Out extends IVec4Like> (out: Out, a: Out) {
@@ -468,7 +546,7 @@ export default class Vec4 extends ValueType {
      * !#en Vector dot product (scalar product)
      * @method dot
      * @typescript
-     * public static dot <Out extends IVec4Like> (a: Out, b: Out)
+     * dot <Out extends IVec4Like> (a: Out, b: Out)
      * @static
      */
     public static dot <Out extends IVec4Like> (a: Out, b: Out) {
@@ -480,7 +558,7 @@ export default class Vec4 extends ValueType {
      * !#en Vector element by element linear interpolation: A + t * (B - A)
      * @method lerp
      * @typescript
-     * public static lerp <Out extends IVec4Like> (out: Out, a: Out, b: Out, t: number)
+     * lerp <Out extends IVec4Like> (out: Out, a: Out, b: Out, t: number)
      * @static
      */
     public static lerp <Out extends IVec4Like> (out: Out, a: Out, b: Out, t: number) {
@@ -496,7 +574,7 @@ export default class Vec4 extends ValueType {
      * !#en Generates a uniformly distributed random vectors on the unit sphere
      * @method random
      * @typescript
-     * public static random <Out extends IVec4Like> (out: Out, scale?: number)
+     * random <Out extends IVec4Like> (out: Out, scale?: number)
      * @param scale 生成的向量长度
      * @static
      */
@@ -519,7 +597,7 @@ export default class Vec4 extends ValueType {
      * !#en Vector matrix multiplication
      * @method transformMat4
      * @typescript
-     * public static transformMat4 <Out extends IVec4Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike)
+     * transformMat4 <Out extends IVec4Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike)
      * @static
      */
     public static transformMat4 <Out extends IVec4Like, MatLike extends IMat4Like> (out: Out, a: Out, mat: MatLike) {
@@ -559,7 +637,7 @@ export default class Vec4 extends ValueType {
      * !#en Vector quaternion multiplication
      * @method transformQuat
      * @typescript
-     * public static transformQuat <Out extends IVec4Like, QuatLike extends IQuatLike> (out: Out, a: Out, q: QuatLike)
+     * transformQuat <Out extends IVec4Like, QuatLike extends IQuatLike> (out: Out, a: Out, q: QuatLike)
      * @static
      */
     public static transformQuat <Out extends IVec4Like, QuatLike extends IQuatLike> (out: Out, a: Out, q: QuatLike) {
@@ -589,7 +667,7 @@ export default class Vec4 extends ValueType {
      * !#en Equivalent vectors Analyzing
      * @method strictEquals
      * @typescript
-     * public static strictEquals <Out extends IVec4Like> (a: Out, b: Out)
+     * strictEquals <Out extends IVec4Like> (a: Out, b: Out)
      * @static
      */
     public static strictEquals <Out extends IVec4Like> (a: Out, b: Out) {
@@ -601,7 +679,7 @@ export default class Vec4 extends ValueType {
      * !#en Negative error vector floating point approximately equivalent Analyzing
      * @method equals
      * @typescript
-     * public static equals <Out extends IVec4Like> (a: Out, b: Out, epsilon = EPSILON)
+     * equals <Out extends IVec4Like> (a: Out, b: Out, epsilon = EPSILON)
      * @static
      */
     public static equals <Out extends IVec4Like> (a: Out, b: Out, epsilon = EPSILON) {
@@ -616,7 +694,7 @@ export default class Vec4 extends ValueType {
      * !#en Vector transfer array
      * @method toArray
      * @typescript
-     * public static toArray <Out extends IWritableArrayLike<number>> (out: Out, v: IVec4Like, ofs = 0)
+     * toArray <Out extends IWritableArrayLike<number>> (out: Out, v: IVec4Like, ofs = 0)
      * @param ofs 数组起始偏移量
      * @static
      */
@@ -633,7 +711,7 @@ export default class Vec4 extends ValueType {
      * !#en Array steering amount
      * @method fromArray
      * @typescript
-     * public static fromArray <Out extends IVec4Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
+     * fromArray <Out extends IVec4Like> (out: Out, arr: IWritableArrayLike<number>, ofs = 0)
      * @param ofs 数组起始偏移量
      * @static
      */

--- a/cocos2d/core/value-types/vec4.ts
+++ b/cocos2d/core/value-types/vec4.ts
@@ -109,8 +109,8 @@ export default class Vec4 extends ValueType {
      * @param {Vec4} [out] - optional, the receiving vector, you can pass the same vec4 to save result to itself, if not provided, a new vec4 will be created
      * @return {Vec4} the result
      */
-    div (vector: Vec4, out?: Vec4) {
-        return Vec4.divide(out || new Vec4(), this, vector);
+    div (num: number, out?: Vec4): Vec4 {
+        return Vec4.multiplyScalar(out || new Vec4(), this, 1/num);
     }
     /**
      * !#en Multiplies two vectors.

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -1240,7 +1240,7 @@ var ParticleSystem = cc.Class({
     },
 
     _updateMaterial () {
-        let material = this._materials[0];
+        let material = this.getMaterial(0);
         if (!material) return;
         
         material.define('CC_USE_MODEL', this._positionType !== PositionType.FREE);

--- a/cocos2d/renderer/core/base-renderer.js
+++ b/cocos2d/renderer/core/base-renderer.js
@@ -327,7 +327,7 @@ export default class Base {
       // set program
       Object.setPrototypeOf(defines, pass._defines);
 
-      let program = programLib.getProgram(pass._programName, defines, effect._name);
+      let program = programLib.getProgram(pass._programName, defines, effect.name);
       device.setProgram(program);
 
       let uniforms = program._uniforms;

--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -128,6 +128,7 @@ cc.TMXObjectGroupInfo = function () {
     this._color = new cc.Color(255, 255, 255, 255);
     this.offset = cc.v2(0,0);
     this._draworder = 'topdown';
+    this.template = '';
 };
 
 cc.TMXObjectGroupInfo.prototype = {
@@ -1051,6 +1052,12 @@ cc.TMXMapInfo.prototype = {
 
                 // Set the name of the object to the value for "name"
                 objectProp["name"] = selObj.getAttribute('name') || "";
+
+                // Check template exists
+                objectProp["template"] = selObj.getAttribute('template') || '';
+                if (objectProp["template"]) {
+                    cc.log(selGroup)
+                }
 
                 // Assign all the attributes as key/name pairs in the properties dictionary
                 objectProp["width"] = parseFloat(selObj.getAttribute('width')) || 0;

--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -665,6 +665,7 @@ cc.TMXMapInfo.prototype = {
         this.properties.length = 0;
         this._tileProperties = {};
         this._tileAnimations = {};
+        this._tileObjectGroups = {};
 
         // tmp vars
         this.currentString = "";
@@ -847,6 +848,13 @@ cc.TMXMapInfo.prototype = {
                     }
 
                     this._tileProperties[this.parentGID] = getPropertyList(tile);
+                    
+                    let objectGroups = tile.getElementsByTagName('objectgroup');
+                    if (objectGroups && objectGroups.length > 0) {
+                        let objectGroup = objectGroups[0];
+                        this._tileObjectGroups[this.parentGID] = this._parseObjectGroup(objectGroup);
+                    }
+                    
                     let animations = tile.getElementsByTagName('animation');
                     if (animations && animations.length > 0) {
                         let animation = animations[0];
@@ -1147,6 +1155,22 @@ cc.TMXMapInfo.prototype = {
      */
     getTileAnimations () {
         return this._tileAnimations;
+    },
+
+    /**
+     * Sets the tile objectGroup.
+     * @return {Object}
+     */
+    setTileObjectGroups (objectGroups) {
+        this._tileObjectGroups = objectGroups;
+    },
+
+    /**
+     * Gets the tile objectGroup.
+     * @return {Object}
+     */
+    getTileObjectGroups () {
+        return this._tileObjectGroups;
     },
 
     /**

--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -1110,6 +1110,12 @@ cc.TMXMapInfo.prototype = {
                 // Add the object to the objectGroup
                 objectGroup._objects.push(objectProp);
             }
+
+            if (draworder !== 'index') {
+                objectGroup._objects.sort(function (a, b) {
+                    return a.y - b.y;
+                });
+            }
         }
         return objectGroup;
     },

--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -1084,7 +1084,7 @@ cc.TMXMapInfo.prototype = {
 
         // Check template exists
         var txName = objectProp["template"] = selObj.getAttribute('template') || '';
-        if (objectProp["template"]) {
+        if (txName) {
             let txXmlString = this._txMap[txName];
             if (txXmlString) {
                 let mapXML = this._parser._parseXML(txXmlString);

--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -267,6 +267,7 @@ let TiledLayer = cc.Class({
         let self = dataComp._tiledLayer;
         self._nodeLocalPosToLayerPos(node, _vec2_temp);
         self._positionToRowCol(_vec2_temp.x, _vec2_temp.y, _tempRowCol);
+        self._limitInLayer(_tempRowCol);
         // users pos not change
         if (_tempRowCol.row === dataComp._row && _tempRowCol.col === dataComp._col) return;
 
@@ -297,27 +298,26 @@ let TiledLayer = cc.Class({
         this._userNodeDirty = true;
     },
 
-    _isInLayer (row, col) {
-        return row >= 0 && col >= 0 && row <= this._rightTop.row && col <= this._rightTop.col;
+    _limitInLayer (rowCol) {
+        let row = rowCol.row;
+        let col = rowCol.col;
+        if (row < 0) rowCol.row = 0;
+        if (row > this._rightTop.row) rowCol.row = this._rightTop.row;
+        if (col < 0) rowCol.col = 0;
+        if (col > this._rightTop.col) rowCol.col = this._rightTop.col;
     },
 
     _addUserNodeToGrid (dataComp, tempRowCol) {
         let row = tempRowCol.row;
         let col = tempRowCol.col;
-        if (this._isInLayer(row, col)) {
-            let rowData = this._userNodeGrid[row] = this._userNodeGrid[row] || {count : 0};
-            let colData = rowData[col] = rowData[col] || {count : 0, list: []};
-            dataComp._row = row;
-            dataComp._col = col;
-            dataComp._index = colData.list.length;
-            rowData.count++;
-            colData.count++;
-            colData.list.push(dataComp);
-        } else {
-            dataComp._row = -1;
-            dataComp._col = -1;
-            dataComp._index = -1;
-        }
+        let rowData = this._userNodeGrid[row] = this._userNodeGrid[row] || {count : 0};
+        let colData = rowData[col] = rowData[col] || {count : 0, list: []};
+        dataComp._row = row;
+        dataComp._col = col;
+        dataComp._index = colData.list.length;
+        rowData.count++;
+        colData.count++;
+        colData.list.push(dataComp);
         this._userNodeDirty = true;
     },
 

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -395,7 +395,7 @@ let TiledMap = cc.Class({
         return this._tileObjectGroups[gid];
     },
 
-    getTileObjectGroups(gid) {
+    getTileObjectGroups() {
         return this._tileObjectGroups;
     },
 

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -391,6 +391,14 @@ let TiledMap = cc.Class({
         return this._groups;
     },
 
+    getTileObjectGroupForGID(gid) {
+        return this._tileObjectGroups[gid];
+    },
+
+    getTileObjectGroups(gid) {
+        return this._tileObjectGroups;
+    },
+
     /**
      * !#en Return the TMXObjectGroup for the specific group.
      * !#zh 获取指定的 TMXObjectGroup。
@@ -761,6 +769,7 @@ let TiledMap = cc.Class({
         this._mapOrientation = mapInfo.orientation;
         this._properties = mapInfo.properties;
         this._tileProperties = mapInfo.getTileProperties();
+        this._tileObjectGroups = mapInfo.getTileObjectGroups();
         this._imageLayers = mapInfo.getImageLayers();
         this._animations = mapInfo.getTileAnimations();
         this._tilesets = mapInfo.getTilesets();

--- a/cocos2d/tilemap/CCTiledMap.js
+++ b/cocos2d/tilemap/CCTiledMap.js
@@ -569,7 +569,16 @@ let TiledMap = cc.Class({
                 }
             }
 
-            let mapInfo = new cc.TMXMapInfo(file.tmxXmlStr, tsxMap, textures, textureSizes, imageLayerTextures);
+            let txFileNames = file.txFileNames;
+            let txFiles = file.txFiles;
+            let txMap = {};
+            for (let i = 0; i < txFileNames.length; ++i) {
+                if (txFileNames[i].length > 0) {
+                    txMap[txFileNames[i]] = txFiles[i]._nativeAsset;
+                }
+            }
+
+            let mapInfo = new cc.TMXMapInfo(file.tmxXmlStr, tsxMap, txMap, textures, textureSizes, imageLayerTextures);
             let tilesets = mapInfo.getTilesets();
             if(!tilesets || tilesets.length === 0)
                 cc.logID(7241);

--- a/cocos2d/tilemap/CCTiledMapAsset.js
+++ b/cocos2d/tilemap/CCTiledMapAsset.js
@@ -73,6 +73,9 @@ let TiledMapAsset = cc.Class({
 
         tsxFiles: [cc.TextAsset],
         tsxFileNames: [cc.String],
+
+        txFiles: [cc.TextAsset],
+        txFileNames: [cc.String],
     },
 
     statics: {

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -122,6 +122,8 @@ let TiledObjectGroup = cc.Class({
         const StaggerAxis = TiledMap.StaggerAxis;
         const TileFlag = TiledMap.TileFlag;
         const FLIPPED_MASK = TileFlag.FLIPPED_MASK;
+        const FLAG_HORIZONTAL = TileFlag.HORIZONTAL;
+        const FLAG_VERTICAL = TileFlag.VERTICAL;
 
         this._groupName = groupInfo.name;
         this._positionOffset = groupInfo.offset;
@@ -156,7 +158,7 @@ let TiledObjectGroup = cc.Class({
 
         let objects = groupInfo._objects;
         let aliveNodes = {};
-        for (let i = 0, childIdx = objects.length - 1, l = objects.length; i < l; i++, childIdx--) {
+        for (let i = 0, l = objects.length; i < l; i++) {
             let object = objects[i];
             let objType = object.type;
             object.offset = cc.v2(object.x, object.y);
@@ -171,7 +173,7 @@ let TiledObjectGroup = cc.Class({
             if (Orientation.ISO !== mapInfo.orientation) {
                 object.y = height - object.y;
             } else {
-                let posIdxX = object.x / tileSize.width * 2;
+                let posIdxX = object.x / tileSize.height;
                 let posIdxY = object.y / tileSize.height;
                 object.x = tileSize.width * 0.5 * (mapSize.height + posIdxX - posIdxY);
                 object.y = tileSize.height * 0.5 * (mapSize.width + mapSize.height - posIdxX - posIdxY);
@@ -195,7 +197,7 @@ let TiledObjectGroup = cc.Class({
                 textNode.parent = this.node;
                 textNode.color = object.color;
                 textNode.opacity = this._opacity;
-                textNode.setSiblingIndex(childIdx);
+                textNode.setSiblingIndex(i);
 
                 let label = textNode.getComponent(cc.Label);
                 if (!label) {
@@ -214,7 +216,8 @@ let TiledObjectGroup = cc.Class({
             }
 
             if (objType === TMXObjectType.IMAGE) {
-                let grid = texGrids[(object.gid & FLIPPED_MASK) >>> 0];
+                let gid = object.gid;
+                let grid = texGrids[(gid & FLIPPED_MASK) >>> 0];
                 if (!grid) continue;
                 let tileset = grid.tileset;
                 let imgName = "img" + object.id;
@@ -250,7 +253,7 @@ let TiledObjectGroup = cc.Class({
                 imgNode.name = imgName;
                 imgNode.parent = this.node;
                 imgNode.opacity = this._opacity;
-                imgNode.setSiblingIndex(childIdx);
+                imgNode.setSiblingIndex(i);
 
                 let sp = imgNode.getComponent(cc.Sprite);
                 if (!sp) {
@@ -260,8 +263,22 @@ let TiledObjectGroup = cc.Class({
                 if (!spf) {
                     spf = new cc.SpriteFrame();
                 }
+
+                if ((gid & FLAG_HORIZONTAL) >>> 0) {
+                    spf.setFlipX(true);
+                } else {
+                    spf.setFlipX(false);
+                }
+
+                if ((gid & FLAG_VERTICAL) >>> 0) {
+                    spf.setFlipY(true);
+                } else {
+                    spf.setFlipY(false);
+                }
+
                 spf.setTexture(grid.tileset.sourceImage, cc.rect(grid));
                 sp.spriteFrame = spf;
+                sp.setVertsDirty();
 
                 // object group may has no width or height info
                 imgNode.width = imgWidth;

--- a/cocos2d/tilemap/editor/tiled-map.js
+++ b/cocos2d/tilemap/editor/tiled-map.js
@@ -70,7 +70,17 @@ async function searchDependFiles(tmxFile, tmxFileData, cb) {
     }
   }
 
-  async function parseObjectGroupTx(parent, tsxPath) {
+  function parseTilesetObjectGroup(tilesetNode, sourcePath) {
+    var tiles = tilesetNode.getElementsByTagName('tile');
+    if(tiles && tiles.length > 0) {        
+      // iterate tiles
+      for (var i = 0, n = tiles.length; i < n; i++) {
+        parseObjectGroupTx(tiles[i], sourcePath);
+      }
+    }
+  }
+
+  function parseObjectGroupTx(parent, tsxPath) {
     // check objectGroup existed
     var groups = parent.getElementsByTagName('objectgroup');
     if(!(groups && groups.length > 0)) {
@@ -87,8 +97,10 @@ async function searchDependFiles(tmxFile, tmxFileData, cb) {
           var txPath = Path.join(Path.dirname(tsxPath), objectTemplate);
           if(Fs.existsSync(txPath)) {
             txFiles.push(objectTemplate);
+          } else {
+            Editor.warn('Parse %s failed.', txPath);
           }
-        }
+        } 
       }
     }
   }
@@ -107,13 +119,7 @@ async function searchDependFiles(tmxFile, tmxFileData, cb) {
         var tsxDoc = new DOMParser().parseFromString(tsxContent);
         if (tsxDoc) {
           await parseTilesetImages(tsxDoc, tsxPath);
-          var tiles = tsxDoc.getElementsByTagName('tile');
-          if(tiles && tiles.length > 0) {        
-            // iterate tiles
-            for (var iii = 0, nnn = tiles.length; iii < nnn; iii++) {
-              await parseObjectGroupTx(tiles[iii], tsxPath);
-            }
-          }
+          parseTilesetObjectGroup(tsxDoc, tsxPath);
         } else {
           Editor.warn('Parse %s failed.', tsxPath);
         }
@@ -122,6 +128,7 @@ async function searchDependFiles(tmxFile, tmxFileData, cb) {
 
     // import images
     await parseTilesetImages(tileset, tmxFile);
+    parseTilesetObjectGroup(tileset, tmxFile);
   }
 
   var imageLayerElements = rootElement.getElementsByTagName('imagelayer');

--- a/cocos2d/tilemap/editor/tiled-map.js
+++ b/cocos2d/tilemap/editor/tiled-map.js
@@ -161,7 +161,7 @@ class TiledMapMeta extends CustomAssetMeta {
     this._imageLayerTextureNames = [];
   }
 
-  static version () { return '2.0.3'; }
+  static version () { return '2.0.4'; }
   static defaultType() { return 'tiled-map'; }
 
   import (fspath, cb) {

--- a/cocos2d/tilemap/editor/tiled-map.js
+++ b/cocos2d/tilemap/editor/tiled-map.js
@@ -45,6 +45,7 @@ async function searchDependFiles(tmxFile, tmxFileData, cb) {
   var imageLayerTextureNames = [];
   var textures = [];
   var tsxFiles = [];
+  var txFiles = [];
   var textureNames = [];
   var textureSizes = [];
   async function parseTilesetImages(tilesetNode, sourcePath) {
@@ -69,6 +70,29 @@ async function searchDependFiles(tmxFile, tmxFileData, cb) {
     }
   }
 
+  async function parseObjectGroupTx(parent, tsxPath) {
+    // check objectGroup existed
+    var groups = parent.getElementsByTagName('objectgroup');
+    if(!(groups && groups.length > 0)) {
+      return;
+    }
+    for(var i = 0, n = groups.length; i < n; i++) {
+      var objects = groups[i].getElementsByTagName('object');
+      if(!(objects && objects.length > 0)) continue;
+      // check template, if existed, push
+      for(var ii = 0, nn = objects.length; ii < nn; ii++) {
+        var object = objects[ii];
+        var objectTemplate = object.getAttribute('template');
+        if(objectTemplate) {
+          var txPath = Path.join(Path.dirname(tsxPath), objectTemplate);
+          if(Fs.existsSync(txPath)) {
+            txFiles.push(objectTemplate);
+          }
+        }
+      }
+    }
+  }
+
   var rootElement = doc.documentElement;
   var tilesetElements = rootElement.getElementsByTagName('tileset');
   for (var i = 0, n = tilesetElements.length; i < n; i++) {
@@ -83,6 +107,13 @@ async function searchDependFiles(tmxFile, tmxFileData, cb) {
         var tsxDoc = new DOMParser().parseFromString(tsxContent);
         if (tsxDoc) {
           await parseTilesetImages(tsxDoc, tsxPath);
+          var tiles = tsxDoc.getElementsByTagName('tile');
+          if(tiles && tiles.length > 0) {        
+            // iterate tiles
+            for (var iii = 0, nnn = tiles.length; iii < nnn; iii++) {
+              await parseObjectGroupTx(tiles[iii], tsxPath);
+            }
+          }
         } else {
           Editor.warn('Parse %s failed.', tsxPath);
         }
@@ -112,7 +143,7 @@ async function searchDependFiles(tmxFile, tmxFileData, cb) {
     }
   }
 
-  cb(null, { textures, tsxFiles, textureNames, textureSizes, imageLayerTextures, imageLayerTextureNames});
+  cb(null, { textures, tsxFiles, txFiles, textureNames, textureSizes, imageLayerTextures, imageLayerTextureNames});
 }
 
 const AssetRootUrl = 'db://assets/';
@@ -123,6 +154,7 @@ class TiledMapMeta extends CustomAssetMeta {
     this._tmxData = '';
     this._textures = [];
     this._tsxFiles = [];
+    this._txFiles = [];
     this._textureNames = [];
     this._textureSizes = [];
     this._imageLayerTextures = [];
@@ -146,6 +178,7 @@ class TiledMapMeta extends CustomAssetMeta {
 
         this._textures = info.textures;
         this._tsxFiles = info.tsxFiles;
+        this._txFiles = info.txFiles;
         this._textureNames = info.textureNames;
         this._textureSizes = info.textureSizes;
         this._imageLayerTextures = info.imageLayerTextures;
@@ -186,6 +219,19 @@ class TiledMapMeta extends CustomAssetMeta {
         }
         return null;
     });
+
+    asset.txFiles = this._txFiles.map(p => {
+        var txPath = Path.join(Path.dirname(fspath), p);
+        var uuid = db.fspathToUuid(txPath);
+        if (uuid) {
+            asset.txFileNames.push(p);
+            return Editor.serialize.asAsset(uuid);
+        } else {
+            Editor.error(`Can not find file ${txPath}`);
+            asset.txFileNames.push('');
+        }
+        return null;
+    })
     db.saveAssetToLibrary(this.uuid, asset);
     cb();
   }

--- a/extensions/dragonbones/ArmatureDisplay.js
+++ b/extensions/dragonbones/ArmatureDisplay.js
@@ -279,6 +279,13 @@ let ArmatureDisplay = cc.Class({
             default: 0,
             type: AnimationCacheMode,
             notify () {
+                if (this._defaultCacheMode !== AnimationCacheMode.REALTIME) {
+                    if (this._armature && !ArmatureCache.canCache(this._armature)) {
+                        this._defaultCacheMode = AnimationCacheMode.REALTIME;
+                        cc.warn("Animation cache mode doesn't support skeletal nesting");
+                        return;
+                    }
+                }
                 this.setAnimationCacheMode(this._defaultCacheMode);
             },
             editorOnly: true,
@@ -739,7 +746,7 @@ let ArmatureDisplay = cc.Class({
     },
 
     _updateCacheModeEnum: CC_EDITOR && function () {
-        if (this._armature && ArmatureCache.canCache(this._armature)) {
+        if (this._armature) {
             setEnumAttr(this, '_defaultCacheMode', AnimationCacheMode);
         } else {
             setEnumAttr(this, '_defaultCacheMode', DefaultCacheMode);

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var _global = typeof window === 'undefined' ? global : window;
 _global.cc = _global.cc || {};
 
 // For internal usage
-_global._cc = _global._cc || {};
+cc.internal = cc.internal || {};
 
 require('./predefine');
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 在CCTMXXMLParser 添加Tile的objectGroups的解析(原本用于碰撞检测)
 * 在TiledMap上暴露接口。
 * 支持objectGroups 模板文件.tx解析。

提出个疑问，目前我想把tile的objectGroup自动构建为Collider，但是layer的渲染是通过Material来做的，如果我想绑定Collider该怎么做？
