### PR TITLE
fix audio can't be destroyed

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -326,11 +326,11 @@ Audio.State = {
             }
             else {
                 this._src = null;
-                if (this._element instanceof HTMLAudioElement) {
-                    this._element.src = '';
+                if (this._element instanceof WebAudioElement) {
+                    this._element = null;
                 }
                 else {
-                    this._element = null;
+                    this._element.src = '';
                 }
                 this._state = Audio.State.INITIALZING;
             }


### PR DESCRIPTION
changeLog:
- 修复小游戏平台 audio 没有被destroy 的问题


`this._element instanceof HTMLAudioElement` 这个判断出问题了