### PR TITLE
fix widget invalid when the native canvas-resize

### DIFF
--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -464,7 +464,7 @@ var widgetManager = cc._widgetManager = module.exports = {
             cc.engine.on('design-resolution-changed', this.onResized.bind(this));
         }
         else {
-            if (cc.sys.isMobile) {
+            if (cc.sys.isBrowser) {
                 let thisOnResized = this.onResized.bind(this);
                 window.addEventListener('resize', thisOnResized);
                 window.addEventListener('orientationchange', thisOnResized);

--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -464,7 +464,7 @@ var widgetManager = cc._widgetManager = module.exports = {
             cc.engine.on('design-resolution-changed', this.onResized.bind(this));
         }
         else {
-            if (cc.sys.isBrowser) {
+            if (cc.sys.isBrowser && cc.sys.isMobile) {
                 let thisOnResized = this.onResized.bind(this);
                 window.addEventListener('resize', thisOnResized);
                 window.addEventListener('orientationchange', thisOnResized);


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 native 出发 canvas-resize 时，widget 无效的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
