### PR TITLE
Fix the reset of childArrivalOrder.

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -3652,7 +3652,8 @@ let NodeDefines = {
 
             // delay update arrivalOrder before sort children
             var _children = this._children, child;
-            this._parent && (this._parent._childArrivalOrder = 1);
+            // reset arrivalOrder before sort children
+            this._childArrivalOrder = 1;
             for (let i = 0, len = _children.length; i < len; i++) {
                 child = _children[i];
                 child._updateOrderOfArrival();


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/6225

@大城小胖 反馈并排查的childArrivalOrder重置问题，之前简化childArrivalOrder计算时，对子节点进行重排时，应该重置当前节点的childArrivalOrder，而不是父节点的childArrivalOrder。
