### PR TITLE
refine editBox updateMatrix

### DIFF
--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -149,7 +149,7 @@ Object.assign(WebEditBoxImpl.prototype, {
     },
 
     update () {
-        this._updateMatrix();
+        // do nothing...
     },
 
     setTabIndex (index) {
@@ -212,6 +212,7 @@ Object.assign(WebEditBoxImpl.prototype, {
     },
 
     _showDom () {
+        this._updateMatrix();
         this._updateMaxLength();
         this._updateInputType();
         this._updateStyleSheet();


### PR DESCRIPTION
changeLog:
- 修复 canvas 组建 fitWidth 情况下，editBox 输入框错位的问题
相关论坛反馈：
https://forum.cocos.org/t/cocos-creator-v2-3-1-rc-1/89099/42?u=endevil


优化 editBox updateMatrix , 只有 showDom 的时候才去更新
之前的问题是屏幕适配之前就 updateMatrix 了，导致 cc.view._scaleX 和 cc.view._scaleY 不正确