### PR TITLE
optimize 2d particle

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -105,10 +105,11 @@ var PositionType = cc.Enum({
 
     /**
      * !#en
-     * Living particles are attached to the world but will follow the emitter repositioning.<br/>
-     * Use case: Attach an emitter to an sprite, and you want that the emitter follows the sprite.
+     * In the relative mode, the particle will move with the parent node, but not with the node where the particle is. 
+     * For example, in a moving train, the coffee in the cup lifts the fog, and the cup moves, the whole fog will not move with the cup, but from the point of view of the train, the whole fog will move with the train.
      * !#zh
-     * 相对模式，粒子会随父节点移动而移动，可用于制作移动角色身上的特效等等。（该选项在 Creator 中暂时不支持）
+     * 相对模式，粒子会跟随父节点移动，但不跟随粒子所在节点移动，例如在一列行进火车中，杯中的咖啡飘起雾气，
+     * 杯子移动，雾气整体并不会随着杯子移动，但从火车整体的角度来看，雾气整体会随着火车移动。
      * @property {Number} RELATIVE
      */
     RELATIVE: 1,

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -106,7 +106,7 @@ var PositionType = cc.Enum({
     /**
      * !#en
      * In the relative mode, the particle will move with the parent node, but not with the node where the particle is. 
-     * For example, in a moving train, the coffee in the cup lifts the fog, and the cup moves, the whole fog will not move with the cup, but from the point of view of the train, the whole fog will move with the train.
+     * For example, the coffee in the cup is steaming. Then the steam moves (forward) with the train, rather than moves with the cup.
      * !#zh
      * 相对模式，粒子会跟随父节点移动，但不跟随粒子所在节点移动，例如在一列行进火车中，杯中的咖啡飘起雾气，
      * 杯子移动，雾气整体并不会随着杯子移动，但从火车整体的角度来看，雾气整体会随着火车移动。

--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -28,8 +28,6 @@ const js = require('../core/platform/js');
 const misc = require('../core/utils/misc');
 
 const ZERO_VEC2 = cc.v2(0, 0);
-
-let _trans = AffineTrans.create();
 let _pos = cc.v2();
 let _tpa = cc.v2();
 let _tpb = cc.v2();
@@ -94,6 +92,7 @@ let Simulator = function (system) {
     this.elapsed = 0;
     this.emitCounter = 0;
     this._uvFilled = 0;
+    this._worldRotation = 0;
 }
 
 Simulator.prototype.stop = function () {
@@ -170,9 +169,7 @@ Simulator.prototype.emitParticle = function (pos) {
     particle.aspectRatio = psys._aspectRatio || 1;
 
     // direction
-    let worldRotation = getWorldRotation(psys.node);
-    let relAngle = psys.positionType === cc.ParticleSystem.PositionType.FREE ? psys.angle + worldRotation : psys.angle;
-    let a = misc.degreesToRadians(relAngle + psys.angleVar * (Math.random() - 0.5) * 2);
+    let a = misc.degreesToRadians( psys.angle + this._worldRotation + psys.angleVar * (Math.random() - 0.5) * 2);
     // Mode Gravity: A
     if (psys.emitterMode === cc.ParticleSystem.EmitterMode.GRAVITY) {
         let s = psys.speed + psys.speedVar * (Math.random() - 0.5) * 2;
@@ -200,6 +197,7 @@ Simulator.prototype.emitParticle = function (pos) {
         particle.degreesPerSecond = misc.degreesToRadians(psys.rotatePerS + psys.rotatePerSVar * (Math.random() - 0.5) * 2);
     }
 };
+
 // In the Free mode to get emit real rotation in the world coordinate.
 function getWorldRotation (node) {
     let rotation = 0;
@@ -296,27 +294,22 @@ Simulator.prototype.step = function (dt) {
     let node = psys.node;
     let particles = this.particles;
     const FLOAT_PER_PARTICLE = 4 * this.sys._assembler._vfmt._bytes / 4;
+    const PositionType = cc.ParticleSystem.PositionType;
 
     // Calculate pos
     node._updateWorldMatrix();
-    _trans = AffineTrans.identity();
-    if (psys.positionType === cc.ParticleSystem.PositionType.FREE) {
+    if (psys.positionType === PositionType.FREE) {
+        this._worldRotation = getWorldRotation(node);
         let m =  node._worldMatrix.m;
-        _trans.tx = m[12];
-        _trans.ty = m[13];
-        AffineTrans.transformVec2(_pos, ZERO_VEC2, _trans);
-    } else if (psys.positionType === cc.ParticleSystem.PositionType.RELATIVE) {
-        let angle = misc.degreesToRadians(-node.angle);
-        let cos = Math.cos(angle);
-        let sin = Math.sin(angle);
-        _trans = AffineTrans.create(cos, -sin, sin, cos, 0, 0);
+        _pos.x = m[12];
+        _pos.y = m[13];
+    } else if (psys.positionType === PositionType.RELATIVE) {
+        this._worldRotation = node.angle;
         _pos.x = node.x;
         _pos.y = node.y;
+    } else {
+        this._worldRotation = 0;
     }
-
-    // Get world to node trans only once
-    AffineTrans.invert(_trans, _trans);
-    let worldToNodeTrans = _trans;
 
     // Emission
     if (this.active && psys.emissionRate) {
@@ -414,24 +407,9 @@ Simulator.prototype.step = function (dt) {
 
             // update values in quad buffer
             let newPos = _tpa;
-            let diff = _tpb;
-            if (psys.positionType === cc.ParticleSystem.PositionType.FREE) {
-                diff.set(particle.startPos);
-                diff.negSelf();  // Unify direction with other positionType
-                newPos.set(particle.pos);
-                newPos.subSelf(diff);
-            }
-            else if (psys.positionType === cc.ParticleSystem.PositionType.RELATIVE) {
-                let startPos = _tpc;
-                // current Position convert To Node Space
-                AffineTrans.transformVec2(diff, _pos, worldToNodeTrans);
-                // start Position convert To Node Space
-                AffineTrans.transformVec2(startPos, particle.startPos, worldToNodeTrans);
-                diff.subSelf(startPos);
-                newPos.set(particle.pos);
-                newPos.subSelf(diff);
-            } else {
-                newPos.set(particle.pos);
+            newPos.set(particle.pos);
+            if (psys.positionType !== PositionType.GROUPED) {
+                newPos.addSelf(particle.startPos);
             }
 
             let offset = FLOAT_PER_PARTICLE * particleIdx;

--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -23,7 +23,6 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-const AffineTrans = require('../core/utils/affine-transform');
 const js = require('../core/platform/js');
 const misc = require('../core/utils/misc');
 

--- a/cocos2d/particle/particle-system-assembler.js
+++ b/cocos2d/particle/particle-system-assembler.js
@@ -59,7 +59,15 @@ class ParticleAssembler extends Assembler {
     fillBuffers (comp, renderer) {
         if (!this._ia) return;
         
-        renderer.node = comp.node;
+        const PositionType = cc.ParticleSystem.PositionType;
+        let pt = comp.positionType;
+        let node = comp.node;
+        if (pt == PositionType.RELATIVE) {
+            let parent = node.parent;
+            renderer.node = parent;
+        } else {
+            renderer.node = node;
+        }
         renderer.material = comp._materials[0];
         renderer._flushIA(this._ia);
     }

--- a/cocos2d/particle/particle-system-assembler.js
+++ b/cocos2d/particle/particle-system-assembler.js
@@ -60,12 +60,10 @@ class ParticleAssembler extends Assembler {
         if (!this._ia) return;
         
         const PositionType = cc.ParticleSystem.PositionType;
-        let node = comp.node;
         if (comp.positionType === PositionType.RELATIVE) {
-            let parent = node.parent;
-            renderer.node = parent;
+            renderer.node = comp.node.parent;
         } else {
-            renderer.node = node;
+            renderer.node = comp.node;
         }
         renderer.material = comp._materials[0];
         renderer._flushIA(this._ia);

--- a/cocos2d/particle/particle-system-assembler.js
+++ b/cocos2d/particle/particle-system-assembler.js
@@ -60,9 +60,8 @@ class ParticleAssembler extends Assembler {
         if (!this._ia) return;
         
         const PositionType = cc.ParticleSystem.PositionType;
-        let pt = comp.positionType;
         let node = comp.node;
-        if (pt == PositionType.RELATIVE) {
+        if (comp.positionType === PositionType.RELATIVE) {
             let parent = node.parent;
             renderer.node = parent;
         } else {


### PR DESCRIPTION
修复relative模式，当前节点旋转时，粒子会跟随的bug
优化free算法，每个节点worldrotation每帧只需计算一次，之前的算法有漏洞，每个发射出去粒子都去算一次，有100个，就计算100次。。。。
优化relative算法，传递父节点的世界矩阵，然后用当前节点的local rotation和local position，去初始化粒子，这样就不用cpu计算当前节点的逆矩阵，也不用挨个粒子去乘以逆矩阵，不仅效率低，还有误差。

关联pr：https://github.com/cocos-creator/cocos2d-x-lite/pull/2196
https://github.com/cocos-creator-packages/jsb-adapter/pull/253
