### PR TITLE
Catch common target initialization error

### DIFF
--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -34,9 +34,10 @@ import { AnimationClip, IRuntimeCurve } from './animation-clip';
 import { AnimationComponent } from './animation-component';
 import { AnimCurve, RatioSampler } from './animation-curve';
 import { additive3D, additiveQuat, BlendFunction } from './blending';
-import { BoundTarget, BufferedTarget } from './bound-target';
+import { createBoundTarget, createBufferedTarget, IBufferedTarget, IBoundTarget } from './bound-target';
 import { Playable } from './playable';
 import { WrapMode, WrapModeMask, WrappedInfo } from './types';
+import { error } from '../platform/debug';
 
 enum PropertySpecialization {
     NodePosition,
@@ -49,7 +50,7 @@ export class ICurveInstance {
     public commonTargetIndex?: number;
 
     private _curve: AnimCurve;
-    private _boundTarget: BoundTarget;
+    private _boundTarget: IBoundTarget;
     private _rootTarget: any;
     private _rootTargetProperty?: string;
     private _isNodeTarget: boolean;
@@ -62,16 +63,12 @@ export class ICurveInstance {
     constructor (
         runtimeCurve: Omit<IRuntimeCurve, 'sampler'>,
         target: any,
+        boundTarget: IBoundTarget,
         blendTarget: PropertyBlendState | null = null) {
         this._curve = runtimeCurve.curve;
         this._curveDetail = runtimeCurve;
 
-        this._boundTarget = new BoundTarget(
-            target,
-            runtimeCurve.modifiers,
-            runtimeCurve.valueAdapter,
-        );
-
+        this._boundTarget = boundTarget;
         this._rootTarget = target;
         this._isNodeTarget = target instanceof Node;
         this._propertySpecialization = PropertySpecialization.None;
@@ -359,8 +356,12 @@ export class AnimationState extends Playable {
     protected _name: string;
     protected _lastIterations?: number;
     protected _samplerSharedGroups: ISamplerSharedGroup[] = [];
-    protected _commonTargetStatuses: Array<{
-        target: BufferedTarget;
+
+    /**
+     * May be `null` due to failed to initialize.
+     */
+    protected _commonTargetStatuses: Array<null | {
+        target: IBufferedTarget;
         changed: boolean;
     }> = [];
     protected _curveLoaded = false;
@@ -395,10 +396,15 @@ export class AnimationState extends Playable {
         }
 
         this._commonTargetStatuses = clip.commonTargets.map((commonTarget, index) => {
-            return {
-                target: new BufferedTarget(root, commonTarget.modifiers, commonTarget.valueAdapter),
-                changed: false,
-            };
+            const target = createBufferedTarget(root, commonTarget.modifiers, commonTarget.valueAdapter);
+            if (target === null) {
+                return null;
+            } else {
+                return {
+                    target,
+                    changed: false,
+                };
+            }
         });
 
         if (!propertyCurves) {
@@ -412,17 +418,28 @@ export class AnimationState extends Playable {
                 this._samplerSharedGroups.push(samplerSharedGroup);
             }
 
-            try {
+            let rootTarget: any = undefined;
+            if (typeof propertyCurve.commonTarget === 'undefined') {
+                rootTarget = root;
+            } else {
+                const commonTargetStatus = this._commonTargetStatuses[propertyCurve.commonTarget];
+                if (!commonTargetStatus) {
+                    continue;
+                }
+                rootTarget = commonTargetStatus.target.peek();
+            }
+
+            const boundTarget = createBoundTarget(rootTarget, propertyCurve.modifiers, propertyCurve.valueAdapter);
+            if (boundTarget === null) {
+                // warn(`Failed to bind "${root.name}" to curve in clip ${clip.name}: ${err}`);
+            } else {
                 const curveInstance = new ICurveInstance(
                     propertyCurve,
-                    (typeof propertyCurve.commonTarget === 'number') ?
-                        this._commonTargetStatuses[propertyCurve.commonTarget].target.peek() :
-                        root,
+                    rootTarget,
+                    boundTarget,
                 );
                 curveInstance.commonTargetIndex = propertyCurve.commonTarget;
                 samplerSharedGroup.curves.push(curveInstance);
-            } catch (err) {
-                // warn(`Failed to bind "${root.name}" to curve in clip ${clip.name}: ${err}`);
             }
         }
     }
@@ -721,9 +738,12 @@ export class AnimationState extends Playable {
     protected _sampleCurves (ratio: number) {
         // Before we sample, we pull values of common targets.
         for (let iCommonTarget = 0; iCommonTarget < this._commonTargetStatuses.length; ++iCommonTarget) {
-            const commonTarget = this._commonTargetStatuses[iCommonTarget];
-            commonTarget.target.pull();
-            commonTarget.changed = false;
+            const commonTargetStatus = this._commonTargetStatuses[iCommonTarget];
+            if (!commonTargetStatus) {
+                continue;
+            }
+            commonTargetStatus.target.pull();
+            commonTargetStatus.changed = false;
         }
 
         for (let iSamplerSharedGroup = 0, szSamplerSharedGroup = this._samplerSharedGroups.length;
@@ -766,6 +786,9 @@ export class AnimationState extends Playable {
         // After sample, we push values of common targets.
         for (let iCommonTarget = 0; iCommonTarget < this._commonTargetStatuses.length; ++iCommonTarget) {
             const commonTargetStatus = this._commonTargetStatuses[iCommonTarget];
+            if (!commonTargetStatus) {
+                continue;
+            }
             if (commonTargetStatus.changed) {
                 commonTargetStatus.target.push();
             }

--- a/cocos/core/animation/bound-target.ts
+++ b/cocos/core/animation/bound-target.ts
@@ -3,103 +3,118 @@
  */
 
 import { Color, Vec2, Vec3, Vec4 } from '../math';
-import { isPropertyPath, PropertyPath, TargetPath } from './target-path';
 import { IValueProxy, IValueProxyFactory } from './value-proxy';
+import { isPropertyPath, PropertyPath, TargetPath } from './target-path';
+import { error } from '../platform/debug';
 
-export class BoundTarget {
-    protected _ap: {
+export interface IBoundTarget {
+    setValue (value: any): void;
+    getValue (): any;
+}
+
+export interface IBufferedTarget extends IBoundTarget {
+    peek(): any;
+    pull(): void;
+    push(): void;
+}
+
+export function createBoundTarget (target: any, modifiers: TargetPath[], valueAdapter?: IValueProxyFactory): null | IBoundTarget {
+    let ap: {
         isProxy: false;
-        object: any,
-        property: PropertyPath,
+        object: any;
+        property: PropertyPath;
     } | {
         isProxy: true;
         proxy: IValueProxy;
     };
-
-    constructor (target: any, modifiers: TargetPath[], valueAdapter?: IValueProxyFactory) {
-        let assignmentModifier: PropertyPath | undefined;
-        for (let iModifier = 0; iModifier < modifiers.length; ++iModifier) {
-            const modifier = modifiers[iModifier];
-            if (isPropertyPath(modifier)) {
-                if (iModifier !== modifiers.length - 1 || valueAdapter) {
-                    if (modifier in target) {
-                        target = target[modifier];
-                    } else {
-                        throw new Error(`Target object has no property "${modifier}"`);
-                    }
+    let assignmentModifier: PropertyPath | undefined;
+    for (let iModifier = 0; iModifier < modifiers.length; ++iModifier) {
+        const modifier = modifiers[iModifier];
+        if (isPropertyPath(modifier)) {
+            if (iModifier !== modifiers.length - 1 || valueAdapter) {
+                if (modifier in target) {
+                    target = target[modifier];
                 } else {
-                    assignmentModifier = modifier;
+                    error(`Target object has no property "${modifier}"`);
+                    return null;
                 }
             } else {
-                target = modifier.get(target);
+                assignmentModifier = modifier;
+            }
+        } else {
+            target = modifier.get(target);
+            if (target === null) {
+                return null;
             }
         }
-
-        if (assignmentModifier !== undefined) {
-            this._ap = {
-                isProxy: false,
-                object: target,
-                property: assignmentModifier,
-            };
-        } else if (valueAdapter) {
-            this._ap = {
-                isProxy: true,
-                proxy: valueAdapter.forTarget(target),
-            };
-        } else {
-            throw new Error(`Bad animation curve.`);
-        }
     }
 
-    public setValue (value: any) {
-        if (this._ap.isProxy) {
-            this._ap.proxy.set(value);
-        } else {
-            this._ap.object[this._ap.property] = value;
-        }
+    if (assignmentModifier !== undefined) {
+        ap = {
+            isProxy: false,
+            object: target,
+            property: assignmentModifier,
+        };
+    } else if (valueAdapter) {
+        ap = {
+            isProxy: true,
+            proxy: valueAdapter.forTarget(target),
+        };
+    } else {
+        error(`Bad animation curve.`);
+        return null;
     }
 
-    protected getValue () {
-        if (this._ap.isProxy) {
-            if (!this._ap.proxy.get) {
-                throw new Error(`Target doesn't provide a get method.`);
+    return {
+        setValue: (value) => {
+            if (ap.isProxy) {
+                ap.proxy.set(value);
             } else {
-                return this._ap.proxy.get();
+                ap.object[ap.property] = value;
             }
-        } else {
-            return this._ap.object[this._ap.property];
-        }
-    }
+        },
+        getValue: () => {
+            if (ap.isProxy) {
+                if (!ap.proxy.get) {
+                    error(`Target doesn't provide a get method.`);
+                    return null;
+                } else {
+                    return ap.proxy.get();
+                }
+            } else {
+                return ap.object[ap.property];
+            }
+        },
+    };
 }
 
-export class BufferedTarget extends BoundTarget {
-    private _buffer: any;
-    private _copy: (out: any, from: any) => void;
-
-    constructor (target: any, modifiers: TargetPath[], valueAdapter?: IValueProxyFactory) {
-        super(target, modifiers, valueAdapter);
-        const value = this.getValue();
-        const copyable = getBuiltinCopy(value);
-        if (!copyable) {
-            throw new Error(`Value is not copyable!`);
-        }
-        this._buffer = copyable.createBuffer();
-        this._copy = copyable.copy;
+export function createBufferedTarget (target: any, modifiers: TargetPath[], valueAdapter?: IValueProxyFactory): null | IBufferedTarget {
+    const boundTarget = createBoundTarget(target, modifiers, valueAdapter);
+    if (boundTarget === null) {
+        return null;
     }
-
-    public peek () {
-        return this._buffer;
+    const value = boundTarget.getValue();
+    const copyable = getBuiltinCopy(value);
+    if (!copyable) {
+        error(`Value is not copyable!`);
+        return null;
     }
-
-    public pull () {
-        const value = this.getValue();
-        this._copy(this._buffer, value);
-    }
-
-    public push () {
-        this.setValue(this._buffer);
-    }
+    const buffer = copyable.createBuffer();
+    const copy = copyable.copy;
+    return Object.assign(boundTarget, {
+        peek: () => {
+            return buffer;
+        },
+        pull: () => {
+            const value = boundTarget.getValue();
+            copy(buffer, value);
+        },
+        push: () => {
+            boundTarget.setValue(buffer);
+        },
+    });
 }
+
 interface ICopyable {
     createBuffer: () => any;
     copy: (out: any, source: any) => any;

--- a/cocos/core/animation/target-path.ts
+++ b/cocos/core/animation/target-path.ts
@@ -4,11 +4,16 @@
 
 import { ccclass, property } from '../data/class-decorator';
 import { Node } from '../scene-graph/node';
+import { error } from '../platform/debug';
 
 export type PropertyPath = string | number;
 
 export interface ICustomTargetPath {
-    get (target: any): any;
+    /**
+     * If errors are encountered, `null` should be returned.
+     * @param target 
+     */
+    get(target: any): any;
 }
 
 export type TargetPath = PropertyPath | ICustomTargetPath;
@@ -32,12 +37,13 @@ export class HierarchyPath implements ICustomTargetPath {
 
     public get (target: Node) {
         if (!(target instanceof Node)) {
-            /* cspell: disable-next-line */
-            throw new Error(`Target of hierachy path shall be Node.`);
+            error(`Target of hierarchy path shall be Node.`);
+            return null;
         }
         const result = target.getChildByPath(this.path);
         if (!result) {
-            throw new Error(`Node "${target.name}" has no path "${this.path}"`);
+            error(`Node "${target.name}" has no path "${this.path}"`);
+            return null;
         }
         return result;
     }
@@ -54,11 +60,13 @@ export class ComponentPath implements ICustomTargetPath {
 
     public get (target: Node) {
         if (!(target instanceof Node)) {
-            throw new Error(`Target of component path shall be Node.`);
+            error(`Target of component path shall be Node.`);
+            return null;
         }
         const result = target.getComponent(this.component);
         if (!result) {
-            throw new Error(`Node "${target.name}" has no component "${this.component}"`);
+            error(`Node "${target.name}" has no component "${this.component}"`);
+            return null;
         }
         return result;
     }

--- a/tests/animation/animation-curve.test.ts
+++ b/tests/animation/animation-curve.test.ts
@@ -2,7 +2,7 @@
 import { AnimCurve, RatioSampler, sampleAnimationCurve } from '../../cocos/core/animation/animation-curve';
 import { ComponentPath, TargetPath, HierarchyPath } from '../../cocos/core/animation/target-path';
 import { Node } from '../../cocos/core/scene-graph';
-import { BoundTarget } from '../../cocos/core/animation/bound-target';
+import { createBoundTarget } from '../../cocos/core/animation/bound-target';
 
 test('sample from animation curve', () => {
     const curve = new AnimCurve({
@@ -19,21 +19,8 @@ test('sample from animation curve', () => {
 });
 
 test('Erroneous target path', () => {
-    const fx = (target: any, modifier: TargetPath | TargetPath[]) => {
-        return () => {
-            new BoundTarget(target, Array.isArray(modifier) ? modifier : [ modifier ]);
-        };
-    };
-
-    expect(fx(new Node("TestNode"), new ComponentPath('cc.ModelComponent'))).toThrow(
-        `Node "TestNode" has no component "cc.ModelComponent"`);
-
-    expect(fx(new Node("TestNode"), new HierarchyPath('/absent'))).toThrow(
-        `Node "TestNode" has no path "/absent"`);
-
-    expect(fx(Object.create(null), ['property', 0])).toThrow(
-        `Target object has no property "property"`);
-    
-    expect(fx([], [1, 0])).toThrow(
-        `Target object has no property "1"`);
+    expect(createBoundTarget(new Node("TestNode"), [new ComponentPath('cc.ModelComponent')])).toBeNull();
+    expect(createBoundTarget(new Node("TestNode"), [new HierarchyPath('/absent')])).toBeNull();
+    expect(createBoundTarget(Object.create(null), ['property', 0])).toBeNull();
+    expect(createBoundTarget([], [1, 0])).toBeNull();
 });


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * This should fix that engine would hang up if there is an error thrown during initialization of animation common target.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
