### PR TITLE
After clearing the PageView, the current index should always stay at 0

### DIFF
--- a/cocos2d/core/components/CCPageView.js
+++ b/cocos2d/core/components/CCPageView.js
@@ -567,10 +567,10 @@ var PageView = cc.Class({
             let bounceBackAmount = this._getHowMuchOutOfBoundary();
             bounceBackAmount = this._clampDelta(bounceBackAmount);
             if (bounceBackAmount.x > 0 || bounceBackAmount.y < 0) {
-                this._curPageIdx = this._pages.length - 1
+                this._curPageIdx = this._pages.length === 0 ? 0 : this._pages.length - 1;
             }
             if (bounceBackAmount.x < 0 || bounceBackAmount.y > 0) {
-                this._curPageIdx = 0
+                this._curPageIdx = 0;
             }
 
             if (this.indicator) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2545

Changes:
 * 修复当 PageView 清空后，滑动，当前索引会变成 -1 的问题（清空 pageview 后，滑动当前索引应该一直保持为 0）