### PR TITLE
Fix a problem of Burst for 3d particle.

### DIFF
--- a/cocos2d/core/3d/particle/burst.ts
+++ b/cocos2d/core/3d/particle/burst.ts
@@ -79,7 +79,7 @@ export default class Burst {
     _curTime = 0;
 
     constructor () {
-        this._remainingCount = 1;
+        this._remainingCount = 0;
         this._curTime = 0.0;
     }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2544

Changes:
修复3D粒子的Burst第一次显示数量不正确的问题。