### PR TITLE
Fix a problem of Burst for 3d particle. (#6269)

### DIFF
--- a/cocos/particle/burst.ts
+++ b/cocos/particle/burst.ts
@@ -71,7 +71,7 @@ export default class Burst {
     private _curTime: number;
 
     constructor () {
-        this._remainingCount = 1;
+        this._remainingCount = 0;
         this._curTime = 0.0;
     }
 


### PR DESCRIPTION
同步修改：https://github.com/cocos-creator/engine/pull/6269

修复粒子Burst第一次播放显示粒子数量错误的问题