### PR TITLE
Optimize the serialization size of particle resources. (#6264)

### DIFF
--- a/cocos2d/core/3d/particle/animator/curve-range.ts
+++ b/cocos2d/core/3d/particle/animator/curve-range.ts
@@ -3,6 +3,13 @@ import Enum  from '../../../platform/CCEnum';
 import { lerp } from '../../../value-types';
 import { AnimationCurve } from '../curve';
 
+const SerializeData = CC_EDITOR && [
+    [ "_mode", "constant", "multiplier" ],
+    [ "_mode", "curve", "multiplier" ],
+    [ "_mode", "curveMin", "curveMax", "multiplier" ],
+    [ "_mode", "constantMin", "constantMax", "multiplier"]
+];
+
 export const Mode = Enum({
     Constant: 0,
     Curve: 1,
@@ -117,31 +124,8 @@ export default class CurveRange {
         }
         return 0;
     }
-
-    _onBeforeSerialize (props: any): any {
-        const self = this;
-        let data = ["mode"];
-        switch (self.mode) {
-            case Mode.Constant:
-                data.push("constant");
-                break;
-            case Mode.Curve:
-                data.push("curve");
-                break;
-            case Mode.TwoConstants:
-                data.push("constantMin");
-                data.push("constantMax");
-                break;
-            case Mode.TwoCurves:
-                data.push("curveMin");
-                data.push("curveMax");
-                break;
-        }
-
-        data.push("multiplier");
-
-        return data;
-    }
 }
+
+Object.assign(CurveRange, { _onBeforeSerialize: CC_EDITOR && function(props){return SerializeData[this.mode];}});
 
 cc.CurveRange = CurveRange;

--- a/cocos2d/core/3d/particle/animator/curve-range.ts
+++ b/cocos2d/core/3d/particle/animator/curve-range.ts
@@ -3,7 +3,7 @@ import Enum  from '../../../platform/CCEnum';
 import { lerp } from '../../../value-types';
 import { AnimationCurve } from '../curve';
 
-const SerializeData = CC_EDITOR && [
+const SerializableTable = CC_EDITOR && [
     [ "_mode", "constant", "multiplier" ],
     [ "_mode", "curve", "multiplier" ],
     [ "_mode", "curveMin", "curveMax", "multiplier" ],
@@ -126,7 +126,7 @@ export default class CurveRange {
     }
 
     _onBeforeSerialize (props) {
-        return SerializeData[this.mode];
+        return SerializableTable[this.mode];
     }
 }
 

--- a/cocos2d/core/3d/particle/animator/curve-range.ts
+++ b/cocos2d/core/3d/particle/animator/curve-range.ts
@@ -117,6 +117,29 @@ export default class CurveRange {
         }
         return 0;
     }
+
+    _onBeforeSerialize (props: any): any {
+        const self = this;
+        let data = ["mode"];
+        switch (self.mode) {
+            case Mode.Constant:
+                data.push("constant");
+                break;
+            case Mode.Curve:
+                data.push("curve");
+                break;
+            case Mode.TwoConstants:
+                data.push("constantMin");
+                data.push("constantMax");
+                break;
+            case Mode.TwoCurves:
+                data.push("curveMin");
+                data.push("curveMax");
+                break;
+        }
+
+        return data;
+    }
 }
 
 cc.CurveRange = CurveRange;

--- a/cocos2d/core/3d/particle/animator/curve-range.ts
+++ b/cocos2d/core/3d/particle/animator/curve-range.ts
@@ -126,6 +126,6 @@ export default class CurveRange {
     }
 }
 
-CC_EDITOR && Object.assign(CurveRange.prototype, {_onBeforeSerialize: function(props){return SerializableTable[this.mode];}});
+CC_EDITOR && (CurveRange.prototype._onBeforeSerialize = function(props){return SerializableTable[this.mode];});
 
 cc.CurveRange = CurveRange;

--- a/cocos2d/core/3d/particle/animator/curve-range.ts
+++ b/cocos2d/core/3d/particle/animator/curve-range.ts
@@ -138,6 +138,8 @@ export default class CurveRange {
                 break;
         }
 
+        data.push("multiplier");
+
         return data;
     }
 }

--- a/cocos2d/core/3d/particle/animator/curve-range.ts
+++ b/cocos2d/core/3d/particle/animator/curve-range.ts
@@ -124,8 +124,10 @@ export default class CurveRange {
         }
         return 0;
     }
-}
 
-Object.assign(CurveRange, { _onBeforeSerialize: CC_EDITOR && function(props){return SerializeData[this.mode];}});
+    _onBeforeSerialize (props) {
+        return SerializeData[this.mode];
+    }
+}
 
 cc.CurveRange = CurveRange;

--- a/cocos2d/core/3d/particle/animator/curve-range.ts
+++ b/cocos2d/core/3d/particle/animator/curve-range.ts
@@ -124,10 +124,8 @@ export default class CurveRange {
         }
         return 0;
     }
-
-    _onBeforeSerialize (props) {
-        return SerializableTable[this.mode];
-    }
 }
+
+CC_EDITOR && Object.assign(CurveRange.prototype, {_onBeforeSerialize: function(props){return SerializableTable[this.mode];}});
 
 cc.CurveRange = CurveRange;

--- a/cocos2d/core/3d/particle/animator/gradient-range.ts
+++ b/cocos2d/core/3d/particle/animator/gradient-range.ts
@@ -137,6 +137,6 @@ export default class GradientRange {
     }
 }
 
-CC_EDITOR && Object.assign(GradientRange.prototype, {_onBeforeSerialize: function(props){return SerializableTable[this._mode];}});
+CC_EDITOR && (GradientRange.prototype._onBeforeSerialize = function(props){return SerializableTable[this._mode];});
 
 cc.GradientRange = GradientRange;

--- a/cocos2d/core/3d/particle/animator/gradient-range.ts
+++ b/cocos2d/core/3d/particle/animator/gradient-range.ts
@@ -135,10 +135,8 @@ export default class GradientRange {
                 return this.color;
         }
     }
-
-    _onBeforeSerialize (props) {
-        return SerializableTable[this._mode];
-    }
 }
+
+CC_EDITOR && Object.assign(GradientRange.prototype, {_onBeforeSerialize: function(props){return SerializableTable[this._mode];}});
 
 cc.GradientRange = GradientRange;

--- a/cocos2d/core/3d/particle/animator/gradient-range.ts
+++ b/cocos2d/core/3d/particle/animator/gradient-range.ts
@@ -110,7 +110,7 @@ export default class GradientRange {
     gradientMax = new Gradient();
 
     evaluate (time, rndRatio) {
-        switch (this.mode) {
+        switch (this._mode) {
             case Mode.Color:
                 return this.color;
             case Mode.TwoColors:
@@ -126,6 +126,30 @@ export default class GradientRange {
             default:
                 return this.color;
         }
+    }
+
+    _onBeforeSerialize (props: any): any {
+        const self = this;
+        let data = ["_mode"];
+        switch (self._mode) {
+            case Mode.Color:
+                data.push("color");
+                break;
+            case Mode.TwoColors:
+                data.push("colorMin");
+                data.push("colorMax");
+                break;
+            case Mode.RandomColor:
+            case Mode.Gradient:
+                data.push("gradient");
+                break;
+            case Mode.TwoGradients:
+                data.push("gradientMin");
+                data.push("gradientMax");
+                break;
+        }
+
+        return data;
     }
 }
 

--- a/cocos2d/core/3d/particle/animator/gradient-range.ts
+++ b/cocos2d/core/3d/particle/animator/gradient-range.ts
@@ -136,11 +136,9 @@ export default class GradientRange {
         }
     }
 
-    _onBeforeSerialize (props: any):any {
+    _onBeforeSerialize (props) {
         return SerializeData[this._mode];
     }
 }
-
-Object.assign(GradientRange, { _onBeforeSerialize: CC_EDITOR && function(props){return SerializeData[this._mode];}});
 
 cc.GradientRange = GradientRange;

--- a/cocos2d/core/3d/particle/animator/gradient-range.ts
+++ b/cocos2d/core/3d/particle/animator/gradient-range.ts
@@ -12,6 +12,14 @@ const GRADIENT_RANGE_MODE_RANDOM_COLOR = 2;
 const GRADIENT_RANGE_MODE_GRADIENT = 3;
 const GRADIENT_RANGE_MODE_TWO_GRADIENT = 4;
 
+const SerializeData = CC_EDITOR && [
+    [ "_mode", "color" ],
+    [ "_mode", "gradient" ],
+    [ "_mode", "colorMin", "colorMax" ],
+    [ "_mode", "gradientMin", "gradientMax"],
+    [ "_mode", "gradient" ]
+];
+
 const Mode = Enum({
     Color: 0,
     Gradient: 1,
@@ -128,29 +136,11 @@ export default class GradientRange {
         }
     }
 
-    _onBeforeSerialize (props: any): any {
-        const self = this;
-        let data = ["_mode"];
-        switch (self._mode) {
-            case Mode.Color:
-                data.push("color");
-                break;
-            case Mode.TwoColors:
-                data.push("colorMin");
-                data.push("colorMax");
-                break;
-            case Mode.RandomColor:
-            case Mode.Gradient:
-                data.push("gradient");
-                break;
-            case Mode.TwoGradients:
-                data.push("gradientMin");
-                data.push("gradientMax");
-                break;
-        }
-
-        return data;
+    _onBeforeSerialize (props: any):any {
+        return SerializeData[this._mode];
     }
 }
+
+Object.assign(GradientRange, { _onBeforeSerialize: CC_EDITOR && function(props){return SerializeData[this._mode];}});
 
 cc.GradientRange = GradientRange;

--- a/cocos2d/core/3d/particle/animator/gradient-range.ts
+++ b/cocos2d/core/3d/particle/animator/gradient-range.ts
@@ -12,7 +12,7 @@ const GRADIENT_RANGE_MODE_RANDOM_COLOR = 2;
 const GRADIENT_RANGE_MODE_GRADIENT = 3;
 const GRADIENT_RANGE_MODE_TWO_GRADIENT = 4;
 
-const SerializeData = CC_EDITOR && [
+const SerializableTable = CC_EDITOR && [
     [ "_mode", "color" ],
     [ "_mode", "gradient" ],
     [ "_mode", "colorMin", "colorMax" ],
@@ -137,7 +137,7 @@ export default class GradientRange {
     }
 
     _onBeforeSerialize (props) {
-        return SerializeData[this._mode];
+        return SerializableTable[this._mode];
     }
 }
 

--- a/cocos2d/core/3d/particle/particle-system-3d.ts
+++ b/cocos2d/core/3d/particle/particle-system-3d.ts
@@ -46,7 +46,7 @@ const { ccclass, menu, property, executeInEditMode, executionOrder} = require('.
 const RenderComponent = require('../../components/CCRenderComponent');
 
 const _world_mat = new Mat4();
-const _module_props = [
+const _module_props = CC_EDITOR && [
     "colorOverLifetimeModule",
     "shapeModule",
     "sizeOvertimeModule",
@@ -867,21 +867,8 @@ export default class ParticleSystem3D extends RenderComponent {
         return this._time;
     }
 
-    public _onBeforeSerialize (props: any): any {
-        const self = this;
-        let data:Array<any> = [];
-        for (let p = 0; p < props.length; p++) {
-            let propName = props[p];
-            let prop = self[propName];
-
-            if (_module_props.indexOf(propName) !== -1 && !prop.enable) {
-                continue;
-            }
-
-            data.push(propName);
-        }
-
-        return data;
+    _onBeforeSerialize (props) {
+        return props.filter(p => !_module_props.includes(p) || this[p].enable);
     }
 }
 

--- a/cocos2d/core/3d/particle/particle-system-3d.ts
+++ b/cocos2d/core/3d/particle/particle-system-3d.ts
@@ -866,10 +866,8 @@ export default class ParticleSystem3D extends RenderComponent {
     get time () {
         return this._time;
     }
-
-    _onBeforeSerialize (props) {
-        return props.filter(p => !_module_props.includes(p) || this[p].enable);
-    }
 }
+
+CC_EDITOR && Object.assign(ParticleSystem3D.prototype, {_onBeforeSerialize: function(props){return props.filter(p => !_module_props.includes(p) || this[p].enable);}});
 
 cc.ParticleSystem3D = ParticleSystem3D;

--- a/cocos2d/core/3d/particle/particle-system-3d.ts
+++ b/cocos2d/core/3d/particle/particle-system-3d.ts
@@ -46,6 +46,17 @@ const { ccclass, menu, property, executeInEditMode, executionOrder} = require('.
 const RenderComponent = require('../../components/CCRenderComponent');
 
 const _world_mat = new Mat4();
+const _module_props = [
+    "colorOverLifetimeModule",
+    "shapeModule",
+    "sizeOvertimeModule",
+    "velocityOvertimeModule",
+    "forceOvertimeModule",
+    "limitVelocityOvertimeModule",
+    "rotationOvertimeModule",
+    "textureAnimationModule",
+    "trailModule"
+]
 
 /**
  * !#en The ParticleSystem3D Component.
@@ -854,6 +865,23 @@ export default class ParticleSystem3D extends RenderComponent {
 
     get time () {
         return this._time;
+    }
+
+    public _onBeforeSerialize (props: any): any {
+        const self = this;
+        let data:Array<any> = [];
+        for (let p = 0; p < props.length; p++) {
+            let propName = props[p];
+            let prop = self[propName];
+
+            if (_module_props.indexOf(propName) !== -1 && !prop.enable) {
+                continue;
+            }
+
+            data.push(propName);
+        }
+
+        return data;
     }
 }
 

--- a/cocos2d/core/3d/particle/particle-system-3d.ts
+++ b/cocos2d/core/3d/particle/particle-system-3d.ts
@@ -868,6 +868,6 @@ export default class ParticleSystem3D extends RenderComponent {
     }
 }
 
-CC_EDITOR && Object.assign(ParticleSystem3D.prototype, {_onBeforeSerialize: function(props){return props.filter(p => !_module_props.includes(p) || this[p].enable);}});
+CC_EDITOR && (ParticleSystem3D.prototype._onBeforeSerialize = function(props){return props.filter(p => !_module_props.includes(p) || this[p].enable);});
 
 cc.ParticleSystem3D = ParticleSystem3D;


### PR DESCRIPTION
**修改说明：**

优化3D粒子序列化资源大小。

关联编辑器修改：https://github.com/cocos-creator/fireball/pull/9467

（默认场景，添加内置3D粒子节点）

- **优化前：**
场景文件数据：2579行 ，40kb

- **优化后：**
场景文件数据： 497行， 9kb

已兼容旧版本数据（由于重写_serialize不能兼容旧版本数据，所以采用剔除不需要记录的属性字段的方式）。其他模块有需要剔除无用数据或者一些默认值数据可以使用该方式进行精简资源大小。
