### PR TITLE
Fix setting Rich Text image string invalid for 2d-tasks/issues/2566

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -612,35 +612,34 @@ let RichText = cc.Class({
                 return true;
             }
             else {
-                if (oldItem.style) {
-                    if (newItem.style) {
-                        if (!!newItem.style.outline !== !!oldItem.style.outline) {
+                let oldStyle = oldItem.style, newStyle = newItem.style;
+                if (oldStyle) {
+                    if (newStyle) {
+                        if (!oldStyle.outline !== !newStyle.outline) {
                             return true;
                         }
-                        if (oldItem.style.size !== newItem.style.size
-                            || oldItem.style.italic !== newItem.style.italic
-                            || oldItem.style.isImage !== newItem.style.isImage) {
+                        if (oldStyle.size !== newStyle.size
+                            || !oldStyle.italic !== !newStyle.italic
+                            || oldStyle.isImage !== newStyle.isImage) {
                             return true;
                         }
-                        if (oldItem.style.isImage === newItem.style.isImage) {
-                            if (oldItem.style.src !== newItem.style.src ||
-                                oldItem.style.imageAlign !== newItem.style.imageAlign ||
-                                oldItem.style.imageHeight !== newItem.style.imageHeight ||
-                                oldItem.style.imageWidth !== newItem.style.imageWidth ||
-                                oldItem.style.imageOffset !== newItem.style.imageOffset) {
-                                return true;
-                            }
+                        if (oldStyle.src !== newStyle.src ||
+                            oldStyle.imageAlign !== newStyle.imageAlign ||
+                            oldStyle.imageHeight !== newStyle.imageHeight ||
+                            oldStyle.imageWidth !== newStyle.imageWidth ||
+                            oldStyle.imageOffset !== newStyle.imageOffset) {
+                            return true;
                         }
                     }
                     else {
-                        if (oldItem.style.size || oldItem.style.italic || oldItem.style.isImage || oldItem.style.outline) {
+                        if (oldStyle.size || oldStyle.italic || oldStyle.isImage || oldStyle.outline) {
                             return true;
                         }
                     }
                 }
                 else {
-                    if (newItem.style) {
-                        if (newItem.style.size || newItem.style.italic || newItem.style.isImage || newItem.style.outline) {
+                    if (newStyle) {
+                        if (newStyle.size || newStyle.italic || newStyle.isImage || newStyle.outline) {
                             return true;
                         }
                     }
@@ -926,7 +925,7 @@ let RichText = cc.Class({
         }
     },
 
-    // When string is null, it means that the text does not need to be updated. 
+    // When string is null, it means that the text does not need to be updated.
     _applyTextAttribute (labelNode, string, force) {
         let labelComponent = labelNode.getComponent(cc.Label);
         if (!labelComponent) {
@@ -954,7 +953,7 @@ let RichText = cc.Class({
         } else {
             labelComponent.fontFamily = this.fontFamily;
         }
-    
+
         labelComponent.useSystemFont = this._isSystemFontUsed;
         labelComponent.lineHeight = this.lineHeight;
         labelComponent.enableBold = textStyle && textStyle.bold;

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -623,7 +623,11 @@ let RichText = cc.Class({
                             return true;
                         }
                         if (oldItem.style.isImage === newItem.style.isImage) {
-                            if (oldItem.style.src !== newItem.style.src) {
+                            if (oldItem.style.src !== newItem.style.src ||
+                                oldItem.style.imageAlign !== newItem.style.imageAlign ||
+                                oldItem.style.imageHeight !== newItem.style.imageHeight ||
+                                oldItem.style.imageWidth !== newItem.style.imageWidth ||
+                                oldItem.style.imageOffset !== newItem.style.imageOffset) {
                                 return true;
                             }
                         }

--- a/cocos2d/core/utils/html-text-parser.js
+++ b/cocos2d/core/utils/html-text-parser.js
@@ -144,11 +144,11 @@ HtmlTextParser.prototype = {
                     tagName = tagName.toLocaleLowerCase();
 
                     attribute = remainingArgument.substring(nextSpace).trim();
-                    if ( tagValue.endsWith( '\/' ) ) tagValue = tagValue.substring( 0, tagValue.length - 1 );
+                    if ( tagValue.endsWith( '\/' ) ) tagValue = tagValue.slice( 0, -1 );
                     if (tagName === "src") {
-                        if ( tagValue.indexOf('\'') === 0 || tagValue.indexOf('"') === 0 ) {
+                        if ( tagValue.charCodeAt("'") === 39 || tagValue.charCodeAt('"') === 34 ) {
                             isValidImageTag = true;
-                            tagValue = tagValue.substring( 1, tagValue.length - 1 );
+                            tagValue = tagValue.slice(1, -1);
                         }
                         obj.isImage = true;
                         obj.src = tagValue;
@@ -157,8 +157,8 @@ HtmlTextParser.prototype = {
                     } else if (tagName === "width") {
                         obj.imageWidth = parseInt(tagValue);
                     } else if (tagName === "align") {
-                        if ( tagValue.indexOf('\'') === 0 || tagValue.indexOf('"') === 0 ) {
-                            tagValue = tagValue.substring( 1, tagValue.length - 1 );
+                        if ( tagValue.charCodeAt("'") === 39 || tagValue.charCodeAt('"') === 34 ) {
+                            tagValue = tagValue.slice(1, -1);
                         }
                         obj.imageAlign = tagValue.toLocaleLowerCase();
                     } else if (tagName === "offset") {

--- a/cocos2d/core/utils/html-text-parser.js
+++ b/cocos2d/core/utils/html-text-parser.js
@@ -144,22 +144,22 @@ HtmlTextParser.prototype = {
                     tagName = tagName.toLocaleLowerCase();
 
                     attribute = remainingArgument.substring(nextSpace).trim();
+                    if ( tagValue.endsWith( '\/' ) ) tagValue = tagValue.substring( 0, tagValue.length - 1 );
                     if (tagName === "src") {
-                        obj.isImage = true
-                        if( tagValue.endsWith( '\/' ) ) tagValue = tagValue.substring( 0, tagValue.length - 1 );
-                        if( tagValue.indexOf('\'')===0 ) {
-                            isValidImageTag = true;
-                            tagValue = tagValue.substring( 1, tagValue.length - 1 );
-                        } else if( tagValue.indexOf('"')===0 ) {
+                        if ( tagValue.indexOf('\'') === 0 || tagValue.indexOf('"') === 0 ) {
                             isValidImageTag = true;
                             tagValue = tagValue.substring( 1, tagValue.length - 1 );
                         }
+                        obj.isImage = true;
                         obj.src = tagValue;
                     } else if (tagName === "height") {
                         obj.imageHeight = parseInt(tagValue);
                     } else if (tagName === "width") {
                         obj.imageWidth = parseInt(tagValue);
                     } else if (tagName === "align") {
+                        if ( tagValue.indexOf('\'') === 0 || tagValue.indexOf('"') === 0 ) {
+                            tagValue = tagValue.substring( 1, tagValue.length - 1 );
+                        }
                         obj.imageAlign = tagValue.toLocaleLowerCase();
                     } else if (tagName === "offset") {
                         obj.imageOffset = tagValue;
@@ -174,8 +174,7 @@ HtmlTextParser.prototype = {
                     header = attribute.match(imageAttrReg);
                 }
 
-                if( isValidImageTag && obj.isImage )
-                {
+                if( isValidImageTag && obj.isImage ) {
                     this._resultObjectArray.push({text: "", style: obj});
                 }
 

--- a/cocos2d/core/utils/html-text-parser.js
+++ b/cocos2d/core/utils/html-text-parser.js
@@ -146,9 +146,12 @@ HtmlTextParser.prototype = {
                     attribute = remainingArgument.substring(nextSpace).trim();
                     if ( tagValue.endsWith( '\/' ) ) tagValue = tagValue.slice( 0, -1 );
                     if (tagName === "src") {
-                        if ( tagValue.charCodeAt("'") === 39 || tagValue.charCodeAt('"') === 34 ) {
-                            isValidImageTag = true;
-                            tagValue = tagValue.slice(1, -1);
+                        switch (tagValue.charCodeAt(0)) {
+                            case 34: // "
+                            case 39: // '
+                                isValidImageTag = true;
+                                tagValue = tagValue.slice(1, -1);
+                                break;
                         }
                         obj.isImage = true;
                         obj.src = tagValue;
@@ -157,8 +160,11 @@ HtmlTextParser.prototype = {
                     } else if (tagName === "width") {
                         obj.imageWidth = parseInt(tagValue);
                     } else if (tagName === "align") {
-                        if ( tagValue.charCodeAt("'") === 39 || tagValue.charCodeAt('"') === 34 ) {
-                            tagValue = tagValue.slice(1, -1);
+                        switch (tagValue.charCodeAt(0)) {
+                            case 34: // "
+                            case 39: // '
+                                tagValue = tagValue.slice(1, -1);
+                                break;
                         }
                         obj.imageAlign = tagValue.toLocaleLowerCase();
                     } else if (tagName === "offset") {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2566

Changes:
 * 修复 RichText 组件修改 img 标签的属性不会立即更新