### PR TITLE
Fix spriteFrame with no texture assigned to Sprite will report an error

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -487,7 +487,7 @@ var Sprite = cc.Class({
         if (spriteFrame) {
             this._updateMaterial();
             let newTexture = spriteFrame.getTexture();
-            if (oldTexture === newTexture && newTexture.loaded) {
+            if (oldTexture === newTexture && (newTexture && newTexture.loaded)) {
                 this._applySpriteSize();
             }
             else {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2583

Changes:
 * 修复 Sprite 赋值没有纹理的 spriteFrame 会报错误
