### PR TITLE
fix decorator warning of ValueTypes

### DIFF
--- a/cocos2d/core/platform/CCClassDecorator.js
+++ b/cocos2d/core/platform/CCClassDecorator.js
@@ -148,17 +148,17 @@ function extractActualDefaultValues (ctor) {
 
 function genProperty (ctor, properties, propName, options, desc, cache) {
     var fullOptions;
+    var isGetset = desc && (desc.get || desc.set);
     if (options) {
-        fullOptions = CC_DEV ? Preprocess.getFullFormOfProperty(options, propName, js.getClassName(ctor)) :
-                               Preprocess.getFullFormOfProperty(options);
+        fullOptions = CC_DEV ? Preprocess.getFullFormOfProperty(options, isGetset, propName, js.getClassName(ctor)) :
+                               Preprocess.getFullFormOfProperty(options, isGetset);
     }
     var existsProperty = properties[propName];
     var prop = js.mixin(existsProperty || {}, fullOptions || options || {});
 
-    var isGetset = desc && (desc.get || desc.set);
     if (isGetset) {
         // typescript or babel
-        if (CC_DEV && options && (options.get || options.set)) {
+        if (CC_DEV && options && ((fullOptions || options).get || (fullOptions || options).set)) {
             var errorProps = getSubDict(cache, 'errorProps');
             if (!errorProps[propName]) {
                 errorProps[propName] = true;

--- a/cocos2d/core/platform/preprocess-class.js
+++ b/cocos2d/core/platform/preprocess-class.js
@@ -250,7 +250,20 @@ function getBaseClassWherePropertyDefined_DEV (propName, cls) {
     }
 }
 
-exports.getFullFormOfProperty = function (options, propname_dev, classname_dev) {
+function _wrapOptions (isES6Getset, _default, type, isUrlType) {
+    let res = isES6Getset ? { _short: true } : { _short: true, default: _default };
+    if (type) {
+        if (isUrlType) {
+            res.url = type;
+        }
+        else {
+            res.type = type;
+        }
+    }
+    return res;
+}
+
+exports.getFullFormOfProperty = function (options, isES6Getset, propname_dev, classname_dev) {
     var isLiteral = options && options.constructor === Object;
     if (isLiteral) {
         return null;
@@ -275,17 +288,9 @@ exports.getFullFormOfProperty = function (options, propname_dev, classname_dev) 
                     '    })\n' +
                     '    %s: cc.Texture2D[] = [];',
                     propname_dev, classname_dev, propname_dev, propname_dev);
-            return {
-                default: [],
-                url: options,
-                _short: true
-            };
+            return _wrapOptions(isES6Getset, [], options, true);
         }
-        return {
-            default: [],
-            type: options,
-            _short: true
-        };
+        return _wrapOptions(isES6Getset, [], options);
     }
     else if (typeof options === 'function') {
         let type = options;
@@ -312,37 +317,23 @@ exports.getFullFormOfProperty = function (options, propname_dev, classname_dev) 
                 }
             }
             else {
-                return {
-                    default: js.isChildClassOf(type, cc.ValueType) ? new type() : null,
-                    type: type,
-                    _short: true
-                };
+                return _wrapOptions(isES6Getset, js.isChildClassOf(type, cc.ValueType) ? new type() : null, type);
             }
         }
-        return {
-            default: '',
-            url: type,
-            _short: true
-        };
+        return _wrapOptions(isES6Getset, '', type, true);
     }
     else if (options instanceof Attrs.PrimitiveType) {
-        return {
-            default: options.default,
-            _short: true
-        };
+        return _wrapOptions(isES6Getset, options.default);
     }
     else {
-        return {
-            default: options,
-            _short: true
-        };
+        return _wrapOptions(isES6Getset, options);
     }
 };
 
 exports.preprocessAttrs = function (properties, className, cls, es6) {
     for (var propName in properties) {
         var val = properties[propName];
-        var fullForm = exports.getFullFormOfProperty(val, propName, className);
+        var fullForm = exports.getFullFormOfProperty(val, false, propName, className);
         if (fullForm) {
             val = properties[propName] = fullForm;
         }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复在 2.3.0 的 TypeScript 中使用简略方式定义 getset 的 `@property` 的类型时可能会报错的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
