### PR TITLE
prevent multiple running instance of mainloop

### DIFF
--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -333,10 +333,6 @@ export class Game extends EventTarget {
             }
         }
         config.frameRate = frameRate;
-        if (this._intervalId) {
-            window.cancelAnimationFrame(this._intervalId);
-        }
-        this._intervalId = 0;
         this._paused = true;
         this._setAnimFrame();
         this._runMainLoop();

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -701,9 +701,9 @@ export class Game extends EventTarget {
             director.mainLoop(time);
         };
 
-        if(this._intervalId) {
+        if (this._intervalId) {
             window.cancelAnimationFrame(this._intervalId);
-            this._intervalId=0;
+            this._intervalId = 0;
         }
 
         this._intervalId = window.requestAnimationFrame(callback);

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -705,6 +705,11 @@ export class Game extends EventTarget {
             director.mainLoop(time);
         };
 
+        if(this._intervalId) {
+            window.cancelAnimationFrame(this._intervalId);
+            this._intervalId=0;
+        }
+
         this._intervalId = window.requestAnimationFrame(callback);
         this._paused = false;
     }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/2673

Changes:
- 重复调用 `_runMainLoop `时, 取消之前的 loop回调


