### PR TITLE
Fix WebGL warning when string is empty.

### DIFF
--- a/cocos2d/core/assets/CCRenderTexture.js
+++ b/cocos2d/core/assets/CCRenderTexture.js
@@ -78,7 +78,7 @@ let RenderTexture = cc.Class({
      * @param {Number} y 
      */
     drawTextureAt (texture, x, y) {
-        if (!texture._image) return;
+        if (!texture._image || texture._image.width === 0) return;
 
         this._texture.updateSubImage({
             x, y,


### PR DESCRIPTION
修改说明：

修复使用BITMAP模式下字符串为空时的WebGL警告。