### PR TITLE
Vertex index channel

### DIFF
--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -251,7 +251,7 @@ export class RenderingSubMesh {
 
     /**
      * Adds a vertex attribute input called 'a_vertexId' into this sub-mesh.
-     * This is useful if you want simulate `gl_VertexId` in WebGL context prior to 2.0.
+     * This is useful if you want to simulate `gl_VertexId` in WebGL context prior to 2.0.
      * Once you call this function, the vertex attribute is permanently added.
      * Subsequent calls to this function take no effect.
      * @param device Device used to create related rendering resources.

--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -208,6 +208,9 @@ export class RenderingSubMesh {
                 buffers.push(this.vertexBuffers[prim.vertexBundelIndices[i]]);
             }
         }
+        if (this._vertexIdChannel) {
+            buffers.push(this._allocVertexIdBuffer(device));
+        }
         return buffers;
     }
 
@@ -217,6 +220,10 @@ export class RenderingSubMesh {
     private _flatBuffers?: IFlatBuffer[];
     private _jointMappedBuffers?: GFXBuffer[];
     private _jointMappedBufferIndices?: number[];
+    private _vertexIdChannel?: {
+        stream: number;
+        index: number;
+    };
 
     constructor (vertexBuffers: GFXBuffer[], attributes: IGFXAttribute[], primitiveMode: GFXPrimitiveMode) {
         this.vertexBuffers = vertexBuffers;
@@ -240,6 +247,57 @@ export class RenderingSubMesh {
             this._jointMappedBuffers = undefined;
             this._jointMappedBufferIndices = undefined;
         }
+    }
+
+    /**
+     * Adds a vertex attribute input called 'a_vertexId' into this sub-mesh.
+     * This is useful if you want simulate `gl_VertexId` in WebGL context prior to 2.0.
+     * Once you call this function, the vertex attribute is permanently added.
+     * Subsequent calls to this function take no effect.
+     * @param device Device used to create related rendering resources.
+     */
+    public enableVertexIdChannel (device: GFXDevice) {
+        if (this._vertexIdChannel) {
+            return;
+        }
+
+        const streamIndex = this.vertexBuffers.length;
+        const attributeIndex = this.attributes.length;
+
+        const vertexIdBuffer = this._allocVertexIdBuffer(device);
+        this.vertexBuffers.push(vertexIdBuffer);
+        this.attributes.push({
+            name: 'a_vertexId',
+            format: GFXFormat.R32F,
+            stream: streamIndex,
+            isNormalized: false,
+        });
+
+        this._vertexIdChannel = {
+            stream: streamIndex,
+            index: attributeIndex,
+        };
+    }
+
+    private _allocVertexIdBuffer (device: GFXDevice) {
+        const vertexCount = (this.vertexBuffers.length === 0 || this.vertexBuffers[0].stride === 0) ?
+            0 :
+            // TODO: This depends how stride of a vertex buffer is defined; Consider padding problem.
+            this.vertexBuffers[0].size / this.vertexBuffers[0].stride;
+        const vertexIds = new Float32Array(vertexCount);
+        for (let iVertex = 0; iVertex < vertexCount; ++iVertex) {
+            vertexIds[iVertex] = iVertex;
+        }
+
+        const vertexIdBuffer = device.createBuffer({
+            usage: GFXBufferUsageBit.VERTEX | GFXBufferUsageBit.TRANSFER_DST,
+            memUsage: GFXMemoryUsageBit.HOST | GFXMemoryUsageBit.DEVICE,
+            size: vertexIds.byteLength,
+            stride: vertexIds.BYTES_PER_ELEMENT,
+        });
+        vertexIdBuffer.update(vertexIds);
+
+        return vertexIdBuffer;
     }
 }
 

--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -282,7 +282,7 @@ export class RenderingSubMesh {
     private _allocVertexIdBuffer (device: GFXDevice) {
         const vertexCount = (this.vertexBuffers.length === 0 || this.vertexBuffers[0].stride === 0) ?
             0 :
-            // TODO: This depends how stride of a vertex buffer is defined; Consider padding problem.
+            // TODO: This depends on how stride of a vertex buffer is defined; Consider padding problem.
             this.vertexBuffers[0].size / this.vertexBuffers[0].stride;
         const vertexIds = new Float32Array(vertexCount);
         for (let iVertex = 0; iVertex < vertexCount; ++iVertex) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Add `enableVertexIdChannel()` method to `RenderingSubMesh` to let simulating `gl_VertexId` be possible.

Request review from @YunHsiao

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
