### PR TITLE
Frame ID should be synced regardless of dirty flag when instancing

### DIFF
--- a/cocos/core/3d/framework/batched-skinning-model-component.ts
+++ b/cocos/core/3d/framework/batched-skinning-model-component.ts
@@ -26,6 +26,7 @@
  * @category model
  */
 
+import { EDITOR } from 'internal:constants';
 import { getWorldTransformUntilRoot } from '../../animation/transform-utils';
 import { Filter, PixelFormat } from '../../assets/asset-enum';
 import { Material } from '../../assets/material';
@@ -41,7 +42,6 @@ import { IGFXAttribute } from '../../gfx/input-assembler';
 import { Mat4, Vec2, Vec3 } from '../../math';
 import { mapBuffer, readBuffer, writeBuffer } from '../misc/buffer';
 import { SkinningModelComponent } from './skinning-model-component';
-import { EDITOR } from 'internal:constants';
 
 const repeat = (n: number) => n - Math.floor(n);
 const batch_id: IGFXAttribute = { name: GFXAttributeName.ATTR_BATCH_ID, format: GFXFormat.R32F, isNormalized: false };

--- a/cocos/core/3d/framework/renderable-component.ts
+++ b/cocos/core/3d/framework/renderable-component.ts
@@ -3,13 +3,13 @@
  */
 
 // @ts-check
+import { EDITOR } from 'internal:constants';
 import { Material } from '../../assets/material';
 import { Component } from '../../components/component';
 import { ccclass, property } from '../../data/class-decorator';
 import { IMaterialInstanceInfo, MaterialInstance } from '../../renderer/core/material-instance';
 import { Model } from '../../renderer/scene/model';
 import { Layers } from '../../scene-graph/layers';
-import { EDITOR } from 'internal:constants';
 
 const _matInsInfo: IMaterialInstanceInfo = {
     parent: null!,
@@ -117,9 +117,10 @@ export class RenderableComponent extends Component {
             console.error('Can\'t set a material instance to a sharedMaterial slot');
         }
         this._materials[index] = material;
-        if (this._materialInstances[index]) {
-            if (this._materialInstances[index]!.parent !== this._materials[index]) {
-                this._materialInstances[index]!.destroy();
+        const inst = this._materialInstances[index];
+        if (inst) {
+            if (inst.parent !== this._materials[index]) {
+                inst.destroy();
                 this._materialInstances[index] = null;
                 this._onMaterialModified(index, this._materials[index]);
             }

--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -3,6 +3,7 @@
  * @category animation
  */
 
+import { EDITOR } from 'internal:constants';
 import { Asset } from '../assets/asset';
 import { SpriteFrame } from '../assets/sprite-frame';
 import { ccclass, property } from '../data/class-decorator';
@@ -16,7 +17,6 @@ import { SkelAnimDataHub } from './skeletal-animation-data-hub';
 import { ComponentPath, HierarchyPath, TargetPath } from './target-path';
 import { WrapMode as AnimationWrapMode } from './types';
 import { IValueProxyFactory } from './value-proxy';
-import { EDITOR } from 'internal:constants';
 
 export interface IObjectCurveData {
     [propertyName: string]: IPropertyCurveData;

--- a/cocos/core/renderer/core/pass.ts
+++ b/cocos/core/renderer/core/pass.ts
@@ -27,6 +27,7 @@
  * @category material
  */
 
+import { EDITOR } from 'internal:constants';
 import { builtinResMgr } from '../../3d/builtin/init';
 import { IPassInfo, IPassStates, IPropertyInfo } from '../../assets/effect-asset';
 import { TextureBase } from '../../assets/texture-base';
@@ -52,7 +53,6 @@ import { customizeType, getBindingFromHandle, getBindingTypeFromHandle,
     getDefaultFromType, getOffsetFromHandle, getTypeFromHandle, IDefineMap, MaterialProperty, type2reader, type2writer } from './pass-utils';
 import { IProgramInfo, programLib } from './program-lib';
 import { samplerLib } from './sampler-lib';
-import { EDITOR } from 'internal:constants';
 
 export interface IPassInfoFull extends IPassInfo {
     // generated part

--- a/cocos/core/renderer/models/baked-skinning-model.ts
+++ b/cocos/core/renderer/models/baked-skinning-model.ts
@@ -125,13 +125,11 @@ export class BakedSkinningModel extends Model {
     public updateUBOs (stamp: number) {
         if (!super.updateUBOs(stamp)) { return false; }
         const info = this._jointsMedium.animInfo;
-        if (info.dirty) {
-            const idx = this._instAnimInfoIdx;
-            if (idx >= 0) {
-                this.instancedAttributes.list[idx].view[1] = info.data[1];
-            } else {
-                info.buffer.update(info.data);
-            }
+        const idx = this._instAnimInfoIdx;
+        if (idx >= 0) {
+            this.instancedAttributes.list[idx].view[1] = info.data[1];
+        } else if (info.dirty) {
+            info.buffer.update(info.data);
             info.dirty = false;
         }
         return true;

--- a/cocos/core/renderer/models/skinning-model.ts
+++ b/cocos/core/renderer/models/skinning-model.ts
@@ -27,6 +27,7 @@
  * @hidden
  */
 
+import { EDITOR } from 'internal:constants';
 import { Material } from '../../assets/material';
 import { Mesh, RenderingSubMesh } from '../../assets/mesh';
 import { Skeleton } from '../../assets/skeleton';
@@ -243,6 +244,9 @@ export class SkinningModel extends Model {
     }
 
     protected createPipelineState (pass: Pass, subModelIdx: number) {
+        if (EDITOR && pass.instancedBuffer) {
+            console.warn('real-time skeletal animation doesn\'t support instancing, expect rendering anomalies');
+        }
         const pso = super.createPipelineState(pass, subModelIdx, patches);
         const bindingLayout = pso.pipelineLayout.layouts[0];
         const buffer = this._buffers[this._bufferIndices![subModelIdx]];


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#2704

Changelog:
 * Frame ID should be synced when instancing regardless of dirty flag, for multiple skinning models could be updating from the same FID buffer

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->