### PR TITLE
fix label substring with emoj

### DIFF
--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -176,6 +176,9 @@ var textUtils = {
         if (this.label_firstEmoji.test(targetString)) {
             targetString = targetString.slice(1);
         }
+        if (endIndex !== undefined && this.label_lastEmoji.test(targetString)) {
+            targetString = targetString.slice(0, -1);
+        }
         return targetString;
     },
 

--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -170,6 +170,15 @@ var textUtils = {
         return width;
     },
 
+    // in case substring of emoj
+    _safeSubstring (targetString, startIndex, endIndex) {
+        targetString = targetString.substring(startIndex, endIndex);
+        if (this.label_firstEmoji.test(targetString)) {
+            targetString = targetString.slice(1);
+        }
+        return targetString;
+    },
+
     fragmentText: function (stringToken, allWidth, maxWidth, measureText) {
         //check the first character
         var wrappedWords = [];
@@ -183,7 +192,7 @@ var textUtils = {
         while (allWidth > maxWidth && text.length > 1) {
 
             var fuzzyLen = text.length * ( maxWidth / allWidth ) | 0;
-            var tmpText = text.substring(fuzzyLen);
+            var tmpText = this._safeSubstring(text, fuzzyLen);
             var width = allWidth - measureText(tmpText);
             var sLine = tmpText;
             var pushNum = 0;
@@ -195,7 +204,7 @@ var textUtils = {
             while (width > maxWidth && checkWhile++ < checkCount) {
                 fuzzyLen *= maxWidth / width;
                 fuzzyLen = fuzzyLen | 0;
-                tmpText = text.substring(fuzzyLen);
+                tmpText = this._safeSubstring(text, fuzzyLen);
                 width = allWidth - measureText(tmpText);
             }
 
@@ -210,17 +219,20 @@ var textUtils = {
                 }
 
                 fuzzyLen = fuzzyLen + pushNum;
-                tmpText = text.substring(fuzzyLen);
+                tmpText = this._safeSubstring(text, fuzzyLen);
+                if (this.label_firstEmoji.test(tmpText)) {
+                    tmpText = tmpText.slice(1);
+                }
                 width = allWidth - measureText(tmpText);
             }
 
             fuzzyLen -= pushNum;
             if (fuzzyLen === 0) {
                 fuzzyLen = 1;
-                sLine = sLine.substring(1);
+                sLine = this._safeSubstring(sLine, 1);
             }
 
-            var sText = text.substring(0, 0 + fuzzyLen), result;
+            var sText = this._safeSubstring(text, 0, fuzzyLen), result;
 
             //symbol in the first
             if (this.label_wrapinspection) {
@@ -229,8 +241,8 @@ var textUtils = {
                     fuzzyLen -= result ? result[0].length : 0;
                     if (fuzzyLen === 0) fuzzyLen = 1;
 
-                    sLine = text.substring(fuzzyLen);
-                    sText = text.substring(0, 0 + fuzzyLen);
+                    sLine = this._safeSubstring(text, fuzzyLen);
+                    sText = this._safeSubstring(text, 0, fuzzyLen);
                 }
             }
 
@@ -240,8 +252,8 @@ var textUtils = {
                 result = this.label_lastEmoji.exec(sText);
                 if (result && sText !== result[0]) {
                     fuzzyLen -= result[0].length;
-                    sLine = text.substring(fuzzyLen);
-                    sText = text.substring(0, 0 + fuzzyLen);
+                    sLine = this._safeSubstring(text, fuzzyLen);
+                    sText = this._safeSubstring(text, 0, fuzzyLen);
                 }
             }
 
@@ -250,8 +262,8 @@ var textUtils = {
                 result = this.label_lastEnglish.exec(sText);
                 if (result && sText !== result[0]) {
                     fuzzyLen -= result[0].length;
-                    sLine = text.substring(fuzzyLen);
-                    sText = text.substring(0, 0 + fuzzyLen);
+                    sLine = this._safeSubstring(text, fuzzyLen);
+                    sText = this._safeSubstring(text, 0, fuzzyLen);
                 }
             }
 

--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -220,9 +220,6 @@ var textUtils = {
 
                 fuzzyLen = fuzzyLen + pushNum;
                 tmpText = this._safeSubstring(text, fuzzyLen);
-                if (this.label_firstEmoji.test(tmpText)) {
-                    tmpText = tmpText.slice(1);
-                }
                 width = allWidth - measureText(tmpText);
             }
 

--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -137,8 +137,8 @@ var textUtils = {
     label_lastWordRex : /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]+|\S)$/,
     label_lastEnglish : /[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]+$/,
     label_firstEnglish : /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]/,
-    label_firstEmoji : /^[\uD83C\uDF00-\uDFFF\uDC00-\uDE4F]/,
-    label_lastEmoji : /([\uDF00-\uDFFF\uDC00-\uDE4F]+|\S)$/,
+    label_startsWithEmoji : /^[\uD83C\uDF00-\uDFFF\uDC00-\uDE4F]/,
+    label_endsWithEmoji : /([\uDF00-\uDFFF\uDC00-\uDE4F]+|\S)$/,
     label_wrapinspection : true,
 
     __CHINESE_REG: /^[\u4E00-\u9FFF\u3400-\u4DFF]+$/,
@@ -173,10 +173,10 @@ var textUtils = {
     // in case substring of emoj
     _safeSubstring (targetString, startIndex, endIndex) {
         targetString = targetString.substring(startIndex, endIndex);
-        if (this.label_firstEmoji.test(targetString)) {
+        if (this.label_startsWithEmoji.test(targetString)) {
             targetString = targetString.slice(1);
         }
-        if (endIndex !== undefined && this.label_lastEmoji.test(targetString)) {
+        if (endIndex !== undefined && this.label_endsWithEmoji.test(targetString)) {
             targetString = targetString.slice(0, -1);
         }
         return targetString;
@@ -248,8 +248,8 @@ var textUtils = {
 
             // To judge whether a Emoji words are truncated
             // todo Some Emoji are not well adapted, such as 🚗 and 🇨🇳
-            if (this.label_firstEmoji.test(sLine)) {
-                result = this.label_lastEmoji.exec(sText);
+            if (this.label_startsWithEmoji.test(sLine)) {
+                result = this.label_endsWithEmoji.exec(sText);
                 if (result && sText !== result[0]) {
                     fuzzyLen -= result[0].length;
                     sLine = this._safeSubstring(text, fuzzyLen);


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/2609

changeLog：
- 修复原生平台，Label 带 emoj 时，自动换行不正确的问题

js 没办法处理占两个长度的字节，substring 操作会把表情包切割开来。。。导致 measureText 的时候出错了
<img width="649" alt="WX20200312-184131@2x" src="https://user-images.githubusercontent.com/17872773/76515535-b1d9cd80-6494-11ea-84d7-a2f2a8430a31.png">
