### PR TITLE
Provide .d.ts file for illustration of DebugInfos.json

### DIFF
--- a/DebugInfos.d.ts
+++ b/DebugInfos.d.ts
@@ -1,0 +1,15 @@
+
+/**
+ * This is a declaration file for 'DebugInfos.json'
+ * which is generated from 'EngineErrorMap.md'.
+ * You may run cli command
+ * `gulp build-debug-infos` or `npx gulp build-debug-infos` to generate the json file.
+ */
+
+/**
+ * Engine error maps.
+ * The keys are error codes and their values are format strings.
+ */
+declare const $: Record<number, string>;
+
+export default $;

--- a/cocos/core/platform/debug.ts
+++ b/cocos/core/platform/debug.ts
@@ -26,7 +26,8 @@
  * @category core
  */
 
- // @ts-ignore
+/* eslint-disable no-console */
+
 import debugInfos from '../../../DebugInfos';
 import { EDITOR, JSB, DEV, DEBUG } from 'internal:constants';
 const ERROR_MAP_URL = 'https://github.com/cocos-creator/engine/blob/3d/EngineErrorMap.md';
@@ -242,7 +243,6 @@ export function _resetDebugSetting (mode: DebugMode) {
 
 export function _throw (error_: any) {
     if (EDITOR) {
-        // @ts-ignore
         return error(error_);
     } else {
         const stack = error_.stack;
@@ -345,7 +345,7 @@ export function getError (errorId: any, ...param: any[]): string {
 }
 
 /**
- * @en Returns whether or not to display the FPS informations.
+ * @en Returns whether or not to display the FPS information.
  * @zh 是否显示 FPS 信息。
  */
 export function isDisplayStats (): boolean {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Provide .d.ts file for illustration of DebugInfos.json. So far as this function, editor depends on https://github.com/cocos-creator/editor-3d/pull/3203

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
