### PR TITLE
fix truncating 4-byte character

### DIFF
--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -247,9 +247,14 @@ var textUtils = {
             }
 
             fuzzyLen -= pushNum;
+            // in case maxWidth cannot contain any characters, need at least one character per line
             if (fuzzyLen === 0) {
                 fuzzyLen = 1;
-                sLine = this._safeSubstring(sLine, 1);
+                sLine = this._safeSubstring(text, 1);
+            }
+            else if (fuzzyLen === 1 && this.highSurrogateRex.test(text[0])) {
+                fuzzyLen = 2;
+                sLine = this._safeSubstring(text, 2);
             }
 
             var sText = this._safeSubstring(text, 0, fuzzyLen), result;

--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -137,10 +137,8 @@ var textUtils = {
     label_lastWordRex : /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]+|\S)$/,
     label_lastEnglish : /[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]+$/,
     label_firstEnglish : /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûаíìÍÌïÁÀáàÉÈÒÓòóŐőÙÚŰúűñÑæÆœŒÃÂãÔõěščřžýáíéóúůťďňĚŠČŘŽÁÍÉÓÚŤżźśóńłęćąŻŹŚÓŃŁĘĆĄ-яА-ЯЁё]/,
-    label_firstEmoji : /^[\uD83C\uDF00-\uDFFF\uDC00-\uDE4F]/,
-    label_lastEmoji : /([\uDF00-\uDFFF\uDC00-\uDE4F]+|\S)$/,
     // The unicode standard will never assign a character from code point 0xD800 to 0xDFFF
-    // high surrogate (0xD800-0xDBFF) and low surrogate(0xDC00-0xDFFF) combines to a 4-byte character
+    // high surrogate (0xD800-0xDBFF) and low surrogate(0xDC00-0xDFFF) combines to a character on the Supplementary Multilingual Plane
     // reference: https://en.wikipedia.org/wiki/UTF-16
     label_startsWithLowSurrogate: /^[\uDC00-\uDFFF]/,
     label_endsWithHighSurrogate: /[\uD800-\uDBFF]$/,
@@ -175,7 +173,7 @@ var textUtils = {
         return width;
     },
 
-    // in case truncate a 4-byte character
+    // in case truncate a character on the Supplementary Multilingual Plane
     _safeSubstring (targetString, startIndex, endIndex) {
         let tmpString = targetString.substring(startIndex, endIndex);
         let newStartIndex = startIndex, newEndIndex = endIndex;
@@ -250,17 +248,6 @@ var textUtils = {
                     fuzzyLen -= result ? result[0].length : 0;
                     if (fuzzyLen === 0) fuzzyLen = 1;
 
-                    sLine = this._safeSubstring(text, fuzzyLen);
-                    sText = this._safeSubstring(text, 0, fuzzyLen);
-                }
-            }
-
-            // To judge whether a Emoji words are truncated
-            // todo Some Emoji are not well adapted, such as 🚗 and 🇨🇳
-            if (this.label_firstEmoji.test(sLine)) {
-                result = this.label_lastEmoji.exec(sText);
-                if (result && sText !== result[0]) {
-                    fuzzyLen -= result[0].length;
                     sLine = this._safeSubstring(text, fuzzyLen);
                     sText = this._safeSubstring(text, 0, fuzzyLen);
                 }


### PR DESCRIPTION
Re: 
cocos-creator/2d-tasks#2609
https://github.com/cocos-creator/engine/issues/3589

changeLog:
- 修复原生平台表情包自动换行效果不正确的问题

好吧，这是第三个版本的修复了，总结一下

<img width="239" alt="WX20200317-175146@2x" src="https://user-images.githubusercontent.com/17872773/76844819-d4932a00-6878-11ea-8c3e-109f26a097f7.png">

表情包字符分为两类（其实不仅仅是表情包）：
- 辅助平面上的字符：这类字符占 4 个字节，在 js 里边被解释为占用两个数组长度，比如：😉🚗。这类字符由高位(0xD800-0xDBFF)+低位(0xDC00-0xDFFF) 组成一个位于辅助平面上的字符，这类字符不应该被拆分，拆分开来是没有意义的，因为 Unicode 标准里，码点 0xD800-0xDFFF 范围内是没有对应字符的。拆分会导致 measureText 返回错误的宽度，这个也是 pr 里要解决的问题
- 组合字符：由多个字符组合成的字符，比如 1⃣️2⃣️ 🏳️‍🌈🇨🇳，🇨🇳由字符 `🇨`和` 🇳`组成。这种情况可以参考第三方实现：https://www.npmjs.com/package/grapheme-splitter 。不过其实没有太大必要去做处理，对性能的损耗比较大。保留现状，至少目前不影响 measureText 