### PR TITLE
修复关于 camera.render的 bug #6351 

### DIFF
--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -770,11 +770,7 @@ let Camera = cc.Class({
         this.node.getWorldMatrix(_mat4_temp_1);
         this.beforeDraw();
 
-        if (!CC_JSB) {
-            renderer._forward.renderCamera(this._camera, renderer.scene);
-        } else {
-            RenderFlow.renderCamera(this._camera, root);
-        }
+        RenderFlow.renderCamera(this._camera, root);
     },
 
     _onAlignWithScreen () {

--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -760,17 +760,17 @@ let Camera = cc.Class({
      * !#zh
      * 手动渲染摄像机。
      * @method render
-     * @param {Node} root 
+     * @param {Node} [rootNode] 
      */
-    render (root) {
-        root = root || cc.director.getScene();
-        if (!root) return null;
+    render (rootNode) {
+        rootNode = rootNode || cc.director.getScene();
+        if (!rootNode) return null;
 
         // force update node world matrix
         this.node.getWorldMatrix(_mat4_temp_1);
         this.beforeDraw();
 
-        RenderFlow.renderCamera(this._camera, root);
+        RenderFlow.renderCamera(this._camera, rootNode);
     },
 
     _onAlignWithScreen () {

--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -769,9 +769,11 @@ let Camera = cc.Class({
         // force update node world matrix
         this.node.getWorldMatrix(_mat4_temp_1);
         this.beforeDraw();
-        RenderFlow.render(root);
+
         if (!CC_JSB) {
             renderer._forward.renderCamera(this._camera, renderer.scene);
+        } else {
+            RenderFlow.renderCamera(this._camera, root);
         }
     },
 

--- a/cocos2d/core/renderer/render-flow.js
+++ b/cocos2d/core/renderer/render-flow.js
@@ -235,11 +235,11 @@ RenderFlow.visitRootNode = function (rootNode) {
     _cullingMask = preCullingMask;
 };
 
-RenderFlow.render = function (scene, dt) {
+RenderFlow.render = function (rootNode, dt) {
     _batcher.reset();
     _batcher.walking = true;
 
-    RenderFlow.visitRootNode(scene);
+    RenderFlow.visitRootNode(rootNode);
 
     _batcher.terminate();
     _batcher.walking = false;
@@ -247,11 +247,11 @@ RenderFlow.render = function (scene, dt) {
     _forward.render(_batcher._renderScene, dt);
 };
 
-RenderFlow.renderCamera = function (camera, scene) {
+RenderFlow.renderCamera = function (camera, rootNode) {
     _batcher.reset();
     _batcher.walking = true;
 
-    RenderFlow.visitRootNode(scene);
+    RenderFlow.visitRootNode(rootNode);
 
     _batcher.terminate();
     _batcher.walking = false;

--- a/cocos2d/core/renderer/render-flow.js
+++ b/cocos2d/core/renderer/render-flow.js
@@ -247,6 +247,18 @@ RenderFlow.render = function (scene, dt) {
     _forward.render(_batcher._renderScene, dt);
 };
 
+RenderFlow.renderCamera = function (camera, scene) {
+    _batcher.reset();
+    _batcher.walking = true;
+
+    RenderFlow.visitRootNode(scene);
+
+    _batcher.terminate();
+    _batcher.walking = false;
+
+    _forward.renderCamera(camera, _batcher._renderScene);
+};
+
 RenderFlow.init = function (batcher, forwardRenderer) {
     _batcher = batcher;
     _forward = forwardRenderer;


### PR DESCRIPTION
修复关于 camera.render的 bug #6351 

其中
```
        if (!CC_JSB) {
            renderer._forward.renderCamera(this._camera, renderer.scene);
        } else {
            RenderFlow.renderCamera(this._camera, root);
        }
```

这部分 因为涉及到 原生, 所以 原生部分还麻烦多测试一下.  我只测试了 web环境.