### PR TITLE
mark render-scene raycast as deprecated

### DIFF
--- a/cocos/core/renderer/scene/deprecated.ts
+++ b/cocos/core/renderer/scene/deprecated.ts
@@ -1,4 +1,4 @@
-import { replaceProperty, removeProperty } from "../../utils";
+import { replaceProperty, removeProperty, markAsWarning } from "../../utils";
 import { RenderScene } from "./render-scene";
 import { Layers } from "../../scene-graph";
 
@@ -32,6 +32,17 @@ removeProperty(RenderScene.prototype, 'RenderScene.prototype', [
     {
         'name': 'raycastUINode',
     }
+]);
+
+markAsWarning(RenderScene.prototype, 'RenderScene.prototype', [
+    { 'name': 'raycastAll', 'suggest': 'using intersect in geometry' },
+    { 'name': 'raycastAllModels', 'suggest': 'using intersect in geometry' },
+    { 'name': 'raycastSingleModel', 'suggest': 'using intersect in geometry' },
+    { 'name': 'raycastAllCanvas', 'suggest': 'using intersect in geometry' },
+    { 'name': 'rayResultCanvas' },
+    { 'name': 'rayResultModels' },
+    { 'name': 'rayResultAll' },
+    { 'name': 'rayResultSingleModel' },
 ]);
 
 const CameraVisFlags = {};

--- a/cocos/particle/animator/curve-range.ts
+++ b/cocos/particle/animator/curve-range.ts
@@ -6,8 +6,9 @@ import { ccclass, property } from '../../core/data/class-decorator';
 import { lerp } from '../../core/math';
 import { Enum } from '../../core/value-types';
 import { AnimationCurve } from '../../core/geometry';
+import { EDITOR } from 'internal:constants';
 
-const SerializableTable = CC_EDITOR && [
+const SerializableTable = EDITOR && [
     [ "mode", "constant", "multiplier" ],
     [ "mode", "curve", "multiplier" ],
     [ "mode", "curveMin", "curveMax", "multiplier" ],

--- a/cocos/particle/animator/gradient-range.ts
+++ b/cocos/particle/animator/gradient-range.ts
@@ -20,7 +20,7 @@ const GRADIENT_RANGE_MODE_RANDOM_COLOR = 2;
 const GRADIENT_RANGE_MODE_GRADIENT = 3;
 const GRADIENT_RANGE_MODE_TWO_GRADIENT = 4;
 
-const SerializableTable = CC_EDITOR && [
+const SerializableTable = EDITOR && [
     [ "_mode", "color" ],
     [ "_mode", "gradient" ],
     [ "_mode", "colorMin", "colorMax" ],


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#2398

Changes:
 * Add deprecated to render scene

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
