### PR TITLE
Fix error when drawline has only one point.

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/graphics/index.js
+++ b/cocos2d/core/renderer/webgl/assemblers/graphics/index.js
@@ -250,6 +250,8 @@ export default class GraphicsAssembler extends Assembler {
                 start = 1;
                 end = pointsLength - 1;
             }
+
+            p1 = p1 || p0;
     
             if (!loop) {
                 // Add cap


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/39078800/77385503-3b599b80-6dc3-11ea-86d1-43c47045af84.png)


修复 drawline 的路径只有一个点时的问题。