### PR TITLE
correction rotateBy effect

### DIFF
--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -997,7 +997,6 @@ cc.RotateBy = cc.Class({
     startWithTarget:function (target) {
         cc.ActionInterval.prototype.startWithTarget.call(this, target);
         this._startAngle = target.angle;
-        this._deltaAngle *= -1;
     },
 
     update:function (dt) {


### PR DESCRIPTION
Re: https://forum.cocos.org/t/cocos-creator-v2-3-3-rc-3/90463/21?u=337031709



之前这个 [PR](https://github.com/cocos-creator/engine/pull/6084) 修改是错误的，结果导致旋转方向变成逆时针的了。调用 rotateTo 和 rotateBy 这两个接口时，节点的默认旋转角度应该是都是顺时针，需要与 2.1.0 版本之前的正确表现保持一致。