### PR TITLE
Fixed 3d particle material error on editor and native.

### DIFF
--- a/cocos2d/core/3d/particle/particle-system-3d.ts
+++ b/cocos2d/core/3d/particle/particle-system-3d.ts
@@ -525,7 +525,7 @@ export default class ParticleSystem3D extends RenderComponent {
 
     set trailMaterial (val) {
         this.setMaterial(1, val);
-        this._onMaterialModified(0, val);
+        this._onMaterialModified(1, val);
     }
 
     _isPlaying;

--- a/cocos2d/core/3d/particle/renderer/particle-system-3d-renderer.ts
+++ b/cocos2d/core/3d/particle/renderer/particle-system-3d-renderer.ts
@@ -335,7 +335,7 @@ export default class ParticleSystem3DAssembler extends Assembler {
             mat = MaterialVariant.create(mat, this._particleSystem);
         }
 
-        mat = this._particleSystem.setMaterial(0, mat);
+        mat = mat || this._defaultMat;
 
         if (this._particleSystem._simulationSpace === Space.World) {
             mat.define(CC_USE_WORLD_SPACE, true);
@@ -384,11 +384,13 @@ export default class ParticleSystem3DAssembler extends Assembler {
         }
 
         mat.setProperty('frameTile_velLenScale', this.frameTile_velLenScale);
+
+        this._particleSystem.setMaterial(0, mat);
     }
 
     _updateTrailMaterial () {
+        let mat = this._particleSystem.trailMaterial;
         if (this._particleSystem.trailModule.enable) {
-            let mat = this._particleSystem.trailMaterial;
             if (mat === null && this._defaultTrailMat === null) {
                 this._defaultTrailMat = MaterialVariant.createWithBuiltin('3d-trail', this);
             }
@@ -405,7 +407,6 @@ export default class ParticleSystem3DAssembler extends Assembler {
             }
 
             //mat.define(CC_DRAW_WIRE_FRAME, true); // <wireframe debug>
-
             this._particleSystem.trailModule._updateMaterial();
         }
     }

--- a/cocos2d/core/3d/particle/renderer/particle-system-3d-renderer.ts
+++ b/cocos2d/core/3d/particle/renderer/particle-system-3d-renderer.ts
@@ -389,6 +389,7 @@ export default class ParticleSystem3DAssembler extends Assembler {
     }
 
     _updateTrailMaterial () {
+        // Here need to create a material variant through the getter call.
         let mat = this._particleSystem.trailMaterial;
         if (this._particleSystem.trailModule.enable) {
             if (mat === null && this._defaultTrailMat === null) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2695

论坛反馈：https://forum.cocos.org/t/2-3-2-3d-this--effect-gethash-is-not-a-function/90451

Changes:
 1. 修复编辑器内删除3d粒子材质时的报错。
 2. 修复原生平台没有开启trailModule时的拖尾材质报错。
