### PR TITLE
fixed that texture can not update when there is no image

### DIFF
--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -506,9 +506,7 @@ var Texture2D = cc.Class({
                 options.images.push(options.image);
             }
 
-            if (options.images && options.images.length > 0) {
-                this._texture.update(options);
-            }
+            this._texture && this._texture.update(options);
 
             this._hashDirty = true;
         }

--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -282,7 +282,6 @@ function _getSharedOptions () {
     }
     _images.length = 0;
     _sharedOpts.images = _images;
-    _sharedOpts.flipY = false;
     return _sharedOpts;
 }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/6419

Changes:
 * 修复texture设置参数无效的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
