### PR TITLE
fixed button effect error when interactable set to false

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -425,6 +425,7 @@ let Button = cc.Class({
     __preload () {
         this._applyTarget();
         this._resetState();
+        this._updateState();
     },
 
     _resetState () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/pull/5740

当执行
`
node.getComponent(cc.Button).interactable = false;
this.node.addChild(node);
`
会出现问题。

需要在 button 初始化的时候再调用一下 _updateState