### PR TITLE
Fix the problem of label cropping on the runtime platform.

### DIFF
--- a/cocos2d/core/renderer/utils/label/ttf.js
+++ b/cocos2d/core/renderer/utils/label/ttf.js
@@ -229,6 +229,8 @@ export default class TTFAssembler extends Assembler2D {
             }
         }
 
+        firstLinelabelY += textUtils.BASELINE_OFFSET * _fontSize;
+
         return cc.v2(labelX + _canvasPadding.x, firstLinelabelY + _canvasPadding.y);
     }
 

--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -28,8 +28,9 @@ import js from '../platform/js'
 
 // Draw text the textBaseline ratio (Can adjust the appropriate baseline ratio based on the platform)
 let _BASELINE_RATIO = 0.26;
+let _BASELINE_OFFSET = 0;
 if (CC_RUNTIME) {
-    _BASELINE_RATIO = -0.05;
+    _BASELINE_OFFSET = _BASELINE_RATIO / 2;
 }
 
 const MAX_CACHE_SIZE = 100;
@@ -131,6 +132,7 @@ var textUtils = {
 
     BASELINE_RATIO: _BASELINE_RATIO,
     MIDDLE_RATIO: (_BASELINE_RATIO + 1) / 2 - _BASELINE_RATIO,
+    BASELINE_OFFSET: _BASELINE_OFFSET,
 
     label_wordRex : /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôûа-яА-ЯЁё]+|\S)/,
     label_symbolRex : /^[!,.:;'}\]%\?>、‘“》？。，！]/,


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2079, https://github.com/cocos-creator/2d-tasks/issues/1679

Changes:
 
runtime 平台的底层差异，baseline 的实现不同，绘制文本的时候增加了留白空间，但是 baseline 需要依据留白进行调整。

oppo手机快应用平台显示效果：

![image](https://user-images.githubusercontent.com/39078800/77757859-ee98ed80-706c-11ea-9794-0e9e85c51149.png)

编辑器中的效果：

![image](https://user-images.githubusercontent.com/39078800/77758063-4df6fd80-706d-11ea-80ce-c465032fea8a.png)
