### PR TITLE
Fix gl crash caused by Model destruction.

### DIFF
--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -283,14 +283,18 @@ export class RenderingSubMesh {
         this.vertexBuffers.length = 0;
         if (this.indexBuffer) {
             this.indexBuffer.destroy();
+            this.indexBuffer = undefined;
         }
-        this.indexBuffer = undefined;
         if (this._jointMappedBuffers && this._jointMappedBufferIndices) {
             for (let i = 0; i < this._jointMappedBufferIndices.length; i++) {
                 this._jointMappedBuffers[this._jointMappedBufferIndices[i]].destroy();
             }
             this._jointMappedBuffers = undefined;
             this._jointMappedBufferIndices = undefined;
+        }
+        if (this.indirectBuffer) {
+            this.indirectBuffer.destroy();
+            this.indirectBuffer = undefined;
         }
     }
 

--- a/cocos/core/renderer/scene/submodel.ts
+++ b/cocos/core/renderer/scene/submodel.ts
@@ -84,10 +84,6 @@ export class SubModel {
         }
         this._cmdBuffers.length = 0;
         this._material = null;
-        if (this._subMeshObject) {
-            this._subMeshObject.destroy();
-            this._subMeshObject = null;
-        }
     }
 
     public updateCommandBuffer () {

--- a/cocos/core/renderer/scene/submodel.ts
+++ b/cocos/core/renderer/scene/submodel.ts
@@ -74,6 +74,7 @@ export class SubModel {
     public destroy () {
         if (this._inputAssembler) {
             this._inputAssembler.destroy();
+            this._inputAssembler = null;
         }
         for (let i = 0; i < this.passes.length; i++) {
             this.passes[i].destroyPipelineState(this._psos![i]);
@@ -83,6 +84,10 @@ export class SubModel {
         }
         this._cmdBuffers.length = 0;
         this._material = null;
+        if (this._subMeshObject) {
+            this._subMeshObject.destroy();
+            this._subMeshObject = null;
+        }
     }
 
     public updateCommandBuffer () {

--- a/cocos/core/root.ts
+++ b/cocos/core/root.ts
@@ -497,10 +497,12 @@ export class Root {
         const p = this._modelPools.get(m.constructor);
         if (p) {
             p.free(m);
-        }
-        m.destroy();
-        if (m.scene) {
-            m.scene.removeModel(m);
+            m.destroy();
+            if (m.scene) {
+                m.scene.removeModel(m);
+            }
+        } else {
+            console.warn(`'${m.constructor.name}'is not in the model pool and cannot be destroyed by destroyModel.`);
         }
     }
 

--- a/cocos/core/root.ts
+++ b/cocos/core/root.ts
@@ -497,10 +497,10 @@ export class Root {
         const p = this._modelPools.get(m.constructor);
         if (p) {
             p.free(m);
-            m.destroy();
-            if (m.scene) {
-                m.scene.removeModel(m);
-            }
+        }
+        m.destroy();
+        if (m.scene) {
+            m.scene.removeModel(m);
         }
     }
 

--- a/cocos/particle/models/line-model.ts
+++ b/cocos/particle/models/line-model.ts
@@ -211,9 +211,9 @@ export class LineModel extends Model {
     }
 
     private destroySubMeshData () {
-        for (const vb of this._subMeshData!.vertexBuffers) {
-            vb.destroy();
+        if (this._subMeshData) {
+            this._subMeshData.destroy();
+            this._subMeshData = null;
         }
-        this._subMeshData!.indexBuffer!.destroy();
     }
 }

--- a/cocos/particle/models/particle-batch-model.ts
+++ b/cocos/particle/models/particle-batch-model.ts
@@ -112,7 +112,7 @@ export default class ParticleBatchModel extends Model {
     }
 
     public _createSubMeshData (): ArrayBuffer {
-        this.destroySubMeshData()
+        this.destroySubMeshData();
         this._vertCount = 4;
         this._indexCount = 6;
         if (this._mesh) {

--- a/cocos/particle/models/particle-batch-model.ts
+++ b/cocos/particle/models/particle-batch-model.ts
@@ -112,9 +112,7 @@ export default class ParticleBatchModel extends Model {
     }
 
     public _createSubMeshData (): ArrayBuffer {
-        if (this._subMeshData) {
-            this.destroySubMeshData();
-        }
+        this.destroySubMeshData()
         this._vertCount = 4;
         this._indexCount = 6;
         if (this._mesh) {
@@ -257,11 +255,8 @@ export default class ParticleBatchModel extends Model {
         super.destroy();
         this._vBuffer = null;
         this._vdataF32 = null;
-        if (this._subMeshData) {
-            this.destroySubMeshData();
-        }
+        this.destroySubMeshData();
         this._iaInfoBuffer.destroy();
-        this._subMeshData = null;
     }
 
     private _recreateBuffer () {
@@ -272,9 +267,9 @@ export default class ParticleBatchModel extends Model {
     }
 
     private destroySubMeshData () {
-        for (const vb of this._subMeshData!.vertexBuffers) {
-            vb.destroy();
+        if (this._subMeshData) {
+            this._subMeshData.destroy();
+            this._subMeshData = null;
         }
-        this._subMeshData!.indexBuffer!.destroy();
     }
 }

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -380,6 +380,7 @@ export default class TrailModule {
     }
 
     public destroy () {
+        this.destroySubMeshData();
         if (this._trailModel) {
             cc.director.root.destroyModel(this._trailModel);
             this._trailModel = null;
@@ -685,6 +686,13 @@ export default class TrailModule {
             currElement.direction = 1 - prevElement.direction;
         } else {
             currElement.direction = prevElement.direction;
+        }
+    }
+
+    private destroySubMeshData () {
+        if (this._subMeshData) {
+            this._subMeshData.destroy();
+            this._subMeshData = null;
         }
     }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/2873

Changes:

修复 Mesh 跟 subModel 销毁不彻底导致的 gl 崩溃。

问题说明：

1. subModel 的 inputassembler 没有置空导致 pool 复用 model 时，会引用同一个对象，数据被其他 model 修改，导致 gl 提交时 buffer 数据不匹配，提交指令崩溃。

2. 部分数据组件 destroy 时没有销毁，可能存在的内存泄漏。

