### PR TITLE
Animation bug squash

### DIFF
--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -198,7 +198,7 @@ export class AnimationComponent extends Component implements IEventTarget {
 
     public onLoad () {
         this.clips = this._clips;
-        for (const stateName of Object.keys(this._nameToState)) {
+        for (const stateName in this._nameToState) {
             const state = this._nameToState[stateName];
             state.initialize(this.node);
         }

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -187,16 +187,26 @@ export class AnimationComponent extends Component implements IEventTarget {
     @property
     protected _defaultClip: AnimationClip | null = null;
 
+    /**
+     * Should the default clip get into playing when this component starts.
+     * In normal, this value is equal to `playOnLoad`.
+     * However, if `crossFade()` or `play()` is called before this component starts,
+     * this field would be set to `false`, regardless of whether `playOnLoad` is set,
+     * even the two playing method fail.
+     */
+    private _playOnStart = false;
+
     public onLoad () {
         this.clips = this._clips;
         for (const stateName of Object.keys(this._nameToState)) {
             const state = this._nameToState[stateName];
             state.initialize(this.node);
         }
+        this._playOnStart = this.playOnLoad;
     }
 
     public start () {
-        if (!EDITOR && this.playOnLoad && this._defaultClip) {
+        if (!EDITOR && this._playOnStart && this._defaultClip) {
             this.crossFade(this._defaultClip.name, 0);
         }
     }
@@ -223,6 +233,7 @@ export class AnimationComponent extends Component implements IEventTarget {
      * @param [name] 目标动画状态的名称；若未指定，使用默认动画剪辑的名称。
      */
     public play (name?: string) {
+        this._playOnStart = false;
         if (!name) {
             if (!this._defaultClip) {
                 return;
@@ -239,6 +250,7 @@ export class AnimationComponent extends Component implements IEventTarget {
      * @param duration 切换周期，单位为秒。
      */
     public crossFade (name: string, duration = 0.3) {
+        this._playOnStart = false;
         const state = this._nameToState[name];
         if (state) {
             this._crossFade.play();

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -719,6 +719,7 @@ export class AnimationState extends Playable {
                         samplerResultCache.fromRatio = sampler.ratios[samplerResultCache.from];
                         samplerResultCache.to = index;
                         samplerResultCache.toRatio = sampler.ratios[samplerResultCache.to];
+                        index = samplerResultCache.from;
                     }
                 }
             }

--- a/cocos/core/animation/skeletal-animation-component.ts
+++ b/cocos/core/animation/skeletal-animation-component.ts
@@ -131,7 +131,6 @@ export class SkeletalAnimationComponent extends AnimationComponent {
     }
     set useBakedAnimation (val) {
         this._useBakedAnimation = val;
-        this.stop();
         const comps = this.node.getComponentsInChildren(SkinningModelComponent);
         for (let i = 0; i < comps.length; ++i) {
             const comp = comps[i];


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:

This PR fixes two animation bugs:

### About execution order

This bug fired when `AnimationComponent.crossFade()` or `AnimationComponent.play()` is called prior to `AnimationComponent.start()` with `AnimationComponent.playOnLoad` set to `true`. The playing functions have no effect since the automatically played animation would overwrite it.

Fix: now invocations on those playing function would add a flag to infer that no automatically playing is needed.

### Looped animation curves with no interpolation would not run into first frame

It's a logic bug.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
