### PR TITLE
Suppress some run-time warns

### DIFF
--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -168,7 +168,12 @@ export class AnimationComponent extends Component implements IEventTarget {
     public static EventType = EventType;
 
     /**
+     * @zh
      * 是否在动画组件开始运行时自动播放默认动画剪辑。
+     * 注意，若在组件开始运行前调用了 `crossFade` 或 `play()`，此字段将不会生效。
+     * @en
+     * Whether the default clip should get into playing when this components starts.
+     * Note, this field takes no effect if `crossFade()` or `play()` has been called before this component starts.
      */
     @property({
         tooltip: '是否在动画组件开始运行时自动播放默认动画剪辑',
@@ -188,13 +193,9 @@ export class AnimationComponent extends Component implements IEventTarget {
     protected _defaultClip: AnimationClip | null = null;
 
     /**
-     * Should the default clip get into playing when this component starts.
-     * In normal, this value is equal to `playOnLoad`.
-     * However, if `crossFade()` or `play()` is called before this component starts,
-     * this field would be set to `false`, regardless of whether `playOnLoad` is set,
-     * even the two playing method fail.
+     * Whether if `crossFade()` or `play()` has been called before this component starts.
      */
-    private _playOnStart = false;
+    private _hasBeenPlayed = false;
 
     public onLoad () {
         this.clips = this._clips;
@@ -202,11 +203,10 @@ export class AnimationComponent extends Component implements IEventTarget {
             const state = this._nameToState[stateName];
             state.initialize(this.node);
         }
-        this._playOnStart = this.playOnLoad;
     }
 
     public start () {
-        if (!EDITOR && this._playOnStart && this._defaultClip) {
+        if (!EDITOR && (this.playOnLoad && !this._hasBeenPlayed) && this._defaultClip) {
             this.crossFade(this._defaultClip.name, 0);
         }
     }
@@ -233,7 +233,7 @@ export class AnimationComponent extends Component implements IEventTarget {
      * @param [name] 目标动画状态的名称；若未指定，使用默认动画剪辑的名称。
      */
     public play (name?: string) {
-        this._playOnStart = false;
+        this._hasBeenPlayed = true;
         if (!name) {
             if (!this._defaultClip) {
                 return;
@@ -250,7 +250,7 @@ export class AnimationComponent extends Component implements IEventTarget {
      * @param duration 切换周期，单位为秒。
      */
     public crossFade (name: string, duration = 0.3) {
-        this._playOnStart = false;
+        this._hasBeenPlayed = true;
         const state = this._nameToState[name];
         if (state) {
             this._crossFade.play();

--- a/cocos/particle/particle-system-component.ts
+++ b/cocos/particle/particle-system-component.ts
@@ -424,11 +424,10 @@ export class ParticleSystemComponent extends RenderableComponent {
 
     // serilized culling
     @property({
-        type: Boolean,
         displayOrder: 27,
         tooltip:'是否剔除非 enable 的模块数据',
     })
-    public enableCulling: Boolean = false;
+    public enableCulling: boolean = false;
 
     /**
      * @ignore

--- a/cocos/particle/renderer/particle-system-renderer-data.ts
+++ b/cocos/particle/renderer/particle-system-renderer-data.ts
@@ -137,10 +137,9 @@ export default class ParticleSystemRenderer {
     }
 
     @property
-    private _useGPU: Boolean = false;
+    private _useGPU: boolean = false;
 
     @property({
-        type: Boolean,
         displayOrder: 10,
         tooltip:'是否启用GPU粒子',
     })

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -628,7 +628,6 @@ export class Terrain extends Component {
     @property({
         type: TerrainAsset,
         visible: true,
-        serializable: false,
     })
     public set _asset (value: TerrainAsset|null) {
         if (this.__asset !== value) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Suppress the following warns:
```text
The type of "cc.ParticleSystemRenderer.useGPU" must be CCBoolean, not Boolean.
The type of "cc.ParticleSystemComponent.enableCulling" must be CCBoolean, not Boolean.
No needs to indicate the 'cc.Boolean' attribute for "cc.ParticleSystemComponent.enableCulling", which its default value is type of Boolean.
'No need to use 'serializable: false' or 'editorOnly: true' for the getter of 'serializable.', every getter is actually non-serialized. _asset
```

Please review these changes @YunHsiao @MSoft1115 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
