### PR TITLE
unify properties order in ValueTypes

### DIFF
--- a/cocos2d/core/assets/material/CCMaterial.js
+++ b/cocos2d/core/assets/material/CCMaterial.js
@@ -54,7 +54,7 @@ const BUILTIN_NAME = cc.Enum({
      * @type {String}
      */
     UNLIT: 'unlit',
-})
+});
 
 
 /**

--- a/cocos2d/core/value-types/quat.ts
+++ b/cocos2d/core/value-types/quat.ts
@@ -859,10 +859,10 @@ export default class Quat extends ValueType {
         super();
 
         if (x && typeof x === 'object') {
-            this.z = x.z;
-            this.y = x.y;
-            this.w = x.w;
             this.x = x.x;
+            this.y = x.y;
+            this.z = x.z;
+            this.w = x.w;
         }
         else {
             this.x = x as number;

--- a/cocos2d/core/value-types/size.ts
+++ b/cocos2d/core/value-types/size.ts
@@ -72,8 +72,8 @@ export default class Size extends ValueType {
     constructor (width: Size | number = 0, height: number = 0) {
         super();
         if (width && typeof width === 'object') {
-            this.height = width.height;
             this.width = width.width;
+            this.height = width.height;
         }
         else {
             this.width = width as number || 0;

--- a/cocos2d/core/value-types/vec2.ts
+++ b/cocos2d/core/value-types/vec2.ts
@@ -755,8 +755,8 @@ export default class Vec2 extends ValueType {
         super();
 
         if (x && typeof x === 'object') {
-            this.y = x.y || 0;
             this.x = x.x || 0;
+            this.y = x.y || 0;
         } else {
             this.x = x as number || 0;
             this.y = y || 0;

--- a/cocos2d/core/value-types/vec3.ts
+++ b/cocos2d/core/value-types/vec3.ts
@@ -1041,9 +1041,9 @@ export default class Vec3 extends ValueType {
     constructor (x: Vec3 | number = 0, y: number = 0, z: number = 0) {
         super();
         if (x && typeof x === 'object') {
-            this.z = x.z;
-            this.y = x.y;
             this.x = x.x;
+            this.y = x.y;
+            this.z = x.z;
         }
         else {
             this.x = x as number;

--- a/cocos2d/core/value-types/vec4.ts
+++ b/cocos2d/core/value-types/vec4.ts
@@ -757,10 +757,10 @@ export default class Vec4 extends ValueType {
     constructor (x: number | Vec4 = 0, y: number = 0, z: number = 0, w: number = 0) {
         super();
         if (x && typeof x === 'object') {
-            this.w = x.w;
-            this.z = x.z;
-            this.y = x.y;
             this.x = x.x;
+            this.y = x.y;
+            this.z = x.z;
+            this.w = x.w;
         } else {
             this.x = x as number;
             this.y = y;


### PR DESCRIPTION
统一 Value Type 属性构造顺序。不知道之前为什么要反过来