### PR TITLE
optimize audio interface

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -235,7 +235,7 @@ Audio.State = {
     };
 
     proto.getDuration = function () {
-        return this._element ? this._element.duration : 0;
+        return this._src ? this._src.duration : 0;
     };
 
     proto.getState = function (forceUpdating = true) {

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -36,16 +36,10 @@ let touchPlayList = [
 
 let Audio = function (src) {
     EventTarget.call(this);
-
     this._shouldRecycleOnEnded = false;
     this._src = src;
     this._element = null;
     this.id = 0;
-
-    this._volume = 1;
-    this._loop = false;
-    this._nextTime = 0;  // playback position to set
-
     this._state = Audio.State.INITIALZING;
 
     this._onended = function () {
@@ -107,27 +101,10 @@ Audio.State = {
         }
     };
 
-    // proto.mount = function (elem) {
-    //     if (CC_DEBUG) {
-    //         cc.warn('Audio.mount(value) is deprecated. Please use Audio._onLoaded().');
-    //     }
-    // };
-
     proto._onLoaded = function () {
         this._createElement();
-        
-        this.setVolume(this._volume);
-        this.setLoop(this._loop);
-        if (this._nextTime !== 0) {
-            this.setCurrentTime(this._nextTime);
-        }
-        // need to skip forceUpdatingState when get state on load, because it's a hack operation
-        if (this.getState(false) === Audio.State.PLAYING) {
-            this.play();
-        }
-        else {
-            this._state = Audio.State.INITIALZING;
-        }
+        this.setVolume(1);
+        this.setLoop(false);
     };
 
     proto._createElement = function () {
@@ -145,17 +122,15 @@ Audio.State = {
     };
 
     proto.play = function () {
-        // marked as playing so it will playOnLoad
-        this._state = Audio.State.PLAYING;
-
-        if (!this._element) {
-            return;
-        }
-
-        this._bindEnded();
-        this._element.play();
-
-        this._touchToPlay();
+        let self = this;
+        this._src && this._src._ensureLoaded(function () {
+            // marked as playing so it will playOnLoad
+            self._state = Audio.State.PLAYING;
+            // IDEA: why?
+            self._bindEnded();
+            self._element.play();
+            self._touchToPlay();
+        });
     };
 
     proto._touchToPlay = function () {
@@ -182,86 +157,77 @@ Audio.State = {
     };
 
     proto.pause = function () {
-        if (!this._element || this.getState() !== Audio.State.PLAYING) return;
-        this._unbindEnded();
-        this._element.pause();
-        this._state = Audio.State.PAUSED;
+        if (this.getState() !== Audio.State.PLAYING) return;
+        let self = this;
+        this._src && this._src._ensureLoaded(function () {
+            // pause operation may fire 'ended' event
+            self._unbindEnded();
+            self._element.pause();
+            self._state = Audio.State.PAUSED;
+        });
     };
 
     proto.resume = function () {
-        if (!this._element || this.getState() !== Audio.State.PAUSED) return;
-        this._bindEnded();
-        this._element.play();
-        this._state = Audio.State.PLAYING;
+        if (this.getState() !== Audio.State.PAUSED) return;
+        let self = this;
+        this._src && this._src._ensureLoaded(function () {
+            self._bindEnded();
+            self._element.play();
+            self._state = Audio.State.PLAYING;
+        });
     };
 
     proto.stop = function () {
-        if (!this._element) return;
-        this._element.pause();
-        try {
-            this._element.currentTime = 0;
-        } catch (error) {}
-        // remove touchPlayList
-        for (let i = 0; i < touchPlayList.length; i++) {
-            if (touchPlayList[i].instance === this) {
-                touchPlayList.splice(i, 1);
-                break;
+        let self = this;
+        this._src && this._src._ensureLoaded(function () {
+            self._element.pause();
+            try {
+                self._element.currentTime = 0;
+            } catch (error) {}
+            // remove touchPlayList
+            for (let i = 0; i < touchPlayList.length; i++) {
+                if (touchPlayList[i].instance === self) {
+                    touchPlayList.splice(i, 1);
+                    break;
+                }
             }
-        }
-        this._unbindEnded();
-        this.emit('stop');
-        this._state = Audio.State.STOPPED;
+            self._unbindEnded();
+            self.emit('stop');
+            self._state = Audio.State.STOPPED;
+        });
     };
 
     proto.setLoop = function (loop) {
-        this._loop = loop;
-        if (this._element) {
-            this._element.loop = loop;
-        }
+        let self = this;
+        this._src && this._src._ensureLoaded(function () {
+            self._element.loop = loop;
+        });
     };
     proto.getLoop = function () {
-        return this._loop;
+        return this._element ? this._element.loop : false;
     };
 
     proto.setVolume = function (num) {
-        this._volume = num;
-        if (this._element) {
-            this._element.volume = num;
-        }
+        let self = this;
+        this._src && this._src._ensureLoaded(function () {
+            self._element.volume = num;
+        });
     };
     proto.getVolume = function () {
-        return this._volume;
+        return this._element ? this._element.volume : 1;
     };
 
     proto.setCurrentTime = function (num) {
-        if (this._element) {
-            this._nextTime = 0;
-        }
-        else {
-            this._nextTime = num;
-            return;
-        }
-
-        // setCurrentTime would fire 'ended' event
-        // so we need to change the callback to rebind ended callback after setCurrentTime
-        this._unbindEnded();
-        this._bindEnded(function () {
-            this._bindEnded();
-        }.bind(this));
-
-        try {
-            this._element.currentTime = num;
-        }
-        catch (err) {
-            let _element = this._element;
-            if (_element.addEventListener) {
-                let func = function () {
-                    _element.removeEventListener('loadedmetadata', func);
-                    _element.currentTime = num;
-                };
-                _element.addEventListener('loadedmetadata', func);
-            }
-        }
+        let self = this;
+        this._src && this._src._ensureLoaded(function () {
+            // setCurrentTime would fire 'ended' event
+            // so we need to change the callback to rebind ended callback after setCurrentTime
+            self._unbindEnded();
+            self._bindEnded(function () {
+                self._bindEnded();
+            });
+            self._element.currentTime = num;
+        });
     };
 
     proto.getCurrentTime = function () {
@@ -278,7 +244,6 @@ Audio.State = {
         if (forceUpdating) {
             this._forceUpdatingState();
         }
-        
         return this._state;
     };
 
@@ -302,18 +267,13 @@ Audio.State = {
             this._unbindEnded();
             if (clip) {
                 this._src = clip;
-                if (clip.loaded) {
-                    this._onLoaded();
-                }
-                else {
-                    let self = this;
-                    clip.once('load', function () {
-                        if (clip === self._src) {
-                            self._onLoaded();
-                        }
-                    });
-                    cc.assetManager.postLoadNative(clip);
-                }
+                let self = this;
+                clip._ensureLoaded(function () {
+                    // In case set a new src when the old one hasn't finished loading
+                    if (clip === self._src) {
+                        self._onLoaded();
+                    }
+                });
             }
             else {
                 this._src = null;

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -103,6 +103,7 @@ Audio.State = {
 
     proto._onLoaded = function () {
         this._createElement();
+        this._state = Audio.State.INITIALZING;
         this.setVolume(1);
         this.setLoop(false);
     };
@@ -126,7 +127,7 @@ Audio.State = {
         this._src && this._src._ensureLoaded(function () {
             // marked as playing so it will playOnLoad
             self._state = Audio.State.PLAYING;
-            // IDEA: why?
+            // TODO: move to audio event listeners
             self._bindEnded();
             self._element.play();
             self._touchToPlay();
@@ -181,9 +182,7 @@ Audio.State = {
         let self = this;
         this._src && this._src._ensureLoaded(function () {
             self._element.pause();
-            try {
-                self._element.currentTime = 0;
-            } catch (error) {}
+            self._element.currentTime = 0;
             // remove touchPlayList
             for (let i = 0; i < touchPlayList.length; i++) {
                 if (touchPlayList[i].instance === self) {

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -426,7 +426,7 @@ var audioEngine = {
      * !#en Getting audio can produce several examples.
      * !#zh 获取一个音频可以设置几个实例
      * @method getMaxAudioInstance
-     * @return {Number} a - number of instances to be created from within an audio
+     * @return {Number} max number of instances to be created from within an audio
      * @example
      * cc.audioEngine.getMaxAudioInstance();
      */

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -770,18 +770,4 @@ var audioEngine = {
     }
 };
 
-
-/**
- * !#en the max number of audio instances that can be played at the same time
- * !#zh 获取最多可以同时播放的音频实例数
- * @property {number} maxAudioInstance
- */
-Object.defineProperty(audioEngine, 'maxAudioInstance', {
-    get () {
-        return audioEngine._maxAudioInstance;
-    },
-    enumerable: true,
-    configurable: true,
-});
-
 module.exports = cc.audioEngine = audioEngine;

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -144,35 +144,17 @@ var audioEngine = {
      * });
      */
     play: function (clip, loop, volume) {
-        var path = clip;
-        var audio;
-        if (typeof clip === 'string') {
-            // backward compatibility since 1.10
-            cc.warnID(8401, 'cc.audioEngine', 'cc.AudioClip', 'AudioClip', 'cc.AudioClip', 'audio');
-            path = clip;
-            // load clip
-            audio = getAudioFromPath(path);
-            AudioClip._loadByUrl(path, function (err, clip) {
-                if (clip) {
-                    audio.src = clip;
-                }
-            });
+        if (!(clip instanceof AudioClip)) {
+            return cc.error('Wrong type of AudioClip.');
         }
-        else {
-            if (!clip) {
-                return;
-            }
-            path = clip.nativeUrl;
-            audio = getAudioFromPath(path);
-            audio.src = clip;
-        }
-
+        let path = clip.nativeUrl;
+        let audio = getAudioFromPath(path);
+        audio.src = clip;
         audio._shouldRecycleOnEnded = true;
         audio.setLoop(loop || false);
         volume = handleVolume(volume);
         audio.setVolume(volume);
         audio.play();
-
         return audio.id;
     },
 
@@ -436,7 +418,7 @@ var audioEngine = {
     setMaxAudioInstance: function (num) {
         if (CC_DEBUG) {
             cc.warn('Since v2.4.0, maxAudioInstance has become a read only property.\n'
-            + 'audioEngine.setMaxAudioInstance() methord will be removed in the future');
+            + 'audioEngine.setMaxAudioInstance() method will be removed in the future');
         }
     },
 

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -429,7 +429,6 @@ var audioEngine = {
      * @return {Number} a - number of instances to be created from within an audio
      * @example
      * cc.audioEngine.getMaxAudioInstance();
-     * @deprecated since v2.4.0
      */
     getMaxAudioInstance: function () {
         return this._maxAudioInstance;

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -126,7 +126,6 @@ var audioEngine = {
 
     AudioState: Audio.State,
 
-    _maxWebAudioSize: 2097152, // 2048kb * 1024
     _maxAudioInstance: 24,
 
     _id2audio: _id2audio,
@@ -144,7 +143,7 @@ var audioEngine = {
      *     var audioID = cc.audioEngine.play(clip, false, 0.5);
      * });
      */
-    play: function (clip, loop, volume/*, profile*/) {
+    play: function (clip, loop, volume) {
         var path = clip;
         var audio;
         if (typeof clip === 'string') {
@@ -432,9 +431,13 @@ var audioEngine = {
      * @param {Number} num - a number of instances to be created from within an audio
      * @example
      * cc.audioEngine.setMaxAudioInstance(20);
+     * @deprecated since v2.4.0
      */
     setMaxAudioInstance: function (num) {
-        this._maxAudioInstance = num;
+        if (CC_DEBUG) {
+            cc.warn('Since v2.4.0, maxAudioInstance has become a read only property.\n'
+            + 'audioEngine.setMaxAudioInstance() methord will be removed in the future');
+        }
     },
 
     /**
@@ -444,6 +447,7 @@ var audioEngine = {
      * @return {Number} a - number of instances to be created from within an audio
      * @example
      * cc.audioEngine.getMaxAudioInstance();
+     * @deprecated since v2.4.0
      */
     getMaxAudioInstance: function () {
         return this._maxAudioInstance;
@@ -505,49 +509,6 @@ var audioEngine = {
         }
         _id2audio = js.createMap(true);
         _url2id = {};
-    },
-
-    /**
-     * !#en Gets an audio profile by name.
-     *
-     * @param profileName A name of audio profile.
-     * @return The audio profile.
-     */
-    getProfile: function (profileName) {},
-
-    /**
-     * !#en Preload audio file.
-     * !#zh 预加载一个音频
-     * @method preload
-     * @param {String} filePath - The file path of an audio.
-     * @param {Function} [callback] - The callback of an audio.
-     * @example
-     * cc.audioEngine.preload(path);
-     * @deprecated `cc.audioEngine.preload` is deprecated, use `cc.resources.load(path, cc.AudioClip)` instead please.
-     */
-    preload: function (filePath, callback) {
-        if (CC_DEBUG) {
-            cc.warn('`cc.audioEngine.preload` is deprecated, use `cc.resources.load(path, cc.AudioClip)` instead please.');
-        }
-
-        cc.resources.load(filePath, cc.AudioClip, null, callback && function (error) {
-            if (!error) {
-                callback();
-            }
-        });
-    },
-
-    /**
-     * !#en Set a size, the unit is KB. Over this size is directly resolved into DOM nodes.
-     * !#zh 设置一个以 KB 为单位的尺寸，大于这个尺寸的音频在加载的时候会强制使用 dom 方式加载
-     * @method setMaxWebAudioSize
-     * @param {Number} kb - The file path of an audio.
-     * @example
-     * cc.audioEngine.setMaxWebAudioSize(300);
-     */
-    // Because webAudio takes up too much memory，So allow users to manually choose
-    setMaxWebAudioSize: function (kb) {
-        this._maxWebAudioSize = kb * 1024;
     },
 
     _breakCache: null,
@@ -826,5 +787,19 @@ var audioEngine = {
         }
     }
 };
+
+
+/**
+ * !#en the max number of audio instances that can be played at the same time
+ * !#zh 获取最多可以同时播放的音频实例数
+ * @property {number} maxAudioInstance
+ */
+Object.defineProperty(audioEngine, 'maxAudioInstance', {
+    get () {
+        return audioEngine._maxAudioInstance;
+    },
+    enumerable: true,
+    configurable: true,
+});
 
 module.exports = cc.audioEngine = audioEngine;

--- a/cocos2d/core/assets/CCAudioClip.js
+++ b/cocos2d/core/assets/CCAudioClip.js
@@ -123,12 +123,8 @@ var AudioClip = cc.Class({
             if (!this._loading) {
                 this._loading = true;
                 let self = this;
-                cc.assetManager.loadNativeFile(this, function (err, audioNativeAsset) {
+                cc.assetManager.postLoadNative(this, function (err) {
                     self._loading = false;
-                    if (err) {
-                        return cc.error(err);
-                    }
-                    self._nativeAsset = audioNativeAsset;
                 });
             }
         }

--- a/cocos2d/core/assets/CCAudioClip.js
+++ b/cocos2d/core/assets/CCAudioClip.js
@@ -45,6 +45,7 @@ var AudioClip = cc.Class({
     mixins: [EventTarget],
 
     ctor () {
+        this._loading = false;
         this.loaded = false;
 
         // the web audio buffer or <audio> element
@@ -108,6 +109,28 @@ var AudioClip = cc.Class({
 
         _parseNativeDepFromJson (json) {
             return { audioLoadMode: json.loadMode,  ext: cc.path.extname(json._native), __isNative__: true };
+        }
+    },
+
+    _ensureLoaded (onComplete) {
+        if (this.loaded) {
+            return onComplete && onComplete();
+        }
+        else {
+            if (onComplete) {
+                this.once('load', onComplete);
+            }
+            if (!this._loading) {
+                this._loading = true;
+                let self = this;
+                cc.assetManager.loadNativeFile(this, function (err, audioNativeAsset) {
+                    self._loading = false;
+                    if (err) {
+                        return cc.error(err);
+                    }
+                    self._nativeAsset = audioNativeAsset;
+                });
+            }
         }
     },
 

--- a/cocos2d/core/assets/CCAudioClip.js
+++ b/cocos2d/core/assets/CCAudioClip.js
@@ -53,6 +53,13 @@ var AudioClip = cc.Class({
     },
 
     properties: {
+        /**
+         * !#en Get the audio clip duration
+         * !#zh 获取音频剪辑的长度
+         * @property duration
+         * @type {Number}
+         */
+        duration: 0,
         loadMode: {
             default: LoadMode.WEB_AUDIO,
             type: LoadMode

--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -94,20 +94,11 @@ var AudioSource = cc.Class({
                 return this._clip;
             },
             set: function (value) {
-                if (typeof value === 'string') {
-                    // backward compatibility since 1.10
-                    cc.warnID(8401, 'cc.AudioSource', 'cc.AudioClip', 'AudioClip', 'cc.AudioClip', 'audio');
-                    let self = this;
-                    AudioClip._loadByUrl(value, function (err, clip) {
-                        if (clip) {
-                            self.clip = clip;
-                        }
-                    });
-                    return;
-                }
-
                 if (value === this._clip) {
                     return;
+                }
+                if (!(value instanceof AudioClip)) {
+                    return cc.error('Wrong type of AudioClip.');
                 }
                 this._clip = value;
                 this.audio.stop();

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -702,4 +702,14 @@ if (CC_DEBUG) {
         }
     };
     
+    // audio
+    markAsRemovedInObject(cc.audioEngine, [
+        'getProfile',
+        'preload',
+        'setMaxWebAudioSize',
+    ], 'cc.audioEngine');
+
+    markFunctionWarning(cc.audioEngine, {
+        getMaxAudioInstance: 'maxAudioInstance',
+    }, 'cc.audioEngine');
 }

--- a/cocos2d/deprecated.js
+++ b/cocos2d/deprecated.js
@@ -708,8 +708,4 @@ if (CC_DEBUG) {
         'preload',
         'setMaxWebAudioSize',
     ], 'cc.audioEngine');
-
-    markFunctionWarning(cc.audioEngine, {
-        getMaxAudioInstance: 'maxAudioInstance',
-    }, 'cc.audioEngine');
 }


### PR DESCRIPTION
changeLog:
- 移除 audioEngine 的 `preload` `setMaxWebAudioSize` `getProfile` 接口, 废弃 `setMaxAudioInstance`
- 移除 audioEngine.play() 对 url 的支持
- CCAudio 的所有操作都需要确认 audioClip 加载完成
- AudioClip 支持访问 duration https://github.com/cocos-creator/fireball/pull/9575

TODO: 
- [x] 同步 adapters  https://github.com/cocos-creator-packages/adapters/pull/110
- [x] ~~`preload` 接口的废弃有待商榷，这是老接口，用户存在需求通过 preload 返回 audioId https://github.com/cocos-creator/2d-tasks/issues/2539~~