### PR TITLE
cc.easeBackOut增加边界值判断

### DIFF
--- a/cocos2d/actions/CCActionEase.js
+++ b/cocos2d/actions/CCActionEase.js
@@ -543,6 +543,9 @@ cc.easeBackIn = function(){
  */
 var _easeBackOutObj = {
     easing: function (time1) {
+        if (time1 === 0 || time1 === 1) {
+            return time1;
+        }
         var overshoot = 1.70158;
         time1 = time1 - 1;
         return time1 * time1 * ((overshoot + 1) * time1 + overshoot) + 1;

--- a/test/qunit/unit-es5/test-component-scheduler.js
+++ b/test/qunit/unit-es5/test-component-scheduler.js
@@ -895,6 +895,39 @@ test('start should always invoke before update', function () {
     node.active = false;
 });
 
+test('different start executionOrder', function () {
+    var invoked = false;
+    var TestComp = cc.Class({
+        extends: cc.Component,
+        start: function () {
+            invoked = true;
+        },
+        update: function () {
+            strictEqual(invoked, true, 'should always be invoked before update');
+        },
+    });
+
+    var AfterTestComp = cc.Class({
+        extends: cc.Component,
+        editor: {
+            executionOrder: 1,
+        },
+        start: function () {
+            // execute inside start phase dynamically
+            this.node.addComponent(TestComp);
+        },
+    });
+
+    var node = new cc.Node();
+    node.addComponent(AfterTestComp);
+
+    cc.director.getScene().addChild(node);
+    cc.game.step();
+    cc.game.step();
+
+    strictEqual(invoked, true, 'start should be invoked on new component with lower executionOrder');
+});
+
 test('start should only called once', function () {
     var TestComp1 = cc.Class({
         extends: cc.Component,
@@ -1003,7 +1036,7 @@ test('should re-call start (to init) before rendering when it is enabled after s
             lateUpdateChildComp.expect(CallbackTester.start, "should execute start in this frame when activated in start",true);
             nodes.lateUpdateChild.active = true;
         }
-    }
+    };
 
     nodes.attachToScene();
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
cc.easeBackOut在输入为边界值0时, 理应返回0值, 但现在返回的是极小的非0值, 导致action node 下带有widget组件的节点无法显示, 修复后显示正常.