### PR TITLE
MaskComponent.isHit not work when type===GRAPHICS_STENCIL

### DIFF
--- a/cocos/ui/components/mask-component.ts
+++ b/cocos/ui/components/mask-component.ts
@@ -296,7 +296,7 @@ export class MaskComponent extends UIRenderComponent {
         testPt.y += ap.y * h;
 
         let result = false;
-        if (this.type === MaskType.RECT /*|| this.type === MaskType.IMAGE_STENCIL*/) {
+        if (this.type === MaskType.RECT || this.type === MaskType.GRAPHICS_STENCIL) {
             result = testPt.x >= 0 && testPt.y >= 0 && testPt.x <= w && testPt.y <= h;
         } else if (this.type === MaskType.ELLIPSE) {
             const rx = w / 2;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * Fixed the issue that `MaskComponent.isHit` not work when `type` is `GRAPHICS_STENCIL`

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [x] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
