### PR TITLE
fix sampler of splash screen

### DIFF
--- a/cocos/core/splash-screen.ts
+++ b/cocos/core/splash-screen.ts
@@ -111,7 +111,12 @@ export class SplashScreen {
             return;
         } else {
             cc.view.enableRetina(true);
-            cc.view.setDesignResolutionSize(960, 640, 4);
+            const designRes = window._CCSettings.designResolution;
+            if (designRes) {
+                cc.view.setDesignResolutionSize(designRes.width, designRes.height, designRes.policy);
+            } else {
+                cc.view.setDesignResolutionSize(960, 640, 4);
+            }
             this.device = device;
             cc.game.once(cc.Game.EVENT_GAME_INITED, () => {
                 cc.director._lateUpdate = performance.now();


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changes:
 * fix sampler of splash screen
 * record command buffer only one times
 * enable retina & resize for splash screen

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
