### PR TITLE
optimize object creation on WeChat Mini Game / iOS

### DIFF
--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -470,63 +470,100 @@ function getInitPropsJit (attrs, propList) {
 }
 
 function getInitProps (attrs, propList) {
-    var advancedProps = [];
-    var advancedValues = [];
-    var simpleProps = [];
-    var simpleValues = [];
+    var props = null;
+    var simpleEnd = 0;
+    var valueTypeEnd = 0;
 
-    for (var i = 0; i < propList.length; ++i) {
-        var prop = propList[i];
-        var attrKey = prop + DELIMETER + 'default';
-        if (attrKey in attrs) { // getter does not have default
-            var def = attrs[attrKey];
-            if ((typeof def === 'object' && def) || typeof def === 'function') {
-                advancedProps.push(prop);
-                advancedValues.push(def);
-            }
-            else {
-                // number, boolean, null, undefined, string
-                simpleProps.push(prop);
-                simpleValues.push(def);
+    (function () {
+
+        // triage properties
+
+        var simples = null;
+        var valueTypes = null;
+        var advanceds = null;
+
+        for (let i = 0; i < propList.length; ++i) {
+            var prop = propList[i];
+            var attrKey = prop + DELIMETER + 'default';
+            if (attrKey in attrs) { // getter does not have default
+                var def = attrs[attrKey];
+                if ((typeof def === 'object' && def) || typeof def === 'function') {
+                    if (def instanceof cc.ValueType) {
+                        if (!valueTypes) {
+                            valueTypes = [];
+                        }
+                        valueTypes.push(prop, def);
+                    }
+                    else {
+                        if (!advanceds) {
+                            advanceds = [];
+                        }
+                        advanceds.push(prop, def);
+                    }
+                }
+                else {
+                    // number, boolean, null, undefined, string
+                    if (!simples) {
+                        simples = [];
+                    }
+                    simples.push(prop, def);
+                }
             }
         }
-    }
+
+        // concat in compact memory
+
+        simpleEnd = simples ? simples.length : 0;
+        valueTypeEnd = simpleEnd + (valueTypes ? valueTypes.length : 0);
+        let totalLength = valueTypeEnd + (advanceds ? advanceds.length : 0);
+        props = new Array(totalLength);
+
+        for (let i = 0; i < simpleEnd; ++i) {
+            props[i] = simples[i];
+        }
+        for (let i = simpleEnd; i < valueTypeEnd; ++i) {
+            props[i] = valueTypes[i - simpleEnd];
+        }
+        for (let i = valueTypeEnd; i < totalLength; ++i) {
+            props[i] = advanceds[i - valueTypeEnd];
+        }
+    })();
 
     return function () {
-        for (let i = 0; i < simpleProps.length; ++i) {
-            this[simpleProps[i]] = simpleValues[i];
+        let i = 0;
+        for (; i < simpleEnd; i += 2) {
+            this[props[i]] = props[i + 1];
         }
-        for (let i = 0; i < advancedProps.length; i++) {
-            let prop = advancedProps[i];
-            var expression;
-            var def = advancedValues[i];
-            if (typeof def === 'object') {
-                if (def instanceof cc.ValueType) {
-                    expression = def.clone();
-                }
-                else if (Array.isArray(def)) {
-                    expression = [];
-                }
-                else {
-                    expression = {};
-                }
+        for (; i < valueTypeEnd; i += 2) {
+            this[props[i]] = props[i + 1].clone();
+        }
+        for (; i < props.length; i += 2) {
+            var def = props[i + 1];
+            if (Array.isArray(def)) {
+                this[props[i]] = [];
             }
             else {
-                // def is function
-                if (CC_EDITOR) {
-                    try {
-                        expression = def();
-                    }
-                    catch (err) {
-                        cc._throw(e);
-                        continue;
-                    }
+                var value;
+                if (typeof def === 'object') {
+                    value = {};
                 }
                 else {
-                    expression = def();
+                    // def is function
+                    if (CC_EDITOR) {
+                        try {
+                            value = def();
+                        }
+                        catch (err) {
+                            cc._throw(e);
+                            continue;
+                        }
+                    }
+                    else {
+                        value = def();
+                    }
                 }
+                this[props[i]] = value;
             }
-            this[prop] = expression;
         }
     };
 }


### PR DESCRIPTION
提升无 jit 的情况下的 CCClass 对象创建性能，以及减少缓存的数组数量。

微信真机测试四轮，耗时结果

1. new cc.Node()

优化前：
1335 + 1347 + 1376 + 1413 = 5,471
优化后：
1280 + 1307 + 1352 + 1365 = 5,304

**提升：3.1%**

2. new cc.Widget() * 10 倍数

优化前：
4602 + 4604 + 4583 + 4703 = 18,492
优化后：
4491 + 4508 + 4505 + 4490 = 17,994

**提升：2.7%**