### PR TITLE
remove RUNTIME from native

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -633,7 +633,7 @@ function initSys () {
      * Is native ? This is set to be true in jsb auto.
      * @property {Boolean} isNative
      */
-    sys.isNative = CC_JSB || CC_RUNTIME;
+    sys.isNative = CC_JSB;
 
 
     /**


### PR DESCRIPTION
breaking change:
- cc.sys.isNative 不包括快游戏平台