### PR TITLE
Modify the disabled state update of the button.

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -201,7 +201,7 @@ let Button = cc.Class({
             default: false,
             tooltip: CC_DEV && 'i18n:COMPONENT.button.auto_gray_effect',
             notify () {
-                this._updateDisabledState();
+                this._updateDisabledState(true);
             }
         },
 
@@ -844,18 +844,15 @@ let Button = cc.Class({
         this.node.setContentSize(this._getTarget().getContentSize());
     },
 
-    _updateDisabledState () {
-        if (this._sprite) {
+    _updateDisabledState (force) {
+        if (!this._sprite) return;
+
+        if (this.enableAutoGrayEffect || force) {
             let useGrayMaterial = false;
 
-            if (this.enableAutoGrayEffect) {
-                if (!(this.transition === Transition.SPRITE && this.disabledSprite)) {
-                    if (!this.interactable) {
-                        useGrayMaterial = true;
-                    }
-                }
+            if (!(this.transition === Transition.SPRITE && this.disabledSprite)) {
+                useGrayMaterial = this.enableAutoGrayEffect && !this.interactable;
             }
-
             this._switchGrayMaterial(useGrayMaterial, this._sprite);
         }
     }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/6555

Changes:

修改按钮禁用状态下的材质更新判定。