### PR TITLE
Fix cross fade bug

### DIFF
--- a/cocos/core/animation/animation-manager.ts
+++ b/cocos/core/animation/animation-manager.ts
@@ -42,7 +42,7 @@ export class AnimationManager extends System {
         const array = iterator.array;
         for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
             const anim = array[iterator.i];
-            if (anim.isPlaying && !anim.isPaused) {
+            if (!anim.isMotionless) {
                 anim.update(dt);
             }
         }

--- a/cocos/core/animation/cross-fade.ts
+++ b/cocos/core/animation/cross-fade.ts
@@ -27,7 +27,7 @@ export class CrossFade extends Playable {
     }
 
     public update (deltaTime: number) {
-        if (!this.isPlaying || this.isPaused) {
+        if (this.isMotionless) {
             return;
         }
 
@@ -70,6 +70,14 @@ export class CrossFade extends Playable {
                 }
             }
             this._fadings.splice(deadFadingBegin);
+        }
+
+        if (this._managedStates.length !== 0) {
+            this._managedStates.forEach((state) => {
+                if (state.state?.isMotionless) {
+                    state.state.sample();
+                }
+            });
         }
     }
 

--- a/cocos/core/animation/cross-fade.ts
+++ b/cocos/core/animation/cross-fade.ts
@@ -72,12 +72,11 @@ export class CrossFade extends Playable {
             this._fadings.splice(deadFadingBegin);
         }
 
-        if (this._managedStates.length !== 0) {
-            this._managedStates.forEach((state) => {
-                if (state.state?.isMotionless) {
-                    state.state.sample();
-                }
-            });
+        for (let iManagedState = 0; iManagedState < this._managedStates.length; ++iManagedState) {
+            const state = this._managedStates[iManagedState].state;
+            if (state && state.isMotionless) {
+                state.sample();
+            }
         }
     }
 

--- a/cocos/core/animation/playable.ts
+++ b/cocos/core/animation/playable.ts
@@ -7,8 +7,8 @@ import { getError } from '../platform/debug';
 export class Playable {
 
     /**
-     * @en Is playing or paused in play mode?
-     * @zh 当前是否正在播放。
+     * @en Whether if this `Playable` is in playing.
+     * @zh 该 `Playable` 是否正在播放状态。
      * @default false
      */
     get isPlaying () {
@@ -16,8 +16,8 @@ export class Playable {
     }
 
     /**
-     * @en Is currently paused? This can be true even if in edit mode(isPlaying == false).
-     * @zh 当前是否正在暂停。
+     * @en Whether if this `Playable` has been paused. This can be true even if in edit mode(isPlaying == false).
+     * @zh 该 `Playable` 是否已被暂停。
      * @default false
      */
     get isPaused () {
@@ -25,8 +25,8 @@ export class Playable {
     }
 
     /**
-     * @en Is paused or stopped?
-     * @zh 是否已被暂停或停止。
+     * @en Whether if this `Playable` has been paused or stopped.
+     * @zh 该 `Playable` 是否已被暂停或停止。
      */
     get isMotionless () {
         return !this.isPlaying || this.isPaused;

--- a/cocos/core/animation/playable.ts
+++ b/cocos/core/animation/playable.ts
@@ -23,6 +23,15 @@ export class Playable {
     get isPaused () {
         return this._isPaused;
     }
+
+    /**
+     * @en Is paused or stopped?
+     * @zh 是否已被暂停或停止。
+     */
+    get isMotionless () {
+        return !this.isPlaying || this.isPaused;
+    }
+
     private _isPlaying = false;
     private _isPaused = false;
     private _stepOnce = false;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Fix a bug when cross fade from/to animations having finite playing time.

**Remark**
The bug might be triggered if the animations under cross fading contain an animation state which:
- has finite playing time. For example, when set to `Normal` wrap mode and its duration is less than cross fade duration. Or
- would be manually stopped or paused while the cross fading will not have been finished.

In either case, the stopped/paused state would not be sampled. The sum weight of blending property would not be 1 therefor.

This PR checks if the cross fading states are stopped/paused. If they do, `sample()` is called to manually sample the state.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
