### PR TITLE
Process when cross fade to a state having already cross faded but stopped

### DIFF
--- a/cocos/core/animation/cross-fade.ts
+++ b/cocos/core/animation/cross-fade.ts
@@ -103,6 +103,8 @@ export class CrossFade extends Playable {
                 state.play();
             }
             this._managedStates.push(target);
+        } else if (target.state?.isMotionless) {
+            target.state.play();
         }
         ++target.reference;
         this._fadings.unshift({


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * This PR processes that when cross fade to a state having already cross faded but stopped:
1. Cross fade to state `S` which has a limit playing time `T1`, in duration `T2`, where `T1` is less than `T2`;
2. After `T1`, the state is stopped but fading is still;
3. Then, before `T2`, again cross fade to `S`;
4. `S` holds on as stopped and would not be played.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
