### PR TITLE
preview mode supports the disallowMultiple

### DIFF
--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -57,7 +57,7 @@ var Component = cc.Class({
         }
         this._id = Editor.Utils.UuidUtils.uuid();
 
-        /*** 
+        /**
          * !#en
          * Register all related EventTargets,
          * all event callbacks will be removed in `_onPreDestroy`.

--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -57,7 +57,8 @@ var Component = cc.Class({
         }
         this._id = Editor.Utils.UuidUtils.uuid();
 
-        /**
+        /*** 
+         * !#en
          * Register all related EventTargets,
          * all event callbacks will be removed in `_onPreDestroy`.
          * !#zh
@@ -620,7 +621,7 @@ var Component = cc.Class({
 
 Component._requireComponent = null;
 Component._executionOrder = 0;
-
+if (CC_EDITOR && CC_PREVIEW) Component._disallowMultiple = null;
 
 if (CC_EDITOR || CC_TEST) {
 
@@ -648,7 +649,6 @@ if (CC_EDITOR || CC_TEST) {
         });
     };
 }
-if (CC_EDITOR && CC_PREVIEW) Component._disallowMultiple = null;
 
 // We make this non-enumerable, to prevent inherited by sub classes.
 js.value(Component, '_registerEditorProps', function (cls, props) {
@@ -659,6 +659,9 @@ js.value(Component, '_registerEditorProps', function (cls, props) {
     var order = props.executionOrder;
     if (order && typeof order === 'number') {
         cls._executionOrder = order;
+    }
+    if ((CC_EDITOR || CC_PREVIEW) && 'disallowMultiple' in props) {
+        cls._disallowMultiple = cls;
     }
     if (CC_EDITOR || CC_TEST) {
         var name = cc.js.getClassName(cls);
@@ -707,9 +710,6 @@ js.value(Component, '_registerEditorProps', function (cls, props) {
                     break;
             }
         }
-    }
-    if ((CC_EDITOR || CC_PREVIEW) && 'disallowMultiple' in props) {
-        cls._disallowMultiple = cls;
     }
 });
 

--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -620,7 +620,7 @@ var Component = cc.Class({
 
 Component._requireComponent = null;
 Component._executionOrder = 0;
-Component._disallowMultiple = null;
+
 
 if (CC_EDITOR || CC_TEST) {
 
@@ -648,6 +648,7 @@ if (CC_EDITOR || CC_TEST) {
         });
     };
 }
+if (CC_EDITOR && CC_PREVIEW) Component._disallowMultiple = null;
 
 // We make this non-enumerable, to prevent inherited by sub classes.
 js.value(Component, '_registerEditorProps', function (cls, props) {

--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -58,7 +58,6 @@ var Component = cc.Class({
         this._id = Editor.Utils.UuidUtils.uuid();
 
         /**
-         * !#en
          * Register all related EventTargets,
          * all event callbacks will be removed in `_onPreDestroy`.
          * !#zh
@@ -621,6 +620,7 @@ var Component = cc.Class({
 
 Component._requireComponent = null;
 Component._executionOrder = 0;
+Component._disallowMultiple = null;
 
 if (CC_EDITOR || CC_TEST) {
 
@@ -628,7 +628,6 @@ if (CC_EDITOR || CC_TEST) {
 
     Component._executeInEditMode = false;
     Component._playOnFocus = false;
-    Component._disallowMultiple = null;
     Component._help = '';
 
     // NON-INHERITED STATIC MEMBERS
@@ -693,10 +692,6 @@ js.value(Component, '_registerEditorProps', function (cls, props) {
                     Component._addMenuItem(cls, val, props.menuPriority);
                     break;
 
-                case 'disallowMultiple':
-                    cls._disallowMultiple = cls;
-                    break;
-
                 case 'requireComponent':
                 case 'executionOrder':
                     // skip here
@@ -711,6 +706,9 @@ js.value(Component, '_registerEditorProps', function (cls, props) {
                     break;
             }
         }
+    }
+    if ((CC_EDITOR || CC_PREVIEW) && 'disallowMultiple' in props) {
+        cls._disallowMultiple = cls;
     }
 });
 

--- a/cocos2d/core/utils/base-node.js
+++ b/cocos2d/core/utils/base-node.js
@@ -861,7 +861,7 @@ var BaseNode = cc.Class({
         return components;
     },
 
-    _checkMultipleComp: CC_EDITOR && function (ctor) {
+    _checkMultipleComp: (CC_EDITOR || CC_PREVIEW) && function (ctor) {
         var existing = this.getComponent(ctor._disallowMultiple);
         if (existing) {
             if (existing.constructor === ctor) {
@@ -926,7 +926,7 @@ var BaseNode = cc.Class({
             return null;
         }
 
-        if (CC_EDITOR && constructor._disallowMultiple) {
+        if ((CC_EDITOR || CC_PREVIEW) && constructor._disallowMultiple) {
             if (!this._checkMultipleComp(constructor)) {
                 return null;
             }


### PR DESCRIPTION
In the game preview can determine whether the script has been added repeatedly, use this feature like this:

Js:
```js
cc.Class({
    extends: cc.Component,
    editor: {
        disallowMultiple = true
    },
    properties: {
        
    },

    // LIFE-CYCLE CALLBACKS:

    // onLoad () {},
});
```

Ts:
```ts
const {ccclass, property, disallowMultiple} = cc._decorator;

@ccclass
@disallowMultiple
export default class NewClass extends cc.Component {

    @property(cc.Label)
    label: cc.Label = null;

    @property
    text: string = 'hello';

    // LIFE-CYCLE CALLBACKS:

    // onLoad () {}
}
```

When you execute the following code:

```
node.addComponent("NewScript");
node.addComponent("NewScript");
```

Warnings are issued in the game:
![image](https://user-images.githubusercontent.com/35944775/79960133-a0360d80-84b7-11ea-858f-555cb0f5be60.png)


