### PR TITLE
V2.4.0 fix set premultiply alpha

### DIFF
--- a/cocos2d/core/assets/CCTexture2D.js
+++ b/cocos2d/core/assets/CCTexture2D.js
@@ -838,6 +838,7 @@ var Texture2D = cc.Class({
         if (this._flipY !== flipY) {
             var opts = _getSharedOptions();
             opts.flipY = flipY;
+            opts.premultiplyAlpha = this._premultiplyAlpha;
             this.update(opts);
         }
     },
@@ -852,6 +853,7 @@ var Texture2D = cc.Class({
     setPremultiplyAlpha (premultiply) {
         if (this._premultiplyAlpha !== premultiply) {
             var opts = _getSharedOptions();
+            opts.flipY = this._flipY;
             opts.premultiplyAlpha = premultiply;
             this.update(opts);
         }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/6546

Changes:
 * fix wrong effect after set premultiplyAlpha

原因在于我之前的[pr](https://github.com/cocos-creator/engine/pull/6420)，把强制初始化 flipY = false 删除了，原因是因为强制设置flipY会让setFilters这些操作也重新上传贴图，没有必要，而且强制初始化 flipY 可能会覆盖用户之前的flipY而导致图片翻转错误。但是删除之后带来了上面的问题，当用户调用setPremultiplyAlpha的时候，因为没有设置flipY的初始值。导致底层默认把flipY看做true，导致了图片翻转。

修复的思路是，在修改 flipY 和 premultiplyAlpha 时，把两个选项都进行设置，保证底层上传时效果正确

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
