### PR TITLE
fix incorrect indirect buffer stride

### DIFF
--- a/cocos/particle/models/line-model.ts
+++ b/cocos/particle/models/line-model.ts
@@ -53,7 +53,7 @@ export class LineModel extends Model {
             usage: GFXBufferUsageBit.INDIRECT,
             memUsage: GFXMemoryUsageBit.HOST | GFXMemoryUsageBit.DEVICE,
             size: GFX_DRAW_INFO_SIZE,
-            stride: 1,
+            stride: GFX_DRAW_INFO_SIZE,
         });
     }
 

--- a/cocos/particle/models/particle-batch-model.ts
+++ b/cocos/particle/models/particle-batch-model.ts
@@ -78,7 +78,7 @@ export default class ParticleBatchModel extends Model {
             usage: GFXBufferUsageBit.INDIRECT,
             memUsage: GFXMemoryUsageBit.HOST | GFXMemoryUsageBit.DEVICE,
             size: GFX_DRAW_INFO_SIZE,
-            stride: 1,
+            stride: GFX_DRAW_INFO_SIZE,
         });
         this._subMeshData = null;
         this._mesh = null;
@@ -187,7 +187,7 @@ export default class ParticleBatchModel extends Model {
                 usage: GFXBufferUsageBit.INDIRECT,
                 memUsage: GFXMemoryUsageBit.HOST | GFXMemoryUsageBit.DEVICE,
                 size: GFX_DRAW_INFO_SIZE,
-                stride: 1,
+                stride: GFX_DRAW_INFO_SIZE,
             });
         }
         this._iaInfoBuffer.update(this._iaInfo);

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -602,7 +602,7 @@ export default class TrailModule {
             usage: GFXBufferUsageBit.INDIRECT,
             memUsage: GFXMemoryUsageBit.HOST | GFXMemoryUsageBit.DEVICE,
             size: GFX_DRAW_INFO_SIZE,
-            stride: 1,
+            stride: GFX_DRAW_INFO_SIZE,
         });
         this._iaInfo.drawInfos[0].vertexCount = (this._trailNum + 1) * 2;
         this._iaInfo.drawInfos[0].indexCount = this._trailNum * 6;


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#2449](https://github.com/cocos-creator/3d-tasks/issues/2449#issuecomment-612860036)

Associated PR: [cocos2d-x-lite/pull#2399](https://github.com/cocos-creator/cocos2d-x-lite/pull/2399)

Changes:
 * indirect buffer stride should be GFX_DRAW_INFO_SIZE

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
