### PR TITLE
Optimize non-morph plain ModelComponent

### DIFF
--- a/cocos/core/3d/framework/model-component.ts
+++ b/cocos/core/3d/framework/model-component.ts
@@ -203,7 +203,11 @@ export class ModelComponent extends RenderableComponent {
 
     @property({
         visible: function (this: ModelComponent) {
-            return !!(this.mesh && this.mesh.struct.morph);
+            return !!(
+                this.mesh &&
+                this.mesh.struct.morph &&
+                this.mesh.struct.morph.subMeshMorphs.some((subMeshMorph) => !!subMeshMorph)
+            );
         },
     })
     get enableMorph () {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Optimizes non-morph plain model components --- a plain `Model` is used to create the model instead of `MorphModel` for those model components.
 * Conditionally display "enableMorph" --- Display "enableMorph" only if there is a valid morph mesh.

This PR should resolve https://github.com/cocos-creator/3d-tasks/issues/2797 @YunHsiao  Please take a look at this.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
