### PR TITLE
bug fix: when reseting particle system, must clear vertex buffer,othe…

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -964,6 +964,15 @@ var ParticleSystem = cc.Class({
     resetSystem: function () {
         this._stopped = false;
         this._simulator.reset();
+        let assembler = this._assembler;
+        if (assembler) {
+            let buffer = assembler.getBuffer()
+            if (buffer) {
+                buffer.reset()
+                buffer.uploadData();
+                assembler._ia._count = 0
+            }
+        }
         this.markForRender(true);
     },
 


### PR DESCRIPTION
bug fix: resetSystem()调用过后，顶点缓冲没删除， 导致在下一个粒子发射之前，一直有残留的粒子渲染在场景里。