### PR TITLE
fix editbox doesn’t fire ‘compositionend’ event on mobile

### DIFF
--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -668,6 +668,10 @@ Object.assign(WebEditBoxImpl.prototype, {
         };
 
         cbs.onBlur = function () {
+            // on mobile, sometimes input element doesn't fire compositionend event
+            if (cc.sys.isMobile && inputLock) {
+                cbs.compositionEnd();
+            }
             impl._editing = false;
             _currentEditBoxImpl = null;
             impl._hideDom();


### PR DESCRIPTION
resolve https://github.com/cocos-creator/2d-tasks/issues/2277

changeLog:
- 修复 iOS 浏览器上，输入中文后，无法再输入英文的问题

**NOTE**： 不同输入法对 composition 的处理方式不同
- 类似搜狗输入法，会将 composition 的过程在输入法内部完成，不会将事件传到浏览器上
![2](https://user-images.githubusercontent.com/17872773/80561946-b9d7d780-8a18-11ea-9051-0b09c9b4d612.jpg)


- 而 iOS 自带的输入法，会在浏览器里触发 compsitionstart 事件 和 compositionend 事件，当然如果是非自然输入完成操作，比如 **点击完成按钮而不是选择拼音搜索结果**， **点击空白区域**，则不会触发 compositionend 事件
![1](https://user-images.githubusercontent.com/17872773/80561910-990f8200-8a18-11ea-97bd-3d136ec31894.jpg)




