### PR TITLE
not need to create texture when width or height is zero

### DIFF
--- a/cocos/core/assets/simple-texture.ts
+++ b/cocos/core/assets/simple-texture.ts
@@ -212,11 +212,15 @@ export class SimpleTexture extends TextureBase {
     }
 
     protected _createTexture (device: GFXDevice) {
+        if(this._width === 0 || this._height === 0) {
+            return;
+        }
         let flags = GFXTextureFlagBit.NONE;
         if (this._mipFilter !== Filter.NONE && canGenerateMipmap(device, this._width, this._height)) {
             this._mipmapLevel = getMipLevel(this._width, this._height);
             flags = GFXTextureFlagBit.GEN_MIPMAP;
         }
+
         const textureCreateInfo = this._getGfxTextureCreateInfo({
             usage: GFXTextureUsageBit.SAMPLED | GFXTextureUsageBit.TRANSFER_DST,
             format: this._getGFXFormat(),

--- a/cocos/core/assets/simple-texture.ts
+++ b/cocos/core/assets/simple-texture.ts
@@ -212,9 +212,6 @@ export class SimpleTexture extends TextureBase {
     }
 
     protected _createTexture (device: GFXDevice) {
-        if(this._width === 0 || this._height === 0) {
-            return;
-        }
         let flags = GFXTextureFlagBit.NONE;
         if (this._mipFilter !== Filter.NONE && canGenerateMipmap(device, this._width, this._height)) {
             this._mipmapLevel = getMipLevel(this._width, this._height);

--- a/cocos/core/assets/simple-texture.ts
+++ b/cocos/core/assets/simple-texture.ts
@@ -204,6 +204,9 @@ export class SimpleTexture extends TextureBase {
 
     protected _tryReset () {
         this._tryDestroyTexture();
+        if(this._mipmapLevel === 0) {
+            return;
+        }
         const device = this._getGFXDevice();
         if (!device) {
             return;

--- a/cocos/ui/assembler/label/ttfUtils.ts
+++ b/cocos/ui/assembler/label/ttfUtils.ts
@@ -265,7 +265,7 @@ export const ttfUtils =  {
                 tex.reset({
                     width: _canvas.width,
                     height: _canvas.height,
-                    mipmapLevel: uploadAgain ? 0 : 1,
+                    mipmapLevel: 1
                 });
                 tex.uploadData(_canvas);
             }

--- a/cocos/ui/assembler/label/ttfUtils.ts
+++ b/cocos/ui/assembler/label/ttfUtils.ts
@@ -259,13 +259,14 @@ export const ttfUtils =  {
                 tex = _texture;
             }
 
-            const uploadAgain = _canvas.width === 0 || _canvas.height === 0;
-            tex.reset({
-                width: _canvas.width,
-                height: _canvas.height,
-                mipmapLevel: uploadAgain ? 0 : 1,
-            });
-            if (!uploadAgain) {
+            const uploadAgain = _canvas.width !== 0 && _canvas.height !== 0;
+
+            if (uploadAgain) {
+                tex.reset({
+                    width: _canvas.width,
+                    height: _canvas.height,
+                    mipmapLevel: uploadAgain ? 0 : 1,
+                });
                 tex.uploadData(_canvas);
             }
         }


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#2449](https://github.com/cocos-creator/3d-tasks/issues/2449#issuecomment-626575221)

Changes:
 * not need to create texture when width or height is zero
 * corresponding PR: [cocos2d-x-lite/pull#2432](https://github.com/cocos-creator/cocos2d-x-lite/pull/2432)

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
