### PR TITLE
Optimize the creation and memory of the runtime particle system.

### DIFF
--- a/cocos/particle/particle-system-component.ts
+++ b/cocos/particle/particle-system-component.ts
@@ -29,6 +29,7 @@ import ParticleSystemRenderer from './renderer/particle-system-renderer-data';
 import TrailModule from './renderer/trail';
 import { IParticleSystemRenderer } from './renderer/particle-system-renderer-base';
 import { PARTICLE_MODULE_PROPERTY } from './particle';
+import { EDITOR } from 'internal:constants';
 
 const _world_mat = new Mat4();
 const _world_rol = new Quat();
@@ -52,7 +53,7 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     public set capacity (val) {
-        this._capacity = val;
+        this._capacity = Math.floor(val);
         // @ts-ignore
         if (this.processor && this.processor._model) {
             // @ts-ignore
@@ -324,6 +325,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // color over lifetime module
+    @property({type: ColorOverLifetimeModule})
+    _colorOverLifetimeModule:ColorOverLifetimeModule | null = null;
     /**
      * @zh 颜色控制模块。
      */
@@ -332,9 +335,24 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 23,
         tooltip:'颜色模块',
     })
-    public colorOverLifetimeModule = new ColorOverLifetimeModule();
+    public get colorOverLifetimeModule () {
+        if (EDITOR) {
+            if (!this._colorOverLifetimeModule) {
+                this._colorOverLifetimeModule = new ColorOverLifetimeModule();
+                this._colorOverLifetimeModule.bindTarget(this.processor!);
+            }
+        }
+        return this._colorOverLifetimeModule;
+    }
 
-    // Shape module
+    public set colorOverLifetimeModule (val) {
+        if (!val) return;
+        this._colorOverLifetimeModule = val;
+    }
+
+    // shape module
+    @property({type: ShapeModule})
+    _shapeModule:ShapeModule | null = null;
     /**
      * @zh 粒子发射器模块。
      */
@@ -343,9 +361,24 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 17,
         tooltip:'发射器模块',
     })
-    public shapeModule = new ShapeModule();
+    public get shapeModule () {
+        if (EDITOR) {
+            if (!this._shapeModule) {
+                this._shapeModule = new ShapeModule();
+                this._shapeModule.onInit(this);
+            }
+        }
+        return this._shapeModule;
+    }
+
+    public set shapeModule (val) {
+        if (!val) return;
+        this._shapeModule = val;
+    }
 
     // size over lifetime module
+    @property({type: SizeOvertimeModule})
+    _sizeOvertimeModule:SizeOvertimeModule | null = null;
     /**
      * @zh 粒子大小模块。
      */
@@ -354,8 +387,24 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 21,
         tooltip:'大小模块',
     })
-    public sizeOvertimeModule = new SizeOvertimeModule();
+    public get sizeOvertimeModule () {
+        if (EDITOR) {
+            if (!this._sizeOvertimeModule) {
+                this._sizeOvertimeModule = new SizeOvertimeModule();
+                this._sizeOvertimeModule.bindTarget(this.processor!);
+            }
+        }
+        return this._sizeOvertimeModule;
+    }
 
+    public set sizeOvertimeModule (val) {
+        if (!val) return;
+        this._sizeOvertimeModule = val;
+    }
+
+    // velocity overtime module
+    @property({type: VelocityOvertimeModule})
+    _velocityOvertimeModule:VelocityOvertimeModule | null = null;
     /**
      * @zh 粒子速度模块。
      */
@@ -364,8 +413,24 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 18,
         tooltip:'速度模块',
     })
-    public velocityOvertimeModule = new VelocityOvertimeModule();
+    public get velocityOvertimeModule () {
+        if (EDITOR) {
+            if (!this._velocityOvertimeModule) {
+                this._velocityOvertimeModule = new VelocityOvertimeModule();
+                this._velocityOvertimeModule.bindTarget(this.processor!);
+            }
+        }
+        return this._velocityOvertimeModule;
+    }
 
+    public set velocityOvertimeModule (val) {
+        if (!val) return;
+        this._velocityOvertimeModule = val;
+    }
+
+    // force overTime module
+    @property({type: ForceOvertimeModule})
+    _forceOvertimeModule:ForceOvertimeModule | null = null;
     /**
      * @zh 粒子加速度模块。
      */
@@ -374,8 +439,24 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 19,
         tooltip:'加速度模块',
     })
-    public forceOvertimeModule = new ForceOvertimeModule();
+    public get forceOvertimeModule () {
+        if (EDITOR) {
+            if (!this._forceOvertimeModule) {
+                this._forceOvertimeModule = new ForceOvertimeModule();
+                this._forceOvertimeModule.bindTarget(this.processor!);
+            }
+        }
+        return this._forceOvertimeModule;
+    }
 
+    public set forceOvertimeModule (val) {
+        if (!val) return;
+        this._forceOvertimeModule = val;
+    }
+
+    // limit velocity overtime module
+    @property({type: LimitVelocityOvertimeModule})
+    _limitVelocityOvertimeModule:LimitVelocityOvertimeModule | null = null;
     /**
      * @zh 粒子限制速度模块（只支持 CPU 粒子）。
      */
@@ -384,8 +465,24 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 20,
         tooltip:'限速模块',
     })
-    public limitVelocityOvertimeModule = new LimitVelocityOvertimeModule();
+    public get limitVelocityOvertimeModule () {
+        if (EDITOR) {
+            if (!this._limitVelocityOvertimeModule) {
+                this._limitVelocityOvertimeModule = new LimitVelocityOvertimeModule();
+                this._limitVelocityOvertimeModule.bindTarget(this.processor!);
+            }
+        }
+        return this._limitVelocityOvertimeModule;
+    }
 
+    public set limitVelocityOvertimeModule (val) {
+        if (!val) return;
+        this._limitVelocityOvertimeModule = val;
+    }
+
+    // rotation overtime module
+    @property({type: RotationOvertimeModule})
+    _rotationOvertimeModule:RotationOvertimeModule | null = null;
     /**
      * @zh 粒子旋转模块。
      */
@@ -394,8 +491,24 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 22,
         tooltip:'旋转模块',
     })
-    public rotationOvertimeModule = new RotationOvertimeModule();
+    public get rotationOvertimeModule () {
+        if (EDITOR) {
+            if (!this._rotationOvertimeModule) {
+                this._rotationOvertimeModule = new RotationOvertimeModule();
+                this._rotationOvertimeModule.bindTarget(this.processor!);
+            }
+        }
+        return this._rotationOvertimeModule;
+    }
 
+    public set rotationOvertimeModule (val) {
+        if (!val) return;
+        this._rotationOvertimeModule = val;
+    }
+
+    // texture animation module
+    @property({type: TextureAnimationModule})
+    _textureAnimationModule:TextureAnimationModule | null = null;
     /**
      * @zh 贴图动画模块。
      */
@@ -404,8 +517,24 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 24,
         tooltip:'贴图动画模块',
     })
-    public textureAnimationModule = new TextureAnimationModule();
+    public get textureAnimationModule () {
+        if (EDITOR) {
+            if (!this._textureAnimationModule) {
+                this._textureAnimationModule = new TextureAnimationModule();
+                this._textureAnimationModule.bindTarget(this.processor!);
+            }
+        }
+        return this._textureAnimationModule;
+    }
 
+    public set textureAnimationModule (val) {
+        if (!val) return;
+        this._textureAnimationModule = val;
+    }
+
+    // trail module
+    @property({type: TrailModule})
+    _trailModule:TrailModule | null = null;
     /**
      * @zh 粒子轨迹模块。
      */
@@ -414,7 +543,21 @@ export class ParticleSystemComponent extends RenderableComponent {
         displayOrder: 25,
         tooltip:'拖尾模块',
     })
-    public trailModule = new TrailModule();
+    public get trailModule () {
+        if (EDITOR) {
+            if (!this._trailModule) {
+                this._trailModule = new TrailModule();
+                this._trailModule.onInit(this);
+                this._trailModule.onEnable();
+            }
+        }
+        return this._trailModule;
+    }
+
+    public set trailModule (val) {
+        if (!val) return;
+        this._trailModule = val;
+    }
 
     // particle system renderer
     @property({
@@ -490,8 +633,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     public onLoad () {
         // HACK, TODO
         this.renderer.onInit(this);
-        this.shapeModule.onInit(this);
-        this.trailModule.onInit(this);
+        this._shapeModule && this._shapeModule.onInit(this);
+        this._trailModule && this._trailModule.onInit(this);
         this.bindModule();
         this._resetPosition();
 
@@ -509,34 +652,34 @@ export class ParticleSystemComponent extends RenderableComponent {
     public _collectModels (): Model[] {
         this._models.length = 0;
         this._models.push((this.processor as any)._model);
-        if (this.trailModule.enable && (this.trailModule as any)._trailModel) {
-            this._models.push((this.trailModule as any)._trailModel);
+        if (this._trailModule && this._trailModule.enable && (this._trailModule as any)._trailModel) {
+            this._models.push((this._trailModule as any)._trailModel);
         }
         return this._models;
     }
 
     protected _attachToScene () {
         this.processor!.attachToScene();
-        if (this.trailModule.enable) {
-            this.trailModule._attachToScene();
+        if (this._trailModule && this._trailModule.enable) {
+            this._trailModule._attachToScene();
         }
     }
 
     protected _detachFromScene () {
         this.processor!.detachFromScene();
-        if (this.trailModule.enable) {
-            this.trailModule._detachFromScene();
+        if (this._trailModule && this._trailModule.enable) {
+            this._trailModule._detachFromScene();
         }
     }
 
     public bindModule () {
-        this.colorOverLifetimeModule.bindTarget(this.processor!);
-        this.sizeOvertimeModule.bindTarget(this.processor!);
-        this.rotationOvertimeModule.bindTarget(this.processor!);
-        this.forceOvertimeModule.bindTarget(this.processor!);
-        this.limitVelocityOvertimeModule.bindTarget(this.processor!);
-        this.velocityOvertimeModule.bindTarget(this.processor!);
-        this.textureAnimationModule.bindTarget(this.processor!);
+        this._colorOverLifetimeModule && this._colorOverLifetimeModule.bindTarget(this.processor!);
+        this._sizeOvertimeModule && this._sizeOvertimeModule.bindTarget(this.processor!);
+        this._rotationOvertimeModule && this._rotationOvertimeModule.bindTarget(this.processor!);
+        this._forceOvertimeModule && this._forceOvertimeModule.bindTarget(this.processor!);
+        this._limitVelocityOvertimeModule && this._limitVelocityOvertimeModule.bindTarget(this.processor!);
+        this._velocityOvertimeModule && this._velocityOvertimeModule.bindTarget(this.processor!);
+        this._textureAnimationModule && this._textureAnimationModule.bindTarget(this.processor!);
     }
 
     // TODO: Fast forward current particle system by simulating particles over given period of time, then pause it.
@@ -609,7 +752,7 @@ export class ParticleSystemComponent extends RenderableComponent {
     public clear () {
         if (this.enabledInHierarchy) {
             this.processor!.clear();
-            this.trailModule.clear();
+            this._trailModule && this._trailModule.clear();
         }
     }
 
@@ -634,7 +777,7 @@ export class ParticleSystemComponent extends RenderableComponent {
     protected onDestroy () {
         // this._system.remove(this);
         this.processor!.onDestroy();
-        this.trailModule.destroy();
+        this._trailModule && this._trailModule.destroy();
     }
 
     protected onEnable () {
@@ -642,11 +785,11 @@ export class ParticleSystemComponent extends RenderableComponent {
             this.play();
         }
         this.processor!.onEnable();
-        this.trailModule.onEnable();
+        this._trailModule && this._trailModule.onEnable();
     }
     protected onDisable () {
         this.processor!.onDisable();
-        this.trailModule.onDisable();
+        this._trailModule && this._trailModule.onDisable();
     }
     protected update (dt) {
         const scaledDeltaTime = dt * this.simulationSpeed;
@@ -665,8 +808,8 @@ export class ParticleSystemComponent extends RenderableComponent {
             this.processor!.updateRenderData();
 
             // update trail
-            if (this.trailModule.enable) {
-                this.trailModule.updateRenderData();
+            if (this._trailModule && this._trailModule.enable) {
+                this._trailModule.updateRenderData();
             }
         }
     }
@@ -694,16 +837,15 @@ export class ParticleSystemComponent extends RenderableComponent {
             }
             const rand = pseudoRandom(randomRangeInt(0, INT_MAX));
 
-            if (this.shapeModule.enable) {
-                this.shapeModule.emit(particle);
-            }
-            else {
+            if (this._shapeModule && this._shapeModule.enable) {
+                this._shapeModule.emit(particle);
+            } else {
                 Vec3.set(particle.position, 0, 0, 0);
                 Vec3.copy(particle.velocity, particleEmitZAxis);
             }
 
-            if (this.textureAnimationModule.enable) {
-                this.textureAnimationModule.init(particle);
+            if (this._textureAnimationModule && this._textureAnimationModule.enable) {
+                this._textureAnimationModule.init(particle);
             }
 
             Vec3.multiplyScalar(particle.velocity, particle.velocity, this.startSpeed.evaluate(delta, rand)!);

--- a/cocos/particle/particle.ts
+++ b/cocos/particle/particle.ts
@@ -71,15 +71,15 @@ export const PARTICLE_MODULE_ORDER = [
 ];
 
 export const PARTICLE_MODULE_PROPERTY = [
-    'colorOverLifetimeModule',
-    'shapeModule',
-    'sizeOvertimeModule',
-    'velocityOvertimeModule',
-    'forceOvertimeModule',
-    'limitVelocityOvertimeModule',
-    'rotationOvertimeModule',
-    'textureAnimationModule',
-    'trailModule'
+    '_colorOverLifetimeModule',
+    '_shapeModule',
+    '_sizeOvertimeModule',
+    '_velocityOvertimeModule',
+    '_forceOvertimeModule',
+    '_limitVelocityOvertimeModule',
+    '_rotationOvertimeModule',
+    '_textureAnimationModule',
+    '_trailModule'
 ];
 
 export interface IParticleModule {

--- a/cocos/particle/renderer/particle-system-renderer-cpu.ts
+++ b/cocos/particle/renderer/particle-system-renderer-cpu.ts
@@ -14,13 +14,13 @@ const _tempAttribUV = new Vec3();
 const _tempWorldTrans = new Mat4();
 
 const _anim_module = [
-    'colorOverLifetimeModule',
-    'sizeOvertimeModule',
-    'velocityOvertimeModule',
-    'forceOvertimeModule',
-    'limitVelocityOvertimeModule',
-    'rotationOvertimeModule',
-    'textureAnimationModule'
+    '_colorOverLifetimeModule',
+    '_sizeOvertimeModule',
+    '_velocityOvertimeModule',
+    '_forceOvertimeModule',
+    '_limitVelocityOvertimeModule',
+    '_rotationOvertimeModule',
+    '_textureAnimationModule'
 ];
 
 const _uvs = [
@@ -126,7 +126,7 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
 
     public clear () {
         this._particles!.reset();
-        this._particleSystem!.trailModule.clear();
+        this._particleSystem!._trailModule && this._particleSystem!._trailModule.clear();
         this.updateRenderData();
     }
 
@@ -154,7 +154,7 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
     private _initModuleList () {
         _anim_module.forEach(val => {
             const pm = this._particleSystem[val];
-            if (pm.enable) {
+            if (pm && pm.enable) {
                 if (pm.needUpdate) {
                     this._updateList[pm.name] = pm;
                 }
@@ -220,8 +220,10 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
             value.update(ps._simulationSpace, _tempWorldTrans);
         });
 
-        if (ps.trailModule.enable) {
-            ps.trailModule.update();
+        const trailModule = ps._trailModule;
+        const trailEnable = trailModule && trailModule.enable;
+        if (trailEnable) {
+            trailModule.update();
         }
 
         for (let i = 0; i < this._particles!.length; ++i) {
@@ -230,8 +232,8 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
             Vec3.set(p.animatedVelocity, 0, 0, 0);
 
             if (p.remainingLifetime < 0.0) {
-                if (ps.trailModule.enable) {
-                    ps.trailModule.removeParticle(p);
+                if (trailEnable) {
+                    trailModule.removeParticle(p);
                 }
                 this._particles!.removeAt(i);
                 --i;
@@ -248,8 +250,8 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
             });
 
             Vec3.scaleAndAdd(p.position, p.position, p.ultimateVelocity, dt); // apply velocity.
-            if (ps.trailModule.enable) {
-                ps.trailModule.animate(p, dt);
+            if (trailEnable) {
+                trailModule.animate(p, dt);
             }
         }
         return this._particles!.length;
@@ -262,7 +264,8 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
         for (let i = 0; i < this._particles!.length; ++i) {
             const p = this._particles!.data[i];
             let fi = 0;
-            if (this._particleSystem!.textureAnimationModule.enable) {
+            const textureModule = this._particleSystem!._textureAnimationModule;
+            if (textureModule && textureModule.enable) {
                 fi = p.frameIndex;
             }
             idx = i * 4;
@@ -289,8 +292,9 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
         if (this._model && index === 0) {
             this._model.setSubModelMaterial(0, material);
         }
-        if (this._particleSystem!.trailModule._trailModel && index === 1) {
-            this._particleSystem!.trailModule._trailModel.setSubModelMaterial(0, material);
+        const trailModule = this._particleSystem!._trailModule;
+        if (trailModule && trailModule._trailModel && index === 1) {
+            trailModule._trailModel.setSubModelMaterial(0, material);
         }
     }
 
@@ -413,9 +417,9 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
         } else {
             console.warn(`particle system renderMode ${renderMode} not support.`);
         }
-
-        if (ps.textureAnimationModule.enable) {
-            Vec2.set(vlenScale, ps.textureAnimationModule.numTilesX, ps.textureAnimationModule.numTilesY);
+        const textureModule = ps._textureAnimationModule;
+        if (textureModule && textureModule.enable) {
+            Vec2.set(vlenScale, textureModule.numTilesX, textureModule.numTilesY);
             pass.setUniform(this._uLenHandle, vlenScale);
         } else {
             pass.setUniform(this._uLenHandle, vlenScale);
@@ -431,8 +435,9 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
             return;
         }
         const ps = this._particleSystem;
-        if (ps.trailModule.enable) {
-            if (ps.simulationSpace === Space.World || ps.trailModule.space === Space.World) {
+        const trailModule = ps._trailModule;
+        if (trailModule && trailModule.enable) {
+            if (ps.simulationSpace === Space.World || trailModule.space === Space.World) {
                 this._trailDefines[CC_USE_WORLD_SPACE] = true;
             } else {
                 this._trailDefines[CC_USE_WORLD_SPACE] = false;
@@ -446,7 +451,7 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
             }
             mat = mat || this._defaultTrailMat;
             mat!.recompileShaders(this._trailDefines);
-            ps.trailModule._updateMaterial();
+            trailModule._updateMaterial();
         }
     }
 }

--- a/cocos/particle/renderer/particle-system-renderer-gpu.ts
+++ b/cocos/particle/renderer/particle-system-renderer-gpu.ts
@@ -218,10 +218,12 @@ export default class ParticleSystemRendererGPU extends ParticleSystemRendererBas
         _tempVec4.y = _sample_interval;
         pass.setUniform(pass.getHandle('u_sampleInfo')!, _tempVec4);
 
+        let enable = false;
         // force
-        const forceModule = this._particleSystem.forceOvertimeModule;
-        this._defines[FORCE_OVER_TIME_MODULE_ENABLE] = forceModule.enable;
-        if (forceModule.enable) {
+        const forceModule = this._particleSystem._forceOvertimeModule;
+        enable = forceModule && forceModule.enable;
+        this._defines[FORCE_OVER_TIME_MODULE_ENABLE] = enable;
+        if (enable) {
             this._forceTexture && this._forceTexture.destroy();
             this._forceTexture = packCurveRangeXYZ(_sample_num, forceModule.x, forceModule.y, forceModule.z);
             const handle = pass.getHandle('force_over_time_tex0');
@@ -235,9 +237,10 @@ export default class ParticleSystemRendererGPU extends ParticleSystemRendererBas
         }
 
         // velocity
-        const velocityModule = this._particleSystem.velocityOvertimeModule;
-        this._defines[VELOCITY_OVER_TIME_MODULE_ENABLE] = velocityModule.enable;
-        if (velocityModule.enable) {
+        const velocityModule = this._particleSystem._velocityOvertimeModule;
+        enable = velocityModule && velocityModule.enable;
+        this._defines[VELOCITY_OVER_TIME_MODULE_ENABLE] = enable;
+        if (enable) {
             this._velocityTexture && this._velocityTexture.destroy();
             this._velocityTexture = packCurveRangeXYZW(_sample_num, velocityModule.x, velocityModule.y, velocityModule.z, velocityModule.speedModifier);
             const handle = pass.getHandle('velocity_over_time_tex0');
@@ -251,9 +254,10 @@ export default class ParticleSystemRendererGPU extends ParticleSystemRendererBas
         }
 
         // color module
-        const colorModule = this._particleSystem.colorOverLifetimeModule;
-        this._defines[COLOR_OVER_TIME_MODULE_ENABLE] = colorModule.enable;
-        if (colorModule.enable) {
+        const colorModule = this._particleSystem._colorOverLifetimeModule;
+        enable = colorModule && colorModule.enable;
+        this._defines[COLOR_OVER_TIME_MODULE_ENABLE] = enable;
+        if (enable) {
             this._colorTexture && this._colorTexture.destroy();
             this._colorTexture = packGradientRange(_sample_num, colorModule.color);
             const handle = pass.getHandle('color_over_time_tex0');
@@ -265,9 +269,10 @@ export default class ParticleSystemRendererGPU extends ParticleSystemRendererBas
         }
 
         // rotation module
-        const roationModule = this._particleSystem.rotationOvertimeModule;
-        this._defines[ROTATION_OVER_TIME_MODULE_ENABLE] = roationModule.enable;
-        if (roationModule.enable) {
+        const roationModule = this._particleSystem._rotationOvertimeModule;
+        enable = roationModule && roationModule.enable;
+        this._defines[ROTATION_OVER_TIME_MODULE_ENABLE] = enable;
+        if (enable) {
             this._rotationTexture && this._rotationTexture.destroy();
             if (roationModule.separateAxes) {
                 this._rotationTexture = packCurveRangeXYZ(_sample_num, roationModule.x, roationModule.y, roationModule.z);
@@ -283,9 +288,10 @@ export default class ParticleSystemRendererGPU extends ParticleSystemRendererBas
         }
 
         // size module
-        const sizeModule = this._particleSystem.sizeOvertimeModule;
-        this._defines[SIZE_OVER_TIME_MODULE_ENABLE] = sizeModule.enable;
-        if (sizeModule.enable) {
+        const sizeModule = this._particleSystem._sizeOvertimeModule;
+        enable = sizeModule && sizeModule.enable;
+        this._defines[SIZE_OVER_TIME_MODULE_ENABLE] = enable;
+        if (enable) {
             this._sizeTexture && this._sizeTexture.destroy();
             if (sizeModule.separateAxes) {
                 this._sizeTexture = packCurveRangeXYZ(_sample_num, sizeModule.x, sizeModule.y, sizeModule.z, true);
@@ -301,12 +307,12 @@ export default class ParticleSystemRendererGPU extends ParticleSystemRendererBas
         }
 
         // texture module
-        const textureModule = this._particleSystem.textureAnimationModule;
-        this._defines[TEXTURE_ANIMATION_MODULE_ENABLE] = textureModule.enable;
-        if (textureModule.enable) {
+        const textureModule = this._particleSystem._textureAnimationModule;
+        enable = textureModule && textureModule.enable;
+        this._defines[TEXTURE_ANIMATION_MODULE_ENABLE] = enable;
+        if (enable) {
             this._animTexture && this._animTexture.destroy();
             this._animTexture = packCurveRangeXY(_sample_num, textureModule.startFrame, textureModule.frameOverTime);
-
             const handle = pass.getHandle('texture_animation_tex0');
             const binding = Pass.getBindingFromHandle(handle!);
             pass.bindSampler(binding, this._animTexture.getGFXSampler()!);
@@ -394,9 +400,9 @@ export default class ParticleSystemRendererGPU extends ParticleSystemRendererBas
         } else {
             console.warn(`particle system renderMode ${renderMode} not support.`);
         }
-
-        if (this._particleSystem.textureAnimationModule.enable) {
-            Vec2.set(this._frameTile_velLenScale, this._particleSystem.textureAnimationModule.numTilesX, this._particleSystem.textureAnimationModule.numTilesY);
+        const textureModule = this._particleSystem._textureAnimationModule;
+        if (textureModule && textureModule.enable) {
+            Vec2.set(this._frameTile_velLenScale, textureModule.numTilesX, textureModule.numTilesY);
         }
 
         this.initShaderUniform(mat!);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/3317, https://github.com/cocos-creator/3d-tasks/issues/3223

Changes:
1. 修复粒子 capacity 设置浮点数时的报错。
2. 优化粒子系统的运行时创建及内存占用，通过 Enable Culling 裁剪的 module 在运行时不会再创建。

空场景 Chrome 内存快照：90M
优化前 Chrome 内存快照：101 M （50个默认粒子，勾选 Enable Culling）
优化后 Chrome 内存快照：96 M （50个默认粒子，勾选 Enable Culling）

关联编辑器数据迁移PR: https://github.com/cocos-creator/editor-3d/pull/3520