### PR TITLE
fix warning when setting button normalColor.a in editor

### DIFF
--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -503,8 +503,10 @@ let Button = cc.Class({
 
     _setTargetColor (color) {
         let target = this._getTarget();
-        target.color = color;
-        target.opacity = color.a;
+        let cloneColor = color.clone();
+        target.opacity = cloneColor.a;
+        cloneColor.a = 255;  // don't set node opacity via node.color.a
+        target.color = cloneColor;
     },
 
     _getStateColor (state) {


### PR DESCRIPTION
resolve https://github.com/cocos-creator/2d-tasks/issues/2810

changeLog:
- 修复在编辑器里，给 button 设置 normalColor 的透明度，引起的警告