### PR TITLE
planar shadow instancing support

### DIFF
--- a/cocos/core/gfx/define.ts
+++ b/cocos/core/gfx/define.ts
@@ -794,7 +794,6 @@ export function GFXFormatSurfaceSize (
         size += GFXFormatSize(format, width, height, depth);
         width = Math.max(width >> 1, 1);
         height = Math.max(height >> 1, 1);
-        depth = Math.max(depth >> 1, 1);
     }
 
     return size;

--- a/cocos/core/gfx/webgl/webgl-window.ts
+++ b/cocos/core/gfx/webgl/webgl-window.ts
@@ -46,7 +46,7 @@ export class WebGLGFXWindow extends GFXWindow {
                 storeOp: GFXStoreOp.STORE,
                 sampleCount: 1,
                 beginLayout: GFXTextureLayout.COLOR_ATTACHMENT_OPTIMAL,
-                endLayout: GFXTextureLayout.COLOR_ATTACHMENT_OPTIMAL,
+                endLayout: GFXTextureLayout.PRESENT_SRC,
             }],
             depthStencilAttachment: {
                 format : this._depthStencilFmt,
@@ -56,7 +56,7 @@ export class WebGLGFXWindow extends GFXWindow {
                 stencilStoreOp : GFXStoreOp.STORE,
                 sampleCount : 1,
                 beginLayout : GFXTextureLayout.DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-                endLayout : GFXTextureLayout.DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+                endLayout : GFXTextureLayout.PRESENT_SRC,
             },
         });
 

--- a/cocos/core/pipeline/forward/forward-stage.ts
+++ b/cocos/core/pipeline/forward/forward-stage.ts
@@ -181,7 +181,7 @@ export class ForwardStage extends RenderStage {
         this._opaqueBatchedQueue.recordCommandBuffer(cmdBuff);
 
         if (camera.visibility & Layers.BitMask.DEFAULT) {
-            cmdBuff.execute(planarShadow.cmdBuffs.array, planarShadow.cmdBuffCount);
+            planarShadow.recordCommandBuffer(cmdBuff);
         }
         cmdBuff.execute(this._renderQueues[1].cmdBuffs.array, this._renderQueues[1].cmdBuffCount);
 

--- a/cocos/core/renderer/models/baked-skinning-model.ts
+++ b/cocos/core/renderer/models/baked-skinning-model.ts
@@ -166,20 +166,12 @@ export class BakedSkinningModel extends MorphModel {
         if (oldTex && oldTex !== texture) { this._dataPoolManager.jointTexturePool.releaseHandle(oldTex); }
         this._jointsMedium.texture = texture;
         if (!texture) { return; }
-        const { buffer, jointTextureInfo: jointTextureInfo } = this._jointsMedium;
+        const { buffer, jointTextureInfo } = this._jointsMedium;
         jointTextureInfo[0] = texture.handle.texture.width;
         jointTextureInfo[1] = this._skeleton!.joints.length;
         jointTextureInfo[2] = texture.pixelOffset + 0.1; // guard against floor() underflow
         jointTextureInfo[3] = 1 / jointTextureInfo[0];
-        const idx = this._instAnimInfoIdx;
-        if (idx >= 0) { // update instancing data too
-            const info = this._jointsMedium.animInfo;
-            const view = this.instancedAttributes.list[idx].view;
-            const pixelsPerJoint = this._dataPoolManager.jointTexturePool.pixelsPerJoint;
-            view[1] = pixelsPerJoint * jointTextureInfo[1];
-            view[2] = jointTextureInfo[2];
-            view[0] = view[1] * info.data[0] + view[2];
-        }
+        this.updateInstancedJointTextureInfo();
         if (buffer) { buffer.update(jointTextureInfo); }
         const tv = texture.handle.texView;
         const it = this._matPSORecord.values(); let res = it.next();
@@ -215,5 +207,18 @@ export class BakedSkinningModel extends MorphModel {
     protected updateInstancedAttributeList (pso: GFXPipelineState, pass: Pass) {
         super.updateInstancedAttributeList(pso, pass);
         this._instAnimInfoIdx = this.getInstancedAttributeIndex(INST_JOINT_ANIM_INFO);
+        this.updateInstancedJointTextureInfo();
+    }
+
+    private updateInstancedJointTextureInfo () {
+        const { jointTextureInfo, animInfo } = this._jointsMedium;
+        const idx = this._instAnimInfoIdx;
+        if (idx >= 0) { // update instancing data too
+            const view = this.instancedAttributes.list[idx].view;
+            const pixelsPerJoint = this._dataPoolManager.jointTexturePool.pixelsPerJoint;
+            view[1] = pixelsPerJoint * jointTextureInfo[1];
+            view[2] = jointTextureInfo[2];
+            view[0] = view[1] * animInfo.data[0] + view[2];
+        }
     }
 }

--- a/cocos/core/renderer/scene/model.ts
+++ b/cocos/core/renderer/scene/model.ts
@@ -279,7 +279,6 @@ export class Model {
             const pass = mat.passes[i];
             ret[i] = this.createPipelineState(pass, subModelIdx);
         }
-        if (ret[0]) { this.updateInstancedAttributeList(ret[0], mat.passes[0]); }
         return ret;
     }
 
@@ -295,6 +294,7 @@ export class Model {
         const bindingLayout = pso.pipelineLayout.layouts[0];
         if (this._localBuffer) { bindingLayout.bindBuffer(UBOLocal.BLOCK.binding, this._localBuffer); }
         if (this._lightBuffer) { bindingLayout.bindBuffer(UBOForwardLight.BLOCK.binding, this._lightBuffer); }
+        this.updateInstancedAttributeList(pso, pass);
         return pso;
     }
 

--- a/cocos/core/renderer/scene/model.ts
+++ b/cocos/core/renderer/scene/model.ts
@@ -85,6 +85,10 @@ export class Model {
         return this._updateStamp;
     }
 
+    get isInstancingEnabled () {
+        return this._instMatWorldIdx >= 0;
+    }
+
     public type = ModelType.DEFAULT;
     public scene: RenderScene | null = null;
     public node: Node = null!;
@@ -280,6 +284,7 @@ export class Model {
             const pass = mat.passes[i];
             ret[i] = this.createPipelineState(pass, subModelIdx);
         }
+        if (ret[0]) { this.updateInstancedAttributeList(ret[0], mat.passes[0]); }
         return ret;
     }
 
@@ -295,7 +300,6 @@ export class Model {
         const bindingLayout = pso.pipelineLayout.layouts[0];
         if (this._localBuffer) { bindingLayout.bindBuffer(UBOLocal.BLOCK.binding, this._localBuffer); }
         if (this._lightBuffer) { bindingLayout.bindBuffer(UBOForwardLight.BLOCK.binding, this._lightBuffer); }
-        this.updateInstancedAttributeList(pso, pass);
         return pso;
     }
 

--- a/cocos/core/renderer/scene/model.ts
+++ b/cocos/core/renderer/scene/model.ts
@@ -14,6 +14,7 @@ import { Layers } from '../../scene-graph/layers';
 import { IMacroPatch, Pass } from '../core/pass';
 import { RenderScene } from './render-scene';
 import { SubModel } from './submodel';
+import { programLib } from '../core/program-lib';
 
 const m4_1 = new Mat4();
 
@@ -344,7 +345,8 @@ export class Model {
         if (!mat) { return; }
         let hasForwardLight = false;
         for (const p of mat.passes) {
-            if (p.bindings.find((b) => b.name === UBOForwardLight.BLOCK.name)) {
+            const blocks = programLib.getTemplate(p.program).builtins.locals.blocks;
+            if (blocks.find((b) => b.name === UBOForwardLight.BLOCK.name)) {
                 hasForwardLight = true;
                 break;
             }

--- a/cocos/core/renderer/scene/planar-shadows.ts
+++ b/cocos/core/renderer/scene/planar-shadows.ts
@@ -1,29 +1,25 @@
 
 import { Material } from '../../assets/material';
 import { aabb, frustum, intersect } from '../../geometry';
-import { GFXCommandBuffer, IGFXCommandBufferInfo } from '../../gfx/command-buffer';
-import { GFXCommandBufferType } from '../../gfx/define';
 import { GFXPipelineState } from '../../gfx/pipeline-state';
 import { Color, Mat4, Quat, Vec3 } from '../../math';
-import { CachedArray } from '../../memop/cached-array';
 import { IInternalBindingInst, UBOShadow } from '../../pipeline/define';
 import { DirectionalLight } from './directional-light';
 import { Model } from './model';
 import { RenderScene } from './render-scene';
 import { SphereLight } from './sphere-light';
+import { GFXCommandBuffer } from '../../gfx';
+import { InstancedBuffer } from '../../pipeline/instanced-buffer';
 
 const _forward = new Vec3(0, 0, -1);
 const _v3 = new Vec3();
 const _ab = new aabb();
 const _qt = new Quat();
-const _info: IGFXCommandBufferInfo = {
-    allocator: null!,
-    type: GFXCommandBufferType.SECONDARY,
-};
 
 interface IShadowRenderData {
+    model: Model;
     psos: GFXPipelineState[];
-    cmdBuffer: GFXCommandBuffer;
+    instancedBuffer: InstancedBuffer | null;
 }
 
 export class PlanarShadows {
@@ -31,7 +27,6 @@ export class PlanarShadows {
     set enabled (enable: boolean) {
         this._enabled = enable;
         if (this._scene.mainLight) { this.updateDirLight(this._scene.mainLight); }
-        this._cmdBuffs.clear();
     }
 
     get enabled (): boolean {
@@ -67,14 +62,6 @@ export class PlanarShadows {
         return this._data;
     }
 
-    get cmdBuffs () {
-        return this._cmdBuffs;
-    }
-
-    get cmdBuffCount () {
-        return this._cmdBuffs.length;
-    }
-
     protected _scene: RenderScene;
     protected _enabled: boolean = false;
     protected _normal = new Vec3(0, 1, 0);
@@ -85,17 +72,18 @@ export class PlanarShadows {
         0.0, 0.0, 0.0, 0.3, // shadowColor
     ]);
     protected _globalBindings: IInternalBindingInst;
-    protected _cmdBuffs: CachedArray<GFXCommandBuffer>;
-    protected _cmdBuffCount = 0;
     protected _record = new Map<Model, IShadowRenderData>();
+    protected _pendingModels: IShadowRenderData[] = [];
     protected _material: Material;
+    protected _instancingMaterial: Material;
 
     constructor (scene: RenderScene) {
         this._scene = scene;
         this._globalBindings = scene.root.pipeline.globalBindings.get(UBOShadow.BLOCK.name)!;
-        this._cmdBuffs = new CachedArray<GFXCommandBuffer>(64);
         this._material = new Material();
         this._material.initialize({ effectName: 'pipeline/planar-shadow' });
+        this._instancingMaterial = new Material();
+        this._instancingMaterial.initialize({ effectName: 'pipeline/planar-shadow', defines: { USE_INSTANCING: true } });
     }
 
     public updateSphereLight (light: SphereLight) {
@@ -154,7 +142,7 @@ export class PlanarShadows {
     }
 
     public updateCommandBuffers (frstm: frustum, stamp: number) {
-        this._cmdBuffs.clear();
+        this._pendingModels.length = 0;
         if (!this._scene.mainLight) { return; }
         const models = this._scene.models;
         for (let i = 0; i < models.length; i++) {
@@ -165,41 +153,67 @@ export class PlanarShadows {
                 if (!intersect.aabb_frustum(_ab, frstm)) { continue; }
             }
             let data = this._record.get(model);
+            if (data && (!!data.instancedBuffer !== model.isInstancingEnabled)) { this.destroyShadowData(model); data = undefined; }
             if (!data) { data = this.createShadowData(model); this._record.set(model, data); }
             if (model.updateStamp !== stamp) { model.updateUBOs(stamp); } // for those outside the frustum
-            this.cmdBuffs.push(data.cmdBuffer);
+            this._pendingModels.push(data);
+        }
+    }
+
+    public recordCommandBuffer (cmdBuff: GFXCommandBuffer) {
+        const models = this._pendingModels;
+        const modelLen = models.length;
+        const buffer = this._instancingMaterial.passes[0].instancedBuffer!;
+        buffer.clear();
+        for (let i = 0; i < modelLen; i++) {
+            const { model, psos, instancedBuffer } = models[i];
+            for (let j = 0; j < psos.length; j++) {
+                const submodel = model.getSubModel(j);
+                const pso = psos[j];
+                if (instancedBuffer) {
+                    instancedBuffer.merge(submodel, model.instancedAttributes, pso);
+                } else {
+                    const ia = submodel.inputAssembler!;
+                    cmdBuff.bindPipelineState(pso);
+                    cmdBuff.bindBindingLayout(pso.pipelineLayout.layouts[0]);
+                    cmdBuff.bindInputAssembler(ia);
+                    cmdBuff.draw(ia);
+                }
+            }
+        }
+        if (buffer.pso) {
+            buffer.uploadBuffers();
+            cmdBuff.bindPipelineState(buffer.pso!);
+            cmdBuff.bindBindingLayout(buffer.pso!.pipelineLayout.layouts[0]);
+            for (let b = 0; b < buffer.instances.length; ++b) {
+                const instance = buffer.instances[b];
+                if (!instance.count) { continue; }
+                cmdBuff.bindInputAssembler(instance.ia);
+                cmdBuff.draw(instance.ia);
+            }
         }
     }
 
     public createShadowData (model: Model): IShadowRenderData {
-        const device = this._scene.root.device;
-        _info.allocator = device.commandAllocator;
-        const cmdBuffer = device.createCommandBuffer(_info);
         const psos: GFXPipelineState[] = [];
-        cmdBuffer.begin();
+        const material = model.isInstancingEnabled ? this._instancingMaterial : this._material;
         for (let i = 0; i < model.subModelNum; i++) {
-            const ia = model.getSubModel(i).inputAssembler!;
             // @ts-ignore TS2445
-            const pso = model.createPipelineState(this._material.passes[0], i);
+            const pso = model.createPipelineState(material.passes[0], i);
             model.insertImplantPSO(pso); // add back to model to sync binding layouts
             pso.pipelineLayout.layouts[0].update(); psos.push(pso);
-            cmdBuffer.bindPipelineState(pso);
-            cmdBuffer.bindBindingLayout(pso.pipelineLayout.layouts[0]);
-            cmdBuffer.bindInputAssembler(ia);
-            cmdBuffer.draw(ia);
         }
-        cmdBuffer.end();
-        return { psos, cmdBuffer };
+        return { model, psos, instancedBuffer: material.passes[0].instancedBuffer };
     }
 
     public destroyShadowData (model: Model) {
         const data = this._record.get(model);
         if (!data) { return; }
-        data.cmdBuffer.destroy();
+        const material = data.instancedBuffer ? this._instancingMaterial : this._material;
         for (let i = 0; i < data.psos.length; i++) {
             const pso = data.psos[i];
             model.removeImplantPSO(pso);
-            this._material.passes[0].destroyPipelineState(pso);
+            material.passes[0].destroyPipelineState(pso);
         }
         this._record.delete(model);
     }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * joint texture attributes should be updated on material change, otherwise dynamically toggling instancing by changing materials will break baked skeletal animations.
* light buffer detection should check the initial shader properties or the builtin materials won't work (no pipeline when initializing, thus no bindings)
* planar shadow now supports instancing (automatically enabled when the model itself is using instancing)

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->