### PR TITLE
not share InputAssembler object across UIDrawBatch objects

### DIFF
--- a/cocos/core/renderer/ui/mesh-buffer.ts
+++ b/cocos/core/renderer/ui/mesh-buffer.ts
@@ -142,6 +142,7 @@ export class MeshBuffer {
         this.vb!.destroy();
         this.ib = null;
         this.vb = null;
+        this.attributes = null;
     }
 
     public uploadData () {

--- a/cocos/core/renderer/ui/mesh-buffer.ts
+++ b/cocos/core/renderer/ui/mesh-buffer.ts
@@ -29,7 +29,7 @@
 
 import { GFXBuffer } from '../../gfx/buffer';
 import { GFXBufferUsageBit, GFXMemoryUsageBit } from '../../gfx/define';
-import { GFXInputAssembler, IGFXAttribute } from '../../gfx/input-assembler';
+import { IGFXAttribute } from '../../gfx/input-assembler';
 import { UI } from './ui';
 
 export class MeshBuffer {
@@ -40,7 +40,7 @@ export class MeshBuffer {
     public iData: Uint16Array | null = null;
     public vb: GFXBuffer | null = null;
     public ib: GFXBuffer | null = null;
-    public ia: GFXInputAssembler | null = null;
+    public attributes: IGFXAttribute[] | null = null;
 
     public byteStart = 0;
     public byteOffset = 0;
@@ -84,11 +84,7 @@ export class MeshBuffer {
             stride: ibStride,
         });
 
-        this.ia = this.ia || this.batcher.device.createInputAssembler({
-            attributes: attrs,
-            vertexBuffers: [this.vb],
-            indexBuffer: this.ib,
-        });
+        this.attributes = attrs;
 
         this._reallocBuffer();
     }
@@ -144,10 +140,8 @@ export class MeshBuffer {
     public destroy () {
         this.ib!.destroy();
         this.vb!.destroy();
-        this.ia!.destroy();
         this.ib = null;
         this.vb = null;
-        this.ia = null;
     }
 
     public uploadData () {

--- a/cocos/core/renderer/ui/ui-draw-batch.ts
+++ b/cocos/core/renderer/ui/ui-draw-batch.ts
@@ -10,10 +10,13 @@ import { Node } from '../../scene-graph';
 import { Camera } from '../scene/camera';
 import { Model } from '../scene/model';
 import { UI } from './ui';
+import { GFXInputAssembler, IGFXAttribute } from '../../gfx/input-assembler';
 
 export class UIDrawBatch {
+    private _bufferBatch: MeshBuffer | null = null;
+
     public camera: Camera | null = null;
-    public bufferBatch: MeshBuffer | null = null;
+    public ia: GFXInputAssembler | null = null;
     public model: Model | null = null;
     public material: Material | null = null;
     public texView: GFXTextureView | null = null;
@@ -34,6 +37,10 @@ export class UIDrawBatch {
         if (this.bindingLayout) {
             this.bindingLayout = null;
         }
+
+        if (this.ia) {
+            this.ia.destroy();
+        }
     }
 
     public clear (ui: UI) {
@@ -42,7 +49,7 @@ export class UIDrawBatch {
             this.pipelineState = null;
         }
         this.camera = null;
-        this.bufferBatch = null;
+        this._bufferBatch = null;
         this.material = null;
         this.texView = null;
         this.sampler = null;
@@ -50,5 +57,36 @@ export class UIDrawBatch {
         this.idxCount = 0;
         this.model = null;
         this.isStatic = false;
+
+        if (this.ia) {
+            this.ia.firstIndex = 0;
+            this.ia.indexCount = 0;
+        }
+
+    }
+
+    get bufferBatch () {
+        return this._bufferBatch!;
+    }
+
+    set bufferBatch(meshBuffer : MeshBuffer | null) {
+        if (this._bufferBatch == meshBuffer) {
+            return;
+        }
+
+        this._bufferBatch = meshBuffer;
+
+        if (this.ia) {
+            this.ia.destroy();
+            this.ia = null;
+        }
+
+        if (this._bufferBatch) {
+            this.ia = this._bufferBatch.batcher.device.createInputAssembler({
+                attributes: this._bufferBatch.attributes!,
+                vertexBuffers: [this._bufferBatch.vb!],
+                indexBuffer: this._bufferBatch.ib!,
+            });
+        }
     }
 }

--- a/cocos/core/renderer/ui/ui-draw-batch.ts
+++ b/cocos/core/renderer/ui/ui-draw-batch.ts
@@ -65,7 +65,7 @@ export class UIDrawBatch {
     }
 
     get bufferBatch () {
-        return this._bufferBatch!;
+        return this._bufferBatch;
     }
 
     set bufferBatch(meshBuffer : MeshBuffer | null) {

--- a/cocos/core/renderer/ui/ui-draw-batch.ts
+++ b/cocos/core/renderer/ui/ui-draw-batch.ts
@@ -40,6 +40,7 @@ export class UIDrawBatch {
 
         if (this.ia) {
             this.ia.destroy();
+            this.ia = null;
         }
     }
 

--- a/cocos/core/renderer/ui/ui-draw-batch.ts
+++ b/cocos/core/renderer/ui/ui-draw-batch.ts
@@ -62,7 +62,6 @@ export class UIDrawBatch {
             this.ia.firstIndex = 0;
             this.ia.indexCount = 0;
         }
-
     }
 
     get bufferBatch () {

--- a/cocos/core/renderer/ui/ui.ts
+++ b/cocos/core/renderer/ui/ui.ts
@@ -336,7 +336,7 @@ export class UI {
                     bindingLayout.bindSampler(UniformBinding.CUSTOM_SAMPLER_BINDING_START_POINT, batch.sampler!);
                     bindingLayout.update();
 
-                    const ia = batch.bufferBatch!.ia!;
+                    const ia = batch.ia!;
                     ia.firstIndex = batch.firstIdx;
                     ia.indexCount = batch.idxCount;
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/2985

Changes:
 * not share InputAssembler object across UIDrawBatch objects
