### PR TITLE
no need to maintain both buffers when instancing

### DIFF
--- a/cocos/core/renderer/models/baked-skinning-model.ts
+++ b/cocos/core/renderer/models/baked-skinning-model.ts
@@ -131,8 +131,7 @@ export class BakedSkinningModel extends MorphModel {
         if (idx >= 0) {
             const view = this.instancedAttributes.list[idx].view;
             view[0] = view[1] * info.data[0] + view[2];
-        }
-        if (info.dirty) {
+        } else if (info.dirty) {
             info.buffer.update(info.data);
             info.dirty = false;
         }

--- a/cocos/core/renderer/scene/model.ts
+++ b/cocos/core/renderer/scene/model.ts
@@ -185,11 +185,12 @@ export class Model {
         if (idx >= 0) {
             const attrs = this.instancedAttributes!.list;
             uploadMat4AsVec4x3(worldMatrix, attrs[idx].view, attrs[idx + 1].view, attrs[idx + 2].view);
+        } else {
+            Mat4.toArray(this._localData, worldMatrix, UBOLocal.MAT_WORLD_OFFSET);
+            Mat4.inverseTranspose(m4_1, worldMatrix);
+            Mat4.toArray(this._localData, m4_1, UBOLocal.MAT_WORLD_IT_OFFSET);
+            this._localBuffer!.update(this._localData);
         }
-        Mat4.toArray(this._localData, worldMatrix, UBOLocal.MAT_WORLD_OFFSET);
-        Mat4.inverseTranspose(m4_1, worldMatrix);
-        Mat4.toArray(this._localData, m4_1, UBOLocal.MAT_WORLD_IT_OFFSET);
-        this._localBuffer!.update(this._localData);
     }
 
     /**


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->