### PR TITLE
fix WebView opacity invalid on iOS

### DIFF
--- a/cocos2d/webview/webview-impl.js
+++ b/cocos2d/webview/webview-impl.js
@@ -122,7 +122,6 @@ let WebViewImpl = cc.Class({
         if (WebViewImpl._polyfill.enableBG)
             this._div.style["background"] = "#FFF";
 
-        this._div.style["background"] = "#FFF";
         this._div.style.height = h + "px";
         this._div.style.width = w + "px";
         this._div.style.overflow = "scroll";


### PR DESCRIPTION
Re: https://forum.cocos.org/t/2-3-3-bug/92994

Changes:
 * fix webview opacity invalid on iOS

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
