### PR TITLE
fix skinning model pose calc when missing joint nodes

### DIFF
--- a/cocos/core/3d/framework/batched-skinning-model-component.ts
+++ b/cocos/core/3d/framework/batched-skinning-model-component.ts
@@ -205,7 +205,7 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
 
     public _onMaterialModified (idx: number, material: Material | null) {
         this.cookMaterials();
-        super._onMaterialModified(idx, this.getMaterial(idx));
+        super._onMaterialModified(idx, this.getMaterialInstance(idx));
     }
 
     public cook () {
@@ -218,7 +218,7 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
         if (!this._batchMaterial) {
             this._batchMaterial = this.getMaterial(0);
         }
-        const mat = this.getMaterial(0);
+        const mat = this.getMaterialInstance(0);
         if (!mat || !this._batchMaterial || !this._batchMaterial.effectAsset) {
             console.warn('incomplete batch material!'); return;
         }

--- a/cocos/core/math/vec3.ts
+++ b/cocos/core/math/vec3.ts
@@ -357,7 +357,7 @@ export class Vec3 extends ValueType {
         const y = a.y;
         const z = a.z;
         let rhw = m.m03 * x + m.m07 * y + m.m11 * z + m.m15;
-        rhw = rhw ? 1 / rhw : 1;
+        rhw = rhw ? Math.abs(1 / rhw) : 1;
         out.x = (m.m00 * x + m.m04 * y + m.m08 * z + m.m12) * rhw;
         out.y = (m.m01 * x + m.m05 * y + m.m09 * z + m.m13) * rhw;
         out.z = (m.m02 * x + m.m06 * y + m.m10 * z + m.m14) * rhw;
@@ -372,7 +372,7 @@ export class Vec3 extends ValueType {
         const y = a.y;
         const z = a.z;
         let rhw = m.m03 * x + m.m07 * y + m.m11 * z;
-        rhw = rhw ? 1 / rhw : 1;
+        rhw = rhw ? Math.abs(1 / rhw) : 1;
         out.x = (m.m00 * x + m.m04 * y + m.m08 * z) * rhw;
         out.y = (m.m01 * x + m.m05 * y + m.m09 * z) * rhw;
         out.z = (m.m02 * x + m.m06 * y + m.m10 * z) * rhw;
@@ -399,9 +399,9 @@ export class Vec3 extends ValueType {
         const x = v.x;
         const y = v.y;
         const z = v.z;
-        out.x = m.m00 * x + m.m01 * y + m.m02 * z + m.m03;
-        out.y = m.m04 * x + m.m05 * y + m.m06 * z + m.m07;
-        out.x = m.m08 * x + m.m09 * y + m.m10 * z + m.m11;
+        out.x = m.m00 * x + m.m04 * y + m.m08 * z + m.m12;
+        out.y = m.m01 * x + m.m05 * y + m.m09 * z + m.m13;
+        out.x = m.m02 * x + m.m06 * y + m.m10 * z + m.m14;
         return out;
     }
 

--- a/cocos/core/renderer/scene/camera.ts
+++ b/cocos/core/renderer/scene/camera.ts
@@ -597,6 +597,7 @@ export class Camera {
         const ch = this.viewport.height * this._height;
 
         Vec3.transformMat4(out, worldPos, this.matViewProj);
+
         out.x = cx + (out.x + 1) * 0.5 * cw;
         out.y = cy + (out.y + 1) * 0.5 * ch;
         out.z = out.z * 0.5 + 0.5;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * When joint node is not present, bounding boxes should still be calculated or culling won't work properly

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->