### PR TITLE
Allow some static members of classes to be type

### DIFF
--- a/cocos/audio/assets/clip.ts
+++ b/cocos/audio/assets/clip.ts
@@ -131,4 +131,9 @@ export class AudioClip extends Asset {
     }
 }
 
+export namespace AudioClip {
+    export type PlayingState = typeof PlayingState;
+    export type AudioType = typeof AudioType;
+}
+
 cc.AudioClip = AudioClip;

--- a/cocos/core/3d/framework/camera-component.ts
+++ b/cocos/core/3d/framework/camera-component.ts
@@ -649,3 +649,12 @@ export class CameraComponent extends Component {
         }
     }
 }
+
+export namespace CameraComponent {
+    export type ProjectionType = typeof ProjectionType;
+    export type FOVAxis = typeof FOVAxis;
+    export type ClearFlag = typeof ClearFlag;
+    export type Aperture = typeof Aperture;
+    export type Shutter = typeof Shutter;
+    export type ISO = typeof ISO;
+}

--- a/cocos/core/3d/framework/light-component.ts
+++ b/cocos/core/3d/framework/light-component.ts
@@ -225,3 +225,8 @@ export class LightComponent extends Component {
         }
     }
 }
+
+export namespace LightComponent {
+    export type Type = typeof LightType;
+    export type PhotometricTerm = typeof PhotometricTerm;
+}

--- a/cocos/core/3d/framework/model-component.ts
+++ b/cocos/core/3d/framework/model-component.ts
@@ -462,3 +462,7 @@ export class ModelComponent extends RenderableComponent {
         subMeshMorphInstance.renderResources.setWeights(subMeshMorphInstance.weights);
     }
 }
+
+export namespace ModelComponent {
+    export type ShadowCastingMode = typeof ModelShadowCastingMode;
+}

--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -394,4 +394,8 @@ export class AnimationClip extends Asset {
     }
 }
 
+export namespace AnimationClip {
+    export type WrapMode = typeof AnimationWrapMode;
+}
+
 cc.AnimationClip = AnimationClip;

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -485,6 +485,10 @@ export class AnimationComponent extends Eventify(Component) {
     }
 }
 
+export namespace AnimationComponent {
+    export type EventType = typeof EventType;
+}
+
 cc.AnimationComponent = AnimationComponent;
 
 function equalClips (clip1: AnimationClip | null, clip2: AnimationClip | null) {

--- a/cocos/core/assets/texture-base.ts
+++ b/cocos/core/assets/texture-base.ts
@@ -326,4 +326,10 @@ export class TextureBase extends Asset {
     }
 }
 
+export namespace TextureBase {
+    export type PixelFormat = typeof PixelFormat;
+    export type WrapMode = typeof WrapMode;
+    export type Filter = typeof Filter;
+}
+
 cc.TextureBase = TextureBase;

--- a/cocos/ui/components/widget-component.ts
+++ b/cocos/ui/components/widget-component.ts
@@ -1078,6 +1078,10 @@ export class WidgetComponent extends Component {
     }
 }
 
+export namespace WidgetComponent {
+    export type AlignMode = typeof AlignMode;
+}
+
 // @ts-ignore
 cc.WidgetComponent = WidgetComponent;
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Solves that many static members of classes can not be used as type, even if they should.

### Background

There are many enumerations/classes embedded in other classes. Such as `PixelFormat` of `TextureBase`, `ProjectionType` of `CameraComponent`. Most of these are implemented through a static member declaration, like this:
```ts
enum PixelFormat {  }
class TextureBase {
  public static PixelFormat = PixelFormat;
}
```
The purpose is to allow user access the `PixelFormat` through a member access expression `TextureBase.PixelFormat`. It works well.
However, this kind of declaration prevent the `TextureBase.PixelFormat` from being used as type. For instance:
```ts
function doSomething(
  pixelFormat: TextureBase.PixelFormat, // Error: compiler hints that "TextureBase.PixelFormat" is not a type
  ) {
  pixelFormat. // No intelligence
}
```

After some researches, I found a solution for this. That's, supply a type declaration:
```ts
enum PixelFormat {  }
class TextureBase {
  public static PixelFormat = PixelFormat;
}
// Supply a type declaration for `TextureBase.PixelFormat`
namespace TextureBase {
  export type PixelFormat = typeof PixelFormat;
}
```
The rational is the supplied type declaration would be merged with the static member declaration.

-----------------------------------------------------------------

@YunHsiao 
@JoneLau 
@MSoft1115 
@troublemaker52025 
@JayceLai 
@LinYunMo 
Please understand what this PR does. For illustration, **I have supplied partial changes on modules that you're mainly maintaining**.

@pandamicro  Could you please request review to them all, for changes applied to their modules.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
