### PR TITLE
fix maxLength for input of number type

### DIFF
--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -637,6 +637,11 @@ Object.assign(WebEditBoxImpl.prototype, {
             if (inputLock) {
                 return;
             }
+            // input of number type doesn't support maxLength attribute
+            let maxLength = impl._delegate.maxLength;
+            if (maxLength >= 0) {
+                elem.value = elem.value.slice(0, maxLength);
+            }
             impl._delegate.editBoxTextChanged(elem.value);
         };
         


### PR DESCRIPTION
changeLog:
- 修复 number 模式下，EditBox.maxLength 属性不生效的问题