### PR TITLE
allow work around for safari 10

### DIFF
--- a/gulp/util/utils.js
+++ b/gulp/util/utils.js
@@ -95,6 +95,7 @@ exports.getUglifyOptions = function (platform, flags) {
                 // http://lisperator.net/uglifyjs/codegen
                 ascii_only: true,
             },
+            safari10: true, // cocos-creator/engine#5144
         };
     }
     else {
@@ -147,6 +148,7 @@ exports.getUglifyOptions = function (platform, flags) {
                 indent_level: 2,
                 ascii_only: true,
             },
+            safari10: true, // cocos-creator/engine#5144
         };
     }
 };


### PR DESCRIPTION
Fix: #5144

Changes:
 * 改善 Safari 10 上代码的兼容性问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
