### PR TITLE
Animation event 'last-frame' fix

### DIFF
--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../components/component';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property } from '../data/class-decorator';
+import { ccclass, executeInEditMode, executionOrder, help, menu, property } from '../data/class-decorator';
 import { Eventify } from '../event/eventify';
 import { warnID } from '../platform/debug';
 import * as ArrayUtils from '../utils/array';
@@ -76,8 +76,6 @@ export enum EventType {
     FINISHED = 'finished',
 }
 ccenum(EventType);
-
-type AnimationEventCallback<ThisType> = (this: ThisType, type: EventType, state: AnimationState) => void;
 
 /**
  * 动画组件管理动画状态来控制动画的播放。
@@ -182,7 +180,7 @@ export class AnimationComponent extends Eventify(Component) {
 
     protected _crossFade = new CrossFade();
 
-    protected _nameToState: { [name: string]: AnimationState; } = createMap(true);
+    protected _nameToState: Record<string, AnimationState> = createMap(true);
 
     @property({ type: [AnimationClip] })
     protected _clips: (AnimationClip | null)[] = [];
@@ -319,6 +317,7 @@ export class AnimationComponent extends Eventify(Component) {
     public removeState (name: string) {
         const state = this._nameToState[name];
         if (state) {
+            state.allowLastFrameEvent = false;
             state.stop();
             delete this._nameToState[name];
         }
@@ -351,11 +350,12 @@ export class AnimationComponent extends Eventify(Component) {
      * @param {Boolean} [force=false] - If force is true, then will always remove the clip and any animation states based on it.
      */
     public removeClip (clip: AnimationClip, force?: boolean) {
-        let state: AnimationState | undefined;
-        for (const name of Object.keys(this._nameToState)) {
-            state = this._nameToState[name];
+        let removalState: AnimationState | undefined;
+        for (const name in this._nameToState) {
+            const state = this._nameToState[name];
             const stateClip = state.clip;
             if (stateClip === clip) {
+                removalState = state;
                 break;
             }
         }
@@ -368,8 +368,8 @@ export class AnimationComponent extends Eventify(Component) {
             }
         }
 
-        if (state && state.isPlaying) {
-            if (force) { state.stop(); }
+        if (removalState && removalState.isPlaying) {
+            if (force) { removalState.stop(); }
             else {
                 if (!TEST) { warnID(3903); }
                 return;
@@ -378,8 +378,8 @@ export class AnimationComponent extends Eventify(Component) {
 
         this._clips = this._clips.filter((item) => item !== clip);
 
-        if (state) {
-            delete this._nameToState[state.name];
+        if (removalState) {
+            delete this._nameToState[removalState.name];
         }
     }
 
@@ -410,10 +410,16 @@ export class AnimationComponent extends Eventify(Component) {
      */
     public on<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
         const ret = super.on(type, callback, thisArg);
-        if (type === 'lastframe') {
-            for (const stateName of Object.keys(this._nameToState)) {
-                this._nameToState[stateName]!._lastframeEventOn = true;
-            }
+        if (type === EventType.LASTFRAME) {
+            this._syncAllowLastFrameEvent();
+        }
+        return ret;
+    }
+
+    public once<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
+        const ret = super.once(type, callback, thisArg);
+        if (type === EventType.LASTFRAME) {
+            this._syncAllowLastFrameEvent();
         }
         return ret;
     }
@@ -433,14 +439,10 @@ export class AnimationComponent extends Eventify(Component) {
      * ```
      */
     public off<TFunction extends Function> (type: EventType, callback?: TFunction, thisArg?: any) {
-        if (type === 'lastframe') {
-            const nameToState = this._nameToState;
-            for (const name of Object.keys(nameToState)) {
-                const state = nameToState[name]!;
-                state._lastframeEventOn = false;
-            }
-        }
         super.off(type, callback, thisArg);
+        if (type === EventType.LASTFRAME) {
+            this._syncDisallowLastFrameEvent();
+        }
     }
 
     protected _createState (clip: AnimationClip, name?: string) {
@@ -450,6 +452,7 @@ export class AnimationComponent extends Eventify(Component) {
     protected _doCreateState (clip: AnimationClip, name: string) {
         const state = this._createState(clip, name);
         state._setEventTarget(this);
+        state.allowLastFrameEvent = this.hasEventListener(EventType.LASTFRAME);
         if (this.node) {
             state.initialize(this.node);
         }
@@ -480,6 +483,22 @@ export class AnimationComponent extends Eventify(Component) {
             if (equalClips(clip, state.clip)) {
                 state.stop();
                 delete this._nameToState[name];
+            }
+        }
+    }
+
+    private _syncAllowLastFrameEvent () {
+        if (this.hasEventListener(EventType.LASTFRAME)) {
+            for (const stateName in this._nameToState) {
+                this._nameToState[stateName].allowLastFrameEvent = true;
+            }
+        }
+    }
+
+    private _syncDisallowLastFrameEvent () {
+        if (!this.hasEventListener(EventType.LASTFRAME)) {
+            for (const stateName in this._nameToState) {
+                this._nameToState[stateName].allowLastFrameEvent = false;
             }
         }
     }

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -277,7 +277,13 @@ export class AnimationState extends Playable {
 
     public frameRate = 0;
 
-    public _lastframeEventOn = false;
+    /**
+     * @zh
+     * 是否允许触发 `LastFrame` 事件。
+     * @en
+     * Whether `LastFrame` should be triggered.
+     */
+    public allowLastFrameEvent = false;
 
     protected _wrapMode = WrapMode.Normal;
 
@@ -423,11 +429,7 @@ export class AnimationState extends Playable {
 
     public emit<K extends string> (type: K, ...args: EventArgumentsOf<K, IAnimationEventDefinitionMap>): void;
 
-    public emit (...restargs: any[]) {
-        const args = new Array(restargs.length);
-        for (let i = 0, l = args.length; i < l; i++) {
-            args[i] = restargs[i];
-        }
+    public emit (...args: any[]) {
         cc.director.getAnimationManager().pushDelayEvent(this, '_emit', args);
     }
 
@@ -436,7 +438,7 @@ export class AnimationState extends Playable {
     public on (type: string, callback: Function, target?: any) {
         if (this._target && this._target.isValid) {
             if (type === 'lastframe') {
-                this._lastframeEventOn = true;
+                this.allowLastFrameEvent = true;
             }
             return this._target.on(type, callback, target);
         }
@@ -450,11 +452,11 @@ export class AnimationState extends Playable {
     public once (type: string, callback: Function, target?: any) {
         if (this._target && this._target.isValid) {
             if (type === 'lastframe') {
-                this._lastframeEventOn = true;
+                this.allowLastFrameEvent = true;
             }
             return this._target.once(type, (event) => {
                 callback.call(target, event);
-                this._lastframeEventOn = false;
+                this.allowLastFrameEvent = false;
             });
         }
         else {
@@ -466,7 +468,7 @@ export class AnimationState extends Playable {
         if (this._target && this._target.isValid) {
             if (type === 'lastframe') {
                 if (!this._target.hasEventListener(type)) {
-                    this._lastframeEventOn = false;
+                    this.allowLastFrameEvent = false;
                 }
             }
             this._target.off(type, callback, target);
@@ -612,7 +614,7 @@ export class AnimationState extends Playable {
         // sample
         const info = this.sample();
 
-        if (this._lastframeEventOn) {
+        if (this.allowLastFrameEvent) {
             let lastInfo;
             if (!this._lastWrapInfo) {
                 lastInfo = this._lastWrapInfo = new WrappedInfo(info);
@@ -646,7 +648,7 @@ export class AnimationState extends Playable {
             }
         }
 
-        if (this._lastframeEventOn) {
+        if (this.allowLastFrameEvent) {
             if (this._lastIterations === undefined) {
                 this._lastIterations = ratio;
             }

--- a/tests/animation/animation-events.test.ts
+++ b/tests/animation/animation-events.test.ts
@@ -1,0 +1,59 @@
+import { Node, AnimationComponent, director, AnimationClip, math } from '../../cocos/core';
+
+
+test('Animation events(general)', () => {
+
+});
+
+test('Animation event(last-frame event optimization)', () => {
+    const animationComponent = createTestAnimationComponent();
+
+    const clip0 = createTestClip('clip0');
+    const clip1 = createTestClip('clip1');
+    const initialClips = [ clip0, clip1 ];
+    const defaultClip = initialClips[0];
+    animationComponent.clips = initialClips;
+    animationComponent.defaultClip = defaultClip;
+    const initialStates = [clip0, clip0].map((clip) => animationComponent.getState(clip.name));
+
+    const handler1 = () => {};
+    const handler2 = () => {};
+
+    expect(initialStates.every((state) => !state.allowLastFrameEvent)).toBeTruthy();
+
+    animationComponent.on(AnimationComponent.EventType.LASTFRAME, handler1);
+    // After subscribe the last-frame event, all states should have `allowLastFrameEvent` set to `true`.
+    expect(initialStates.every((state) => state.allowLastFrameEvent)).toBeTruthy();
+
+    animationComponent.on(AnimationComponent.EventType.LASTFRAME, handler2);
+    // Should no problem.
+    expect(initialStates.every((state) => state.allowLastFrameEvent)).toBeTruthy();
+
+    animationComponent.off(AnimationComponent.EventType.LASTFRAME, handler2);
+    // Now we unsubscribe one, but this should still true.
+    expect(initialStates.every((state) => state.allowLastFrameEvent)).toBeTruthy();
+
+    animationComponent.off(AnimationComponent.EventType.LASTFRAME, handler1);
+    // All states should have `allowLastFrameEvent` set to `false`
+    // if no any subscribe on 'last-frame' event.
+    expect(initialStates.every((state) => !state.allowLastFrameEvent)).toBeTruthy();
+
+    animationComponent.on(AnimationComponent.EventType.LASTFRAME, handler1);
+    // The newly added state should automatically have `allowLastFrameEvent` set to `true`.
+    const newState = animationComponent.createState(createTestClip('clip-new'));
+    // The newly added state should also have `allowLastFrameEvent` set to `true`.
+    expect(newState.allowLastFrameEvent).toBeTruthy();
+});
+
+function createTestAnimationComponent() {
+    const node = new Node();
+    const animationComponent = node.addComponent(AnimationComponent);
+    return animationComponent;
+}
+
+function createTestClip(name: string, duration: number = math.randomRange(0, 1)) {
+    const clip = new AnimationClip();
+    clip.name = name;
+    clip.duration = 0;
+    return clip;
+}


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Fix that newly added animation state won't subscribe to 'last-frame' event before

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
