### PR TITLE
fix outline\shadow\motionStreak\light set color invalid in timeline

### DIFF
--- a/cocos2d/core/3d/CCLightComponent.js
+++ b/cocos2d/core/3d/CCLightComponent.js
@@ -218,7 +218,9 @@ export default class Light extends CCComponent {
     }
 
     set color(val) {
-        this._color = val;
+        if (!this._color.equals(val)) {
+            this._color.set(val);
+        }
         this._light.setColor(val.r / 255, val.g / 255, val.b / 255);
     }
 

--- a/cocos2d/core/components/CCLabelOutline.js
+++ b/cocos2d/core/components/CCLabelOutline.js
@@ -65,7 +65,9 @@ let LabelOutline = cc.Class({
                 return this._color;
             },
             set: function (value) {
-                this._color = value;
+                if (!this._color.equals(value)) {
+                    this._color.set(value);
+                }
                 this._updateRenderData();
             }
         },

--- a/cocos2d/core/components/CCLabelShadow.js
+++ b/cocos2d/core/components/CCLabelShadow.js
@@ -66,7 +66,9 @@ let LabelShadow = cc.Class({
                 return this._color;
             },
             set: function (value) {
-                this._color = value;
+                if (!this._color.equals(value)) {
+                    this._color.set(value);
+                }
                 this._updateRenderData();
             }
         },

--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -182,7 +182,9 @@ var MotionStreak = cc.Class({
                 return this._color;
             },
             set (value) {
-                this._color = value;
+                if (!this._color.equals(value)) {
+                    this._color.set(value);
+                }
             },
             type: cc.Color,
             tooltip: CC_DEV && 'i18n:COMPONENT.motionStreak.color'


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

![image](https://user-images.githubusercontent.com/7564028/82970737-97c77a00-a003-11ea-9660-e1500c1cf784.png)


Changes:
 * fix outline\shadow\motionStreak\light component set color invalid in timeline
