### PR TITLE
Mark event-related API of AnimationState as deprecated

### DIFF
--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -371,8 +371,7 @@ export class AnimationComponent extends Eventify(Component) {
      */
     public on<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
         const ret = super.on(type, callback, thisArg);
-        if (type === EventType.LASTFRAME ||
-            type === EventType.ITERATION_END) {
+        if (type === EventType.LASTFRAME) {
             this._syncAllowLastFrameEvent();
         }
         return ret;
@@ -380,8 +379,7 @@ export class AnimationComponent extends Eventify(Component) {
 
     public once<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
         const ret = super.once(type, callback, thisArg);
-        if (type === EventType.LASTFRAME ||
-            type === EventType.ITERATION_END) {
+        if (type === EventType.LASTFRAME) {
             this._syncAllowLastFrameEvent();
         }
         return ret;
@@ -403,8 +401,7 @@ export class AnimationComponent extends Eventify(Component) {
      */
     public off (type: EventType, callback?: Function, thisArg?: any) {
         super.off(type, callback, thisArg);
-        if (type === EventType.LASTFRAME ||
-            type === EventType.ITERATION_END) {
+        if (type === EventType.LASTFRAME) {
             this._syncDisallowLastFrameEvent();
         }
     }
@@ -452,8 +449,7 @@ export class AnimationComponent extends Eventify(Component) {
     }
 
     private _syncAllowLastFrameEvent () {
-        if (this.hasEventListener(EventType.LASTFRAME) ||
-            this.hasEventListener(EventType.ITERATION_END)) {
+        if (this.hasEventListener(EventType.LASTFRAME)) {
             for (const stateName in this._nameToState) {
                 this._nameToState[stateName].allowLastFrameEvent(true);
             }
@@ -461,8 +457,7 @@ export class AnimationComponent extends Eventify(Component) {
     }
 
     private _syncDisallowLastFrameEvent () {
-        if (!this.hasEventListener(EventType.LASTFRAME) &&
-            !this.hasEventListener(EventType.ITERATION_END)) {
+        if (!this.hasEventListener(EventType.LASTFRAME)) {
             for (const stateName in this._nameToState) {
                 this._nameToState[stateName].allowLastFrameEvent(false);
             }

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -372,7 +372,7 @@ export class AnimationComponent extends Eventify(Component) {
     public on<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
         const ret = super.on(type, callback, thisArg);
         if (type === EventType.LASTFRAME ||
-            type === EventType.LAST_FRAME_ARRIVED) {
+            type === EventType.ITERATION_END) {
             this._syncAllowLastFrameEvent();
         }
         return ret;
@@ -381,7 +381,7 @@ export class AnimationComponent extends Eventify(Component) {
     public once<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
         const ret = super.once(type, callback, thisArg);
         if (type === EventType.LASTFRAME ||
-            type === EventType.LAST_FRAME_ARRIVED) {
+            type === EventType.ITERATION_END) {
             this._syncAllowLastFrameEvent();
         }
         return ret;
@@ -404,7 +404,7 @@ export class AnimationComponent extends Eventify(Component) {
     public off (type: EventType, callback?: Function, thisArg?: any) {
         super.off(type, callback, thisArg);
         if (type === EventType.LASTFRAME ||
-            type === EventType.LAST_FRAME_ARRIVED) {
+            type === EventType.ITERATION_END) {
             this._syncDisallowLastFrameEvent();
         }
     }
@@ -452,7 +452,8 @@ export class AnimationComponent extends Eventify(Component) {
     }
 
     private _syncAllowLastFrameEvent () {
-        if (this.hasEventListener(EventType.LASTFRAME)) {
+        if (this.hasEventListener(EventType.LASTFRAME) ||
+            this.hasEventListener(EventType.ITERATION_END)) {
             for (const stateName in this._nameToState) {
                 this._nameToState[stateName].allowLastFrameEvent(true);
             }
@@ -460,7 +461,8 @@ export class AnimationComponent extends Eventify(Component) {
     }
 
     private _syncDisallowLastFrameEvent () {
-        if (!this.hasEventListener(EventType.LASTFRAME)) {
+        if (!this.hasEventListener(EventType.LASTFRAME) &&
+            !this.hasEventListener(EventType.ITERATION_END)) {
             for (const stateName in this._nameToState) {
                 this._nameToState[stateName].allowLastFrameEvent(false);
             }

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -33,49 +33,10 @@ import { Eventify } from '../event/eventify';
 import { warnID } from '../platform/debug';
 import * as ArrayUtils from '../utils/array';
 import { createMap } from '../utils/js-typed';
-import { ccenum } from '../value-types/enum';
 import { AnimationClip } from './animation-clip';
-import { AnimationState } from './animation-state';
+import { AnimationState, EventType } from './animation-state';
 import { CrossFade } from './cross-fade';
 import { EDITOR, TEST } from 'internal:constants';
-
-/**
- * @en The event type supported by Animation
- * @zh Animation 支持的事件类型。
- */
-export enum EventType {
-    /**
-     * @en Emit when begin playing animation
-     * @zh 开始播放时触发。
-     */
-    PLAY = 'play',
-    /**
-     * @en Emit when stop playing animation
-     * @zh 停止播放时触发。
-     */
-    STOP = 'stop',
-    /**
-     * @en Emit when pause animation
-     * @zh 暂停播放时触发。
-     */
-    PAUSE = 'pause',
-    /**
-     * @en Emit when resume animation
-     * @zh 恢复播放时触发。
-     */
-    RESUME = 'resume',
-    /**
-     * @en If animation repeat count is larger than 1, emit when animation play to the last frame
-     * @zh 假如动画循环次数大于 1，当动画播放到最后一帧时触发。
-     */
-    LASTFRAME = 'lastframe',
-    /**
-     * @en Emit when finish playing animation
-     * @zh 动画播放完成时触发。
-     */
-    FINISHED = 'finished',
-}
-ccenum(EventType);
 
 /**
  * 动画组件管理动画状态来控制动画的播放。
@@ -317,7 +278,7 @@ export class AnimationComponent extends Eventify(Component) {
     public removeState (name: string) {
         const state = this._nameToState[name];
         if (state) {
-            state.allowLastFrameEvent = false;
+            state.allowLastFrameEvent(false);
             state.stop();
             delete this._nameToState[name];
         }
@@ -410,7 +371,8 @@ export class AnimationComponent extends Eventify(Component) {
      */
     public on<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
         const ret = super.on(type, callback, thisArg);
-        if (type === EventType.LASTFRAME) {
+        if (type === EventType.LASTFRAME ||
+            type === EventType.LAST_FRAME_ARRIVED) {
             this._syncAllowLastFrameEvent();
         }
         return ret;
@@ -418,7 +380,8 @@ export class AnimationComponent extends Eventify(Component) {
 
     public once<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
         const ret = super.once(type, callback, thisArg);
-        if (type === EventType.LASTFRAME) {
+        if (type === EventType.LASTFRAME ||
+            type === EventType.LAST_FRAME_ARRIVED) {
             this._syncAllowLastFrameEvent();
         }
         return ret;
@@ -440,7 +403,8 @@ export class AnimationComponent extends Eventify(Component) {
      */
     public off (type: EventType, callback?: Function, thisArg?: any) {
         super.off(type, callback, thisArg);
-        if (type === EventType.LASTFRAME) {
+        if (type === EventType.LASTFRAME ||
+            type === EventType.LAST_FRAME_ARRIVED) {
             this._syncDisallowLastFrameEvent();
         }
     }
@@ -452,7 +416,7 @@ export class AnimationComponent extends Eventify(Component) {
     protected _doCreateState (clip: AnimationClip, name: string) {
         const state = this._createState(clip, name);
         state._setEventTarget(this);
-        state.allowLastFrameEvent = this.hasEventListener(EventType.LASTFRAME);
+        state.allowLastFrameEvent(this.hasEventListener(EventType.LASTFRAME));
         if (this.node) {
             state.initialize(this.node);
         }
@@ -490,7 +454,7 @@ export class AnimationComponent extends Eventify(Component) {
     private _syncAllowLastFrameEvent () {
         if (this.hasEventListener(EventType.LASTFRAME)) {
             for (const stateName in this._nameToState) {
-                this._nameToState[stateName].allowLastFrameEvent = true;
+                this._nameToState[stateName].allowLastFrameEvent(true);
             }
         }
     }
@@ -498,7 +462,7 @@ export class AnimationComponent extends Eventify(Component) {
     private _syncDisallowLastFrameEvent () {
         if (!this.hasEventListener(EventType.LASTFRAME)) {
             for (const stateName in this._nameToState) {
-                this._nameToState[stateName].allowLastFrameEvent = false;
+                this._nameToState[stateName].allowLastFrameEvent(false);
             }
         }
     }

--- a/cocos/core/animation/animation-manager.ts
+++ b/cocos/core/animation/animation-manager.ts
@@ -29,7 +29,11 @@ export class AnimationManager extends System {
 
     public static ID = 'animation';
     private _anims = new MutableForwardIterator<AnimationState>([]);
-    private _delayEvents: {target: Node; func: string; args: any[]}[] = [];
+    private _delayEvents: {
+        fn: Function;
+        thisArg: any;
+        args: any[];
+    }[] = [];
     private _blendStateBuffer: BlendStateBuffer = new BlendStateBuffer();
     private _crossFades: CrossFade[] = [];
     private _sockets: ISocketData[] = [];
@@ -66,7 +70,7 @@ export class AnimationManager extends System {
 
         for (let i = 0, l = _delayEvents.length; i < l; i++) {
             const event = _delayEvents[i];
-            event.target[event.func].apply(event.target, event.args);
+            event.fn.apply(event.thisArg, event.args);
         }
         _delayEvents.length = 0;
     }
@@ -91,10 +95,10 @@ export class AnimationManager extends System {
         }
     }
 
-    public pushDelayEvent (target: Node, func: string, args: any[]) {
+    public pushDelayEvent (fn: Function, thisArg: any, args: any[]) {
         this._delayEvents.push({
-            target,
-            func,
+            fn,
+            thisArg,
             args,
         });
     }

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -75,12 +75,6 @@ export enum EventType {
      * @zh 动画完成播放时触发。
      */
     FINISHED = 'finished',
-
-    /**
-     * @en Triggered when the animation playing to the last frame or when finish its playing.
-     * @zh 当动画完成播放时，或每当动画播放到最后一帧时触发。
-     */
-    ITERATION_END = 'iteration-end',
 }
 ccenum(EventType);
 
@@ -438,7 +432,7 @@ export class AnimationState extends Playable {
      * To process animation events, use `AnimationComponent` instead.
      */
     public emit (...args: any[]) {
-        cc.director.getAnimationManager().pushDelayEvent(this, '_emit', args);
+        cc.director.getAnimationManager().pushDelayEvent(this._emit, this, args);
     }
 
     /**
@@ -635,7 +629,6 @@ export class AnimationState extends Playable {
 
             if (this.repeatCount > 1 && ((info.iterations | 0) > (lastInfo.iterations | 0))) {
                 this.emit(EventType.LASTFRAME, this);
-                this.emit(EventType.ITERATION_END, this);
             }
 
             lastInfo.set(info);
@@ -644,7 +637,6 @@ export class AnimationState extends Playable {
         if (info.stopped) {
             this.stop();
             this.emit(EventType.FINISHED, this);
-            this.emit(EventType.ITERATION_END, this);
         }
     }
 
@@ -668,7 +660,6 @@ export class AnimationState extends Playable {
 
             if ((this.time > 0 && this._lastIterations > ratio) || (this.time < 0 && this._lastIterations < ratio)) {
                 this.emit(EventType.LASTFRAME, this);
-                this.emit(EventType.ITERATION_END, this);
             }
 
             this._lastIterations = ratio;

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -82,7 +82,7 @@ export enum EventType {
      * @en Triggered when the animation playing to the last frame or when finish its playing.
      * @zh 当动画完成播放时，或每当动画播放到最后一帧时触发。
      */
-    LAST_FRAME_ARRIVED = 'last-frame-arrived',
+    ITERATION_END = 'iteration-end',
 }
 ccenum(EventType);
 
@@ -457,7 +457,7 @@ export class AnimationState extends Eventify(Playable) {
 
     public on<TFunction extends Function> (type: string, callback: TFunction, thisArg?: any) {
         if (type === EventType.LASTFRAME ||
-            type === EventType.LAST_FRAME_ARRIVED) {
+            type === EventType.ITERATION_END) {
             this.allowLastFrameEvent(true, stateAspect);
         }
         return super.once(type, callback, thisArg);
@@ -465,7 +465,7 @@ export class AnimationState extends Eventify(Playable) {
 
     public once<TFunction extends Function> (type: string, callback: TFunction, thisArg?: any) {
         if (type === EventType.LASTFRAME ||
-            type === EventType.LAST_FRAME_ARRIVED) {
+            type === EventType.ITERATION_END) {
             this.allowLastFrameEvent(true, stateAspect);
         }
         return super.once(type, callback, thisArg);
@@ -474,8 +474,9 @@ export class AnimationState extends Eventify(Playable) {
     public off<TFunction extends Function> (type: string, callback?: TFunction, thisArg?: any) {
         super.off(type, callback, thisArg);
         if ((type === EventType.LASTFRAME ||
-            type === EventType.LAST_FRAME_ARRIVED) &&
-            this.hasEventListener(type)) {
+            type === EventType.ITERATION_END) &&
+            (this.hasEventListener(EventType.LASTFRAME ||
+            this.hasEventListener(EventType.ITERATION_END)))) {
             this.allowLastFrameEvent(false, stateAspect);
         }
     }
@@ -629,7 +630,7 @@ export class AnimationState extends Eventify(Playable) {
 
             if (this.repeatCount > 1 && ((info.iterations | 0) > (lastInfo.iterations | 0))) {
                 this._delayEmit(EventType.LASTFRAME, this);
-                this._delayEmit(EventType.LAST_FRAME_ARRIVED, this);
+                this._delayEmit(EventType.ITERATION_END, this);
             }
 
             lastInfo.set(info);
@@ -638,7 +639,7 @@ export class AnimationState extends Eventify(Playable) {
         if (info.stopped) {
             this.stop();
             this._delayEmit(EventType.FINISHED, this);
-            this._delayEmit(EventType.LAST_FRAME_ARRIVED, this);
+            this._delayEmit(EventType.ITERATION_END, this);
         }
     }
 
@@ -662,7 +663,7 @@ export class AnimationState extends Eventify(Playable) {
 
             if ((this.time > 0 && this._lastIterations > ratio) || (this.time < 0 && this._lastIterations < ratio)) {
                 this._delayEmit(EventType.LASTFRAME, this);
-                this._delayEmit(EventType.LAST_FRAME_ARRIVED, this);
+                this._delayEmit(EventType.ITERATION_END, this);
             }
 
             this._lastIterations = ratio;

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -433,10 +433,18 @@ export class AnimationState extends Playable {
         this._destroyBlendStateWriters();
     }
 
+    /**
+     * @deprecated Since V1.1.1, animation states were no longer defined as event targets.
+     * To process animation events, use `AnimationComponent` instead.
+     */
     public emit (...args: any[]) {
         cc.director.getAnimationManager().pushDelayEvent(this, '_emit', args);
     }
 
+    /**
+     * @deprecated Since V1.1.1, animation states were no longer defined as event targets.
+     * To process animation events, use `AnimationComponent` instead.
+     */
     public on (type: string, callback: Function, target?: any) {
         if (this._target && this._target.isValid) {
             return this._target.on(type, callback, target);
@@ -445,6 +453,10 @@ export class AnimationState extends Playable {
         }
     }
 
+    /**
+     * @deprecated Since V1.1.1, animation states were no longer defined as event targets.
+     * To process animation events, use `AnimationComponent` instead.
+     */
     public once (type: string, callback: Function, target?: any) {
         if (this._target && this._target.isValid) {
             return this._target.once(type, callback, target);
@@ -453,6 +465,10 @@ export class AnimationState extends Playable {
         }
     }
 
+    /**
+     * @deprecated Since V1.1.1, animation states were no longer defined as event targets.
+     * To process animation events, use `AnimationComponent` instead.
+     */
     public off (type: string, callback: Function, target?: any) {
         if (this._target && this._target.isValid) {
             this._target.off(type, callback, target);

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -442,7 +442,10 @@ export class AnimationState extends Eventify(Playable) {
      * @en
      * Whether `LastFrame` should be triggered.
      * @param allowed True if the last frame events may be triggered.
-     * @param aspect DO NOT pass this argument. It's for internal usage.
+     * @param aspect DO NOT pass this argument. It indicates who fired the 'allowLastFrameEvent' request:
+     * either from `AnimationState` itself or from `AnimationComponent`.
+     * Because both `AnimationState` and `AnimationComponent` can subscribe to the 'last-frame' event or not.
+     * We should distinguish here to keep them isolated.
      */
     public allowLastFrameEvent (allowed: boolean, aspect: number = 1) {
         if (allowed) {

--- a/tests/animation/animation-events.test.ts
+++ b/tests/animation/animation-events.test.ts
@@ -116,7 +116,7 @@ test('Animation event(last-frame event optimization)', () => {
     const handler1 = () => {};
     const handler2 = () => {};
 
-    const isLastFrameEventAllowed = (state: AnimationState) => (state as any)['_allowLastFrameEventMask'] !== 0;
+    const isLastFrameEventAllowed = (state: AnimationState) => (state as any)['_allowLastFrame'] !== 0;
 
     expect(initialStates.every(state => !isLastFrameEventAllowed(state))).toBeTruthy();
 

--- a/tests/animation/animation-events.test.ts
+++ b/tests/animation/animation-events.test.ts
@@ -116,7 +116,7 @@ test('Animation event(last-frame event optimization)', () => {
     const handler1 = () => {};
     const handler2 = () => {};
 
-    const isLastFrameEventAllowed = (state: AnimationState) => (state as any)['_allowLastFrame'] !== 0;
+    const isLastFrameEventAllowed = (state: AnimationState) => (state as any)['_allowLastFrame'];
 
     expect(initialStates.every(state => !isLastFrameEventAllowed(state))).toBeTruthy();
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * ~Add `'last-frame-arrived'` event(`AnimationComponent.EventType.LAST_FRAME_ARRIVED`);~
* ~Refine the meaning of `on()`, `once`, `off()` on `AnimationState`.~ (For stability, we only mark those API as deprecated)

### The last-frame-arrived event
<del>Users usually expect an animation event which is triggered as long as the last frame is arrived. The `'last-frame'` event is likely but not fully satisfied, it only works on infinite loop case. In compare, the `'finished'` event would only be triggered on non-loop animation. So this PR add a `"last-frame-arrived"` event covering both cases.</del>

### ~Refine the event APIs of `AnimationState`~
<del>Prior to this PR, `AnimationState` provides very similar API to `IEventified`: `on()`, `once()`, `off()`. However their behaviors are not clear: these API forward the invocation to `AnimationComponent.*()`. This means if you call `.on()` on an individual animation state, you may receive events from other animation states:
```ts
animationStateA.on(AnimationComponent.EventType.PLAY, () => {
  console.log('I'm on playing!'); // may be triggered even not from `animationStateA`
});
```
</del>

(We have now undone this change. Because @gameall3d thought it isn't necessary! )

### Little optimization

I changed the `AnimationManager.prototype.pushDelayEvent` to accept `target: any`, `fn: Function` and `args: any[]`. In comparison, the `fn: Function` replace the `funcName: string` as before. I don't understand the idea why not directly pass function but pass function name and use `target[funcName]` to visit the function. @2youyou2 

Please review these change. @2youyou2 @gameall3d 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
