### PR TITLE
Solve the "once-off" problem

### DIFF
--- a/cocos/core/event/callbacks-invoker.ts
+++ b/cocos/core/event/callbacks-invoker.ts
@@ -161,189 +161,189 @@ export interface ICallbackTable {
  * @en CallbacksInvoker is used to manager and invoke event listeners with different event keys, 
  * each key is mapped to a CallbackList.
  */
-export class CallbacksInvoker {
-    public _callbackTable: ICallbackTable = createMap(true);
+export function CallbacksInvoker (this: any) {
+    this._callbackTable = createMap(true);
+};
 
-    /**
-     * @zh 向一个事件名注册一个新的事件监听器，包含回调函数和调用者
-     * @en Register an event listener to a given event key with callback and target.
-     *
-     * @param key - Event type
-     * @param callback - Callback function when event triggered
-     * @param target - Callback callee
-     * @param once - Whether invoke the callback only once (and remove it)
-     */
-    public on (key: string, callback: Function, target?: Object, once?: boolean) {
-        let list = this._callbackTable[key];
-        if (!list) {
-            list = this._callbackTable[key] = callbackListPool.alloc();
-        }
-        const info = callbackInfoPool.alloc();
-        info.set(callback, target, once);
-        list.callbackInfos.push(info);
+/**
+ * @zh 向一个事件名注册一个新的事件监听器，包含回调函数和调用者
+ * @en Register an event listener to a given event key with callback and target.
+ *
+ * @param key - Event type
+ * @param callback - Callback function when event triggered
+ * @param target - Callback callee
+ * @param once - Whether invoke the callback only once (and remove it)
+ */
+CallbacksInvoker.prototype.on = function (key: string, callback: Function, target?: Object, once?: boolean) {
+    let list = this._callbackTable[key];
+    if (!list) {
+        list = this._callbackTable[key] = callbackListPool.alloc();
     }
+    const info = callbackInfoPool.alloc();
+    info.set(callback, target, once);
+    list.callbackInfos.push(info);
+};
 
-    /**
-     * @zh 检查指定事件是否已注册回调。
-     * @en Checks whether there is correspond event listener registered on the given event
-     * @param key - Event type
-     * @param callback - Callback function when event triggered
-     * @param target - Callback callee
-     */
-    public hasEventListener (key: string, callback?: Function, target: Object | null = null) {
-        const list = this._callbackTable[key];
-        if (!list) {
-            return false;
-        }
-
-        // check any valid callback
-        const infos = list.callbackInfos;
-        if (!callback) {
-            // Make sure no cancelled callbacks
-            if (list.isInvoking) {
-                for (const info of infos) {
-                    if (info) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-            else {
-                return infos.length > 0;
-            }
-        }
-
-        for (const info of infos) {
-            if (info && info.callback === callback && info.target === target) {
-                return true;
-            }
-        }
+/**
+ * @zh 检查指定事件是否已注册回调。
+ * @en Checks whether there is correspond event listener registered on the given event
+ * @param key - Event type
+ * @param callback - Callback function when event triggered
+ * @param target - Callback callee
+ */
+CallbacksInvoker.prototype.hasEventListener = function (key: string, callback?: Function, target: Object | null = null) {
+    const list = this._callbackTable[key];
+    if (!list) {
         return false;
     }
 
-    /**
-     * @zh 移除在特定事件类型中注册的所有回调或在某个目标中注册的所有回调。
-     * @en Removes all callbacks registered in a certain event type or all callbacks registered with a certain target
-     * @param keyOrTarget - The event type or target with which the listeners will be removed
-     */
-    public removeAll (keyOrTarget?: string | Object) {
-        if (typeof keyOrTarget === 'string') {
-            // remove by key
-            const list = this._callbackTable[keyOrTarget];
-            if (list) {
-                if (list.isInvoking) {
-                    list.cancelAll();
-                }
-                else {
-                    list.clear();
-                    callbackListPool.free(list);
-                    delete this._callbackTable[keyOrTarget];
+    // check any valid callback
+    const infos = list.callbackInfos;
+    if (!callback) {
+        // Make sure no cancelled callbacks
+        if (list.isInvoking) {
+            for (const info of infos) {
+                if (info) {
+                    return true;
                 }
             }
+            return false;
         }
-        else if (keyOrTarget) {
-            // remove by target
-            for (const key in this._callbackTable) {
-                const list = this._callbackTable[key]!;
-                if (list.isInvoking) {
-                    const infos = list.callbackInfos;
-                    for (let i = 0; i < infos.length; ++i) {
-                        const info = infos[i];
-                        if (info && info.target === keyOrTarget) {
-                            list.cancel(i);
-                        }
-                    }
-                }
-                else {
-                    list.removeByTarget(keyOrTarget);
-                }
-            }
+        else {
+            return infos.length > 0;
         }
     }
 
-    /**
-     * @zh 删除以指定事件，回调函数，目标注册的回调。
-     * @en Remove event listeners registered with the given event key, callback and target
-     * @param key - Event type
-     * @param callback - The callback function of the event listener, if absent all event listeners for the given type will be removed
-     * @param target - The callback callee of the event listener
-     */
-    public off (key: string, callback?: Function, target?: Object) {
-        const list = this._callbackTable[key];
+    for (const info of infos) {
+        if (info && info.callback === callback && info.target === target) {
+            return true;
+        }
+    }
+    return false;
+};
+
+/**
+ * @zh 移除在特定事件类型中注册的所有回调或在某个目标中注册的所有回调。
+ * @en Removes all callbacks registered in a certain event type or all callbacks registered with a certain target
+ * @param keyOrTarget - The event type or target with which the listeners will be removed
+ */
+CallbacksInvoker.prototype.removeAll = function (keyOrTarget?: string | Object) {
+    if (typeof keyOrTarget === 'string') {
+        // remove by key
+        const list = this._callbackTable[keyOrTarget];
         if (list) {
-            const infos = list.callbackInfos;
-            if (callback) {
+            if (list.isInvoking) {
+                list.cancelAll();
+            }
+            else {
+                list.clear();
+                callbackListPool.free(list);
+                delete this._callbackTable[keyOrTarget];
+            }
+        }
+    }
+    else if (keyOrTarget) {
+        // remove by target
+        for (const key in this._callbackTable) {
+            const list = this._callbackTable[key]!;
+            if (list.isInvoking) {
+                const infos = list.callbackInfos;
                 for (let i = 0; i < infos.length; ++i) {
                     const info = infos[i];
-                    if (info && info.callback === callback && info.target === target) {
-                        if (list.isInvoking) {
-                            list.cancel(i);
-                        }
-                        else {
-                            fastRemoveAt(infos, i);
-                            callbackInfoPool.free(info);
-                        }
-                        break;
+                    if (info && info.target === keyOrTarget) {
+                        list.cancel(i);
                     }
                 }
             }
             else {
-                this.removeAll(key);
+                list.removeByTarget(keyOrTarget);
             }
         }
     }
+};
 
-    /**
-     * @zh 派发一个指定事件，并传递需要的参数
-     * @en Trigger an event directly with the event name and necessary arguments.
-     * @param key - event type
-     * @param arg0 - The first argument to be passed to the callback
-     * @param arg1 - The second argument to be passed to the callback
-     * @param arg2 - The third argument to be passed to the callback
-     * @param arg3 - The fourth argument to be passed to the callback
-     * @param arg4 - The fifth argument to be passed to the callback
-     */
-    public emit (key: string, arg0?: any, arg1?: any, arg2?: any, arg3?: any, arg4?: any) {
-        const list: CallbackList = this._callbackTable[key]!;
-        if (list) {
-            const rootInvoker = !list.isInvoking;
-            list.isInvoking = true;
-
-            const infos = list.callbackInfos;
-            for (let i = 0, len = infos.length; i < len; ++i) {
+/**
+ * @zh 删除以指定事件，回调函数，目标注册的回调。
+ * @en Remove event listeners registered with the given event key, callback and target
+ * @param key - Event type
+ * @param callback - The callback function of the event listener, if absent all event listeners for the given type will be removed
+ * @param target - The callback callee of the event listener
+ */
+CallbacksInvoker.prototype.off = function (key: string, callback?: Function, target?: Object) {
+    const list = this._callbackTable[key];
+    if (list) {
+        const infos = list.callbackInfos;
+        if (callback) {
+            for (let i = 0; i < infos.length; ++i) {
                 const info = infos[i];
-                if (info) {
-                    const callback = info.callback;
-                    const target = info.target;
-                    // Pre off once callbacks to avoid influence on logic in callback
-                    if (info.once) {
-                        this.off(key, callback, target);
-                    }
-                    if (target) {
-                        callback.call(target, arg0, arg1, arg2, arg3, arg4);
+                if (info && info.callback === callback && info.target === target) {
+                    if (list.isInvoking) {
+                        list.cancel(i);
                     }
                     else {
-                        callback(arg0, arg1, arg2, arg3, arg4);
+                        fastRemoveAt(infos, i);
+                        callbackInfoPool.free(info);
                     }
-                }
-            }
-
-            if (rootInvoker) {
-                list.isInvoking = false;
-                if (list.containCanceled) {
-                    list.purgeCanceled();
+                    break;
                 }
             }
         }
+        else {
+            this.removeAll(key);
+        }
     }
+};
 
-    /**
-     * 移除所有回调。
-     */
-    public clear () {
-        this._callbackTable = createMap(true);
+/**
+ * @zh 派发一个指定事件，并传递需要的参数
+ * @en Trigger an event directly with the event name and necessary arguments.
+ * @param key - event type
+ * @param arg0 - The first argument to be passed to the callback
+ * @param arg1 - The second argument to be passed to the callback
+ * @param arg2 - The third argument to be passed to the callback
+ * @param arg3 - The fourth argument to be passed to the callback
+ * @param arg4 - The fifth argument to be passed to the callback
+ */
+CallbacksInvoker.prototype.emit = function (key: string, arg0?: any, arg1?: any, arg2?: any, arg3?: any, arg4?: any) {
+    const list: CallbackList = this._callbackTable[key]!;
+    if (list) {
+        const rootInvoker = !list.isInvoking;
+        list.isInvoking = true;
+
+        const infos = list.callbackInfos;
+        for (let i = 0, len = infos.length; i < len; ++i) {
+            const info = infos[i];
+            if (info) {
+                const callback = info.callback;
+                const target = info.target;
+                // Pre off once callbacks to avoid influence on logic in callback
+                if (info.once) {
+                    this.off(key, callback, target);
+                }
+                if (target) {
+                    callback.call(target, arg0, arg1, arg2, arg3, arg4);
+                }
+                else {
+                    callback(arg0, arg1, arg2, arg3, arg4);
+                }
+            }
+        }
+
+        if (rootInvoker) {
+            list.isInvoking = false;
+            if (list.containCanceled) {
+                list.purgeCanceled();
+            }
+        }
     }
-}
+};
+
+/**
+ * 移除所有回调。
+ */
+CallbacksInvoker.prototype.clear = function () {
+    this._callbackTable = createMap(true);
+};
 
 if (TEST) {
     cc._Test.CallbacksInvoker = CallbacksInvoker;

--- a/cocos/core/event/eventify.ts
+++ b/cocos/core/event/eventify.ts
@@ -4,7 +4,7 @@
 
 import { fastRemove } from '../utils/array';
 import { CallbacksInvoker } from './callbacks-invoker';
-import { createMap, mixin } from '../utils/js';
+import { createMap } from '../utils/js';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 
@@ -183,7 +183,13 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
         }
     };
 
-    mixin(Eventified.prototype, CallbacksInvoker.prototype);
+    // Mixin with `CallbacksInvokers`'s prototype
+    const propertyDescriptors = Object.getOwnPropertyDescriptors(CallbacksInvoker.prototype);
+    for (const propertyName in propertyDescriptors) {
+        if (!(propertyName in Eventified.prototype)) {
+            Object.defineProperty(Eventified.prototype, propertyName, propertyDescriptors[propertyName]);
+        }
+    }
 
     return Eventified as unknown as any;
 }

--- a/cocos/core/event/eventify.ts
+++ b/cocos/core/event/eventify.ts
@@ -4,6 +4,7 @@
 
 import { fastRemove } from '../utils/array';
 import { CallbacksInvoker } from './callbacks-invoker';
+import { createMap, mixin } from '../utils/js';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 
@@ -127,16 +128,12 @@ export interface IEventified {
  * ```
  */
 export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & IEventified> {
-    return class extends (base as unknown as any) implements IEventified {
-        private _callbacksInvoker: CallbacksInvoker = new CallbacksInvoker();
-
-        public hasEventListener (type: string, callback?: Function, target?: object): boolean {
-            return this._callbacksInvoker.hasEventListener(type, callback, target);
-        }
-
+    class Eventified extends (base as unknown as any) {
+        private _callbackTable = createMap(true);
+        
         public on<Callback extends Function> (type: EventType, callback: Callback, target?: object) {
             if (!this.hasEventListener(type, callback, target)) {
-                this._callbacksInvoker.on(type, callback, target);
+                CallbacksInvoker.prototype.on.call(this, type, callback, target);
                 if (target) {
                     this._registerThisIntoTarget(target);
                 }
@@ -146,7 +143,7 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
 
         public once<Callback extends Function> (type: EventType, callback: Callback, target?: object) {
             if (!this.hasEventListener(type, callback, target)) {
-                this._callbacksInvoker.on(type, callback, target, true);
+                CallbacksInvoker.prototype.on.call(this, type, callback, target, true);
                 if (target) {
                     this._registerThisIntoTarget(target);
                 }
@@ -158,7 +155,7 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
             if (!callback) {
                 this.removeAll(type);
             } else {
-                this._callbacksInvoker.off(type, callback, target);
+                CallbacksInvoker.prototype.off.call(this, type, callback, target);
                 if (target) {
                     this._unregisterThisIntoTarget(target);
                 }
@@ -167,14 +164,6 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
 
         public targetOff (typeOrTarget: string | object) {
             this.removeAll(typeOrTarget);
-        }
-
-        public removeAll (typeOrTarget: string | object) {
-            this._callbacksInvoker.removeAll(typeOrTarget);
-        }
-
-        public emit (type: EventType, arg0?: any, arg1?: any, arg2?: any, arg3?: any, arg4?: any) {
-            return this._callbacksInvoker.emit(type, arg0, arg1, arg2, arg3, arg4);
         }
 
         private _registerThisIntoTarget (target: ITargetImpl) {
@@ -192,11 +181,14 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
                 fastRemove(target.node.__eventTargets, this);
             }
         }
+    };
 
-    } as unknown as any;
+    mixin(Eventified.prototype, CallbacksInvoker.prototype);
+
+    return Eventified as unknown as any;
 }
 
 interface ITargetImpl extends Object {
-    __eventTargets?: IEventified[];
+    __eventTargets?: any[];
     node?: ITargetImpl;
 }

--- a/cocos/core/event/eventify.ts
+++ b/cocos/core/event/eventify.ts
@@ -10,6 +10,13 @@ type Constructor<T = {}> = new (...args: any[]) => T;
 
 type EventType = string;
 
+const {
+    prototype: {
+        on: callbacksInvokerOn,
+        off: callbacksInvokerOff,
+    },
+} = CallbacksInvoker;
+
 /**
  * @zh
  * 实现该接口的对象具有处理事件的能力。
@@ -133,7 +140,7 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
         
         public on<Callback extends Function> (type: EventType, callback: Callback, target?: object) {
             if (!this.hasEventListener(type, callback, target)) {
-                CallbacksInvoker.prototype.on.call(this, type, callback, target);
+                callbacksInvokerOn.call(this, type, callback, target);
                 if (target) {
                     this._registerThisIntoTarget(target);
                 }
@@ -143,7 +150,7 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
 
         public once<Callback extends Function> (type: EventType, callback: Callback, target?: object) {
             if (!this.hasEventListener(type, callback, target)) {
-                CallbacksInvoker.prototype.on.call(this, type, callback, target, true);
+                callbacksInvokerOn.call(this, type, callback, target, true);
                 if (target) {
                     this._registerThisIntoTarget(target);
                 }
@@ -155,7 +162,7 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
             if (!callback) {
                 this.removeAll(type);
             } else {
-                CallbacksInvoker.prototype.off.call(this, type, callback, target);
+                callbacksInvokerOff.call(this, type, callback, target);
                 if (target) {
                     this._unregisterThisIntoTarget(target);
                 }

--- a/tests/core/eventify.test.ts
+++ b/tests/core/eventify.test.ts
@@ -1,0 +1,38 @@
+import { Eventify } from '../../cocos/core';
+
+test('Eventify', () => {
+    class Base {
+        public _nickName: string;
+
+        constructor(nickName: string) {
+            this._nickName = nickName;
+        }
+
+        public getNickName() {
+            return this._nickName;
+        }
+    }
+
+    const hookOnOff = jest.fn(() => {});
+
+    class Derived extends Eventify(Base) {
+        public off(type: string, callback?: Function, target?: object) {
+            super.off(type, callback, target);
+            hookOnOff();
+        }
+    }
+
+    const nickName = 'Jack';
+    const derived = new Derived(nickName);
+    expect(derived.getNickName()).toEqual(nickName);
+
+    const eventName = 'test';
+    const eventCallback = jest.fn(() => {});
+
+    derived.off(eventName, eventCallback);
+    expect(hookOnOff).toBeCalledTimes(1);
+
+    derived.once(eventName, eventCallback);
+    derived.emit(eventName);
+    expect(hookOnOff).toBeCalledTimes(2);
+});


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Solve the "once-off" problem, see below.

### The "once-off" problem
After "once subscription" is triggered the corresponding `CallbacksInvoker.prototype.off` was going to be called as a matter of course. But `Eventify(base).prototype.off` was not called though it should be. This is because `Eventify(base)` use `CallbacksInvoker` in a composition way.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
