### PR TITLE
Improve node color Settings

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -1402,14 +1402,14 @@ let NodeDefines = {
             set (value) {
                 if (!this._color.equals(value)) {
                     this._color.set(value);
-                    if (CC_DEV && value.a !== 255) {
+                    if (CC_DEV && this._color.a !== 255) {
                         cc.warnID(1626);
                     }
 
                     this._renderFlag |= RenderFlow.FLAG_COLOR;
 
                     if (this._eventMask & COLOR_ON) {
-                        this.emit(EventType.COLOR_CHANGED, value);
+                        this.emit(EventType.COLOR_CHANGED, this._color);
                     }
                 }
             },


### PR DESCRIPTION
Re: https://forum.cocos.org/t/v2-3-3-should-not-set-alpha-via-color-set-opacity-please/92487/4

Changes:
 * new cc.Color.BLACK.fromHEX("#FFFF33"); 使用十六进制设置 node 颜色会出现 "Should not set alpha via 'color', set 'opacity' please." 警告
 * 发送 color-change 事件的 color 应该是 this._color 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
