### PR TITLE
handle restore operation

### DIFF
--- a/cocos/core/3d/framework/model-component.ts
+++ b/cocos/core/3d/framework/model-component.ts
@@ -241,6 +241,11 @@ export class ModelComponent extends RenderableComponent {
         this._updateCastShadow();
     }
 
+    // Redo, Undo, Prefab restore, etc.
+    public onRestore () {
+        this._updateModels();
+    }
+
     public onEnable () {
         if (!this._model) {
             this._updateModels();


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#3397

Changelog:
 * on prefab restore, properties like `_skinningRoot` will be set first before invoking the setter methods, e.g. `set skinningRoot`. This is problematic for those setters usually have repetition guards like `if (value === this._skinningRoot) { return; }`. So on restoring, an flush operation is required to correctly update the rendering data.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->