### PR TITLE
no need to flip render target texcoord for metal and vulkan

### DIFF
--- a/cocos/core/assets/sprite-frame.ts
+++ b/cocos/core/assets/sprite-frame.ts
@@ -632,7 +632,8 @@ export class SpriteFrame extends Asset {
             }
             // hack
             if (this._texture instanceof RenderTexture) {
-                this._flipUv = true;
+                // no need to flip render target texcoord on metal and vulkan.
+                this._flipUv = cc.director.root.device.projectionSignY < 0 ? false : true;
             }
 
             calUV = true;


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#3425](https://github.com/cocos-creator/3d-tasks/issues/3425#issue-628124224)

Changes:
 * no need to flip render target texcoord for metal and vulkan

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
