### PR TITLE
Fix the black board of Label when using blend ONE.

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -743,7 +743,7 @@ let Label = cc.Class({
                 if (this.cacheMode !== CacheMode.CHAR) {
                     this._frame._resetDynamicAtlasFrame();
                     this._frame._refreshTexture(this._ttfTexture);
-                    if (this._srcBlendFactor === cc.macro.BlendFactor.ONE) {
+                    if (this._srcBlendFactor === cc.macro.BlendFactor.ONE && !CC_NATIVERENDERER) {
                         this._ttfTexture.setPremultiplyAlpha(true);
                     }
                 }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2874

Changes:

原生平台在切换到 ONE 时取消了反预乘，纹理内容本来就是预乘过的，不需要再设置GL_UNPACK_PREMULTIPLY_ALPHA_WEBGL