### PR TITLE
error when design resolution is valid

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -558,7 +558,7 @@ cc.Layer.addLayer(): layer should be non-null
 
 ### 2200
 
-Resolution not valid
+Design resolution not valid
 
 ### 2201
 

--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -707,7 +707,7 @@ cc.js.mixin(View.prototype, {
     setDesignResolutionSize: function (width, height, resolutionPolicy) {
         // Defensive code
         if( !(width > 0 || height > 0) ){
-            cc.logID(2200);
+            cc.errorID(2200);
             return;
         }
 


### PR DESCRIPTION
For: https://forum.cocos.org/t/cocos-creator-v2-4-0-rc-3/92303/555

编辑器不太好约束设计分辨率的输入范围，
不知道项目升级的过程什么情况下会把默认设计分辨率改为 `0 x 0` 了，暂时没有复现

如果设计分辨率无效时，引擎应该给出报错

