### PR TITLE
update default value of line width

### DIFF
--- a/cocos2d/core/graphics/graphics.js
+++ b/cocos2d/core/graphics/graphics.js
@@ -48,7 +48,7 @@ let Graphics = cc.Class({
     },
 
     properties: {
-        _lineWidth: 1,
+        _lineWidth: 2,
         _strokeColor: cc.Color.BLACK,
         _lineJoin: LineJoin.MITER,
         _lineCap: LineCap.BUTT,


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 调整默认宽度

Graphic 加了 aa 之后，线变得很细，而且像素点可能变透明，一些debug的框很不明显，调整一下默认宽度。

宽度为1时
![image](https://user-images.githubusercontent.com/15109777/84143286-e4419980-aa88-11ea-895e-1999d23384f6.png)

宽度为2时
![image](https://user-images.githubusercontent.com/15109777/84143072-81e89900-aa88-11ea-9e41-c2e3569cab02.png)

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
