### PR TITLE
Type fix for inherited CCObject.destroy()

### DIFF
--- a/cocos/core/assets/sprite-frame.ts
+++ b/cocos/core/assets/sprite-frame.ts
@@ -653,7 +653,7 @@ export class SpriteFrame extends Asset {
             // hack
             if (this._texture instanceof RenderTexture) {
                 // no need to flip render target texcoord on metal and vulkan.
-                this._flipUv = cc.director.root.device.projectionSignY < 0 ? false : true;
+                this._flipUv = legacyCC.director.root.device.projectionSignY < 0 ? false : true;
             }
 
             calUV = true;

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -372,7 +372,7 @@ class Component extends CCObject {
                 legacyCC.director._compScheduler.disableComp(this);
             }
         }
-        return false;
+        return true;
     }
 
     public _onPreDestroy () {

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -371,8 +371,9 @@ class Component extends CCObject {
             if (this._enabled && this.node.activeInHierarchy) {
                 legacyCC.director._compScheduler.disableComp(this);
             }
+            return true;
         }
-        return true;
+        return false;
     }
 
     public _onPreDestroy () {

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -362,8 +362,9 @@ class Component extends CCObject {
             // @ts-ignore
             const depend = this.node._getDependComponent(this);
             if (depend) {
-                return legacyCC.errorID(3626,
+                legacyCC.errorID(3626,
                     getClassName(this), getClassName(depend));
+                return false;
             }
         }
         if (super.destroy()) {
@@ -371,6 +372,7 @@ class Component extends CCObject {
                 legacyCC.director._compScheduler.disableComp(this);
             }
         }
+        return false;
     }
 
     public _onPreDestroy () {

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -148,7 +148,7 @@ class TerrainRenderable extends RenderableComponent {
             this._model = null;
         }
 
-        super.destroy();
+        return super.destroy();
     }
 
     public _invalidMaterial () {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * `CCObject.prototype.destroy()` and its derivations should definitely return boolean values, valueless return is forbidden. cc @pandamicro 

This PR BTW repairs a typo BUG. cc @JoneLau 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
