### PR TITLE
Treat node:eulerAngle curve as skeletal curve; skeletal blending for common targets

### DIFF
--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -357,24 +357,6 @@ export class AnimationState extends Playable {
             this.repeatCount = 1;
         }
 
-        this._commonTargetStatuses = clip.commonTargets.map((commonTarget, index) => {
-            const target = createBoundTargetOptimized(
-                createBufferedTarget,
-                root,
-                commonTarget.modifiers,
-                commonTarget.valueAdapter,
-                false,
-            );
-            if (target === null) {
-                return null;
-            } else {
-                return {
-                    target,
-                    changed: false,
-                };
-            }
-        });
-
         /**
          * Create the bound target. Especially optimized for skeletal case.
          */
@@ -404,6 +386,24 @@ export class AnimationState extends Playable {
             }
             return null;
         };
+
+        this._commonTargetStatuses = clip.commonTargets.map((commonTarget, index) => {
+            const target = createBoundTargetOptimized(
+                createBufferedTarget,
+                root,
+                commonTarget.modifiers,
+                commonTarget.valueAdapter,
+                false,
+            );
+            if (target === null) {
+                return null;
+            } else {
+                return {
+                    target,
+                    changed: false,
+                };
+            }
+        });
 
         if (!propertyCurves) {
             propertyCurves = clip.getPropertyCurves();

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -34,9 +34,10 @@ import { createBoundTarget, createBufferedTarget, IBufferedTarget, IBoundTarget 
 import { Playable } from './playable';
 import { WrapMode, WrapModeMask, WrappedInfo } from './types';
 import { EDITOR } from 'internal:constants';
-import { HierarchyPath, evaluatePath } from './target-path';
+import { HierarchyPath, evaluatePath, TargetPath } from './target-path';
 import { BlendStateBuffer, createBlendStateWriter, IBlendStateWriter } from './skeletal-animation-blending';
 import { ccenum } from '../value-types/enum';
+import { IValueProxyFactory } from './value-proxy';
 
 /**
  * @en The event type supported by Animation
@@ -357,7 +358,13 @@ export class AnimationState extends Playable {
         }
 
         this._commonTargetStatuses = clip.commonTargets.map((commonTarget, index) => {
-            const target = createBufferedTarget(root, commonTarget.modifiers, commonTarget.valueAdapter);
+            const target = createBoundTargetOptimized(
+                createBufferedTarget,
+                root,
+                commonTarget.modifiers,
+                commonTarget.valueAdapter,
+                false,
+            );
             if (target === null) {
                 return null;
             } else {
@@ -367,6 +374,36 @@ export class AnimationState extends Playable {
                 };
             }
         });
+
+        /**
+         * Create the bound target. Especially optimized for skeletal case.
+         */
+        const createBoundTargetOptimized = <BoundTargetT extends IBoundTarget>(
+            createFn: (...args: Parameters<typeof createBoundTarget>) => BoundTargetT | null,
+            rootTarget: any,
+            path: TargetPath[],
+            valueAdapter: IValueProxyFactory | undefined,
+            isConstant: boolean,
+        ): BoundTargetT | null => {
+            if (!isTargetingTrs(path) || !this._blendStateBuffer) {
+                return createFn(rootTarget, path, valueAdapter);
+            } else {
+                const targetNode = evaluatePath(rootTarget, ...path.slice(0, path.length - 1));
+                if (targetNode !== null && targetNode instanceof Node) {
+                    const propertyName = path[path.length - 1] as 'position' | 'rotation' | 'scale' | 'eulerAngles';
+                    const blendStateWriter = createBlendStateWriter(
+                        this._blendStateBuffer,
+                        targetNode,
+                        propertyName,
+                        this,
+                        isConstant,
+                    );
+                    this._blendStateWriters.push(blendStateWriter);
+                    return createFn(rootTarget, [], blendStateWriter);
+                }
+            }
+            return null;
+        };
 
         if (!propertyCurves) {
             propertyCurves = clip.getPropertyCurves();
@@ -390,24 +427,13 @@ export class AnimationState extends Playable {
                 rootTarget = commonTargetStatus.target.peek();
             }
 
-            let boundTarget: IBoundTarget | null = null;
-            if (!isSkeletonCurve(propertyCurve) || !this._blendStateBuffer) {
-                boundTarget = createBoundTarget(rootTarget, propertyCurve.modifiers, propertyCurve.valueAdapter);
-            } else {
-                const targetNode = evaluatePath(rootTarget, ...propertyCurve.modifiers.slice(0, propertyCurve.modifiers.length - 1));
-                if (targetNode !== null && targetNode instanceof Node) {
-                    const propertyName = propertyCurve.modifiers[propertyCurve.modifiers.length - 1] as 'position' | 'rotation' | 'scale';
-                    const blendStateWriter = createBlendStateWriter(
-                        this._blendStateBuffer,
-                        targetNode,
-                        propertyName,
-                        this,
-                        propertyCurve.curve.constant(),
-                    );
-                    this._blendStateWriters.push(blendStateWriter);
-                    boundTarget = createBoundTarget(rootTarget, [], blendStateWriter);
-                }
-            }
+            const boundTarget = createBoundTargetOptimized(
+                createBoundTarget,
+                rootTarget,
+                propertyCurve.modifiers,
+                propertyCurve.valueAdapter,
+                propertyCurve.curve.constant(),
+            );
 
             if (boundTarget === null) {
                 // warn(`Failed to bind "${root.name}" to curve in clip ${clip.name}: ${err}`);
@@ -889,22 +915,23 @@ export class AnimationState extends Playable {
     }
 }
 
-function isSkeletonCurve (curve: IRuntimeCurve) {
+function isTargetingTrs (path: TargetPath[]) {
     let prs: string | undefined;
-    if (curve.modifiers.length === 1 && typeof curve.modifiers[0] === 'string') {
-        prs = curve.modifiers[0];
-    } else if (curve.modifiers.length > 1) {
-        for (let i = 0; i < curve.modifiers.length - 1; ++i) {
-            if (!(curve.modifiers[i] instanceof HierarchyPath)) {
+    if (path.length === 1 && typeof path[0] === 'string') {
+        prs = path[0];
+    } else if (path.length > 1) {
+        for (let i = 0; i < path.length - 1; ++i) {
+            if (!(path[i] instanceof HierarchyPath)) {
                 return false;
             }
         }
-        prs = curve.modifiers[curve.modifiers.length - 1] as string;
+        prs = path[path.length - 1] as string;
     }
     switch (prs) {
         case 'position':
         case 'scale':
         case 'rotation':
+        case 'eulerAngles':
             return true;
         default:
             return false;

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -367,7 +367,7 @@ export class AnimationState extends Playable {
             valueAdapter: IValueProxyFactory | undefined,
             isConstant: boolean,
         ): BoundTargetT | null => {
-            if (!isTargetingTrs(path) || !this._blendStateBuffer) {
+            if (!isTargetingTRS(path) || !this._blendStateBuffer) {
                 return createFn(rootTarget, path, valueAdapter);
             } else {
                 const targetNode = evaluatePath(rootTarget, ...path.slice(0, path.length - 1));
@@ -915,7 +915,7 @@ export class AnimationState extends Playable {
     }
 }
 
-function isTargetingTrs (path: TargetPath[]) {
+function isTargetingTRS (path: TargetPath[]) {
     let prs: string | undefined;
     if (path.length === 1 && typeof path[0] === 'string') {
         prs = path[0];

--- a/cocos/core/animation/skeletal-animation-blending.ts
+++ b/cocos/core/animation/skeletal-animation-blending.ts
@@ -122,6 +122,12 @@ export function createBlendStateWriter<P extends BlendingProperty> (
         },
         forTarget: () => {
             return {
+                /**
+                 * Gets the node's actual property for now.
+                 */
+                get: () => {
+                    return node[property];
+                },
                 set: (value: BlendingPropertyValue<P>) => {
                     if (!isEnabled) {
                         return;

--- a/cocos/core/animation/skeletal-animation-blending.ts
+++ b/cocos/core/animation/skeletal-animation-blending.ts
@@ -20,7 +20,7 @@ export class BlendStateBuffer {
             propertyBlendState = nodeBlendState.properties[property] = {
                 refCount: 0,
                 weight: 0,
-                value: ((property === 'position' || property === 'scale') ? new Vec3() : new Quat()) as any,
+                value: (isVec3Property(property) ? new Vec3() : new Quat()) as any,
             };
         }
         ++propertyBlendState.refCount;
@@ -48,10 +48,10 @@ export class BlendStateBuffer {
 
     public apply () {
         this._nodeBlendStates.forEach((nodeBlendState, node) => {
-            const { position, scale, rotation } = nodeBlendState.properties;
+            const { position, scale, rotation, eulerAngles } = nodeBlendState.properties;
             let t: Vec3 | undefined;
             let s: Vec3 | undefined;
-            let r: Quat | undefined;
+            let r: Quat | Vec3 | undefined;
             let anyChanged = false;
             if (position && position.weight !== 0) {
                 position.weight = 0;
@@ -63,11 +63,19 @@ export class BlendStateBuffer {
                 s = scale.value;
                 anyChanged = true;
             }
+
+            // Note: rotation and eulerAngles can not co-exist.
             if (rotation && rotation.weight !== 0) {
                 rotation.weight = 0;
                 r = rotation.value;
                 anyChanged = true;
             }
+            if (eulerAngles && eulerAngles.weight !== 0) {
+                eulerAngles.weight = 0;
+                r = eulerAngles.value;
+                anyChanged = true;
+            }
+
             if (anyChanged) {
                 node.setRTS(r, t, s);
             }
@@ -92,9 +100,7 @@ export function createBlendStateWriter<P extends BlendingProperty> (
     constants: boolean,
 ): IBlendStateWriter {
     const blendFunction: BlendFunction<BlendingPropertyValue<P>> =
-        (property === 'position' || property === 'scale') ?
-            additive3D as any:
-            additiveQuat as any;
+        isVec3Property(property) ? additive3D as any: additiveQuat as any;
     let propertyBlendState: PropertyBlendState<BlendingPropertyValue<P>> | null = null;
     let isConstCacheValid = false;
     let lastWeight = -1;
@@ -147,6 +153,14 @@ export function createBlendStateWriter<P extends BlendingProperty> (
     };
 }
 
+function isQuatProperty (property: BlendingProperty) {
+    return property === 'rotation';
+}
+
+function isVec3Property (property: BlendingProperty) {
+    return !isQuatProperty(property);
+}
+
 type BlendingProperty = keyof NodeBlendState['properties'];
 
 type BlendingPropertyValue<P extends BlendingProperty> = NonNullable<NodeBlendState['properties'][P]>['value'];
@@ -165,6 +179,7 @@ interface NodeBlendState {
     properties: {
         position?: PropertyBlendState<Vec3>;
         rotation?: PropertyBlendState<Quat>;
+        eulerAngles?: PropertyBlendState<Vec3>;
         scale?: PropertyBlendState<Vec3>;
     };
 }
@@ -173,6 +188,7 @@ function isEmptyNodeBlendState (nodeBlendState: NodeBlendState) {
     // Which is equal to `Object.keys(nodeBlendState.properties).length === 0`.
     return !nodeBlendState.properties.position &&
         !nodeBlendState.properties.rotation &&
+        !nodeBlendState.properties.eulerAngles &&
         !nodeBlendState.properties.scale;
 }
 

--- a/tests/animation/animation-clip.test.ts
+++ b/tests/animation/animation-clip.test.ts
@@ -1,5 +1,5 @@
 import { AnimationClip, js, AnimationState, Node, Component, Vec3, AnimationManager } from '../../cocos/core';
-import { ComponentPath } from '../../cocos/core/animation/animation';
+import { ComponentPath, HierarchyPath } from '../../cocos/core/animation/animation';
 import { ccclass } from '../../cocos/core/data/class-decorator';
 
 test('Common target', () => {
@@ -64,6 +64,54 @@ test('Common target', () => {
         animationState.sample();
         expect(testComponent.c).toEqual(c);
     }
+});
+
+test('Common targets that modify eulerAngles', () => {
+    const animationManager = new AnimationManager();
+    const mockInstance = jest.spyOn((global as any).cc.director, 'getAnimationManager').mockImplementation(() => {
+        return animationManager;
+    });
+
+    const partialNodeName = 'partial';
+
+    const clip = new AnimationClip('default');
+    clip.duration = 2.0;
+    const keys = [0, 0.1, 0.2];
+    const eulerValues = [new Vec3(), new Vec3(1), new Vec3(2)];
+    const eulerXValues = [0, 1, 2];
+    clip.keys = [keys];
+    clip.commonTargets = [{
+        modifiers: [new HierarchyPath('partial'), 'eulerAngles'],
+    }];
+    clip.curves = [{
+        modifiers: ['eulerAngles'],
+        data: {keys: 0, values: eulerValues},
+    }, {
+        commonTarget: 0, // euler angles
+        modifiers: ['x'],
+        data: {keys: 0, values: eulerXValues},
+    }];
+
+    const state = new AnimationState(clip, clip.name);
+    state.weight = 1.0;
+    
+    const node = new Node();
+    const partialNode = new Node(partialNodeName);
+    node.addChild(partialNode);
+    state.initialize(node);
+
+    animationManager.update(0);
+    state.play();
+    state.pause();
+
+    state.setTime(keys[1]);
+    state.update(0);
+    animationManager.update(0);
+    
+    expect(node.eulerAngles).toEqual(eulerValues[1]);
+    expect(partialNode.eulerAngles.x).toEqual(eulerXValues[1]);
+
+    mockInstance.mockRestore();
 });
 
 test('animation state', () => {

--- a/tests/animation/animation-clip.test.ts
+++ b/tests/animation/animation-clip.test.ts
@@ -81,7 +81,7 @@ test('Common targets that modify eulerAngles', () => {
     const eulerXValues = [0, 1, 2];
     clip.keys = [keys];
     clip.commonTargets = [{
-        modifiers: [new HierarchyPath('partial'), 'eulerAngles'],
+        modifiers: [new HierarchyPath(partialNodeName), 'eulerAngles'],
     }];
     clip.curves = [{
         modifiers: ['eulerAngles'],


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Curves that would modify `Node.prototype.eulerAngles` are also considered as skeletal curves. So they would be subjected to skeletal animation blending.
 * Common targets that would modify T, R, S, or the `eulerAngles` would be subjected to skeletal animation blending like skeletal curves do.

Request reviews from @YunHsiao  @gameall3d 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
