### PR TITLE
revert: revert fix duration of network requested audio

### DIFF
--- a/cocos2d/core/asset-manager/factory.js
+++ b/cocos2d/core/asset-manager/factory.js
@@ -43,6 +43,7 @@ function createAudioClip (id, data, options, onComplete) {
     out._uuid = id;
     out._nativeUrl = id;
     out._nativeAsset = data;
+    out.duration = data.duration;
     onComplete && onComplete(null, out);
 }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks/issues/2897

Changes:
 * 回退，之前回退修复 audio 的 duration 为 0 的 pr
