### PR TITLE
widget refreshScene after scene loaded

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -508,7 +508,7 @@ cc.Director.prototype = {
         scene._load();
 
         // Delay run / replace scene to the end of the frame
-        this.once(cc.Director.EVENT_AFTER_UPDATE, function () {
+        this.once(cc.Director.EVENT_BEFORE_UPDATE, function () {
             this.runSceneImmediate(scene, onBeforeLoadScene, onLaunched);
         }, this);
     },

--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -508,7 +508,7 @@ cc.Director.prototype = {
         scene._load();
 
         // Delay run / replace scene to the end of the frame
-        this.once(cc.Director.EVENT_BEFORE_UPDATE, function () {
+        this.once(cc.Director.EVENT_AFTER_DRAW, function () {
             this.runSceneImmediate(scene, onBeforeLoadScene, onLaunched);
         }, this);
     },


### PR DESCRIPTION
resolve https://github.com/cocos-creator/2d-tasks/issues/2895

changeLog:
- 修复 widget 组件在加载场景后的第一帧不生效的问题

由于 widgetManager.refreshScene 和 runSceneImmediately 都是在 `EVENT_AFTER_UPDATE` 事件里回调的，refreshScene 注册事件比较早，所以主循环里第一帧的执行顺序是 
```
widgetManager.refreshScene -> runSceneImmediately -> renderScene
```

正确的顺序应该是 
```
runSceneImmediately  -> widgetManager.refreshScene -> renderScene
```