### PR TITLE
Fix once bug

### DIFF
--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -369,8 +369,8 @@ export class AnimationComponent extends Eventify(Component) {
      * animation.on('play', this.onPlay, this);
      * ```
      */
-    public on<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any) {
-        const ret = super.on(type, callback, thisArg);
+    public on<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any, once?: boolean) {
+        const ret = super.on(type, callback, thisArg, once);
         if (type === EventType.LASTFRAME) {
             this._syncAllowLastFrameEvent();
         }

--- a/cocos/core/event/eventify.ts
+++ b/cocos/core/event/eventify.ts
@@ -42,7 +42,7 @@ export interface IEventified {
      *     cc.log("fire in the hole");
      * }, node);
      */
-    on<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any): typeof callback;
+    on<TFunction extends Function> (type: EventType, callback: TFunction, thisArg?: any, once?: boolean): typeof callback;
 
     /**
      * @en

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -524,13 +524,13 @@ export class Game extends EventTarget {
      * @param {Object} [target] - The target (this object) to invoke the callback, can be null
      * @return {Function} - Just returns the incoming callback so you can save the anonymous function easier.
      */
-    public on (type: string, callback: Function, target?: object): any {
+    public on (type: string, callback: Function, target?: object, once?: boolean): any {
         // Make sure EVENT_ENGINE_INITED callbacks to be invoked
         if (this._inited && type === Game.EVENT_ENGINE_INITED) {
             callback.call(target);
         }
         else {
-            this.eventTargetOn(type, callback, target);
+            this.eventTargetOn(type, callback, target, once);
         }
     }
 

--- a/cocos/core/platform/event-manager/system-event.ts
+++ b/cocos/core/platform/event-manager/system-event.ts
@@ -115,11 +115,11 @@ export class SystemEvent extends EventTarget {
      * @param callback - The event listener's callback
      * @param target - The event listener's target and callee
      */
-    public on (type: string, callback: Function, target?: Object) {
+    public on (type: string, callback: Function, target?: Object, once?: boolean) {
         if (EDITOR) {
             return;
         }
-        super.on(type, callback, target);
+        super.on(type, callback, target, once);
 
         // Keyboard
         if (type === SystemEventType.KEY_DOWN || type === SystemEventType.KEY_UP) {

--- a/cocos/physics/framework/components/collider/collider-component.ts
+++ b/cocos/physics/framework/components/collider/collider-component.ts
@@ -185,8 +185,8 @@ export class ColliderComponent extends Eventify(Component) {
      * @param callback - The event callback, signature:`(event?:ICollisionEvent|ITriggerEvent)=>void`.
      * @param target - The event callback target.
      */
-    public on (type: TriggerEventType | CollisionEventType, callback: Function, target?: Object): any {
-        super.on(type, callback, target);
+    public on (type: TriggerEventType | CollisionEventType, callback: Function, target?: Object, once?: boolean): any {
+        super.on(type, callback, target, once);
     }
 
     /**

--- a/tests/core/eventify.test.ts
+++ b/tests/core/eventify.test.ts
@@ -36,3 +36,23 @@ test('Eventify', () => {
     derived.emit(eventName);
     expect(hookOnOff).toBeCalledTimes(2);
 });
+
+test('Overwrite Eventify.prototype.on', () => {
+    class Base {}
+    class Derived extends Eventify(Base) {
+        public on <TFunction extends Function> (type: string, callback: TFunction, thisArg?: any, once?: boolean) {
+            return super.on(type, callback, thisArg, once);
+        }
+    }
+
+    const derived = new Derived();
+
+    const eventName = 'event';
+    const onceFn = jest.fn(() => {});
+
+    derived.once(eventName, onceFn);
+    derived.emit(eventName);
+    expect(onceFn).toBeCalledTimes(1);
+    derived.emit(eventName);
+    expect(onceFn).toBeCalledTimes(1);
+});


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Fix that if derived classes override `Eventify.prototype.on`, the `once` did not work properly.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
