### PR TITLE
Fix videoplay component not triggering node touch and mouse events

### DIFF
--- a/cocos2d/videoplayer/CCVideoPlayer.js
+++ b/cocos2d/videoplayer/CCVideoPlayer.js
@@ -24,6 +24,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
+const Node = require('../core/CCNode');
 const VideoPlayerImpl = require('./video-player-impl');
 
 /**
@@ -364,6 +365,13 @@ let VideoPlayer = cc.Class({
                 impl.setEventListener(EventType.META_LOADED, this.onMetaLoaded.bind(this));
                 impl.setEventListener(EventType.CLICKED, this.onClicked.bind(this));
                 impl.setEventListener(EventType.READY_TO_PLAY, this.onReadyToPlay.bind(this));
+                //
+                impl.setEventListener(Node.EventType.MOUSE_DOWN, this.onMouseDown.bind(this));
+                impl.setEventListener(Node.EventType.MOUSE_MOVE, this.onMouseMove.bind(this));
+                impl.setEventListener(Node.EventType.MOUSE_ENTER, this.onMouseEnter.bind(this));
+                impl.setEventListener(Node.EventType.MOUSE_LEAVE, this.onMouseLeave.bind(this));
+                impl.setEventListener(Node.EventType.MOUSE_UP, this.onMouseUp.bind(this));
+                impl.setEventListener(Node.EventType.MOUSE_WHEEL, this.onMouseWheel.bind(this));
             }
         }
     },
@@ -397,6 +405,34 @@ let VideoPlayer = cc.Class({
         if (this._impl) {
             this._impl.updateMatrix(this.node);
         }
+    },
+
+    onMouseDown () {
+        this.node.emit(Node.EventType.TOUCH_START, this);
+        this.node.emit(Node.EventType.MOUSE_DOWN, this);
+    },
+
+    onMouseMove () {
+        this.node.emit(Node.EventType.TOUCH_MOVE, this);
+        this.node.emit(Node.EventType.MOUSE_MOVE, this);
+    },
+
+    onMouseEnter () {
+        this.node.emit(Node.EventType.MOUSE_ENTER, this);
+    },
+
+    onMouseLeave () {
+        this.node.emit(Node.EventType.TOUCH_CANCEL, this);
+        this.node.emit(Node.EventType.MOUSE_LEAVE, this);
+    },
+
+    onMouseUp () {
+        this.node.emit(Node.EventType.TOUCH_END, this);
+        this.node.emit(Node.EventType.MOUSE_UP, this);
+    },
+
+    onMouseWheel () {
+        this.node.emit(Node.EventType.MOUSE_WHEEL, this);
     },
 
     onReadyToPlay () {

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -26,6 +26,7 @@
 const utils = require('../core/platform/utils');
 const sys = require('../core/platform/CCSys');
 const macro = require('../core/platform/CCMacro');
+const Node = require('../core/CCNode');
 
 const READY_STATE = {
     HAVE_NOTHING: 0,
@@ -114,6 +115,30 @@ let VideoPlayerImpl = cc.Class({
         video.addEventListener("play", cbs.play);
         video.addEventListener("pause", cbs.pause);
         video.addEventListener("click", cbs.click);
+
+        video.onmousedown = function () {
+            self._dispatchEvent(Node.EventType.TOUCH_START);
+            self._dispatchEvent(Node.EventType.MOUSE_DOWN);
+        };
+        video.onmousemove = function () {
+            self._dispatchEvent(Node.EventType.TOUCH_MOVE);
+            self._dispatchEvent(Node.EventType.MOUSE_MOVE);
+        };
+        video.onmouseenter = function () {
+            self._dispatchEvent(Node.EventType.MOUSE_LEAVE);
+        };
+        video.onmouseleave = function () {
+            self._dispatchEvent(Node.EventType.TOUCH_CANCEL);
+            self._dispatchEvent(Node.EventType.MOUSE_LEAVE);
+        };
+        video.onmouseup = function () {
+            self._dispatchEvent(Node.EventType.TOUCH_END);
+            self._dispatchEvent(Node.EventType.MOUSE_UP);
+        };
+        video.onmousewheel = function () {
+            self._dispatchEvent(Node.EventType.MOUSE_WHEEL);
+        };
+
 
         function onCanPlay () {
             if (self._loaded || self._playing)


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2937

Changes:
 * 修正视频播放组件不能触发节点触摸和鼠标事件（目前只支持 web，其它平台估计也需要适配一下）