### PR TITLE
Remove npm script build-rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "build:dev": "gulp build-code",
     "build:min": "gulp build-code-minified",
     "build-declaration": "gulp build-declarations",
-    "build-rollup": "echo \"[WARN]You are not required to run 'build-rollup' anymore.\"",
-    "postinstall": "npm run build-rollup",
     "build-api-json": "gulp build-api-json -i index.ts -o ./3d-api-docs/tempJson",
     "build-api": "npm run build-api-json && gulp build-3d-api -i index.ts -o ./3d-api-docs -j ./3d-api-docs/tempJson",
     "test": "gulp test"


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * We had marked the npm script build-rollup as deprecated at 1.1, now let's remove it.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
