### PR TITLE
Fixed CCNode _checkListeners

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -596,16 +596,15 @@ function _searchComponentsInParent (node, comp) {
 
 function _checkListeners (node, events) {
     if (!(node._objFlags & Destroying)) {
-        var i = 0;
         if (node._bubblingListeners) {
-            for (; i < events.length; ++i) {
+            for (let i = 0, l = events.length; i < l; ++i) {
                 if (node._bubblingListeners.hasEventListener(events[i])) {
                     return true;
                 }
             }
         }
         if (node._capturingListeners) {
-            for (; i < events.length; ++i) {
+            for (let i = 0, l = events.length; i < l; ++i) {
                 if (node._capturingListeners.hasEventListener(events[i])) {
                     return true;
                 }


### PR DESCRIPTION
The index should reset to zero.

Re: cocos-creator/2d-tasks#

Changes:
 * The index should reset to zero.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
