### PR TITLE
fixed web cannot fullscreen

### DIFF
--- a/cocos2d/core/platform/CCScreen.js
+++ b/cocos2d/core/platform/CCScreen.js
@@ -220,7 +220,6 @@ cc.screen = /** @lends cc.screen# */{
         let self = this;
         let touchTarget = cc.game.canvas || element;
         let fullScreenErrorEventName = this._fn.fullscreenerror;
-        if (typeof document[fullScreenErrorEventName] === "undefined") return;
         let touchEventName = this._touchEvent;
         
         function onFullScreenError () {


### PR DESCRIPTION
When the autoFullScreen fails, the game should be able to request full screen again by touch the screen.

Currently, The UC mobile browser cannot support multi-touch after requesting full screen.

I added tips on this in example-case project. https://github.com/cocos-creator/example-cases/pull/842