### PR TITLE
fix GFX_DRAW_INFO_SIZE

### DIFF
--- a/cocos/core/gfx/buffer.ts
+++ b/cocos/core/gfx/buffer.ts
@@ -31,7 +31,7 @@ export interface IGFXDrawInfo {
     firstInstance: number;
 }
 
-export const GFX_DRAW_INFO_SIZE: number = 56;
+export const GFX_DRAW_INFO_SIZE: number = 28;
 
 export interface IGFXIndirectBuffer {
     drawInfos: IGFXDrawInfo[];


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#3425](https://github.com/cocos-creator/3d-tasks/issues/3425#issue-628124224)

Changes:
 * fix GFX_DRAW_INFO_SIZE to sizeof(GFXDrawInfo)

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
