### PR TITLE
set audio volume and loop after _ensureDataLoaded

### DIFF
--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -213,11 +213,6 @@ var AudioSource = cc.Class({
         this._pausedFlag = false;
     },
 
-    onLoad: function () {
-        this.audio.setVolume(this._mute ? 0 : this._volume);
-        this.audio.setLoop(this._loop);
-    },
-
     onEnable: function () {
         if (this.preload) {
             this.audio.src = this._clip;
@@ -254,6 +249,8 @@ var AudioSource = cc.Class({
             audio.stop();
         }
         this._ensureDataLoaded();
+        audio.setVolume(this._mute ? 0 : this._volume);
+        audio.setLoop(this._loop);
         audio.setCurrentTime(0);
         audio.play();
     },


### PR DESCRIPTION
resolve https://github.com/cocos-creator/2d-tasks/issues/2930

changeLog:
- 修复 AudioSource 组件勾选 loop 和 mute 无效的问题

对 audio 的操作，需要先确保 audio.src 存在