### PR TITLE
dump dependency of SpriteFrame explicitly

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -2,6 +2,7 @@
 declare let CC_JSB: boolean
 declare let CC_NATIVERENDERER: boolean
 declare let CC_EDITOR: boolean
+declare let CC_PREVIEW: boolean
 declare let CC_TEST: boolean
 declare let CC_DEBUG: boolean
 

--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -745,7 +745,7 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
 
     // SERIALIZATION
 
-    _serialize: (CC_EDITOR || CC_TEST) && function (exporting) {
+    _serialize: (CC_EDITOR || CC_TEST) && function (exporting, ctx) {
         let rect = this._rect;
         let offset = this._offset;
         let size = this._originalSize;
@@ -762,6 +762,7 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
         }
         if (uuid && exporting) {
             uuid = Editor.Utils.UuidUtils.compressUuid(uuid, true);
+            ctx.dependsOn('_textureSetter', uuid);
         }
 
         let vertices;
@@ -777,7 +778,7 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
 
         return {
             name: this._name,
-            texture: uuid || undefined,
+            texture: (!exporting && uuid) || undefined,
             atlas: exporting ? undefined : this._atlasUuid,  // strip from json if exporting
             rect: rect ? [rect.x, rect.y, rect.width, rect.height] : undefined,
             offset: offset ? [offset.x, offset.y] : undefined,
@@ -821,10 +822,12 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
             this.vertices.nv = [];
         }
 
-        // load texture via _textureSetter
-        let textureUuid = data.texture;
-        if (textureUuid) {
-            handle.result.push(this, '_textureSetter', textureUuid);
+        if (!CC_BUILD) {
+            // manually load texture via _textureSetter
+            let textureUuid = data.texture;
+            if (textureUuid) {
+                handle.result.push(this, '_textureSetter', textureUuid);
+            }
         }
     }
 });

--- a/cocos2d/core/platform/deserialize-compiled.ts
+++ b/cocos2d/core/platform/deserialize-compiled.ts
@@ -1013,6 +1013,7 @@ if (CC_TEST) {
         deserializeCCObject,
         deserializeCustomCCObject,
         parseInstances,
+        parseResult,
         cacheMasks,
         File: {
             Version: File.Version,

--- a/cocos2d/core/platform/deserialize-editor.js
+++ b/cocos2d/core/platform/deserialize-editor.js
@@ -29,6 +29,8 @@ var Attr = require('./attribute');
 var CCClass = require('./CCClass');
 var misc = require('../utils/misc');
 
+import deserializeCompiled from './deserialize-compiled';
+
 // HELPERS
 
 /**
@@ -715,14 +717,6 @@ let deserialize = module.exports = function (data, details, options) {
     var createAssetRefs = options.createAssetRefs || cc.sys.platform === cc.sys.EDITOR_CORE;
     var customEnv = options.customEnv;
     var ignoreEditorOnly = options.ignoreEditorOnly;
-
-    if (CC_EDITOR && Buffer.isBuffer(data)) {
-        data = data.toString();
-    }
-
-    if (typeof data === 'string') {
-        data = JSON.parse(data);
-    }
 
     //var oldJson = JSON.stringify(data, null, 2);
 

--- a/cocos2d/core/platform/deserialize.js
+++ b/cocos2d/core/platform/deserialize.js
@@ -24,9 +24,9 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-import deserialize from './deserialize-compiled';
+import deserializeForCompiled from './deserialize-compiled';
 
-deserialize.reportMissingClass = function (id) {
+deserializeForCompiled.reportMissingClass = function (id) {
     if (CC_EDITOR && Editor.Utils.UuidUtils.isUuid(id)) {
         id = Editor.Utils.UuidUtils.decompressUuid(id);
         cc.warnID(5301, id);
@@ -37,9 +37,26 @@ deserialize.reportMissingClass = function (id) {
 };
 
 if (CC_BUILD) {
-    cc.deserialize = deserialize;
+    cc.deserialize = deserializeForCompiled;
 }
 else {
-    cc.deserialize = require('./deserialize-editor');
-    cc.deserialize.reportMissingClass = deserialize.reportMissingClass;
+    let deserializeForEditor = require('./deserialize-editor');
+
+    cc.deserialize = function (data, details, options) {
+        if (CC_EDITOR && Buffer.isBuffer(data)) {
+            data = data.toString();
+        }
+        if (typeof data === 'string') {
+            data = JSON.parse(data);
+        }
+        if (CC_PREVIEW) {
+            // support for loading Asset Bundle from server
+            if (deserializeForCompiled.isCompiledJson(data)) {
+                return deserializeForCompiled(data, details, options);
+            }
+        }
+        return deserializeForEditor(data, details, options);
+    };
+    cc.deserialize.reportMissingClass = deserializeForEditor.reportMissingClass;
+    cc.deserialize.Details = deserializeForEditor.Details;
 }

--- a/cocos2d/core/value-types/quat.ts
+++ b/cocos2d/core/value-types/quat.ts
@@ -396,6 +396,7 @@ export default class Quat extends ValueType {
     /**
      * !#zh 四元数球面插值
      * !#en Spherical quaternion interpolation
+     * @method slerp
      * @typescript
      * slerp<Out extends IQuatLike, QuatLike_1 extends IQuatLike, QuatLike_2 extends IQuatLike>(out: Out, a: QuatLike_1, b: QuatLike_2, t: number): Out
      * @static

--- a/gulp/util/create-bundler.js
+++ b/gulp/util/create-bundler.js
@@ -89,7 +89,24 @@ module.exports = function createBundler(entryFiles, options) {
                 // "bugfixes": true, since babel 7.9
             }
         ],
-        require('@babel/preset-typescript'),
+        {
+            plugins: [
+                [
+                    require('@babel/plugin-proposal-decorators'),
+                    { legacy: true },
+                ],
+                [
+                    require('@babel/plugin-proposal-class-properties'),
+                    { loose: true },
+                ],
+            ]
+        },
+        [
+            require('@babel/preset-typescript'),
+            {
+                allowDeclareFields: true,
+            }
+        ],
     ];
 
     var plugins = [
@@ -98,14 +115,6 @@ module.exports = function createBundler(entryFiles, options) {
         [
             require('babel-plugin-const-enum'),
             { transform: "constObject" },
-        ],
-        [
-            require('@babel/plugin-proposal-decorators'),
-            { legacy: true },
-        ],
-        [
-            require('@babel/plugin-proposal-class-properties'),
-            { loose: true },
         ],
         [
             require('babel-plugin-add-module-exports'),

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-proposal-decorators": "^7.1.6",
     "@babel/plugin-transform-runtime": "7.8.3",
     "@babel/preset-env": "7.8.7",
-    "@babel/preset-typescript": "^7.1.0",
+    "@babel/preset-typescript": "7.8.3",
     "@babel/runtime": "7.8.7",
     "aliasify": "^2.1.0",
     "async": "1.5.2",

--- a/test/qunit/unit-es5/test-pack-unpack.js
+++ b/test/qunit/unit-es5/test-pack-unpack.js
@@ -25,13 +25,11 @@
         __born__: 1985,
         $$: 'Amoy'
     }, { stringify: false });
-    JSON1[0] = { "version": JSON1[0] };
 
     var KEY2 = 'hallelujah';
     var JSON2 = Editor.serializeCompiled([{
         text: 'hallelujah\nalujah\\alujah...\uD83D\uDE02'
     }], { stringify: false });
-    JSON2[0] = { "version": JSON2[0] };
 
     test('pack and unpack something', function () {
         var packer = new Editor.JsonPacker();
@@ -42,6 +40,8 @@
         ok(res.indices.indexOf(KEY1) !== -1 && res.indices.indexOf(KEY2) !== -1, 'should generate index data when packing');
 
         cc.assetManager.packManager.unpack(res.indices, JSON.parse(res.data), '.json', null, function (err, data) {
+            JSON1[0] = data[KEY1 + '@import'][0];
+            JSON2[0] = data[KEY2 + '@import'][0];
             deepEqual(data[KEY1 + '@import'], JSON1, 'should unpack JSON1');
             deepEqual(data[KEY2 + '@import'], JSON2, 'should unpack JSON2');
         });

--- a/test/qunit/unit/test-deserialize-compiled.js
+++ b/test/qunit/unit/test-deserialize-compiled.js
@@ -373,7 +373,7 @@ test('dereference', function () {
 }
 
 test('deserializeCustomCCObject', function () {
-    let { File, DataTypeID, parseInstances, deserialize: deserializeCompiled, cacheMasks } = cc._Test.deserializeCompiled;
+    let { File, DataTypeID, parseInstances, parseResult, deserialize: deserializeCompiled, cacheMasks } = cc._Test.deserializeCompiled;
 
     var MyClass = cc.Class({
         name: 'a a b b',
@@ -393,9 +393,11 @@ test('deserializeCustomCCObject', function () {
     let Ctor = function () {
     };
 
-    let details = new cc.deserialize.Details();
+    let details = new cc._deserializeCompiled.Details();
     let data = {
         [File.Context]: { result: details },
+        [File.SharedUuids]: ['outer-uuid-233'],
+        [File.SharedStrings]: ['ref'],
         [File.SharedClasses]: [[
             Ctor,
             ['obj'],
@@ -406,22 +408,25 @@ test('deserializeCustomCCObject', function () {
         [File.Instances]: [
             [0, [1, ['inner prop1', 'inner-uuid-123']]], [23333, 'outer-uuid-123'], 0
         ],
-        [File.InstanceTypes]: [
-            1,
-        ]
+        [File.InstanceTypes]: [1],
+        [File.DependObjs]: [1],
+        [File.DependKeys]: [0],
+        [File.DependUuidIndices]: [0],
     };
+    details.init(data);
 
     cacheMasks(data);
     parseInstances(data);
+    parseResult(data);
     let instances = data[File.Instances];
     ok(instances[0].obj instanceof MyClass, 'embedded custom class should be created');
     strictEqual(instances[0].obj.prop1, 'inner prop1', 'embedded custom class should be deserialized correctly');
     ok(instances[1] instanceof MyClass, 'indexed custom class should be created');
     strictEqual(instances[1].prop1, 23333, 'indexed custom class should be deserialized correctly');
 
-    deepEqual(details.uuidObjList, [instances[0].obj, instances[1]], 'uuid objects should be deserialized correctly');
-    deepEqual(details.uuidPropList, ['asset', 'asset'], 'uuid keys should be deserialized correctly');
-    deepEqual(details.uuidList, ['inner-uuid-123', 'outer-uuid-123'], 'uuids should be deserialized correctly');
+    deepEqual(details.uuidObjList, [instances[1], instances[0].obj, instances[1]], 'uuid objects should be deserialized correctly');
+    deepEqual(details.uuidPropList, ['ref', 'asset', 'asset'], 'uuid keys should be deserialized correctly');
+    deepEqual(details.uuidList, ['outer-uuid-233', 'inner-uuid-123', 'outer-uuid-123'], 'uuids should be deserialized correctly');
 
     cc.js.unregisterClass(MyClass);
 });

--- a/test/qunit/unit/test-serialize-compiled.js
+++ b/test/qunit/unit/test-serialize-compiled.js
@@ -341,7 +341,8 @@ if (TestEditorExtends) { (function () {
     test('multi custom classes (not asset)', function () {
         var MyClass1 = cc.Class({
             name: 'a',
-            _serialize: function () {
+            _serialize: function (exporting, ctx) {
+                ctx.dependsOn('ref', '2333');
                 return ['aaa'];
             },
             _deserialize: function (data) {}
@@ -355,15 +356,15 @@ if (TestEditorExtends) { (function () {
         });
         var a = new MyClass1();
         var b = new MyClass2();
-        var obj = [a, b, a, b];
+        var obj = [a, b, a, b, new MyClass1()];
 
         var expect = [
-            1, 0, 0,
+            1, ['2333'], ['ref'],
             ["a", "b"],
             0,
-            [['aaa'], 'bbb', [0, 1, 0, 1], 2],
-            [0, 1, -3],
-            0, [], [], []
+            [['aaa'], 'bbb', ['aaa'], [0, 1, 0, 1, 2], 3],
+            [0, 1, 0, -3],
+            0, [0, 2], [0, 0], [0, 0]
         ];
         match(obj, expect);
 


### PR DESCRIPTION
Changes of deserialization:
 * dump dependency of SpriteFrame explicitly for preloading
 * support for loading Asset Bundle from server
 * support for checking native asset for preloading

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
