### PR TITLE
Throw the error instead of return null in instantiate and addComponent

### DIFF
--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -412,99 +412,124 @@ CCClass.fastDefine('cc.Object', CCObject, { _name: '', _objFlags: 0 });
  * @private
  */
 js.value(CCObject, 'Flags', {
-
     Destroyed,
-    // ToDestroy: ToDestroy,
-
-    /**
-     * @en The object will not be saved.
-     * @zh 该对象将不会被保存。
-     */
     DontSave,
-
-    /**
-     * @en The object will not be saved when building a player.
-     * @zh 构建项目时，该对象将不会被保存。
-     */
     EditorOnly,
-
     Dirty,
-
-    /**
-     * @en Dont destroy automatically when loading a new scene.
-     * @zh 加载一个新场景时，不自动删除该对象
-     * @property DontDestroy
-     * @private
-     */
     DontDestroy,
-
     PersistentMask,
-
-    // FLAGS FOR ENGINE
-
     Destroying,
-
-    /**
-     * @en The node is deactivating.
-     * @zh 节点正在反激活的过程中。
-     * @private
-     */
     Deactivating,
-
-    /**
-     * @en The lock node, when the node is locked, cannot be clicked in the scene.
-     * @zh 锁定节点，锁定后场景内不能点击
-     * @private
-     */
     LockedInEditor,
-
-    /// **
-    // * @en
-    // * Hide in game and hierarchy.
-    // * This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
-    // * @zh
-    // * 在游戏和层级中隐藏该对象。<br/>
-    // * 该标记只读，它只能被用作 scene.addEntity()的一个参数。
-    // * @property {Number} HideInGame
-    // */
-    // HideInGame: HideInGame,
-
-    // FLAGS FOR EDITOR
-
-    /// **
-    // * @en This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
-    // * @zh 该标记只读，它只能被用作 scene.addEntity()的一个参数。
-    // */
     HideInHierarchy,
-
-    /// **
-    // * @en
-    // * Hide in game view, hierarchy, and scene view... etc.
-    // * This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
-    // * @zh
-    // * 在游戏视图，层级，场景视图等等...中隐藏该对象。
-    // * 该标记只读，它只能被用作 scene.addEntity()的一个参数。
-    // */
-    // Hide: Hide,
-
-    //// UUID Registered in editor
-    // RegisteredInEditor: RegisteredInEditor,
-
-    // FLAGS FOR COMPONENT
-
     IsPreloadStarted,
     IsOnLoadStarted,
     IsOnLoadCalled,
     IsOnEnableCalled,
     IsStartCalled,
     IsEditorOnEnableCalled,
-
     IsPositionLocked,
     IsRotationLocked,
     IsScaleLocked,
     IsAnchorLocked,
     IsSizeLocked,
 });
+
+declare namespace CCObject {
+    export enum Flags {
+        Destroyed,
+        // ToDestroy: ToDestroy,
+
+        /**
+         * @en The object will not be saved.
+         * @zh 该对象将不会被保存。
+         */
+        DontSave,
+
+        /**
+         * @en The object will not be saved when building a player.
+         * @zh 构建项目时，该对象将不会被保存。
+         */
+        EditorOnly,
+
+        Dirty,
+
+        /**
+         * @en Dont destroy automatically when loading a new scene.
+         * @zh 加载一个新场景时，不自动删除该对象
+         * @property DontDestroy
+         * @private
+         */
+        DontDestroy,
+
+        PersistentMask,
+
+        // FLAGS FOR ENGINE
+
+        Destroying,
+
+        /**
+         * @en The node is deactivating.
+         * @zh 节点正在反激活的过程中。
+         * @private
+         */
+        Deactivating,
+
+        /**
+         * @en The lock node, when the node is locked, cannot be clicked in the scene.
+         * @zh 锁定节点，锁定后场景内不能点击
+         * @private
+         */
+        LockedInEditor,
+
+        /// **
+        // * @en
+        // * Hide in game and hierarchy.
+        // * This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
+        // * @zh
+        // * 在游戏和层级中隐藏该对象。<br/>
+        // * 该标记只读，它只能被用作 scene.addEntity()的一个参数。
+        // * @property {Number} HideInGame
+        // */
+        // HideInGame: HideInGame,
+
+        // FLAGS FOR EDITOR
+
+        /// **
+        // * @en This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
+        // * @zh 该标记只读，它只能被用作 scene.addEntity()的一个参数。
+        // */
+        HideInHierarchy,
+
+        /// **
+        // * @en
+        // * Hide in game view, hierarchy, and scene view... etc.
+        // * This flag is readonly, it can only be used as an argument of scene.addEntity() or Entity.createWithFlags().
+        // * @zh
+        // * 在游戏视图，层级，场景视图等等...中隐藏该对象。
+        // * 该标记只读，它只能被用作 scene.addEntity()的一个参数。
+        // */
+        // Hide: Hide,
+
+        //// UUID Registered in editor
+        // RegisteredInEditor: RegisteredInEditor,
+
+        // FLAGS FOR COMPONENT
+
+        IsPreloadStarted,
+        IsOnLoadStarted,
+        IsOnLoadCalled,
+        IsOnEnableCalled,
+        IsStartCalled,
+        IsEditorOnEnableCalled,
+
+        IsPositionLocked,
+        IsRotationLocked,
+        IsScaleLocked,
+        IsAnchorLocked,
+        IsSizeLocked,
+    }
+}
 
 /*
  * @en

--- a/cocos/core/scene-graph/base-node-dev.ts
+++ b/cocos/core/scene-graph/base-node-dev.ts
@@ -31,9 +31,8 @@ import { CCObject } from '../data/object';
 import * as js from '../utils/js';
 import { EDITOR, DEV, TEST } from 'internal:constants';
 import { legacyCC } from '../global-exports';
-import { error, errorID } from '../platform/debug';
+import { error, errorID, getError } from '../platform/debug';
 
-// @ts-ignore
 const Destroying = CCObject.Flags.Destroying;
 
 export function baseNodePolyfill (BaseNode) {
@@ -42,13 +41,11 @@ export function baseNodePolyfill (BaseNode) {
             const existing = this.getComponent(ctor._disallowMultiple);
             if (existing) {
                 if (existing.constructor === ctor) {
-                    errorID(3805, js.getClassName(ctor), this._name);
+                    throw Error(getError(3805, js.getClassName(ctor), this._name));
                 } else {
-                    errorID(3806, js.getClassName(ctor), this._name, js.getClassName(existing));
+                    throw Error(getError(3806, js.getClassName(ctor), this._name, js.getClassName(existing)));
                 }
-                return false;
             }
-            return true;
         };
 
         /**

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -31,7 +31,7 @@ import { Component } from '../components/component';
 import { ccclass, property } from '../data/class-decorator';
 import { CCObject } from '../data/object';
 import { Event } from '../event';
-import { errorID, warnID, error, log, assertID } from '../platform/debug';
+import { errorID, warnID, error, log, assertID, getError } from '../platform/debug';
 import { SystemEventType } from '../platform/event-manager/event-enum';
 import { ISchedulable } from '../scheduler';
 import IdGenerator from '../utils/id-generator';
@@ -886,28 +886,29 @@ export class BaseNode extends CCObject implements ISchedulable {
      * @en Adds a component class to the node. You can also add component to node by passing in the name of the script.
      * @zh 向节点添加一个指定类型的组件类，你还可以通过传入脚本的名称来添加组件。
      * @param classConstructor The class of the component to add
+     * @throws `TypeError` if the `classConstructor` does not specify a cc-class constructor extending the `Component`.
      * @example
      * ```
      * var sprite = node.addComponent(SpriteComponent);
      * ```
      */
-    public addComponent<T extends Component> (classConstructor: Constructor<T>): T | null;
+    public addComponent<T extends Component> (classConstructor: Constructor<T>): T;
 
     /**
      * @en Adds a component class to the node. You can also add component to node by passing in the name of the script.
      * @zh 向节点添加一个指定类型的组件类，你还可以通过传入脚本的名称来添加组件。
      * @param className The class name of the component to add
+     * @throws `TypeError` if the `className` does not specify a cc-class constructor extending the `Component`.
      * @example
      * ```
      * var test = node.addComponent("Test");
      * ```
      */
-    public addComponent (className: string): Component | null;
+    public addComponent (className: string): Component;
 
     public addComponent (typeOrClassName: string | Function) {
         if (EDITOR && (this._objFlags & Destroying)) {
-            error('isDestroying');
-            return null;
+            throw Error(`isDestroying`);
         }
 
         // get component
@@ -916,16 +917,14 @@ export class BaseNode extends CCObject implements ISchedulable {
         if (typeof typeOrClassName === 'string') {
             constructor = js.getClassByName(typeOrClassName);
             if (!constructor) {
-                errorID(3807, typeOrClassName);
                 if (legacyCC._RF.peek()) {
                     errorID(3808, typeOrClassName);
                 }
-                return null;
+                throw TypeError(getError(3807, typeOrClassName));
             }
         } else {
             if (!typeOrClassName) {
-                errorID(3804);
-                return null;
+                throw TypeError(getError(3804));
             }
             constructor = typeOrClassName;
         }
@@ -933,17 +932,15 @@ export class BaseNode extends CCObject implements ISchedulable {
         // check component
 
         if (typeof constructor !== 'function') {
-            errorID(3809);
-            return null;
+            throw TypeError(getError(3809));
         }
         if (!js.isChildClassOf(constructor, legacyCC.Component)) {
-            errorID(3810);
-            return null;
+            throw TypeError(getError(3810));
         }
 
         if (EDITOR && constructor._disallowMultiple) {
             if (!this._checkMultipleComp!(constructor)) {
-                return null;
+                throw Error(`Only singleton component is allowed.`);
             }
         }
 
@@ -951,11 +948,7 @@ export class BaseNode extends CCObject implements ISchedulable {
 
         const ReqComp = constructor._requireComponent;
         if (ReqComp && !this.getComponent(ReqComp)) {
-            const depended = this.addComponent(ReqComp);
-            if (!depended) {
-                // depend conflicts
-                return null;
-            }
+            this.addComponent(ReqComp);
         }
 
         //// check conflict

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -939,9 +939,7 @@ export class BaseNode extends CCObject implements ISchedulable {
         }
 
         if (EDITOR && constructor._disallowMultiple) {
-            if (!this._checkMultipleComp!(constructor)) {
-                throw Error(`Only singleton component is allowed.`);
-            }
+            this._checkMultipleComp!(constructor);
         }
 
         // check requirement
@@ -1399,7 +1397,12 @@ export class BaseNode extends CCObject implements ISchedulable {
 
     protected _onSiblingIndexChanged? (siblingIndex: number): void;
 
-    protected _checkMultipleComp? (constructor: Function): boolean;
+    /**
+     * Ensures that this node has already had the specified component(s). If not, this method throws.
+     * @param constructor Constructor of the component.
+     * @throws If one or more component of same type have been existed in this node.
+     */
+    protected _checkMultipleComp? (constructor: Function): void;
 }
 
 baseNodePolyfill(BaseNode);

--- a/cocos/core/scene-graph/scene.ts
+++ b/cocos/core/scene-graph/scene.ts
@@ -29,12 +29,13 @@
 
 import { ccclass, property } from '../data/class-decorator';
 import { Mat4, Quat, Vec3 } from '../math';
-import { warnID, assert } from '../platform/debug';
+import { warnID, assert, getError } from '../platform/debug';
 import { RenderScene } from '../renderer/scene/render-scene';
 import { BaseNode } from './base-node';
 import { SceneGlobals } from './scene-globals';
 import { EDITOR, TEST } from 'internal:constants';
 import { legacyCC } from '../global-exports';
+import { Component } from '../components/component';
 
 /**
  * @en
@@ -109,9 +110,8 @@ export class Scene extends BaseNode {
      * @en Only for compatibility purpose, user should not add any component to the scene
      * @zh 仅为兼容性保留，用户不应该在场景上直接添加任何组件
      */
-    public addComponent (typeOrClassName: string | Function) {
-        warnID(3822);
-        return null;
+    public addComponent (typeOrClassName: string | Function): Component {
+        throw new Error(getError(3822));
     }
 
     public _onHierarchyChanged () { }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * In usual, developers won't expect and won't handle the error during invocation of  these method as a matter of fact that in most cases these methods do never fail if arguments are correctly passed to them accordingly to the method specification. This PR changes the way how `instantiate()` and `Node.prototype.addComponent()` report their error. Instead of printing the error to console and return a `null` as result, this PR change to throw the error.

Reference about error design:
- [Error Handling in Node.js](https://www.joyent.com/node-js/production/design/errors)

This should fixes https://forum.cocos.org/t/c3d-1-1-1-instantiate/94620/4

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
