### PR TITLE
CCAudioEngine bug fixed

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -83,7 +83,9 @@ let getAudioFromPath = function (path) {
         if (this._finishCallback) {
             this._finishCallback();
         }
-        callback.call(this);
+        if(!this.getLoop()){
+            callback.call(this);
+        }
     }, audio);
 
     audio.on('stop', callback, audio);


### PR DESCRIPTION
There is no need to callback the 'ended' event when the audio is loop, in some case the ended event will trigger immediately and '_id2audio' will lose the audio;
不需要将设置循环音乐的完成事件，并且在web上在某些情况下播放循环音乐会立即触发此事件导致_id2audio被清除