### PR TITLE
Fix a gl error of particle trail.

### DIFF
--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -354,7 +354,8 @@ export default class TrailModule {
         const psTime = ps.startLifetime.getMax();
         const psRate = ps.rateOverTime.getMax();
         const duration = ps.duration;
-        for (const b of ps.bursts) {
+        for (const k in ps.bursts) {
+            const b = ps.bursts[k];
             burstCount += b.getMaxCount(ps) * Math.ceil(psTime / duration);
         }
         this._trailNum = Math.ceil(psTime * this.lifeTime.getMax() * 60 * (psRate * duration + burstCount));

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -351,11 +351,14 @@ export default class TrailModule {
         this._particleSystem = ps;
         this.minParticleDistance = this._minParticleDistance;
         let burstCount = 0;
-        for (const b of this._particleSystem.bursts) {
-            burstCount += b.getMaxCount(this._particleSystem);
+        const psTime = ps.startLifetime.getMax();
+        const psRate = ps.rateOverTime.getMax();
+        const duration = ps.duration;
+        for (const b of ps.bursts) {
+            burstCount += b.getMaxCount(ps) * Math.ceil(psTime / duration);
         }
-        this._trailNum = Math.ceil(this._particleSystem.startLifetime.getMax() * this.lifeTime.getMax() * 60 * (this._particleSystem.rateOverTime.getMax() * this._particleSystem.duration + burstCount));
-        this._trailSegments = new Pool(() => new TrailSegment(10), Math.ceil(this._particleSystem.rateOverTime.getMax() * this._particleSystem.duration));
+        this._trailNum = Math.ceil(psTime * this.lifeTime.getMax() * 60 * (psRate * duration + burstCount));
+        this._trailSegments = new Pool(() => new TrailSegment(10), Math.ceil(psRate * duration));
         if (this._enable) {
             this.enable = this._enable;
             this._updateMaterial();

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -354,8 +354,8 @@ export default class TrailModule {
         const psTime = ps.startLifetime.getMax();
         const psRate = ps.rateOverTime.getMax();
         const duration = ps.duration;
-        for (const k in ps.bursts) {
-            const b = ps.bursts[k];
+        for (let i = 0, len = ps.bursts.length; i < len; i++) {
+            const b = ps.bursts[i];
             burstCount += b.getMaxCount(ps) * Math.ceil(psTime / duration);
         }
         this._trailNum = Math.ceil(psTime * this.lifeTime.getMax() * 60 * (psRate * duration + burstCount));
@@ -393,7 +393,7 @@ export default class TrailModule {
     public destroy () {
         this.destroySubMeshData();
         if (this._trailModel) {
-            cc.director.root.destroyModel(this._trailModel);
+            director.root!.destroyModel(this._trailModel);
             this._trailModel = null;
         }
         if (this._trailSegments) {
@@ -624,7 +624,7 @@ export default class TrailModule {
         this._subMeshData.indexBuffer = indexBuffer;
         this._subMeshData.indirectBuffer = this._iaInfoBuffer;
 
-        this._trailModel = cc.director.root.createModel(Model);
+        this._trailModel = director.root!.createModel(Model);
         this._trailModel!.initialize(this._particleSystem.node);
         this._trailModel!.visFlags = this._particleSystem.visibility;
         this._trailModel!.setSubModelMesh(0, this._subMeshData);


### PR DESCRIPTION
Re: https://forum.cocos.org/t/3d-1-1-0/95312

Changes:

Fix the error of 'range out of bounds for buffer' because the number of bursts is incorrectly calculated when the particle's startLifeTime is higher than duration.