### PR TITLE
node setParent firstly send oldParent change message

### DIFF
--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -424,16 +424,6 @@ export class BaseNode extends CCObject implements ISchedulable {
             this.emit(SystemEventType.PARENT_CHANGED, oldParent);
         }
 
-        if (newParent) {
-            if (DEBUG && (newParent._objFlags & Deactivating)) {
-                errorID(3821);
-            }
-            newParent._children.push(this);
-            this._siblingIndex = newParent._children.length - 1;
-            if (newParent.emit) {
-                newParent.emit(SystemEventType.CHILD_ADDED, this);
-            }
-        }
         if (oldParent) {
             if (!(oldParent._objFlags & Destroying)) {
                 const removeAt = oldParent._children.indexOf(this);
@@ -447,8 +437,19 @@ export class BaseNode extends CCObject implements ISchedulable {
                 }
             }
         }
-        this._onHierarchyChanged(oldParent);
 
+        if (newParent) {
+            if (DEBUG && (newParent._objFlags & Deactivating)) {
+                errorID(3821);
+            }
+            newParent._children.push(this);
+            this._siblingIndex = newParent._children.length - 1;
+            if (newParent.emit) {
+                newParent.emit(SystemEventType.CHILD_ADDED, this);
+            }
+        }
+
+        this._onHierarchyChanged(oldParent);
     }
 
     /**


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * when node setParent， firstly send its old parent change ipc message，then send the new parent change message.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
