### PR TITLE
preventing Camera is null exception, for example recalculating editbox constraints after a resize , or even when rendering screen first time.

### DIFF
--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -470,7 +470,7 @@ let Camera = cc.Class({
          * @static
          */
         findCamera (node) {
-            let camera;
+            let camera=null;
             for (let i = 0, l = _cameras.length; i < l; i++) {
                  camera = _cameras[i];
                 if (camera.containsNode(node)) {

--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -470,14 +470,21 @@ let Camera = cc.Class({
          * @static
          */
         findCamera (node) {
+            let camera;
             for (let i = 0, l = _cameras.length; i < l; i++) {
-                let camera = _cameras[i];
+                 camera = _cameras[i];
                 if (camera.containsNode(node)) {
                     return camera;
                 }
             }
-
-            return null;
+                if(!camera){
+                    if(_cameras.length>0) camera=_cameras[0]; 
+                    /// return the first camera instead of returning null. EditBox raises error if no camera found , 
+                        ///this may also prevent some other bugs in some other cases. Generally, gamedev would not want to check if the camera is null.. 
+                    /// return the first camera to precalculate even not active objects, thus preventing exceptions. ...
+                     
+                }
+            return camera;
         },
 
         _findRendererCamera (node) {


### PR DESCRIPTION
When resizing the screen, editbox impl raises exception while calculating its position.

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
