### PR TITLE
fix rare editor crash caused by invalid PrivateNode data

### DIFF
--- a/cocos2d/core/CCPrivateNode.js
+++ b/cocos2d/core/CCPrivateNode.js
@@ -171,7 +171,27 @@ let PrivateNode = cc.Class({
     _updateOrderOfArrival() {},
 });
 
-cc.js.getset(PrivateNode.prototype, "parent", PrivateNode.prototype.getParent, PrivateNode.prototype.setParent);
-cc.js.getset(PrivateNode.prototype, "position", PrivateNode.prototype.getPosition, PrivateNode.prototype.setPosition);
+let proto = PrivateNode.prototype;
+cc.js.getset(proto, "parent", proto.getParent, proto.setParent);
+cc.js.getset(proto, "position", proto.getPosition, proto.setPosition);
+
+if (CC_EDITOR) {
+    // check components to avoid missing node reference serialied in previous version
+    proto._onBatchCreated = function () {
+        for (let comp of this._components) {
+            comp.node = this;
+        }
+
+        Node.prototype._onBatchCreated.call(this);
+    };
+    // check components to avoid missing node reference serialied in previous version
+    proto._onBatchRestored = function () {
+        for (let comp of this._components) {
+            comp.node = this;
+        }
+        
+        Node.prototype._onBatchRestored.call(this);
+    };
+}
 
 cc.PrivateNode = module.exports = PrivateNode;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复罕见的情况下场景或预制中的 RichText 数据如有问题时会导致编辑器崩溃的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
