### PR TITLE
Solve duplicated menu issue

### DIFF
--- a/@types/editor-extends.d.ts
+++ b/@types/editor-extends.d.ts
@@ -79,7 +79,7 @@ declare namespace EditorExtends {
          * Called when a cc-class is registered.
          * @param classConstructor Registering class.
          */
-        'class-registered'(classConstructor: Function, metadata?: Readonly<any>):  void;
+        'class-registered'(classConstructor: Function, metadata: Readonly<any> | undefined, className: string):  void;
     }
 
     type EventArgs<EventName extends keyof EventMap> = Parameters<EventMap[EventName]>;

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -746,6 +746,7 @@ value(Component, '_registerEditorProps', function (cls, props) {
                         menu = 'i18n:menu.custom_script/' + menu;
                     }
 
+                    EDITOR && EditorExtends.Component.removeMenu(cls);
                     EDITOR && EditorExtends.Component.addMenu(cls, menu, props.menuPriority);
                     break;
 

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -410,7 +410,7 @@ function define (className, baseClass, mixins, options) {
         // cc-class is defined by `cc.Class({/* ... */})`.
         // In such case, `options.ctor` may be `undefined`.
         // So we can not use `options.ctor`. Instead we should use `cls` which is the "real" registered cc-class.
-        EditorExtends.emit('class-registered', cls, frame);
+        EditorExtends.emit('class-registered', cls, frame, className);
     }
 
     if (frame) {
@@ -420,9 +420,6 @@ function define (className, baseClass, mixins, options) {
             if (uuid) {
                 js._setClassId(uuid, cls);
                 if (EDITOR) {
-                    // @ts-ignore
-                    // tslint:disable-next-line:no-unused-expression
-                    EditorExtends.Component.addMenu(cls, 'i18n:menu.custom_script/' + className, -1);
                     cls.prototype.__scriptUuid = EditorExtends.UuidUtils.decompressUuid(uuid);
                 }
             }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Solves that `@_decorator.menu` add a duplicated menu item into Editor. After this PR, it will override the default menu.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
