### PR TITLE
richtext use canvas api

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -773,8 +773,10 @@ let Label = cc.Class({
         BlendFunc.prototype._updateMaterial.call(this);
     },
 
+    _forceUseCanvas: false,
+
     _nativeTTF() {
-        return !!this._assembler && !!this._assembler._updateTTFMaterial
+        return  !this._forceUseCanvas && !!this._assembler && !!this._assembler._updateTTFMaterial;
     },
 
     _forceUpdateRenderData () {

--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -96,6 +96,7 @@ pool.get = function (string, richtext) {
     labelComponent.string = "";
     labelComponent.horizontalAlign = HorizontalAlign.LEFT;
     labelComponent.verticalAlign = VerticalAlign.CENTER;
+    labelComponent._forceUseCanvas = true;
 
     return labelNode;
 };

--- a/cocos2d/core/renderer/webgl/assemblers/label/index.js
+++ b/cocos2d/core/renderer/webgl/assemblers/label/index.js
@@ -77,7 +77,7 @@ Assembler.register(cc.Label, {
             ctor = is3DNode ? Bmfont3D : Bmfont;
         } else if (label.cacheMode === Label.CacheMode.CHAR) {
 
-            if(CC_JSB && !is3DNode && !!jsb.LabelRenderer && label.font instanceof cc.TTFFont){
+            if(CC_JSB && !is3DNode && !!jsb.LabelRenderer && label.font instanceof cc.TTFFont && !label._forceUseCanvas){
                 ctor = NativeTTF;
             } else if (cc.sys.platform === cc.sys.WECHAT_GAME_SUB) {
                 cc.warn('sorry, subdomain does not support CHAR mode currently!');


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2985

Changes:
 * `RichText`  use canvas API instead of NativeTTF assembler


