### PR TITLE
fix audio sometimes not work in wkwebview

### DIFF
--- a/cocos/audio/assets/player-web.ts
+++ b/cocos/audio/assets/player-web.ts
@@ -73,7 +73,13 @@ export class AudioPlayerWeb extends AudioPlayer {
 
     public play () {
         if (!this._audio || this._state === PlayingState.PLAYING) { return; }
-        if (this._blocking || this._context.state !== 'running') { this._interrupted = true; return; }
+        if (this._blocking || this._context.state !== 'running') { 
+            this._interrupted = true; 
+            if ('interrupted' === this._context.state as any && this._context.resume) {
+                this._onGesture();
+            }
+            return; 
+        }
         this._doPlay();
     }
 


### PR DESCRIPTION
fix audio wich use player-web sometimes not work in wkwebview

场景：打包web-mobile，在ios的wkwebview中加载。
问题1：预加载音频时，this._context.state为running，但是播放的时候this._context.state为interrupted。
问题2：切到后台再切回，this._context.state为interrupted。
解决方案：如果在播放的时候，如果状态为interrupted，强制resume一下。
相关信息：https://github.com/goldfire/howler.js/pull/928

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
