### PR TITLE
Optimize editor decorators

### DIFF
--- a/cocos/audio/audio-source-component.ts
+++ b/cocos/audio/audio-source-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../core/components/component';
-import { ccclass, help, menu, property } from '../core/data/class-decorator';
+import { ccclass, help, menu, property, tooltip } from '../core/data/class-decorator';
 import { clamp } from '../core/math';
 import { AudioClip } from './assets/clip';
 
@@ -62,8 +62,8 @@ export class AudioSourceComponent extends Component {
      */
     @property({
         type: AudioClip,
-        tooltip: 'i18n:audio.clip',
     })
+    @tooltip('i18n:audio.clip')
     set clip (val) {
         this._clip = val;
         this._syncStates();
@@ -78,9 +78,7 @@ export class AudioSourceComponent extends Component {
      * @zh
      * 是否循环播放音频？
      */
-    @property({
-        tooltip: 'i18n:audio.loop',
-    })
+    @tooltip('i18n:audio.loop')
     set loop (val) {
         this._loop = val;
         if (this._clip) { this._clip.setLoop(val); }
@@ -100,9 +98,7 @@ export class AudioSourceComponent extends Component {
      * 请注意，根据最新的自动播放策略，现在对大多数平台，自动播放只会在第一次收到用户输入后生效。 <br>
      * 参考：https://www.chromium.org/audio-video/autoplay
      */
-    @property({
-        tooltip: 'i18n:audio.playOnAwake',
-    })
+    @tooltip('i18n:audio.playOnAwake')
     set playOnAwake (val) {
         this._playOnAwake = val;
     }
@@ -120,8 +116,8 @@ export class AudioSourceComponent extends Component {
      */
     @property({
         range: [0.0, 1.0],
-        tooltip: 'i18n:audio.volume',
     })
+    @tooltip('i18n:audio.volume')
     set volume (val) {
         if (isNaN(val)) { console.warn('illegal audio volume!'); return; }
         val = clamp(val, 0, 1);

--- a/cocos/core/3d/framework/batched-skinning-model-component.ts
+++ b/cocos/core/3d/framework/batched-skinning-model-component.ts
@@ -33,7 +33,7 @@ import { Material } from '../../assets/material';
 import { Mesh } from '../../assets/mesh';
 import { Skeleton } from '../../assets/skeleton';
 import { Texture2D } from '../../assets/texture-2d';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../data/class-decorator';
 import { CCString } from '../../data/utils/attribute';
 import { GFXAttributeName, GFXBufferTextureCopy, GFXFormatInfos } from '../../gfx/define';
 import { GFXFormat, GFXType } from '../../gfx/define';
@@ -140,9 +140,7 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
      * @en Size of the generated texture atlas.
      * @zh 合图生成的最终图集的边长。
      */
-    @property({
-        tooltip: 'i18n:batched_skinning_model.atlas_size',
-    })
+    @tooltip('i18n:batched_skinning_model.atlas_size')
     public atlasSize: number = 1024;
 
     /**
@@ -154,8 +152,8 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
      */
     @property({
         type: [CCString],
-        tooltip: 'i18n:batched_skinning_model.batchable_texture_names',
     })
+    @tooltip('i18n:batched_skinning_model.batchable_texture_names')
     public batchableTextureNames: string[] = [];
 
     /**
@@ -164,8 +162,8 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
      */
     @property({
         type: [SkinningModelUnit],
-        tooltip: 'i18n:batched_skinning_model.units',
     })
+    @tooltip('i18n:batched_skinning_model.units')
     public units: SkinningModelUnit[] = [];
 
     private _textures: Record<string, Texture2D> = {};

--- a/cocos/core/3d/framework/camera-component.ts
+++ b/cocos/core/3d/framework/camera-component.ts
@@ -31,7 +31,7 @@ import { EDITOR } from 'internal:constants';
 import { RenderTexture } from '../../assets/render-texture';
 import { UITransformComponent } from '../../components';
 import { Component } from '../../components/component';
-import { ccclass, help, executeInEditMode, menu, property } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../../data/class-decorator';
 import { ray } from '../../geometry';
 import { GFXClearFlag } from '../../gfx/define';
 import { Color, Rect, toRadian, Vec3 } from '../../math';
@@ -142,9 +142,9 @@ export class CameraComponent extends Component {
      * @zh 相机的渲染优先级，值越小越优先渲染。
      */
     @property({
-        tooltip: 'i18n:camera.priority',
         displayOrder: 0,
     })
+    @tooltip('i18n:camera.priority')
     get priority () {
         return this._priority;
     }
@@ -162,9 +162,9 @@ export class CameraComponent extends Component {
      */
     @property({
         type: Layers.BitMask,
-        tooltip: 'i18n:camera.visibility',
         displayOrder: 1,
     })
+    @tooltip('i18n:camera.visibility')
     get visibility () {
         return this._visibility;
     }
@@ -182,9 +182,9 @@ export class CameraComponent extends Component {
      */
     @property({
         type: ClearFlag,
-        tooltip: 'i18n:camera.clear_flags',
         displayOrder: 2,
     })
+    @tooltip('i18n:camera.clear_flags')
     get clearFlags () {
         return this._clearFlags;
     }
@@ -199,9 +199,9 @@ export class CameraComponent extends Component {
      * @zh 相机的颜色缓冲默认值。
      */
     @property({
-        tooltip: 'i18n:camera.color',
         displayOrder: 3,
     })
+    @tooltip('i18n:camera.color')
     // @constget
     get clearColor (): Readonly<Color> {
         return this._color;
@@ -222,9 +222,9 @@ export class CameraComponent extends Component {
      * @zh 相机的深度缓冲默认值。
      */
     @property({
-        tooltip: 'i18n:camera.depth',
         displayOrder: 4,
     })
+    @tooltip('i18n:camera.depth')
     get clearDepth () {
         return this._depth;
     }
@@ -239,9 +239,9 @@ export class CameraComponent extends Component {
      * @zh 相机的模板缓冲默认值。
      */
     @property({
-        tooltip: 'i18n:camera.stencil',
         displayOrder: 5,
     })
+    @tooltip('i18n:camera.stencil')
     get clearStencil () {
         return this._stencil;
     }
@@ -257,9 +257,9 @@ export class CameraComponent extends Component {
      */
     @property({
         type: ProjectionType,
-        tooltip: 'i18n:camera.projection',
         displayOrder: 6,
     })
+    @tooltip('i18n:camera.projection')
     get projection () {
         return this._projection;
     }
@@ -275,9 +275,9 @@ export class CameraComponent extends Component {
      */
     @property({
         type: FOVAxis,
-        tooltip: 'i18n:camera.fov_axis',
         displayOrder: 7,
     })
+    @tooltip('i18n:camera.fov_axis')
     get fovAxis () {
         return this._fovAxis;
     }
@@ -297,9 +297,9 @@ export class CameraComponent extends Component {
      * @zh 相机的视角大小。
      */
     @property({
-        tooltip: 'i18n:camera.fov',
         displayOrder: 8,
     })
+    @tooltip('i18n:camera.fov')
     get fov () {
         return this._fov;
     }
@@ -314,9 +314,9 @@ export class CameraComponent extends Component {
      * @zh 正交模式下的相机视角高度。
      */
     @property({
-        tooltip: 'i18n:camera.ortho_height',
         displayOrder: 9,
     })
+    @tooltip('i18n:camera.ortho_height')
     get orthoHeight () {
         return this._orthoHeight;
     }
@@ -331,9 +331,9 @@ export class CameraComponent extends Component {
      * @zh 相机的近裁剪距离，应在可接受范围内尽量取最大。
      */
     @property({
-        tooltip: 'i18n:camera.near',
         displayOrder: 10,
     })
+    @tooltip('i18n:camera.near')
     get near () {
         return this._near;
     }
@@ -348,9 +348,9 @@ export class CameraComponent extends Component {
      * @zh 相机的远裁剪距离，应在可接受范围内尽量取最小。
      */
     @property({
-        tooltip: 'i18n:camera.far',
         displayOrder: 11,
     })
+    @tooltip('i18n:camera.far')
     get far () {
         return this._far;
     }
@@ -366,9 +366,9 @@ export class CameraComponent extends Component {
      */
     @property({
         type: Aperture,
-        tooltip: 'i18n:camera.aperture',
         displayOrder: 12,
     })
+    @tooltip('i18n:camera.aperture')
     get aperture () {
         return this._aperture;
     }
@@ -384,9 +384,9 @@ export class CameraComponent extends Component {
      */
     @property({
         type: Shutter,
-        tooltip: 'i18n:camera.shutter',
         displayOrder: 13,
     })
+    @tooltip('i18n:camera.shutter')
     get shutter () {
         return this._shutter;
     }
@@ -402,9 +402,9 @@ export class CameraComponent extends Component {
      */
     @property({
         type: ISO,
-        tooltip: 'i18n:camera.ISO',
         displayOrder: 14,
     })
+    @tooltip('i18n:camera.ISO')
     get iso () {
         return this._iso;
     }
@@ -419,9 +419,9 @@ export class CameraComponent extends Component {
      * @zh 此相机最终渲染到屏幕上的视口位置和大小。
      */
     @property({
-        tooltip: 'i18n:camera.rect',
         displayOrder: 15,
     })
+    @tooltip('i18n:camera.rect')
     get rect () {
         return this._rect;
     }
@@ -437,9 +437,9 @@ export class CameraComponent extends Component {
      */
     @property({
         type: RenderTexture,
-        tooltip: 'i18n:camera.target_texture',
         displayOrder: 16,
     })
+    @tooltip('i18n:camera.target_texture')
     get targetTexture () {
         return this._targetTexture;
     }

--- a/cocos/core/3d/framework/directional-light-component.ts
+++ b/cocos/core/3d/framework/directional-light-component.ts
@@ -27,7 +27,7 @@
  * @category component/light
  */
 
-import { ccclass, help, executeInEditMode, menu, property } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../../data/class-decorator';
 import { DirectionalLight } from '../../renderer/scene/directional-light';
 import { LightType } from '../../renderer/scene/light';
 import { LightComponent } from './light-component';
@@ -52,8 +52,8 @@ export class DirectionalLightComponent extends LightComponent {
      */
     @property({
         unit: 'lx',
-        tooltip: 'i18n:lights.illuminance',
     })
+    @tooltip('i18n:lights.illuminance')
     get illuminance () {
         return this._illuminance;
     }

--- a/cocos/core/3d/framework/light-component.ts
+++ b/cocos/core/3d/framework/light-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../../components/component';
-import { ccclass, property } from '../../data/class-decorator';
+import { ccclass, property, tooltip } from '../../data/class-decorator';
 import { Color } from '../../math';
 import { Enum } from '../../value-types';
 
@@ -127,9 +127,7 @@ export class LightComponent extends Component {
      * @zh
      * 光源颜色。
      */
-    @property({
-        tooltip: 'i18n:lights.color',
-    })
+    @tooltip('i18n:lights.color')
     // @constget
     get color (): Readonly<Color> {
         return this._color;
@@ -149,9 +147,7 @@ export class LightComponent extends Component {
      * @zh
      * 是否启用光源色温。
      */
-    @property({
-        tooltip: 'i18n:lights.use_color_temperature',
-    })
+    @tooltip('i18n:lights.use_color_temperature')
     get useColorTemperature () {
         return this._useColorTemperature;
     }
@@ -169,8 +165,8 @@ export class LightComponent extends Component {
     @property({
         slide: true,
         range: [1000, 15000, 1],
-        tooltip: 'i18n:lights.color_temperature',
     })
+    @tooltip('i18n:lights.color_temperature')
     get colorTemperature () {
         return this._colorTemperature;
     }

--- a/cocos/core/3d/framework/model-component.ts
+++ b/cocos/core/3d/framework/model-component.ts
@@ -30,7 +30,7 @@
 import { Texture2D } from '../../assets';
 import { Material } from '../../assets/material';
 import { Mesh } from '../../assets/mesh';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../data/class-decorator';
 import { Vec4 } from '../../math';
 import { Model } from '../../renderer/scene/model';
 import { MorphModel } from '../../renderer/models/morph-model';
@@ -187,8 +187,8 @@ export class ModelComponent extends RenderableComponent {
      */
     @property({
         type: ModelShadowCastingMode,
-        tooltip: 'i18n:model.shadow_casting_model',
     })
+    @tooltip('i18n:model.shadow_casting_model')
     get shadowCastingMode () {
         return this._shadowCastingMode;
     }
@@ -204,8 +204,8 @@ export class ModelComponent extends RenderableComponent {
      */
     @property({
         type: ModelShadowReceivingMode,
-        tooltip: 'i18n:model.shadow_receiving_model',
     })
+    @tooltip('i18n:model.shadow_receiving_model')
     get receiveShadow () {
         return this._shadowReceivingMode;
     }
@@ -221,8 +221,8 @@ export class ModelComponent extends RenderableComponent {
      */
     @property({
         type: Mesh,
-        tooltip: 'i18n:model.mesh',
     })
+    @tooltip('i18n:model.mesh')
     get mesh () {
         return this._mesh;
     }

--- a/cocos/core/3d/framework/skinning-model-component.ts
+++ b/cocos/core/3d/framework/skinning-model-component.ts
@@ -31,7 +31,7 @@ import { AnimationClip } from '../../animation/animation-clip';
 import { BatchingSchemes } from '../../renderer/core/pass';
 import { Material } from '../../assets';
 import { Skeleton } from '../../assets/skeleton';
-import { ccclass, executeInEditMode, executionOrder, help, menu, property } from '../../data/class-decorator';
+import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip } from '../../data/class-decorator';
 import { BakedSkinningModel } from '../../renderer/models/baked-skinning-model';
 import { SkinningModel } from '../../renderer/models/skinning-model';
 import { Node } from '../../scene-graph/node';
@@ -81,8 +81,8 @@ export class SkinningModelComponent extends ModelComponent {
      */
     @property({
         type: Node,
-        tooltip: 'i18n:model.skinning_root',
     })
+    @tooltip('i18n:model.skinning_root')
     get skinningRoot () {
         return this._skinningRoot;
     }

--- a/cocos/core/3d/framework/sphere-light-component.ts
+++ b/cocos/core/3d/framework/sphere-light-component.ts
@@ -26,7 +26,7 @@
  * @category component/light
  */
 
-import { ccclass, help, executeInEditMode, menu, property } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../../data/class-decorator';
 import { LightType, nt2lm } from '../../renderer/scene/light';
 import { SphereLight } from '../../renderer/scene/sphere-light';
 import { LightComponent, PhotometricTerm } from './light-component';
@@ -55,8 +55,8 @@ export class SphereLightComponent extends LightComponent {
      */
     @property({
         unit: 'lm',
-        tooltip: 'i18n:lights.luminous_power',
     })
+    @tooltip('i18n:lights.luminous_power')
     get luminousPower () {
         return this._luminance * nt2lm(this._size);
     }
@@ -71,8 +71,8 @@ export class SphereLightComponent extends LightComponent {
      */
     @property({
         unit: 'cd/m²',
-        tooltip: 'i18n:lights.luminance',
     })
+    @tooltip('i18n:lights.luminance')
     get luminance () {
         return this._luminance;
     }
@@ -87,8 +87,8 @@ export class SphereLightComponent extends LightComponent {
      */
     @property({
         type: PhotometricTerm,
-        tooltip: 'i18n:lights.term',
     })
+    @tooltip('i18n:lights.term')
     get term () {
         return this._term;
     }
@@ -102,9 +102,7 @@ export class SphereLightComponent extends LightComponent {
      * @zh
      * 光源大小。
      */
-    @property({
-        tooltip: 'i18n:lights.size',
-    })
+    @tooltip('i18n:lights.size')
     get size () {
         return this._size;
     }
@@ -119,9 +117,7 @@ export class SphereLightComponent extends LightComponent {
      * @zh
      * 光源范围。
      */
-    @property({
-        tooltip: 'i18n:lights.range',
-    })
+    @tooltip('i18n:lights.range')
     get range () {
         return this._range;
     }

--- a/cocos/core/3d/framework/spot-light-component.ts
+++ b/cocos/core/3d/framework/spot-light-component.ts
@@ -27,7 +27,7 @@
  * @category component/light
  */
 
-import { ccclass, help, executeInEditMode, menu, property } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../../data/class-decorator';
 import { toRadian } from '../../math';
 import { LightType, nt2lm } from '../../renderer/scene/light';
 import { SpotLight } from '../../renderer/scene/spot-light';
@@ -59,8 +59,8 @@ export class SpotLightComponent extends LightComponent {
      */
     @property({
         unit: 'lm',
-        tooltip: 'i18n:lights.luminous_power',
     })
+    @tooltip('i18n:lights.luminous_power')
     get luminousPower () {
         return this._luminance * nt2lm(this._size);
     }
@@ -75,8 +75,8 @@ export class SpotLightComponent extends LightComponent {
      */
     @property({
         unit: 'cd/m²',
-        tooltip: 'i18n:lights.luminance',
     })
+    @tooltip('i18n:lights.luminance')
     get luminance () {
         return this._luminance;
     }
@@ -91,8 +91,8 @@ export class SpotLightComponent extends LightComponent {
      */
     @property({
         type: PhotometricTerm,
-        tooltip: 'i18n:lights.term',
     })
+    @tooltip('i18n:lights.term')
     get term () {
         return this._term;
     }
@@ -106,9 +106,7 @@ export class SpotLightComponent extends LightComponent {
      * @zh
      * 光源大小。
      */
-    @property({
-        tooltip: 'i18n:lights.size',
-    })
+    @tooltip('i18n:lights.size')
     get size () {
         return this._size;
     }
@@ -123,9 +121,7 @@ export class SpotLightComponent extends LightComponent {
      * @zh
      * 光源范围。
      */
-    @property({
-        tooltip: 'i18n:lights.range',
-    })
+    @tooltip('i18n:lights.range')
     get range () {
         return this._range;
     }
@@ -143,8 +139,8 @@ export class SpotLightComponent extends LightComponent {
     @property({
         slide: true,
         range: [2, 180, 1],
-        tooltip: 'The spot light cone angle',
     })
+    @tooltip('The spot light cone angle')
     get spotAngle () {
         return this._spotAngle;
     }

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../components/component';
-import { ccclass, executeInEditMode, executionOrder, help, menu, property } from '../data/class-decorator';
+import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip } from '../data/class-decorator';
 import { Eventify } from '../event/eventify';
 import { warnID } from '../platform/debug';
 import * as ArrayUtils from '../utils/array';
@@ -70,8 +70,8 @@ export class AnimationComponent extends Eventify(Component) {
      */
     @property({
         type: [AnimationClip],
-        tooltip: '此动画组件管理的动画剪辑',
     })
+    @tooltip('此动画组件管理的动画剪辑')
     get clips () {
         return this._clips;
     }
@@ -113,8 +113,8 @@ export class AnimationComponent extends Eventify(Component) {
      */
     @property({
         type: AnimationClip,
-        tooltip: '默认动画剪辑',
     })
+    @tooltip('默认动画剪辑')
     get defaultClip () {
         return this._defaultClip;
     }
@@ -141,9 +141,7 @@ export class AnimationComponent extends Eventify(Component) {
      * 是否在组件开始运行时自动播放默认剪辑。
      * 注意，若在组件开始运行前调用了 `crossFade` 或 `play()`，此字段将不会生效。
      */
-    @property({
-        tooltip: '是否在动画组件开始运行时自动播放默认动画剪辑',
-    })
+    @tooltip('是否在动画组件开始运行时自动播放默认动画剪辑')
     public playOnLoad = false;
 
     protected _crossFade = new CrossFade();

--- a/cocos/core/animation/skeletal-animation-component.ts
+++ b/cocos/core/animation/skeletal-animation-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { SkinningModelComponent } from '../3d/framework/skinning-model-component';
-import { ccclass, executeInEditMode, executionOrder, help, menu, property } from '../data/class-decorator';
+import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip } from '../data/class-decorator';
 import { Mat4 } from '../math';
 import { DataPoolManager } from '../renderer/data-pool-manager';
 import { Node } from '../scene-graph/node';
@@ -106,8 +106,8 @@ export class SkeletalAnimationComponent extends AnimationComponent {
      */
     @property({
         type: [Socket],
-        tooltip: 'i18n:animation.sockets',
     })
+    @tooltip('i18n:animation.sockets')
     get sockets () {
         return this._sockets;
     }
@@ -130,9 +130,7 @@ export class SkeletalAnimationComponent extends AnimationComponent {
      * 是否使用预烘焙动画，默认启用，可以大幅提高运行效时率，但所有动画效果会被彻底固定，不支持任何形式的编辑和混合。<br>
      * 运行时动态修改此选项会在播放下一条动画片段时生效。
      */
-    @property({
-        tooltip: 'i18n:animation.use_baked_animation',
-    })
+    @tooltip('i18n:animation.use_baked_animation')
     get useBakedAnimation () {
         return this._useBakedAnimation;
     }

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -31,7 +31,7 @@
  */
 
 import { Script } from '../assets/scripts';
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, tooltip } from '../data/class-decorator';
 import { CCObject } from '../data/object';
 import IDGenerator from '../utils/id-generator';
 import { getClassName, value } from '../utils/js';
@@ -107,8 +107,8 @@ class Component extends CCObject {
     @property({
         displayName: 'Script',
         type: Script,
-        tooltip: DEV ? 'i18n:INSPECTOR.component.script' : undefined,
     })
+    @tooltip('i18n:INSPECTOR.component.script')
     get __scriptAsset () { return null; }
 
     /**

--- a/cocos/core/components/ui-base/canvas-component.ts
+++ b/cocos/core/components/ui-base/canvas-component.ts
@@ -30,7 +30,7 @@
 
 import { CameraComponent } from '../../3d/framework/camera-component';
 import { RenderTexture } from '../../assets/render-texture';
-import { ccclass, help, disallowMultiple, executeInEditMode, executionOrder, menu, property, requireComponent } from '../../data/class-decorator';
+import { ccclass, help, disallowMultiple, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip } from '../../data/class-decorator';
 import { director, Director } from '../../director';
 import { game } from '../../game';
 import { GFXClearFlag } from '../../gfx/define';
@@ -87,8 +87,8 @@ export class CanvasComponent extends Component {
      */
     @property({
         type: CanvasClearFlag,
-        tooltip: '清理屏幕缓冲标记',
     })
+    @tooltip('清理屏幕缓冲标记')
     get clearFlag () {
         return this._clearFlag;
     }
@@ -107,9 +107,7 @@ export class CanvasComponent extends Component {
      * @zh
      * 内置相机的颜色缓冲默认值。
      */
-    @property({
-        tooltip: '清理颜色缓冲区后的颜色',
-    })
+    @property('清理颜色缓冲区后的颜色')
     get color () {
         return this._color;
     }
@@ -139,8 +137,8 @@ export class CanvasComponent extends Component {
      */
     @property({
         type: RenderMode,
-        tooltip: 'Canvas 渲染模式，intersperse 下可以指定 Canvas 与场景中的相机的渲染顺序，overlay 下 Canvas 会在所有场景相机渲染完成后渲染。\n注意：注意：场景里的相机（包括 Canvas 内置的相机）必须有一个的 ClearFlag 选择 SOLID_COLOR，否则在移动端可能会出现闪屏',
     })
+    @tooltip('Canvas 渲染模式，intersperse 下可以指定 Canvas 与场景中的相机的渲染顺序，overlay 下 Canvas 会在所有场景相机渲染完成后渲染。\n注意：注意：场景里的相机（包括 Canvas 内置的相机）必须有一个的 ClearFlag 选择 SOLID_COLOR，否则在移动端可能会出现闪屏')
     get renderMode () {
         return this._renderMode;
     }
@@ -163,9 +161,7 @@ export class CanvasComponent extends Component {
      *
      * @param value - 渲染优先级。
      */
-    @property({
-        tooltip: '相机排序优先级。当 RenderMode 为 intersperse 时，指定与其它相机的渲染顺序，当 RenderMode 为 overlay 时，指定跟其余 Canvas 做排序使用。需要对多 Canvas 设定 priority 以免出现不同平台下的闪屏问题。',
-    })
+    @tooltip('相机排序优先级。当 RenderMode 为 intersperse 时，指定与其它相机的渲染顺序，当 RenderMode 为 overlay 时，指定跟其余 Canvas 做排序使用。需要对多 Canvas 设定 priority 以免出现不同平台下的闪屏问题。')
     get priority () {
         return this._priority;
     }
@@ -190,8 +186,8 @@ export class CanvasComponent extends Component {
      */
     @property({
         type: RenderTexture,
-        tooltip: '目标渲染纹理',
     })
+    @tooltip('目标渲染纹理')
     get targetTexture (){
         return this._targetTexture;
     }

--- a/cocos/core/components/ui-base/ui-render-component.ts
+++ b/cocos/core/components/ui-base/ui-render-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { RenderableComponent } from '../../../core/3d/framework/renderable-component';
-import { ccclass, property } from '../../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../../core/data/class-decorator';
 import { Color } from '../../../core/math';
 import { SystemEventType } from '../../../core/platform/event-manager/event-enum';
 import { ccenum } from '../../../core/value-types/enum';
@@ -134,8 +134,8 @@ export class UIRenderComponent extends UIComponent {
     @property({
         type: GFXBlendFactor,
         displayOrder: 0,
-        tooltip: '原图混合模式',
     })
+    @tooltip('原图混合模式')
     get srcBlendFactor () {
         return this._srcBlendFactor;
     }
@@ -165,8 +165,8 @@ export class UIRenderComponent extends UIComponent {
     @property({
         type: GFXBlendFactor,
         displayOrder: 1,
-        tooltip: '目标混合模式',
     })
+    @tooltip('目标混合模式')
     get dstBlendFactor () {
         return this._dstBlendFactor;
     }
@@ -191,8 +191,8 @@ export class UIRenderComponent extends UIComponent {
      */
     @property({
         displayOrder: 2,
-        tooltip: '渲染颜色',
     })
+    @tooltip('渲染颜色')
     // @constget
     get color (): Readonly<Color> {
         return this._color;
@@ -217,9 +217,9 @@ export class UIRenderComponent extends UIComponent {
     @property({
         type: Material,
         displayOrder: 3,
-        tooltip: '源材质',
         visible: false,
     })
+    @tooltip('源材质')
     get sharedMaterial () {
         return this._sharedMaterial;
     }

--- a/cocos/core/components/ui-base/ui-transform-component.ts
+++ b/cocos/core/components/ui-base/ui-transform-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../component';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../data/class-decorator';
 import { SystemEventType } from '../../platform/event-manager/event-enum';
 import { EventListener, IListenerMask } from '../../platform/event-manager/event-listener';
 import { Mat4, Rect, Size, Vec2, Vec3 } from '../../math';
@@ -69,8 +69,8 @@ export class UITransformComponent extends Component {
      */
     @property({
         displayOrder: 0,
-        tooltip:'内容尺寸',
     })
+    @tooltip('内容尺寸')
     // @constget
     get contentSize (): Readonly<Size> {
         return this._contentSize;
@@ -151,8 +151,8 @@ export class UITransformComponent extends Component {
      */
     @property({
         displayOrder: 1,
-        tooltip:'锚点位置',
     })
+    @tooltip('锚点位置')
     // @constget
     get anchorPoint (): Readonly<Vec2> {
         return this._anchorPoint;
@@ -201,9 +201,7 @@ export class UITransformComponent extends Component {
      * @zh
      * 渲染先后顺序，按照广度渲染排列，按同级节点下进行一次排列。
      */
-    @property({
-        tooltip: '渲染排序优先级'
-    })
+    @tooltip('渲染排序优先级')
     get priority() {
         return this._priority;
     }

--- a/cocos/core/components/ui-coodinate-tracker-component.ts
+++ b/cocos/core/components/ui-coodinate-tracker-component.ts
@@ -30,7 +30,7 @@
 
 import { Component } from './component';
 import { EventHandler } from './component-event-handler';
-import { ccclass, help, property, menu, executionOrder } from '../data/class-decorator';
+import { ccclass, help, property, menu, executionOrder, tooltip } from '../data/class-decorator';
 import { Node } from '../scene-graph';
 import { convertUtils } from '../utils';
 import { CameraComponent } from '../3d';
@@ -51,8 +51,8 @@ export class UICoordinateTrackerComponent extends Component {
      */
     @property({
         type: Node,
-        tooltip: '目标对象',
     })
+    @tooltip('目标对象')
     get target () {
         return this._target;
     }
@@ -72,8 +72,8 @@ export class UICoordinateTrackerComponent extends Component {
      */
     @property({
         type: CameraComponent,
-        tooltip: '照射相机',
     })
+    @tooltip('照射相机')
     get camera () {
         return this._camera;
     }
@@ -91,9 +91,7 @@ export class UICoordinateTrackerComponent extends Component {
      * @zh
      * 是否是缩放映射。
      */
-    @property({
-        tooltip: '是否是缩放映射',
-    })
+    @tooltip('是否是缩放映射')
     get useScale () {
         return this._useScale;
     }
@@ -110,9 +108,7 @@ export class UICoordinateTrackerComponent extends Component {
      * @zh
      * 距相机多少距离为正常显示计算大小。
      */
-    @property({
-        tooltip: '距相机多少距离为正常显示计算大小',
-    })
+    @tooltip('距相机多少距离为正常显示计算大小')
     get distance () {
         return this._distance;
     }
@@ -131,8 +127,8 @@ export class UICoordinateTrackerComponent extends Component {
      */
     @property({
         type: [EventHandler],
-        tooltip: '映射数据事件。回调的第一个参数是映射后的本地坐标，第二个是距相机距离比',
     })
+    @tooltip('映射数据事件。回调的第一个参数是映射后的本地坐标，第二个是距相机距离比')
     public syncEvents: EventHandler[] = [];
 
     @property

--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -361,6 +361,18 @@ export function property (ctorProtoOrOptions?, propName?, desc?) {
 
 // Editor Decorators
 
+/**
+ * A class decorator which does nothing.
+ */
+const emptyClassDecorator: ClassDecorator | PropertyDecorator = () => {};
+
+/**
+ * Ignoring all arguments and return the `emptyClassDecorator`.
+ */
+const ignoringArgsClassDecorator = () => emptyClassDecorator;
+
+const ignoringArgsPropertyDecorator = () => emptyClassDecorator as PropertyDecorator;
+
 function createEditorDecorator (argCheckFunc, editorPropName, staticValue?) {
     return argCheckFunc(function (ctor, decoratedValue) {
         const cache = getClassCache(ctor, editorPropName);
@@ -429,7 +441,7 @@ export const requireComponent: (requiredComponent: Function) => Function = creat
  * }
  * ```
  */
-export const menu: (path: string) => Function = (DEV ? createEditorDecorator : createDummyDecorator)(checkStringArgument, 'menu');
+export const menu: (path: string) => ClassDecorator = DEV ? createEditorDecorator(checkStringArgument, 'menu') : ignoringArgsClassDecorator;
 
 /**
  * @en Set the component priority, it decides at which order the life cycle functions of components will be invoked. Smaller priority get invoked before larger priority.
@@ -447,7 +459,7 @@ export const menu: (path: string) => Function = (DEV ? createEditorDecorator : c
  * }
  * ```
  */
-export const executionOrder: (priority: number) => Function = createEditorDecorator(checkNumberArgument, 'executionOrder');
+export const executionOrder: (priority: number) => ClassDecorator = createEditorDecorator(checkNumberArgument, 'executionOrder');
 
 /**
  * @en Forbid add multiple instances of the component to the same node.
@@ -497,7 +509,7 @@ export const playOnFocus = (DEV ? createEditorDecorator : createDummyDecorator)(
  * }
  * ```
  */
-export const inspector: (url: string) => Function = (DEV ? createEditorDecorator : createDummyDecorator)(checkStringArgument, 'inspector');
+export const inspector: (url: string) => ClassDecorator = DEV ? createEditorDecorator(checkStringArgument, 'inspector') : ignoringArgsClassDecorator;
 
 /**
  * @en Define the icon of the component.
@@ -515,7 +527,7 @@ export const inspector: (url: string) => Function = (DEV ? createEditorDecorator
  * }
  * ```
  */
-export const icon: (url: string) => Function = (DEV ? createEditorDecorator : createDummyDecorator)(checkStringArgument, 'icon');
+export const icon: (url: string) => ClassDecorator = DEV ? createEditorDecorator(checkStringArgument, 'icon') : ignoringArgsClassDecorator;
 
 /**
  * @en Define the help documentation url, if given, the component section in the **inspector** will have a help documentation icon reference to the web page given. 
@@ -532,7 +544,7 @@ export const icon: (url: string) => Function = (DEV ? createEditorDecorator : cr
  * }
  * ```
  */
-export const help: (url: string) => Function = (DEV ? createEditorDecorator : createDummyDecorator)(checkStringArgument, 'help');
+export const help: (url: string) => ClassDecorator = DEV ? createEditorDecorator(checkStringArgument, 'help') : ignoringArgsClassDecorator;
 
 // Other Decorators
 
@@ -578,3 +590,17 @@ export function type<T> (type: PrimitiveType<T> | Function | [PrimitiveType<T>] 
         type,
     });
 }
+
+/**
+ * @en
+ * Set the editor tooltip content of the property.
+ * @zh
+ * 设置该属性在编辑器中的工具提示内容。
+ * @param text 工具提示。
+ */
+export const tooltip: (text: string) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (text: string): PropertyDecorator => {
+        return property({
+            tooltip: text,
+        });
+    };

--- a/cocos/core/platform/SubContextView.ts
+++ b/cocos/core/platform/SubContextView.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../components/component';
-import { property, ccclass, help, menu, executionOrder, requireComponent } from '../data/class-decorator';
+import { property, ccclass, help, menu, executionOrder, requireComponent, tooltip } from '../data/class-decorator';
 import { view } from './view';
 import { SpriteComponent } from '../../ui/components/sprite-component';
 import { Node } from '../scene-graph';
@@ -65,9 +65,7 @@ import { legacyCC } from '../global-exports';
 @requireComponent(UITransformComponent)
 @menu('Components/SubContextView')
 export class SubContextView extends Component {
-    @property({
-        tooltip:'帧数',
-    })
+    @tooltip('帧数')
     get fps (){
         return this._fps;
     }

--- a/cocos/particle/animator/force-overtime.ts
+++ b/cocos/particle/animator/force-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { pseudoRandom, Quat, Vec3 } from '../../core/math';
 import { Space } from '../enum';
 import { calculateTransform } from '../particle-general-function';
@@ -44,8 +44,8 @@ export default class ForceOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 2,
-        tooltip:'X 轴方向上的加速度分量',
     })
+    @tooltip('X 轴方向上的加速度分量')
     public x = new CurveRange();
 
     /**
@@ -55,8 +55,8 @@ export default class ForceOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 3,
-        tooltip:'Y 轴方向上的加速度分量',
     })
+    @tooltip('Y 轴方向上的加速度分量')
     public y = new CurveRange();
 
     /**
@@ -66,8 +66,8 @@ export default class ForceOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 4,
-        tooltip:'Z 轴方向上的加速度分量',
     })
+    @tooltip('Z 轴方向上的加速度分量')
     public z = new CurveRange();
 
     /**
@@ -76,8 +76,8 @@ export default class ForceOvertimeModule extends ParticleModuleBase {
     @property({
         type: Space,
         displayOrder: 1,
-        tooltip:'加速度计算时采用的坐标',
     })
+    @tooltip('加速度计算时采用的坐标')
     public space = Space.Local;
 
     // TODO:currently not supported

--- a/cocos/particle/animator/limit-velocity-overtime.ts
+++ b/cocos/particle/animator/limit-velocity-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { lerp, pseudoRandom, Vec3, Mat4, Quat } from '../../core/math';
 import { Space, ModuleRandSeed } from '../enum';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
@@ -45,8 +45,8 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 4,
-        tooltip:'X 轴方向上的速度下限',
     })
+    @tooltip('X 轴方向上的速度下限')
     public limitX = new CurveRange();
 
     /**
@@ -56,8 +56,8 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 5,
-        tooltip:'Y 轴方向上的速度下限',
     })
+    @tooltip('Y 轴方向上的速度下限')
     public limitY = new CurveRange();
 
     /**
@@ -67,8 +67,8 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 6,
-        tooltip:'Z 轴方向上的速度下限',
     })
+    @tooltip('Z 轴方向上的速度下限')
     public limitZ = new CurveRange();
 
     /**
@@ -78,8 +78,8 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 3,
-        tooltip:'速度下限',
     })
+    @tooltip('速度下限')
     public limit = new CurveRange();
 
     /**
@@ -87,8 +87,8 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 7,
-        tooltip:'当前速度与速度下限的插值',
     })
+    @tooltip('当前速度与速度下限的插值')
     public dampen = 3;
 
     /**
@@ -96,8 +96,8 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 2,
-        tooltip:'是否三个轴分开限制',
     })
+    @tooltip('是否三个轴分开限制')
     public separateAxes = false;
 
     /**
@@ -106,8 +106,8 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
     @property({
         type: Space,
         displayOrder: 1,
-        tooltip:'计算速度下限时采用的坐标系',
     })
+    @tooltip('计算速度下限时采用的坐标系')
     public space = Space.Local;
 
     // TODO:functions related to drag are temporarily not supported

--- a/cocos/particle/animator/rotation-overtime.ts
+++ b/cocos/particle/animator/rotation-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { pseudoRandom } from '../../core/math';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
 import CurveRange from './curve-range';
@@ -41,8 +41,8 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 1,
-        tooltip:'是否三个轴分开设定旋转（暂不支持）',
     })
+    @tooltip('是否三个轴分开设定旋转（暂不支持）')
     get separateAxes () {
         return this._separateAxes;
     }
@@ -59,8 +59,8 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
         range: [-1, 1],
         radian: true,
         displayOrder: 2,
-        tooltip:'绕 X 轴设定旋转',
     })
+    @tooltip('绕 X 轴设定旋转')
     public x = new CurveRange();
 
     /**
@@ -71,8 +71,8 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
         range: [-1, 1],
         radian: true,
         displayOrder: 3,
-        tooltip:'绕 Y 轴设定旋转',
     })
+    @tooltip('绕 Y 轴设定旋转')
     public y = new CurveRange();
 
     /**
@@ -83,8 +83,8 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
         range: [-1, 1],
         radian: true,
         displayOrder: 4,
-        tooltip:'绕 Z 轴设定旋转',
     })
+    @tooltip('绕 Z 轴设定旋转')
     public z = new CurveRange();
 
     public name = PARTICLE_MODULE_NAME.ROTATION;

--- a/cocos/particle/animator/size-overtime.ts
+++ b/cocos/particle/animator/size-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { pseudoRandom, Vec3 } from '../../core/math';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
 import CurveRange from './curve-range';
@@ -38,8 +38,8 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 1,
-        tooltip:'决定是否在每个轴上独立控制粒子大小',
     })
+    @tooltip('决定是否在每个轴上独立控制粒子大小')
     public separateAxes = false;
 
     /**
@@ -48,8 +48,8 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     @property({
         type: CurveRange,
         displayOrder: 2,
-        tooltip:'定义一条曲线来决定粒子在其生命周期中的大小变化',
     })
+    @tooltip('定义一条曲线来决定粒子在其生命周期中的大小变化')
     public size = new CurveRange();
 
     /**
@@ -58,8 +58,8 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     @property({
         type: CurveRange,
         displayOrder: 3,
-        tooltip:'定义一条曲线来决定粒子在其生命周期中 X 轴方向上的大小变化',
     })
+    @tooltip('定义一条曲线来决定粒子在其生命周期中 X 轴方向上的大小变化')
     public x = new CurveRange();
 
     /**
@@ -68,8 +68,8 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     @property({
         type: CurveRange,
         displayOrder: 4,
-        tooltip:'定义一条曲线来决定粒子在其生命周期中 Y 轴方向上的大小变化',
     })
+    @tooltip('定义一条曲线来决定粒子在其生命周期中 Y 轴方向上的大小变化')
     public y = new CurveRange();
 
     /**
@@ -78,8 +78,8 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     @property({
         type: CurveRange,
         displayOrder: 5,
-        tooltip:'定义一条曲线来决定粒子在其生命周期中 Z 轴方向上的大小变化',
     })
+    @tooltip('定义一条曲线来决定粒子在其生命周期中 Z 轴方向上的大小变化')
     public z = new CurveRange();
 
     public name = PARTICLE_MODULE_NAME.SIZE;

--- a/cocos/particle/animator/texture-animation.ts
+++ b/cocos/particle/animator/texture-animation.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { lerp, pseudoRandom, repeat } from '../../core/math';
 import { Enum } from '../../core/value-types';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
@@ -91,8 +91,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
     @property({
         type: Mode,
         displayOrder: 1,
-        tooltip:'设定粒子贴图动画的类型（暂只支持 Grid 模式）',
     })
+    @tooltip('设定粒子贴图动画的类型（暂只支持 Grid 模式）')
     get mode () {
         return this._mode;
     }
@@ -109,8 +109,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 2,
-        tooltip:'X 方向动画帧数',
     })
+    @tooltip('X 方向动画帧数')
     get numTilesX () {
         return this._numTilesX;
     }
@@ -127,8 +127,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 3,
-        tooltip:'Y 方向动画帧数',
     })
+    @tooltip('Y 方向动画帧数')
     get numTilesY () {
         return this._numTilesY;
     }
@@ -146,8 +146,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
     @property({
         type: Animation,
         displayOrder: 4,
-        tooltip:'动画播放方式',
     })
+    @tooltip('动画播放方式')
     public animation = Animation.WholeSheet;
 
     /**
@@ -156,8 +156,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
     @property({
         type: CurveRange,
         displayOrder: 7,
-        tooltip:'一个周期内动画播放的帧与时间变化曲线',
     })
+    @tooltip('一个周期内动画播放的帧与时间变化曲线')
     public frameOverTime = new CurveRange();
 
     /**
@@ -166,8 +166,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
     @property({
         type: CurveRange,
         displayOrder: 8,
-        tooltip:'从第几帧开始播放，时间为整个粒子系统的生命周期',
     })
+    @tooltip('从第几帧开始播放，时间为整个粒子系统的生命周期')
     public startFrame = new CurveRange();
 
     /**
@@ -175,8 +175,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 9,
-        tooltip:'一个生命周期内播放循环的次数',
     })
+    @tooltip('一个生命周期内播放循环的次数')
     public cycleCount = 0;
 
     @property
@@ -221,8 +221,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 5,
-        tooltip:'随机从动画贴图中选择一行以生成动画。\n此选项仅在动画播放方式为 SingleRow 时生效'
     })
+    @tooltip('随机从动画贴图中选择一行以生成动画。\n此选项仅在动画播放方式为 SingleRow 时生效')
     public randomRow = false;
 
     /**
@@ -231,8 +231,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
      */
     @property({
         displayOrder: 6,
-        tooltip:'从动画贴图中选择特定行以生成动画。\n此选项仅在动画播放方式为 SingleRow 时且禁用 randomRow 时可用'
     })
+    @tooltip('从动画贴图中选择特定行以生成动画。\n此选项仅在动画播放方式为 SingleRow 时且禁用 randomRow 时可用')
     public rowIndex = 0;
     public name = PARTICLE_MODULE_NAME.TEXTURE;
 

--- a/cocos/particle/animator/velocity-overtime.ts
+++ b/cocos/particle/animator/velocity-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { Mat4, pseudoRandom, Quat, Vec3 } from '../../core/math';
 import { Space } from '../enum';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
@@ -46,8 +46,8 @@ export default class VelocityOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 2,
-        tooltip:'X 轴方向上的速度分量',
     })
+    @tooltip('X 轴方向上的速度分量')
     public x = new CurveRange();
 
     /**
@@ -57,8 +57,8 @@ export default class VelocityOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 3,
-        tooltip:'Y 轴方向上的速度分量',
     })
+    @tooltip('Y 轴方向上的速度分量')
     public y = new CurveRange();
 
     /**
@@ -68,8 +68,8 @@ export default class VelocityOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 4,
-        tooltip:'Z 轴方向上的速度分量',
     })
+    @tooltip('Z 轴方向上的速度分量')
     public z = new CurveRange();
 
     /**
@@ -79,8 +79,8 @@ export default class VelocityOvertimeModule extends ParticleModuleBase {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 5,
-        tooltip:'速度修正系数（只支持 CPU 粒子）',
     })
+    @tooltip('速度修正系数（只支持 CPU 粒子）')
     public speedModifier = new CurveRange();
 
     /**
@@ -89,8 +89,8 @@ export default class VelocityOvertimeModule extends ParticleModuleBase {
     @property({
         type: Space,
         displayOrder: 1,
-        tooltip:'速度计算时采用的坐标系',
     })
+    @tooltip('速度计算时采用的坐标系')
     public space = Space.Local;
 
     private rotation: Quat;

--- a/cocos/particle/billboard-component.ts
+++ b/cocos/particle/billboard-component.ts
@@ -7,7 +7,7 @@ import { builtinResMgr } from '../core/3d/builtin';
 import { createMesh } from '../core/3d/misc/utils';
 import { Material, Mesh, Texture2D } from '../core/assets';
 import { Component } from '../core/components/component';
-import { ccclass, help, executeInEditMode, menu, property } from '../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../core/data/class-decorator';
 import { GFXAttributeName, GFXFormat, GFXPrimitiveMode } from '../core/gfx';
 import { Color, toDegree, toRadian, Vec4 } from '../core/math';
 import { Model } from '../core/renderer/scene/model';
@@ -29,8 +29,8 @@ export class BillboardComponent extends Component {
      */
     @property({
         type: Texture2D,
-        tooltip: 'billboard显示的贴图',
     })
+    @tooltip('billboard显示的贴图')
     get texture () {
         return this._texture;
     }
@@ -49,8 +49,9 @@ export class BillboardComponent extends Component {
      * @zh 高度。
      */
     @property({
-        tooltip: 'billboard的高度',
+        
     })
+    @tooltip('billboard的高度')
     get height () {
         return this._height;
     }
@@ -70,8 +71,9 @@ export class BillboardComponent extends Component {
      * @zh 宽度。
      */
     @property({
-        tooltip: 'billboard的宽度',
+        
     })
+    @tooltip('billboard的宽度')
     public get width () {
         return this._width;
     }
@@ -91,8 +93,9 @@ export class BillboardComponent extends Component {
      * @zh 角度。
      */
     @property({
-        tooltip: 'billboard绕中心点旋转的角度',
+        
     })
+    @tooltip('billboard绕中心点旋转的角度')
     public get rotation () {
         return Math.round(toDegree(this._rotation) * 100) / 100;
     }

--- a/cocos/particle/emitter/shape-module.ts
+++ b/cocos/particle/emitter/shape-module.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { Mat4, Quat, Vec2, Vec3 } from '../../core/math';
 import { clamp, pingPong, random, randomRange, repeat, toDegree, toRadian } from '../../core/math';
 import CurveRange from '../animator/curve-range';
@@ -24,8 +24,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 13,
-        tooltip:'粒子发射器位置',
     })
+    @tooltip('粒子发射器位置')
     get position () {
         return this._position;
     }
@@ -39,8 +39,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 14,
-        tooltip:'粒子发射器旋转角度',
     })
+    @tooltip('粒子发射器旋转角度')
     get rotation () {
         return this._rotation;
     }
@@ -54,8 +54,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 15,
-        tooltip:'粒子发射器缩放比例',
     })
+    @tooltip('粒子发射器缩放比例')
     get scale () {
         return this._scale;
     }
@@ -69,8 +69,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 6,
-        tooltip:'粒子发射器在一个扇形范围内发射',
     })
+    @tooltip('粒子发射器在一个扇形范围内发射')
     get arc () {
         return toDegree(this._arc);
     }
@@ -85,8 +85,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 5,
-        tooltip:'圆锥的轴与母线的夹角\n决定圆锥发射器的开合程度',
     })
+    @tooltip('圆锥的轴与母线的夹角\n决定圆锥发射器的开合程度')
     get angle () {
         return Math.round(toDegree(this._angle) * 100) / 100;
     }
@@ -123,8 +123,8 @@ export default class ShapeModule {
 
     @property({
         type: ShapeType,
-        tooltip:'粒子发射器类型',
     })
+    @tooltip('粒子发射器类型')
     public get shapeType () {
         return this._shapeType;
     }
@@ -157,8 +157,8 @@ export default class ShapeModule {
     @property({
         type: EmitLocation,
         displayOrder: 2,
-        tooltip:'粒子从发射器哪个部位发射',
     })
+    @tooltip('粒子从发射器哪个部位发射')
     public emitFrom = EmitLocation.Volume;
 
     /**
@@ -166,8 +166,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 16,
-        tooltip:'根据粒子的初始方向决定粒子的移动方向',
     })
+    @tooltip('根据粒子的初始方向决定粒子的移动方向')
     public alignToDirection = false;
 
     /**
@@ -175,8 +175,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 17,
-        tooltip:'粒子生成方向随机设定',
     })
+    @tooltip('粒子生成方向随机设定')
     public randomDirectionAmount = 0;
 
     /**
@@ -184,8 +184,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 18,
-        tooltip:'表示当前发射方向与当前位置到结点中心连线方向的插值',
     })
+    @tooltip('表示当前发射方向与当前位置到结点中心连线方向的插值')
     public sphericalDirectionAmount = 0;
 
     /**
@@ -193,8 +193,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 19,
-        tooltip:'粒子生成位置随机设定（设定此值为非 0 会使粒子生成位置超出生成器大小范围）',
     })
+    @tooltip('粒子生成位置随机设定（设定此值为非 0 会使粒子生成位置超出生成器大小范围）')
     public randomPositionAmount = 0;
 
     /**
@@ -202,8 +202,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 3,
-        tooltip:'粒子发射器半径',
     })
+    @tooltip('粒子发射器半径')
     public radius = 1;
 
     /**
@@ -214,8 +214,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 4,
-        tooltip:'粒子发射器发射位置（对 Box 类型的发射器无效）:\n - 0 表示从表面发射；\n - 1 表示从中心发射；\n - 0 ~ 1 之间表示在中心到表面之间发射。',
     })
+    @tooltip('粒子发射器发射位置（对 Box 类型的发射器无效）:\n - 0 表示从表面发射；\n - 1 表示从中心发射；\n - 0 ~ 1 之间表示在中心到表面之间发射。')
     public radiusThickness = 1;
 
     /**
@@ -224,8 +224,8 @@ export default class ShapeModule {
     @property({
         type: ArcMode,
         displayOrder: 7,
-        tooltip:'粒子在扇形范围内的发射方式',
     })
+    @tooltip('粒子在扇形范围内的发射方式')
     public arcMode = ArcMode.Random;
 
     /**
@@ -233,8 +233,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 9,
-        tooltip:'控制可能产生粒子的弧周围的离散间隔',
     })
+    @tooltip('控制可能产生粒子的弧周围的离散间隔')
     public arcSpread = 0;
 
     /**
@@ -243,8 +243,8 @@ export default class ShapeModule {
     @property({
         type: CurveRange,
         displayOrder: 10,
-        tooltip:'粒子沿圆周发射的速度',
     })
+    @tooltip('粒子沿圆周发射的速度')
     public arcSpeed = new CurveRange();
 
     /**
@@ -253,8 +253,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 11,
-        tooltip:'圆锥顶部截面距离底部的轴长\n决定圆锥发射器的高度',
     })
+    @tooltip('圆锥顶部截面距离底部的轴长\n决定圆锥发射器的高度')
     public length = 5;
 
     /**
@@ -262,8 +262,8 @@ export default class ShapeModule {
      */
     @property({
         displayOrder: 12,
-        tooltip:'粒子发射器发射位置（针对 Box 类型的粒子发射器）',
     })
+    @tooltip('粒子发射器发射位置（针对 Box 类型的粒子发射器）')
     public boxThickness = new Vec3(0, 0, 0);
 
     @property

--- a/cocos/particle/line-component.ts
+++ b/cocos/particle/line-component.ts
@@ -7,7 +7,7 @@
 
 import { Material, Texture2D } from '../core/assets';
 import { Component } from '../core/components';
-import { ccclass, help, executeInEditMode, menu, property } from '../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../core/data/class-decorator';
 import { Vec3, Vec2, Vec4 } from '../core/math';
 import { LineModel } from './models/line-model';
 import { builtinResMgr } from '../core/3d/builtin';
@@ -34,8 +34,8 @@ export class LineComponent extends Component {
     @property({
         type: Texture2D,
         displayOrder: 0,
-        tooltip:'线段中显示的贴图',
     })
+    @tooltip('线段中显示的贴图')
     get texture () {
         return this._texture;
     }
@@ -57,8 +57,8 @@ export class LineComponent extends Component {
      */
     @property({
         displayOrder: 1,
-        tooltip:'线段中各个点的坐标采用哪个坐标系，勾选使用世界坐标系，不选使用本地坐标系',
     })
+    @tooltip('线段中各个点的坐标采用哪个坐标系，勾选使用世界坐标系，不选使用本地坐标系')
     get worldSpace () {
         return this._worldSpace;
     }
@@ -85,8 +85,8 @@ export class LineComponent extends Component {
     @property({
         type: [Vec3],
         displayOrder: 2,
-        tooltip:'每个线段端点的坐标',
     })
+    @tooltip('每个线段端点的坐标')
     get positions () {
         return this._positions;
     }
@@ -109,8 +109,8 @@ export class LineComponent extends Component {
     @property({
         type: CurveRange,
         displayOrder: 3,
-        tooltip:'线段宽度，如果采用曲线，则表示沿着线段方向上的曲线变化',
     })
+    @tooltip('线段宽度，如果采用曲线，则表示沿着线段方向上的曲线变化')
     get width () {
         return this._width;
     }
@@ -131,8 +131,8 @@ export class LineComponent extends Component {
     @property({
         type: Vec2,
         displayOrder: 4,
-        tooltip:'贴图平铺次数',
     })
+    @tooltip('贴图平铺次数')
     get tile () {
         return this._tile;
     }
@@ -152,8 +152,8 @@ export class LineComponent extends Component {
     @property({
         type: Vec2,
         displayOrder: 5,
-        tooltip:'贴图坐标的偏移',
     })
+    @tooltip('贴图坐标的偏移')
     get offset () {
         return this._offset;
     }
@@ -178,8 +178,8 @@ export class LineComponent extends Component {
     @property({
         type: GradientRange,
         displayOrder: 6,
-        tooltip:'线段颜色，如果采用渐变色，则表示沿着线段方向上的颜色渐变',
     })
+    @tooltip('线段颜色，如果采用渐变色，则表示沿着线段方向上的颜色渐变')
     get color () {
         return this._color;
     }

--- a/cocos/particle/particle-system-component.ts
+++ b/cocos/particle/particle-system-component.ts
@@ -8,7 +8,7 @@
 
 import { RenderableComponent } from '../core/3d/framework/renderable-component';
 import { Material } from '../core/assets/material';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property } from '../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../core/data/class-decorator';
 import { Mat4, pseudoRandom, Quat, randomRangeInt, Vec2, Vec3 } from '../core/math';
 import { INT_MAX } from '../core/math/bits';
 import { Model } from '../core/renderer';
@@ -46,8 +46,8 @@ export class ParticleSystemComponent extends RenderableComponent {
      */
     @property({
         displayOrder: 1,
-        tooltip:'粒子系统能生成的最大粒子数量',
     })
+    @tooltip('粒子系统能生成的最大粒子数量')
     public get capacity () {
         return this._capacity;
     }
@@ -67,21 +67,21 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: GradientRange,
         displayOrder: 8,
-        tooltip:'粒子初始颜色',
     })
+    @tooltip('粒子初始颜色')
     public startColor = new GradientRange();
 
     @property({
         type: Space,
         displayOrder: 9,
-        tooltip:'选择缩放坐标系',
     })
+    @tooltip('选择缩放坐标系')
     public scaleSpace = Space.Local;
 
     @property({
         displayOrder: 10,
-        tooltip:'粒子初始大小',
     })
+    @tooltip('粒子初始大小')
     public startSize3D = false;
 
     /**
@@ -91,8 +91,8 @@ export class ParticleSystemComponent extends RenderableComponent {
         type: CurveRange,
         displayOrder: 10,
         formerlySerializedAs: 'startSize',
-        tooltip:'粒子初始大小',
     })
+    @tooltip('粒子初始大小')
     public startSizeX = new CurveRange();
 
     /**
@@ -101,8 +101,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: CurveRange,
         displayOrder: 10,
-        tooltip:'粒子初始大小',
     })
+    @tooltip('粒子初始大小')
     public startSizeY = new CurveRange();
 
     /**
@@ -111,8 +111,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: CurveRange,
         displayOrder: 10,
-        tooltip:'粒子初始大小',
     })
+    @tooltip('粒子初始大小')
     public startSizeZ = new CurveRange();
 
     /**
@@ -122,14 +122,14 @@ export class ParticleSystemComponent extends RenderableComponent {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 11,
-        tooltip:'粒子初始速度',
     })
+    @tooltip('粒子初始速度')
     public startSpeed = new CurveRange();
 
     @property({
         displayOrder: 12,
-        tooltip:'粒子初始旋转角度',
     })
+    @tooltip('粒子初始旋转角度')
     public startRotation3D = false;
 
     /**
@@ -140,8 +140,8 @@ export class ParticleSystemComponent extends RenderableComponent {
         range: [-1, 1],
         radian: true,
         displayOrder: 12,
-        tooltip:'粒子初始旋转角度'
     })
+    @tooltip('粒子初始旋转角度')
     public startRotationX = new CurveRange();
 
     /**
@@ -152,8 +152,8 @@ export class ParticleSystemComponent extends RenderableComponent {
         range: [-1, 1],
         radian: true,
         displayOrder: 12,
-        tooltip:'粒子初始旋转角度'
     })
+    @tooltip('粒子初始旋转角度')
     public startRotationY = new CurveRange();
 
     /**
@@ -165,8 +165,8 @@ export class ParticleSystemComponent extends RenderableComponent {
         radian: true,
         displayOrder: 12,
         formerlySerializedAs: 'startRotation',
-        tooltip:'粒子初始旋转角度'
     })
+    @tooltip('粒子初始旋转角度')
     public startRotationZ = new CurveRange();
 
     /**
@@ -175,8 +175,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: CurveRange,
         displayOrder: 6,
-        tooltip:'粒子系统开始运行后，延迟粒子发射的时间',
     })
+    @tooltip('粒子系统开始运行后，延迟粒子发射的时间')
     public startDelay = new CurveRange();
 
     /**
@@ -185,8 +185,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: CurveRange,
         displayOrder: 7,
-        tooltip:'粒子生命周期',
     })
+    @tooltip('粒子生命周期')
     public startLifetime = new CurveRange();
 
     /**
@@ -194,8 +194,8 @@ export class ParticleSystemComponent extends RenderableComponent {
      */
     @property({
         displayOrder: 0,
-        tooltip:'粒子系统运行时间',
     })
+    @tooltip('粒子系统运行时间')
     public duration = 5.0;
 
     /**
@@ -203,8 +203,8 @@ export class ParticleSystemComponent extends RenderableComponent {
      */
     @property({
         displayOrder: 2,
-        tooltip:'粒子系统是否循环播放',
     })
+    @tooltip('粒子系统是否循环播放')
     public loop = true;
 
     /**
@@ -212,8 +212,8 @@ export class ParticleSystemComponent extends RenderableComponent {
      */
     @property({
         displayOrder: 3,
-        tooltip:'选中之后，粒子系统会以已播放完一轮之后的状态开始播放（仅当循环播放启用时有效）',
     })
+    @tooltip('选中之后，粒子系统会以已播放完一轮之后的状态开始播放（仅当循环播放启用时有效）')
     get prewarm () {
         return this._prewarm;
     }
@@ -231,8 +231,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: Space,
         displayOrder: 4,
-        tooltip:'控制粒子坐标计算所在的坐标系',
     })
+    @tooltip('控制粒子坐标计算所在的坐标系')
     get simulationSpace () {
         return this._simulationSpace;
     }
@@ -252,8 +252,8 @@ export class ParticleSystemComponent extends RenderableComponent {
      */
     @property({
         displayOrder: 5,
-        tooltip:'控制整个粒子系统的更新速度',
     })
+    @tooltip('控制整个粒子系统的更新速度')
     public simulationSpeed = 1.0;
 
     /**
@@ -261,8 +261,8 @@ export class ParticleSystemComponent extends RenderableComponent {
      */
     @property({
         displayOrder: 2,
-        tooltip:'粒子系统加载后是否自动开始播放',
     })
+    @tooltip('粒子系统加载后是否自动开始播放')
     public playOnAwake = true;
 
     /**
@@ -272,8 +272,8 @@ export class ParticleSystemComponent extends RenderableComponent {
         type: CurveRange,
         range: [-1, 1],
         displayOrder: 13,
-        tooltip:'粒子受重力影响的重力系数',
     })
+    @tooltip('粒子受重力影响的重力系数')
     public gravityModifier = new CurveRange();
 
     // emission module
@@ -283,8 +283,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: CurveRange,
         displayOrder: 14,
-        tooltip:'每秒发射的粒子数',
     })
+    @tooltip('每秒发射的粒子数')
     public rateOverTime = new CurveRange();
 
     /**
@@ -293,8 +293,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: CurveRange,
         displayOrder: 15,
-        tooltip:'每移动单位距离发射的粒子数',
     })
+    @tooltip('每移动单位距离发射的粒子数')
     public rateOverDistance = new CurveRange();
 
     /**
@@ -303,8 +303,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: [Burst],
         displayOrder: 16,
-        tooltip:'在某个时间点发射给定数量的粒子'
     })
+    @tooltip('在某个时间点发射给定数量的粒子')
     public bursts: Burst[] = new Array();
 
     @property({
@@ -333,8 +333,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: ColorOverLifetimeModule,
         displayOrder: 23,
-        tooltip:'颜色模块',
     })
+    @tooltip('颜色模块')
     public get colorOverLifetimeModule () {
         if (EDITOR) {
             if (!this._colorOverLifetimeModule) {
@@ -359,8 +359,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: ShapeModule,
         displayOrder: 17,
-        tooltip:'发射器模块',
     })
+    @tooltip('发射器模块')
     public get shapeModule () {
         if (EDITOR) {
             if (!this._shapeModule) {
@@ -385,8 +385,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: SizeOvertimeModule,
         displayOrder: 21,
-        tooltip:'大小模块',
     })
+    @tooltip('大小模块')
     public get sizeOvertimeModule () {
         if (EDITOR) {
             if (!this._sizeOvertimeModule) {
@@ -411,8 +411,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: VelocityOvertimeModule,
         displayOrder: 18,
-        tooltip:'速度模块',
     })
+    @tooltip('速度模块')
     public get velocityOvertimeModule () {
         if (EDITOR) {
             if (!this._velocityOvertimeModule) {
@@ -437,8 +437,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: ForceOvertimeModule,
         displayOrder: 19,
-        tooltip:'加速度模块',
     })
+    @tooltip('加速度模块')
     public get forceOvertimeModule () {
         if (EDITOR) {
             if (!this._forceOvertimeModule) {
@@ -463,8 +463,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: LimitVelocityOvertimeModule,
         displayOrder: 20,
-        tooltip:'限速模块',
     })
+    @tooltip('限速模块')
     public get limitVelocityOvertimeModule () {
         if (EDITOR) {
             if (!this._limitVelocityOvertimeModule) {
@@ -489,8 +489,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: RotationOvertimeModule,
         displayOrder: 22,
-        tooltip:'旋转模块',
     })
+    @tooltip('旋转模块')
     public get rotationOvertimeModule () {
         if (EDITOR) {
             if (!this._rotationOvertimeModule) {
@@ -515,8 +515,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: TextureAnimationModule,
         displayOrder: 24,
-        tooltip:'贴图动画模块',
     })
+    @tooltip('贴图动画模块')
     public get textureAnimationModule () {
         if (EDITOR) {
             if (!this._textureAnimationModule) {
@@ -541,8 +541,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: TrailModule,
         displayOrder: 25,
-        tooltip:'拖尾模块',
     })
+    @tooltip('拖尾模块')
     public get trailModule () {
         if (EDITOR) {
             if (!this._trailModule) {
@@ -563,15 +563,15 @@ export class ParticleSystemComponent extends RenderableComponent {
     @property({
         type: ParticleSystemRenderer,
         displayOrder: 26,
-        tooltip:'渲染模块',
     })
+    @tooltip('渲染模块')
     public renderer: ParticleSystemRenderer = new ParticleSystemRenderer();
 
     // serilized culling
     @property({
         displayOrder: 27,
-        tooltip:'是否剔除非 enable 的模块数据',
     })
+    @tooltip('是否剔除非 enable 的模块数据')
     public enableCulling: boolean = false;
 
     /**

--- a/cocos/particle/renderer/particle-system-renderer-data.ts
+++ b/cocos/particle/renderer/particle-system-renderer-data.ts
@@ -1,5 +1,5 @@
 import { Material, Mesh, Texture2D } from '../../core/assets';
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { RenderMode} from '../enum';
 import ParticleSystemRendererCPU from './particle-system-renderer-cpu';
 import ParticleSystemRendererGPU from './particle-system-renderer-gpu';
@@ -25,8 +25,8 @@ export default class ParticleSystemRenderer {
     @property({
         type: RenderMode,
         displayOrder: 0,
-        tooltip: '设定粒子生成模式',
     })
+    @tooltip('设定粒子生成模式')
     public get renderMode () {
         return this._renderMode;
     }
@@ -44,8 +44,8 @@ export default class ParticleSystemRenderer {
      */
     @property({
         displayOrder: 1,
-        tooltip: '在粒子生成方式为 StrecthedBillboard 时,对粒子在运动方向上按速度大小进行拉伸',
     })
+    @tooltip('在粒子生成方式为 StrecthedBillboard 时,对粒子在运动方向上按速度大小进行拉伸')
     public get velocityScale () {
         return this._velocityScale;
     }
@@ -61,8 +61,8 @@ export default class ParticleSystemRenderer {
      */
     @property({
         displayOrder: 2,
-        tooltip: '在粒子生成方式为 StrecthedBillboard 时,对粒子在运动方向上按粒子大小进行拉伸',
     })
+    @tooltip('在粒子生成方式为 StrecthedBillboard 时,对粒子在运动方向上按粒子大小进行拉伸')
     public get lengthScale () {
         return this._lengthScale;
     }
@@ -100,8 +100,8 @@ export default class ParticleSystemRenderer {
     @property({
         type: Mesh,
         displayOrder: 7,
-        tooltip: '粒子发射的模型',
     })
+    @tooltip('粒子发射的模型')
     public get mesh () {
         return this._mesh;
     }
@@ -117,8 +117,8 @@ export default class ParticleSystemRenderer {
     @property({
         type: Material,
         displayOrder: 8,
-        tooltip: '粒子使用的材质',
     })
+    @tooltip('粒子使用的材质')
     public get particleMaterial () {
         if (!this._particleSystem) {
             return null;
@@ -136,8 +136,8 @@ export default class ParticleSystemRenderer {
     @property({
         type: Material,
         displayOrder: 9,
-        tooltip: '拖尾使用的材质',
     })
+    @tooltip('拖尾使用的材质')
     public get trailMaterial () {
         if (!this._particleSystem) {
             return null;
@@ -165,8 +165,8 @@ export default class ParticleSystemRenderer {
 
     @property({
         displayOrder: 10,
-        tooltip:'是否启用GPU粒子',
     })
+    @tooltip('是否启用GPU粒子')
     public get useGPU () {
         return this._useGPU;
     }

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -5,7 +5,7 @@
 
 import { Material } from '../../core/assets/material';
 import { RenderingSubMesh } from '../../core/assets/mesh';
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../core/data/class-decorator';
 import { director } from '../../core/director';
 import { GFX_DRAW_INFO_SIZE, GFXBuffer, IGFXIndirectBuffer } from '../../core/gfx/buffer';
 import { GFXAttributeName, GFXBufferUsageBit, GFXFormat, GFXFormatInfos, GFXMemoryUsageBit, GFXPrimitiveMode } from '../../core/gfx/define';
@@ -185,8 +185,8 @@ export default class TrailModule {
     @property({
         type: TrailMode,
         displayOrder: 1,
-        tooltip: 'Particle在每个粒子的运动轨迹上形成拖尾效果',
     })
+    @tooltip('Particle在每个粒子的运动轨迹上形成拖尾效果')
     public mode = TrailMode.Particles;
 
     /**
@@ -195,8 +195,8 @@ export default class TrailModule {
     @property({
         type: CurveRange,
         displayOrder: 3,
-        tooltip: '拖尾的生命周期',
     })
+    @tooltip('拖尾的生命周期')
     public lifeTime = new CurveRange();
 
     @property
@@ -207,8 +207,8 @@ export default class TrailModule {
      */
     @property({
         displayOrder: 5,
-        tooltip: '粒子每生成一个拖尾节点所运行的最短距离',
     })
+    @tooltip('粒子每生成一个拖尾节点所运行的最短距离')
     public get minParticleDistance () {
         return this._minParticleDistance;
     }
@@ -221,8 +221,8 @@ export default class TrailModule {
     @property({
         type: Space,
         displayOrder: 6,
-        tooltip: '拖尾所在的坐标系，World在世界坐标系中运行，Local在本地坐标系中运行',
     })
+    @tooltip('拖尾所在的坐标系，World在世界坐标系中运行，Local在本地坐标系中运行')
     public get space () {
         return this._space;
     }
@@ -239,9 +239,9 @@ export default class TrailModule {
      */
     @property({
         displayOrder: 7,
-        tooltip: '拖尾是否跟随粒子一起消失',
         visible: false,
     })
+    @tooltip('拖尾是否跟随粒子一起消失')
     public existWithParticles = true;
 
     /**
@@ -250,14 +250,14 @@ export default class TrailModule {
     @property({
         type: TextureMode,
         displayOrder: 8,
-        tooltip: '贴图在拖尾上的展开形式，Stretch贴图覆盖在整条拖尾上，Repeat贴图覆盖在一段拖尾上',
     })
+    @tooltip('贴图在拖尾上的展开形式，Stretch贴图覆盖在整条拖尾上，Repeat贴图覆盖在一段拖尾上')
     public textureMode = TextureMode.Stretch;
 
     @property({
         displayOrder: 9,
-        tooltip: '拖尾宽度继承自粒子大小',
     })
+    @tooltip('拖尾宽度继承自粒子大小')
     public widthFromParticle = true;
 
     /**
@@ -266,28 +266,28 @@ export default class TrailModule {
     @property({
         type: CurveRange,
         displayOrder: 10,
-        tooltip: '拖尾宽度，如果继承自粒子则是粒子大小的比例',
     })
+    @tooltip('拖尾宽度，如果继承自粒子则是粒子大小的比例')
     public widthRatio = new CurveRange();
 
     @property({
         displayOrder: 11,
-        tooltip: '拖尾颜色是否继承自粒子',
     })
+    @tooltip('拖尾颜色是否继承自粒子')
     public colorFromParticle = false;
 
     @property({
         type: GradientRange,
         displayOrder: 12,
-        tooltip: '拖尾颜色随拖尾自身长度的颜色渐变',
     })
+    @tooltip('拖尾颜色随拖尾自身长度的颜色渐变')
     public colorOverTrail = new GradientRange();
 
     @property({
         type: GradientRange,
         displayOrder: 13,
-        tooltip: '拖尾颜色随时间的颜色渐变',
     })
+    @tooltip('拖尾颜色随时间的颜色渐变')
     public colorOvertime = new GradientRange();
 
     /**

--- a/cocos/physics/framework/components/colliders/box-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/box-collider-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    tooltip,
 } from '../../../../core/data/class-decorator';
 import { Vec3 } from '../../../../core/math';
 import { ColliderComponent } from './collider-component';
@@ -36,8 +37,8 @@ export class BoxColliderComponent extends ColliderComponent {
      */
     @property({
         type: Vec3,
-        tooltip: '盒的大小，即长、宽、高'
     })
+    @tooltip('盒的大小，即长、宽、高')
     public get size () {
         return this._size;
     }

--- a/cocos/physics/framework/components/colliders/capsule-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/capsule-collider-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    tooltip,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { ICapsuleShape } from '../../../spec/i-physics-shape';
@@ -34,7 +35,7 @@ export class CapsuleColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置胶囊体在本地坐标系下的球半径。
      */
-    @property({ tooltip: '本地坐标系下胶囊体上的球的半径' })
+    @tooltip('本地坐标系下胶囊体上的球的半径')
     public get radius () {
         return this._radius;
     }
@@ -53,7 +54,7 @@ export class CapsuleColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置在本地坐标系下的胶囊体上圆柱体的高度。
      */
-    @property({ tooltip: '本地坐标系下胶囊体上的圆柱体的高度' })
+    @tooltip('本地坐标系下胶囊体上的圆柱体的高度')
     public get cylinderHeight () {
         return this._cylinderHeight;
     }
@@ -72,7 +73,8 @@ export class CapsuleColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置在本地坐标系下胶囊体的方向。
      */
-    @property({ type: EAxisDirection, tooltip: "本地坐标系下胶囊体的朝向" })
+    @property({ type: EAxisDirection })
+    @tooltip("本地坐标系下胶囊体的朝向")
     public get direction () {
         return this._direction;
     }

--- a/cocos/physics/framework/components/colliders/collider-component.ts
+++ b/cocos/physics/framework/components/colliders/collider-component.ts
@@ -2,7 +2,7 @@
  * @category physics
  */
 
-import { ccclass, property } from '../../../../core/data/class-decorator';
+import { ccclass, property, tooltip } from '../../../../core/data/class-decorator';
 import { Eventify } from '../../../../core/event';
 import { Vec3 } from '../../../../core/math';
 import { CollisionCallback, CollisionEventType, TriggerCallback, TriggerEventType } from '../../physics-interface';
@@ -57,8 +57,8 @@ export class ColliderComponent extends Eventify(Component) {
         type: PhysicMaterial,
         displayName: 'Material',
         displayOrder: -1,
-        tooltip: '源材质',
     })
+    @tooltip('源材质')
     public get sharedMaterial () {
         return this._material;
     }
@@ -115,8 +115,8 @@ export class ColliderComponent extends Eventify(Component) {
      */
     @property({
         displayOrder: 0,
-        tooltip: '是否与其它碰撞器产生碰撞，并产生物理行为',
     })
+    @tooltip('是否与其它碰撞器产生碰撞，并产生物理行为')
     public get isTrigger () {
         return this._isTrigger;
     }
@@ -137,8 +137,8 @@ export class ColliderComponent extends Eventify(Component) {
     @property({
         type: Vec3,
         displayOrder: 1,
-        tooltip: '形状的中心点（与所在 Node 中心点的相对位置）',
     })
+    @tooltip('形状的中心点（与所在 Node 中心点的相对位置）')
     public get center () {
         return this._center;
     }

--- a/cocos/physics/framework/components/colliders/cone-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/cone-collider-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    tooltip,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { IConeShape } from '../../../spec/i-physics-shape';
@@ -33,7 +34,7 @@ export class ConeColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置圆锥体上圆面半径。
      */
-    @property({ tooltip: '圆锥体上圆面的半径' })
+    @tooltip('圆锥体上圆面的半径')
     public get radius () {
         return this._radius;
     }
@@ -53,7 +54,7 @@ export class ConeColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置圆锥体在相应轴向的高度。
      */
-    @property({ tooltip: '圆锥体在相应轴向的高度' })
+    @tooltip('圆锥体在相应轴向的高度')
     public get height () {
         return this._height;
     }

--- a/cocos/physics/framework/components/colliders/cylinder-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/cylinder-collider-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    tooltip,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { ICylinderShape } from '../../../spec/i-physics-shape';
@@ -33,7 +34,7 @@ export class CylinderColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置圆柱体上圆面半径。
      */
-    @property({ tooltip: '圆柱体上圆面的半径' })
+    @tooltip('圆柱体上圆面的半径')
     public get radius () {
         return this._radius;
     }
@@ -53,7 +54,7 @@ export class CylinderColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置圆柱体在相应轴向的高度。
      */
-    @property({ tooltip: '圆柱体在相应轴向的高度' })
+    @tooltip('圆柱体在相应轴向的高度')
     public get height () {
         return this._height;
     }

--- a/cocos/physics/framework/components/colliders/plane-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/plane-collider-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    tooltip,
 } from '../../../../core/data/class-decorator';
 import { Vec3 } from '../../../../core/math';
 import { ColliderComponent } from './collider-component';
@@ -37,8 +38,8 @@ export class PlaneColliderComponent extends ColliderComponent {
      */
     @property({
         type: Vec3,
-        tooltip: '平面的法线'
     })
+    @tooltip('平面的法线')
     public get normal () {
         return this._normal;
     }

--- a/cocos/physics/framework/components/colliders/sphere-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/sphere-collider-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    tooltip,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { ISphereShape } from '../../../spec/i-physics-shape';
@@ -34,9 +35,7 @@ export class SphereColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置球的半径。
      */
-    @property({
-        tooltip: '球的半径',
-    })
+    @tooltip('球的半径')
     public get radius () {
         return this._radius;
     }

--- a/cocos/physics/framework/components/constant-force.ts
+++ b/cocos/physics/framework/components/constant-force.ts
@@ -10,6 +10,7 @@ import {
     property,
     requireComponent,
     disallowMultiple,
+    tooltip,
 } from '../../../core/data/class-decorator';
 import { Component } from '../../../core/components/component';
 import { RigidBodyComponent } from './rigid-body-component';
@@ -53,8 +54,8 @@ export class ConstantForce extends Component {
      */
     @property({
         displayOrder: 0,
-        tooltip: '世界坐标系下的力',
     })
+    @tooltip('世界坐标系下的力')
     public get force () {
         return this._force;
     }
@@ -72,8 +73,8 @@ export class ConstantForce extends Component {
      */
     @property({
         displayOrder: 1,
-        tooltip: '本地坐标系下的力',
     })
+    @tooltip('本地坐标系下的力')
     public get localForce () {
         return this._localForce;
     }
@@ -91,8 +92,8 @@ export class ConstantForce extends Component {
      */
     @property({
         displayOrder: 2,
-        tooltip: '世界坐标系下的扭转力',
     })
+    @tooltip('世界坐标系下的扭转力')
     public get torque () {
         return this._torque;
     }
@@ -110,8 +111,8 @@ export class ConstantForce extends Component {
      */
     @property({
         displayOrder: 3,
-        tooltip: '本地坐标系下的扭转力',
     })
+    @tooltip('本地坐标系下的扭转力')
     public get localTorque () {
         return this._localTorque;
     }

--- a/cocos/physics/framework/components/rigid-body-component.ts
+++ b/cocos/physics/framework/components/rigid-body-component.ts
@@ -11,6 +11,7 @@ import {
     menu,
     property,
     executionOrder,
+    tooltip,
 } from '../../../core/data/class-decorator';
 import { Vec3 } from '../../../core/math';
 import { Component, error, Layers } from '../../../core';
@@ -47,8 +48,8 @@ export class RigidBodyComponent extends Component {
     @property({
         type: Layers.Enum,
         displayOrder: -2,
-        tooltip: '设置分组',
     })
+    @tooltip('设置分组')
     public get group (): number {
         return this._group;
     }
@@ -68,8 +69,8 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 0,
-        tooltip: '刚体的质量',
     })
+    @tooltip('刚体的质量')
     public get mass () {
         return this._mass;
     }
@@ -90,9 +91,9 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 0.5,
-        tooltip: '是否允许休眠',
         visible: function (this: RigidBodyComponent) { return this._mass != 0; },
     })
+    @tooltip('是否允许休眠')
     public get allowSleep (): boolean {
         return this._allowSleep;
     }
@@ -112,9 +113,9 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 1,
-        tooltip: '线性阻尼',
         visible: function (this: RigidBodyComponent) { return this._mass != 0; },
     })
+    @tooltip('线性阻尼')
     public get linearDamping () {
         return this._linearDamping;
     }
@@ -134,9 +135,9 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 2,
-        tooltip: '旋转阻尼',
         visible: function (this: RigidBodyComponent) { return this._mass != 0; },
     })
+    @tooltip('旋转阻尼')
     public get angularDamping () {
         return this._angularDamping;
     }
@@ -156,9 +157,9 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 3,
-        tooltip: '刚体是否由物理系统控制运动',
         visible: function (this: RigidBodyComponent) { return this._mass != 0; },
     })
+    @tooltip('刚体是否由物理系统控制运动')
     public get isKinematic () {
         return this._isKinematic;
     }
@@ -178,9 +179,9 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 4,
-        tooltip: '刚体是否使用重力',
         visible: function (this: RigidBodyComponent) { return this._mass != 0; },
     })
+    @tooltip('刚体是否使用重力')
     public get useGravity () {
         return this._useGravity;
     }
@@ -200,9 +201,9 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 5,
-        tooltip: '刚体是否固定旋转',
         visible: function (this: RigidBodyComponent) { return this._mass != 0; },
     })
+    @tooltip('刚体是否固定旋转')
     public get fixedRotation () {
         return this._fixedRotation;
     }
@@ -222,9 +223,9 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 6,
-        tooltip: '线性速度的因子，可以用来控制每个轴方向上的速度的缩放',
         visible: function (this: RigidBodyComponent) { return this._mass != 0; },
     })
+    @tooltip('线性速度的因子，可以用来控制每个轴方向上的速度的缩放')
     public get linearFactor () {
         return this._linearFactor;
     }
@@ -244,9 +245,9 @@ export class RigidBodyComponent extends Component {
      */
     @property({
         displayOrder: 7,
-        tooltip: '旋转速度的因子，可以用来控制每个轴方向上的旋转速度的缩放',
         visible: function (this: RigidBodyComponent) { return this._mass != 0; },
     })
+    @tooltip('旋转速度的因子，可以用来控制每个轴方向上的旋转速度的缩放')
     public get angularFactor () {
         return this._angularFactor;
     }

--- a/cocos/ui/components/button-component.ts
+++ b/cocos/ui/components/button-component.ts
@@ -31,7 +31,7 @@
 
 import { SpriteFrame } from '../../core/assets';
 import { Component, EventHandler as ComponentEventHandler, UITransformComponent } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
 import { EventMouse, EventTouch, SystemEventType } from '../../core/platform';
 import { Color, Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
@@ -169,8 +169,8 @@ export class ButtonComponent extends Component {
     @property({
         type: Node,
         displayOrder: 0,
-        tooltip: '指定 Button 背景节点，Button 状态改变时会修改此节点的 Color 或 Sprite 属性',
     })
+    @tooltip('指定 Button 背景节点，Button 状态改变时会修改此节点的 Color 或 Sprite 属性')
     get target () {
         return this._target;
     }
@@ -194,8 +194,8 @@ export class ButtonComponent extends Component {
      */
     @property({
         displayOrder: 1,
-        tooltip:'按钮是否可交互，这一项未选中时，按钮处在禁用状态',
     })
+    @tooltip('按钮是否可交互，这一项未选中时，按钮处在禁用状态')
     get interactable () {
         return this._interactable;
     }
@@ -232,8 +232,8 @@ export class ButtonComponent extends Component {
     @property({
         type: Transition,
         displayOrder: 2,
-        tooltip:'按钮状态变化时的过渡类型',
     })
+    @tooltip('按钮状态变化时的过渡类型')
     get transition () {
         return this._transition;
     }
@@ -255,9 +255,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 普通状态下按钮所显示的颜色。
      */
-    @property({
-        tooltip:'普通状态的按钮背景颜色',
-    })
+    @tooltip('普通状态的按钮背景颜色')
     // @constget
     get normalColor (): Readonly<Color> {
         return this._normalColor;
@@ -279,9 +277,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 按下状态时按钮所显示的颜色。
      */
-    @property({
-        tooltip:'按下状态的按钮背景颜色',
-    })
+    @tooltip('按下状态的按钮背景颜色')
     // @constget
     get pressedColor (): Readonly<Color> {
         return this._pressColor;
@@ -302,9 +298,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 悬停状态下按钮所显示的颜色。
      */
-    @property({
-        tooltip:'悬停状态的按钮背景颜色',
-    })
+    @tooltip('悬停状态的按钮背景颜色')
     // @constget
     get hoverColor (): Readonly<Color> {
         return this._hoverColor;
@@ -324,9 +318,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 禁用状态下按钮所显示的颜色。
      */
-    @property({
-        tooltip:'禁用状态的按钮背景颜色',
-    })
+    @tooltip('禁用状态的按钮背景颜色')
     // @constget
     get disabledColor (): Readonly<Color> {
         return this._disabledColor;
@@ -351,8 +343,8 @@ export class ButtonComponent extends Component {
     @property({
         min: 0,
         max: 10,
-        tooltip:'按钮颜色变化或者缩放变化的过渡时间',
     })
+    @tooltip('按钮颜色变化或者缩放变化的过渡时间')
     get duration () {
         return this._duration;
     }
@@ -373,9 +365,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 当用户点击按钮后，按钮会缩放到一个值，这个值等于 Button 原始 scale * zoomScale。
      */
-    @property({
-        tooltip:'当用户点击按钮后，按钮会缩放到一个值，这个值等于 Button 原始 scale * zoomScale。',
-    })
+    @tooltip('当用户点击按钮后，按钮会缩放到一个值，这个值等于 Button 原始 scale * zoomScale。')
     get zoomScale () {
         return this._zoomScale;
     }
@@ -398,8 +388,8 @@ export class ButtonComponent extends Component {
      */
     @property({
         type: SpriteFrame,
-        tooltip:'普通状态的按钮背景图资源',
     })
+    @tooltip('普通状态的按钮背景图资源')
     get normalSprite () {
         return this._normalSprite;
     }
@@ -427,8 +417,8 @@ export class ButtonComponent extends Component {
      */
     @property({
         type: SpriteFrame,
-        tooltip:'按下状态的按钮背景图资源',
     })
+    @tooltip('按下状态的按钮背景图资源')
     get pressedSprite () {
         return this._pressedSprite;
     }
@@ -451,8 +441,8 @@ export class ButtonComponent extends Component {
      */
     @property({
         type: SpriteFrame,
-        tooltip:'悬停状态的按钮背景图资源',
     })
+    @tooltip('悬停状态的按钮背景图资源')
     get hoverSprite () {
         return this._hoverSprite;
     }
@@ -475,8 +465,8 @@ export class ButtonComponent extends Component {
      */
     @property({
         type: SpriteFrame,
-        tooltip:'禁用状态的按钮背景图资源',
     })
+    @tooltip('禁用状态的按钮背景图资源')
     get disabledSprite () {
         return this._disabledSprite;
     }
@@ -502,8 +492,8 @@ export class ButtonComponent extends Component {
     @property({
         type: [ComponentEventHandler],
         displayOrder: 20,
-        tooltip:'按钮点击事件的列表。先将数量改为1或更多，就可以为每个点击事件设置接受者和处理方法',
     })
+    @tooltip('按钮点击事件的列表。先将数量改为1或更多，就可以为每个点击事件设置接受者和处理方法')
     public clickEvents: ComponentEventHandler[] = [];
     @property
     protected _interactable = true;

--- a/cocos/ui/components/editbox/edit-box-component.ts
+++ b/cocos/ui/components/editbox/edit-box-component.ts
@@ -32,7 +32,7 @@ import { math, UITransformComponent } from '../../../core';
 import { SpriteFrame } from '../../../core/assets/sprite-frame';
 import { Component } from '../../../core/components/component';
 import { EventHandler as ComponentEventHandler } from '../../../core/components/component-event-handler';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent } from '../../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip } from '../../../core/data/class-decorator';
 import { Color, Size, Vec3 } from '../../../core/math';
 import { EventTouch } from '../../../core/platform';
 import { SystemEventType } from '../../../core/platform/event-manager/event-enum';
@@ -88,9 +88,9 @@ export class EditBoxComponent extends Component {
      * 输入框的初始输入内容，如果为空则会显示占位符的文本。
      */
     @property({
-        tooltip: '输入框的初始输入内容，如果为空则会显示占位符的文本',
         displayOrder: 1,
     })
+    @tooltip('输入框的初始输入内容，如果为空则会显示占位符的文本')
     get string () {
         return this._string;
     }
@@ -112,9 +112,9 @@ export class EditBoxComponent extends Component {
      * 输入框占位符的文本内容。
      */
     @property({
-        tooltip: '输入框占位符的文本内容',
         displayOrder: 2,
     })
+    @tooltip('输入框占位符的文本内容')
     get placeholder () {
         if (!this._placeholderLabel) {
             return '';
@@ -136,10 +136,10 @@ export class EditBoxComponent extends Component {
      * 输入框输入文本节点上挂载的 Label 组件对象
      */
     @property({
-        tooltip: '输入框输入文本节点上挂载的 Label 组件对象',
         type: LabelComponent,
         displayOrder: 3,
     })
+    @tooltip('输入框输入文本节点上挂载的 Label 组件对象')
     get textLabel () {
         return this._textLabel;
     }
@@ -162,10 +162,10 @@ export class EditBoxComponent extends Component {
      * 输入框占位符节点上挂载的 Label 组件对象。
      */
     @property({
-        tooltip: '输入框占位符节点上挂载的 Label 组件对象',
         type: LabelComponent,
         displayOrder: 4,
     })
+    @tooltip('输入框占位符节点上挂载的 Label 组件对象')
     get placeholderLabel () {
         return this._placeholderLabel;
     }
@@ -189,9 +189,9 @@ export class EditBoxComponent extends Component {
      */
     @property({
         type: SpriteFrame,
-        tooltip: '输入框的背景图片',
         displayOrder: 5,
     })
+    @tooltip('输入框的背景图片')
     get backgroundImage () {
         return this._backgroundImage;
     }
@@ -214,9 +214,9 @@ export class EditBoxComponent extends Component {
      */
     @property({
         type: InputFlag,
-        tooltip: '指定输入标志位，可以指定输入方式为密码或者单词首字母大写',
         displayOrder: 6,
     })
+    @tooltip('指定输入标志位，可以指定输入方式为密码或者单词首字母大写')
     get inputFlag () {
         return this._inputFlag;
     }
@@ -236,9 +236,9 @@ export class EditBoxComponent extends Component {
      */
     @property({
         type: InputMode,
-        tooltip: '指定输入模式: ANY 表示多行输入，其它都是单行输入，移动平台上还可以指定键盘样式',
         displayOrder: 7,
     })
+    @tooltip('指定输入模式: ANY 表示多行输入，其它都是单行输入，移动平台上还可以指定键盘样式')
     get inputMode () {
         return this._inputMode;
     }
@@ -262,9 +262,9 @@ export class EditBoxComponent extends Component {
      */
     @property({
         type: KeyboardReturnType,
-        tooltip: '指定移动设备上面回车按钮的样式',
         displayOrder: 8,
     })
+    @tooltip('指定移动设备上面回车按钮的样式')
     get returnType () {
         return this._returnType;
     }
@@ -285,9 +285,9 @@ export class EditBoxComponent extends Component {
      * - 如果值为 0，则不允许用户进行任何输入。
      */
     @property({
-        tooltip: '输入框最大允许输入的字符个数',
         displayOrder: 9,
     })
+    @tooltip('输入框最大允许输入的字符个数')
     get maxLength () {
         return this._maxLength;
     }
@@ -303,9 +303,9 @@ export class EditBoxComponent extends Component {
      * 修改 DOM 输入元素的 tabIndex（这个属性只有在 Web 上面修改有意义）。
      */
     @property({
-        tooltip: '修改 DOM 输入元素的 tabIndex（这个属性只有在 Web 上面修改有意义）',
         displayOrder: 10,
     })
+    @tooltip('修改 DOM 输入元素的 tabIndex（这个属性只有在 Web 上面修改有意义）')
     get tabIndex () {
         return this._tabIndex;
     }
@@ -333,9 +333,9 @@ export class EditBoxComponent extends Component {
      */
     @property({
         type: [ComponentEventHandler],
-        tooltip: '该事件在用户点击输入框获取焦点的时候被触发',
         displayOrder: 11,
     })
+    @tooltip('该事件在用户点击输入框获取焦点的时候被触发')
     public editingDidBegan: ComponentEventHandler[] = [];
 
     /**
@@ -347,9 +347,9 @@ export class EditBoxComponent extends Component {
      */
     @property({
         type: [ComponentEventHandler],
-        tooltip: '编辑文本输入框时触发的事件回调',
         displayOrder: 12,
     })
+    @tooltip('编辑文本输入框时触发的事件回调')
     public textChanged: ComponentEventHandler[] = [];
 
     /**
@@ -361,9 +361,9 @@ export class EditBoxComponent extends Component {
      */
     @property({
         type: [ComponentEventHandler],
-        tooltip: '在单行模式下面，一般是在用户按下回车或者点击屏幕输入框以外的地方调用该函数。 如果是多行输入，一般是在用户点击屏幕输入框以外的地方调用该函数',
         displayOrder: 13,
     })
+    @tooltip('在单行模式下面，一般是在用户按下回车或者点击屏幕输入框以外的地方调用该函数。 如果是多行输入，一般是在用户点击屏幕输入框以外的地方调用该函数')
     public editingDidEnded: ComponentEventHandler[] = [];
 
     /**
@@ -375,9 +375,9 @@ export class EditBoxComponent extends Component {
      */
     @property({
         type: [ComponentEventHandler],
-        tooltip: '该事件在用户按下回车键的时候被触发, 如果是单行输入框，按回车键还会使输入框失去焦点',
         displayOrder: 14,
     })
+    @tooltip('该事件在用户按下回车键的时候被触发, 如果是单行输入框，按回车键还会使输入框失去焦点')
     public editingReturn: ComponentEventHandler[] = [];
 
     public _impl: EditBoxImplBase | null = null;

--- a/cocos/ui/components/graphics-component.ts
+++ b/cocos/ui/components/graphics-component.ts
@@ -31,7 +31,7 @@
 import { builtinResMgr } from '../../core/3d/builtin';
 import { RenderableComponent } from '../../core/3d/framework/renderable-component';
 import { InstanceMaterialType, UIRenderComponent } from '../../core/components/ui-base/ui-render-component';
-import { ccclass, help, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { director } from '../../core/director';
 import { Color } from '../../core/math';
 import { IMaterialInstanceInfo, MaterialInstance, Model } from '../../core/renderer';
@@ -89,8 +89,8 @@ export class GraphicsComponent extends UIRenderComponent {
      */
     @property({
         type: LineJoin,
-        tooltip: '两条线相交时，所创建的拐角类型',
     })
+    @tooltip('两条线相交时，所创建的拐角类型')
     get lineJoin () {
         return this._lineJoin;
     }
@@ -113,8 +113,8 @@ export class GraphicsComponent extends UIRenderComponent {
      */
     @property({
         type: LineCap,
-        tooltip: '线条的结束端点样式',
     })
+    @tooltip('线条的结束端点样式')
     get lineCap () {
         return this._lineCap;
     }
@@ -135,9 +135,7 @@ export class GraphicsComponent extends UIRenderComponent {
      * @zh
      * 线段颜色。
      */
-    @property({
-        tooltip: '笔触的颜色',
-    })
+    @tooltip('笔触的颜色')
     // @constget
     get strokeColor (): Readonly<Color> {
         return this._strokeColor;
@@ -159,9 +157,7 @@ export class GraphicsComponent extends UIRenderComponent {
      * @zh
      * 填充颜色。
      */
-    @property({
-        tooltip: '填充绘画的颜色',
-    })
+    @tooltip('填充绘画的颜色')
     // @constget
     get fillColor (): Readonly<Color> {
         return this._fillColor;
@@ -183,9 +179,7 @@ export class GraphicsComponent extends UIRenderComponent {
      * @zh
      * 设置斜接面限制比例。
      */
-    @property({
-        tooltip: '最大斜接长度',
-    })
+    @tooltip('最大斜接长度')
     get miterLimit () {
         return this._miterLimit;
     }

--- a/cocos/ui/components/label-component.ts
+++ b/cocos/ui/components/label-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { BitmapFont, Font, ImageAsset, SpriteFrame, Texture2D } from '../../core/assets';
-import { ccclass, help, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { ccenum } from '../../core/value-types/enum';
 import { UI } from '../../core/renderer/ui/ui';
 import { FontAtlas } from '../assembler/label/bmfontUtils';
@@ -202,8 +202,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         displayOrder: 4,
         multiline: true,
-        tooltip:'Label 显示的文本内容字符串',
     })
+    @tooltip('Label 显示的文本内容字符串')
     get string () {
         return this._string;
     }
@@ -227,8 +227,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         type: HorizontalTextAlignment,
         displayOrder: 5,
-        tooltip:'文字水平对齐模式',
     })
+    @tooltip('文字水平对齐模式')
     get horizontalAlign () {
         return this._horizontalAlign;
     }
@@ -252,8 +252,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         type: VerticalTextAlignment,
         displayOrder: 6,
-        tooltip:'文字垂直对齐模式',
     })
+    @tooltip('文字垂直对齐模式')
     get verticalAlign () {
         return this._verticalAlign;
     }
@@ -296,8 +296,8 @@ export class LabelComponent extends UIRenderComponent {
      */
     @property({
         displayOrder: 7,
-        tooltip:'文字尺寸，以 point 为单位',
     })
+    @tooltip('文字尺寸，以 point 为单位')
     get fontSize () {
         return this._fontSize;
     }
@@ -320,8 +320,8 @@ export class LabelComponent extends UIRenderComponent {
      */
     @property({
         displayOrder: 8,
-        tooltip:'文字字体名字',
     })
+    @tooltip('文字字体名字')
     get fontFamily () {
         return this._fontFamily;
     }
@@ -344,8 +344,8 @@ export class LabelComponent extends UIRenderComponent {
      */
     @property({
         displayOrder: 8,
-        tooltip:'文字行高，以 point 为单位',
     })
+    @tooltip('文字行高，以 point 为单位')
     get lineHeight () {
         return this._lineHeight;
     }
@@ -368,8 +368,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         type: Overflow,
         displayOrder: 9,
-        tooltip:'文字排版模式，包括以下三种：\n 1. CLAMP: 节点约束框之外的文字会被截断 \n 2. SHRINK: 自动根据节点约束框缩小文字\n 3. RESIZE_HEIGHT: 根据文本内容自动更新节点的 height 属性.',
     })
+    @tooltip('文字排版模式，包括以下三种：\n 1. CLAMP: 节点约束框之外的文字会被截断 \n 2. SHRINK: 自动根据节点约束框缩小文字\n 3. RESIZE_HEIGHT: 根据文本内容自动更新节点的 height 属性.')
     get overflow () {
         return this._overflow;
     }
@@ -392,8 +392,8 @@ export class LabelComponent extends UIRenderComponent {
      */
     @property({
         displayOrder: 10,
-        tooltip:'自动换行',
     })
+    @tooltip('自动换行')
     get enableWrapText () {
         return this._enableWrapText;
     }
@@ -416,8 +416,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         type: Font,
         displayOrder: 11,
-        tooltip:'Label 使用的字体资源',
     })
+    @tooltip('Label 使用的字体资源')
     get font () {
         // return this._N$file;
         return this._font;
@@ -462,8 +462,8 @@ export class LabelComponent extends UIRenderComponent {
      */
     @property({
         displayOrder: 12,
-        tooltip:'是否使用系统默认字体',
     })
+    @tooltip('是否使用系统默认字体')
     get useSystemFont () {
         return this._isSystemFontUsed;
     }
@@ -506,8 +506,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         type: CacheMode,
         displayOrder: 13,
-        tooltip:'文本缓存模式，包括以下三种：\n 1. NONE: 不做任何缓存，文本内容进行一次绘制 \n 2. BITMAP: 将文本作为静态图像加入动态图集进行批次合并，但是不能频繁动态修改文本内容 \n 3. CHAR: 将文本拆分为字符并且把字符纹理缓存到一张字符图集中进行复用，适用于字符内容重复并且频繁更新的文本内容',
     })
+    @tooltip('文本缓存模式，包括以下三种：\n 1. NONE: 不做任何缓存，文本内容进行一次绘制 \n 2. BITMAP: 将文本作为静态图像加入动态图集进行批次合并，但是不能频繁动态修改文本内容 \n 3. CHAR: 将文本拆分为字符并且把字符纹理缓存到一张字符图集中进行复用，适用于字符内容重复并且频繁更新的文本内容')
     get cacheMode () {
         return this._cacheMode;
     }
@@ -543,8 +543,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         // visible: false,
         displayOrder: 15,
-        tooltip:'字体加粗',
     })
+    @tooltip('字体加粗')
     get isBold () {
         return this._isBold;
     }
@@ -568,8 +568,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         // visible: false,
         displayOrder: 16,
-        tooltip:'字体倾斜',
     })
+    @tooltip('字体倾斜')
     get isItalic () {
         return this._isItalic;
     }
@@ -593,8 +593,8 @@ export class LabelComponent extends UIRenderComponent {
     @property({
         // visible: false,
         displayOrder: 17,
-        tooltip:'字体加下划线',
     })
+    @tooltip('字体加下划线')
     get isUnderline () {
         return this._isUnderline;
     }

--- a/cocos/ui/components/label-outline-component.ts
+++ b/cocos/ui/components/label-outline-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component } from '../../core/components/component';
-import { ccclass, help, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { Color } from '../../core/math';
 import { LabelComponent } from './label-component';
 import { legacyCC } from '../../core/global-exports';
@@ -73,9 +73,7 @@ export class LabelOutlineComponent extends Component {
      * outline.color = cc.color(0.5, 0.3, 0.7, 1.0);
      * ```
      */
-    @property({
-        tooltip:'描边的颜色',
-    })
+    @tooltip('描边的颜色')
     // @constget
     get color (): Readonly<Color> {
         return this._color;
@@ -102,9 +100,7 @@ export class LabelOutlineComponent extends Component {
      * outline.width = 3;
      * ```
      */
-    @property({
-        tooltip:'描边的宽度',
-    })
+    @tooltip('描边的宽度')
     get width () {
         return this._width;
     }

--- a/cocos/ui/components/layout-component.ts
+++ b/cocos/ui/components/layout-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component } from '../../core/components/component';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent } from '../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
 import { Rect, Size, Vec2, Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
 import { UITransformComponent } from '../../core/components/ui-base/ui-transform-component';
@@ -200,8 +200,8 @@ export class LayoutComponent extends Component {
      */
     @property({
         type: Type,
-        tooltip:'自动布局模式，包括：\n 1. NONE，不会对子节点进行自动布局 \n 2. HORIZONTAL，横向自动排布子物体 \n 3. VERTICAL，垂直自动排布子物体\n 4. GRID, 采用网格方式对子物体自动进行布局',
     })
+    @tooltip('自动布局模式，包括：\n 1. NONE，不会对子节点进行自动布局 \n 2. HORIZONTAL，横向自动排布子物体 \n 3. VERTICAL，垂直自动排布子物体\n 4. GRID, 采用网格方式对子物体自动进行布局')
     get type () {
         return this._N$layoutType;
     }
@@ -228,8 +228,8 @@ export class LayoutComponent extends Component {
      */
     @property({
         type: ResizeMode,
-        tooltip:'缩放模式，包括：\n 1. NONE，不会对子节点和容器进行大小缩放 \n 2. CONTAINER, 对容器的大小进行缩放 \n 3. CHILDREN, 对子节点的大小进行缩放',
     })
+    @tooltip('缩放模式，包括：\n 1. NONE，不会对子节点和容器进行大小缩放 \n 2. CONTAINER, 对容器的大小进行缩放 \n 3. CHILDREN, 对子节点的大小进行缩放')
     get resizeMode () {
         return this._resizeMode;
     }
@@ -255,9 +255,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 每个格子的大小，只有布局类型为 GRID 的时候才有效。
      */
-    @property({
-        tooltip: '每个格子的大小，只有布局类型为 GRID 的时候才有效',
-    })
+    @tooltip('每个格子的大小，只有布局类型为 GRID 的时候才有效')
     // @constget
     get cellSize (): Readonly<Size> {
         return this._cellSize;
@@ -282,8 +280,8 @@ export class LayoutComponent extends Component {
      */
     @property({
         type: AxisDirection,
-        tooltip: '起始轴方向类型，可进行水平和垂直布局排列，只有布局类型为 GRID 的时候才有效',
     })
+    @tooltip('起始轴方向类型，可进行水平和垂直布局排列，只有布局类型为 GRID 的时候才有效')
     get startAxis () {
         return this._startAxis;
     }
@@ -310,9 +308,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 容器内左边距，只会在一个布局方向上生效。
      */
-    @property({
-        tooltip: '容器内左边距，只会在一个布局方向上生效',
-    })
+    @tooltip('容器内左边距，只会在一个布局方向上生效')
     get paddingLeft () {
         return this._paddingLeft;
     }
@@ -332,9 +328,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 容器内右边距，只会在一个布局方向上生效。
      */
-    @property({
-        tooltip: '容器内右边距，只会在一个布局方向上生效',
-    })
+    @tooltip('容器内右边距，只会在一个布局方向上生效')
     get paddingRight () {
         return this._paddingRight;
     }
@@ -354,9 +348,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 容器内上边距，只会在一个布局方向上生效。
      */
-    @property({
-        tooltip: '容器内上边距，只会在一个布局方向上生效',
-    })
+    @tooltip('容器内上边距，只会在一个布局方向上生效')
     get paddingTop () {
         return this._paddingTop;
     }
@@ -376,9 +368,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 容器内下边距，只会在一个布局方向上生效。
      */
-    @property({
-        tooltip: '容器内下边距，只会在一个布局方向上生效',
-    })
+    @tooltip('容器内下边距，只会在一个布局方向上生效')
     get paddingBottom () {
         return this._paddingBottom;
     }
@@ -398,9 +388,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 子节点之间的水平间距。
      */
-    @property({
-        tooltip: '子节点之间的水平间距',
-    })
+    @tooltip('子节点之间的水平间距')
     get spacingX () {
         return this._spacingX;
     }
@@ -421,9 +409,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 子节点之间的垂直间距。
      */
-    @property({
-        tooltip: '子节点之间的垂直间距',
-    })
+    @tooltip('子节点之间的垂直间距')
     get spacingY () {
         return this._spacingY;
     }
@@ -447,8 +433,8 @@ export class LayoutComponent extends Component {
      */
     @property({
         type: VerticalDirection,
-        tooltip: '垂直排列子节点的方向',
     })
+    @tooltip('垂直排列子节点的方向')
     get verticalDirection () {
         return this._verticalDirection;
     }
@@ -472,8 +458,8 @@ export class LayoutComponent extends Component {
      */
     @property({
         type: HorizontalDirection,
-        tooltip: '水平排列子节点的方向',
     })
+    @tooltip('水平排列子节点的方向')
     get horizontalDirection () {
         return this._horizontalDirection;
     }
@@ -494,9 +480,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 容器内边距，该属性会在四个布局方向上生效。
      */
-    @property({
-        tooltip: '容器内边距，该属性会在四个布局方向上生效',
-    })
+    @tooltip('容器内边距，该属性会在四个布局方向上生效')
     get padding () {
         return this._paddingLeft;
     }
@@ -515,9 +499,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 子节点缩放比例是否影响布局。
      */
-    @property({
-        tooltip: '子节点缩放比例是否影响布局',
-    })
+    @tooltip('子节点缩放比例是否影响布局')
     get affectedByScale () {
         return this._affectedByScale;
     }

--- a/cocos/ui/components/mask-component.ts
+++ b/cocos/ui/components/mask-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { InstanceMaterialType, UIRenderComponent } from '../../core/components/ui-base/ui-render-component';
-import { ccclass, help, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { clamp, Color, Mat4, Vec2, Vec3 } from '../../core/math';
 import { view, warnID } from '../../core/platform';
 import visibleRect from '../../core/platform/visible-rect';
@@ -114,8 +114,8 @@ export class MaskComponent extends UIRenderComponent {
     @property({
         type: MaskType,
         displayOrder: 4,
-        tooltip: '遮罩类型',
     })
+    @tooltip('遮罩类型')
     get type () {
         return this._type;
     }
@@ -140,9 +140,7 @@ export class MaskComponent extends UIRenderComponent {
      * @zh
      * 反向遮罩（不支持 Canvas 模式）。
      */
-    @property({
-        tooltip: '反向遮罩',
-    })
+    @tooltip('反向遮罩')
     get inverted () {
         return this._inverted;
     }

--- a/cocos/ui/components/page-view-component.ts
+++ b/cocos/ui/components/page-view-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { EventHandler as ComponentEventHandler } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { EventTouch, SystemEventType } from '../../core/platform';
 import { Vec2, Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
@@ -116,8 +116,8 @@ export class PageViewComponent extends ScrollViewComponent {
      */
     @property({
         type: SizeMode,
-        tooltip: '页面视图中每个页面大小类型',
     })
+    @tooltip('页面视图中每个页面大小类型')
     get sizeMode() {
         return this._sizeMode;
     }
@@ -140,8 +140,8 @@ export class PageViewComponent extends ScrollViewComponent {
      */
     @property({
         type: Direction,
-        tooltip: '页面视图滚动类型',
     })
+    @tooltip('页面视图滚动类型')
     get direction() {
         return this._direction;
     }
@@ -166,8 +166,8 @@ export class PageViewComponent extends ScrollViewComponent {
     @property({
         slide: true,
         range: [0, 1, 0.01],
-        tooltip: '滚动临界值，默认单位百分比，当拖拽超出该数值时，松开会自动滚动下一页，小于时则还原',
     })
+    @tooltip('滚动临界值，默认单位百分比，当拖拽超出该数值时，松开会自动滚动下一页，小于时则还原')
     get scrollThreshold() {
         return this._scrollThreshold;
     }
@@ -190,8 +190,8 @@ export class PageViewComponent extends ScrollViewComponent {
     @property({
         slide: true,
         range: [0, 1, 0.01],
-        tooltip: '设置 PageView PageTurning 事件的发送时机',
     })
+    @tooltip('设置 PageView PageTurning 事件的发送时机')
     get pageTurningEventTiming() {
         return this._pageTurningEventTiming;
     }
@@ -213,8 +213,8 @@ export class PageViewComponent extends ScrollViewComponent {
      */
     @property({
         type: PageViewIndicatorComponent,
-        tooltip: '页面视图指示器组件',
     })
+    @tooltip('页面视图指示器组件')
     get indicator() {
         return this._indicator;
     }
@@ -249,9 +249,7 @@ export class PageViewComponent extends ScrollViewComponent {
      * 当用户快速滑动时，会根据滑动开始和结束的距离与时间计算出一个速度值，
      * 该值与此临界值相比较，如果大于临界值，则进行自动翻页。
      */
-    @property({
-        tooltip: '快速滑动翻页临界值\n当用户快速滑动时，会根据滑动开始和结束的距离与时间计算出一个速度值\n该值与此临界值相比较，如果大于临界值，则进行自动翻页'
-    })
+    @tooltip('快速滑动翻页临界值\n当用户快速滑动时，会根据滑动开始和结束的距离与时间计算出一个速度值\n该值与此临界值相比较，如果大于临界值，则进行自动翻页')
     public autoPageTurningThreshold = 100;
 
     @property({
@@ -319,8 +317,8 @@ export class PageViewComponent extends ScrollViewComponent {
      */
     @property({
         type: [ComponentEventHandler],
-        tooltip: '滚动视图的事件回调函数',
     })
+    @tooltip('滚动视图的事件回调函数')
     public pageEvents: ComponentEventHandler[] = [];
 
     @property

--- a/cocos/ui/components/page-view-indicator-component.ts
+++ b/cocos/ui/components/page-view-indicator-component.ts
@@ -30,7 +30,7 @@
 
 import { SpriteFrame } from '../../core/assets';
 import { Component } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { Color, Size } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
 import { Node } from '../../core/scene-graph';
@@ -87,8 +87,8 @@ export class PageViewIndicatorComponent extends Component {
      */
     @property({
         type: SpriteFrame,
-        tooltip:'每个页面标记显示的图片',
     })
+    @tooltip('每个页面标记显示的图片')
     get spriteFrame () {
         return this._spriteFrame;
     }
@@ -111,8 +111,8 @@ export class PageViewIndicatorComponent extends Component {
      */
     @property({
         type: Direction,
-        tooltip:'页面标记摆放方向',
     })
+    @tooltip('页面标记摆放方向')
     get direction () {
         return this._direction;
     }
@@ -133,8 +133,8 @@ export class PageViewIndicatorComponent extends Component {
      */
     @property({
         type: Size,
-        tooltip:'每个页面标记的大小',
     })
+    @tooltip('每个页面标记的大小')
     get cellSize () {
         return this._cellSize;
     }
@@ -155,9 +155,7 @@ export class PageViewIndicatorComponent extends Component {
      * @zh
      * 每个页面标记之间的边距
      */
-    @property({
-        tooltip:'每个页面标记之间的边距',
-    })
+    @tooltip('每个页面标记之间的边距')
     public spacing = 0;
     @property
     protected _spriteFrame: SpriteFrame | null = null;

--- a/cocos/ui/components/progress-bar-component.ts
+++ b/cocos/ui/components/progress-bar-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component, UITransformComponent} from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
 import { Size, Vec2, Vec3 } from '../../core/math';
 import { Enum } from '../../core/value-types';
 import { clamp01 } from '../../core/math/utils';
@@ -114,8 +114,8 @@ export class ProgressBarComponent extends Component {
      */
     @property({
         type: SpriteComponent,
-        tooltip:'进度条显示用的 Sprite 节点，可以动态改变尺寸',
     })
+    @tooltip('进度条显示用的 Sprite 节点，可以动态改变尺寸')
     get barSprite () {
         return this._barSprite;
     }
@@ -138,8 +138,8 @@ export class ProgressBarComponent extends Component {
      */
     @property({
         type: Mode,
-        tooltip:'进度条显示模式，目前支持水平和垂直两种',
     })
+    @tooltip('进度条显示模式，目前支持水平和垂直两种')
     get mode () {
         return this._mode;
     }
@@ -172,9 +172,7 @@ export class ProgressBarComponent extends Component {
      * @zh
      * 进度条实际的总长度。
      */
-    @property({
-        tooltip:'进度条在 progress 为 1 时的最大长度',
-    })
+    @tooltip('进度条在 progress 为 1 时的最大长度')
     get totalLength () {
         return this._totalLength;
     }
@@ -197,8 +195,8 @@ export class ProgressBarComponent extends Component {
     @property({
         range: [0, 1, 0.1],
         slide: true,
-        tooltip:'当前进度指示，范围从 0 到 1',
     })
+    @tooltip('当前进度指示，范围从 0 到 1')
     get progress () {
         return this._progress;
     }
@@ -219,9 +217,7 @@ export class ProgressBarComponent extends Component {
      * @zh
      * 进度条是否进行反方向变化。
      */
-    @property({
-        tooltip:'是否反向驱动进度条',
-    })
+    @tooltip('是否反向驱动进度条')
     get reverse () {
         return this._reverse;
     }

--- a/cocos/ui/components/rich-text-component.ts
+++ b/cocos/ui/components/rich-text-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Font, SpriteAtlas, TTFFont, BitmapFont } from '../../core/assets';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { EventTouch } from '../../core/platform';
 import { fragmentText, HtmlTextParser, IHtmlTextParserResultObj, IHtmlTextParserStack, isUnicodeCJK, isUnicodeSpace, BASELINE_RATIO } from '../../core/utils';
 import Pool from '../../core/utils/pool';
@@ -185,8 +185,8 @@ export class RichTextComponent extends UIComponent {
      */
     @property({
         multiline: true,
-        tooltip:'富文本显示的文本内容',
     })
+    @tooltip('富文本显示的文本内容')
     get string () {
         return this._string;
     }
@@ -208,8 +208,8 @@ export class RichTextComponent extends UIComponent {
      */
     @property({
         type: HorizontalTextAlignment,
-        tooltip:'文本内容的水平对齐方式',
     })
+    @tooltip('文本内容的水平对齐方式')
     get horizontalAlign () {
         return this._horizontalAlign;
     }
@@ -231,9 +231,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本字体大小。
      */
-    @property({
-        tooltip:'富文本字体大小',
-    })
+    @tooltip('富文本字体大小')
     get fontSize () {
         return this._fontSize;
     }
@@ -257,8 +255,8 @@ export class RichTextComponent extends UIComponent {
      */
     @property({
         type: Font,
-        tooltip:'富文本定制字体',
     })
+    @tooltip('富文本定制字体')
     get font () {
         return this._font;
     }
@@ -286,9 +284,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本的最大宽度。
      */
-    @property({
-        tooltip:'富文本的最大宽度',
-    })
+    @tooltip('富文本的最大宽度')
     get maxWidth () {
         return this._maxWidth;
     }
@@ -310,9 +306,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本行高。
      */
-    @property({
-        tooltip:'富文本行高',
-    })
+    @tooltip('富文本行高')
     get lineHeight () {
         return this._lineHeight;
     }
@@ -336,8 +330,8 @@ export class RichTextComponent extends UIComponent {
      */
     @property({
         type: SpriteAtlas,
-        tooltip:'对于 img 标签里面的 src 属性名称，都需要在 imageAtlas 里面找到一个有效的 spriteFrame，否则 img tag 会判定为无效',
     })
+    @tooltip('对于 img 标签里面的 src 属性名称，都需要在 imageAtlas 里面找到一个有效的 spriteFrame，否则 img tag 会判定为无效')
     get imageAtlas () {
         return this._imageAtlas;
     }
@@ -360,9 +354,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 选中此选项后，RichText 将阻止节点边界框中的所有输入事件（鼠标和触摸），从而防止输入事件穿透到底层节点。
      */
-    @property({
-        tooltip:'选中此选项后，RichText 将阻止节点边界框中的所有输入事件（鼠标和触摸），从而防止输入事件穿透到底层节点',
-    })
+    @tooltip('选中此选项后，RichText 将阻止节点边界框中的所有输入事件（鼠标和触摸），从而防止输入事件穿透到底层节点')
     get handleTouchEvent () {
         return this._handleTouchEvent;
     }

--- a/cocos/ui/components/scroll-bar-component.ts
+++ b/cocos/ui/components/scroll-bar-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component, UITransformComponent } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
 import { Color, Size, Vec2, Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
 import { clamp01 } from '../../core/math/utils';
@@ -97,9 +97,9 @@ export class ScrollBarComponent extends Component {
      */
     @property({
         type: SpriteComponent,
-        tooltip: '作为当前滚动区域位置显示的滑块 Sprite',
         displayOrder: 0,
     })
+    @tooltip('作为当前滚动区域位置显示的滑块 Sprite')
     get handle () {
         return this._handle;
     }
@@ -121,9 +121,9 @@ export class ScrollBarComponent extends Component {
      */
     @property({
         type: Direction,
-        tooltip: 'ScrollBar 的滚动方向',
         displayOrder: 1,
     })
+    @tooltip('ScrollBar 的滚动方向')
     get direction () {
         return this._direction;
     }
@@ -145,9 +145,9 @@ export class ScrollBarComponent extends Component {
      * 是否在没有滚动动作时自动隐藏 ScrollBar。
      */
     @property({
-        tooltip: '是否在没有滚动动作时自动隐藏 ScrollBar',
         displayOrder: 2,
     })
+    @tooltip('是否在没有滚动动作时自动隐藏 ScrollBar')
     get enableAutoHide () {
         return this._enableAutoHide;
     }
@@ -173,9 +173,9 @@ export class ScrollBarComponent extends Component {
      * 注意：只要当 “enableAutoHide” 为 true 时，才有效。
      */
     @property({
-        tooltip: '没有滚动动作后经过多久会自动隐藏。\n注意：只要当 “enableAutoHide” 为 true 时，才有效。',
         displayOrder: 3,
     })
+    @tooltip('没有滚动动作后经过多久会自动隐藏。\n注意：只要当 “enableAutoHide” 为 true 时，才有效。')
     get autoHideTime () {
         return this._autoHideTime;
     }

--- a/cocos/ui/components/scroll-view-component.ts
+++ b/cocos/ui/components/scroll-view-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { EventHandler as ComponentEventHandler, UITransformComponent } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
 import { Event } from '../../core/event';
 import { EventMouse, EventTouch, Touch, logID } from '../../core/platform';
 import { Size, Vec2, Vec3 } from '../../core/math';
@@ -219,9 +219,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      */
     @property({
         range: [0, 10],
-        tooltip: '回弹持续的时间，0 表示将立即反弹',
         displayOrder: 0,
     })
+    @tooltip('回弹持续的时间，0 表示将立即反弹')
     public bounceDuration = 1;
 
     /**
@@ -234,9 +234,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      */
     @property({
         range: [0, 1, 0.1],
-        tooltip: '开启惯性后，在用户停止触摸后滚动多快停止，0 表示永不停止，1 表示立刻停止',
         displayOrder: 1,
     })
+    @tooltip('开启惯性后，在用户停止触摸后滚动多快停止，0 表示永不停止，1 表示立刻停止')
     public brake = 0.5;
 
     /**
@@ -247,9 +247,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * 是否允许滚动内容超过边界，并在停止触摸后回弹。
      */
     @property({
-        tooltip: '是否允许滚动内容超过边界，并在停止触摸后回弹',
         displayOrder: 2,
     })
+    @tooltip('是否允许滚动内容超过边界，并在停止触摸后回弹')
     public elastic = true;
 
     /**
@@ -260,9 +260,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * 是否开启滚动惯性。
      */
     @property({
-        tooltip: '是否开启滚动惯性',
         displayOrder: 3,
     })
+    @tooltip('是否开启滚动惯性')
     public inertia = true;
 
     /**
@@ -274,9 +274,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      */
     @property({
         type: Node,
-        tooltip: '可滚动展示内容的节点',
         displayOrder: 4,
     })
+    @tooltip('可滚动展示内容的节点')
     get content () {
         return this._content;
     }
@@ -303,9 +303,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * 是否开启水平滚动。
      */
     @property({
-        tooltip: '是否开启水平滚动',
         displayOrder: 5,
     })
+    @tooltip('是否开启水平滚动')
     public horizontal = true;
 
     /**
@@ -316,9 +316,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      */
     @property({
         type: ScrollBarComponent,
-        tooltip: '水平滚动的 ScrollBar',
         displayOrder: 6,
     })
+    @tooltip('水平滚动的 ScrollBar')
     get horizontalScrollBar () {
         return this._horizontalScrollBar;
     }
@@ -344,9 +344,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * 是否开启垂直滚动。
      */
     @property({
-        tooltip: '是否开启垂直滚动',
         displayOrder: 7,
     })
+    @tooltip('是否开启垂直滚动')
     public vertical = true;
 
     /**
@@ -358,9 +358,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      */
     @property({
         type: ScrollBarComponent,
-        tooltip: '垂直滚动的 ScrollBar',
         displayOrder: 8,
     })
+    @tooltip('垂直滚动的 ScrollBar')
     get verticalScrollBar () {
         return this._verticalScrollBar;
     }
@@ -388,9 +388,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * 注意，子节点上的 touchstart 事件仍然会触发，触点移动距离非常短的情况下 touchmove 和 touchend 也不会受影响。
      */
     @property({
-        tooltip: '滚动行为是否会取消子节点上注册的触摸事件',
         displayOrder: 9,
     })
+    @tooltip('滚动行为是否会取消子节点上注册的触摸事件')
     public cancelInnerEvents = true;
 
     /**
@@ -402,9 +402,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      */
     @property({
         type: [ComponentEventHandler],
-        tooltip: '滚动视图的事件回调函数',
         displayOrder: 10,
     })
+    @tooltip('滚动视图的事件回调函数')
     public scrollEvents: ComponentEventHandler[] = [];
 
     get view () {

--- a/cocos/ui/components/slider-component.ts
+++ b/cocos/ui/components/slider-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component, EventHandler, UITransformComponent } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
 import { EventTouch, SystemEventType, Touch } from '../../core/platform';
 import { Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
@@ -90,8 +90,8 @@ export class SliderComponent extends Component {
      */
     @property({
         type: SpriteComponent,
-        tooltip:'滑块按钮部件',
     })
+    @tooltip('滑块按钮部件')
     get handle () {
         return this._handle;
     }
@@ -116,8 +116,8 @@ export class SliderComponent extends Component {
      */
     @property({
         type: Direction,
-        tooltip:'滑动方向',
     })
+    @tooltip('滑动方向')
     get direction () {
         return this._direction;
     }
@@ -141,8 +141,8 @@ export class SliderComponent extends Component {
     @property({
         slide: true,
         range: [0, 1, 0.01],
-        tooltip:'当前进度值，该数值的区间是 0 - 1 之间。',
     })
+    @tooltip('当前进度值，该数值的区间是 0 - 1 之间。')
     get progress () {
         return this._progress;
     }
@@ -167,8 +167,8 @@ export class SliderComponent extends Component {
      */
     @property({
         type: EventHandler,
-        tooltip:'滑动器组件事件回调函数',
     })
+    @tooltip('滑动器组件事件回调函数')
     public slideEvents: EventHandler[] = [];
     @property
     private _handle: SpriteComponent | null = null;

--- a/cocos/ui/components/sprite-component.ts
+++ b/cocos/ui/components/sprite-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { SpriteAtlas, SpriteFrame } from '../../core/assets';
-import { ccclass, help, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { SystemEventType } from '../../core/platform/event-manager/event-enum';
 import { Vec2 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
@@ -188,8 +188,8 @@ export class SpriteComponent extends UIRenderComponent {
     @property({
         type: SpriteAtlas,
         displayOrder: 4,
-        tooltip:'图片资源所属的 Atlas 图集资源',
     })
+    @tooltip('图片资源所属的 Atlas 图集资源')
     get spriteAtlas () {
         return this._atlas;
     }
@@ -213,8 +213,8 @@ export class SpriteComponent extends UIRenderComponent {
     @property({
         type: SpriteFrame,
         displayOrder: 5,
-        tooltip:'渲染 Sprite 使用的 SpriteFrame 图片资源',
     })
+    @tooltip('渲染 Sprite 使用的 SpriteFrame 图片资源')
     get spriteFrame () {
         return this._spriteFrame;
     }
@@ -250,10 +250,10 @@ export class SpriteComponent extends UIRenderComponent {
     @property({
         type: SpriteType,
         displayOrder: 6,
-        tooltip:'渲染模式：\n- 普通（Simple）：修改尺寸会整体拉伸图像，适用于序列帧动画和普通图像 \n' +
-        '- 九宫格（Sliced）：修改尺寸时四个角的区域不会拉伸，适用于 UI 按钮和面板背景 \n' +
-        '- 填充（Filled）：设置一定的填充起始位置和方向，能够以一定比率剪裁显示图片',
     })
+    @tooltip('渲染模式：\n- 普通（Simple）：修改尺寸会整体拉伸图像，适用于序列帧动画和普通图像 \n' +
+    '- 九宫格（Sliced）：修改尺寸时四个角的区域不会拉伸，适用于 UI 按钮和面板背景 \n' +
+    '- 填充（Filled）：设置一定的填充起始位置和方向，能够以一定比率剪裁显示图片')
     get type () {
         return this._type;
     }
@@ -278,8 +278,8 @@ export class SpriteComponent extends UIRenderComponent {
      */
     @property({
         type: FillType,
-        tooltip:'填充方向，可以选择横向（Horizontal），纵向（Vertical）和扇形（Radial）三种方向',
     })
+    @tooltip('填充方向，可以选择横向（Horizontal），纵向（Vertical）和扇形（Radial）三种方向')
     get fillType () {
         return this._fillType;
     }
@@ -311,9 +311,7 @@ export class SpriteComponent extends UIRenderComponent {
      * sprite.fillCenter = cc.v2(0, 0);
      * ```
      */
-    @property({
-        tooltip:'扇形填充时，指定扇形的中心点，取值范围 0 ~ 1',
-    })
+    @tooltip('扇形填充时，指定扇形的中心点，取值范围 0 ~ 1')
     get fillCenter () {
         return this._fillCenter;
     }
@@ -340,8 +338,8 @@ export class SpriteComponent extends UIRenderComponent {
      */
     @property({
         range: [0, 1, 0.1],
-        tooltip:'填充起始位置，输入一个 0 ~ 1 之间的小数表示起始位置的百分比',
     })
+    @tooltip('填充起始位置，输入一个 0 ~ 1 之间的小数表示起始位置的百分比')
     get fillStart () {
         return this._fillStart;
     }
@@ -369,8 +367,8 @@ export class SpriteComponent extends UIRenderComponent {
      */
     @property({
         range: [0, 1, 0.1],
-        tooltip:'填充总量，取值范围 0 ~ 1 指定显示图像范围的百分比',
     })
+    @tooltip('填充总量，取值范围 0 ~ 1 指定显示图像范围的百分比')
     get fillRange () {
         return this._fillRange;
     }
@@ -396,8 +394,8 @@ export class SpriteComponent extends UIRenderComponent {
      */
     @property({
         displayOrder: 8,
-        tooltip:'节点约束框内是否包括透明像素区域，勾选此项会去除节点约束框内的透明区域',
     })
+    @tooltip('节点约束框内是否包括透明像素区域，勾选此项会去除节点约束框内的透明区域')
     get trim () {
         return this._isTrimmedMode;
     }
@@ -446,8 +444,8 @@ export class SpriteComponent extends UIRenderComponent {
     @property({
         type: SizeMode,
         displayOrder: 7,
-        tooltip:'指定 Sprite 所在节点的尺寸，CUSTOM 表示自定义尺寸，TRIMMED 表示取原始图片剪裁透明像素后的尺寸，RAW 表示取原始图片未剪裁的尺寸',
     })
+    @tooltip('指定 Sprite 所在节点的尺寸，CUSTOM 表示自定义尺寸，TRIMMED 表示取原始图片剪裁透明像素后的尺寸，RAW 表示取原始图片未剪裁的尺寸')
     get sizeMode () {
         return this._sizeMode;
     }

--- a/cocos/ui/components/toggle-component.ts
+++ b/cocos/ui/components/toggle-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { EventHandler as ComponentEventHandler, UITransformComponent } from '../../core/components';
-import { ccclass, help, requireComponent, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, requireComponent, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { ButtonComponent } from './button-component';
 import { SpriteComponent } from './sprite-component';
 import { ToggleContainerComponent } from './toggle-container-component';
@@ -66,9 +66,9 @@ export class ToggleComponent extends ButtonComponent {
      * 如果这个设置为 true，则 check mark 组件会处于 enabled 状态，否则处于 disabled 状态。
      */
     @property({
-        tooltip: '如果这个设置为 true，则 check mark 组件会处于 enabled 状态，否则处于 disabled 状态。',
         displayOrder: 2,
     })
+    @tooltip('如果这个设置为 true，则 check mark 组件会处于 enabled 状态，否则处于 disabled 状态。')
     get isChecked () {
         return this._isChecked;
     }
@@ -91,9 +91,9 @@ export class ToggleComponent extends ButtonComponent {
      */
     @property({
         type: SpriteComponent,
-        tooltip: 'Toggle 处于选中状态时显示的精灵图片',
         displayOrder: 3,
     })
+    @tooltip('Toggle 处于选中状态时显示的精灵图片')
     get checkMark () {
         return this._checkMark;
     }
@@ -116,9 +116,9 @@ export class ToggleComponent extends ButtonComponent {
      */
     @property({
         type: ToggleContainerComponent,
-        tooltip: 'Toggle 所属的 ToggleGroup，这个属性是可选的。如果这个属性为 null，则 Toggle 是一个 CheckBox，否则，Toggle 是一个 RadioButton。',
          displayOrder: 4,
     })
+    @tooltip('Toggle 所属的 ToggleGroup，这个属性是可选的。如果这个属性为 null，则 Toggle 是一个 CheckBox，否则，Toggle 是一个 RadioButton。')
     get toggleGroup () {
         return this._toggleGroup;
     }
@@ -163,8 +163,8 @@ export class ToggleComponent extends ButtonComponent {
      */
     @property({
         type: [ComponentEventHandler],
-        tooltip: '列表类型，默认为空，用户添加的每一个事件由节点引用，组件名称和一个响应函数组成',
     })
+    @tooltip('列表类型，默认为空，用户添加的每一个事件由节点引用，组件名称和一个响应函数组成')
     public checkEvents: ComponentEventHandler[] = [];
     @property
     private _isChecked: boolean = true;

--- a/cocos/ui/components/toggle-container-component.ts
+++ b/cocos/ui/components/toggle-container-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component, EventHandler as ComponentEventHandler } from '../../core/components';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property } from '../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
 import { ToggleComponent} from './toggle-component';
 import { legacyCC } from '../../core/global-exports';
 
@@ -59,8 +59,8 @@ export class ToggleContainerComponent extends Component {
      */
     @property({
         type: [ComponentEventHandler],
-        tooltip:'选中事件。列表类型，默认为空，用户添加的每一个事件由节点引用，组件名称和一个响应函数组成。',
     })
+    @tooltip('选中事件。列表类型，默认为空，用户添加的每一个事件由节点引用，组件名称和一个响应函数组成。')
     public checkEvents: ComponentEventHandler[] = [];
     @property
     protected _allowSwitchOff: boolean = false;
@@ -75,9 +75,7 @@ export class ToggleContainerComponent extends Component {
      * @zh
      * 如果这个设置为 true，那么 toggle 按钮在被点击的时候可以反复地被选中和未选中。
      */
-    @property({
-        tooltip:'如果这个设置为 true， 那么 toggle 按钮在被点击的时候可以反复地被选中和未选中。',
-    })
+    @tooltip('如果这个设置为 true， 那么 toggle 按钮在被点击的时候可以反复地被选中和未选中。')
     get allowSwitchOff () {
         return this._allowSwitchOff;
     }

--- a/cocos/ui/components/widget-component.ts
+++ b/cocos/ui/components/widget-component.ts
@@ -30,7 +30,7 @@
 
 import { Component } from '../../core/components';
 import { UITransformComponent } from '../../core/components/ui-base/ui-transform-component';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent } from '../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
 import { Size, Vec3 } from '../../core/math';
 import { errorID, warnID } from '../../core/platform/debug';
 import { SystemEventType } from '../../core/platform/event-manager/event-enum';
@@ -221,8 +221,8 @@ export class WidgetComponent extends Component {
      */
     @property({
         type: Node,
-        tooltip:'对齐目标',
     })
+    @tooltip('对齐目标')
     get target () {
         return this._target;
     }
@@ -252,9 +252,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 是否对齐上边。
      */
-    @property({
-        tooltip:'是否对齐上边',
-    })
+    @tooltip('是否对齐上边')
     get isAlignTop () {
         return (this._alignFlags & AlignFlags.TOP) > 0;
     }
@@ -270,9 +268,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 是否对齐下边。
      */
-    @property({
-        tooltip:'是否对齐下边',
-    })
+    @tooltip('是否对齐下边')
     get isAlignBottom () {
         return (this._alignFlags & AlignFlags.BOT) > 0;
     }
@@ -288,9 +284,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 是否对齐左边。
      */
-    @property({
-        tooltip:'是否对齐左边',
-    })
+    @tooltip('是否对齐左边')
     get isAlignLeft () {
         return (this._alignFlags & AlignFlags.LEFT) > 0;
     }
@@ -306,9 +300,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 是否对齐右边。
      */
-    @property({
-        tooltip:'是否对齐右边',
-    })
+    @tooltip('是否对齐右边')
     get isAlignRight () {
         return (this._alignFlags & AlignFlags.RIGHT) > 0;
     }
@@ -324,9 +316,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 是否垂直方向对齐中点，开启此项会将垂直方向其他对齐选项取消。
      */
-    @property({
-        tooltip:'是否垂直方向对齐中点，开启此项会将垂直方向其他对齐选项取消',
-    })
+    @tooltip('是否垂直方向对齐中点，开启此项会将垂直方向其他对齐选项取消')
     get isAlignVerticalCenter () {
         return (this._alignFlags & AlignFlags.MID) > 0;
     }
@@ -349,9 +339,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 是否水平方向对齐中点，开启此选项会将水平方向其他对齐选项取消。
      */
-    @property({
-        tooltip:'是否水平方向对齐中点，开启此选项会将水平方向其他对齐选项取消',
-    })
+    @tooltip('是否水平方向对齐中点，开启此选项会将水平方向其他对齐选项取消')
     get isAlignHorizontalCenter () {
         return (this._alignFlags & AlignFlags.CENTER) > 0;
     }
@@ -700,8 +688,8 @@ export class WidgetComponent extends Component {
      */
     @property({
         type: AlignMode,
-        tooltip:'指定 widget 的对齐方式，用于决定运行时 widget 应何时更新',
     })
+    @tooltip('指定 widget 的对齐方式，用于决定运行时 widget 应何时更新')
     get alignMode () {
         return this._alignMode;
     }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Optimize editor decorators for package size.

There is an optimization point: arguments passed to editor-only decorators can be eliminated from source code when build engine for runtime.

At first, we use Rollup. We use the tree-shaking functionality of Rollup. But our editor decorator arguments are not culled because there was a BUG at https://github.com/rollup/rollup/issues/3674. Fortunately, Rollup has fixed this BUG and published a new verison.

`createDummyDecorator` was not tree-shakable. I've changed that.

Property decorator `property`'s `tooltip` option carried a lot of string literals. We have to separate it from `property` and export a new decorator `tooltip` which is tree-shakable.

---------------------

#### Benchmark

I've test this PR based on commit 8f1a22812a180f59a7a2560f1aec613fec9d9302.

|  	| Commit 8f1a22 	| Cherry-pick this PR 	|
|-	|-	|-	|
| cc.js 	| 4,380 KB 	| 4,363 KB 	|
| cc.min.js 	| 1,983 KB 	| 1,967 KB 	|

You can see that **about 16 KB** space is saved.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
