### PR TITLE
Reduce the usage of Object.getOwnPropertyDescriptors

### DIFF
--- a/cocos/core/event/eventify.ts
+++ b/cocos/core/event/eventify.ts
@@ -140,10 +140,17 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
     };
 
     // Mixin with `CallbacksInvokers`'s prototype
-    const propertyDescriptors = Object.getOwnPropertyDescriptors(CallbacksInvoker.prototype);
-    for (const propertyName in propertyDescriptors) {
-        if (!(propertyName in Eventified.prototype)) {
-            Object.defineProperty(Eventified.prototype, propertyName, propertyDescriptors[propertyName]);
+    const callbacksInvokerPrototype = CallbacksInvoker.prototype;
+    const propertyKeys: (string | symbol)[] =
+        (Object.getOwnPropertyNames(callbacksInvokerPrototype) as (string | symbol)[]).concat(
+            Object.getOwnPropertySymbols(callbacksInvokerPrototype));
+    for (let iPropertyKey = 0; iPropertyKey < propertyKeys.length; ++iPropertyKey) {
+        const propertyKey = propertyKeys[iPropertyKey];
+        const propertyDescriptor = Object.getOwnPropertyDescriptor(callbacksInvokerPrototype, propertyKey);
+        if (propertyDescriptor) {
+            if (!(propertyKey in Eventified.prototype)) {
+                Object.defineProperty(Eventified.prototype, propertyKey, propertyDescriptor);
+            }
         }
     }
 

--- a/cocos/core/event/eventify.ts
+++ b/cocos/core/event/eventify.ts
@@ -146,9 +146,9 @@ export function Eventify<TBase> (base: Constructor<TBase>): Constructor<TBase & 
             Object.getOwnPropertySymbols(callbacksInvokerPrototype));
     for (let iPropertyKey = 0; iPropertyKey < propertyKeys.length; ++iPropertyKey) {
         const propertyKey = propertyKeys[iPropertyKey];
-        const propertyDescriptor = Object.getOwnPropertyDescriptor(callbacksInvokerPrototype, propertyKey);
-        if (propertyDescriptor) {
-            if (!(propertyKey in Eventified.prototype)) {
+        if (!(propertyKey in Eventified.prototype)) {
+            const propertyDescriptor = Object.getOwnPropertyDescriptor(callbacksInvokerPrototype, propertyKey);
+            if (propertyDescriptor) {
                 Object.defineProperty(Eventified.prototype, propertyKey, propertyDescriptor);
             }
         }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Reduce the usage of `Object.getOwnPropertyDescriptors`, which is an ES2017 feature

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
