### PR TITLE
resolve conflict between gfx and splash

### DIFF
--- a/cocos/core/splash-screen-webgl.ts
+++ b/cocos/core/splash-screen-webgl.ts
@@ -8,6 +8,7 @@ import { easing } from "./animation";
 import { macro } from "./platform";
 import { sys } from "./platform/sys";
 import { COCOSPLAY, XIAOMI, JSB, ALIPAY } from 'internal:constants';
+import { game } from "./game";
 
 type SplashEffectType = 'none' | 'Fade-InOut';
 
@@ -467,6 +468,15 @@ export class SplashScreenWebgl {
         this.gl.deleteBuffer(this.texcoordBuffer);
         this.gl.deleteTexture(this.textureLogo);
         this.gl.deleteTexture(this.textureText);
+
+        /** HACK: reset gfx texture unit cache */
+        const device = game._gfxDevice;
+        if (device && device.stateCache) {
+            const glTexUnits = device.stateCache.glTexUnits;
+            for (let i = 0; i < glTexUnits.length; i++) {
+                if (glTexUnits[i] != null) glTexUnits[i].glTexture = null;
+            }
+        }
     }
 
     private static _ins: SplashScreenWebgl;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changes:
 * reset gfx texture unit cache when splash destroy

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
