### PR TITLE
improve get color for outline shadow motion streak

### DIFF
--- a/cocos2d/core/components/CCLabelOutline.js
+++ b/cocos2d/core/components/CCLabelOutline.js
@@ -62,7 +62,7 @@ let LabelOutline = cc.Class({
         color: {
             tooltip: CC_DEV && 'i18n:COMPONENT.outline.color',
             get: function () {
-                return this._color;
+                return this._color.clone();
             },
             set: function (value) {
                 if (!this._color.equals(value)) {

--- a/cocos2d/core/components/CCLabelShadow.js
+++ b/cocos2d/core/components/CCLabelShadow.js
@@ -63,7 +63,7 @@ let LabelShadow = cc.Class({
         color: {
             tooltip: CC_DEV && 'i18n:COMPONENT.shadow.color',
             get: function () {
-                return this._color;
+                return this._color.clone();
             },
             set: function (value) {
                 if (!this._color.equals(value)) {

--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -179,7 +179,7 @@ var MotionStreak = cc.Class({
         _color: cc.Color.WHITE,
         color: {
             get () {
-                return this._color;
+                return this._color.clone();
             },
             set (value) {
                 if (!this._color.equals(value)) {


### PR DESCRIPTION
Re: https://forum.cocos.org/t/node-color-get-labeloutline-color-get/96095

Changes:
 * 修复如果用户获取 LabelOutline、LabelShadow、MotionStreak 的 color 进行缓存后，如果重新修改了 color 的数值，缓存起来的 color 也会跟着改变

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
