### PR TITLE
【再议】修复手动关闭 动态合图 无效的bug

### DIFF
--- a/cocos2d/core/CCGame.js
+++ b/cocos2d/core/CCGame.js
@@ -773,7 +773,7 @@ var game = {
             
             // Enable dynamic atlas manager by default
             if (!cc.macro.CLEANUP_IMAGE_CACHE && dynamicAtlasManager) {
-                dynamicAtlasManager.enabled = true;
+                dynamicAtlasManager.enabled = dynamicAtlasManager.enabled === false ? false : true;
             }
         }
         if (!this._renderContext) {


### PR DESCRIPTION
如果用户 手动设置了 dynamicAtlasManager.enabled=false , 应该以用户设置的为主, 而不应该总是变成true.

