### PR TITLE
Fix SpriteFrame clone issue: sharing object from original SpriteFrame

### DIFF
--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -438,8 +438,11 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
      * @method clone
      * @return {SpriteFrame}
      */
-    clone: function () {
-        return new SpriteFrame(this._texture, this._rect, this._rotated, this._offset, this._originalSize);
+    clone: function() {
+        let rect = this._rect ? this.getRect() : null;
+        let offset = this._offset ? this.getOffset() : null;
+        let originalSize = this._originalSize ? this.getOriginalSize() : null;
+        return new SpriteFrame(this._texture, rect, this._rotated, offset, originalSize);
     },
 
     /**

--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -439,10 +439,7 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
      * @return {SpriteFrame}
      */
     clone: function() {
-        let rect = this._rect ? this.getRect() : null;
-        let offset = this._offset ? this.getOffset() : null;
-        let originalSize = this._originalSize ? this.getOriginalSize() : null;
-        return new SpriteFrame(this._texture, rect, this._rotated, offset, originalSize);
+        return new SpriteFrame(this._texture, this.getRect(), this._rotated, this.getOffset(), this.getOriginalSize());
     },
 
     /**


### PR DESCRIPTION
目前版本的 SpriteFrame clone 存在严重bug.

b = a.clone();
b里面会直接引用 a的 rect ,  会出现 a的rect变化(比如生成动态图集时)  会引起b变化.

该PR 修复此bug

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
