### PR TITLE
TiledMap相关: 让 ObjectLayer 支持动画tile

### DIFF
--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -355,15 +355,7 @@ let TiledObjectGroup = cc.Class({
             sp.spriteFrame = spf;
             sp.setVertsDirty();
         }
-    },
-
-    onDestroy () {
-        this._texGrids = null;
-        this._animations = null;
-        this.aniObjects = null;
-        this._hasAniObj = false;
     }
-
 });
 
 cc.TiledObjectGroup = module.exports = TiledObjectGroup;

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -125,8 +125,6 @@ let TiledObjectGroup = cc.Class({
         const FLAG_HORIZONTAL = TileFlag.HORIZONTAL;
         const FLAG_VERTICAL = TileFlag.VERTICAL;
 
-        this._texGrids = texGrids;
-
         this._groupName = groupInfo.name;
         this._positionOffset = groupInfo.offset;
         this._mapInfo = mapInfo;
@@ -134,6 +132,7 @@ let TiledObjectGroup = cc.Class({
         this._offset = cc.v2(groupInfo.offset.x, -groupInfo.offset.y);
         this._opacity = groupInfo._opacity;
 
+        this._texGrids = texGrids;
         this._animations = mapInfo.getTileAnimations();
         this.aniObjects = [];
         this._hasAniObj = false;
@@ -145,7 +144,7 @@ let TiledObjectGroup = cc.Class({
 
         const iso = Orientation.ISO === mapInfo.orientation;
 
-        if (Orientation.HEX === mapInfo.orientation) {
+        if (mapInfo.orientation === Orientation.HEX) {
             if (mapInfo.getStaggerAxis() === StaggerAxis.STAGGERAXIS_X) {
                 height = tileSize.height * (mapSize.height + 0.5);
                 width = (tileSize.width + mapInfo.getHexSideLength()) * Math.floor(mapSize.width / 2) + tileSize.width * (mapSize.width % 2);
@@ -233,6 +232,8 @@ let TiledObjectGroup = cc.Class({
                 let imgName = "img" + object.id;
                 aliveNodes[imgName] = true;
                 let imgNode = this.node.getChildByName(imgName);
+                object.width = object.width || grid.width;
+                object.height = object.height || grid.height;
 
                 // Delete image nodes implemented as private nodes
                 // Use cc.Node to implement node-level requirements
@@ -245,9 +246,6 @@ let TiledObjectGroup = cc.Class({
                 if (!imgNode) {
                     imgNode = new cc.Node();
                 }
-
-                object.width = object.width || grid.width;
-                object.height = object.height || grid.height;
 
                 if (this._animations[gridGID]) {
                     this.aniObjects.push({
@@ -357,7 +355,15 @@ let TiledObjectGroup = cc.Class({
             sp.spriteFrame = spf;
             sp.setVertsDirty();
         }
+    },
+
+    onDestroy () {
+        this._texGrids = null;
+        this._animations = null;
+        this.aniObjects = null;
+        this._hasAniObj = false;
     }
+
 });
 
 cc.TiledObjectGroup = module.exports = TiledObjectGroup;

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -44,7 +44,7 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let offset = tMXObjectGroup.getPositionOffset();
      */
-    getPositionOffset() {
+    getPositionOffset () {
         return this._positionOffset;
     },
 
@@ -56,7 +56,7 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let offset = tMXObjectGroup.getProperties();
      */
-    getProperties() {
+    getProperties () {
         this._properties;
     },
 
@@ -68,7 +68,7 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let groupName = tMXObjectGroup.getGroupName;
      */
-    getGroupName() {
+    getGroupName () {
         return this._groupName;
     },
 
@@ -77,7 +77,7 @@ let TiledObjectGroup = cc.Class({
      * @param {String} propertyName
      * @return {Object}
      */
-    getProperty(propertyName) {
+    getProperty (propertyName) {
         return this._properties[propertyName.toString()];
     },
 
@@ -92,7 +92,7 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let object = tMXObjectGroup.getObject("Group");
      */
-    getObject(objectName) {
+    getObject (objectName) {
         for (let i = 0, len = this._objects.length; i < len; i++) {
             let obj = this._objects[i];
             if (obj && obj.name === objectName) {
@@ -111,11 +111,11 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let objects = tMXObjectGroup.getObjects();
      */
-    getObjects() {
+    getObjects () {
         return this._objects;
     },
 
-    _init(groupInfo, mapInfo, texGrids) {
+    _init (groupInfo, mapInfo, texGrids) {
         const TiledMap = cc.TiledMap;
         const TMXObjectType = TiledMap.TMXObjectType;
         const Orientation = TiledMap.Orientation;
@@ -318,7 +318,7 @@ let TiledObjectGroup = cc.Class({
         }
     },
 
-    update(dt) {
+    update (dt) {
         if (!this._hasAniObj) {
             return;
         }

--- a/cocos2d/tilemap/CCTiledObjectGroup.js
+++ b/cocos2d/tilemap/CCTiledObjectGroup.js
@@ -44,7 +44,7 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let offset = tMXObjectGroup.getPositionOffset();
      */
-    getPositionOffset () {
+    getPositionOffset() {
         return this._positionOffset;
     },
 
@@ -56,7 +56,7 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let offset = tMXObjectGroup.getProperties();
      */
-    getProperties () {
+    getProperties() {
         this._properties;
     },
 
@@ -68,7 +68,7 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let groupName = tMXObjectGroup.getGroupName;
      */
-    getGroupName () {
+    getGroupName() {
         return this._groupName;
     },
 
@@ -77,7 +77,7 @@ let TiledObjectGroup = cc.Class({
      * @param {String} propertyName
      * @return {Object}
      */
-    getProperty (propertyName) {
+    getProperty(propertyName) {
         return this._properties[propertyName.toString()];
     },
 
@@ -92,7 +92,7 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let object = tMXObjectGroup.getObject("Group");
      */
-    getObject (objectName) {
+    getObject(objectName) {
         for (let i = 0, len = this._objects.length; i < len; i++) {
             let obj = this._objects[i];
             if (obj && obj.name === objectName) {
@@ -111,11 +111,11 @@ let TiledObjectGroup = cc.Class({
      * @example
      * let objects = tMXObjectGroup.getObjects();
      */
-    getObjects () {
+    getObjects() {
         return this._objects;
     },
 
-    _init (groupInfo, mapInfo, texGrids) {
+    _init(groupInfo, mapInfo, texGrids) {
         const TiledMap = cc.TiledMap;
         const TMXObjectType = TiledMap.TMXObjectType;
         const Orientation = TiledMap.Orientation;
@@ -125,6 +125,8 @@ let TiledObjectGroup = cc.Class({
         const FLAG_HORIZONTAL = TileFlag.HORIZONTAL;
         const FLAG_VERTICAL = TileFlag.VERTICAL;
 
+        this._texGrids = texGrids;
+
         this._groupName = groupInfo.name;
         this._positionOffset = groupInfo.offset;
         this._mapInfo = mapInfo;
@@ -132,10 +134,18 @@ let TiledObjectGroup = cc.Class({
         this._offset = cc.v2(groupInfo.offset.x, -groupInfo.offset.y);
         this._opacity = groupInfo._opacity;
 
+        this._animations = mapInfo.getTileAnimations();
+        this.aniObjects = [];
+        this._hasAniObj = false;
+
         let mapSize = mapInfo._mapSize;
         let tileSize = mapInfo._tileSize;
-        let width = 0, height = 0;
-        if (mapInfo.orientation === Orientation.HEX) {
+        let width = 0,
+            height = 0;
+
+        const iso = Orientation.ISO === mapInfo.orientation;
+
+        if (Orientation.HEX === mapInfo.orientation) {
             if (mapInfo.getStaggerAxis() === StaggerAxis.STAGGERAXIS_X) {
                 height = tileSize.height * (mapSize.height + 0.5);
                 width = (tileSize.width + mapInfo.getHexSideLength()) * Math.floor(mapSize.width / 2) + tileSize.width * (mapSize.width % 2);
@@ -143,12 +153,12 @@ let TiledObjectGroup = cc.Class({
                 width = tileSize.width * (mapSize.width + 0.5);
                 height = (tileSize.height + mapInfo.getHexSideLength()) * Math.floor(mapSize.height / 2) + tileSize.height * (mapSize.height % 2);
             }
-        } else if (mapInfo.orientation === Orientation.ISO) {
+        } else if (iso) {
             let wh = mapSize.width + mapSize.height;
             width = tileSize.width * 0.5 * wh;
             height = tileSize.height * 0.5 * wh;
         } else {
-            width = mapSize.width * tileSize.width; 
+            width = mapSize.width * tileSize.width;
             height = mapSize.height * tileSize.height;
         }
         this.node.setContentSize(width, height);
@@ -162,21 +172,21 @@ let TiledObjectGroup = cc.Class({
             let object = objects[i];
             let objType = object.type;
             object.offset = cc.v2(object.x, object.y);
-            
+
             let points = object.points || object.polylinePoints;
             if (points) {
                 for (let pi = 0; pi < points.length; pi++) {
                     points[pi].y *= -1;
                 }
-            }         
+            }
 
-            if (Orientation.ISO !== mapInfo.orientation) {
-                object.y = height - object.y;
-            } else {
+            if (iso) {
                 let posIdxX = object.x / tileSize.height;
                 let posIdxY = object.y / tileSize.height;
                 object.x = tileSize.width * 0.5 * (mapSize.height + posIdxX - posIdxY);
                 object.y = tileSize.height * 0.5 * (mapSize.width + mapSize.height - posIdxX - posIdxY);
+            } else {
+                object.y = height - object.y;
             }
 
             if (objType === TMXObjectType.TEXT) {
@@ -204,7 +214,7 @@ let TiledObjectGroup = cc.Class({
                 if (!label) {
                     label = textNode.addComponent(cc.Label);
                 }
-                
+
                 label.overflow = cc.Label.Overflow.SHRINK;
                 label.lineHeight = object.height;
                 label.string = object.text;
@@ -214,20 +224,15 @@ let TiledObjectGroup = cc.Class({
 
                 textNode.width = object.width;
                 textNode.height = object.height;
-            }
-
-            if (objType === TMXObjectType.IMAGE) {
+            } else if (objType === TMXObjectType.IMAGE) {
                 let gid = object.gid;
-                let grid = texGrids[(gid & FLIPPED_MASK) >>> 0];
+                let gridGID = ((gid & FLIPPED_MASK) >>> 0);
+                let grid = texGrids[gridGID];
                 if (!grid) continue;
                 let tileset = grid.tileset;
                 let imgName = "img" + object.id;
                 aliveNodes[imgName] = true;
                 let imgNode = this.node.getChildByName(imgName);
-                let imgWidth = object.width || grid.width;
-                let imgHeight = object.height || grid.height;
-                let tileOffsetX = tileset.tileOffset.x;
-                let tileOffsetY = tileset.tileOffset.y;
 
                 // Delete image nodes implemented as private nodes
                 // Use cc.Node to implement node-level requirements
@@ -241,13 +246,28 @@ let TiledObjectGroup = cc.Class({
                     imgNode = new cc.Node();
                 }
 
-                if (Orientation.ISO == mapInfo.orientation) {
-                    imgNode.anchorX = 0.5 + tileOffsetX / imgWidth;
-                    imgNode.anchorY = tileOffsetY / imgHeight;
-                } else {
-                    imgNode.anchorX = tileOffsetX / imgWidth;
-                    imgNode.anchorY = tileOffsetY / imgHeight;
+                object.width = object.width || grid.width;
+                object.height = object.height || grid.height;
+
+                if (this._animations[gridGID]) {
+                    this.aniObjects.push({
+                        object: object,
+                        imgNode: imgNode,
+                        gridGID: gridGID,
+                    })
+                    this._hasAniObj = true;
                 }
+
+                let tileOffsetX = tileset.tileOffset.x;
+                let tileOffsetY = tileset.tileOffset.y;
+                if (iso) {
+                    imgNode.anchorX = 0.5 + tileOffsetX / object.width;
+                    imgNode.anchorY = tileOffsetY / object.height;
+                } else {
+                    imgNode.anchorX = tileOffsetX / object.width;
+                    imgNode.anchorY = tileOffsetY / object.height;
+                }
+
                 imgNode.active = object.visible;
                 imgNode.angle = -object.rotation;
                 imgNode.x = object.x - leftTopX;
@@ -283,8 +303,8 @@ let TiledObjectGroup = cc.Class({
                 sp.setVertsDirty();
 
                 // object group may has no width or height info
-                imgNode.width = imgWidth;
-                imgNode.height = imgHeight;
+                imgNode.width = object.width;
+                imgNode.height = object.height;
             }
         }
         this._objects = objects;
@@ -297,6 +317,45 @@ let TiledObjectGroup = cc.Class({
             let cName = c._name;
             let isUseless = uselessExp.test(cName);
             if (isUseless && !aliveNodes[cName]) c.destroy();
+        }
+    },
+
+    update(dt) {
+        if (!this._hasAniObj) {
+            return;
+        }
+
+        const aniObjects = this.aniObjects;
+        const _texGrids = this._texGrids;
+        const iso = cc.TiledMap.Orientation.ISO === this._mapInfo.orientation
+
+        for (let i = 0, len = aniObjects.length; i < len; i++) {
+            let aniObj = aniObjects[i];
+            let gridGID = aniObj.gridGID;
+            let grid = _texGrids[gridGID];
+            if (!grid) {
+                continue;
+            }
+
+            let tileset = grid.tileset;
+            let object = aniObj.object;
+            let imgNode = aniObj.imgNode;
+
+            let tileOffsetX = tileset.tileOffset.x;
+            let tileOffsetY = tileset.tileOffset.y;
+            if (iso) {
+                imgNode.anchorX = 0.5 + tileOffsetX / object.width;
+                imgNode.anchorY = tileOffsetY / object.height;
+            } else {
+                imgNode.anchorX = tileOffsetX / object.width;
+                imgNode.anchorY = tileOffsetY / object.height;
+            }
+
+            let sp = imgNode.getComponent(cc.Sprite);
+            let spf = sp.spriteFrame;
+            spf.setTexture(grid.tileset.sourceImage, cc.rect(grid));
+            sp.spriteFrame = spf;
+            sp.setVertsDirty();
         }
     }
 });


### PR DESCRIPTION
TiledMap 的 ObjectLayer 里可以放入 tile,  而且支持 动画tile.
之前版本的 CCTiledMap组件不支持这个特性.
该pr实现了这个特性.

同时优化了一点代码结构.
比如 对 ISO地图的判定 统一放到了前面.

