### PR TITLE
RenderView remove dependence of Root

### DIFF
--- a/cocos/core/pipeline/render-view.ts
+++ b/cocos/core/pipeline/render-view.ts
@@ -3,7 +3,6 @@
  */
 
 import { Camera } from '../renderer/scene/camera';
-import { Root } from '../root';
 import { CAMERA_DEFAULT_MASK } from './define';
 import { RenderFlowType } from './pipeline-serialization';
 import { RenderFlow } from './render-flow';
@@ -118,13 +117,6 @@ export class RenderView {
         return this._flows;
     }
 
-    /**
-     * Internal usage
-     */
-    public static registerCreateFunc (root: Root) {
-        root._createViewFun = (_root: Root, _camera: Camera): RenderView => new RenderView(_camera);
-    }
-
     private _name: string = '';
     private _window: RenderWindow | null = null;
     private _priority: number = 0;
@@ -136,10 +128,9 @@ export class RenderView {
     /**
      * @en The constructor
      * @zh 构造函数。
-     * @param root
      * @param camera
      */
-    private constructor (camera: Camera) {
+    public constructor (camera: Camera) {
         this._camera = camera;
     }
 

--- a/cocos/core/root.ts
+++ b/cocos/core/root.ts
@@ -174,7 +174,6 @@ export class Root {
     }
 
     public _createSceneFun: (root: Root) => RenderScene = null!;
-    public _createViewFun: (root: Root, camera: Camera) => RenderView = null!;
     public _createWindowFun: (root: Root) => RenderWindow = null!;
 
     private _device: GFXDevice;
@@ -207,7 +206,6 @@ export class Root {
         this._dataPoolMgr = new DataPoolManager(device);
 
         RenderScene.registerCreateFunc(this);
-        RenderView.registerCreateFunc(this);
         RenderWindow.registerCreateFunc(this);
 
         this._cameraPool = new Pool(() => new Camera(this._device), 4);
@@ -456,7 +454,7 @@ export class Root {
      * @param info 渲染视图描述信息
      */
     public createView (info: IRenderViewInfo): RenderView {
-        const view: RenderView = this._createViewFun(this, info.camera);
+        const view: RenderView = new RenderView(info.camera);
         view.initialize(info);
         // view.camera.resize(cc.game.canvas.width, cc.game.canvas.height);
         this._views.push(view);


### PR DESCRIPTION
Because native will implement RenderView, so should remove the dependence of Root.