### PR TITLE
Improve cc.Quat.rotateX, cc.Quat.rotateY, cc.Quat.rotateZ.

### DIFF
--- a/cocos2d/core/value-types/quat.ts
+++ b/cocos2d/core/value-types/quat.ts
@@ -261,10 +261,16 @@ export default class Quat extends ValueType {
         const bx = Math.sin(rad);
         const bw = Math.cos(rad);
 
-        out.x = a.x * bw + a.w * bx;
-        out.y = a.y * bw + a.z * bx;
-        out.z = a.z * bw - a.y * bx;
-        out.w = a.w * bw - a.x * bx;
+        _x = a.x * bw + a.w * bx;
+        _y = a.y * bw + a.z * bx;
+        _z = a.z * bw - a.y * bx;
+        _w = a.w * bw - a.x * bx;
+
+        out.x = _x;
+        out.y = _y;
+        out.z = _z;
+        out.w = _w;
+
         return out;
     }
 
@@ -283,10 +289,16 @@ export default class Quat extends ValueType {
         const by = Math.sin(rad);
         const bw = Math.cos(rad);
 
-        out.x = a.x * bw - a.z * by;
-        out.y = a.y * bw + a.w * by;
-        out.z = a.z * bw + a.x * by;
-        out.w = a.w * bw - a.y * by;
+        _x = a.x * bw - a.z * by;
+        _y = a.y * bw + a.w * by;
+        _z = a.z * bw + a.x * by;
+        _w = a.w * bw - a.y * by;
+
+        out.x = _x;
+        out.y = _y;
+        out.z = _z;
+        out.w = _w;
+
         return out;
     }
 
@@ -305,10 +317,16 @@ export default class Quat extends ValueType {
         const bz = Math.sin(rad);
         const bw = Math.cos(rad);
 
-        out.x = a.x * bw + a.y * bz;
-        out.y = a.y * bw - a.x * bz;
-        out.z = a.z * bw + a.w * bz;
-        out.w = a.w * bw - a.z * bz;
+        _x = a.x * bw + a.y * bz;
+        _y = a.y * bw - a.x * bz;
+        _z = a.z * bw + a.w * bz;
+        _w = a.w * bw - a.z * bz;
+
+        out.x = _x;
+        out.y = _y;
+        out.z = _z;
+        out.w = _w;
+
         return out;
     }
 


### PR DESCRIPTION
Improve cc.Quat.rotateX, cc.Quat.rotateY, cc.Quat.rotateZ.
Ensure these 3 methods giving correct result when 'out' and 'a' are same object.

Re: cocos-creator/2d-tasks#

Changes:
 * cocos2d/core/value-types/quat.ts

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [✔] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [✔] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
