### PR TITLE
editorOnly should takes effect for asset culling

### DIFF
--- a/cocos2d/core/platform/deserialize-editor.js
+++ b/cocos2d/core/platform/deserialize-editor.js
@@ -117,7 +117,7 @@ var _Deserializer = (function () {
         this.deserializedList = [];
         this.deserializedData = null;
         this._classFinder = classFinder;
-        if (CC_DEV) {
+        if (!CC_BUILD) {
             this._ignoreEditorOnly = ignoreEditorOnly;
         }
         this._idList = [];
@@ -683,7 +683,7 @@ var _Deserializer = (function () {
             cache.result = result;
             cache.customEnv = customEnv;
             cache._classFinder = classFinder;
-            if (CC_DEV) {
+            if (!CC_BUILD) {
                 cache._ignoreEditorOnly = ignoreEditorOnly;
             }
             return cache;

--- a/test/qunit/unit-es5/_init.js
+++ b/test/qunit/unit-es5/_init.js
@@ -155,7 +155,11 @@ cc.engine = new (cc.Class({
 Editor.log = cc.log;
 Editor.warn = cc.warn;
 Editor.error = cc.error;
-Editor.Utils = Editor.Utils || {};
+Editor.Utils = Editor.Utils || {
+    UuidUtils: {
+        uuid: function () { return '' + Math.floor(Math.random() * 100000000) + Math.floor(Math.random() * 100000000); }
+    }
+};
 Editor.Utils.UuidCache = {};
 
 var assetDir = '../test/qunit/assets';

--- a/test/qunit/unit-es5/test-deserialize.js
+++ b/test/qunit/unit-es5/test-deserialize.js
@@ -170,9 +170,12 @@ if (TestEditorExtends) {
          */
 
         var serializedAsset = Editor.serialize(asset);
-        var deserializedAsset = cc.deserialize(serializedAsset);
+        var details = new cc.deserialize.Details();
+        var deserializedAsset = cc.deserialize(serializedAsset, details);
 
         ok(deserializedAsset.refSelf === deserializedAsset, 'should ref to self');
+        strictEqual(details.uuidList.length, 0, 'should not depends on self');
+
         //deepEqual(Editor.serialize(deserializedAsset), serializedAsset, 'test deserialize');
     });
 


### PR DESCRIPTION
Re: https://forum.cocos.org/t/ui/96354

Changes:
 * 修复 editorOnly 作用于资源属性时，资源无法从构建中剔除的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
