### PR TITLE
fix canvas node can't fit width on simulator preview

### DIFF
--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -492,7 +492,7 @@ var widgetManager = cc._widgetManager = module.exports = {
         }
     },
     refreshWidgetOnResized (node) {
-        var widget = cc.Node.isNode(node) && node._widget;
+        var widget = cc.Node.isNode(node) && node.getComponent(cc.Widget);
         if (widget && widget.enabled && widget.alignMode === AlignMode.ON_WINDOW_RESIZE) {
             this.add(widget);
         }


### PR DESCRIPTION
widget 被 remove 之后，node._widget 就没有定义了
导致 widget 不能再被 add