### PR TITLE
set InputAssembler.length to 0 when there is no particle

### DIFF
--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -427,9 +427,9 @@ Simulator.prototype.step = function (dt) {
         }
     }
 
+    psys._assembler._ia._count = particles.length * 6;
     if (particles.length > 0) {
         buffer.uploadData();
-        psys._assembler._ia._count = particles.length * 6;
     }
     else if (!this.active && !this.readyToPlay) {
         this.finished = true;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 粒子系统的粒子数为0时，设置InputAssembler的长度为0。
<br/>如果不这么做，在下一次重新播放粒子系统的时候，由于IA里残留了老数据，第1帧渲染的粒子是老的（如果第1帧没有及时发射新粒子）



<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
