### PR TITLE
Fix label.string cannot be set to null or undefined.

### DIFF
--- a/cocos/ui/components/label-component.ts
+++ b/cocos/ui/components/label-component.ts
@@ -208,7 +208,7 @@ export class LabelComponent extends UIRenderComponent {
         return this._string;
     }
     set string (value) {
-        value = value.toString();
+        value = value + '';
         if (this._string === value) {
             return;
         }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/4023

Changes:
 * Fix label.string cannot be set to null or undefined.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
