### PR TITLE
sync bug fix for EditBox from 2d branch

### DIFF
--- a/cocos/core/platform/sys.ts
+++ b/cocos/core/platform/sys.ts
@@ -402,6 +402,12 @@ export const sys: { [x: string]: any; } = {
      */
     BROWSER_TYPE_IE: 'ie',
     /**
+     * @en Browser Type - Microsoft Edge
+     * @zh 浏览器类型 - 微软 Edge
+     * @default "edge"
+     */
+    BROWSER_TYPE_EDGE: "edge",
+    /**
      * @en Browser Type - QQ Browser
      * @zh 浏览器类型 - QQ 浏览器
      * @default "qqbrowser"
@@ -887,7 +893,7 @@ else {
     /* Determine the browser type */
     (function () {
         const typeReg1 = /mqqbrowser|micromessenger|qq|sogou|qzone|liebao|maxthon|ucbs|360 aphone|360browser|baiduboxapp|baidubrowser|maxthon|mxbrowser|miuibrowser/i;
-        const typeReg2 = /qqbrowser|ucbrowser/i;
+        const typeReg2 = /qqbrowser|ucbrowser|edge/i;
         const typeReg3 = /chrome|safari|firefox|trident|opera|opr\/|oupeng/i;
         let browserTypes = typeReg1.exec(ua);
         if (!browserTypes) { browserTypes = typeReg2.exec(ua); }
@@ -929,6 +935,9 @@ else {
         }
         else if (browserType === 'trident') {
             browserType = sys.BROWSER_TYPE_IE;
+        }
+        else if (browserType === 'edge') {
+            browserType === sys.BROWSER_TYPE_EDGE;
         }
         else if (browserType === '360 aphone') {
             browserType = sys.BROWSER_TYPE_360;

--- a/cocos/ui/components/editbox/edit-box-component.ts
+++ b/cocos/ui/components/editbox/edit-box-component.ts
@@ -95,7 +95,7 @@ export class EditBoxComponent extends Component {
         return this._string;
     }
 
-    set string (value: string) {
+    set string (value) {
         if (this._maxLength >= 0 && value.length >= this._maxLength) {
             value = value.slice(0, this._maxLength);
         }
@@ -122,7 +122,7 @@ export class EditBoxComponent extends Component {
         return this._placeholderLabel.string;
     }
 
-    set placeholder (value: string) {
+    set placeholder (value) {
         if (this._placeholderLabel) {
             this._placeholderLabel.string = value;
         }
@@ -144,7 +144,7 @@ export class EditBoxComponent extends Component {
         return this._textLabel;
     }
 
-    set textLabel (oldValue: LabelComponent | null) {
+    set textLabel (oldValue) {
         if (this._textLabel !== oldValue) {
             this._textLabel = oldValue;
             if (this._textLabel) {
@@ -170,7 +170,7 @@ export class EditBoxComponent extends Component {
         return this._placeholderLabel;
     }
 
-    set placeholderLabel (oldValue: LabelComponent | null) {
+    set placeholderLabel (oldValue) {
         if (this._placeholderLabel !== oldValue) {
             this._placeholderLabel = oldValue;
             if (this._placeholderLabel) {
@@ -221,7 +221,7 @@ export class EditBoxComponent extends Component {
         return this._inputFlag;
     }
 
-    set inputFlag (value: InputFlag) {
+    set inputFlag (value) {
         this._inputFlag = value;
         this._updateString(this._string);
     }
@@ -243,7 +243,7 @@ export class EditBoxComponent extends Component {
         return this._inputMode;
     }
 
-    set inputMode (oldValue: InputMode) {
+    set inputMode (oldValue) {
         if (this._inputMode !== oldValue) {
             this._inputMode = oldValue;
             this._updateTextLabel();
@@ -310,7 +310,7 @@ export class EditBoxComponent extends Component {
         return this._tabIndex;
     }
 
-    set tabIndex (value: number) {
+    set tabIndex (value) {
         if (this._tabIndex !== value) {
             this._tabIndex = value;
             if (this._impl) {

--- a/cocos/ui/components/editbox/edit-box-component.ts
+++ b/cocos/ui/components/editbox/edit-box-component.ts
@@ -95,7 +95,7 @@ export class EditBoxComponent extends Component {
         return this._string;
     }
 
-    set string (value) {
+    set string (value: string) {
         if (this._maxLength >= 0 && value.length >= this._maxLength) {
             value = value.slice(0, this._maxLength);
         }
@@ -122,7 +122,7 @@ export class EditBoxComponent extends Component {
         return this._placeholderLabel.string;
     }
 
-    set placeholder (value) {
+    set placeholder (value: string) {
         if (this._placeholderLabel) {
             this._placeholderLabel.string = value;
         }
@@ -144,7 +144,7 @@ export class EditBoxComponent extends Component {
         return this._textLabel;
     }
 
-    set textLabel (oldValue) {
+    set textLabel (oldValue: LabelComponent | null) {
         if (this._textLabel !== oldValue) {
             this._textLabel = oldValue;
             if (this._textLabel) {
@@ -170,7 +170,7 @@ export class EditBoxComponent extends Component {
         return this._placeholderLabel;
     }
 
-    set placeholderLabel (oldValue) {
+    set placeholderLabel (oldValue: LabelComponent | null) {
         if (this._placeholderLabel !== oldValue) {
             this._placeholderLabel = oldValue;
             if (this._placeholderLabel) {
@@ -221,7 +221,7 @@ export class EditBoxComponent extends Component {
         return this._inputFlag;
     }
 
-    set inputFlag (value) {
+    set inputFlag (value: InputFlag) {
         this._inputFlag = value;
         this._updateString(this._string);
     }
@@ -243,7 +243,7 @@ export class EditBoxComponent extends Component {
         return this._inputMode;
     }
 
-    set inputMode (oldValue) {
+    set inputMode (oldValue: InputMode) {
         if (this._inputMode !== oldValue) {
             this._inputMode = oldValue;
             this._updateTextLabel();
@@ -310,7 +310,7 @@ export class EditBoxComponent extends Component {
         return this._tabIndex;
     }
 
-    set tabIndex (value) {
+    set tabIndex (value: number) {
         if (this._tabIndex !== value) {
             this._tabIndex = value;
             if (this._impl) {

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -462,7 +462,7 @@ export class EditBoxImpl extends EditBoxImplBase {
             font = textLabel.fontFamily;
         }
 
-        let fontSize = textLabel.fontSize * textLabel.node._scale.y;
+        let fontSize = textLabel.fontSize * textLabel.node.scale.y;
 
         if (this._textLabelFont === font
             && this._textLabelFontSize === fontSize
@@ -512,7 +512,7 @@ export class EditBoxImpl extends EditBoxImplBase {
         }
 
 
-        let fontSize = placeholderLabel.fontSize * placeholderLabel.node._scale.y;
+        let fontSize = placeholderLabel.fontSize * placeholderLabel.node.scale.y;
 
         if (this._placeholderLabelFont === font
             && this._placeholderLabelFontSize === fontSize

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -630,6 +630,10 @@ export class EditBoxImpl extends EditBoxImplBase {
         };
 
         cbs.onBlur = () => {
+            // on mobile, sometimes input element doesn't fire compositionend event
+            if (sys.isMobile && inputLock) {
+                cbs.compositionEnd();
+            }
             impl._editing = false;
             _currentEditBoxImpl = null;
             impl._hideDom();

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -602,7 +602,13 @@ export class EditBoxImpl extends EditBoxImplBase {
             if (inputLock) {
                 return;
             }
-            impl._delegate!._editBoxTextChanged(elem!.value);
+            let delegate = impl._delegate;
+            // input of number type doesn't support maxLength attribute
+            let maxLength = delegate!.maxLength;
+            if (maxLength >= 0) {
+                elem.value = elem.value.slice(0, maxLength);
+            }
+            delegate!._editBoxTextChanged(elem!.value);
         };
 
         cbs.onClick = () => {

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -187,11 +187,9 @@ export class EditBoxImpl extends EditBoxImplBase {
 
         this._editing = true;
         _currentEditBoxImpl = this;
+        this._delegate!._editBoxEditingDidBegan();
         this._showDom();
-        if (this._edTxt && this._delegate){
-            this._edTxt.focus();
-            this._delegate._editBoxEditingDidBegan();
-        }
+        this._edTxt!.focus();
     }
 
     public endEditing () {

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -45,6 +45,7 @@ import { sys } from '../../../core/platform/sys';
 import visibleRect from '../../../core/platform/visible-rect';
 import { Node } from '../../../core';
 import { EditBoxImplBase } from './edit-box-impl-base';
+import { legacyCC } from '../../../core/global-exports';
 
 // https://segmentfault.com/q/1010000002914610
 const SCROLLY = 40;
@@ -617,6 +618,13 @@ export class EditBoxImpl extends EditBoxImplBase {
                 text-align: ${horizontalAlign};
             }
         `;
+        // EDGE_BUG_FIX: hide clear button, because clearing input box in Edge does not emit input event 
+        // issue refference: https://github.com/angular/angular/issues/26307
+        if (legacyCC.sys.browserType === legacyCC.sys.BROWSER_TYPE_EDGE) {
+            styleEl!.innerHTML += `#${this._domId}::-ms-clear{
+                display: none;
+            }`;
+        }
     }
 
     private _registerEventListeners () {

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -487,7 +487,7 @@ export class EditBoxImpl extends EditBoxImplBase {
             font = textLabel.fontFamily;
         }
 
-        let fontSize = textLabel.fontSize * textLabel.node.scaleY;
+        let fontSize = textLabel.fontSize * textLabel.node._scale.y;
 
         if (this._textLabelFont === font
             && this._textLabelFontSize === fontSize
@@ -537,7 +537,7 @@ export class EditBoxImpl extends EditBoxImplBase {
         }
 
 
-        let fontSize = placeholderLabel.fontSize * placeholderLabel.node.scaleY;
+        let fontSize = placeholderLabel.fontSize * placeholderLabel.node._scale.y;
 
         if (this._placeholderLabelFont === font
             && this._placeholderLabelFontSize === fontSize
@@ -570,8 +570,9 @@ export class EditBoxImpl extends EditBoxImplBase {
                 break;
         }
 
-        styleEl!.innerHTML = `#${this._domId}::-webkit-input-placeholder,#${this._domId}::-moz-placeholder,#${this._domId}:-ms-input-placeholder` +
-            `{text-transform: initial;-family: ${font};font-size: ${fontSize}px;color: ${fontColor};line-height: ${lineHeight}px;text-align: ${horizontalAlign};}`;
+        styleEl!.innerHTML = `#${this._domId}::-webkit-input-placeholder{text-transform: initial;-family: ${font};font-size: ${fontSize}px;color: ${fontColor};line-height: ${lineHeight}px;text-align: ${horizontalAlign};}` +
+                            `#${this._domId}::-moz-placeholder{text-transform: initial;-family: ${font};font-size: ${fontSize}px;color: ${fontColor};line-height: ${lineHeight}px;text-align: ${horizontalAlign};}` + 
+                            `#${this._domId}::-ms-input-placeholder{text-transform: initial;-family: ${font};font-size: ${fontSize}px;color: ${fontColor};line-height: ${lineHeight}px;text-align: ${horizontalAlign};}`;
         // EDGE_BUG_FIX: hide clear button, because clearing input box in Edge does not emit input event 
         // issue refference: https://github.com/angular/angular/issues/26307
         if (legacyCC.sys.browserType === legacyCC.sys.BROWSER_TYPE_EDGE) {

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -92,11 +92,11 @@ export class EditBoxImpl extends EditBoxImplBase {
     private _isTextArea = false;
 
     private _textLabelFont = null;
-    private _textLabelFontSize = null;
+    private _textLabelFontSize: number | null = null;
     private _textLabelFontColor = null;
     private _textLabelAlign = null;
     private _placeholderLabelFont = null;
-    private _placeholderLabelFontSize = null;
+    private _placeholderLabelFontSize: number | null = null;
     private _placeholderLabelFontColor = null;
     private _placeholderLabelAlign = null;
     private _placeholderLineHeight = null;
@@ -513,15 +513,17 @@ export class EditBoxImpl extends EditBoxImplBase {
             font = textLabel.fontFamily;
         }
 
+        let fontSize = textLabel.fontSize * textLabel.node.scaleY;
+
         if (this._textLabelFont === font
-            && this._textLabelFontSize === textLabel.fontSize
+            && this._textLabelFontSize === fontSize
             && this._textLabelFontColor === textLabel.fontColor
             && this._textLabelAlign === textLabel.horizontalAlign) {
                 return;
         }
 
         this._textLabelFont = font;
-        this._textLabelFontSize = textLabel.fontSize;
+        this._textLabelFontSize = fontSize;
         this._textLabelFontColor = textLabel.fontColor;
         this._textLabelAlign = textLabel.horizontalAlign;
 
@@ -530,7 +532,7 @@ export class EditBoxImpl extends EditBoxImplBase {
         }
 
         const elem = this._edTxt;
-        elem.style.fontSize = `${textLabel.fontSize}px`;
+        elem.style.fontSize = `${fontSize}px`;
         elem.style.color = textLabel.color.toCSS('rgba');
         elem.style.fontFamily = font;
 
@@ -560,8 +562,11 @@ export class EditBoxImpl extends EditBoxImplBase {
             font = placeholderLabel.fontFamily;
         }
 
+
+        let fontSize = placeholderLabel.fontSize * placeholderLabel.node.scaleY;
+
         if (this._placeholderLabelFont === font
-            && this._placeholderLabelFontSize === placeholderLabel.fontSize
+            && this._placeholderLabelFontSize === fontSize
             && this._placeholderLabelFontColor === placeholderLabel.fontColor
             && this._placeholderLabelAlign === placeholderLabel.horizontalAlign
             && this._placeholderLineHeight === placeholderLabel.fontSize) {
@@ -569,13 +574,12 @@ export class EditBoxImpl extends EditBoxImplBase {
         }
 
         this._placeholderLabelFont = font;
-        this._placeholderLabelFontSize = placeholderLabel.fontSize;
+        this._placeholderLabelFontSize = fontSize;
         this._placeholderLabelFontColor = placeholderLabel.fontColor;
         this._placeholderLabelAlign = placeholderLabel.horizontalAlign;
         this._placeholderLineHeight = placeholderLabel.fontSize;
 
         const styleEl = this._placeholderStyleSheet;
-        const fontSize = placeholderLabel.fontSize;
         const fontColor = placeholderLabel.color.toCSS('rgba');
         const lineHeight = placeholderLabel.fontSize;
 

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -76,11 +76,9 @@ export class EditBoxImpl extends EditBoxImplBase {
     public _inputMode = InputMode.ANY;
     public _inputFlag = InputFlag.DEFAULT;
     public _returnType = KeyboardReturnType.DEFAULT;
-    public _maxLength = 50;
     public _placeholderText = '';
     public _size: Size = new Size();
     public _node: Node | null = null;
-    public _editing = false;
     public __eventListeners: any = {};
     public __fullscreen = false;
     public __autoResize = false;
@@ -125,16 +123,6 @@ export class EditBoxImpl extends EditBoxImplBase {
         this.__autoResize = view._resizeWithBrowserSize;
     }
 
-    public onEnable () {
-        // Do nothing
-    }
-
-    public onDisable () {
-        if (this._editing && this._edTxt) {
-            this._edTxt.blur();
-        }
-    }
-
     public clear () {
         this._removeEventListeners();
         this._removeDomFromGameContainer();
@@ -167,19 +155,6 @@ export class EditBoxImpl extends EditBoxImplBase {
 
     }
 
-    public setFocus (value: boolean) {
-        if (value){
-            this.beginEditing();
-        }
-        else {
-            this._edTxt!.blur();
-        }
-    }
-
-    public isFocused () {
-        return this._editing;
-    }
-
     public beginEditing () {
         if (_currentEditBoxImpl && _currentEditBoxImpl !== this) {
             _currentEditBoxImpl.setFocus(false);
@@ -193,7 +168,7 @@ export class EditBoxImpl extends EditBoxImplBase {
     }
 
     public endEditing () {
-        // Do nothing, handle endEditing on blur callback
+        this._edTxt!.blur();
     }
 
     private _createInput () {

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -244,13 +244,14 @@ export class EditBoxImpl extends EditBoxImplBase {
 
     private _hideDomOnMobile () {
         if (sys.os === sys.OS_ANDROID) {
+            if (this.__autoResize) {
+                view.resizeWithBrowserSize(true);
+            }
+            // In case enter full screen when soft keyboard still showing
             setTimeout(() => {
                 if (!_currentEditBoxImpl) {
                     if (this.__fullscreen) {
                         view.enableAutoFullScreen(true);
-                    }
-                    if (this.__autoResize) {
-                        view.resizeWithBrowserSize(true);
                     }
                 }
             }, DELAY_TIME);

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -596,38 +596,12 @@ export class EditBoxImpl extends EditBoxImplBase {
                 break;
         }
 
-        styleEl!.innerHTML = `
-            #${this._domId}::-webkit-input-placeholder {
-                text-transform: initial;
-                font-family: ${font};
-                font-size: ${fontSize}px;
-                color: ${fontColor};
-                line-height: ${lineHeight}px;
-                text-align: ${horizontalAlign};
-            }
-            #${this._domId}::-moz-placeholder {
-                text-transform: initial;
-                font-family: ${font};
-                font-size: ${fontSize}px;
-                color: ${fontColor};
-                line-height: ${lineHeight}px;
-                text-align: ${horizontalAlign};
-            }
-            #${this._domId}:-ms-input-placeholder {
-                text-transform: initial;
-                font-family: ${font};
-                font-size: ${fontSize}px;
-                color: ${fontColor};
-                line-height: ${lineHeight}px;
-                text-align: ${horizontalAlign};
-            }
-        `;
+        styleEl!.innerHTML = `#${this._domId}::-webkit-input-placeholder,#${this._domId}::-moz-placeholder,#${this._domId}:-ms-input-placeholder` +
+            `{text-transform: initial;-family: ${font};font-size: ${fontSize}px;color: ${fontColor};line-height: ${lineHeight}px;text-align: ${horizontalAlign};}`;
         // EDGE_BUG_FIX: hide clear button, because clearing input box in Edge does not emit input event 
         // issue refference: https://github.com/angular/angular/issues/26307
         if (legacyCC.sys.browserType === legacyCC.sys.BROWSER_TYPE_EDGE) {
-            styleEl!.innerHTML += `#${this._domId}::-ms-clear{
-                display: none;
-            }`;
+            styleEl!.innerHTML += `#${this._domId}::-ms-clear{display: none;}`;
         }
     }
 

--- a/cocos/ui/components/editbox/edit-box-impl.ts
+++ b/cocos/ui/components/editbox/edit-box-impl.ts
@@ -60,33 +60,16 @@ let _currentEditBoxImpl: EditBoxImpl | null = null;
 
 let _domCount = 0;
 
-// polyfill
-const polyfill = {
-    zoomInvalid: false,
-};
-
-if (sys.OS_ANDROID === sys.os &&
-    (sys.browserType === sys.BROWSER_TYPE_SOUGOU ||
-        sys.browserType === sys.BROWSER_TYPE_360)) {
-    polyfill.zoomInvalid = true;
-}
-
 export class EditBoxImpl extends EditBoxImplBase {
     public _delegate: EditBoxComponent | null = null;
     public _inputMode = InputMode.ANY;
     public _inputFlag = InputFlag.DEFAULT;
     public _returnType = KeyboardReturnType.DEFAULT;
-    public _placeholderText = '';
-    public _size: Size = new Size();
-    public _node: Node | null = null;
     public __eventListeners: any = {};
     public __fullscreen = false;
     public __autoResize = false;
-    public __rotateScreen = false;
     public __orientationChanged: any;
     public _edTxt: HTMLInputElement | HTMLTextAreaElement | null = null;
-    public _textColor: Color = Color.WHITE.clone();
-    public _edFontSize = 14;
     private _isTextArea = false;
 
     private _textLabelFont = null;
@@ -336,12 +319,6 @@ export class EditBoxImpl extends EditBoxImplBase {
         const tx = _matrix_temp.m12 * scaleX + offsetX;
         const ty = _matrix_temp.m13 * scaleY + offsetY;
 
-        if (polyfill.zoomInvalid) {
-            this.setSize(this._size.width * a, this._size.height * d);
-            a = 1;
-            d = 1;
-        }
-
         const matrix = 'matrix(' + a + ',' + -b + ',' + -c + ',' + d + ',' + tx + ',' + -ty + ')';
         this._edTxt.style.transform = matrix;
         this._edTxt.style['-webkit-transform'] = matrix;
@@ -431,7 +408,6 @@ export class EditBoxImpl extends EditBoxImplBase {
             return;
         }
         let elem = this._edTxt;
-        elem.style.fontSize = this._edFontSize + 'px';
         elem.style.color = '#000000';
         elem.style.border = '0px';
         elem.style.background = 'transparent';
@@ -456,7 +432,6 @@ export class EditBoxImpl extends EditBoxImplBase {
         else {
             elem.style.resize = 'none';
             elem.style.overflowY = 'scroll';
-
         }
 
         this._placeholderStyleSheet = document.createElement('style');


### PR DESCRIPTION
re: 
https://github.com/cocos-creator/3d-tasks/issues/3986
https://github.com/cocos-creator/3d-tasks/issues/4026

changeLog:
- add type definition for setter in EditBox (from commit: https://github.com/cocos-creator/engine/pull/5088/commits/4c7670faf249c380dff8a17a8d6b46107907841e in pr: https://github.com/cocos-creator/engine/pull/5088)
- support browser type EDGE (from commit: https://github.com/cocos-creator/engine/pull/4910/commits/8e041123e2bd7bbeba3a04469f0cc029a3d24d34 in pr: https://github.com/cocos-creator/engine/pull/4910)
- hide clear button of input on EDGE browser (from commit: https://github.com/cocos-creator/engine/pull/5088/commits/be6c94c4444c59b47c62ca96403b552b6a80a225 in pr: https://github.com/cocos-creator/engine/pull/5088)
- sync label node scale to dom input fontSize (from commit: https://github.com/cocos-creator/engine/pull/5088/commits/b7e80b8977af64dbe9cf4252871f6ec85594d6b8 in pr: https://github.com/cocos-creator/engine/pull/5088)
- refine editbox placeholderLabel css-in-js (from pr: https://github.com/cocos-creator/engine/pull/5203)
- refine editbox begin editing callback (from pr: https://github.com/cocos-creator/engine/pull/5732)
- extend some method from parent class (related pr: https://github.com/cocos-creator-packages/adapters/pull/156)
- fix not resize browser size when editbox end editing (from pr: https://github.com/cocos-creator/engine/pull/6115)
- fix editbox doesn’t fire ‘compositionend’ event on mobile  (from pr: https://github.com/cocos-creator/engine/pull/6631)
- fix maxLength for input of number type (from pr: https://github.com/cocos-creator/engine/pull/6725)