### PR TITLE
fix that setTexture failed and SkinnedMeshRenderer is not a component

### DIFF
--- a/cocos2d/core/3d/skeleton/CCSkinnedMeshRenderer.js
+++ b/cocos2d/core/3d/skeleton/CCSkinnedMeshRenderer.js
@@ -38,6 +38,7 @@ let _m4_tmp2 = cc.mat4();
  * !#zh
  * 蒙皮渲染组件
  * @class SkinnedMeshRenderer
+ * @extends MeshRenderer
  */
 let SkinnedMeshRenderer = cc.Class({
     name: 'cc.SkinnedMeshRenderer',

--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -454,6 +454,8 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
      * @return {Boolean}
      */
     setTexture: function (texture, rect, rotated, offset, originalSize) {
+        if (arguments.length === 1 && texture === this._texture) return;
+
         if (rect) {
             this._rect = rect;
         }
@@ -481,7 +483,7 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
             cc.errorID(3401);
             return;
         }
-        if (texture instanceof cc.Texture2D && this._texture !== texture) {
+        if (texture instanceof cc.Texture2D) {
             this._refreshTexture(texture);
         }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 修复 SkinnedMeshRenderer 不是组件的问题，https://discuss.cocos2d-x.org/t/possible-bug-in-skinnedmeshrenderer-ts/51074
 * 修复 setTexture 传相同 texture 时报错的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
