### PR TITLE
should init camera in preload

### DIFF
--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -596,7 +596,7 @@ let Camera = cc.Class({
         this.beforeDraw();
     },
 
-    onLoad () {
+    __preload () {
         this._init();
     },
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * 在用户代码中 onLoad 获取不到 camera 的正确尺寸，改到在 preload 中初始化 camera

