### PR TITLE
Fix bug with exceptions in _val data for getting color from HSV.

### DIFF
--- a/cocos2d/core/value-types/color.ts
+++ b/cocos2d/core/value-types/color.ts
@@ -793,7 +793,7 @@ export default class Color extends ValueType {
         r *= 255;
         g *= 255;
         b *= 255;
-        this._val = ((this.a << 24) >>> 0) + (b << 16) + (g << 8) + r;
+        this._val = ((this.a << 24) >>> 0) + (b << 16) + (g << 8) + Math.floor(r);
         return this;
     }
 

--- a/cocos2d/core/value-types/color.ts
+++ b/cocos2d/core/value-types/color.ts
@@ -230,7 +230,7 @@ export default class Color extends ValueType {
         out.g = parseInt(hexString.substr(2, 2), 16) || 0;
         out.b = parseInt(hexString.substr(4, 2), 16) || 0;
         out.a = parseInt(hexString.substr(6, 2), 16) || 255;
-        out._val = ((out.a << 24) >>> 0) + (out.b << 16) + (out.g << 8) + (out.r|0);
+        out._val = ((out.a << 24) >>> 0) + (out.b << 16) + (out.g << 8) + out.r;
         return out;
     }
 
@@ -674,7 +674,7 @@ export default class Color extends ValueType {
         let g = parseInt(hexString.substr(2, 2), 16) || 0;
         let b = parseInt(hexString.substr(4, 2), 16) || 0;
         let a = parseInt(hexString.substr(6, 2), 16) || 255;
-        this._val = ((a << 24) >>> 0) + (b << 16) + (g << 8) + (r|0);
+        this._val = ((a << 24) >>> 0) + (b << 16) + (g << 8) + r;
         return this;
     }
 

--- a/cocos2d/core/value-types/color.ts
+++ b/cocos2d/core/value-types/color.ts
@@ -230,7 +230,7 @@ export default class Color extends ValueType {
         out.g = parseInt(hexString.substr(2, 2), 16) || 0;
         out.b = parseInt(hexString.substr(4, 2), 16) || 0;
         out.a = parseInt(hexString.substr(6, 2), 16) || 255;
-        out._val = ((out.a << 24) >>> 0) + (out.b << 16) + (out.g << 8) + out.r;
+        out._val = ((out.a << 24) >>> 0) + (out.b << 16) + (out.g << 8) + (out.r|0);
         return out;
     }
 
@@ -402,7 +402,7 @@ export default class Color extends ValueType {
             r = r.r;
         }
 
-        this._val = ((a << 24) >>> 0) + (b << 16) + (g << 8) + r;
+        this._val = ((a << 24) >>> 0) + (b << 16) + (g << 8) + (r|0);
     }
 
     /**
@@ -674,7 +674,7 @@ export default class Color extends ValueType {
         let g = parseInt(hexString.substr(2, 2), 16) || 0;
         let b = parseInt(hexString.substr(4, 2), 16) || 0;
         let a = parseInt(hexString.substr(6, 2), 16) || 255;
-        this._val = ((a << 24) >>> 0) + (b << 16) + (g << 8) + r;
+        this._val = ((a << 24) >>> 0) + (b << 16) + (g << 8) + (r|0);
         return this;
     }
 
@@ -793,7 +793,7 @@ export default class Color extends ValueType {
         r *= 255;
         g *= 255;
         b *= 255;
-        this._val = ((this.a << 24) >>> 0) + (b << 16) + (g << 8) + Math.floor(r);
+        this._val = ((this.a << 24) >>> 0) + (b << 16) + (g << 8) + (r|0);
         return this;
     }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

var color = cc.Color.YELLOW;
修改前：
color.fromHSV(0.171875, 1, 1); // _val：4278255607.03125

修改后：
color.fromHSV(0.171875, 1, 1); // _val：4278255607

Changes:
 * 修复通过 fromHSV 获取 color 的 _val 数据异常的 bug

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
