### PR TITLE
disable retina on iOS 14

### DIFF
--- a/cocos2d/core/platform/CCView.js
+++ b/cocos2d/core/platform/CCView.js
@@ -445,6 +445,12 @@ cc.js.mixin(View.prototype, {
         if (CC_EDITOR) {
             return false;
         }
+        // HACK: iOS 14 can't release page memory 
+        // so need to disable retina
+        let ua = window.navigator.userAgent;
+        if (/iPhone OS 14_0/.test(ua)) {
+            return false;
+        }
         return this._retinaEnabled;
     },
 


### PR DESCRIPTION
re: https://forum.cocos.org/t/ios14-resize/96554

changeLog:
- 在 iOS 14 的浏览器上禁用 retina

目前 iOS14 在 resize 时设置 canvas 分辨率，会导致页面内存泄漏，不使用 retina 可以减缓一些，但是还是会有页面内存泄漏

# 禁用 retina 的情况 ，resize 8 次之后，内存涨了  140 m
![tset2](https://user-images.githubusercontent.com/17872773/89495623-3eda4600-d7eb-11ea-81fa-b8079c654425.png)

# 开启 retina 的情况，resize 8 次之后，内存涨了 340 m
![test1](https://user-images.githubusercontent.com/17872773/89495671-54e80680-d7eb-11ea-8d99-715652500025.png)
