### PR TITLE
Fix an error when event-target destroy.

### DIFF
--- a/cocos2d/core/event/event-target.js
+++ b/cocos2d/core/event/event-target.js
@@ -228,7 +228,7 @@ proto.clear = function () {
     for (const key in this._callbackTable) {
         const list = this._callbackTable[key];
         const infos = list.callbackInfos;
-        for (let i = 0, len = infos.length; i < len; ++i) {
+        for (let i = infos.length - 1; i >= 0; i--) {
             const info = infos[i];
             this.off(key, info.callback, info.target);
         }


### PR DESCRIPTION
Re: https://forum.cocos.org/t/cocos-creator-v2-4-3-beta-2/96344/146?u=cary

修复切换场景时事件销毁的报错