### PR TITLE
[bugfix] Tilemap apply default tileset offset

### DIFF
--- a/cocos2d/tilemap/CCTiledLayer.js
+++ b/cocos2d/tilemap/CCTiledLayer.js
@@ -489,8 +489,12 @@ let TiledLayer = cc.Class({
 
         let index = Math.floor(col) + Math.floor(row) * this._layerSize.width;
         let gid = this._tiles[index];
-        let tileset = this._texGrids[gid].tileset;
-        let offset = tileset.tileOffset;
+        let offset;
+        if (this._texGrids[gid]) {
+            offset = this._texGrids[gid].tileset.tileOffset;
+        } else {
+            offset = { x: 0, y: 0 }
+        }
 
         let odd_even = (this._staggerIndex === cc.TiledMap.StaggerIndex.STAGGERINDEX_ODD) ? 1 : -1;
         let x = 0, y = 0;


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

`tiledLayer.getTiledTileAt(i, j, forceCreate: true)`  时调用 `_positionForHexAt` 对应位置的 `tileset` 不存在, 需要提供 默认值. 

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
