### PR TITLE
Change type of `Mesh.prototype.data` as non-nullable

### DIFF
--- a/cocos/core/3d/framework/batched-skinning-model-component.ts
+++ b/cocos/core/3d/framework/batched-skinning-model-component.ts
@@ -337,7 +337,7 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
             const unit = this.units[i];
             if (!unit || !unit.mesh || !unit.mesh.data) { continue; }
             const newMesh = this._createUnitMesh(i, unit.mesh);
-            const dataView = new DataView(newMesh.data!.buffer);
+            const dataView = new DataView(newMesh.data.buffer);
             Mat4.inverseTranspose(m4_local, unit._localTransform);
             const offset = unit.offset;
             const size = unit.size;
@@ -545,7 +545,7 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
         }
         // now, we ride!
         const newMeshData = new Uint8Array(totalLength);
-        const oldMeshData = mesh.data!;
+        const oldMeshData = mesh.data;
         const newDataView = new DataView(newMeshData.buffer);
         const oldDataView = new DataView(oldMeshData.buffer);
         const isLittleEndian = legacyCC.sys.isLittleEndian;

--- a/cocos/core/3d/misc/read-mesh.ts
+++ b/cocos/core/3d/misc/read-mesh.ts
@@ -13,7 +13,7 @@ enum _keyMap {
 
 export function readMesh (mesh: Mesh, iPrimitive: number = 0) {
     const out: IGeometry = { positions: [] };
-    const dataView = new DataView(mesh._nativeAsset);
+    const dataView = new DataView(mesh.data.buffer, mesh.data.byteOffset, mesh.data.byteLength);
     const struct = mesh.struct;
     const primitive = struct.primitives[iPrimitive];
     for (const idx of primitive.vertexBundelIndices) {

--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -473,8 +473,8 @@ export class Mesh extends Asset {
     set _nativeAsset (value: ArrayBuffer) {
         if (this._data.byteLength === value.byteLength) {
             this._data.set(new Uint8Array(value));
-            if (legacyCC.loader._cache[this.nativeUrl]) {	
-                legacyCC.loader._cache[this.nativeUrl].content = this._data.buffer;	
+            if (legacyCC.loader._cache[this.nativeUrl]) {
+                legacyCC.loader._cache[this.nativeUrl].content = this._data.buffer;
             }
         } else {
             this._data = new Uint8Array(value);

--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -685,6 +685,7 @@ export class Mesh extends Asset {
         this.destroyRenderingMesh();
         this._struct = info.struct;
         this._data = info.data;
+        this._dataLength = this.data.byteLength;
         this._hash = 0;
         this.loaded = true;
         this.emit('load');

--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -559,8 +559,12 @@ export class Mesh extends Asset {
 
         this._initialized = true;
 
-        this._data = new Uint8Array(this._dataLength);
-        postLoadMesh(this);
+        if (this._data.byteLength !== this._dataLength) {
+            // In the case of deferred loading, `this._data` is created before
+            // the actual binary buffer is loaded.
+            this._data = new Uint8Array(this._dataLength);
+            postLoadMesh(this);
+        }
         const buffer = this._data.buffer;
         const gfxDevice: GFXDevice = legacyCC.director.root.device;
         const vertexBuffers = this._createVertexBuffers(gfxDevice, buffer);

--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -471,7 +471,14 @@ export class Mesh extends Asset {
     }
 
     set _nativeAsset (value: ArrayBuffer) {
-        this._data = new Uint8Array(value);
+        if (this._data.byteLength === value.byteLength) {
+            this._data.set(new Uint8Array(value));
+            if (legacyCC.loader._cache[this.nativeUrl]) {	
+                legacyCC.loader._cache[this.nativeUrl].content = this._data.buffer;	
+            }
+        } else {
+            this._data = new Uint8Array(value);
+        }
         this.loaded = true;
         this.emit('load');
     }

--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -458,6 +458,7 @@ export declare namespace Mesh {
 
 const v3_1 = new Vec3();
 const v3_2 = new Vec3();
+const globalEmptyMeshBuffer = new Uint8Array();
 
 /**
  * 网格资源。
@@ -548,7 +549,7 @@ export class Mesh extends Asset {
     @property
     private _hash = 0;
 
-    private _data: Uint8Array = new Uint8Array();
+    private _data: Uint8Array = globalEmptyMeshBuffer;
     private _initialized = false;
     private _renderingSubMeshes: RenderingSubMesh[] | null = null;
     private _boneSpaceBounds = new Map<number, (aabb | null)[]>();

--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -471,15 +471,7 @@ export class Mesh extends Asset {
     }
 
     set _nativeAsset (value: ArrayBuffer) {
-        const dataU8 = new Uint8Array(value);
-        if (this._data.byteLength === value.byteLength) {
-            this._data.set(dataU8);
-            if (legacyCC.loader._cache[this.nativeUrl]) {
-                legacyCC.loader._cache[this.nativeUrl].content = this._data.buffer;
-            }
-        } else {
-            this._data = dataU8;
-        }
+        this._data = new Uint8Array(value);
         this.loaded = true;
         this.emit('load');
     }

--- a/cocos/core/assets/morph-rendering.ts
+++ b/cocos/core/assets/morph-rendering.ts
@@ -172,9 +172,7 @@ class GpuComputing implements SubMeshMorphRendering {
     }[];
 
     constructor (mesh: Mesh, subMeshIndex: number, morph: Morph, gfxDevice: GFXDevice) {
-        assertIsNonNullable(mesh.data);
         this._gfxDevice = gfxDevice;
-        const meshData = mesh.data.buffer;
         const subMeshMorph = morph.subMeshMorphs[subMeshIndex];
         assertIsNonNullable(subMeshMorph);
         this._subMeshMorph = subMeshMorph;
@@ -208,7 +206,7 @@ class GpuComputing implements SubMeshMorphRendering {
                 let nVec4s = subMeshMorph.targets.length;
                 subMeshMorph.targets.forEach((morphTarget) => {
                     const displacementsView = morphTarget.displacements[attributeIndex];
-                    const displacements = new Float32Array(meshData, displacementsView.offset, displacementsView.count);
+                    const displacements = new Float32Array(mesh.data.buffer, mesh.data.byteOffset + displacementsView.offset, displacementsView.count);
                     const nVec3s = displacements.length / 3;
                     valueView[pHead] = nVec4s;
                     const displacementsOffset = nVec4s * 4;
@@ -292,8 +290,6 @@ class CpuComputing implements SubMeshMorphRendering {
 
     constructor (mesh: Mesh, subMeshIndex: number, morph: Morph, gfxDevice: GFXDevice) {
         this._gfxDevice = gfxDevice;
-        assertIsNonNullable(mesh.data);
-        const meshData = mesh.data.buffer;
         const subMeshMorph = morph.subMeshMorphs[subMeshIndex];
         assertIsNonNullable(subMeshMorph);
         enableVertexId(mesh, subMeshIndex, gfxDevice);
@@ -302,8 +298,8 @@ class CpuComputing implements SubMeshMorphRendering {
                 name: attributeName,
                 targets: subMeshMorph.targets.map((attributeDisplacement) => ({
                     displacements: new Float32Array(
-                        meshData,
-                        attributeDisplacement.displacements[attributeIndex].offset,
+                        mesh.data.buffer,
+                        mesh.data.byteOffset + attributeDisplacement.displacements[attributeIndex].offset,
                         attributeDisplacement.displacements[attributeIndex].count),
                 })),
             };

--- a/cocos/core/assets/utils/mesh-utils.ts
+++ b/cocos/core/assets/utils/mesh-utils.ts
@@ -40,7 +40,7 @@ export function postLoadMesh (mesh: Mesh, callback?: Function) {
     // load image
     legacyCC.loader.load({
         url: mesh.nativeUrl,
-    }, (err, arrayBuffer) => {
+    }, (err: Error | null, arrayBuffer: ArrayBuffer | null) => {
         if (arrayBuffer) {
             if (!mesh.loaded) {
                 mesh._nativeAsset = arrayBuffer;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Change the type of the `Mesh.prototype.data` from `Uint8Array | null` to `Uint8Array`

The type of the `Mesh.prototype.data` was set to be `Uint8Array | null`. It can be `null` since at initial we think empty meshes naturally shall not have binary data associated.

However empty meshes are rare. Meshes are usually imported from model file. In most case, no empty meshes are produced except that: during mesh de-serialization or when you are going to create and fill a mesh, the `Mesh` constructor have to be called to produce an empty mesh.

As a consequence, we decide to let it be non-nullable. To avoid uncessary `new Uint8Arrray(0)`, empty meshes created as result of constructor invocation would associate with an global, singleton 0-length binary buffer.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
