### PR TITLE
(已有更好解决方案) 修复 USE_TEXTURE == false时, 无效的bug

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -442,10 +442,14 @@ var Sprite = cc.Class({
         // make sure material is belong to self.
         let material = this.getMaterial(0);
         if (material) {
-            if (material.getDefine('USE_TEXTURE') !== undefined) {
+            let useTexture = material.getDefine('USE_TEXTURE');
+            if (useTexture !== undefined) {
+                useTexture = true;
                 material.define('USE_TEXTURE', true);
             }
-            material.setProperty('texture', texture);
+            if (useTexture) {
+                material.setProperty('texture', texture);
+            }
         }
 
         BlendFunc.prototype._updateMaterial.call(this);


### PR DESCRIPTION
原代码 USE_TEXTURE == false时, 仍然会强制设置 texture, 从而引起大量无法设置texture的警告.
此PR修复该问题.

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
