### PR TITLE
Avoid undefined of uniform and define

### DIFF
--- a/cocos2d/core/assets/material/effect-parser.ts
+++ b/cocos2d/core/assets/material/effect-parser.ts
@@ -31,7 +31,7 @@ function parseProperties (effectAsset, passJson) {
             prop = properties[name] = Object.assign({}, u),
             propInfo = propertiesJson[name];
 
-        let value = enums2default[u.type];
+        let value;
         if (propInfo) {
             if (propInfo.type === enums.PARAM_TEXTURE_2D) {
                 value = null;
@@ -45,6 +45,10 @@ function parseProperties (effectAsset, passJson) {
         }
         else {
             value = enums2default[u.type];
+
+            if (value === undefined) {
+                value = null;
+            }
         }
 
         prop.value = value;

--- a/cocos2d/core/assets/material/effect-parser.ts
+++ b/cocos2d/core/assets/material/effect-parser.ts
@@ -45,10 +45,10 @@ function parseProperties (effectAsset, passJson) {
         }
         else {
             value = enums2default[u.type];
+        }
 
-            if (value === undefined) {
-                value = null;
-            }
+        if (value === undefined) {
+            value = null;
         }
 
         prop.value = value;

--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -445,7 +445,9 @@ var Sprite = cc.Class({
             if (material.getDefine('USE_TEXTURE') !== undefined) {
                 material.define('USE_TEXTURE', true);
             }
-            material.setProperty('texture', texture);
+            if (material.getProperty('texture') !== undefined) {
+                material.setProperty('texture', texture);
+            }
         }
 
         BlendFunc.prototype._updateMaterial.call(this);


### PR DESCRIPTION
去掉重复取值 这个不用解释了.

说一下为什么要 避免 undefined.  如果能够很好的避免undefined ,
那么 我们就可以通过   `getProperty(name) 是否等于undefined` 来判断属性是否存在了.
否则 当 getProperty(name)  返回 undefined 时, 我们不知道是 到底是没有这个属性, 还是属性值为 undefined.

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
