### PR TITLE
update default-assets meta to v1.0.31

### DIFF
--- a/editor/assets/default_prefab/3d/Capsule.prefab.meta
+++ b/editor/assets/default_prefab/3d/Capsule.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "73ce1f7f-d1f4-4942-ad93-66ca3b3041ab",

--- a/editor/assets/default_prefab/3d/Cone.prefab.meta
+++ b/editor/assets/default_prefab/3d/Cone.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "6350d660-e888-4acf-a552-f3b719ae9110",

--- a/editor/assets/default_prefab/3d/Cube.prefab.meta
+++ b/editor/assets/default_prefab/3d/Cube.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "30da77a1-f02d-4ede-aa56-403452ee7fde",

--- a/editor/assets/default_prefab/3d/Cylinder.prefab.meta
+++ b/editor/assets/default_prefab/3d/Cylinder.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "ab3e16f9-671e-48a7-90b7-d0884d9cbb85",

--- a/editor/assets/default_prefab/3d/Plane.prefab.meta
+++ b/editor/assets/default_prefab/3d/Plane.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "40563723-f8fc-4216-99ea-a81636435c10",

--- a/editor/assets/default_prefab/3d/Quad.prefab.meta
+++ b/editor/assets/default_prefab/3d/Quad.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "34a07346-9f62-4a84-90ae-cb83f7a426c1",

--- a/editor/assets/default_prefab/3d/Sphere.prefab.meta
+++ b/editor/assets/default_prefab/3d/Sphere.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "655c9519-1a37-472b-bae6-29fefac0b550",

--- a/editor/assets/default_prefab/3d/Torus.prefab.meta
+++ b/editor/assets/default_prefab/3d/Torus.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "d47f5d5e-c931-4ff4-987b-cc818a728b82",

--- a/editor/assets/default_prefab/Camera.prefab.meta
+++ b/editor/assets/default_prefab/Camera.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "bb0a6472-cd67-4afb-a031-94fca8f4cc92",

--- a/editor/assets/default_prefab/Terrain.prefab.meta
+++ b/editor/assets/default_prefab/Terrain.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "90e8b0d4-12dc-412d-9156-ea1fdb18c15b",

--- a/editor/assets/default_prefab/effects/Particle System.prefab.meta
+++ b/editor/assets/default_prefab/effects/Particle System.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "f09a0597-10e6-49e5-8759-a148b5e85395",

--- a/editor/assets/default_prefab/light/Directional Light.prefab.meta
+++ b/editor/assets/default_prefab/light/Directional Light.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "a0e9756d-9128-4f49-8097-e041c8b733b8",

--- a/editor/assets/default_prefab/light/Sphere Light.prefab.meta
+++ b/editor/assets/default_prefab/light/Sphere Light.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "4182ee46-ffa0-4de2-b66b-c93cc6c7e9b8",

--- a/editor/assets/default_prefab/light/Spot Light.prefab.meta
+++ b/editor/assets/default_prefab/light/Spot Light.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "7a49aa24-bd7a-40a8-b31a-b2a9da85abcd",

--- a/editor/assets/default_prefab/ui/Button.prefab.meta
+++ b/editor/assets/default_prefab/ui/Button.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "90bdd2a9-2838-4888-b66c-e94c8b7a5169",

--- a/editor/assets/default_prefab/ui/Canvas.prefab.meta
+++ b/editor/assets/default_prefab/ui/Canvas.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "f773db21-62b8-4540-956a-29bacf5ddbf5",

--- a/editor/assets/default_prefab/ui/EditBox.prefab.meta
+++ b/editor/assets/default_prefab/ui/EditBox.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "05e79121-8675-4551-9ad7-1b901a4025db",

--- a/editor/assets/default_prefab/ui/Label.prefab.meta
+++ b/editor/assets/default_prefab/ui/Label.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "36008810-7ad3-47c0-8112-e30aee089e45",

--- a/editor/assets/default_prefab/ui/Layout.prefab.meta
+++ b/editor/assets/default_prefab/ui/Layout.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "a9ef7dfc-ea8b-4cf8-918e-36da948c4de0",

--- a/editor/assets/default_prefab/ui/Mask.prefab.meta
+++ b/editor/assets/default_prefab/ui/Mask.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "7fa63aed-f3e2-46a5-8a7c-c1a1adf6cea6",

--- a/editor/assets/default_prefab/ui/ProgressBar.prefab.meta
+++ b/editor/assets/default_prefab/ui/ProgressBar.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "0d9353c4-6fb9-49bb-bc62-77f1750078c2",

--- a/editor/assets/default_prefab/ui/ScrollView.prefab
+++ b/editor/assets/default_prefab/ui/ScrollView.prefab
@@ -365,7 +365,7 @@
     "scrollEvents": [],
     "cancelInnerEvents": true,
     "_content": {
-      "__id__": 12
+      "__id__": 21
     },
     "_horizontalScrollBar": null,
     "_verticalScrollBar": {

--- a/editor/assets/default_prefab/ui/ScrollView.prefab.meta
+++ b/editor/assets/default_prefab/ui/ScrollView.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "c1baa707-78d6-4b89-8d5d-0b7fdf0c39bc",

--- a/editor/assets/default_prefab/ui/Slider.prefab.meta
+++ b/editor/assets/default_prefab/ui/Slider.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "2bd7e5b6-cd8c-41a1-8136-ddb8efbf6326",

--- a/editor/assets/default_prefab/ui/Sprite.prefab.meta
+++ b/editor/assets/default_prefab/ui/Sprite.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "9db8cd0b-cbe4-42e7-96a9-a239620c0a9d",

--- a/editor/assets/default_prefab/ui/Toggle.prefab.meta
+++ b/editor/assets/default_prefab/ui/Toggle.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "0e89afe7-56de-4f99-96a1-cba8a75bedd2",

--- a/editor/assets/default_prefab/ui/ToggleContainer.prefab.meta
+++ b/editor/assets/default_prefab/ui/ToggleContainer.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "2af73429-41d1-4346-9062-7798e42945dd",

--- a/editor/assets/default_prefab/ui/Widget.prefab.meta
+++ b/editor/assets/default_prefab/ui/Widget.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.30",
+  "ver": "1.0.31",
   "importer": "prefab",
   "imported": true,
   "uuid": "36ed4422-3542-4cc4-bf02-dc4bfc590836",


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * update meta to 1.0.31, migrate ScrollView and PageView

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
