### PR TITLE
@cocos/build-engine@3.0.4: force to make "cc.wait-for-ammo-instantiation" to be standalone

### DIFF
--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -225,10 +225,22 @@ async function _doBuild ({
     if (split) {
         rollupEntries = Object.assign({}, engineEntries);
     } else {
-        rpVirtualOptions['cc'] = generateCCSource(Object.values(engineEntries).map(file => filePathToModuleRequest(file)));
         rollupEntries = {
             'cc': 'cc',
         };
+        const bundledModules = [];
+        for (const moduleName of Object.keys(engineEntries)) {
+            const moduleEntryFile = engineEntries[moduleName];
+            if (moduleName === 'cc.wait-for-ammo-instantiation') {
+                rollupEntries[moduleName] = moduleEntryFile;
+            } else {
+                bundledModules.push(filePathToModuleRequest(moduleEntryFile));
+            }
+        }
+
+        rpVirtualOptions['cc'] = generateCCSource(bundledModules);
+        rollupEntries['cc'] = 'cc';
+
         console.debug(`Module source "cc":\n${rpVirtualOptions['cc']}`);
     }
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * fForce to make "cc.wait-for-ammo-instantiation" to be standalone

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
