### PR TITLE
Full optimize decorators

### DIFF
--- a/cocos/audio/assets/clip.ts
+++ b/cocos/audio/assets/clip.ts
@@ -28,7 +28,7 @@
  */
 
 import { Asset } from '../../core/assets/asset';
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, type } from '../../core/data/class-decorator';
 import { Enum } from '../../core/value-types';
 import { AudioPlayer, PlayingState } from './player';
 import { AudioPlayerDOM } from './player-dom';
@@ -64,7 +64,7 @@ export class AudioClip extends Asset {
     @property
     protected _duration = 0; // we serialize this because it's unavailable at runtime on some platforms
 
-    @property({ type: AudioType })
+    @type(AudioType)
     protected _loadMode = AudioType.UNKNOWN_AUDIO;
 
     protected _audio: any = null;

--- a/cocos/audio/audio-source-component.ts
+++ b/cocos/audio/audio-source-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../core/components/component';
-import { ccclass, help, menu, property, tooltip } from '../core/data/class-decorator';
+import { ccclass, help, menu, property, tooltip, type, range } from '../core/data/class-decorator';
 import { clamp } from '../core/math';
 import { AudioClip } from './assets/clip';
 
@@ -43,7 +43,7 @@ import { AudioClip } from './assets/clip';
 @help('i18n:cc.AudioSourceComponent')
 @menu('Components/AudioSource')
 export class AudioSourceComponent extends Component {
-    @property(AudioClip)
+    @type(AudioClip)
     protected _clip: AudioClip | null = null;
     @property
     protected _loop = false;
@@ -60,9 +60,7 @@ export class AudioSourceComponent extends Component {
      * @zh
      * 设定要播放的音频。
      */
-    @property({
-        type: AudioClip,
-    })
+    @type(AudioClip)
     @tooltip('i18n:audio.clip')
     set clip (val) {
         this._clip = val;
@@ -114,9 +112,8 @@ export class AudioSourceComponent extends Component {
      * 音频的音量（大小范围为 0.0 到 1.0）。<br>
      * 请注意，在某些平台上，音量控制可能不起效。<br>
      */
-    @property({
-        range: [0.0, 1.0],
-    })
+    @property
+    @range([0.0, 1.0])
     @tooltip('i18n:audio.volume')
     set volume (val) {
         if (isNaN(val)) { console.warn('illegal audio volume!'); return; }

--- a/cocos/core/3d/framework/batched-skinning-model-component.ts
+++ b/cocos/core/3d/framework/batched-skinning-model-component.ts
@@ -33,7 +33,7 @@ import { Material } from '../../assets/material';
 import { Mesh } from '../../assets/mesh';
 import { Skeleton } from '../../assets/skeleton';
 import { Texture2D } from '../../assets/texture-2d';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip, type, visible, override } from '../../data/class-decorator';
 import { CCString } from '../../data/utils/attribute';
 import { GFXAttributeName, GFXBufferTextureCopy, GFXFormatInfos } from '../../gfx/define';
 import { GFXFormat, GFXType } from '../../gfx/define';
@@ -56,21 +56,21 @@ export class SkinningModelUnit {
      * @en Skinning mesh of this unit.
      * @zh 子蒙皮模型的网格模型。
      */
-    @property(Mesh)
+    @type(Mesh)
     public mesh: Mesh | null = null;
 
     /**
      * @en Skeleton of this unit.
      * @zh 子蒙皮模型的骨骼。
      */
-    @property(Skeleton)
+    @type(Skeleton)
     public skeleton: Skeleton | null = null;
 
     /**
      * @en Skinning material of this unit.
      * @zh 子蒙皮模型使用的材质。
      */
-    @property(Material)
+    @type(Material)
     public material: Material | null = null;
 
     @property
@@ -108,7 +108,7 @@ export class SkinningModelUnit {
      * @en Convenient setter, copying all necessary information from target skinning model component.
      * @zh 复制目标 SkinningModelComponent 的所有属性到本单元，方便快速配置。
      */
-    @property({ type: SkinningModelComponent })
+    @type(SkinningModelComponent)
     set copyFrom (comp: SkinningModelComponent | null) {
         if (!comp) { return; }
         this.mesh = comp.mesh;
@@ -151,9 +151,7 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
      * @zh
      * 材质中真正参与合图的贴图属性，不参与的属性统一使用第一个 unit 的贴图。
      */
-    @property({
-        type: [CCString],
-    })
+    @type([CCString])
     @tooltip('i18n:batched_skinning_model.batchable_texture_names')
     public batchableTextureNames: string[] = [];
 
@@ -161,16 +159,15 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
      * @en Source skinning model components, containing all the data to be batched.
      * @zh 合批前的子蒙皮模型数组，最主要的数据来源。
      */
-    @property({
-        type: [SkinningModelUnit],
-    })
+    @type([SkinningModelUnit])
     @tooltip('i18n:batched_skinning_model.units')
     public units: SkinningModelUnit[] = [];
 
     private _textures: Record<string, Texture2D> = {};
     private _batchMaterial: Material | null = null;
 
-    @property({ override: true, visible: false })
+    @override(true)
+    @visible(false)
     get mesh () {
         return super.mesh;
     }
@@ -178,7 +175,8 @@ export class BatchedSkinningModelComponent extends SkinningModelComponent {
         super.mesh = val;
     }
 
-    @property({ override: true, visible: false })
+    @override(true)
+    @visible(false)
     get skeleton () {
         return super.skeleton;
     }

--- a/cocos/core/3d/framework/camera-component.ts
+++ b/cocos/core/3d/framework/camera-component.ts
@@ -31,7 +31,7 @@ import { EDITOR } from 'internal:constants';
 import { RenderTexture } from '../../assets/render-texture';
 import { UITransformComponent } from '../../components';
 import { Component } from '../../components/component';
-import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip, displayOrder, type } from '../../data/class-decorator';
 import { ray } from '../../geometry';
 import { GFXClearFlag } from '../../gfx/define';
 import { Color, Rect, toRadian, Vec3 } from '../../math';
@@ -141,9 +141,7 @@ export class CameraComponent extends Component {
      * @en Render priority of the camera, in ascending-order.
      * @zh 相机的渲染优先级，值越小越优先渲染。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     @tooltip('i18n:camera.priority')
     get priority () {
         return this._priority;
@@ -160,10 +158,8 @@ export class CameraComponent extends Component {
      * @en Visibility mask, declaring a set of node layers that will be visible to this camera.
      * @zh 可见性掩码，声明在当前相机中可见的节点层级集合。
      */
-    @property({
-        type: Layers.BitMask,
-        displayOrder: 1,
-    })
+    @type(Layers.BitMask)
+    @displayOrder(1)
     @tooltip('i18n:camera.visibility')
     get visibility () {
         return this._visibility;
@@ -180,10 +176,8 @@ export class CameraComponent extends Component {
      * @en Clearing flags of the camera, specifies which part of the framebuffer will be actually cleared every frame.
      * @zh 相机的缓冲清除标志位，指定帧缓冲的哪部分要每帧清除。
      */
-    @property({
-        type: ClearFlag,
-        displayOrder: 2,
-    })
+    @type(ClearFlag)
+    @displayOrder(2)
     @tooltip('i18n:camera.clear_flags')
     get clearFlags () {
         return this._clearFlags;
@@ -198,9 +192,7 @@ export class CameraComponent extends Component {
      * @en Clearing color of the camera.
      * @zh 相机的颜色缓冲默认值。
      */
-    @property({
-        displayOrder: 3,
-    })
+    @displayOrder(3)
     @tooltip('i18n:camera.color')
     // @constget
     get clearColor (): Readonly<Color> {
@@ -221,9 +213,7 @@ export class CameraComponent extends Component {
      * @en Clearing depth of the camera.
      * @zh 相机的深度缓冲默认值。
      */
-    @property({
-        displayOrder: 4,
-    })
+    @displayOrder(4)
     @tooltip('i18n:camera.depth')
     get clearDepth () {
         return this._depth;
@@ -238,9 +228,7 @@ export class CameraComponent extends Component {
      * @en Clearing stencil of the camera.
      * @zh 相机的模板缓冲默认值。
      */
-    @property({
-        displayOrder: 5,
-    })
+    @displayOrder(5)
     @tooltip('i18n:camera.stencil')
     get clearStencil () {
         return this._stencil;
@@ -255,10 +243,8 @@ export class CameraComponent extends Component {
      * @en Projection type of the camera.
      * @zh 相机的投影类型。
      */
-    @property({
-        type: ProjectionType,
-        displayOrder: 6,
-    })
+    @type(ProjectionType)
+    @displayOrder(6)
     @tooltip('i18n:camera.projection')
     get projection () {
         return this._projection;
@@ -273,10 +259,8 @@ export class CameraComponent extends Component {
      * @en The axis on which the FOV would be fixed regardless of screen aspect changes.
      * @zh 指定视角的固定轴向，在此轴上不会跟随屏幕长宽比例变化。
      */
-    @property({
-        type: FOVAxis,
-        displayOrder: 7,
-    })
+    @type(FOVAxis)
+    @displayOrder(7)
     @tooltip('i18n:camera.fov_axis')
     get fovAxis () {
         return this._fovAxis;
@@ -296,9 +280,7 @@ export class CameraComponent extends Component {
      * @en Field of view of the camera.
      * @zh 相机的视角大小。
      */
-    @property({
-        displayOrder: 8,
-    })
+    @displayOrder(8)
     @tooltip('i18n:camera.fov')
     get fov () {
         return this._fov;
@@ -313,9 +295,7 @@ export class CameraComponent extends Component {
      * @en Viewport height in orthographic mode.
      * @zh 正交模式下的相机视角高度。
      */
-    @property({
-        displayOrder: 9,
-    })
+    @displayOrder(9)
     @tooltip('i18n:camera.ortho_height')
     get orthoHeight () {
         return this._orthoHeight;
@@ -330,9 +310,7 @@ export class CameraComponent extends Component {
      * @en Near clipping distance of the camera, should be as large as possible within acceptable range.
      * @zh 相机的近裁剪距离，应在可接受范围内尽量取最大。
      */
-    @property({
-        displayOrder: 10,
-    })
+    @displayOrder(10)
     @tooltip('i18n:camera.near')
     get near () {
         return this._near;
@@ -347,9 +325,7 @@ export class CameraComponent extends Component {
      * @en Far clipping distance of the camera, should be as small as possible within acceptable range.
      * @zh 相机的远裁剪距离，应在可接受范围内尽量取最小。
      */
-    @property({
-        displayOrder: 11,
-    })
+    @displayOrder(11)
     @tooltip('i18n:camera.far')
     get far () {
         return this._far;
@@ -364,10 +340,8 @@ export class CameraComponent extends Component {
      * @en Camera aperture, controls the exposure parameter.
      * @zh 相机光圈，影响相机的曝光参数。
      */
-    @property({
-        type: Aperture,
-        displayOrder: 12,
-    })
+    @type(Aperture)
+    @displayOrder(12)
     @tooltip('i18n:camera.aperture')
     get aperture () {
         return this._aperture;
@@ -382,10 +356,8 @@ export class CameraComponent extends Component {
      * @en Camera shutter, controls the exposure parameter.
      * @zh 相机快门，影响相机的曝光参数。
      */
-    @property({
-        type: Shutter,
-        displayOrder: 13,
-    })
+    @type(Shutter)
+    @displayOrder(13)
     @tooltip('i18n:camera.shutter')
     get shutter () {
         return this._shutter;
@@ -400,10 +372,8 @@ export class CameraComponent extends Component {
      * @en Camera ISO, controls the exposure parameter.
      * @zh 相机感光度，影响相机的曝光参数。
      */
-    @property({
-        type: ISO,
-        displayOrder: 14,
-    })
+    @type(ISO)
+    @displayOrder(14)
     @tooltip('i18n:camera.ISO')
     get iso () {
         return this._iso;
@@ -418,9 +388,7 @@ export class CameraComponent extends Component {
      * @en Screen viewport of the camera wrt. the sceen size.
      * @zh 此相机最终渲染到屏幕上的视口位置和大小。
      */
-    @property({
-        displayOrder: 15,
-    })
+    @displayOrder(15)
     @tooltip('i18n:camera.rect')
     get rect () {
         return this._rect;
@@ -435,10 +403,8 @@ export class CameraComponent extends Component {
      * @en Output render texture of the camera. Default to null, which outputs directly to screen.
      * @zh 指定此相机的渲染输出目标贴图，默认为空，直接渲染到屏幕。
      */
-    @property({
-        type: RenderTexture,
-        displayOrder: 16,
-    })
+    @type(RenderTexture)
+    @displayOrder(16)
     @tooltip('i18n:camera.target_texture')
     get targetTexture () {
         return this._targetTexture;

--- a/cocos/core/3d/framework/directional-light-component.ts
+++ b/cocos/core/3d/framework/directional-light-component.ts
@@ -27,7 +27,7 @@
  * @category component/light
  */
 
-import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip, unit } from '../../data/class-decorator';
 import { DirectionalLight } from '../../renderer/scene/directional-light';
 import { LightType } from '../../renderer/scene/light';
 import { LightComponent } from './light-component';
@@ -50,9 +50,7 @@ export class DirectionalLightComponent extends LightComponent {
      * @zh
      * 光源强度。
      */
-    @property({
-        unit: 'lx',
-    })
+    @unit('lx')
     @tooltip('i18n:lights.illuminance')
     get illuminance () {
         return this._illuminance;

--- a/cocos/core/3d/framework/light-component.ts
+++ b/cocos/core/3d/framework/light-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../../components/component';
-import { ccclass, property, tooltip } from '../../data/class-decorator';
+import { ccclass, property, tooltip, range, slide, type } from '../../data/class-decorator';
 import { Color } from '../../math';
 import { Enum } from '../../value-types';
 
@@ -162,10 +162,8 @@ export class LightComponent extends Component {
      * @zh
      * 光源色温。
      */
-    @property({
-        slide: true,
-        range: [1000, 15000, 1],
-    })
+    @slide(true)
+    @range([1000, 15000, 1])
     @tooltip('i18n:lights.color_temperature')
     get colorTemperature () {
         return this._colorTemperature;
@@ -182,9 +180,7 @@ export class LightComponent extends Component {
      * @zh
      * 静态灯光设置。
      */
-    @property({
-        type: StaticLightSettings,
-    })
+    @type(StaticLightSettings)
     get staticSettings () {
         return this._staticSettings;
     }

--- a/cocos/core/3d/framework/model-component.ts
+++ b/cocos/core/3d/framework/model-component.ts
@@ -30,7 +30,7 @@
 import { Texture2D } from '../../assets';
 import { Material } from '../../assets/material';
 import { Mesh } from '../../assets/mesh';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip, visible, type, formerlySerializedAs } from '../../data/class-decorator';
 import { Vec4 } from '../../math';
 import { Model } from '../../renderer/scene/model';
 import { MorphModel } from '../../renderer/models/morph-model';
@@ -83,21 +83,17 @@ const ModelShadowReceivingMode = Enum({
  */
 @ccclass('cc.ModelLightmapSettings')
 class ModelLightmapSettings {
-    @property({
-        visible: false,
-    })
+    @property
+    @visible(false)
     public texture: Texture2D|null = null;
-    @property({
-        visible: false,
-    })
+    @property
+    @visible(false)
     public uvParam: Vec4 = new Vec4();
     @property
     protected _bakeable: boolean = false;
     @property
     protected _castShadow: boolean = false;
-    @property({
-        formerlySerializedAs: '_recieveShadow',
-    })
+    @formerlySerializedAs('_recieveShadow')
     protected _receiveShadow: boolean = false;
     @property
     protected _lightmapSize: number = 64;
@@ -185,9 +181,7 @@ export class ModelComponent extends RenderableComponent {
      * @en Shadow projection mode.
      * @zh 阴影投射方式。
      */
-    @property({
-        type: ModelShadowCastingMode,
-    })
+    @type(ModelShadowCastingMode)
     @tooltip('i18n:model.shadow_casting_model')
     get shadowCastingMode () {
         return this._shadowCastingMode;
@@ -202,9 +196,7 @@ export class ModelComponent extends RenderableComponent {
      * @en receive shadow.
      * @zh 是否接受阴影。
      */
-    @property({
-        type: ModelShadowReceivingMode,
-    })
+    @type(ModelShadowReceivingMode)
     @tooltip('i18n:model.shadow_receiving_model')
     get receiveShadow () {
         return this._shadowReceivingMode;
@@ -219,9 +211,7 @@ export class ModelComponent extends RenderableComponent {
      * @en The mesh of the model.
      * @zh 模型的网格数据。
      */
-    @property({
-        type: Mesh,
-    })
+    @type(Mesh)
     @tooltip('i18n:model.mesh')
     get mesh () {
         return this._mesh;
@@ -243,14 +233,12 @@ export class ModelComponent extends RenderableComponent {
         return this._model;
     }
 
-    @property({
-        visible (this: ModelComponent) {
-            return !!(
-                this.mesh &&
-                this.mesh.struct.morph &&
-                this.mesh.struct.morph.subMeshMorphs.some((subMeshMorph) => !!subMeshMorph)
-            );
-        },
+    @visible(function (this: ModelComponent) {
+        return !!(
+            this.mesh &&
+            this.mesh.struct.morph &&
+            this.mesh.struct.morph.subMeshMorphs.some((subMeshMorph) => !!subMeshMorph)
+        );
     })
     get enableMorph () {
         return this._enableMorph;

--- a/cocos/core/3d/framework/renderable-component.ts
+++ b/cocos/core/3d/framework/renderable-component.ts
@@ -5,7 +5,7 @@
 import { EDITOR } from 'internal:constants';
 import { Material } from '../../assets/material';
 import { Component } from '../../components/component';
-import { ccclass, property } from '../../data/class-decorator';
+import { ccclass, property, type, visible, displayName } from '../../data/class-decorator';
 import { IMaterialInstanceInfo, MaterialInstance } from '../../renderer/core/material-instance';
 import { Model } from '../../renderer/scene/model';
 import { Layers } from '../../scene-graph/layers';
@@ -18,15 +18,13 @@ const _matInsInfo: IMaterialInstanceInfo = {
 
 @ccclass('cc.RenderableComponent')
 export class RenderableComponent extends Component {
-    @property({
-        type: [Material],
-    })
+    @type([Material])
     protected _materials: (Material | null)[] = [];
 
     @property
     protected _visFlags = Layers.Enum.NONE;
 
-    @property({ visible: false })
+    @visible(false)
     get visibility () {
         return this._visFlags;
     }
@@ -36,10 +34,8 @@ export class RenderableComponent extends Component {
         this._onVisibilityChange(val);
     }
 
-    @property({
-        type: Material,
-        displayName: 'Materials',
-    })
+    @type(Material)
+    @displayName('Materials')
     get sharedMaterials () {
         // if we don't create an array copy, the editor will modify the original array directly.
         return EDITOR && this._materials.slice() || this._materials;

--- a/cocos/core/3d/framework/skinning-model-component.ts
+++ b/cocos/core/3d/framework/skinning-model-component.ts
@@ -31,7 +31,7 @@ import { AnimationClip } from '../../animation/animation-clip';
 import { BatchingSchemes } from '../../renderer/core/pass';
 import { Material } from '../../assets';
 import { Skeleton } from '../../assets/skeleton';
-import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip } from '../../data/class-decorator';
+import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip, type } from '../../data/class-decorator';
 import { BakedSkinningModel } from '../../renderer/models/baked-skinning-model';
 import { SkinningModel } from '../../renderer/models/skinning-model';
 import { Node } from '../../scene-graph/node';
@@ -50,10 +50,10 @@ import { legacyCC } from '../../global-exports';
 @menu('Components/SkinningModel')
 export class SkinningModelComponent extends ModelComponent {
 
-    @property(Skeleton)
+    @type(Skeleton)
     protected _skeleton: Skeleton | null = null;
 
-    @property(Node)
+    @type(Node)
     protected _skinningRoot: Node | null = null;
 
     protected _clip: AnimationClip | null = null;
@@ -62,9 +62,7 @@ export class SkinningModelComponent extends ModelComponent {
      * @en The skeleton asset.
      * @zh 骨骼资源。
      */
-    @property({
-        type: Skeleton,
-    })
+    @type(Skeleton)
     get skeleton () {
         return this._skeleton;
     }
@@ -79,9 +77,7 @@ export class SkinningModelComponent extends ModelComponent {
      * @en The skinning root. (The node where the controlling AnimationComponent is located)
      * 骨骼根节点的引用，对应控制此模型的动画组件所在节点。
      */
-    @property({
-        type: Node,
-    })
+    @type(Node)
     @tooltip('i18n:model.skinning_root')
     get skinningRoot () {
         return this._skinningRoot;

--- a/cocos/core/3d/framework/sphere-light-component.ts
+++ b/cocos/core/3d/framework/sphere-light-component.ts
@@ -26,7 +26,7 @@
  * @category component/light
  */
 
-import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip, type, unit } from '../../data/class-decorator';
 import { LightType, nt2lm } from '../../renderer/scene/light';
 import { SphereLight } from '../../renderer/scene/sphere-light';
 import { LightComponent, PhotometricTerm } from './light-component';
@@ -53,9 +53,7 @@ export class SphereLightComponent extends LightComponent {
      * @en Luminous power of the light.
      * @zh 光通量。
      */
-    @property({
-        unit: 'lm',
-    })
+    @unit('lm')
     @tooltip('i18n:lights.luminous_power')
     get luminousPower () {
         return this._luminance * nt2lm(this._size);
@@ -69,9 +67,7 @@ export class SphereLightComponent extends LightComponent {
      * @en Luminance of the light.
      * @zh 光亮度。
      */
-    @property({
-        unit: 'cd/m²',
-    })
+    @unit('cd/m²')
     @tooltip('i18n:lights.luminance')
     get luminance () {
         return this._luminance;
@@ -85,9 +81,7 @@ export class SphereLightComponent extends LightComponent {
      * @en The photometric term currently being used.
      * @zh 当前使用的光度学计量单位。
      */
-    @property({
-        type: PhotometricTerm,
-    })
+    @type(PhotometricTerm)
     @tooltip('i18n:lights.term')
     get term () {
         return this._term;

--- a/cocos/core/3d/framework/spot-light-component.ts
+++ b/cocos/core/3d/framework/spot-light-component.ts
@@ -27,7 +27,7 @@
  * @category component/light
  */
 
-import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip, type, slide, range, unit } from '../../data/class-decorator';
 import { toRadian } from '../../math';
 import { LightType, nt2lm } from '../../renderer/scene/light';
 import { SpotLight } from '../../renderer/scene/spot-light';
@@ -57,9 +57,7 @@ export class SpotLightComponent extends LightComponent {
      * @en Luminous power of the light.
      * @zh 光通量。
      */
-    @property({
-        unit: 'lm',
-    })
+    @unit('lm')
     @tooltip('i18n:lights.luminous_power')
     get luminousPower () {
         return this._luminance * nt2lm(this._size);
@@ -73,9 +71,7 @@ export class SpotLightComponent extends LightComponent {
      * @en Luminance of the light.
      * @zh 光亮度。
      */
-    @property({
-        unit: 'cd/m²',
-    })
+    @unit('cd/m²')
     @tooltip('i18n:lights.luminance')
     get luminance () {
         return this._luminance;
@@ -89,9 +85,7 @@ export class SpotLightComponent extends LightComponent {
      * @en The photometric term currently being used.
      * @zh 当前使用的光度学计量单位。
      */
-    @property({
-        type: PhotometricTerm,
-    })
+    @type(PhotometricTerm)
     @tooltip('i18n:lights.term')
     get term () {
         return this._term;
@@ -136,10 +130,8 @@ export class SpotLightComponent extends LightComponent {
      * @zh
      * 聚光灯锥角。
      */
-    @property({
-        slide: true,
-        range: [2, 180, 1],
-    })
+    @slide(true)
+    @range([2, 180, 1])
     @tooltip('The spot light cone angle')
     get spotAngle () {
         return this._spotAngle;

--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -6,7 +6,7 @@
 import { EDITOR } from 'internal:constants';
 import { Asset } from '../assets/asset';
 import { SpriteFrame } from '../assets/sprite-frame';
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, visible } from '../data/class-decorator';
 import { CompactValueTypeArray } from '../data/utils/compact-value-type-array';
 import { errorID } from '../platform/debug';
 import { DataPoolManager } from '../renderer/data-pool-manager';
@@ -164,7 +164,8 @@ export class AnimationClip extends Asset {
      * @zh 动画包含的事件数据。
      * @en Associated event data.
      */
-    @property({visible: false})
+    @property
+    @visible(false)
     public events: AnimationClip.IEvent[] = [];
 
     @property

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../components/component';
-import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip } from '../data/class-decorator';
+import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip, type } from '../data/class-decorator';
 import { Eventify } from '../event/eventify';
 import { warnID } from '../platform/debug';
 import * as ArrayUtils from '../utils/array';
@@ -68,9 +68,7 @@ export class AnimationComponent extends Eventify(Component) {
      * 获取或设置此组件管理的剪辑。
      * 设置时，已有剪辑关联的动画状态将被停止；若默认剪辑不在新的动画剪辑中，将被重置为空。
      */
-    @property({
-        type: [AnimationClip],
-    })
+    @type([AnimationClip])
     @tooltip('此动画组件管理的动画剪辑')
     get clips () {
         return this._clips;
@@ -111,9 +109,7 @@ export class AnimationComponent extends Eventify(Component) {
      * 设置时，若指定的剪辑不在 `this.clips` 中则会被自动添加至 `this.clips`。
      * @see [[playOnLoad]]
      */
-    @property({
-        type: AnimationClip,
-    })
+    @type(AnimationClip)
     @tooltip('默认动画剪辑')
     get defaultClip () {
         return this._defaultClip;
@@ -149,7 +145,7 @@ export class AnimationComponent extends Eventify(Component) {
 
     protected _nameToState: Record<string, AnimationState> = createMap(true);
 
-    @property({ type: [AnimationClip] })
+    @type([AnimationClip])
     protected _clips: (AnimationClip | null)[] = [];
 
     @property

--- a/cocos/core/animation/skeletal-animation-component.ts
+++ b/cocos/core/animation/skeletal-animation-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { SkinningModelComponent } from '../3d/framework/skinning-model-component';
-import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip } from '../data/class-decorator';
+import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip, type } from '../data/class-decorator';
 import { Mat4 } from '../math';
 import { DataPoolManager } from '../renderer/data-pool-manager';
 import { Node } from '../scene-graph/node';
@@ -54,7 +54,7 @@ export class Socket {
      * @en Transform output node.
      * @zh 此挂点的变换信息输出节点。
      */
-    @property(Node)
+    @type(Node)
     public target: Node | null = null;
 
     constructor (path = '', target: Node | null = null) {
@@ -104,9 +104,7 @@ export class SkeletalAnimationComponent extends AnimationComponent {
      * @zh
      * 当前动画组件维护的挂点数组。要挂载自定义节点到受动画驱动的骨骼上，必须先在此注册挂点。
      */
-    @property({
-        type: [Socket],
-    })
+    @type([Socket])
     @tooltip('i18n:animation.sockets')
     get sockets () {
         return this._sockets;
@@ -150,7 +148,7 @@ export class SkeletalAnimationComponent extends AnimationComponent {
     @property
     protected _useBakedAnimation = true;
 
-    @property({ type: [Socket] })
+    @type([Socket])
     protected _sockets: Socket[] = [];
 
     public onDestroy () {

--- a/cocos/core/assets/bitmap-font.ts
+++ b/cocos/core/assets/bitmap-font.ts
@@ -28,7 +28,7 @@
  * @category asset
  */
 
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, type } from '../data/class-decorator';
 import { Font } from './font';
 import { SpriteFrame } from './sprite-frame';
 import { legacyCC } from '../global-exports';
@@ -53,9 +53,7 @@ export class BitmapFont extends Font {
      * @zh
      * bitmap font 依赖精灵。
      */
-    @property({
-        type: SpriteFrame,
-    })
+    @type(SpriteFrame)
     public spriteFrame: SpriteFrame | null = null;
 
     /**

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -28,7 +28,7 @@
  */
 
 // @ts-check
-import {ccclass, property} from '../data/class-decorator';
+import {ccclass, property, override} from '../data/class-decorator';
 import { GFXDevice, GFXFeature } from '../gfx/device';
 import { Asset } from './asset';
 import { PixelFormat } from './asset-enum';
@@ -62,7 +62,7 @@ function fetchImageSource (imageSource: ImageSource) {
 @ccclass('cc.ImageAsset')
 export class ImageAsset extends Asset {
 
-    @property({override: true})
+    @override(true)
     get _nativeAsset () {
         // Maybe returned to pool in webgl.
         return this._nativeData;

--- a/cocos/core/assets/material.ts
+++ b/cocos/core/assets/material.ts
@@ -28,7 +28,7 @@
  * @category material
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, type } from '../../core/data/class-decorator';
 import { builtinResMgr } from '../3d/builtin/init';
 import { RenderableComponent } from '../3d/framework/renderable-component';
 import { GFXTexture } from '../gfx/texture';
@@ -105,7 +105,7 @@ export class Material extends Asset {
         return hash;
     }
 
-    @property(EffectAsset)
+    @type(EffectAsset)
     protected _effectAsset: EffectAsset | null = null;
     @property
     protected _techIdx = 0;

--- a/cocos/core/assets/render-texture.ts
+++ b/cocos/core/assets/render-texture.ts
@@ -27,7 +27,7 @@
  * @category asset
  */
 
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, visible, rangeMin, rangeMax } from '../data/class-decorator';
 import { GFXTexture, GFXSampler, GFXColorAttachment, GFXDepthStencilAttachment, GFXTextureLayout, IGFXRenderPassInfo } from '../gfx';
 import { legacyCC } from '../global-exports';
 import { RenderWindow } from '../pipeline';
@@ -60,18 +60,16 @@ const _windowInfo: IRenderWindowInfo = {
 @ccclass('cc.RenderTexture')
 export class RenderTexture extends Asset {
 
-    @property({
-        min: 1,
-        max: 2048,
-        visible: true,
-    })
+    @property
+    @rangeMin(1)
+    @rangeMax(2048)
+    @visible(true)
     private _width = 1;
 
-    @property({
-        min: 1,
-        max: 2048,
-        visible: true,
-    })
+    @property
+    @rangeMin(1)
+    @rangeMax(2048)
+    @visible(true)
     private _height = 1;
 
     private _window: RenderWindow | null = null;

--- a/cocos/core/assets/skeleton.ts
+++ b/cocos/core/assets/skeleton.ts
@@ -27,7 +27,7 @@
  * @category asset
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, type } from '../../core/data/class-decorator';
 import { CCString } from '../../core/data/utils/attribute';
 import { Mat4 } from '../../core/math';
 import { murmurhash2_32_gc } from '../../core/utils/murmurhash2_gc';
@@ -42,10 +42,10 @@ import { legacyCC } from '../global-exports';
 @ccclass('cc.Skeleton')
 export class Skeleton extends Asset {
 
-    @property([CCString])
+    @type([CCString])
     private _joints: string[] = [];
 
-    @property([Mat4])
+    @type([Mat4])
     private _bindposes: Mat4[] = [];
 
     @property

--- a/cocos/core/assets/texture-2d.ts
+++ b/cocos/core/assets/texture-2d.ts
@@ -28,7 +28,7 @@
  * @category asset
  */
 
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, type } from '../data/class-decorator';
 import { GFXTextureType } from '../gfx/define';
 import { PixelFormat } from './asset-enum';
 import { ImageAsset } from './image-asset';
@@ -112,7 +112,7 @@ export class Texture2D extends SimpleTexture {
         this.mipmaps = value ? [value] : [];
     }
 
-    @property([ImageAsset])
+    @type([ImageAsset])
     public _mipmaps: ImageAsset[] = [];
 
     public initialize () {

--- a/cocos/core/assets/ttf-font.ts
+++ b/cocos/core/assets/ttf-font.ts
@@ -28,7 +28,7 @@
  * @category asset
  */
 
-import {ccclass, property, string} from '../data/class-decorator';
+import {ccclass, property, string, override} from '../data/class-decorator';
 import { Font } from './font';
 import { legacyCC } from '../global-exports';
 
@@ -44,9 +44,7 @@ export class TTFFont extends Font {
     @property
     public _fontFamily: any = null;
 
-    @property({
-        override: true,
-    })
+    @override(true)
     @string
     get _nativeAsset () {
         return this._fontFamily;

--- a/cocos/core/components/component-event-handler.ts
+++ b/cocos/core/components/component-event-handler.ts
@@ -28,7 +28,7 @@
  * @category event
  */
 
-import {ccclass, property} from '../data/class-decorator';
+import {ccclass, property, type} from '../data/class-decorator';
 import { Node } from '../scene-graph';
 import { legacyCC } from '../global-exports';
 
@@ -79,7 +79,7 @@ export class EventHandler {
      * @zh
      * 目标节点。
      */
-    @property(legacyCC.Node)
+    @type(legacyCC.Node)
     public target: Node | null = null;
     /**
      * @zh

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -31,7 +31,7 @@
  */
 
 import { Script } from '../assets/scripts';
-import { ccclass, property, tooltip } from '../data/class-decorator';
+import { ccclass, property, tooltip, visible, displayName, type } from '../data/class-decorator';
 import { CCObject } from '../data/object';
 import IDGenerator from '../utils/id-generator';
 import { getClassName, value } from '../utils/js';
@@ -68,9 +68,7 @@ const NullNode = null as unknown as Node;
 @ccclass('cc.Component')
 class Component extends CCObject {
 
-    @property({
-        visible: false,
-    })
+    @visible(false)
     get name () {
         if (this._name) {
             return this._name;
@@ -98,17 +96,14 @@ class Component extends CCObject {
      * log(comp.uuid);
      * ```
      */
-    @property({
-        visible: false,
-    })
+    @visible(false)
     get uuid () {
         return this._id;
     }
 
-    @property({
-        displayName: 'Script',
-        type: Script,
-    })
+    @property
+    @displayName('Script')
+    @type(Script)
     @tooltip('i18n:INSPECTOR.component.script')
     get __scriptAsset () { return null; }
 
@@ -125,9 +120,7 @@ class Component extends CCObject {
      * log(comp.enabled);
      * ```
      */
-    @property({
-        visible: false,
-    })
+    @visible(false)
     get enabled () {
         return this._enabled;
     }
@@ -158,9 +151,7 @@ class Component extends CCObject {
      * log(comp.enabledInHierarchy);
      * ```
      */
-    @property({
-        visible: false,
-    })
+    @visible(false)
     get enabledInHierarchy () {
         return this._enabled && this.node && this.node.activeInHierarchy;
     }
@@ -193,9 +184,8 @@ class Component extends CCObject {
      * log(comp.node);
      * ```
      */
-    @property({
-        visible: false,
-    })
+    @property
+    @visible(false)
     public node: Node = NullNode;
 
     /**

--- a/cocos/core/components/missing-script.ts
+++ b/cocos/core/components/missing-script.ts
@@ -28,7 +28,7 @@
  * @category component
  */
 
-import {ccclass, inspector, property} from '../data/class-decorator';
+import {ccclass, inspector, property, visible, editorOnly, serializable} from '../data/class-decorator';
 import {_getClassById} from '../utils/js';
 import {BUILTIN_CLASSID_RE} from '../utils/misc';
 import { Component } from './component';
@@ -45,10 +45,9 @@ import { warnID } from '../platform/debug';
 @ccclass('cc.MissingClass')
 class MissingClass {
     // the serialized data for original object
-    @property({
-        visible: false,
-        editorOnly: true,
-    })
+    @property
+    @editorOnly(true)
+    @visible(false)
     public _$erialized = null;
 }
 
@@ -97,16 +96,13 @@ export default class MissingScript extends Component {
         }
     }
 
-    @property({
-        serializable: false,
-    })
+    @serializable(false)
     public compiled = false;
 
     // the serialized data for original script object
-    @property({
-        visible: false,
-        editorOnly: true,
-    })
+    @property
+    @visible(false)
+    @editorOnly(true)
     public _$erialized = null;
 
     constructor () {

--- a/cocos/core/components/ui-base/canvas-component.ts
+++ b/cocos/core/components/ui-base/canvas-component.ts
@@ -30,7 +30,7 @@
 
 import { CameraComponent } from '../../3d/framework/camera-component';
 import { RenderTexture } from '../../assets/render-texture';
-import { ccclass, help, disallowMultiple, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip } from '../../data/class-decorator';
+import { ccclass, help, disallowMultiple, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip, type } from '../../data/class-decorator';
 import { director, Director } from '../../director';
 import { game } from '../../game';
 import { GFXClearFlag } from '../../gfx/define';
@@ -85,9 +85,7 @@ export class CanvasComponent extends Component {
      * @zh
      * 清理屏幕缓冲标记。
      */
-    @property({
-        type: CanvasClearFlag,
-    })
+    @type(CanvasClearFlag)
     @tooltip('清理屏幕缓冲标记')
     get clearFlag () {
         return this._clearFlag;
@@ -135,9 +133,7 @@ export class CanvasComponent extends Component {
      * intersperse 下可以指定 Canvas 与场景中的相机的渲染顺序，overlay 下 Canvas 会在所有场景相机渲染完成后渲染。
      * 注意：场景里的相机（包括 Canvas 内置的相机）必须有一个的 ClearFlag 选择 SOLID_COLOR，否则在移动端可能会出现闪屏。
      */
-    @property({
-        type: RenderMode,
-    })
+    @type(RenderMode)
     @tooltip('Canvas 渲染模式，intersperse 下可以指定 Canvas 与场景中的相机的渲染顺序，overlay 下 Canvas 会在所有场景相机渲染完成后渲染。\n注意：注意：场景里的相机（包括 Canvas 内置的相机）必须有一个的 ClearFlag 选择 SOLID_COLOR，否则在移动端可能会出现闪屏')
     get renderMode () {
         return this._renderMode;
@@ -184,9 +180,7 @@ export class CanvasComponent extends Component {
      * @zh
      * 设置目标渲染纹理。
      */
-    @property({
-        type: RenderTexture,
-    })
+    @type(RenderTexture)
     @tooltip('目标渲染纹理')
     get targetTexture (){
         return this._targetTexture;
@@ -225,15 +219,11 @@ export class CanvasComponent extends Component {
     protected _priority = 0;
     @property
     protected _targetTexture: RenderTexture | null = null;
-    @property({
-        type: CanvasClearFlag,
-    })
+    @type(CanvasClearFlag)
     protected _clearFlag = CanvasClearFlag.DONT_CLEAR;
     @property
     protected _color = new Color(0, 0, 0, 0);
-    @property({
-        type: RenderMode,
-    })
+    @type(RenderMode)
     protected _renderMode = RenderMode.OVERLAY;
 
     protected _thisOnResized: () => void;

--- a/cocos/core/components/ui-base/ui-render-component.ts
+++ b/cocos/core/components/ui-base/ui-render-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { RenderableComponent } from '../../../core/3d/framework/renderable-component';
-import { ccclass, property, executeInEditMode, requireComponent, disallowMultiple, tooltip } from '../../../core/data/class-decorator';
+import { ccclass, property, executeInEditMode, requireComponent, disallowMultiple, tooltip, type, displayOrder } from '../../../core/data/class-decorator';
 import { Color } from '../../../core/math';
 import { SystemEventType } from '../../../core/platform/event-manager/event-enum';
 import { ccenum } from '../../../core/value-types/enum';
@@ -134,10 +134,8 @@ export class UIRenderComponent extends RenderableComponent {
      * sprite.srcBlendFactor = GFXBlendFactor.ONE;
      * ```
      */
-    @property({
-        type: GFXBlendFactor,
-        displayOrder: 0,
-    })
+    @type(GFXBlendFactor)
+    @displayOrder(0)
     @tooltip('原图混合模式')
     get srcBlendFactor () {
         return this._srcBlendFactor;
@@ -165,10 +163,8 @@ export class UIRenderComponent extends RenderableComponent {
      * sprite.dstBlendFactor = GFXBlendFactor.ONE;
      * ```
      */
-    @property({
-        type: GFXBlendFactor,
-        displayOrder: 1,
-    })
+    @type(GFXBlendFactor)
+    @displayOrder(1)
     @tooltip('目标混合模式')
     get dstBlendFactor () {
         return this._dstBlendFactor;
@@ -192,9 +188,7 @@ export class UIRenderComponent extends RenderableComponent {
      *
      * @param value 渲染颜色。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @displayOrder(2)
     @tooltip('渲染颜色')
     get color (): Readonly<Color> {
         return this._color;

--- a/cocos/core/components/ui-base/ui-transform-component.ts
+++ b/cocos/core/components/ui-base/ui-transform-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { Component } from '../component';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip, displayOrder } from '../../data/class-decorator';
 import { SystemEventType } from '../../platform/event-manager/event-enum';
 import { EventListener, IListenerMask } from '../../platform/event-manager/event-listener';
 import { Mat4, Rect, Size, Vec2, Vec3 } from '../../math';
@@ -67,9 +67,7 @@ export class UITransformComponent extends Component {
      * @zh
      * 内容尺寸。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     @tooltip('内容尺寸')
     // @constget
     get contentSize (): Readonly<Size> {
@@ -149,9 +147,7 @@ export class UITransformComponent extends Component {
      * @zh
      * 锚点位置。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @displayOrder(1)
     @tooltip('锚点位置')
     // @constget
     get anchorPoint (): Readonly<Vec2> {

--- a/cocos/core/components/ui-coodinate-tracker-component.ts
+++ b/cocos/core/components/ui-coodinate-tracker-component.ts
@@ -30,7 +30,7 @@
 
 import { Component } from './component';
 import { EventHandler } from './component-event-handler';
-import { ccclass, help, property, menu, executionOrder, tooltip } from '../data/class-decorator';
+import { ccclass, help, property, menu, executionOrder, tooltip, type } from '../data/class-decorator';
 import { Node } from '../scene-graph';
 import { convertUtils } from '../utils';
 import { CameraComponent } from '../3d';
@@ -49,9 +49,7 @@ export class UICoordinateTrackerComponent extends Component {
      * @zh
      * 目标对象。
      */
-    @property({
-        type: Node,
-    })
+    @type(Node)
     @tooltip('目标对象')
     get target () {
         return this._target;
@@ -70,9 +68,7 @@ export class UICoordinateTrackerComponent extends Component {
      * @zh
      * 照射相机。
      */
-    @property({
-        type: CameraComponent,
-    })
+    @type(CameraComponent)
     @tooltip('照射相机')
     get camera () {
         return this._camera;
@@ -125,9 +121,7 @@ export class UICoordinateTrackerComponent extends Component {
      * @zh
      * 映射数据事件。回调的第一个参数是映射后的本地坐标，第二个是距相机距离比。
      */
-    @property({
-        type: [EventHandler],
-    })
+    @type([EventHandler])
     @tooltip('映射数据事件。回调的第一个参数是映射后的本地坐标，第二个是距相机距离比')
     public syncEvents: EventHandler[] = [];
 

--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -618,7 +618,7 @@ export function override (value: boolean): PropertyDecorator {
     });
 }
 
-export function immutable (value: boolean): PropertyDecorator {
+export function readOnly (value: boolean): PropertyDecorator {
     return property({
         readonly: value,
     });

--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -586,7 +586,7 @@ export const string = type(CCString);
  * @zh 标记该属性的类型。
  * @param type
  */
-export function type (type: Function): PropertyDecorator;
+export function type (type: Function | any): PropertyDecorator;
 
 export function type (type: [Function]): PropertyDecorator;
 
@@ -600,16 +600,222 @@ export function type<T> (type: PrimitiveType<T> | Function | [PrimitiveType<T>] 
     });
 }
 
+export function serializable (value: boolean): PropertyDecorator {
+    return property({
+        serializable: value,
+    });
+}
+
+export function formerlySerializedAs (name: string): PropertyDecorator {
+    return property({
+        formerlySerializedAs: name,
+    });
+}
+
+export function override (value: boolean): PropertyDecorator {
+    return property({
+        override: value,
+    });
+}
+
+export function immutable (value: boolean): PropertyDecorator {
+    return property({
+        readonly: value,
+    });
+}
+
+/**
+ * 
+ * @param value 
+ */
+export function animatable (value: boolean): PropertyDecorator {
+    return property({
+        animatable: value,
+    });
+}
+
 /**
  * @en
- * Set the editor tooltip content of the property.
+ * Sets whether the property is editor only.
+ * @zh
+ * 设置该属性是否仅在编辑器中生效。
+ * @param yes 是否仅在编辑器中生效。
+ */
+export const editorOnly: (yes: boolean) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (yes) => {
+        return property({
+            editorOnly: yes,
+        });
+    };
+
+/**
+ * @en
+ * Sets whether the property is visible in editor.
+ * @zh
+ * 设置是否在编辑器中展示该属性。
+ * @param text 工具提示。
+ */
+export const visible: (yes: boolean | (() => boolean)) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (yes) => {
+        return property({
+            visible: yes,
+        });
+    };
+
+/**
+ * @en
+ * Sets the display name of the property in editor.
+ * @zh
+ * 设置该属性在编辑器中的显示名称。
+ * @param text 显示名称。
+ */
+export const displayName: (text: string) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (text) => {
+        return property({
+            displayName: text,
+        });
+    };
+
+/**
+ * @en
+ * Sets the tooltip content of the property in editor.
  * @zh
  * 设置该属性在编辑器中的工具提示内容。
  * @param text 工具提示。
  */
 export const tooltip: (text: string) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
-    (text: string): PropertyDecorator => {
+    (text) => {
         return property({
             tooltip: text,
+        });
+    };
+
+/**
+ * @en
+ * Sets the allowed range of the property in editor.
+ * @zh
+ * 设置该属性在编辑器中允许设置的范围。
+ * @param values 范围。
+ */
+export const range: (values: [number, number, number] | [number, number]) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (values) => {
+        return property({
+            range: values,
+        });
+    };
+
+/**
+ * @en
+ * Sets the allowed min value of the property in editor.
+ * @zh
+ * 设置该属性在编辑器中允许的最小值。
+ * @param value 最小值。
+ */
+export const rangeMin: (value: number) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (value) => {
+        return property({
+            min: value,
+        });
+    };
+
+/**
+ * @en
+ * Sets the allowed max value of the property in editor.
+ * @zh
+ * 设置该属性在编辑器中允许的最大值。
+ * @param value 最大值。
+ */
+export const rangeMax: (value: number) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (value) => {
+        return property({
+            max: value,
+        });
+    };
+
+/**
+ * @en
+ * Sets the step of the property in editor.
+ * @zh
+ * 设置该属性在编辑器中的步进值。
+ * @param value 步进值。
+ */
+export const rangeStep: (value: number) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (value) => {
+        return property({
+            step: value,
+        });
+    };
+
+/**
+ * @en
+ * Sets whether a slider should be given to coordinate the property in editor.
+ * @zh
+ * 设置是否在编辑器中提供滑动条来调节值
+ * @param enabled 是否允许。
+ */
+export const slide: (enabled: boolean) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (enabled) => {
+        return property({
+            slide: enabled,
+        });
+    };
+
+/**
+ * @en
+ * Sets the display order of the property in editor.
+ * @zh
+ * 设置该属性在编辑器中的显示顺序。
+ * @param order 显示顺序。
+ */
+export const displayOrder: (order: number) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (order) => {
+        return property({
+            displayOrder: order,
+        });
+    };
+
+/**
+ * @en
+ * Sets the unit of the property in editor.
+ * @zh
+ * 设置该属性在编辑器中的计量单位。
+ * @param name 计量单位的名称。
+ */
+export const unit: (name:
+| 'lm'
+| 'lx'
+| 'cd/m²'
+) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (name) => {
+        return property({
+            unit: name,
+        });
+    };
+
+/**
+ * @en
+ * Sets whether to convert the value into radian before feed it to the property in editor.
+ * @zh
+ * 设置是否在赋值该属性前将值先转换为弧度制。
+ * @param enabled 是否进行转换。
+ */
+export const radian: (enabled: boolean) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (enabled) => {
+        return property({
+            radian: enabled,
+        });
+    };
+
+/**
+ * @en
+ * Sets whether to enable multi-line display of the property in editor.
+ * @zh
+ * 设置是否允许在编辑器中对该属性进行多行显示。
+ * @param enabled 是否允许多行显示。
+ */
+export const multiline: (enabled: boolean) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
+    (enabled) => {
+        return property({
+            multiline: enabled,
         });
     };

--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -641,12 +641,11 @@ export function animatable (value: boolean): PropertyDecorator {
  * 设置该属性是否仅在编辑器中生效。
  * @param yes 是否仅在编辑器中生效。
  */
-export const editorOnly: (yes: boolean) => PropertyDecorator = !DEV ? ignoringArgsPropertyDecorator:
-    (yes) => {
-        return property({
-            editorOnly: yes,
-        });
-    };
+export function editorOnly (yes: boolean): PropertyDecorator {
+    return property({
+        editorOnly: yes,
+    });
+}
 
 /**
  * @en

--- a/cocos/core/pipeline/forward/forward-pipeline.ts
+++ b/cocos/core/pipeline/forward/forward-pipeline.ts
@@ -2,7 +2,7 @@
  * @category pipeline
  */
 
-import { ccclass, property } from '../../data/class-decorator';
+import { ccclass, property, displayOrder, visible, type } from '../../data/class-decorator';
 import { RenderPipeline, IRenderPipelineInfo } from '../render-pipeline';
 import { UIFlow } from '../ui/ui-flow';
 import { ForwardFlow } from './forward-flow';
@@ -65,47 +65,36 @@ export class ForwardPipeline extends RenderPipeline {
         return this._shadowUBO;
     }
 
-    @property({
-        type: [RenderTextureConfig],
-        displayOrder: 2,
-    })
+    @type([RenderTextureConfig])
+    @displayOrder(2)
     protected renderTextures: RenderTextureConfig[] = [];
 
-    @property({
-        type: [MaterialConfig],
-        displayOrder: 3,
-    })
+    @type([MaterialConfig])
+    @displayOrder(3)
     protected materials: MaterialConfig[] = [];
 
-    @property({
-        type: Fog,
-        displayOrder: 7,
-        visible: true,
-    })
+    @type(Fog)
+    @visible(true)
+    @displayOrder(7)
     public fog: Fog = new Fog();
-    @property({
-        type: Ambient,
-        displayOrder: 4,
-        visible: true,
-    })
+
+    @type(Ambient)
+    @visible(true)
+    @displayOrder(4)
     public ambient: Ambient = new Ambient();
-    @property({
-        type: Skybox,
-        displayOrder: 5,
-        visible: true,
-    })
+
+    @type(Skybox)
+    @visible(true)
+    @displayOrder(5)
     public skybox: Skybox = new Skybox();
-    @property({
-        type: PlanarShadows,
-        displayOrder: 6,
-        visible: true,
-    })
+
+    @type(PlanarShadows)
+    @visible(true)
+    @displayOrder(6)
     public planarShadows: PlanarShadows = new PlanarShadows();
-    @property({
-        type: Shadow,
-        displayOrder: 7,
-        visible: true,
-    })
+    @type(Shadow)
+    @displayOrder(7)
+    @visible(true)
     public shadowMap: Shadow = new Shadow();
     /**
      * @en The list for render objects, only available after the scene culling of the current frame.

--- a/cocos/core/pipeline/forward/forward-stage.ts
+++ b/cocos/core/pipeline/forward/forward-stage.ts
@@ -2,7 +2,7 @@
  * @category pipeline
  */
 
-import { ccclass, property } from '../../data/class-decorator';
+import { ccclass, property, visible, displayOrder, type } from '../../data/class-decorator';
 import { IRenderPass, SetIndex } from '../define';
 import { getPhaseID } from '../pass-phase';
 import { opaqueCompareFn, RenderQueue, transparentCompareFn } from '../render-queue';
@@ -36,11 +36,9 @@ export class ForwardStage extends RenderStage {
     };
 
 
-    @property({
-        type: [RenderQueueDesc],
-        displayOrder: 2,
-        visible: true,
-    })
+    @type([RenderQueueDesc])
+    @visible(true)
+    @displayOrder(2)
     protected renderQueues: RenderQueueDesc[] = [];
     protected _renderQueues: RenderQueue[] = [];
 

--- a/cocos/core/pipeline/pipeline-serialization.ts
+++ b/cocos/core/pipeline/pipeline-serialization.ts
@@ -3,7 +3,7 @@
  */
 
 import { CCString } from '../data';
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, type } from '../data/class-decorator';
 import { GFXFormat, GFXLoadOp, GFXStoreOp, GFXTextureLayout, GFXTextureType, GFXTextureUsageBit} from '../gfx/define';
 import { ccenum } from '../value-types/enum';
 import { RenderTexture } from './../assets/render-texture';
@@ -31,11 +31,11 @@ ccenum(RenderFlowTag);
 export class RenderTextureDesc {
     @property
     public name: string = '';
-    @property({ type: GFXTextureType })
+    @type(GFXTextureType)
     public type: GFXTextureType = GFXTextureType.TEX2D;
-    @property({ type: GFXTextureUsageBit })
+    @type(GFXTextureUsageBit)
     public usage: GFXTextureUsageBit = GFXTextureUsageBit.COLOR_ATTACHMENT;
-    @property({ type: GFXFormat })
+    @type(GFXFormat)
     public format: GFXFormat = GFXFormat.UNKNOWN;
     @property
     public width: number = -1;
@@ -47,7 +47,7 @@ export class RenderTextureDesc {
 export class RenderTextureConfig {
     @property
     public name: string = '';
-    @property({ type: RenderTexture })
+    @type(RenderTexture)
     public texture: RenderTexture | null = null;
 }
 
@@ -55,7 +55,7 @@ export class RenderTextureConfig {
 export class MaterialConfig {
     @property
     public name: string = '';
-    @property({ type: Material })
+    @type(Material)
     public material: Material | null = null;
 }
 
@@ -65,47 +65,47 @@ export class FrameBufferDesc {
     public name: string = '';
     @property
     public renderPass: number = 0;
-    @property({ type: [CCString] })
+    @type([CCString])
     public colorTextures: string[] = [];
     @property
     public depthStencilTexture: string = '';
-    @property({ type: RenderTexture })
+    @type(RenderTexture)
     public texture: RenderTexture | null = null;
 }
 
 @ccclass('ColorDesc')
 export class ColorDesc {
-    @property({ type: GFXFormat })
+    @type(GFXFormat)
     public format: GFXFormat = GFXFormat.UNKNOWN;
-    @property({ type: GFXLoadOp })
+    @type(GFXLoadOp)
     public loadOp: GFXLoadOp = GFXLoadOp.CLEAR;
-    @property({ type: GFXStoreOp })
+    @type(GFXStoreOp)
     public storeOp: GFXStoreOp = GFXStoreOp.STORE;
     @property
     public sampleCount: number = 1;
-    @property({ type: GFXTextureLayout })
+    @type(GFXTextureLayout)
     public beginLayout: GFXTextureLayout = GFXTextureLayout.UNDEFINED;
-    @property({ type: GFXTextureLayout })
+    @type(GFXTextureLayout)
     public endLayout: GFXTextureLayout = GFXTextureLayout.PRESENT_SRC;
 }
 
 @ccclass('DepthStencilDesc')
 export class DepthStencilDesc {
-    @property({ type: GFXFormat })
+    @type(GFXFormat)
     public format: GFXFormat = GFXFormat.UNKNOWN;
-    @property({ type: GFXLoadOp })
+    @type(GFXLoadOp)
     public depthLoadOp: GFXLoadOp = GFXLoadOp.CLEAR;
-    @property({ type: GFXStoreOp })
+    @type(GFXStoreOp)
     public depthStoreOp: GFXStoreOp = GFXStoreOp.STORE;
-    @property({ type: GFXLoadOp })
+    @type(GFXLoadOp)
     public stencilLoadOp: GFXLoadOp = GFXLoadOp.CLEAR;
-    @property({ type: GFXStoreOp })
+    @type(GFXStoreOp)
     public stencilStoreOp: GFXStoreOp = GFXStoreOp.STORE;
     @property
     public sampleCount: number = 1;
-    @property({ type: GFXTextureLayout })
+    @type(GFXTextureLayout)
     public beginLayout: GFXTextureLayout = GFXTextureLayout.UNDEFINED;
-    @property({ type: GFXTextureLayout })
+    @type(GFXTextureLayout)
     public endLayout: GFXTextureLayout = GFXTextureLayout.DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 }
 
@@ -113,9 +113,9 @@ export class DepthStencilDesc {
 export class RenderPassDesc {
     @property
     public index: number = -1;
-    @property({ type: [ColorDesc] })
+    @type([ColorDesc])
     public colorAttachments = [];
-    @property({ type: DepthStencilDesc })
+    @type(DepthStencilDesc)
     public depthStencilAttachment: DepthStencilDesc = new DepthStencilDesc();
 }
 
@@ -144,13 +144,13 @@ export class RenderQueueDesc {
      * @en The sort mode of the render queue
      * @zh 渲染队列的排序模式
      */
-    @property({ type: RenderQueueSortMode })
+    @type(RenderQueueSortMode)
     public sortMode: RenderQueueSortMode = RenderQueueSortMode.FRONT_TO_BACK;
 
     /**
      * @en The stages using this queue
      * @zh 使用当前渲染队列的阶段列表
      */
-    @property({ type: [CCString] })
+    @type([CCString])
     public stages: string[] = [];
 }

--- a/cocos/core/pipeline/render-flow.ts
+++ b/cocos/core/pipeline/render-flow.ts
@@ -1,7 +1,7 @@
 /**
  * @category pipeline
  */
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, visible, displayOrder, type } from '../data/class-decorator';
 import { RenderStage } from './render-stage';
 import { RenderView } from './render-view';
 import { RenderPipeline } from './render-pipeline';
@@ -56,29 +56,24 @@ export abstract class RenderFlow {
         return this._stages;
     }
 
-    @property({
-        displayOrder: 0,
-        visible: true,
-    })
+    @property
+    @displayOrder(0)
+    @visible(true)
     protected _name: string = '';
 
-    @property({
-        displayOrder: 1,
-        visible: true,
-    })
+    @property
+    @displayOrder(1)
+    @visible(true)
     protected _priority: number = 0;
 
-    @property({
-        displayOrder: 2,
-        visible: true,
-    })
+    @property
+    @displayOrder(2)
+    @visible(true)
     protected _tag: number = 0;
 
-    @property({
-        type: [RenderStage],
-        displayOrder: 3,
-        visible: true,
-    })
+    @type([RenderStage])
+    @displayOrder(3)
+    @visible(true)
     protected _stages: RenderStage[] = [];
     protected _pipeline!: RenderPipeline;
 

--- a/cocos/core/pipeline/render-pipeline.ts
+++ b/cocos/core/pipeline/render-pipeline.ts
@@ -4,7 +4,7 @@
 
 import { legacyCC } from '../global-exports';
 import { Asset } from '../assets/asset';
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, visible, displayOrder, type } from '../data/class-decorator';
 import { RenderFlow } from './render-flow';
 import { RenderView } from './render-view';
 import { MacroRecord } from '../renderer/core/pass-utils';
@@ -82,10 +82,9 @@ export abstract class RenderPipeline extends Asset {
      * @zh 标签
      * @readonly
      */
-    @property({
-        displayOrder: 0,
-        visible: true,
-    })
+    @property
+    @displayOrder(0)
+    @visible(true)
     protected _tag: number = 0;
 
     /**
@@ -93,11 +92,9 @@ export abstract class RenderPipeline extends Asset {
      * @zh 渲染流程列表
      * @readonly
      */
-    @property({
-        displayOrder: 1,
-        type: [RenderFlow],
-        visible: true,
-    })
+    @type([RenderFlow])
+    @displayOrder(1)
+    @visible(true)
     protected _flows: RenderFlow[] = [];
 
     protected _globalDescriptorSetLayout: IDescriptorSetLayoutInfo = { bindings: [], record: {} };

--- a/cocos/core/pipeline/render-stage.ts
+++ b/cocos/core/pipeline/render-stage.ts
@@ -2,7 +2,7 @@
  * @category pipeline
  */
 
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, displayOrder, visible } from '../data/class-decorator';
 import { RenderView } from './render-view';
 import { legacyCC } from '../global-exports';
 import { RenderPipeline } from './render-pipeline';
@@ -55,30 +55,27 @@ export abstract class RenderStage {
      * @en Name
      * @zh 名称。
      */
-    @property({
-        displayOrder: 0,
-        visible: true,
-    })
+    @property
+    @visible(true)
+    @displayOrder(0)
     protected _name: string = '';
 
     /**
      * @en Priority
      * @zh 优先级。
      */
-    @property({
-        displayOrder: 1,
-        visible: true,
-    })
+    @property
+    @visible(true)
+    @displayOrder(1)
     protected _priority: number = 0;
 
     /**
      * @en Type
      * @zh 类型。
      */
-    @property({
-        displayOrder: 2,
-        visible: true,
-    })
+    @property
+    @visible(true)
+    @displayOrder(2)
     protected _tag: number = 0;
     protected _pipeline!: RenderPipeline;
     protected _flow!: RenderFlow;

--- a/cocos/core/pipeline/ui/ui-stage.ts
+++ b/cocos/core/pipeline/ui/ui-stage.ts
@@ -2,7 +2,7 @@
  * @category pipeline
  */
 
-import { ccclass, property } from '../../data/class-decorator';
+import { ccclass, property, visible, displayOrder, type } from '../../data/class-decorator';
 import { GFXColor, GFXRect } from '../../gfx/define';
 import { IRenderStageInfo, RenderStage } from '../render-stage';
 import { RenderView } from '../render-view';
@@ -27,11 +27,9 @@ export class UIStage extends RenderStage {
         priority: ForwardStagePriority.UI,
     };
 
-    @property({
-        type: [RenderQueueDesc],
-        displayOrder: 2,
-        visible: true,
-    })
+    @type([RenderQueueDesc])
+    @visible(true)
+    @displayOrder(2)
     protected renderQueues: RenderQueueDesc[] = [];
     protected _renderQueues: RenderQueue[] = [];
 

--- a/cocos/core/primitive/primitive.ts
+++ b/cocos/core/primitive/primitive.ts
@@ -4,7 +4,7 @@
 
 import { createMesh } from '../3d/misc/utils';
 import { Mesh } from '../assets/mesh';
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, type } from '../data/class-decorator';
 import * as primitives from '../primitive';
 import { ccenum } from '../value-types/enum';
 import { legacyCC } from '../global-exports';
@@ -38,7 +38,7 @@ export class Primitive extends Mesh {
      * @zh
      * 此基础图形网格的类型，请在 onLoaded 调用之前设置。
      */
-    @property({ type: PrimitiveType })
+    @type(PrimitiveType)
     public type: number = PrimitiveType.BOX;
 
     /**

--- a/cocos/core/renderer/scene/ambient.ts
+++ b/cocos/core/renderer/scene/ambient.ts
@@ -1,4 +1,4 @@
-import { property, ccclass } from '../../data/class-decorator';
+import { property, ccclass, visible, type } from '../../data/class-decorator';
 import { Color, Vec3 } from '../../math';
 import { EDITOR } from 'internal:constants';
 
@@ -68,19 +68,16 @@ export class Ambient {
     }
 
     protected _enabled = true;
-    @property({
-        type: Color,
-        visible: true,
-    })
+    @type(Color)
+    @visible(true)
     protected _skyColor = new Color(51, 128, 204, 1.0);
-    @property({
-        visible: true,
-    })
+
+    @property
+    @visible(true)
     protected _skyIllum: number = Ambient.SKY_ILLUM;
-    @property({
-        type: Color,
-        visible: true,
-    })
+
+    @type(Color)
+    @visible(true)
     protected _groundAlbedo = new Color(51, 51, 51, 255);
 
     protected _albedoArray = Float32Array.from([0.2, 0.2, 0.2, 1.0]);

--- a/cocos/core/renderer/scene/fog.ts
+++ b/cocos/core/renderer/scene/fog.ts
@@ -1,5 +1,5 @@
 import { Enum } from '../../value-types';
-import { ccclass, property } from '../../data/class-decorator';
+import { ccclass, property, visible, type, displayOrder, slide, range, rangeStep } from '../../data/class-decorator';
 import { Color } from '../../../core/math';
 import { CCBoolean, CCFloat } from '../../data/utils/attribute';
 import { legacyCC } from '../../global-exports';
@@ -191,80 +191,61 @@ export class Fog {
         return this._colorArray;
     }
 
-    @property({
-        type: FogType,
-        visible: true,
-        displayOrder: 1,
-    })
+    @type(FogType)
+    @visible(true)
+    @displayOrder(1)
     protected _type = FogType.LINEAR;
-    @property({
-        type: Color,
-        visible: true,
-        displayOrder: 2,
-    })
+    
+    @type(Color)
+    @visible(true)
+    @displayOrder(2)
     protected _fogColor = new Color('#C8C8C8');
-    @property({
-        type: CCBoolean,
-        visible: true,
-        displayOrder: 0,
-    })
+
+    @type(CCBoolean)
+    @visible(true)
+    @displayOrder(0)
     protected _enabled = false;
-    @property({
-        type: CCFloat,
-        range: [0, 1],
-        step: 0.01,
-        slide: true,
-        displayOrder: 3,
-        visible: function(this: Fog) {
-            return this._type !== FogType.LAYERED && this._type !== FogType.LINEAR;
-        }
+
+    @type(CCFloat)
+    @range([0, 1])
+    @rangeStep(0.01)
+    @slide(true)
+    @displayOrder(3)
+    @visible(function (this: Fog) {
+        return this._type !== FogType.LAYERED && this._type !== FogType.LINEAR;
     })
     protected _fogDensity = 0.3;
-    @property({
-        type: CCFloat,
-        step: 0.1,
-        displayOrder: 4,
-        visible: function(this: Fog) { 
-            return this._type === FogType.LINEAR;
-        }
-    })
+
+    @type(CCFloat)
+    @rangeStep(0.1)
+    @displayOrder(4)
+    @visible(function (this: Fog) { return this._type === FogType.LINEAR; })
     protected _fogStart = 0.5;
-    @property({
-        type: CCFloat,
-        step: 0.1,
-        displayOrder: 5,
-        visible: function (this: Fog){ 
-            return this._type === FogType.LINEAR;
-        }
-    })
+
+    @type(CCFloat)
+    @rangeStep(0.1)
+    @displayOrder(5)
+    @visible(function (this: Fog) {  return this._type === FogType.LINEAR; })
     protected _fogEnd = 300;
-    @property({
-        type: CCFloat,
-        step: 0.1,
-        displayOrder: 6,
-        visible: function (this: Fog){ 
-            return this._type !== FogType.LINEAR;
-        }
-    })
+
+    @type(CCFloat)
+    @rangeStep(0.1)
+    @displayOrder(6)
+    @visible(function (this: Fog) { return this._type !== FogType.LINEAR; })
     protected _fogAtten = 5;
-    @property({
-        type: CCFloat,
-        step: 0.1,
-        displayOrder: 7,
-        visible: function (this: Fog){ 
-            return this._type === FogType.LAYERED;
-        }
-    })
+
+    @type(CCFloat)
+    @rangeStep(0.1)
+    @displayOrder(7)
+    @visible(function (this: Fog) { return this._type === FogType.LAYERED; })
     protected _fogTop = 1.5;
-    @property({
-        type: CCFloat,
-        step: 0.1,
-        displayOrder: 8,
-        visible: function (this: Fog) { 
-            return this._type === FogType.LAYERED;
-        }
-    })
+    
+    @type(CCFloat)
+    @rangeStep(0.1)
+    @displayOrder(8)
+    @visible(function (this: Fog) { return this._type === FogType.LAYERED; })
     protected _fogRange = 1.2;
+
     protected _currType = 0;
     protected _colorArray: Float32Array = new Float32Array([0.2, 0.2, 0.2, 1.0]);
 

--- a/cocos/core/renderer/scene/planar-shadows.ts
+++ b/cocos/core/renderer/scene/planar-shadows.ts
@@ -10,7 +10,7 @@ import { SphereLight } from './sphere-light';
 import { GFXCommandBuffer, GFXDevice, GFXRenderPass, GFXDescriptorSet, GFXShader } from '../../gfx';
 import { InstancedBuffer } from '../../pipeline/instanced-buffer';
 import { PipelineStateManager } from '../../pipeline/pipeline-state-manager';
-import { ccclass, property } from '../../data/class-decorator';
+import { ccclass, property, type, visible } from '../../data/class-decorator';
 import { CCFloat, CCBoolean } from '../../data/utils/attribute';
 import { legacyCC } from '../../global-exports';
 import { RenderScene } from './render-scene';
@@ -104,25 +104,17 @@ export class PlanarShadows {
         return this._data;
     }
 
-    @property({
-        type: CCBoolean,
-        visible: true,
-    })
+    @type(CCBoolean)
+    @visible(true)
     protected _enabled: boolean = false;
-    @property({
-        type: Vec3,
-        visible: true,
-    })
+    @type(Vec3)
+    @visible(true)
     protected _normal = new Vec3(0, 1, 0);
-    @property({
-        type: CCFloat,
-        visible: true,
-    })
+    @type(CCFloat)
+    @visible(true)
     protected _distance = 0;
-    @property({
-        type: Color,
-        visible: true,
-    })
+    @type(Color)
+    @visible(true)
     protected _shadowColor = new Color(0, 0, 0, 76);
     protected _matLight = new Mat4();
     protected _data = Float32Array.from([

--- a/cocos/core/renderer/scene/skybox.ts
+++ b/cocos/core/renderer/scene/skybox.ts
@@ -8,7 +8,7 @@ import { box } from '../../primitive';
 import { MaterialInstance } from '../core/material-instance';
 import { samplerLib } from '../core/sampler-lib';
 import { Model } from './model';
-import { ccclass, property } from '../../data/class-decorator';
+import { ccclass, property, visible, type } from '../../data/class-decorator';
 import { CCBoolean } from '../../data/utils/attribute';
 import { legacyCC } from '../../global-exports';
 import { GFXDescriptorSet } from '../../gfx';
@@ -92,26 +92,22 @@ export class Skybox {
         }
     }
 
-    @property({
-        type: CCBoolean,
-        visible: true,
-    })
+    @type(CCBoolean)
+    @visible(true)
     protected _enabled = false;
-    @property({
-        type: CCBoolean,
-        visible: true,
-    })
+
+    @type(CCBoolean)
+    @visible(true)
     protected _isRGBE = false;
-    @property({
-        type: CCBoolean,
-        visible: true,
-    })
+    
+    @type(CCBoolean)
+    @visible(true)
     protected _useIBL = false;
-    @property({
-        type: TextureCube,
-        visible: true,
-    })
+
+    @type(TextureCube)
+    @visible(true)
     protected _envmap: TextureCube | null = null;
+    
     protected _globalDescriptorSet: GFXDescriptorSet | null = null;
     protected _model: Model | null = null;
     protected _default: TextureCube | null = null;

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -27,7 +27,7 @@
  * @category scene-graph
  */
 
-import { ccclass, property } from '../data/class-decorator';
+import { ccclass, property, type } from '../data/class-decorator';
 import { Mat3, Mat4, Quat, Size, Vec2, Vec3 } from '../math';
 import { SystemEventType } from '../platform/event-manager/event-enum';
 import { eventManager } from '../platform/event-manager/event-manager';
@@ -171,7 +171,7 @@ export class Node extends BaseNode {
      * @en Rotation in local coordinate system, represented by euler angles
      * @zh 本地坐标系下的旋转，用欧拉角表示
      */
-    @property({ type: Vec3 })
+    @type(Vec3)
     set eulerAngles (val: Readonly<Vec3>) {
         this.setRotationFromEuler(val.x, val.y, val.z);
     }

--- a/cocos/particle/animator/color-overtime.ts
+++ b/cocos/particle/animator/color-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, displayOrder, type } from '../../core/data/class-decorator';
 import { pseudoRandom } from '../../core/math';
 import { Particle, PARTICLE_MODULE_NAME } from '../particle';
 import GradientRange from './gradient-range';
@@ -21,9 +21,7 @@ export default class ColorOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     public get enable () {
         return this._enable;
     }
@@ -38,10 +36,8 @@ export default class ColorOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 颜色随时间变化的参数，各个 key 之间线性差值变化。
      */
-    @property({
-        type: GradientRange,
-        displayOrder: 1,
-    })
+    @type(GradientRange)
+    @displayOrder(1)
     public color = new GradientRange();
     public name = PARTICLE_MODULE_NAME.COLOR;
 

--- a/cocos/particle/animator/curve-range.ts
+++ b/cocos/particle/animator/curve-range.ts
@@ -2,7 +2,7 @@
  * @hidden
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, type } from '../../core/data/class-decorator';
 import { lerp } from '../../core/math';
 import { Enum } from '../../core/value-types';
 import { AnimationCurve } from '../../core/geometry';
@@ -32,33 +32,25 @@ export default class CurveRange  {
     /**
      * @zh 曲线类型[[Mode]]。
      */
-    @property({
-        type: Mode,
-    })
+    @type(Mode)
     public mode = Mode.Constant;
 
     /**
      * @zh 当mode为Curve时，使用的曲线。
      */
-    @property({
-        type: AnimationCurve,
-    })
+    @type(AnimationCurve)
     public curve = new AnimationCurve();
 
     /**
      * @zh 当mode为TwoCurves时，使用的曲线下限。
      */
-    @property({
-        type: AnimationCurve,
-    })
+    @type(AnimationCurve)
     public curveMin = new AnimationCurve();
 
     /**
      * @zh 当mode为TwoCurves时，使用的曲线上限。
      */
-    @property({
-        type: AnimationCurve,
-    })
+    @type(AnimationCurve)
     public curveMax = new AnimationCurve();
 
     /**

--- a/cocos/particle/animator/force-overtime.ts
+++ b/cocos/particle/animator/force-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, range, type } from '../../core/data/class-decorator';
 import { pseudoRandom, Quat, Vec3 } from '../../core/math';
 import { Space } from '../enum';
 import { calculateTransform } from '../particle-general-function';
@@ -23,9 +23,7 @@ export default class ForceOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     public get enable () {
         return this._enable;
     }
@@ -40,43 +38,35 @@ export default class ForceOvertimeModule extends ParticleModuleBase {
     /**
      * @zh X 轴方向上的加速度分量。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 2,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(2)
     @tooltip('X 轴方向上的加速度分量')
     public x = new CurveRange();
 
     /**
      * @zh Y 轴方向上的加速度分量。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 3,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(3)
     @tooltip('Y 轴方向上的加速度分量')
     public y = new CurveRange();
 
     /**
      * @zh Z 轴方向上的加速度分量。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 4,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(4)
     @tooltip('Z 轴方向上的加速度分量')
     public z = new CurveRange();
 
     /**
      * @zh 加速度计算时采用的坐标系 [[Space]]。
      */
-    @property({
-        type: Space,
-        displayOrder: 1,
-    })
+    @type(Space)
+    @displayOrder(1)
     @tooltip('加速度计算时采用的坐标')
     public space = Space.Local;
 

--- a/cocos/particle/animator/gradient-range.ts
+++ b/cocos/particle/animator/gradient-range.ts
@@ -3,7 +3,7 @@
  * @hidden
  */
 
-import { ccclass, property } from '../../core/data/class-decorator';
+import { ccclass, property, type } from '../../core/data/class-decorator';
 import { Color } from '../../core/math';
 import { Enum } from '../../core/value-types';
 import Gradient, { AlphaKey, ColorKey } from './gradient';
@@ -34,9 +34,7 @@ export default class GradientRange {
     /**
      * @zh 渐变色类型 [[Mode]]。
      */
-    @property({
-        type: Mode,
-    })
+    @type(Mode)
     get mode () {
         return this._mode;
     }
@@ -78,30 +76,22 @@ export default class GradientRange {
     /**
      * @zh 当mode为Gradient时的颜色渐变。
      */
-    @property({
-        type: Gradient,
-    })
+    @type(Gradient)
     public gradient = new Gradient();
 
     /**
      * @zh 当mode为TwoGradients时的颜色渐变下限。
      */
-    @property({
-        type: Gradient,
-    })
+    @type(Gradient)
     public gradientMin = new Gradient();
 
     /**
      * @zh 当mode为TwoGradients时的颜色渐变上限。
      */
-    @property({
-        type: Gradient,
-    })
+    @type(Gradient)
     public gradientMax = new Gradient();
 
-    @property({
-        type: Mode,
-    })
+    @type(Mode)
     private _mode = Mode.Color;
 
     private _color = Color.WHITE.clone();

--- a/cocos/particle/animator/limit-velocity-overtime.ts
+++ b/cocos/particle/animator/limit-velocity-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, range, type } from '../../core/data/class-decorator';
 import { lerp, pseudoRandom, Vec3, Mat4, Quat } from '../../core/math';
 import { Space, ModuleRandSeed } from '../enum';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
@@ -24,9 +24,7 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     public get enable () {
         return this._enable;
     }
@@ -41,72 +39,60 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
     /**
      * @zh X 轴方向上的速度下限。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 4,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(4)
     @tooltip('X 轴方向上的速度下限')
     public limitX = new CurveRange();
 
     /**
      * @zh Y 轴方向上的速度下限。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 5,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(5)
     @tooltip('Y 轴方向上的速度下限')
     public limitY = new CurveRange();
 
     /**
      * @zh Z 轴方向上的速度下限。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 6,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(6)
     @tooltip('Z 轴方向上的速度下限')
     public limitZ = new CurveRange();
 
     /**
      * @zh 速度下限。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 3,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(3)
     @tooltip('速度下限')
     public limit = new CurveRange();
 
     /**
      * @zh 当前速度与速度下限的插值。
      */
-    @property({
-        displayOrder: 7,
-    })
+    @property
+    @displayOrder(7)
     @tooltip('当前速度与速度下限的插值')
     public dampen = 3;
 
     /**
      * @zh 是否三个轴分开限制。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @property
+    @displayOrder(2)
     @tooltip('是否三个轴分开限制')
     public separateAxes = false;
 
     /**
      * @zh 计算速度下限时采用的坐标系 [[Space]]。
      */
-    @property({
-        type: Space,
-        displayOrder: 1,
-    })
+    @type(Space)
+    @displayOrder(1)
     @tooltip('计算速度下限时采用的坐标系')
     public space = Space.Local;
 

--- a/cocos/particle/animator/rotation-overtime.ts
+++ b/cocos/particle/animator/rotation-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, range, type, radian } from '../../core/data/class-decorator';
 import { pseudoRandom } from '../../core/math';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
 import CurveRange from './curve-range';
@@ -19,9 +19,7 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     public get enable () {
         return this._enable;
     }
@@ -39,9 +37,7 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 是否三个轴分开设定旋转（暂不支持）。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @displayOrder(1)
     @tooltip('是否三个轴分开设定旋转（暂不支持）')
     get separateAxes () {
         return this._separateAxes;
@@ -54,36 +50,30 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 绕 X 轴设定旋转。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        radian: true,
-        displayOrder: 2,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @radian(true)
+    @displayOrder(2)
     @tooltip('绕 X 轴设定旋转')
     public x = new CurveRange();
 
     /**
      * @zh 绕 Y 轴设定旋转。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        radian: true,
-        displayOrder: 3,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @radian(true)
+    @displayOrder(3)
     @tooltip('绕 Y 轴设定旋转')
     public y = new CurveRange();
 
     /**
      * @zh 绕 Z 轴设定旋转。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        radian: true,
-        displayOrder: 4,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @radian(true)
+    @displayOrder(4)
     @tooltip('绕 Z 轴设定旋转')
     public z = new CurveRange();
 

--- a/cocos/particle/animator/size-overtime.ts
+++ b/cocos/particle/animator/size-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, type } from '../../core/data/class-decorator';
 import { pseudoRandom, Vec3 } from '../../core/math';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
 import CurveRange from './curve-range';
@@ -19,9 +19,7 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     public get enable () {
         return this._enable;
     }
@@ -36,49 +34,40 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 决定是否在每个轴上独立控制粒子大小。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @property
+    @displayOrder(1)
     @tooltip('决定是否在每个轴上独立控制粒子大小')
     public separateAxes = false;
 
     /**
      * @zh 定义一条曲线来决定粒子在其生命周期中的大小变化。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 2,
-    })
+    @type(CurveRange)
+    @displayOrder(2)
     @tooltip('定义一条曲线来决定粒子在其生命周期中的大小变化')
     public size = new CurveRange();
 
     /**
      * @zh 定义一条曲线来决定粒子在其生命周期中 X 轴方向上的大小变化。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 3,
-    })
+    @type(CurveRange)
+    @displayOrder(3)
     @tooltip('定义一条曲线来决定粒子在其生命周期中 X 轴方向上的大小变化')
     public x = new CurveRange();
 
     /**
      * @zh 定义一条曲线来决定粒子在其生命周期中 Y 轴方向上的大小变化。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 4,
-    })
+    @type(CurveRange)
+    @displayOrder(4)
     @tooltip('定义一条曲线来决定粒子在其生命周期中 Y 轴方向上的大小变化')
     public y = new CurveRange();
 
     /**
      * @zh 定义一条曲线来决定粒子在其生命周期中 Z 轴方向上的大小变化。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 5,
-    })
+    @type(CurveRange)
+    @displayOrder(5)
     @tooltip('定义一条曲线来决定粒子在其生命周期中 Z 轴方向上的大小变化')
     public z = new CurveRange();
 

--- a/cocos/particle/animator/texture-animation.ts
+++ b/cocos/particle/animator/texture-animation.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, type, formerlySerializedAs } from '../../core/data/class-decorator';
 import { lerp, pseudoRandom, repeat } from '../../core/math';
 import { Enum } from '../../core/value-types';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
@@ -52,22 +52,16 @@ export default class TextureAnimationModule extends ParticleModuleBase {
     @property
     private _enable = false;
 
-    @property({
-        formerlySerializedAs: 'numTilesX',
-    })
+    @formerlySerializedAs('numTilesX')
     private _numTilesX = 0;
 
-    @property({
-        formerlySerializedAs: 'numTilesY',
-    })
+    @formerlySerializedAs('numTilesY')
     private _numTilesY = 0;
 
     /**
      * @zh 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     get enable () {
         return this._enable;
     }
@@ -80,18 +74,14 @@ export default class TextureAnimationModule extends ParticleModuleBase {
         this.target.enableModule(this.name, val, this);
     }
 
-    @property({
-        type: Mode,
-    })
+    @type(Mode)
     private _mode = Mode.Grid;
 
     /**
      * @zh 设定粒子贴图动画的类型（暂只支持 Grid 模式）[[Mode]]。
      */
-    @property({
-        type: Mode,
-        displayOrder: 1,
-    })
+    @type(Mode)
+    @displayOrder(1)
     @tooltip('设定粒子贴图动画的类型（暂只支持 Grid 模式）')
     get mode () {
         return this._mode;
@@ -107,9 +97,7 @@ export default class TextureAnimationModule extends ParticleModuleBase {
     /**
      * @zh X 方向动画帧数。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @displayOrder(2)
     @tooltip('X 方向动画帧数')
     get numTilesX () {
         return this._numTilesX;
@@ -125,9 +113,7 @@ export default class TextureAnimationModule extends ParticleModuleBase {
     /**
      * @zh Y 方向动画帧数。
      */
-    @property({
-        displayOrder: 3,
-    })
+    @displayOrder(3)
     @tooltip('Y 方向动画帧数')
     get numTilesY () {
         return this._numTilesY;
@@ -143,39 +129,32 @@ export default class TextureAnimationModule extends ParticleModuleBase {
     /**
      * @zh 动画播放方式 [[Animation]]。
      */
-    @property({
-        type: Animation,
-        displayOrder: 4,
-    })
+    @type(Animation)
+    @displayOrder(4)
     @tooltip('动画播放方式')
     public animation = Animation.WholeSheet;
 
     /**
      * @zh 一个周期内动画播放的帧与时间变化曲线。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 7,
-    })
+    @type(CurveRange)
+    @displayOrder(7)
     @tooltip('一个周期内动画播放的帧与时间变化曲线')
     public frameOverTime = new CurveRange();
 
     /**
      * @zh 从第几帧开始播放，时间为整个粒子系统的生命周期。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 8,
-    })
+    @type(CurveRange)
+    @displayOrder(8)
     @tooltip('从第几帧开始播放，时间为整个粒子系统的生命周期')
     public startFrame = new CurveRange();
 
     /**
      * @zh 一个生命周期内播放循环的次数。
      */
-    @property({
-        displayOrder: 9,
-    })
+    @property
+    @displayOrder(9)
     @tooltip('一个生命周期内播放循环的次数')
     public cycleCount = 0;
 
@@ -219,9 +198,8 @@ export default class TextureAnimationModule extends ParticleModuleBase {
      * @zh 随机从动画贴图中选择一行以生成动画。<br>
      * 此选项仅在动画播放方式为 SingleRow 时生效。
      */
-    @property({
-        displayOrder: 5,
-    })
+    @property
+    @displayOrder(5)
     @tooltip('随机从动画贴图中选择一行以生成动画。\n此选项仅在动画播放方式为 SingleRow 时生效')
     public randomRow = false;
 
@@ -229,11 +207,11 @@ export default class TextureAnimationModule extends ParticleModuleBase {
      * @zh 从动画贴图中选择特定行以生成动画。<br>
      * 此选项仅在动画播放方式为 SingleRow 时且禁用 randomRow 时可用。
      */
-    @property({
-        displayOrder: 6,
-    })
+    @property
+    @displayOrder(6)
     @tooltip('从动画贴图中选择特定行以生成动画。\n此选项仅在动画播放方式为 SingleRow 时且禁用 randomRow 时可用')
     public rowIndex = 0;
+    
     public name = PARTICLE_MODULE_NAME.TEXTURE;
 
     public init (p: Particle) {

--- a/cocos/particle/animator/velocity-overtime.ts
+++ b/cocos/particle/animator/velocity-overtime.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, range, type } from '../../core/data/class-decorator';
 import { Mat4, pseudoRandom, Quat, Vec3 } from '../../core/math';
 import { Space } from '../enum';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
@@ -25,9 +25,7 @@ export default class VelocityOvertimeModule extends ParticleModuleBase {
     /**
      * @zh 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     public get enable () {
         return this._enable;
     }
@@ -42,54 +40,44 @@ export default class VelocityOvertimeModule extends ParticleModuleBase {
     /**
      * @zh X 轴方向上的速度分量。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 2,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(2)
     @tooltip('X 轴方向上的速度分量')
     public x = new CurveRange();
 
     /**
      * @zh Y 轴方向上的速度分量。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 3,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(3)
     @tooltip('Y 轴方向上的速度分量')
     public y = new CurveRange();
 
     /**
      * @zh Z 轴方向上的速度分量。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 4,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(4)
     @tooltip('Z 轴方向上的速度分量')
     public z = new CurveRange();
 
     /**
      * @zh 速度修正系数（只支持 CPU 粒子）。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 5,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(5)
     @tooltip('速度修正系数（只支持 CPU 粒子）')
     public speedModifier = new CurveRange();
 
     /**
      * @zh 速度计算时采用的坐标系[[Space]]。
      */
-    @property({
-        type: Space,
-        displayOrder: 1,
-    })
+    @type(Space)
+    @displayOrder(1)
     @tooltip('速度计算时采用的坐标系')
     public space = Space.Local;
 

--- a/cocos/particle/billboard-component.ts
+++ b/cocos/particle/billboard-component.ts
@@ -7,7 +7,7 @@ import { builtinResMgr } from '../core/3d/builtin';
 import { createMesh } from '../core/3d/misc/utils';
 import { Material, Mesh, Texture2D } from '../core/assets';
 import { Component } from '../core/components/component';
-import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip, type } from '../core/data/class-decorator';
 import { GFXAttributeName, GFXFormat, GFXPrimitiveMode } from '../core/gfx';
 import { Color, toDegree, toRadian, Vec4 } from '../core/math';
 import { Model } from '../core/renderer/scene/model';
@@ -19,17 +19,13 @@ import { legacyCC } from '../core/global-exports';
 @executeInEditMode
 export class BillboardComponent extends Component {
 
-    @property({
-        type: Texture2D,
-    })
+    @type(Texture2D)
     private _texture = null;
 
     /**
      * @zh Billboard纹理。
      */
-    @property({
-        type: Texture2D,
-    })
+    @type(Texture2D)
     @tooltip('billboard显示的贴图')
     get texture () {
         return this._texture;
@@ -48,9 +44,6 @@ export class BillboardComponent extends Component {
     /**
      * @zh 高度。
      */
-    @property({
-        
-    })
     @tooltip('billboard的高度')
     get height () {
         return this._height;
@@ -70,9 +63,6 @@ export class BillboardComponent extends Component {
     /**
      * @zh 宽度。
      */
-    @property({
-        
-    })
     @tooltip('billboard的宽度')
     public get width () {
         return this._width;
@@ -92,9 +82,6 @@ export class BillboardComponent extends Component {
     /**
      * @zh 角度。
      */
-    @property({
-        
-    })
     @tooltip('billboard绕中心点旋转的角度')
     public get rotation () {
         return Math.round(toDegree(this._rotation) * 100) / 100;

--- a/cocos/particle/burst.ts
+++ b/cocos/particle/burst.ts
@@ -2,7 +2,7 @@
  * @hidden
  */
 
-import { ccclass, property } from '../core/data/class-decorator';
+import { ccclass, property, type } from '../core/data/class-decorator';
 import { repeat } from '../core/math';
 import CurveRange from './animator/curve-range';
 
@@ -50,9 +50,7 @@ export default class Burst {
     /**
      * @zh 发射的粒子的数量。
      */
-    @property({
-        type: CurveRange,
-    })
+    @type(CurveRange)
     public count: CurveRange = new CurveRange();
 
     private _remainingCount: number;

--- a/cocos/particle/emitter/shape-module.ts
+++ b/cocos/particle/emitter/shape-module.ts
@@ -3,7 +3,7 @@
  * @category particle
  */
 
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, type, formerlySerializedAs } from '../../core/data/class-decorator';
 import { Mat4, Quat, Vec2, Vec3 } from '../../core/math';
 import { clamp, pingPong, random, randomRange, repeat, toDegree, toRadian } from '../../core/math';
 import CurveRange from '../animator/curve-range';
@@ -22,9 +22,7 @@ export default class ShapeModule {
     /**
      * @zh 粒子发射器位置。
      */
-    @property({
-        displayOrder: 13,
-    })
+    @displayOrder(13)
     @tooltip('粒子发射器位置')
     get position () {
         return this._position;
@@ -37,9 +35,7 @@ export default class ShapeModule {
     /**
      * @zh 粒子发射器旋转角度。
      */
-    @property({
-        displayOrder: 14,
-    })
+    @displayOrder(14)
     @tooltip('粒子发射器旋转角度')
     get rotation () {
         return this._rotation;
@@ -52,9 +48,7 @@ export default class ShapeModule {
     /**
      * @zh 粒子发射器缩放比例。
      */
-    @property({
-        displayOrder: 15,
-    })
+    @displayOrder(15)
     @tooltip('粒子发射器缩放比例')
     get scale () {
         return this._scale;
@@ -67,9 +61,7 @@ export default class ShapeModule {
     /**
      * @zh 粒子发射器在一个扇形范围内发射。
      */
-    @property({
-        displayOrder: 6,
-    })
+    @displayOrder(6)
     @tooltip('粒子发射器在一个扇形范围内发射')
     get arc () {
         return toDegree(this._arc);
@@ -83,9 +75,7 @@ export default class ShapeModule {
      * @zh 圆锥的轴与母线的夹角<bg>。
      * 决定圆锥发射器的开合程度。
      */
-    @property({
-        displayOrder: 5,
-    })
+    @displayOrder(5)
     @tooltip('圆锥的轴与母线的夹角\n决定圆锥发射器的开合程度')
     get angle () {
         return Math.round(toDegree(this._angle) * 100) / 100;
@@ -100,9 +90,7 @@ export default class ShapeModule {
     /**
      * @zh 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     public get enable () {
         return this._enable;
     }
@@ -114,16 +102,12 @@ export default class ShapeModule {
     /**
      * @zh 粒子发射器类型 [[ShapeType]]。
      */
-    @property({
-        type: ShapeType,
-        displayOrder: 1,
-        formerlySerializedAs: 'shapeType',
-    })
+    @type(ShapeType)
+    @formerlySerializedAs('shapeType')
+    @displayOrder(1)
     public _shapeType = ShapeType.Cone;
 
-    @property({
-        type: ShapeType,
-    })
+    @type(ShapeType)
     @tooltip('粒子发射器类型')
     public get shapeType () {
         return this._shapeType;
@@ -154,55 +138,48 @@ export default class ShapeModule {
     /**
      * @zh 粒子从发射器哪个部位发射 [[EmitLocation]]。
      */
-    @property({
-        type: EmitLocation,
-        displayOrder: 2,
-    })
+    @type(EmitLocation)
+    @displayOrder(2)
     @tooltip('粒子从发射器哪个部位发射')
     public emitFrom = EmitLocation.Volume;
 
     /**
      * @zh 根据粒子的初始方向决定粒子的移动方向。
      */
-    @property({
-        displayOrder: 16,
-    })
+    @property
+    @displayOrder(16)
     @tooltip('根据粒子的初始方向决定粒子的移动方向')
     public alignToDirection = false;
 
     /**
      * @zh 粒子生成方向随机设定。
      */
-    @property({
-        displayOrder: 17,
-    })
+    @property
+    @displayOrder(17)
     @tooltip('粒子生成方向随机设定')
     public randomDirectionAmount = 0;
 
     /**
      * @zh 表示当前发射方向与当前位置到结点中心连线方向的插值。
      */
-    @property({
-        displayOrder: 18,
-    })
+    @property
+    @displayOrder(18)
     @tooltip('表示当前发射方向与当前位置到结点中心连线方向的插值')
     public sphericalDirectionAmount = 0;
 
     /**
      * @zh 粒子生成位置随机设定（设定此值为非 0 会使粒子生成位置超出生成器大小范围）。
      */
-    @property({
-        displayOrder: 19,
-    })
+    @property
+    @displayOrder(19)
     @tooltip('粒子生成位置随机设定（设定此值为非 0 会使粒子生成位置超出生成器大小范围）')
     public randomPositionAmount = 0;
 
     /**
      * @zh 粒子发射器半径。
      */
-    @property({
-        displayOrder: 3,
-    })
+    @property
+    @displayOrder(3)
     @tooltip('粒子发射器半径')
     public radius = 1;
 
@@ -212,38 +189,32 @@ export default class ShapeModule {
      * - 1 表示从中心发射；
      * - 0 ~ 1 之间表示在中心到表面之间发射。
      */
-    @property({
-        displayOrder: 4,
-    })
+    @property
+    @displayOrder(4)
     @tooltip('粒子发射器发射位置（对 Box 类型的发射器无效）:\n - 0 表示从表面发射；\n - 1 表示从中心发射；\n - 0 ~ 1 之间表示在中心到表面之间发射。')
     public radiusThickness = 1;
 
     /**
      * @zh 粒子在扇形范围内的发射方式 [[ArcMode]]。
      */
-    @property({
-        type: ArcMode,
-        displayOrder: 7,
-    })
+    @type(ArcMode)
+    @displayOrder(7)
     @tooltip('粒子在扇形范围内的发射方式')
     public arcMode = ArcMode.Random;
 
     /**
      * @zh 控制可能产生粒子的弧周围的离散间隔。
      */
-    @property({
-        displayOrder: 9,
-    })
+    @property
+    @displayOrder(9)
     @tooltip('控制可能产生粒子的弧周围的离散间隔')
     public arcSpread = 0;
 
     /**
      * @zh 粒子沿圆周发射的速度。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 10,
-    })
+    @type(CurveRange)
+    @displayOrder(10)
     @tooltip('粒子沿圆周发射的速度')
     public arcSpeed = new CurveRange();
 
@@ -251,18 +222,16 @@ export default class ShapeModule {
      * @zh 圆锥顶部截面距离底部的轴长<bg>。
      * 决定圆锥发射器的高度。
      */
-    @property({
-        displayOrder: 11,
-    })
+    @property
+    @displayOrder(11)
     @tooltip('圆锥顶部截面距离底部的轴长\n决定圆锥发射器的高度')
     public length = 5;
 
     /**
      * @zh 粒子发射器发射位置（针对 Box 类型的粒子发射器）。
      */
-    @property({
-        displayOrder: 12,
-    })
+    @property
+    @displayOrder(12)
     @tooltip('粒子发射器发射位置（针对 Box 类型的粒子发射器）')
     public boxThickness = new Vec3(0, 0, 0);
 

--- a/cocos/particle/line-component.ts
+++ b/cocos/particle/line-component.ts
@@ -7,7 +7,7 @@
 
 import { Material, Texture2D } from '../core/assets';
 import { Component } from '../core/components';
-import { ccclass, help, executeInEditMode, menu, property, tooltip } from '../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, menu, property, tooltip, displayOrder, type } from '../core/data/class-decorator';
 import { Vec3, Vec2, Vec4 } from '../core/math';
 import { LineModel } from './models/line-model';
 import { builtinResMgr } from '../core/3d/builtin';
@@ -30,18 +30,14 @@ const define = { CC_USE_WORLD_SPACE: false };
 @menu('Components/Line')
 @executeInEditMode
 export class LineComponent extends Component {
-    @property({
-        type: Texture2D,
-    })
+    @type(Texture2D)
     private _texture = null;
 
     /**
      * @zh 显示的纹理。
      */
-    @property({
-        type: Texture2D,
-        displayOrder: 0,
-    })
+    @type(Texture2D)
+    @displayOrder(0)
     @tooltip('线段中显示的贴图')
     get texture () {
         return this._texture;
@@ -63,9 +59,7 @@ export class LineComponent extends Component {
     /**
      * @zh positions是否为世界空间坐标。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @displayOrder(1)
     @tooltip('线段中各个点的坐标采用哪个坐标系，勾选使用世界坐标系，不选使用本地坐标系')
     get worldSpace () {
         return this._worldSpace;
@@ -82,18 +76,14 @@ export class LineComponent extends Component {
         }
     }
 
-    @property({
-        type: [Vec3],
-    })
+    @type(Vec3)
     private _positions = [];
 
     /**
      * 每段折线的拐点坐标。
      */
-    @property({
-        type: [Vec3],
-        displayOrder: 2,
-    })
+    @type([Vec3])
+    @displayOrder(2)
     @tooltip('每个线段端点的坐标')
     get positions () {
         return this._positions;
@@ -106,18 +96,14 @@ export class LineComponent extends Component {
         }
     }
 
-    @property({
-        type: CurveRange,
-    })
+    @type(CurveRange)
     private _width = new CurveRange();
 
     /**
      * @zh 线段的宽度。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 3,
-    })
+    @type(CurveRange)
+    @displayOrder(3)
     @tooltip('线段宽度，如果采用曲线，则表示沿着线段方向上的曲线变化')
     get width () {
         return this._width;
@@ -136,10 +122,8 @@ export class LineComponent extends Component {
     /**
      * @zh 图块数。
      */
-    @property({
-        type: Vec2,
-        displayOrder: 4,
-    })
+    @type(Vec2)
+    @displayOrder(4)
     @tooltip('贴图平铺次数')
     get tile () {
         return this._tile;
@@ -157,10 +141,8 @@ export class LineComponent extends Component {
     @property
     private _offset = new Vec2(0, 0);
 
-    @property({
-        type: Vec2,
-        displayOrder: 5,
-    })
+    @type(Vec2)
+    @displayOrder(5)
     @tooltip('贴图坐标的偏移')
     get offset () {
         return this._offset;
@@ -175,18 +157,14 @@ export class LineComponent extends Component {
         }
     }
 
-    @property({
-        type: GradientRange,
-    })
+    @type(GradientRange)
     private _color = new GradientRange();
 
     /**
      * @zh 线段颜色。
      */
-    @property({
-        type: GradientRange,
-        displayOrder: 6,
-    })
+    @type(GradientRange)
+    @displayOrder(6)
     @tooltip('线段颜色，如果采用渐变色，则表示沿着线段方向上的颜色渐变')
     get color () {
         return this._color;

--- a/cocos/particle/line-component.ts
+++ b/cocos/particle/line-component.ts
@@ -76,7 +76,7 @@ export class LineComponent extends Component {
         }
     }
 
-    @type(Vec3)
+    @type([Vec3])
     private _positions = [];
 
     /**

--- a/cocos/particle/particle-system-component.ts
+++ b/cocos/particle/particle-system-component.ts
@@ -8,7 +8,7 @@
 
 import { RenderableComponent } from '../core/3d/framework/renderable-component';
 import { Material } from '../core/assets/material';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip, displayOrder, type, range, displayName, visible, formerlySerializedAs, override, radian } from '../core/data/class-decorator';
 import { Mat4, pseudoRandom, Quat, randomRangeInt, Vec2, Vec3 } from '../core/math';
 import { INT_MAX } from '../core/math/bits';
 import { Model } from '../core/renderer';
@@ -44,9 +44,7 @@ export class ParticleSystemComponent extends RenderableComponent {
     /**
      * @zh 粒子系统能生成的最大粒子数量。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @displayOrder(1)
     @tooltip('粒子系统能生成的最大粒子数量')
     public get capacity () {
         return this._capacity;
@@ -64,155 +62,127 @@ export class ParticleSystemComponent extends RenderableComponent {
     /**
      * @zh 粒子初始颜色。
      */
-    @property({
-        type: GradientRange,
-        displayOrder: 8,
-    })
+    @type(GradientRange)
+    @displayOrder(8)
     @tooltip('粒子初始颜色')
     public startColor = new GradientRange();
 
-    @property({
-        type: Space,
-        displayOrder: 9,
-    })
+    @type(Space)
+    @displayOrder(9)
     @tooltip('选择缩放坐标系')
     public scaleSpace = Space.Local;
 
-    @property({
-        displayOrder: 10,
-    })
+    @property
+    @displayOrder(10)
     @tooltip('粒子初始大小')
     public startSize3D = false;
 
     /**
      * @zh 粒子初始大小。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 10,
-        formerlySerializedAs: 'startSize',
-    })
+    @formerlySerializedAs('startSize')
+    @type(CurveRange)
+    @displayOrder(10)
     @tooltip('粒子初始大小')
     public startSizeX = new CurveRange();
 
     /**
      * @zh 粒子初始大小。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 10,
-    })
+    @type(CurveRange)
+    @displayOrder(10)
     @tooltip('粒子初始大小')
     public startSizeY = new CurveRange();
 
     /**
      * @zh 粒子初始大小。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 10,
-    })
+    @type(CurveRange)
+    @displayOrder(10)
     @tooltip('粒子初始大小')
     public startSizeZ = new CurveRange();
 
     /**
      * @zh 粒子初始速度。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 11,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(11)
     @tooltip('粒子初始速度')
     public startSpeed = new CurveRange();
 
-    @property({
-        displayOrder: 12,
-    })
+    @property
+    @displayOrder(12)
     @tooltip('粒子初始旋转角度')
     public startRotation3D = false;
 
     /**
      * @zh 粒子初始旋转角度。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        radian: true,
-        displayOrder: 12,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @radian(true)
+    @displayOrder(12)
     @tooltip('粒子初始旋转角度')
     public startRotationX = new CurveRange();
 
     /**
      * @zh 粒子初始旋转角度。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        radian: true,
-        displayOrder: 12,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @radian(true)
+    @displayOrder(12)
     @tooltip('粒子初始旋转角度')
     public startRotationY = new CurveRange();
 
     /**
      * @zh 粒子初始旋转角度。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        radian: true,
-        displayOrder: 12,
-        formerlySerializedAs: 'startRotation',
-    })
+    @type(CurveRange)
+    @formerlySerializedAs('startRotation')
+    @range([-1, 1])
+    @radian(true)
+    @displayOrder(12)
     @tooltip('粒子初始旋转角度')
     public startRotationZ = new CurveRange();
 
     /**
      * @zh 粒子系统开始运行后，延迟粒子发射的时间。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 6,
-    })
+    @type(CurveRange)
+    @displayOrder(6)
     @tooltip('粒子系统开始运行后，延迟粒子发射的时间')
     public startDelay = new CurveRange();
 
     /**
      * @zh 粒子生命周期。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 7,
-    })
+    @type(CurveRange)
+    @displayOrder(7)
     @tooltip('粒子生命周期')
     public startLifetime = new CurveRange();
 
     /**
      * @zh 粒子系统运行时间。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @property
+    @displayOrder(0)
     @tooltip('粒子系统运行时间')
     public duration = 5.0;
 
     /**
      * @zh 粒子系统是否循环播放。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @property
+    @displayOrder(2)
     @tooltip('粒子系统是否循环播放')
     public loop = true;
 
     /**
      * @zh 选中之后，粒子系统会以已播放完一轮之后的状态开始播放（仅当循环播放启用时有效）。
      */
-    @property({
-        displayOrder: 3,
-    })
+    @displayOrder(3)
     @tooltip('选中之后，粒子系统会以已播放完一轮之后的状态开始播放（仅当循环播放启用时有效）')
     get prewarm () {
         return this._prewarm;
@@ -228,10 +198,8 @@ export class ParticleSystemComponent extends RenderableComponent {
     /**
      * @zh 选择粒子系统所在的坐标系[[Space]]。<br>
      */
-    @property({
-        type: Space,
-        displayOrder: 4,
-    })
+    @type(Space)
+    @displayOrder(4)
     @tooltip('控制粒子坐标计算所在的坐标系')
     get simulationSpace () {
         return this._simulationSpace;
@@ -250,29 +218,25 @@ export class ParticleSystemComponent extends RenderableComponent {
     /**
      * @zh 控制整个粒子系统的更新速度。
      */
-    @property({
-        displayOrder: 5,
-    })
+    @property
+    @displayOrder(5)
     @tooltip('控制整个粒子系统的更新速度')
     public simulationSpeed = 1.0;
 
     /**
      * @zh 粒子系统加载后是否自动开始播放。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @property
+    @displayOrder(2)
     @tooltip('粒子系统加载后是否自动开始播放')
     public playOnAwake = true;
 
     /**
      * @zh 粒子受重力影响的重力系数。
      */
-    @property({
-        type: CurveRange,
-        range: [-1, 1],
-        displayOrder: 13,
-    })
+    @type(CurveRange)
+    @range([-1, 1])
+    @displayOrder(13)
     @tooltip('粒子受重力影响的重力系数')
     public gravityModifier = new CurveRange();
 
@@ -280,39 +244,31 @@ export class ParticleSystemComponent extends RenderableComponent {
     /**
      * @zh 每秒发射的粒子数。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 14,
-    })
+    @type(CurveRange)
+    @displayOrder(14)
     @tooltip('每秒发射的粒子数')
     public rateOverTime = new CurveRange();
 
     /**
      * @zh 每移动单位距离发射的粒子数。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 15,
-    })
+    @type(CurveRange)
+    @displayOrder(15)
     @tooltip('每移动单位距离发射的粒子数')
     public rateOverDistance = new CurveRange();
 
     /**
      * @zh 设定在指定时间发射指定数量的粒子的 burst 的数量。
      */
-    @property({
-        type: [Burst],
-        displayOrder: 16,
-    })
+    @type([Burst])
+    @displayOrder(16)
     @tooltip('在某个时间点发射给定数量的粒子')
-    public bursts: Burst[] = new Array();
+    public bursts: Burst[] = [];
 
-    @property({
-        type: Material,
-        displayName: 'Materials',
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @type(Material)
+    @displayName('Materials')
+    @visible(false)
     get sharedMaterials () {
         // if we don't create an array copy, the editor will modify the original array directly.
         // @ts-ignore
@@ -325,15 +281,13 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // color over lifetime module
-    @property({type: ColorOverLifetimeModule})
+    @type(ColorOverLifetimeModule)
     _colorOverLifetimeModule:ColorOverLifetimeModule | null = null;
     /**
      * @zh 颜色控制模块。
      */
-    @property({
-        type: ColorOverLifetimeModule,
-        displayOrder: 23,
-    })
+    @type(ColorOverLifetimeModule)
+    @displayOrder(23)
     @tooltip('颜色模块')
     public get colorOverLifetimeModule () {
         if (EDITOR) {
@@ -351,15 +305,13 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // shape module
-    @property({type: ShapeModule})
+    @type(ShapeModule)
     _shapeModule:ShapeModule | null = null;
     /**
      * @zh 粒子发射器模块。
      */
-    @property({
-        type: ShapeModule,
-        displayOrder: 17,
-    })
+    @type(ShapeModule)
+    @displayOrder(17)
     @tooltip('发射器模块')
     public get shapeModule () {
         if (EDITOR) {
@@ -377,15 +329,13 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // size over lifetime module
-    @property({type: SizeOvertimeModule})
+    @type(SizeOvertimeModule)
     _sizeOvertimeModule:SizeOvertimeModule | null = null;
     /**
      * @zh 粒子大小模块。
      */
-    @property({
-        type: SizeOvertimeModule,
-        displayOrder: 21,
-    })
+    @type(SizeOvertimeModule)
+    @displayOrder(21)
     @tooltip('大小模块')
     public get sizeOvertimeModule () {
         if (EDITOR) {
@@ -403,15 +353,13 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // velocity overtime module
-    @property({type: VelocityOvertimeModule})
+    @type(VelocityOvertimeModule)
     _velocityOvertimeModule:VelocityOvertimeModule | null = null;
     /**
      * @zh 粒子速度模块。
      */
-    @property({
-        type: VelocityOvertimeModule,
-        displayOrder: 18,
-    })
+    @type(VelocityOvertimeModule)
+    @displayOrder(18)
     @tooltip('速度模块')
     public get velocityOvertimeModule () {
         if (EDITOR) {
@@ -429,15 +377,13 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // force overTime module
-    @property({type: ForceOvertimeModule})
+    @type(ForceOvertimeModule)
     _forceOvertimeModule:ForceOvertimeModule | null = null;
     /**
      * @zh 粒子加速度模块。
      */
-    @property({
-        type: ForceOvertimeModule,
-        displayOrder: 19,
-    })
+    @type(ForceOvertimeModule)
+    @displayOrder(19)
     @tooltip('加速度模块')
     public get forceOvertimeModule () {
         if (EDITOR) {
@@ -455,15 +401,14 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // limit velocity overtime module
-    @property({type: LimitVelocityOvertimeModule})
+    @type(LimitVelocityOvertimeModule)
     _limitVelocityOvertimeModule:LimitVelocityOvertimeModule | null = null;
+
     /**
      * @zh 粒子限制速度模块（只支持 CPU 粒子）。
      */
-    @property({
-        type: LimitVelocityOvertimeModule,
-        displayOrder: 20,
-    })
+    @type(LimitVelocityOvertimeModule)
+    @displayOrder(20)
     @tooltip('限速模块')
     public get limitVelocityOvertimeModule () {
         if (EDITOR) {
@@ -481,15 +426,13 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // rotation overtime module
-    @property({type: RotationOvertimeModule})
+    @type(RotationOvertimeModule)
     _rotationOvertimeModule:RotationOvertimeModule | null = null;
     /**
      * @zh 粒子旋转模块。
      */
-    @property({
-        type: RotationOvertimeModule,
-        displayOrder: 22,
-    })
+    @type(RotationOvertimeModule)
+    @displayOrder(22)
     @tooltip('旋转模块')
     public get rotationOvertimeModule () {
         if (EDITOR) {
@@ -507,15 +450,13 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // texture animation module
-    @property({type: TextureAnimationModule})
+    @type(TextureAnimationModule)
     _textureAnimationModule:TextureAnimationModule | null = null;
     /**
      * @zh 贴图动画模块。
      */
-    @property({
-        type: TextureAnimationModule,
-        displayOrder: 24,
-    })
+    @type(TextureAnimationModule)
+    @displayOrder(24)
     @tooltip('贴图动画模块')
     public get textureAnimationModule () {
         if (EDITOR) {
@@ -533,15 +474,13 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // trail module
-    @property({type: TrailModule})
+    @type(TrailModule)
     _trailModule:TrailModule | null = null;
     /**
      * @zh 粒子轨迹模块。
      */
-    @property({
-        type: TrailModule,
-        displayOrder: 25,
-    })
+    @type(TrailModule)
+    @displayOrder(25)
     @tooltip('拖尾模块')
     public get trailModule () {
         if (EDITOR) {
@@ -560,17 +499,14 @@ export class ParticleSystemComponent extends RenderableComponent {
     }
 
     // particle system renderer
-    @property({
-        type: ParticleSystemRenderer,
-        displayOrder: 26,
-    })
+    @type(ParticleSystemRenderer)
+    @displayOrder(26)
     @tooltip('渲染模块')
     public renderer: ParticleSystemRenderer = new ParticleSystemRenderer();
 
     // serilized culling
-    @property({
-        displayOrder: 27,
-    })
+    @property
+    @displayOrder(27)
     @tooltip('是否剔除非 enable 的模块数据')
     public enableCulling: boolean = false;
 

--- a/cocos/particle/renderer/particle-system-renderer-data.ts
+++ b/cocos/particle/renderer/particle-system-renderer-data.ts
@@ -1,5 +1,5 @@
 import { Material, Mesh, Texture2D } from '../../core/assets';
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, type } from '../../core/data/class-decorator';
 import { RenderMode} from '../enum';
 import ParticleSystemRendererCPU from './particle-system-renderer-cpu';
 import ParticleSystemRendererGPU from './particle-system-renderer-gpu';
@@ -22,10 +22,8 @@ export default class ParticleSystemRenderer {
     /**
      * @zh 设定粒子生成模式。
      */
-    @property({
-        type: RenderMode,
-        displayOrder: 0,
-    })
+    @type(RenderMode)
+    @displayOrder(0)
     @tooltip('设定粒子生成模式')
     public get renderMode () {
         return this._renderMode;
@@ -42,9 +40,7 @@ export default class ParticleSystemRenderer {
     /**
      * @zh 在粒子生成方式为 StrecthedBillboard 时,对粒子在运动方向上按速度大小进行拉伸。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @displayOrder(1)
     @tooltip('在粒子生成方式为 StrecthedBillboard 时,对粒子在运动方向上按速度大小进行拉伸')
     public get velocityScale () {
         return this._velocityScale;
@@ -59,9 +55,7 @@ export default class ParticleSystemRenderer {
     /**
      * @zh 在粒子生成方式为 StrecthedBillboard 时,对粒子在运动方向上按粒子大小进行拉伸。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @displayOrder(2)
     @tooltip('在粒子生成方式为 StrecthedBillboard 时,对粒子在运动方向上按粒子大小进行拉伸')
     public get lengthScale () {
         return this._lengthScale;
@@ -73,34 +67,27 @@ export default class ParticleSystemRenderer {
         // this._updateModel();
     }
 
-    @property({
-        type: RenderMode,
-        displayOrder: 3,
-    })
+    @type(RenderMode)
+    @displayOrder(3)
     private _renderMode = RenderMode.Billboard;
 
-    @property({
-        displayOrder: 4,
-    })
+    @property
+    @displayOrder(4)
     private _velocityScale = 1;
 
-    @property({
-        displayOrder: 5,
-    })
+    @property
+    @displayOrder(5)
     private _lengthScale = 1;
 
-    @property({
-        displayOrder: 6,
-    })
+    @property
+    @displayOrder(6)
     private _mesh: Mesh | null = null;
 
     /**
      * @zh 粒子发射的模型。
      */
-    @property({
-        type: Mesh,
-        displayOrder: 7,
-    })
+    @type(Mesh)
+    @displayOrder(7)
     @tooltip('粒子发射的模型')
     public get mesh () {
         return this._mesh;
@@ -114,10 +101,8 @@ export default class ParticleSystemRenderer {
     /**
      * @zh 粒子使用的材质。
      */
-    @property({
-        type: Material,
-        displayOrder: 8,
-    })
+    @type(Material)
+    @displayOrder(8)
     @tooltip('粒子使用的材质')
     public get particleMaterial () {
         if (!this._particleSystem) {
@@ -133,10 +118,8 @@ export default class ParticleSystemRenderer {
     /**
      * @zh 拖尾使用的材质。
      */
-    @property({
-        type: Material,
-        displayOrder: 9,
-    })
+    @type(Material)
+    @displayOrder(9)
     @tooltip('拖尾使用的材质')
     public get trailMaterial () {
         if (!this._particleSystem) {
@@ -163,9 +146,7 @@ export default class ParticleSystemRenderer {
     @property
     private _useGPU: boolean = false;
 
-    @property({
-        displayOrder: 10,
-    })
+    @displayOrder(10)
     @tooltip('是否启用GPU粒子')
     public get useGPU () {
         return this._useGPU;

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -5,7 +5,7 @@
 
 import { Material } from '../../core/assets/material';
 import { RenderingSubMesh } from '../../core/assets/mesh';
-import { ccclass, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, type, visible } from '../../core/data/class-decorator';
 import { director } from '../../core/director';
 import { GFX_DRAW_INFO_SIZE, GFXBuffer, IGFXIndirectBuffer } from '../../core/gfx/buffer';
 import { GFXAttributeName, GFXBufferUsageBit, GFXFormat, GFXFormatInfos, GFXMemoryUsageBit, GFXPrimitiveMode } from '../../core/gfx/define';
@@ -150,9 +150,7 @@ export default class TrailModule {
     /**
      * 是否启用。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     public get enable () {
         return this._enable;
     }
@@ -183,20 +181,16 @@ export default class TrailModule {
     /**
      * 设定粒子生成轨迹的方式。
      */
-    @property({
-        type: TrailMode,
-        displayOrder: 1,
-    })
+    @type(TrailMode)
+    @displayOrder(1)
     @tooltip('Particle在每个粒子的运动轨迹上形成拖尾效果')
     public mode = TrailMode.Particles;
 
     /**
      * 轨迹存在的生命周期。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 3,
-    })
+    @type(CurveRange)
+    @displayOrder(3)
     @tooltip('拖尾的生命周期')
     public lifeTime = new CurveRange();
 
@@ -206,9 +200,8 @@ export default class TrailModule {
     /**
      * 每个轨迹粒子之间的最小间距。
      */
-    @property({
-        displayOrder: 5,
-    })
+    @property
+    @displayOrder(5)
     @tooltip('粒子每生成一个拖尾节点所运行的最短距离')
     public get minParticleDistance () {
         return this._minParticleDistance;
@@ -219,10 +212,8 @@ export default class TrailModule {
         this._minSquaredDistance = val * val;
     }
 
-    @property({
-        type: Space,
-        displayOrder: 6,
-    })
+    @type(Space)
+    @displayOrder(6)
     @tooltip('拖尾所在的坐标系，World在世界坐标系中运行，Local在本地坐标系中运行')
     public get space () {
         return this._space;
@@ -238,65 +229,52 @@ export default class TrailModule {
     /**
      * 粒子本身是否存在。
      */
-    @property({
-        displayOrder: 7,
-        visible: false,
-    })
+    @property
+    @visible(false)
+    @displayOrder(7)
     @tooltip('拖尾是否跟随粒子一起消失')
     public existWithParticles = true;
 
     /**
      * 设定纹理填充方式。
      */
-    @property({
-        type: TextureMode,
-        displayOrder: 8,
-    })
+    @type(TextureMode)
+    @displayOrder(8)
     @tooltip('贴图在拖尾上的展开形式，Stretch贴图覆盖在整条拖尾上，Repeat贴图覆盖在一段拖尾上')
     public textureMode = TextureMode.Stretch;
 
-    @property({
-        displayOrder: 9,
-    })
+    @property
+    @displayOrder(9)
     @tooltip('拖尾宽度继承自粒子大小')
     public widthFromParticle = true;
 
     /**
      * 控制轨迹长度的曲线。
      */
-    @property({
-        type: CurveRange,
-        displayOrder: 10,
-    })
+    @type(CurveRange)
+    @displayOrder(10)
     @tooltip('拖尾宽度，如果继承自粒子则是粒子大小的比例')
     public widthRatio = new CurveRange();
 
-    @property({
-        displayOrder: 11,
-    })
+    @property
+    @displayOrder(11)
     @tooltip('拖尾颜色是否继承自粒子')
     public colorFromParticle = false;
 
-    @property({
-        type: GradientRange,
-        displayOrder: 12,
-    })
+    @type(GradientRange)
+    @displayOrder(12)
     @tooltip('拖尾颜色随拖尾自身长度的颜色渐变')
     public colorOverTrail = new GradientRange();
 
-    @property({
-        type: GradientRange,
-        displayOrder: 13,
-    })
+    @type(GradientRange)
+    @displayOrder(13)
     @tooltip('拖尾颜色随时间的颜色渐变')
     public colorOvertime = new GradientRange();
 
     /**
      * 轨迹设定时的坐标系。
      */
-    @property({
-        type: Space,
-    })
+    @type(Space)
     private _space = Space.World;
 
     @property

--- a/cocos/physics/framework/components/colliders/box-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/box-collider-component.ts
@@ -9,6 +9,7 @@ import {
     menu,
     property,
     tooltip,
+    type,
 } from '../../../../core/data/class-decorator';
 import { Vec3 } from '../../../../core/math';
 import { ColliderComponent } from './collider-component';
@@ -35,9 +36,7 @@ export class BoxColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置盒的大小。
      */
-    @property({
-        type: Vec3,
-    })
+    @type(Vec3)
     @tooltip('盒的大小，即长、宽、高')
     public get size () {
         return this._size;

--- a/cocos/physics/framework/components/colliders/capsule-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/capsule-collider-component.ts
@@ -9,6 +9,7 @@ import {
     menu,
     property,
     tooltip,
+    type,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { ICapsuleShape } from '../../../spec/i-physics-shape';
@@ -73,7 +74,7 @@ export class CapsuleColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置在本地坐标系下胶囊体的方向。
      */
-    @property({ type: EAxisDirection })
+    @type(EAxisDirection)
     @tooltip("本地坐标系下胶囊体的朝向")
     public get direction () {
         return this._direction;

--- a/cocos/physics/framework/components/colliders/collider-component.ts
+++ b/cocos/physics/framework/components/colliders/collider-component.ts
@@ -2,7 +2,7 @@
  * @category physics
  */
 
-import { ccclass, property, tooltip, displayOrder, displayName, immutable, type } from '../../../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, displayName, readOnly, type } from '../../../../core/data/class-decorator';
 import { Eventify } from '../../../../core/event';
 import { Vec3 } from '../../../../core/math';
 import { CollisionCallback, CollisionEventType, TriggerCallback, TriggerEventType } from '../../physics-interface';
@@ -37,7 +37,7 @@ export class ColliderComponent extends Eventify(Component) {
      * 获取碰撞器所绑定的刚体组件，可能为 null 。
      */
     @type(RigidBodyComponent)
-    @immutable(true)
+    @readOnly(true)
     @displayName('Attached')
     @displayOrder(-2)
     public get attachedRigidBody (): RigidBodyComponent | null {

--- a/cocos/physics/framework/components/colliders/collider-component.ts
+++ b/cocos/physics/framework/components/colliders/collider-component.ts
@@ -2,7 +2,7 @@
  * @category physics
  */
 
-import { ccclass, property, tooltip } from '../../../../core/data/class-decorator';
+import { ccclass, property, tooltip, displayOrder, displayName, immutable, type } from '../../../../core/data/class-decorator';
 import { Eventify } from '../../../../core/event';
 import { Vec3 } from '../../../../core/math';
 import { CollisionCallback, CollisionEventType, TriggerCallback, TriggerEventType } from '../../physics-interface';
@@ -36,12 +36,10 @@ export class ColliderComponent extends Eventify(Component) {
      * @zh
      * 获取碰撞器所绑定的刚体组件，可能为 null 。
      */
-    @property({
-        type: RigidBodyComponent,
-        displayName: 'Attached',
-        displayOrder: -2,
-        readonly: true,
-    })
+    @type(RigidBodyComponent)
+    @immutable(true)
+    @displayName('Attached')
+    @displayOrder(-2)
     public get attachedRigidBody (): RigidBodyComponent | null {
         return findAttachedBody(this.node);
         // return this._attachedRigidBody;
@@ -53,11 +51,9 @@ export class ColliderComponent extends Eventify(Component) {
      * @zh
      * 获取或设置此碰撞器的物理材质。
      */
-    @property({
-        type: PhysicMaterial,
-        displayName: 'Material',
-        displayOrder: -1,
-    })
+    @type(PhysicMaterial)
+    @displayName('Material')
+    @displayOrder(-1)
     @tooltip('源材质')
     public get sharedMaterial () {
         return this._material;
@@ -113,9 +109,7 @@ export class ColliderComponent extends Eventify(Component) {
      * @zh
      * 获取或设置碰撞器是否为触发器，若使用 builtin ，属性值无论真假 ，此碰撞器都为触发器。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     @tooltip('是否与其它碰撞器产生碰撞，并产生物理行为')
     public get isTrigger () {
         return this._isTrigger;
@@ -134,10 +128,8 @@ export class ColliderComponent extends Eventify(Component) {
      * @zh
      * 获取或设置碰撞器的中心点。
      */
-    @property({
-        type: Vec3,
-        displayOrder: 1,
-    })
+    @type(Vec3)
+    @displayOrder(1)
     @tooltip('形状的中心点（与所在 Node 中心点的相对位置）')
     public get center () {
         return this._center;
@@ -192,7 +184,7 @@ export class ColliderComponent extends Eventify(Component) {
     protected _needCollisionEvent: boolean = false;
     // protected _attachedRigidBody: RigidBodyComponent | null = null;
 
-    @property({ type: PhysicMaterial })
+    @type(PhysicMaterial)
     protected _material: PhysicMaterial | null = null;
 
     @property

--- a/cocos/physics/framework/components/colliders/cone-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/cone-collider-component.ts
@@ -9,6 +9,7 @@ import {
     menu,
     property,
     tooltip,
+    type,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { IConeShape } from '../../../spec/i-physics-shape';
@@ -74,7 +75,7 @@ export class ConeColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置在圆锥体本地空间上的方向。
      */
-    @property({ type: EAxisDirection })
+    @type(EAxisDirection)
     public get direction () {
         return this._direction;
     }

--- a/cocos/physics/framework/components/colliders/cylinder-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/cylinder-collider-component.ts
@@ -9,6 +9,7 @@ import {
     menu,
     property,
     tooltip,
+    type,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { ICylinderShape } from '../../../spec/i-physics-shape';
@@ -74,7 +75,7 @@ export class CylinderColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置在圆柱体本地空间上的方向。
      */
-    @property({ type: EAxisDirection })
+    @type(EAxisDirection)
     public get direction () {
         return this._direction;
     }

--- a/cocos/physics/framework/components/colliders/mesh-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/mesh-collider-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    type,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { Mesh } from '../../../../core';
@@ -35,9 +36,7 @@ export class MeshColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置此碰撞体引用的网格资源.
      */
-    @property({
-        type: Mesh,
-    })
+    @type(Mesh)
     get mesh () {
         return this._mesh;
     }

--- a/cocos/physics/framework/components/colliders/plane-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/plane-collider-component.ts
@@ -9,6 +9,7 @@ import {
     menu,
     property,
     tooltip,
+    type,
 } from '../../../../core/data/class-decorator';
 import { Vec3 } from '../../../../core/math';
 import { ColliderComponent } from './collider-component';
@@ -36,9 +37,7 @@ export class PlaneColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置平面在本地坐标系下的法线。
      */
-    @property({
-        type: Vec3,
-    })
+    @type(Vec3)
     @tooltip('平面的法线')
     public get normal () {
         return this._normal;

--- a/cocos/physics/framework/components/colliders/simplex-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/simplex-collider-component.ts
@@ -8,6 +8,8 @@ import {
     executeInEditMode,
     menu,
     property,
+    visible,
+    type,
 } from '../../../../core/data/class-decorator';
 import { Vec3 } from '../../../../core/math';
 import { ColliderComponent } from './collider-component';
@@ -32,9 +34,7 @@ export class SimplexColliderComponent extends ColliderComponent {
 
     /// PUBLIC PROPERTY GETTER\SETTER ///
 
-    @property({
-        type: ESimplexType
-    })
+    @type(ESimplexType)
     get shapeType () {
         return this._shapeType;
     }
@@ -56,11 +56,7 @@ export class SimplexColliderComponent extends ColliderComponent {
         this.updateVertices();
     }
 
-    @property({
-        visible: function (this: SimplexColliderComponent) {
-            return this._shapeType > 1;
-        }
-    })
+    @visible(function (this: SimplexColliderComponent) { return this._shapeType > 1; })
     get vertex1 () {
         return this._vertices[1];
     }
@@ -70,11 +66,7 @@ export class SimplexColliderComponent extends ColliderComponent {
         this.updateVertices();
     }
 
-    @property({
-        visible: function (this: SimplexColliderComponent) {
-            return this._shapeType > 2;
-        }
-    })
+    @visible(function (this: SimplexColliderComponent) { return this._shapeType > 2; })
     get vertex2 () {
         return this._vertices[2];
     }
@@ -84,11 +76,7 @@ export class SimplexColliderComponent extends ColliderComponent {
         this.updateVertices();
     }
 
-    @property({
-        visible: function (this: SimplexColliderComponent) {
-            return this._shapeType > 3;
-        }
-    })
+    @visible(function (this: SimplexColliderComponent) { return this._shapeType > 3; })
     get vertex3 () {
         return this._vertices[3];
     }

--- a/cocos/physics/framework/components/colliders/terrain-collider-component.ts
+++ b/cocos/physics/framework/components/colliders/terrain-collider-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    type,
 } from '../../../../core/data/class-decorator';
 import { ColliderComponent } from './collider-component';
 import { ITerrainShape } from '../../../spec/i-physics-shape';
@@ -36,8 +37,7 @@ export class TerrainColliderComponent extends ColliderComponent {
      * @zh
      * 获取或设置此碰撞体引用的网格资源.
      */
-    // @property({ type: js.getClassByName('cc.TerrainAsset') })    
-    @property({ type: TerrainAsset })
+    @type(TerrainAsset)
     get terrain () {
         return this._terrain;
     }

--- a/cocos/physics/framework/components/constant-force.ts
+++ b/cocos/physics/framework/components/constant-force.ts
@@ -11,6 +11,7 @@ import {
     requireComponent,
     disallowMultiple,
     tooltip,
+    displayOrder,
 } from '../../../core/data/class-decorator';
 import { Component } from '../../../core/components/component';
 import { RigidBodyComponent } from './rigid-body-component';
@@ -53,9 +54,7 @@ export class ConstantForce extends Component {
      * @zh
      * 获取或设置世界坐标系下的力。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     @tooltip('世界坐标系下的力')
     public get force () {
         return this._force;
@@ -72,9 +71,7 @@ export class ConstantForce extends Component {
      * @zh
      * 获取或设置本地坐标系下的力。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @displayOrder(1)
     @tooltip('本地坐标系下的力')
     public get localForce () {
         return this._localForce;
@@ -91,9 +88,7 @@ export class ConstantForce extends Component {
      * @zh
      * 获取或设置世界坐标系下的扭转力。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @displayOrder(2)
     @tooltip('世界坐标系下的扭转力')
     public get torque () {
         return this._torque;
@@ -110,9 +105,7 @@ export class ConstantForce extends Component {
      * @zh
      * 获取或设置本地坐标系下的扭转力。
      */
-    @property({
-        displayOrder: 3,
-    })
+    @displayOrder(3)
     @tooltip('本地坐标系下的扭转力')
     public get localTorque () {
         return this._localTorque;

--- a/cocos/physics/framework/components/constraints/constraint-component.ts
+++ b/cocos/physics/framework/components/constraints/constraint-component.ts
@@ -2,7 +2,7 @@
  * @category physics
  */
 
-import { ccclass, property, requireComponent } from '../../../../core/data/class-decorator';
+import { ccclass, property, requireComponent, displayOrder, type, immutable } from '../../../../core/data/class-decorator';
 import { Component } from '../../../../core';
 import { RigidBodyComponent } from '../rigid-body-component';
 import { Eventify } from '../../../../core/event';
@@ -17,19 +17,15 @@ export class ConstraintComponent extends Eventify(Component) {
 
     static readonly EConstraintType = EConstraintType;
 
-    @property({
-        type: RigidBodyComponent,
-        displayOrder: -2,
-        readonly: true,
-    })
+    @type(RigidBodyComponent)
+    @immutable(true)
+    @displayOrder(-2)
     get attachedBody (): RigidBodyComponent | null {
         return this.getComponent(RigidBodyComponent);
     }
 
-    @property({
-        type: RigidBodyComponent,
-        displayOrder: -1,
-    })
+    @type(RigidBodyComponent)
+    @displayOrder(-1)
     get connectedBody (): RigidBodyComponent | null {
         return this._connectedBody;
     }
@@ -41,9 +37,7 @@ export class ConstraintComponent extends Eventify(Component) {
         }
     }
 
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     get enableCollision () {
         return this._enableCollision;
     }
@@ -62,7 +56,7 @@ export class ConstraintComponent extends Eventify(Component) {
     @property
     protected _enableCollision = true;
 
-    @property({ type: RigidBodyComponent })
+    @type(RigidBodyComponent)
     protected _connectedBody: RigidBodyComponent | null = null;
 
     protected _constraint: IBaseConstraint | null = null;

--- a/cocos/physics/framework/components/constraints/constraint-component.ts
+++ b/cocos/physics/framework/components/constraints/constraint-component.ts
@@ -2,7 +2,7 @@
  * @category physics
  */
 
-import { ccclass, property, requireComponent, displayOrder, type, immutable } from '../../../../core/data/class-decorator';
+import { ccclass, property, requireComponent, displayOrder, type, readOnly } from '../../../../core/data/class-decorator';
 import { Component } from '../../../../core';
 import { RigidBodyComponent } from '../rigid-body-component';
 import { Eventify } from '../../../../core/event';
@@ -18,7 +18,7 @@ export class ConstraintComponent extends Eventify(Component) {
     static readonly EConstraintType = EConstraintType;
 
     @type(RigidBodyComponent)
-    @immutable(true)
+    @readOnly(true)
     @displayOrder(-2)
     get attachedBody (): RigidBodyComponent | null {
         return this.getComponent(RigidBodyComponent);

--- a/cocos/physics/framework/components/constraints/point-to-point-constraint-component.ts
+++ b/cocos/physics/framework/components/constraints/point-to-point-constraint-component.ts
@@ -8,6 +8,7 @@ import {
     executeInEditMode,
     menu,
     property,
+    type,
 } from '../../../../core/data/class-decorator';
 import { ConstraintComponent } from './constraint-component';
 import { Vec3, IVec3Like } from '../../../../core';
@@ -20,9 +21,7 @@ import { IPointToPointConstraint } from '../../../spec/i-physics-constraint';
 @menu('Physics/PointToPointConstraint(beta)')
 export class PointToPointConstraintComponent extends ConstraintComponent {
 
-    @property({
-        type: Vec3,
-    })
+    @type(Vec3)
     get pivotA () {
         return this._pivotA;
     }
@@ -34,9 +33,7 @@ export class PointToPointConstraintComponent extends ConstraintComponent {
         }
     }
 
-    @property({
-        type: Vec3,
-    })
+    @type(Vec3)
     get pivotB () {
         return this._pivotB;
     }

--- a/cocos/physics/framework/components/rigid-body-component.ts
+++ b/cocos/physics/framework/components/rigid-body-component.ts
@@ -12,6 +12,9 @@ import {
     property,
     executionOrder,
     tooltip,
+    displayOrder,
+    visible,
+    type,
 } from '../../../core/data/class-decorator';
 import { Vec3 } from '../../../core/math';
 import { Component, error, Layers } from '../../../core';
@@ -45,10 +48,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置分组。
      */
-    @property({
-        type: Layers.Enum,
-        displayOrder: -2,
-    })
+    @type(Layers.Enum)
+    @displayOrder(-2)
     @tooltip('设置分组')
     public get group (): number {
         return this._group;
@@ -67,9 +68,7 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置刚体的质量。
      */
-    @property({
-        displayOrder: 0,
-    })
+    @displayOrder(0)
     @tooltip('刚体的质量')
     public get mass () {
         return this._mass;
@@ -89,10 +88,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置是否允许休眠。
      */
-    @property({
-        displayOrder: 0.5,
-        visible: function (this: RigidBodyComponent) { return this._mass != 0; },
-    })
+    @displayOrder(0.5)
+    @visible(function (this: RigidBodyComponent) { return this._mass != 0; })
     @tooltip('是否允许休眠')
     public get allowSleep (): boolean {
         return this._allowSleep;
@@ -111,10 +108,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置线性阻尼。
      */
-    @property({
-        displayOrder: 1,
-        visible: function (this: RigidBodyComponent) { return this._mass != 0; },
-    })
+    @displayOrder(1)
+    @visible(function (this: RigidBodyComponent) { return this._mass != 0; })
     @tooltip('线性阻尼')
     public get linearDamping () {
         return this._linearDamping;
@@ -133,10 +128,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置旋转阻尼。
      */
-    @property({
-        displayOrder: 2,
-        visible: function (this: RigidBodyComponent) { return this._mass != 0; },
-    })
+    @displayOrder(2)
+    @visible(function (this: RigidBodyComponent) { return this._mass != 0; })
     @tooltip('旋转阻尼')
     public get angularDamping () {
         return this._angularDamping;
@@ -155,10 +148,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置刚体是否由物理系统控制运动。
      */
-    @property({
-        displayOrder: 3,
-        visible: function (this: RigidBodyComponent) { return this._mass != 0; },
-    })
+    @displayOrder(3)
+    @visible(function (this: RigidBodyComponent) { return this._mass != 0; })
     @tooltip('刚体是否由物理系统控制运动')
     public get isKinematic () {
         return this._isKinematic;
@@ -177,10 +168,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置刚体是否使用重力。
      */
-    @property({
-        displayOrder: 4,
-        visible: function (this: RigidBodyComponent) { return this._mass != 0; },
-    })
+    @displayOrder(4)
+    @visible(function (this: RigidBodyComponent) { return this._mass != 0; })
     @tooltip('刚体是否使用重力')
     public get useGravity () {
         return this._useGravity;
@@ -199,10 +188,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置刚体是否固定旋转。
      */
-    @property({
-        displayOrder: 5,
-        visible: function (this: RigidBodyComponent) { return this._mass != 0; },
-    })
+    @displayOrder(5)
+    @visible(function (this: RigidBodyComponent) { return this._mass != 0; })
     @tooltip('刚体是否固定旋转')
     public get fixedRotation () {
         return this._fixedRotation;
@@ -221,10 +208,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置线性速度的因子，可以用来控制每个轴方向上的速度的缩放。
      */
-    @property({
-        displayOrder: 6,
-        visible: function (this: RigidBodyComponent) { return this._mass != 0; },
-    })
+    @displayOrder(6)
+    @visible(function (this: RigidBodyComponent) { return this._mass != 0; })
     @tooltip('线性速度的因子，可以用来控制每个轴方向上的速度的缩放')
     public get linearFactor () {
         return this._linearFactor;
@@ -243,10 +228,8 @@ export class RigidBodyComponent extends Component {
      * @zh
      * 获取或设置旋转速度的因子，可以用来控制每个轴方向上的旋转速度的缩放。
      */
-    @property({
-        displayOrder: 7,
-        visible: function (this: RigidBodyComponent) { return this._mass != 0; },
-    })
+    @displayOrder(7)
+    @visible(function (this: RigidBodyComponent) { return this._mass != 0; })
     @tooltip('旋转速度的因子，可以用来控制每个轴方向上的旋转速度的缩放')
     public get angularFactor () {
         return this._angularFactor;

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -8,7 +8,7 @@ import { Filter, PixelFormat, WrapMode } from '../core/assets/asset-enum';
 import { Material } from '../core/assets/material';
 import { RenderingSubMesh } from '../core/assets/mesh';
 import { Component } from '../core/components';
-import { ccclass, disallowMultiple, executeInEditMode, help, property } from '../core/data/class-decorator';
+import { ccclass, disallowMultiple, executeInEditMode, help, property, visible, animatable, type } from '../core/data/class-decorator';
 import { isValid } from '../core/data/object';
 import { director } from '../core/director';
 import { GFXBuffer } from '../core/gfx/buffer';
@@ -661,30 +661,23 @@ export class TerrainBlock {
 @executeInEditMode
 @disallowMultiple
 export class Terrain extends Component {
-    @property({
-        type: TerrainAsset,
-        visible: false,
-        animatable: false,
-    })
+    @type(TerrainAsset)
+    @animatable(false)
+    @visible(false)
     protected __asset: TerrainAsset|null = null;
 
-    @property({
-        type: TerrainLayer,
-        visible: true,
-        animatable: false,
-    })
+    @type(TerrainLayer)
+    @animatable(false)
+    @visible(true)
     protected _layers: (TerrainLayer|null)[] = [];
 
-    @property({
-        visible: false,
-        animatable: false,
-    })
+    @animatable(false)
+    @visible(false)
     protected _blockInfos: TerrainBlockInfo[] = [];
 
-    @property({
-        visible: false,
-        animatable: false,
-    })
+    @property
+    @animatable(false)
+    @visible(false)
     protected _lightmapInfos: TerrainBlockLightmapInfo[] = [];
 
     protected _tileSize: number = 1;
@@ -706,10 +699,8 @@ export class Terrain extends Component {
         }
     }
 
-    @property({
-        type: TerrainAsset,
-        visible: true,
-    })
+    @type(TerrainAsset)
+    @visible(true)
     public set _asset (value: TerrainAsset|null) {
         if (this.__asset !== value) {
             this.__asset = value;
@@ -820,10 +811,8 @@ export class Terrain extends Component {
      * @en get terrain info
      * @zh 获得地形信息
      */
-    @property({
-        type: TerrainInfo,
-        visible: true,
-    })
+    @type(TerrainInfo)
+    @visible(true)
     public get info () {
         const ti = new TerrainInfo();
         ti.tileSize = this.tileSize;

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -671,6 +671,7 @@ export class Terrain extends Component {
     @visible(true)
     protected _layers: (TerrainLayer|null)[] = [];
 
+    @property
     @animatable(false)
     @visible(false)
     protected _blockInfos: TerrainBlockInfo[] = [];

--- a/cocos/ui/components/button-component.ts
+++ b/cocos/ui/components/button-component.ts
@@ -31,7 +31,7 @@
 
 import { SpriteFrame } from '../../core/assets';
 import { Component, EventHandler as ComponentEventHandler, UITransformComponent } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip, displayOrder, type, rangeMin, rangeMax } from '../../core/data/class-decorator';
 import { EventMouse, EventTouch, SystemEventType } from '../../core/platform';
 import { Color, Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
@@ -167,10 +167,8 @@ export class ButtonComponent extends Component {
      * - 如果 Transition type 选择 Button.Transition.COLOR，按钮会对目标颜色进行颜色之间的过渡。
      * - 如果 Transition type 选择 Button.Transition.Sprite，按钮会对目标 Sprite 进行 Sprite 之间的过渡。
      */
-    @property({
-        type: Node,
-        displayOrder: 0,
-    })
+    @type(Node)
+    @displayOrder(0)
     @tooltip('指定 Button 背景节点，Button 状态改变时会修改此节点的 Color 或 Sprite 属性')
     get target () {
         return this._target;
@@ -193,9 +191,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 按钮事件是否被响应，如果为 false，则按钮将被禁用。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @displayOrder(1)
     @tooltip('按钮是否可交互，这一项未选中时，按钮处在禁用状态')
     get interactable () {
         return this._interactable;
@@ -230,10 +226,8 @@ export class ButtonComponent extends Component {
      * @zh
      * 按钮状态改变时过渡方式。
      */
-    @property({
-        type: Transition,
-        displayOrder: 2,
-    })
+    @type(Transition)
+    @displayOrder(2)
     @tooltip('按钮状态变化时的过渡类型')
     get transition () {
         return this._transition;
@@ -341,10 +335,8 @@ export class ButtonComponent extends Component {
      * @zh
      * 颜色过渡和缩放过渡时所需时间。
      */
-    @property({
-        min: 0,
-        max: 10,
-    })
+    @rangeMin(0)
+    @rangeMax(10)
     @tooltip('按钮颜色变化或者缩放变化的过渡时间')
     get duration () {
         return this._duration;
@@ -387,9 +379,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 普通状态下按钮所显示的 Sprite。
      */
-    @property({
-        type: SpriteFrame,
-    })
+    @type(SpriteFrame)
     @tooltip('普通状态的按钮背景图资源')
     get normalSprite () {
         return this._normalSprite;
@@ -416,9 +406,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 按下状态时按钮所显示的 Sprite。
      */
-    @property({
-        type: SpriteFrame,
-    })
+    @type(SpriteFrame)
     @tooltip('按下状态的按钮背景图资源')
     get pressedSprite () {
         return this._pressedSprite;
@@ -440,9 +428,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 悬停状态下按钮所显示的 Sprite。
      */
-    @property({
-        type: SpriteFrame,
-    })
+    @type(SpriteFrame)
     @tooltip('悬停状态的按钮背景图资源')
     get hoverSprite () {
         return this._hoverSprite;
@@ -464,9 +450,7 @@ export class ButtonComponent extends Component {
      * @zh
      * 禁用状态下按钮所显示的 Sprite。
      */
-    @property({
-        type: SpriteFrame,
-    })
+    @type(SpriteFrame)
     @tooltip('禁用状态的按钮背景图资源')
     get disabledSprite () {
         return this._disabledSprite;
@@ -490,10 +474,8 @@ export class ButtonComponent extends Component {
      * @zh
      * 按钮的点击事件列表。
      */
-    @property({
-        type: [ComponentEventHandler],
-        displayOrder: 20,
-    })
+    @type([ComponentEventHandler])
+    @displayOrder(20)
     @tooltip('按钮点击事件的列表。先将数量改为1或更多，就可以为每个点击事件设置接受者和处理方法')
     public clickEvents: ComponentEventHandler[] = [];
     @property

--- a/cocos/ui/components/editbox/edit-box-component.ts
+++ b/cocos/ui/components/editbox/edit-box-component.ts
@@ -32,7 +32,7 @@ import { math, UITransformComponent } from '../../../core';
 import { SpriteFrame } from '../../../core/assets/sprite-frame';
 import { Component } from '../../../core/components/component';
 import { EventHandler as ComponentEventHandler } from '../../../core/components/component-event-handler';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip } from '../../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip, displayOrder, type } from '../../../core/data/class-decorator';
 import { Color, Size, Vec3 } from '../../../core/math';
 import { EventTouch } from '../../../core/platform';
 import { SystemEventType } from '../../../core/platform/event-manager/event-enum';
@@ -87,9 +87,7 @@ export class EditBoxComponent extends Component {
      * @zh
      * 输入框的初始输入内容，如果为空则会显示占位符的文本。
      */
-    @property({
-        displayOrder: 1,
-    })
+    @displayOrder(1)
     @tooltip('输入框的初始输入内容，如果为空则会显示占位符的文本')
     get string () {
         return this._string;
@@ -111,9 +109,7 @@ export class EditBoxComponent extends Component {
      * @zh
      * 输入框占位符的文本内容。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @displayOrder(2)
     @tooltip('输入框占位符的文本内容')
     get placeholder () {
         if (!this._placeholderLabel) {
@@ -135,10 +131,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 输入框输入文本节点上挂载的 Label 组件对象
      */
-    @property({
-        type: LabelComponent,
-        displayOrder: 3,
-    })
+    @type(LabelComponent)
+    @displayOrder(3)
     @tooltip('输入框输入文本节点上挂载的 Label 组件对象')
     get textLabel () {
         return this._textLabel;
@@ -161,10 +155,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 输入框占位符节点上挂载的 Label 组件对象。
      */
-    @property({
-        type: LabelComponent,
-        displayOrder: 4,
-    })
+    @type(LabelComponent)
+    @displayOrder(4)
     @tooltip('输入框占位符节点上挂载的 Label 组件对象')
     get placeholderLabel () {
         return this._placeholderLabel;
@@ -187,10 +179,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 输入框的背景图片。
      */
-    @property({
-        type: SpriteFrame,
-        displayOrder: 5,
-    })
+    @type(SpriteFrame)
+    @displayOrder(5)
     @tooltip('输入框的背景图片')
     get backgroundImage () {
         return this._backgroundImage;
@@ -212,10 +202,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 指定输入标志位，可以指定输入方式为密码或者单词首字母大写。
      */
-    @property({
-        type: InputFlag,
-        displayOrder: 6,
-    })
+    @type(InputFlag)
+    @displayOrder(6)
     @tooltip('指定输入标志位，可以指定输入方式为密码或者单词首字母大写')
     get inputFlag () {
         return this._inputFlag;
@@ -234,10 +222,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 指定输入模式: ANY表示多行输入，其它都是单行输入，移动平台上还可以指定键盘样式。
      */
-    @property({
-        type: InputMode,
-        displayOrder: 7,
-    })
+    @type(InputMode)
+    @displayOrder(7)
     @tooltip('指定输入模式: ANY 表示多行输入，其它都是单行输入，移动平台上还可以指定键盘样式')
     get inputMode () {
         return this._inputMode;
@@ -260,10 +246,8 @@ export class EditBoxComponent extends Component {
      * 指定移动设备上面回车按钮的样式。
      * 注意：这个选项对 web 平台与 desktop 平台无效。
      */
-    @property({
-        type: KeyboardReturnType,
-        displayOrder: 8,
-    })
+    @type(KeyboardReturnType)
+    @displayOrder(8)
     @tooltip('指定移动设备上面回车按钮的样式')
     get returnType () {
         return this._returnType;
@@ -284,9 +268,7 @@ export class EditBoxComponent extends Component {
      * - 如果值为小于 0 的值，则不会限制输入字符个数。
      * - 如果值为 0，则不允许用户进行任何输入。
      */
-    @property({
-        displayOrder: 9,
-    })
+    @displayOrder(9)
     @tooltip('输入框最大允许输入的字符个数')
     get maxLength () {
         return this._maxLength;
@@ -302,9 +284,7 @@ export class EditBoxComponent extends Component {
      * @zh
      * 修改 DOM 输入元素的 tabIndex（这个属性只有在 Web 上面修改有意义）。
      */
-    @property({
-        displayOrder: 10,
-    })
+    @displayOrder(10)
     @tooltip('修改 DOM 输入元素的 tabIndex（这个属性只有在 Web 上面修改有意义）')
     get tabIndex () {
         return this._tabIndex;
@@ -331,10 +311,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 开始编辑文本输入框触发的事件回调。
      */
-    @property({
-        type: [ComponentEventHandler],
-        displayOrder: 11,
-    })
+    @type([ComponentEventHandler])
+    @displayOrder(11)
     @tooltip('该事件在用户点击输入框获取焦点的时候被触发')
     public editingDidBegan: ComponentEventHandler[] = [];
 
@@ -345,10 +323,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 编辑文本输入框时触发的事件回调。
      */
-    @property({
-        type: [ComponentEventHandler],
-        displayOrder: 12,
-    })
+    @type([ComponentEventHandler])
+    @displayOrder(12)
     @tooltip('编辑文本输入框时触发的事件回调')
     public textChanged: ComponentEventHandler[] = [];
 
@@ -359,10 +335,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 结束编辑文本输入框时触发的事件回调。
      */
-    @property({
-        type: [ComponentEventHandler],
-        displayOrder: 13,
-    })
+    @type([ComponentEventHandler])
+    @displayOrder(13)
     @tooltip('在单行模式下面，一般是在用户按下回车或者点击屏幕输入框以外的地方调用该函数。 如果是多行输入，一般是在用户点击屏幕输入框以外的地方调用该函数')
     public editingDidEnded: ComponentEventHandler[] = [];
 
@@ -373,10 +347,8 @@ export class EditBoxComponent extends Component {
      * @zh
      * 当用户按下回车按键时的事件回调，目前不支持 windows 平台
      */
-    @property({
-        type: [ComponentEventHandler],
-        displayOrder: 14,
-    })
+    @type([ComponentEventHandler])
+    @displayOrder(14)
     @tooltip('该事件在用户按下回车键的时候被触发, 如果是单行输入框，按回车键还会使输入框失去焦点')
     public editingReturn: ComponentEventHandler[] = [];
 

--- a/cocos/ui/components/graphics-component.ts
+++ b/cocos/ui/components/graphics-component.ts
@@ -31,7 +31,7 @@
 import { builtinResMgr } from '../../core/3d/builtin';
 import { RenderableComponent } from '../../core/3d/framework/renderable-component';
 import { InstanceMaterialType, UIRenderComponent } from '../../core/components/ui-base/ui-render-component';
-import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip, type, visible, override } from '../../core/data/class-decorator';
 import { director } from '../../core/director';
 import { Color } from '../../core/math';
 import { IMaterialInstanceInfo, MaterialInstance, Model } from '../../core/renderer';
@@ -87,9 +87,7 @@ export class GraphicsComponent extends UIRenderComponent {
      * @zh
      * 用来设置2个长度不为0的相连部分（线段，圆弧，曲线）如何连接在一起的属性。
      */
-    @property({
-        type: LineJoin,
-    })
+    @type(LineJoin)
     @tooltip('两条线相交时，所创建的拐角类型')
     get lineJoin () {
         return this._lineJoin;
@@ -111,9 +109,7 @@ export class GraphicsComponent extends UIRenderComponent {
      * @zh
      * 指定如何绘制每一条线段末端。
      */
-    @property({
-        type: LineCap,
-    })
+    @type(LineCap)
     @tooltip('线条的结束端点样式')
     get lineCap () {
         return this._lineCap;
@@ -189,10 +185,8 @@ export class GraphicsComponent extends UIRenderComponent {
         // this.impl.miterLimit = value;
     }
 
-    @property({
-        override: true,
-        visible: false,
-    })
+    @override(true)
+    @visible(false)
     get color () {
         return this._color;
     }

--- a/cocos/ui/components/label-component.ts
+++ b/cocos/ui/components/label-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { BitmapFont, Font, ImageAsset, SpriteFrame, Texture2D, Material } from '../../core/assets';
-import { ccclass, help, executionOrder, menu, property, tooltip, displayOrder, visible, displayName, multiline, type, immutable, override } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip, displayOrder, visible, displayName, multiline, type, readOnly, override } from '../../core/data/class-decorator';
 import { ccenum } from '../../core/value-types/enum';
 import { UI } from '../../core/renderer/ui/ui';
 import { FontAtlas } from '../assembler/label/bmfontUtils';
@@ -269,7 +269,7 @@ export class LabelComponent extends UIRenderComponent {
      * SHRINK 模式下面文本实际渲染的字体大小。
      */
     @property
-    @immutable(true)
+    @readOnly(true)
     @displayName('Actual Font Size')
     @visible(false)
     get actualFontSize () {

--- a/cocos/ui/components/label-component.ts
+++ b/cocos/ui/components/label-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { BitmapFont, Font, ImageAsset, SpriteFrame, Texture2D, Material } from '../../core/assets';
-import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip, displayOrder, visible, displayName, multiline, type, immutable, override } from '../../core/data/class-decorator';
 import { ccenum } from '../../core/value-types/enum';
 import { UI } from '../../core/renderer/ui/ui';
 import { FontAtlas } from '../assembler/label/bmfontUtils';
@@ -199,11 +199,9 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 标签显示的文本内容。
      */
-    @property({
-        displayOrder: 4,
-        multiline: true,
-    })
+    @displayOrder(4)
     @tooltip('Label 显示的文本内容字符串')
+    @multiline(true)
     get string () {
         return this._string;
     }
@@ -224,10 +222,8 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 文本内容的水平对齐方式。
      */
-    @property({
-        type: HorizontalTextAlignment,
-        displayOrder: 5,
-    })
+    @type(HorizontalTextAlignment)
+    @displayOrder(5)
     @tooltip('文字水平对齐模式')
     get horizontalAlign () {
         return this._horizontalAlign;
@@ -249,10 +245,8 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 文本内容的垂直对齐方式。
      */
-    @property({
-        type: VerticalTextAlignment,
-        displayOrder: 6,
-    })
+    @type(VerticalTextAlignment)
+    @displayOrder(6)
     @tooltip('文字垂直对齐模式')
     get verticalAlign () {
         return this._verticalAlign;
@@ -274,11 +268,10 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * SHRINK 模式下面文本实际渲染的字体大小。
      */
-    @property({
-        readonly: true,
-        displayName: 'Actual Font Size',
-        visible: false,
-    })
+    @property
+    @immutable(true)
+    @displayName('Actual Font Size')
+    @visible(false)
     get actualFontSize () {
         return this._actualFontSize;
     }
@@ -294,9 +287,7 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 文本字体大小。
      */
-    @property({
-        displayOrder: 7,
-    })
+    @displayOrder(7)
     @tooltip('文字尺寸，以 point 为单位')
     get fontSize () {
         return this._fontSize;
@@ -318,9 +309,7 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 文本字体名称, 只在 useSystemFont 属性为 true 的时候生效。
      */
-    @property({
-        displayOrder: 8,
-    })
+    @displayOrder(8)
     @tooltip('文字字体名字')
     get fontFamily () {
         return this._fontFamily;
@@ -342,9 +331,7 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 文本行高。
      */
-    @property({
-        displayOrder: 8,
-    })
+    @displayOrder(8)
     @tooltip('文字行高，以 point 为单位')
     get lineHeight () {
         return this._lineHeight;
@@ -365,10 +352,8 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 文字显示超出范围时的处理方式。
      */
-    @property({
-        type: Overflow,
-        displayOrder: 9,
-    })
+    @type(Overflow)
+    @displayOrder(9)
     @tooltip('文字排版模式，包括以下三种：\n 1. CLAMP: 节点约束框之外的文字会被截断 \n 2. SHRINK: 自动根据节点约束框缩小文字\n 3. RESIZE_HEIGHT: 根据文本内容自动更新节点的 height 属性.')
     get overflow () {
         return this._overflow;
@@ -390,9 +375,7 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 是否自动换行。
      */
-    @property({
-        displayOrder: 10,
-    })
+    @displayOrder(10)
     @tooltip('自动换行')
     get enableWrapText () {
         return this._enableWrapText;
@@ -413,10 +396,8 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 文本字体。
      */
-    @property({
-        type: Font,
-        displayOrder: 11,
-    })
+    @type(Font)
+    @displayOrder(11)
     @tooltip('Label 使用的字体资源')
     get font () {
         // return this._N$file;
@@ -460,9 +441,7 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 是否使用系统字体。
      */
-    @property({
-        displayOrder: 12,
-    })
+    @displayOrder(12)
     @tooltip('是否使用系统默认字体')
     get useSystemFont () {
         return this._isSystemFontUsed;
@@ -503,10 +482,8 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 文本缓存模式, 该模式只支持系统字体。
      */
-    @property({
-        type: CacheMode,
-        displayOrder: 13,
-    })
+    @type(CacheMode)
+    @displayOrder(13)
     @tooltip('文本缓存模式，包括以下三种：\n 1. NONE: 不做任何缓存，文本内容进行一次绘制 \n 2. BITMAP: 将文本作为静态图像加入动态图集进行批次合并，但是不能频繁动态修改文本内容 \n 3. CHAR: 将文本拆分为字符并且把字符纹理缓存到一张字符图集中进行复用，适用于字符内容重复并且频繁更新的文本内容')
     get cacheMode () {
         return this._cacheMode;
@@ -540,10 +517,7 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 字体是否加粗。
      */
-    @property({
-        // visible: false,
-        displayOrder: 15,
-    })
+    @displayOrder(15)
     @tooltip('字体加粗')
     get isBold () {
         return this._isBold;
@@ -565,10 +539,7 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 字体是否倾斜。
      */
-    @property({
-        // visible: false,
-        displayOrder: 16,
-    })
+    @displayOrder(16)
     @tooltip('字体倾斜')
     get isItalic () {
         return this._isItalic;
@@ -590,10 +561,7 @@ export class LabelComponent extends UIRenderComponent {
      * @zh
      * 字体是否加下划线。
      */
-    @property({
-        // visible: false,
-        displayOrder: 17,
-    })
+    @displayOrder(17)
     @tooltip('字体加下划线')
     get isUnderline () {
         return this._isUnderline;
@@ -608,12 +576,10 @@ export class LabelComponent extends UIRenderComponent {
         this.updateRenderData();
     }
 
-    @property({
-        type: Material,
-        displayName: 'Materials',
-        visible: false,
-        override: true,
-    })
+    @type(Material)
+    @override(true)
+    @displayName('Materials')
+    @visible(false)
     get sharedMaterials () {
         return super.sharedMaterials;
     }

--- a/cocos/ui/components/layout-component.ts
+++ b/cocos/ui/components/layout-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component } from '../../core/components/component';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip, type } from '../../core/data/class-decorator';
 import { Rect, Size, Vec2, Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
 import { UITransformComponent } from '../../core/components/ui-base/ui-transform-component';
@@ -198,9 +198,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 布局类型。
      */
-    @property({
-        type: Type,
-    })
+    @type(Type)
     @tooltip('自动布局模式，包括：\n 1. NONE，不会对子节点进行自动布局 \n 2. HORIZONTAL，横向自动排布子物体 \n 3. VERTICAL，垂直自动排布子物体\n 4. GRID, 采用网格方式对子物体自动进行布局')
     get type () {
         return this._N$layoutType;
@@ -226,9 +224,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 缩放模式。
      */
-    @property({
-        type: ResizeMode,
-    })
+    @type(ResizeMode)
     @tooltip('缩放模式，包括：\n 1. NONE，不会对子节点和容器进行大小缩放 \n 2. CONTAINER, 对容器的大小进行缩放 \n 3. CHILDREN, 对子节点的大小进行缩放')
     get resizeMode () {
         return this._resizeMode;
@@ -278,9 +274,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 起始轴方向类型，可进行水平和垂直布局排列，只有布局类型为 GRID 的时候才有效。
      */
-    @property({
-        type: AxisDirection,
-    })
+    @type(AxisDirection)
     @tooltip('起始轴方向类型，可进行水平和垂直布局排列，只有布局类型为 GRID 的时候才有效')
     get startAxis () {
         return this._startAxis;
@@ -431,9 +425,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 垂直排列子节点的方向。
      */
-    @property({
-        type: VerticalDirection,
-    })
+    @type(VerticalDirection)
     @tooltip('垂直排列子节点的方向')
     get verticalDirection () {
         return this._verticalDirection;
@@ -456,9 +448,7 @@ export class LayoutComponent extends Component {
      * @zh
      * 水平排列子节点的方向。
      */
-    @property({
-        type: HorizontalDirection,
-    })
+    @type(HorizontalDirection)
     @tooltip('水平排列子节点的方向')
     get horizontalDirection () {
         return this._horizontalDirection;

--- a/cocos/ui/components/mask-component.ts
+++ b/cocos/ui/components/mask-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { InstanceMaterialType, UIRenderComponent } from '../../core/components/ui-base/ui-render-component';
-import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip, displayOrder, type, visible, override } from '../../core/data/class-decorator';
 import { clamp, Color, Mat4, Vec2, Vec3 } from '../../core/math';
 import { view, warnID } from '../../core/platform';
 import visibleRect from '../../core/platform/visible-rect';
@@ -111,10 +111,8 @@ export class MaskComponent extends UIRenderComponent {
      * @zh
      * 遮罩类型。
      */
-    @property({
-        type: MaskType,
-        displayOrder: 4,
-    })
+    @type(MaskType)
+    @displayOrder(4)
     @tooltip('遮罩类型')
     get type () {
         return this._type;
@@ -184,10 +182,8 @@ export class MaskComponent extends UIRenderComponent {
         return this._clearGraphics;
     }
 
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     get dstBlendFactor () {
         return this._dstBlendFactor;
     }
@@ -201,10 +197,8 @@ export class MaskComponent extends UIRenderComponent {
         this._updateBlendFunc();
     }
 
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     get srcBlendFactor () {
         return this._srcBlendFactor;
     }
@@ -218,10 +212,8 @@ export class MaskComponent extends UIRenderComponent {
         this._updateBlendFunc();
     }
 
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     // @constget
     get color (): Readonly<Color> {
         return this._color;

--- a/cocos/ui/components/page-view-component.ts
+++ b/cocos/ui/components/page-view-component.ts
@@ -28,7 +28,7 @@
  */
 
 import { EventHandler as ComponentEventHandler } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip, type, slide, range, visible, override } from '../../core/data/class-decorator';
 import { EventTouch, SystemEventType } from '../../core/platform';
 import { Vec2, Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
@@ -114,9 +114,7 @@ export class PageViewComponent extends ScrollViewComponent {
      * @zh
      * 页面视图中每个页面大小类型
      */
-    @property({
-        type: SizeMode,
-    })
+    @type(SizeMode)
     @tooltip('页面视图中每个页面大小类型')
     get sizeMode() {
         return this._sizeMode;
@@ -138,9 +136,7 @@ export class PageViewComponent extends ScrollViewComponent {
      * @zh
      * 页面视图滚动类型
      */
-    @property({
-        type: Direction,
-    })
+    @type(Direction)
     @tooltip('页面视图滚动类型')
     get direction() {
         return this._direction;
@@ -163,10 +159,8 @@ export class PageViewComponent extends ScrollViewComponent {
      * @zh
      * 滚动临界值，默认单位百分比，当拖拽超出该数值时，松开会自动滚动下一页，小于时则还原。
      */
-    @property({
-        slide: true,
-        range: [0, 1, 0.01],
-    })
+    @slide(true)
+    @range([0, 1, 0.01])
     @tooltip('滚动临界值，默认单位百分比，当拖拽超出该数值时，松开会自动滚动下一页，小于时则还原')
     get scrollThreshold() {
         return this._scrollThreshold;
@@ -187,16 +181,14 @@ export class PageViewComponent extends ScrollViewComponent {
      * @zh
      * 设置 PageView PageTurning 事件的发送时机。
      */
-    @property({
-        slide: true,
-        range: [0, 1, 0.01],
-    })
+    @slide(true)
+    @range([0, 1, 0.01])
     @tooltip('设置 PageView PageTurning 事件的发送时机')
-    get pageTurningEventTiming() {
+    get pageTurningEventTiming () {
         return this._pageTurningEventTiming;
     }
 
-    set pageTurningEventTiming(value) {
+    set pageTurningEventTiming (value) {
         if (this._pageTurningEventTiming === value) {
             return;
         }
@@ -211,9 +203,7 @@ export class PageViewComponent extends ScrollViewComponent {
      * @zh
      * 页面视图指示器组件
      */
-    @property({
-        type: PageViewIndicatorComponent,
-    })
+    @type(PageViewIndicatorComponent)
     @tooltip('页面视图指示器组件')
     get indicator() {
         return this._indicator;
@@ -253,11 +243,9 @@ export class PageViewComponent extends ScrollViewComponent {
     @tooltip('快速滑动翻页临界值\n当用户快速滑动时，会根据滑动开始和结束的距离与时间计算出一个速度值\n该值与此临界值相比较，如果大于临界值，则进行自动翻页')
     public autoPageTurningThreshold = 100;
 
-    @property({
-        type: ScrollBarComponent,
-        visible: false,
-        override: true,
-    })
+    @type(ScrollBarComponent)
+    @override(true)
+    @visible(false)
     get verticalScrollBar () {
         return super.verticalScrollBar;
     }
@@ -266,11 +254,9 @@ export class PageViewComponent extends ScrollViewComponent {
         super.verticalScrollBar = value;
     }
 
-    @property({
-        type: ScrollBarComponent,
-        visible: false,
-        override: true,
-    })
+    @type(ScrollBarComponent)
+    @override(true)
+    @visible(false)
     get horizontalScrollBar () {
         return super.horizontalScrollBar;
     }
@@ -279,29 +265,21 @@ export class PageViewComponent extends ScrollViewComponent {
         super.horizontalScrollBar = value;
     }
 
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     public horizontal = true;
 
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     public vertical = true;
 
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     public cancelInnerEvents = true;
 
-    @property({
-        visible: false,
-        override: true,
-        type: [ComponentEventHandler]
-    })
+    @type([ComponentEventHandler])
+    @override(true)
+    @visible(false)
     public scrollEvents: ComponentEventHandler[] = [];
 
     /**
@@ -316,9 +294,7 @@ export class PageViewComponent extends ScrollViewComponent {
      * @en PageView events callback
      * @zh 滚动视图的事件回调函数
      */
-    @property({
-        type: [ComponentEventHandler],
-    })
+    @type([ComponentEventHandler])
     @tooltip('滚动视图的事件回调函数')
     public pageEvents: ComponentEventHandler[] = [];
 

--- a/cocos/ui/components/page-view-component.ts
+++ b/cocos/ui/components/page-view-component.ts
@@ -265,14 +265,17 @@ export class PageViewComponent extends ScrollViewComponent {
         super.horizontalScrollBar = value;
     }
 
+    @property
     @override(true)
     @visible(false)
     public horizontal = true;
 
+    @property
     @override(true)
     @visible(false)
     public vertical = true;
 
+    @property
     @override(true)
     @visible(false)
     public cancelInnerEvents = true;

--- a/cocos/ui/components/page-view-indicator-component.ts
+++ b/cocos/ui/components/page-view-indicator-component.ts
@@ -30,7 +30,7 @@
 
 import { SpriteFrame } from '../../core/assets';
 import { Component } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip, type } from '../../core/data/class-decorator';
 import { Color, Size } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
 import { Node } from '../../core/scene-graph';
@@ -85,9 +85,7 @@ export class PageViewIndicatorComponent extends Component {
      * @zh
      * 每个页面标记显示的图片
      */
-    @property({
-        type: SpriteFrame,
-    })
+    @type(SpriteFrame)
     @tooltip('每个页面标记显示的图片')
     get spriteFrame () {
         return this._spriteFrame;
@@ -109,9 +107,7 @@ export class PageViewIndicatorComponent extends Component {
      *
      * @param direction 摆放方向
      */
-    @property({
-        type: Direction,
-    })
+    @type(Direction)
     @tooltip('页面标记摆放方向')
     get direction () {
         return this._direction;
@@ -131,9 +127,7 @@ export class PageViewIndicatorComponent extends Component {
      * @zh
      * 每个页面标记的大小
      */
-    @property({
-        type: Size,
-    })
+    @type(Size)
     @tooltip('每个页面标记的大小')
     get cellSize () {
         return this._cellSize;

--- a/cocos/ui/components/progress-bar-component.ts
+++ b/cocos/ui/components/progress-bar-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component, UITransformComponent} from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip, type, range, slide } from '../../core/data/class-decorator';
 import { Size, Vec2, Vec3 } from '../../core/math';
 import { Enum } from '../../core/value-types';
 import { clamp01 } from '../../core/math/utils';
@@ -112,9 +112,7 @@ export class ProgressBarComponent extends Component {
      * @zh
      * 用来显示进度条比例的 Sprite 对象。
      */
-    @property({
-        type: SpriteComponent,
-    })
+    @type(SpriteComponent)
     @tooltip('进度条显示用的 Sprite 节点，可以动态改变尺寸')
     get barSprite () {
         return this._barSprite;
@@ -136,9 +134,7 @@ export class ProgressBarComponent extends Component {
      * @zh
      * 进度条的模式。
      */
-    @property({
-        type: Mode,
-    })
+    @type(Mode)
     @tooltip('进度条显示模式，目前支持水平和垂直两种')
     get mode () {
         return this._mode;
@@ -192,10 +188,8 @@ export class ProgressBarComponent extends Component {
      * @zh
      * 当前进度值，该数值的区间是 0-1 之间。
      */
-    @property({
-        range: [0, 1, 0.1],
-        slide: true,
-    })
+    @range([0, 1, 0.1])
+    @slide(true)
     @tooltip('当前进度指示，范围从 0 到 1')
     get progress () {
         return this._progress;

--- a/cocos/ui/components/rich-text-component.ts
+++ b/cocos/ui/components/rich-text-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Font, SpriteAtlas, TTFFont } from '../../core/assets';
-import { ccclass, executeInEditMode, executionOrder, help, menu, property } from '../../core/data/class-decorator';
+import { ccclass, executeInEditMode, executionOrder, help, menu, property, tooltip, multiline, type } from '../../core/data/class-decorator';
 import { assert, EventTouch, warnID } from '../../core/platform';
 import { BASELINE_RATIO, fragmentText, HtmlTextParser, IHtmlTextParserResultObj, IHtmlTextParserStack, isUnicodeCJK, isUnicodeSpace } from '../../core/utils';
 import Pool from '../../core/utils/pool';
@@ -145,10 +145,8 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本显示的文本内容。
      */
-    @property({
-        multiline: true,
-        tooltip:'富文本显示的文本内容',
-    })
+    @multiline(true)
+    @tooltip('富文本显示的文本内容')
     get string () {
         return this._string;
     }
@@ -168,10 +166,8 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 文本内容的水平对齐方式。
      */
-    @property({
-        type: HorizontalTextAlignment,
-        tooltip:'文本内容的水平对齐方式',
-    })
+    @type(HorizontalTextAlignment)
+    @tooltip('文本内容的水平对齐方式')
     get horizontalAlign () {
         return this._horizontalAlign;
     }
@@ -193,9 +189,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本字体大小。
      */
-    @property({
-        tooltip:'富文本字体大小',
-    })
+    @tooltip('富文本字体大小')
     get fontSize () {
         return this._fontSize;
     }
@@ -217,9 +211,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本定制系统字体
      */
-    @property({
-        tooltip:'富文本定制系统字体',
-    })
+    @tooltip('富文本定制系统字体')
     get fontFamily () {
         return this._fontFamily;
     }
@@ -237,10 +229,8 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本定制字体。
      */
-    @property({
-        type: Font,
-        tooltip:'富文本定制字体',
-    })
+    @type(Font)
+    @tooltip('富文本定制字体')
     get font () {
         return this._font;
     }
@@ -270,9 +260,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 是否使用系统字体。
      */
-    @property({
-        tooltip:'是否使用系统字体',
-    })
+    @tooltip('是否使用系统字体')
     get useSystemFont () {
         return this._isSystemFontUsed;
     }
@@ -303,10 +291,8 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 文本缓存模式, 该模式只支持系统字体。
      */
-    @property({
-        type: CacheMode,
-        tooltip:'文本缓存模式, 该模式只支持系统字体。',
-    })
+    @type(CacheMode)
+    @tooltip('文本缓存模式, 该模式只支持系统字体。')
     get cacheMode () {
         return this._cacheMode;
     }
@@ -325,9 +311,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本的最大宽度。
      */
-    @property({
-        tooltip:'富文本的最大宽度',
-    })
+    @tooltip('富文本的最大宽度')
     get maxWidth () {
         return this._maxWidth;
     }
@@ -349,9 +333,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 富文本行高。
      */
-    @property({
-        tooltip:'富文本行高',
-    })
+    @tooltip('富文本行高')
     get lineHeight () {
         return this._lineHeight;
     }
@@ -373,10 +355,8 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 对于 img 标签里面的 src 属性名称，都需要在 imageAtlas 里面找到一个有效的 spriteFrame，否则 img tag 会判定为无效。
      */
-    @property({
-        type: SpriteAtlas,
-        tooltip:'对于 img 标签里面的 src 属性名称，都需要在 imageAtlas 里面找到一个有效的 spriteFrame，否则 img tag 会判定为无效',
-    })
+    @type(SpriteAtlas)
+    @tooltip('对于 img 标签里面的 src 属性名称，都需要在 imageAtlas 里面找到一个有效的 spriteFrame，否则 img tag 会判定为无效')
     get imageAtlas () {
         return this._imageAtlas;
     }
@@ -399,9 +379,7 @@ export class RichTextComponent extends UIComponent {
      * @zh
      * 选中此选项后，RichText 将阻止节点边界框中的所有输入事件（鼠标和触摸），从而防止输入事件穿透到底层节点。
      */
-    @property({
-        tooltip:'选中此选项后，RichText 将阻止节点边界框中的所有输入事件（鼠标和触摸），从而防止输入事件穿透到底层节点',
-    })
+    @tooltip('选中此选项后，RichText 将阻止节点边界框中的所有输入事件（鼠标和触摸），从而防止输入事件穿透到底层节点')
     get handleTouchEvent () {
         return this._handleTouchEvent;
     }

--- a/cocos/ui/components/scroll-bar-component.ts
+++ b/cocos/ui/components/scroll-bar-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component, UITransformComponent } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip, displayOrder, type } from '../../core/data/class-decorator';
 import { Color, Size, Vec2, Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
 import { clamp01 } from '../../core/math/utils';
@@ -95,10 +95,8 @@ export class ScrollBarComponent extends Component {
      * @zh
      * 作为当前滚动区域位置显示的滑块 Sprite。
      */
-    @property({
-        type: SpriteComponent,
-        displayOrder: 0,
-    })
+    @type(SpriteComponent)
+    @displayOrder(0)
     @tooltip('作为当前滚动区域位置显示的滑块 Sprite')
     get handle () {
         return this._handle;
@@ -119,10 +117,8 @@ export class ScrollBarComponent extends Component {
      * @zh
      * ScrollBar 的滚动方向。
      */
-    @property({
-        type: Direction,
-        displayOrder: 1,
-    })
+    @type(Direction)
+    @displayOrder(1)
     @tooltip('ScrollBar 的滚动方向')
     get direction () {
         return this._direction;
@@ -144,9 +140,7 @@ export class ScrollBarComponent extends Component {
      * @zh
      * 是否在没有滚动动作时自动隐藏 ScrollBar。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @displayOrder(2)
     @tooltip('是否在没有滚动动作时自动隐藏 ScrollBar')
     get enableAutoHide () {
         return this._enableAutoHide;
@@ -172,9 +166,7 @@ export class ScrollBarComponent extends Component {
      * 没有滚动动作后经过多久会自动隐藏。<br/>
      * 注意：只要当 “enableAutoHide” 为 true 时，才有效。
      */
-    @property({
-        displayOrder: 3,
-    })
+    @displayOrder(3)
     @tooltip('没有滚动动作后经过多久会自动隐藏。\n注意：只要当 “enableAutoHide” 为 true 时，才有效。')
     get autoHideTime () {
         return this._autoHideTime;

--- a/cocos/ui/components/scroll-view-component.ts
+++ b/cocos/ui/components/scroll-view-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { EventHandler as ComponentEventHandler, UITransformComponent } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip, displayOrder, range, type } from '../../core/data/class-decorator';
 import { Event } from '../../core/event';
 import { EventMouse, EventTouch, Touch, logID } from '../../core/platform';
 import { Size, Vec2, Vec3 } from '../../core/math';
@@ -217,10 +217,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 回弹持续的时间，0 表示将立即反弹。
      */
-    @property({
-        range: [0, 10],
-        displayOrder: 0,
-    })
+    @property
+    @range([0, 10])
+    @displayOrder(0)
     @tooltip('回弹持续的时间，0 表示将立即反弹')
     public bounceDuration = 1;
 
@@ -232,10 +231,9 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 开启惯性后，在用户停止触摸后滚动多快停止，0表示永不停止，1表示立刻停止。
      */
-    @property({
-        range: [0, 1, 0.1],
-        displayOrder: 1,
-    })
+    @property
+    @range([0, 1, 0.1])
+    @displayOrder(1)
     @tooltip('开启惯性后，在用户停止触摸后滚动多快停止，0 表示永不停止，1 表示立刻停止')
     public brake = 0.5;
 
@@ -246,9 +244,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 是否允许滚动内容超过边界，并在停止触摸后回弹。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @property
+    @displayOrder(2)
     @tooltip('是否允许滚动内容超过边界，并在停止触摸后回弹')
     public elastic = true;
 
@@ -259,9 +256,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 是否开启滚动惯性。
      */
-    @property({
-        displayOrder: 3,
-    })
+    @property
+    @displayOrder(3)
     @tooltip('是否开启滚动惯性')
     public inertia = true;
 
@@ -272,10 +268,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 可滚动展示内容的节点。
      */
-    @property({
-        type: UITransformComponent,
-        displayOrder: 4,
-    })
+    @type(UITransformComponent)
+    @displayOrder(4)
     @tooltip('可滚动展示内容的节点')
     get content () {
         return this._content;
@@ -301,9 +295,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 是否开启水平滚动。
      */
-    @property({
-        displayOrder: 5,
-    })
+    @property
+    @displayOrder(5)
     @tooltip('是否开启水平滚动')
     public horizontal = true;
 
@@ -313,10 +306,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 水平滚动的 ScrollBar。
      */
-    @property({
-        type: ScrollBarComponent,
-        displayOrder: 6,
-    })
+    @type(ScrollBarComponent)
+    @displayOrder(6)
     @tooltip('水平滚动的 ScrollBar')
     get horizontalScrollBar () {
         return this._horizontalScrollBar;
@@ -342,9 +333,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 是否开启垂直滚动。
      */
-    @property({
-        displayOrder: 7,
-    })
+    @property
+    @displayOrder(7)
     @tooltip('是否开启垂直滚动')
     public vertical = true;
 
@@ -355,10 +345,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 垂直滚动的 ScrollBar。
      */
-    @property({
-        type: ScrollBarComponent,
-        displayOrder: 8,
-    })
+    @type(ScrollBarComponent)
+    @displayOrder(8)
     @tooltip('垂直滚动的 ScrollBar')
     get verticalScrollBar () {
         return this._verticalScrollBar;
@@ -386,9 +374,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * 如果这个属性被设置为 true，那么滚动行为会取消子节点上注册的触摸事件，默认被设置为 true。<br/>
      * 注意，子节点上的 touchstart 事件仍然会触发，触点移动距离非常短的情况下 touchmove 和 touchend 也不会受影响。
      */
-    @property({
-        displayOrder: 9,
-    })
+    @property
+    @displayOrder(9)
     @tooltip('滚动行为是否会取消子节点上注册的触摸事件')
     public cancelInnerEvents = true;
 
@@ -399,10 +386,8 @@ export class ScrollViewComponent extends ViewGroupComponent {
      * @zh
      * 滚动视图的事件回调函数。
      */
-    @property({
-        type: [ComponentEventHandler],
-        displayOrder: 10,
-    })
+    @type([ComponentEventHandler])
+    @displayOrder(10)
     @tooltip('滚动视图的事件回调函数')
     public scrollEvents: ComponentEventHandler[] = [];
 

--- a/cocos/ui/components/slider-component.ts
+++ b/cocos/ui/components/slider-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component, EventHandler, UITransformComponent } from '../../core/components';
-import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, requireComponent, tooltip, type, slide, range } from '../../core/data/class-decorator';
 import { EventTouch, SystemEventType, Touch } from '../../core/platform';
 import { Vec3 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
@@ -88,9 +88,7 @@ export class SliderComponent extends Component {
      * @zh
      * 滑动器滑块按钮部件。
      */
-    @property({
-        type: SpriteComponent,
-    })
+    @type(SpriteComponent)
     @tooltip('滑块按钮部件')
     get handle () {
         return this._handle;
@@ -114,9 +112,7 @@ export class SliderComponent extends Component {
      * @zh
      * 滑动器方向。
      */
-    @property({
-        type: Direction,
-    })
+    @type(Direction)
     @tooltip('滑动方向')
     get direction () {
         return this._direction;
@@ -138,10 +134,8 @@ export class SliderComponent extends Component {
      * @zh
      * 当前进度值，该数值的区间是 0-1 之间。
      */
-    @property({
-        slide: true,
-        range: [0, 1, 0.01],
-    })
+    @slide(true)
+    @range([0, 1, 0.01])
     @tooltip('当前进度值，该数值的区间是 0 - 1 之间。')
     get progress () {
         return this._progress;
@@ -165,9 +159,7 @@ export class SliderComponent extends Component {
      * @zh
      * 滑动器组件事件回调函数。
      */
-    @property({
-        type: EventHandler,
-    })
+    @type([EventHandler])
     @tooltip('滑动器组件事件回调函数')
     public slideEvents: EventHandler[] = [];
     @property

--- a/cocos/ui/components/sprite-component.ts
+++ b/cocos/ui/components/sprite-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { SpriteAtlas, SpriteFrame } from '../../core/assets';
-import { ccclass, help, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executionOrder, menu, property, tooltip, displayOrder, type, range } from '../../core/data/class-decorator';
 import { SystemEventType } from '../../core/platform/event-manager/event-enum';
 import { Vec2 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
@@ -185,10 +185,8 @@ export class SpriteComponent extends UIRenderComponent {
      * @zh
      * 精灵的图集。
      */
-    @property({
-        type: SpriteAtlas,
-        displayOrder: 4,
-    })
+    @type(SpriteAtlas)
+    @displayOrder(4)
     @tooltip('图片资源所属的 Atlas 图集资源')
     get spriteAtlas () {
         return this._atlas;
@@ -210,10 +208,8 @@ export class SpriteComponent extends UIRenderComponent {
      * @zh
      * 精灵的精灵帧。
      */
-    @property({
-        type: SpriteFrame,
-        displayOrder: 5,
-    })
+    @type(SpriteFrame)
+    @displayOrder(5)
     @tooltip('渲染 Sprite 使用的 SpriteFrame 图片资源')
     get spriteFrame () {
         return this._spriteFrame;
@@ -248,10 +244,8 @@ export class SpriteComponent extends UIRenderComponent {
      * sprite.type = SpriteComponent.Type.SIMPLE;
      * ```
      */
-    @property({
-        type: SpriteType,
-        displayOrder: 6,
-    })
+    @type(SpriteType)
+    @displayOrder(6)
     @tooltip('渲染模式：\n- 普通（Simple）：修改尺寸会整体拉伸图像，适用于序列帧动画和普通图像 \n' +
     '- 九宫格（Sliced）：修改尺寸时四个角的区域不会拉伸，适用于 UI 按钮和面板背景 \n' +
     '- 填充（Filled）：设置一定的填充起始位置和方向，能够以一定比率剪裁显示图片')
@@ -278,9 +272,7 @@ export class SpriteComponent extends UIRenderComponent {
      * sprite.fillType = SpriteComponent.FillType.HORIZONTAL;
      * ```
      */
-    @property({
-        type: FillType,
-    })
+    @type(FillType)
     @tooltip('填充方向，可以选择横向（Horizontal），纵向（Vertical）和扇形（Radial）三种方向')
     get fillType () {
         return this._fillType;
@@ -339,9 +331,7 @@ export class SpriteComponent extends UIRenderComponent {
      * sprite.fillStart = 0.5;
      * ```
      */
-    @property({
-        range: [0, 1, 0.1],
-    })
+    @range([0, 1, 0.1])
     @tooltip('填充起始位置，输入一个 0 ~ 1 之间的小数表示起始位置的百分比')
     get fillStart () {
         return this._fillStart;
@@ -368,9 +358,7 @@ export class SpriteComponent extends UIRenderComponent {
      * sprite.fillRange = 1;
      * ```
      */
-    @property({
-        range: [0, 1, 0.1],
-    })
+    @range([0, 1, 0.1])
     @tooltip('填充总量，取值范围 0 ~ 1 指定显示图像范围的百分比')
     get fillRange () {
         return this._fillRange;
@@ -395,9 +383,7 @@ export class SpriteComponent extends UIRenderComponent {
      * sprite.trim = true;
      * ```
      */
-    @property({
-        displayOrder: 8,
-    })
+    @displayOrder(8)
     @tooltip('节点约束框内是否包括透明像素区域，勾选此项会去除节点约束框内的透明区域')
     get trim () {
         return this._isTrimmedMode;
@@ -445,10 +431,8 @@ export class SpriteComponent extends UIRenderComponent {
      * sprite.sizeMode = SpriteComponent.SizeMode.CUSTOM;
      * ```
      */
-    @property({
-        type: SizeMode,
-        displayOrder: 7,
-    })
+    @type(SizeMode)
+    @displayOrder(7)
     @tooltip('指定 Sprite 所在节点的尺寸，CUSTOM 表示自定义尺寸，TRIMMED 表示取原始图片剪裁透明像素后的尺寸，RAW 表示取原始图片未剪裁的尺寸')
     get sizeMode () {
         return this._sizeMode;

--- a/cocos/ui/components/toggle-component.ts
+++ b/cocos/ui/components/toggle-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { EventHandler as ComponentEventHandler, UITransformComponent } from '../../core/components';
-import { ccclass, help, requireComponent, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, requireComponent, executionOrder, menu, property, tooltip, displayOrder, type } from '../../core/data/class-decorator';
 import { ButtonComponent } from './button-component';
 import { SpriteComponent } from './sprite-component';
 import { ToggleContainerComponent } from './toggle-container-component';
@@ -65,9 +65,7 @@ export class ToggleComponent extends ButtonComponent {
      * @zh
      * 如果这个设置为 true，则 check mark 组件会处于 enabled 状态，否则处于 disabled 状态。
      */
-    @property({
-        displayOrder: 2,
-    })
+    @displayOrder(2)
     @tooltip('如果这个设置为 true，则 check mark 组件会处于 enabled 状态，否则处于 disabled 状态。')
     get isChecked () {
         return this._isChecked;
@@ -84,10 +82,8 @@ export class ToggleComponent extends ButtonComponent {
      * @zh
      * Toggle 处于选中状态时显示的图片。
      */
-    @property({
-        type: SpriteComponent,
-        displayOrder: 3,
-    })
+    @type(SpriteComponent)
+    @displayOrder(3)
     @tooltip('Toggle 处于选中状态时显示的精灵图片')
     get checkMark () {
         return this._checkMark;
@@ -124,9 +120,7 @@ export class ToggleComponent extends ButtonComponent {
      * @zh
      * Toggle 按钮的点击事件列表。
      */
-    @property({
-        type: [ComponentEventHandler],
-    })
+    @type([ComponentEventHandler])
     @tooltip('列表类型，默认为空，用户添加的每一个事件由节点引用，组件名称和一个响应函数组成')
     public checkEvents: ComponentEventHandler[] = [];
     @property

--- a/cocos/ui/components/toggle-container-component.ts
+++ b/cocos/ui/components/toggle-container-component.ts
@@ -29,7 +29,7 @@
  */
 
 import { Component, EventHandler as ComponentEventHandler } from '../../core/components';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, tooltip, type } from '../../core/data/class-decorator';
 import { ToggleComponent } from './toggle-component';
 import { legacyCC } from '../../core/global-exports';
 
@@ -78,9 +78,7 @@ export class ToggleContainerComponent extends Component {
      * @zh
      * Toggle 按钮的点击事件列表。
      */
-    @property({
-        type: [ComponentEventHandler],
-    })
+    @type([ComponentEventHandler])
     @tooltip('选中事件。列表类型，默认为空，用户添加的每一个事件由节点引用，组件名称和一个响应函数组成。')
     public checkEvents: ComponentEventHandler[] = [];
 

--- a/cocos/ui/components/ui-static-batch-component.ts
+++ b/cocos/ui/components/ui-static-batch-component.ts
@@ -30,7 +30,7 @@
 import { UIRenderComponent } from '../../core/components/ui-base/ui-render-component';
 import { UI } from '../../core/renderer/ui/ui';
 import { MeshBuffer } from '../../core/renderer/ui/mesh-buffer';
-import { ccclass, help, menu, executionOrder, property } from '../../core/data/class-decorator';
+import { ccclass, help, menu, executionOrder, property, visible, type, displayName, override } from '../../core/data/class-decorator';
 import { UIDrawBatch } from '../../core/renderer/ui/ui-draw-batch';
 import { director, Color, Material, warnID } from '../../core';
 import { vfmt } from '../../core/renderer/ui/ui-vertex-format';
@@ -57,10 +57,8 @@ import { GFXBlendFactor } from '../../core/gfx';
 @menu('UI/Render/UIStaticBatch')
 @executionOrder(110)
 export class UIStaticBatchComponent extends UIRenderComponent {
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     get dstBlendFactor () {
         return this._dstBlendFactor;
     }
@@ -74,10 +72,8 @@ export class UIStaticBatchComponent extends UIRenderComponent {
         this._updateBlendFunc();
     }
 
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     get srcBlendFactor () {
         return this._srcBlendFactor;
     }
@@ -91,10 +87,8 @@ export class UIStaticBatchComponent extends UIRenderComponent {
         this._updateBlendFunc();
     }
 
-    @property({
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @visible(false)
     get color (): Readonly<Color> {
         return this._color;
     }
@@ -109,12 +103,10 @@ export class UIStaticBatchComponent extends UIRenderComponent {
         this.markForUpdateRenderData();
     }
 
-    @property({
-        type: Material,
-        displayName: 'Materials',
-        visible: false,
-        override: true,
-    })
+    @override(true)
+    @type(Material)
+    @displayName('Materials')
+    @visible(false)
     get sharedMaterials () {
         return super.sharedMaterials;
     }

--- a/cocos/ui/components/widget-component.ts
+++ b/cocos/ui/components/widget-component.ts
@@ -30,7 +30,7 @@
 
 import { Component } from '../../core/components';
 import { UITransformComponent } from '../../core/components/ui-base/ui-transform-component';
-import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip } from '../../core/data/class-decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, property, requireComponent, tooltip, type, visible, editorOnly } from '../../core/data/class-decorator';
 import { Size, Vec3 } from '../../core/math';
 import { errorID, warnID } from '../../core/platform/debug';
 import { SystemEventType } from '../../core/platform/event-manager/event-enum';
@@ -219,9 +219,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 指定一个对齐目标，只能是当前节点的其中一个父节点，默认为空，为空时表示当前父节点。
      */
-    @property({
-        type: Node,
-    })
+    @type(Node)
     @tooltip('对齐目标')
     get target () {
         return this._target;
@@ -362,9 +360,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 当前是否水平拉伸。当同时启用左右对齐时，节点将会被水平拉伸。此时节点的宽度（只读）。
      */
-    @property({
-        visible: false,
-    })
+    @visible(false)
     get isStretchWidth () {
         return (this._alignFlags & LEFT_RIGHT) === LEFT_RIGHT;
     }
@@ -377,9 +373,7 @@ export class WidgetComponent extends Component {
      * @zh
      * 当前是否垂直拉伸。当同时启用上下对齐时，节点将会被垂直拉伸，此时节点的高度（只读）。
      */
-    @property({
-        visible: false,
-    })
+    @visible(false)
     get isStretchHeight () {
         return (this._alignFlags & TOP_BOT) === TOP_BOT;
     }
@@ -687,9 +681,7 @@ export class WidgetComponent extends Component {
      * widget.alignMode = Widget.AlignMode.ON_WINDOW_RESIZE;
      * ```
      */
-    @property({
-        type: AlignMode,
-    })
+    @type(AlignMode)
     @tooltip('指定 widget 的对齐方式，用于决定运行时 widget 应何时更新')
     get alignMode () {
         return this._alignMode;
@@ -757,9 +749,8 @@ export class WidgetComponent extends Component {
     private _originalHeight = 0;
     @property
     private _alignMode = AlignMode.ON_WINDOW_RESIZE;
-    @property({
-        editorOnly: true,
-    })
+    @property
+    @editorOnly(true)
     private _lockFlags = 0;
 
     /**


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Full optimize decorators.

In PR https://github.com/cocos-creator/engine/pull/7002 , we optimized decorator `@tooltip`. This PR continues that work.

The following decorators are added to replace options of `@property`:
| Decorator 	| Corresponding `@property` option 	| Marked as editor-only 	|
|-	|-	|-	|
| `@serializable(boolean)` 	| `.serializable` 	| ❌ 	|
| `@formerlySerializedAs(boolean)` 	| `.formerlySerializedAs` 	| ❌ 	|
| `@override(boolean)` 	| `.override` 	| ❌ 	|
| ❕`@readOnly(boolean)` 	| `.readonly` 	| ❌	|
| `@animatable(boolean)` 	| `.animatable` 	| ❌ 	|
| `@editorOnly(boolean)` 	| `.editorOnly` 	| ❌ 	|
| `@visible(boolean)` 	| `.visible` 	| ✔	|
| `@displayName(string)` 	| `.displayName` 	| ✔ 	|
| `@range([number, number] \| [number, number, number])` 	| `.range` 	| ✔	|
| ❕`@rangeMin(number)` 	| `.min` 	|✔	|
| ❕`@rangeMax(number)` 	| `.max` 	|✔	|
| ❕`@rangeStep(number)` 	| `.step` 	| ✔ 	|
| `@slide(boolean)` 	| `.slide` 	| ✔ 	|
| `@displayOrder(number)` 	| `.displayOrder` 	|✔ 	|
| `@unit(string)` 	| `.unit` 	| ✔ 	|
| `@radian(boolean)` 	| `.radian` 	| ✔ 	|
| `@multiline(boolean)` 	| `.multiline` 	| ✔ 	|

Decorator names prefixed with ❕ indicates the name is different from the option one:
1. - `readonly` is a TypeScript Keyword and may occur at where decoarators may occur;
2. - Words `min`, `max` are so common, so I advise to rename them; so the `step`.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
