### PR TITLE
Fix pass error when use dynamic defines.

### DIFF
--- a/cocos/core/renderer/core/pass.ts
+++ b/cocos/core/renderer/core/pass.ts
@@ -472,8 +472,7 @@ export class Pass {
         const pipeline = this._root.pipeline;
         if (!pipeline) { return null; }
         this._syncBatchingScheme();
-        const key = programLib.getKey(this._programName, this._defines);
-        this._hShaderDefault = programLib.getGFXShader(this._device, this._programName, this._defines, pipeline, key);
+        this._hShaderDefault = programLib.getGFXShader(this._device, this._programName, this._defines, pipeline);
         if (!this._hShaderDefault) { console.warn(`create shader ${this._programName} failed`); return false; }
         PassPool.set(this._handle, PassView.PIPELINE_LAYOUT, programLib.getPipelineLayout(this._programName).hPipelineLayout);
         PassPool.set(this._handle, PassView.HASH, Pass.getPassHash(this._handle, this._hShaderDefault));


### PR DESCRIPTION
getGFXShader 的时候会先设置 pipeline 的全局 defines 再获取 pass 的 hash，先执行 getKey 会导致动态更新的 defines 没有设置，取到的 hash 值还是旧的。