### PR TITLE
fix calculate final Position X bug for layout component

### DIFF
--- a/cocos/ui/components/layout-component.ts
+++ b/cocos/ui/components/layout-component.ts
@@ -905,7 +905,7 @@ export class LayoutComponent extends Component {
                 }
             }
 
-            const finalPositionX = fnPositionX(child, columnMaxWidth, column);
+            const finalPositionX = fnPositionX(child, childTrans, columnMaxWidth, column);
             if (baseHeight >= (childBoundingBoxHeight + (this._paddingTop + this._paddingBottom))) {
                 if (applyChildren) {
                     child.getPosition(_tempPos);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/4190

Changes:
 * fix calculate final Position X bug for layout component

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
