### PR TITLE
fix crash when no camera render EditBox

### DIFF
--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -316,13 +316,19 @@ Object.assign(WebEditBoxImpl.prototype, {
         }
         else {
             let camera = cc.Camera.findCamera(node);
+            if (!camera) {
+                return false;
+            }
             camera.getWorldToScreenMatrix2D(this._cameraMat);
             Mat4.mul(this._cameraMat, this._cameraMat, worldMat);
         }
+        return true;
     },
 
     _updateMatrix () {    
-        this._updateCameraMatrix();
+        if (CC_EDITOR || !this._updateCameraMatrix()) {
+            return;
+        }
         let cameraMatm = this._cameraMat.m;
         let node = this._delegate.node;
         let localView = cc.view;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/pull/6969

changeLog:
- fix crash when no camera render EditBox

update matrix is meaningless when no camera render EditBox,
so is it in the Editor Environment

relative commit:
https://github.com/cocos-creator-packages/adapters/pull/162
https://github.com/cocos-creator-packages/jsb-adapter/pull/332