### PR TITLE
修复在画面切换到下一帧之前就收到EventAfterDraw事件

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -864,9 +864,11 @@ cc.Director.prototype = {
         renderer.render(this._scene, deltaTime);
         
         // After draw
-        this.emit(cc.Director.EVENT_AFTER_DRAW);
+        setTimeout(function() {
+            this.emit(cc.Director.EVENT_AFTER_DRAW);
 
-        this._totalFrames++;
+            this._totalFrames++;
+        }.bind(this), 0);
 
     } : function (now) {
         if (this._purgeDirectorInNextLoop) {
@@ -905,10 +907,12 @@ cc.Director.prototype = {
             renderer.render(this._scene, this._deltaTime);
 
             // After draw
-            this.emit(cc.Director.EVENT_AFTER_DRAW);
+            setTimeout(function() {
+                this.emit(cc.Director.EVENT_AFTER_DRAW);
 
-            eventManager.frameUpdateListeners();
-            this._totalFrames++;
+                eventManager.frameUpdateListeners();
+                this._totalFrames++;
+            }.bind(this), 0);
         }
     },
 


### PR DESCRIPTION
发现当切换场景时，如果切换的场景有大量的图集资源在使用，会出现画面还卡在上一个场景的画面时就收到下一个场景的生命周期start和EventAfterDraw事件，因为渲染画面本身是异步执行的，所以希望能等画面切换到下一帧时再发送事件

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
