### PR TITLE
【再议】增加 refreshTexture 方法

### DIFF
--- a/cocos2d/core/assets/CCSpriteFrame.js
+++ b/cocos2d/core/assets/CCSpriteFrame.js
@@ -491,6 +491,33 @@ let SpriteFrame = cc.Class(/** @lends cc.SpriteFrame# */{
     },
 
     /**
+     * !#en Change or refresh SpriteFrame with Texture, rect, rotated, offset and originalSize.<br/>
+     * !#zh 运行时，改变 SpriteFrame 的 Texture，rect，rotated，offset 和 originalSize。该方法比 setTexture 更简单快捷。
+     * @method setTexture
+     * @param {Texture2D} texture
+     * @param {Rect} [rect=null]
+     * @param {Boolean} [rotated=false]
+     * @param {Vec2} [offset=cc.v2(0,0)]
+     * @param {Size} [originalSize=rect.size]
+     * @return {Boolean}
+     */
+    refreshTexture (texture, rect, rotated, offset, originalSize) {
+        if (rect) {
+            this._rect = rect;
+        }
+        if (rotated === true || rotated === false) {
+            this._rotated = rotated;
+        }
+        if (offset) {
+            this._offset = offset;
+        }
+        if (originalSize) {
+            this._originalSize = originalSize;
+        }
+        this._refreshTexture(texture);
+    },
+    
+    /**
      * !#en If a loading scene (or prefab) is marked as `asyncLoadAssets`, all the textures of the SpriteFrame which
      * associated by user's custom Components in the scene, will not preload automatically.
      * These textures will be load when Sprite component is going to render the SpriteFrames.


### PR DESCRIPTION
该方法主要用来在运行时 更方便的 更改 spriteframe内部的几个核心属性.

该方法比 setTexture 方法更简单快捷,  也能解决 setTexture  的如下问题:

* 当texture不变时,  无法正确触发 _calculateUV 方法
* setTexture更像是初始化方法, 会有很多额外计算.   比如  运行时, 当不传入 _rect时, 本意是 不改变_rect, 但是 setTexture 方法却选择初始化rect

总之 `setTexture` 更像是 `initWithTexture`  , cc代码里确实也有  ```proto.initWithTexture = proto.setTexture```
而我这个方法 更像是真正意义上的 setTexture.

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
