### PR TITLE
Correct the misspelling of TOUCH_MOVE.

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -491,7 +491,7 @@ Private node's zIndex can't be set, it will keep cc.macro.MIN_ZINDEX as its valu
 
 ### 1639
 
-cc.Action is not recommended to use, please use cc.Tween instead
+cc.Action is deprecated, please use cc.Tween instead
 
 ### 1700
 

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -491,7 +491,7 @@ Private node's zIndex can't be set, it will keep cc.macro.MIN_ZINDEX as its valu
 
 ### 1639
 
-cc.Action is deprecated, please use cc.TweenAction instead
+cc.Action is not recommended to use, please use cc.Tween instead
 
 ### 1700
 

--- a/cocos2d/core/components/CCButton.js
+++ b/cocos2d/core/components/CCButton.js
@@ -99,7 +99,7 @@ const State = cc.Enum({
  * 以下事件可以在全平台上都触发：
  * 
  *   - cc.Node.EventType.TOUCH_START  // 按下时事件
- *   - cc.Node.EventType.TOUCH_Move   // 按住移动后事件
+ *   - cc.Node.EventType.TOUCH_MOVE   // 按住移动后事件
  *   - cc.Node.EventType.TOUCH_END    // 按下后松开后事件
  *   - cc.Node.EventType.TOUCH_CANCEL // 按下取消事件
  * 


### PR DESCRIPTION
1. Correct the misspelling of `cc.Node.EventType.TOUCH_MOVE`. Re: https://github.com/cocos-creator/creator-api-docs/issues/178

2. Fix a prompt that replaces cc.Action with cc.Tween.