### PR TITLE
fix widget update when set content size

### DIFF
--- a/cocos2d/core/base-ui/CCWidgetManager.js
+++ b/cocos2d/core/base-ui/CCWidgetManager.js
@@ -465,7 +465,7 @@ var widgetManager = cc._widgetManager = module.exports = {
         }
         else {
             let thisOnResized = this.onResized.bind(this);
-            window.addEventListener('resize', thisOnResized);
+            cc.view.on('canvas-resize', thisOnResized);
             window.addEventListener('orientationchange', thisOnResized);
         }
     },


### PR DESCRIPTION
Re: https://forum.cocos.org/t/2-4-2-wiget-alignmode-always/97706/7

这样改动的原因是因为如果是监听了系统的 resize 的话，通过 setContentSize 修改的时候并不会，它只会触发 canvas-resize 事件，同时看了一下 CCView 也有去监听 resize 事件，所以干脆直接最终监听 view 的 canvas-resize 事件


Changes:
 * 修复 widget 设置为 ON_WINDOW_RESIZE， 当使用 setContentSize 时， 并没有没有重新更新

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
