### PR TITLE
Fix `js.setClassAlias` error

### DIFF
--- a/cocos/core/utils/js-typed.ts
+++ b/cocos/core/utils/js-typed.ts
@@ -529,11 +529,11 @@ export function setClassAlias (target: Function, alias: string) {
     const nameRegistry = _nameToClass[alias];
     const idRegistry = _idToClass[alias];
     let ok = true;
-    if (nameRegistry !== target) {
+    if (nameRegistry && nameRegistry !== target) {
         error(`"${alias}" has already been set as name or alias of another class.`);
         ok = false;
     }
-    if (idRegistry !== target) {
+    if (idRegistry && idRegistry !== target) {
         error(`"${alias}" has already been set as id or alias of another class.`);
         ok = false;
     }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Fix `js.setClassAlias` error

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
