### PR TITLE
Handle WebGL context lost event

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1848,3 +1848,7 @@ The sub-mesh contains %d vertices, which beyonds the capability (%d vertices mos
 ### 10002
 
 Sub-mesh may include at most %d morph targets, but you specified %d.
+
+### 11000
+
+WebGL context lost.

--- a/cocos/core/gfx/webgl/webgl-device.ts
+++ b/cocos/core/gfx/webgl/webgl-device.ts
@@ -803,6 +803,7 @@ export class WebGLDevice extends GFXDevice {
     private _onWebGLContextLost (event: Event) {
         warnID(11000);
         warn(event);
-        event.preventDefault();
+        // 2020.9.3: `preventDefault` is not available on some platforms
+        // event.preventDefault();
     }
 }

--- a/cocos/core/gfx/webgl2/webgl2-device.ts
+++ b/cocos/core/gfx/webgl2/webgl2-device.ts
@@ -695,6 +695,7 @@ export class WebGL2Device extends GFXDevice {
     private _onWebGLContextLost (event: Event) {
         warnID(11000);
         warn(event);
-        event.preventDefault();
+        // 2020.9.3: `preventDefault` is not available on some platforms
+        // event.preventDefault();
     }
 }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * This PR lets both the `WebGLDevice` and `WebGL2Device` simply handle the WebGL context lost event.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
