### PR TITLE
support new SubContextView

### DIFF
--- a/@types/global-adapter.d.ts
+++ b/@types/global-adapter.d.ts
@@ -1,3 +1,4 @@
 declare namespace __globalAdapter {
     function getOpenDataContext (): any;
+    function getSystemInfoSync (): any;
 }

--- a/cocos/core/platform/SubContextView.ts
+++ b/cocos/core/platform/SubContextView.ts
@@ -192,7 +192,8 @@ export class SubContextView extends Component {
         let height = systemInfo.screenHeight * (box.height / visibleSize.height);
 
         this._openDataContext.postMessage({
-            fromEngine: true,
+            fromEngine: true,  // compatible deprecated property
+            type: 'engine',
             event: 'viewport',
             x, y,
             width, height,

--- a/cocos/core/platform/SubContextView.ts
+++ b/cocos/core/platform/SubContextView.ts
@@ -126,7 +126,6 @@ export class SubContextView extends Component {
 
     public onEnable () {
         this._registerNodeEvent();
-        // this._updateSubContextViewport();
     }
 
     public onDisable () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/3766

changeLog:
- reimplement SubContextView component for new Canvas Engine

the subcontext template here:
https://github.com/cocos-creator-packages/adapters/pull/165

editor builder support:
https://github.com/cocos-creator/editor-3d/pull/4154

<img width="572" alt="WX20200904-104944@2x" src="https://user-images.githubusercontent.com/17872773/92194069-5c5b0800-ee9c-11ea-904b-7fcb046b550b.png">

## Use SHOW_ALL policy to avoid stretching the sharedCanvas 
Node with subContextView component is a container, a private node is implemented to render the sharedCanvas

<img width="562" alt="WX20200904-111545@2x" src="https://user-images.githubusercontent.com/17872773/92195632-07b98c00-eea0-11ea-8344-894cf6bcc5ca.png">

<img width="318" alt="WX20200904-114309@2x" src="https://user-images.githubusercontent.com/17872773/92197257-d478fc00-eea3-11ea-9f92-592561075bf0.png">
