### PR TITLE
auto stop tween when target was destroyed

### DIFF
--- a/cocos/tween/actions/action-manager.ts
+++ b/cocos/tween/actions/action-manager.ts
@@ -32,7 +32,7 @@
 import * as js from '../../core/utils/js';
 import { errorID, logID, assertID } from '../../core/platform/debug';
 import { Action } from './action';
-import { Node } from '../../core';
+import { Node, CCObject } from '../../core';
 import { legacyCC } from '../../core/global-exports';
 
 let ID_COUNTER = 0;
@@ -432,6 +432,14 @@ export class ActionManager {
         for (var elt = 0; elt < locTargets.length; elt++) {
             this._currentTarget = locTargets[elt];
             locCurrTarget = this._currentTarget;
+
+            let target = locCurrTarget.target;
+            if (target instanceof CCObject && !target.isValid) {
+                this.removeAllActionsFromTarget(target as any);
+                elt--;
+                continue;
+            }
+
             if (!locCurrTarget.paused && locCurrTarget.actions) {
                 locCurrTarget.lock = true;
                 // The 'actions' CCMutableArray may change while inside this loop.

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -3,7 +3,7 @@
  */
 
 import { TweenSystem } from './tween-system';
-import { warn, Node, SystemEventType } from '../core';
+import { warn } from '../core';
 import { ActionInterval, sequence, repeat, repeatForever, reverseTime, delayTime, spawn } from './actions/action-interval';
 import { removeSelf, show, hide, callFunc } from './actions/action-instant';
 import { Action } from './actions/action';
@@ -35,9 +35,6 @@ export class Tween {
 
     constructor (target?: object | null) {
         this._target = target === undefined ? null : target;
-        if (this._target && this._target instanceof Node) {
-            this._target.on(SystemEventType.NODE_DESTROYED, this._destroy, this);
-        }
     }
 
     /**
@@ -78,15 +75,7 @@ export class Tween {
      * @return {Tween}
      */
     target (target: object | null): Tween {
-        if (this._target && this._target instanceof Node) {
-            this._target.off(SystemEventType.NODE_DESTROYED, this._destroy, this);
-        }
-
         this._target = target;
-
-        if (this._target && this._target instanceof Node) {
-            this._target.on(SystemEventType.NODE_DESTROYED, this._destroy, this);
-        }
         return this;
     }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * auto stop tween when target was destroyed

现在只处理了 target 是 node 的情况，这个方法可以支持 target 是 CCObject 的情况