### PR TITLE
fix audio can't play

### DIFF
--- a/cocos2d/core/components/CCAudioSource.js
+++ b/cocos2d/core/components/CCAudioSource.js
@@ -254,9 +254,6 @@ var AudioSource = cc.Class({
         if ( !this._clip ) return;
 
         var audio = this.audio;
-        if (this._clip.loaded) {
-            audio.stop();
-        }
         audio.setVolume(this._mute ? 0 : this._volume);
         audio.setLoop(this._loop);
         audio.setCurrentTime(0);


### PR DESCRIPTION
resolve:
https://github.com/cocos-creator/2d-tasks/issues/3071
https://github.com/cocos-creator/2d-tasks/issues/3078

Changes:
- 修复音频不能播放的问题

在 AudioSource 的 play 操作里进行 stop 是多余的
猜测平台底层实现，在音频加载完成之前的请求没有做排队，导致 stop 后 play , 在加载完成后没有播放
![WechatIMG40](https://user-images.githubusercontent.com/17872773/92562367-6fa91180-f2a8-11ea-977f-3cc9cb54ef55.jpeg)
