### PR TITLE
 fix click video player callback use isPlaying when the pause invalid

### DIFF
--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -315,12 +315,6 @@ let VideoPlayerImpl = cc.Class({
     },
 
     isPlaying: function () {
-        let video = this._video;
-        if (VideoPlayerImpl._polyfill.autoplayAfterOperation && this._playing) {
-            setTimeout(function () {
-                video.play();
-            }, 20);
-        }
         return this._playing;
     },
 

--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -251,16 +251,7 @@ let VideoPlayerImpl = cc.Class({
     play: function () {
         let video = this._video;
         if (!video || !this._visible || this._playing) return;
-
-        if (VideoPlayerImpl._polyfill.autoplayAfterOperation) {
-            let self = this;
-            setTimeout(function () {
-                video.play();
-            }, 20);
-        }
-        else {
-            video.play();
-        }
+        video.play();
     },
 
     pause: function () {
@@ -306,11 +297,6 @@ let VideoPlayerImpl = cc.Class({
                 video.removeEventListener(VideoPlayerImpl._polyfill.event, cb);
             };
             video.addEventListener(VideoPlayerImpl._polyfill.event, cb);
-        }
-        if (VideoPlayerImpl._polyfill.autoplayAfterOperation && this.isPlaying()) {
-            setTimeout(function () {
-                video.play();
-            }, 20);
         }
     },
 
@@ -581,10 +567,6 @@ if (dom.canPlayType) {
     if (dom.canPlayType("video/webm")) {
         VideoPlayerImpl._polyfill.canPlayType.push(".webm");
     }
-}
-
-if (sys.browserType === sys.BROWSER_TYPE_FIREFOX) {
-    VideoPlayerImpl._polyfill.autoplayAfterOperation = true;
 }
 
 if (


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/3129

Changes:
 * 修复如果在 click 视频回调的时候使用了 isPlaying 会导致 pause 无效 （我发现这个代码很魔幻，为什么我在获取播放状态的时候还要去 play 它，奇怪的知识有增加了）

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
