### PR TITLE
Bump rollup; @cocos/build-engine 3.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1314,9 +1314,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-3.0.5.tgz?cache=0&sync_timestamp=1598516436331&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40cocos%2Fbuild-engine%2Fdownload%2F%40cocos%2Fbuild-engine-3.0.5.tgz",
-      "integrity": "sha1-u0PCychOCAZi8pDLpxmrhuolrHg=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-3.0.6.tgz?cache=0&sync_timestamp=1600154923095&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40cocos%2Fbuild-engine%2Fdownload%2F%40cocos%2Fbuild-engine-3.0.6.tgz",
+      "integrity": "sha1-RPci6c0ZX2BR80L7Wp7t6f5NxoM=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -1331,7 +1331,7 @@
         "@rollup/plugin-virtual": "^2.0.1",
         "fs-extra": "^8.1.0",
         "resolve": "^1.17.0",
-        "rollup": "^1.29.0",
+        "rollup": "^2.26.11",
         "rollup-plugin-progress": "^1.1.1",
         "rollup-plugin-terser": "^5.2.0",
         "yargs": "^15.1.0"
@@ -1476,13 +1476,13 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz?cache=0&sync_timestamp=1599868278022&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fy18n%2Fdownload%2Fy18n-4.0.0.tgz",
           "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
           "dev": true
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1598505705729&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1599709346664&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
           "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
           "dev": true,
           "requires": {
@@ -1878,9 +1878,9 @@
       }
     },
     "@rollup/plugin-babel": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-babel/download/@rollup/plugin-babel-5.2.0.tgz",
-      "integrity": "sha1-uHVW1h7RCLTq+dGLUyOWWt+Nm+4=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-babel/download/@rollup/plugin-babel-5.2.1.tgz",
+      "integrity": "sha1-IPyPiGTcDqocVXhAhFlgaAj3KSQ=",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -1903,9 +1903,9 @@
           "dev": true
         },
         "@babel/types": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npm.taobao.org/@babel/types/download/@babel/types-7.11.0.tgz?cache=0&sync_timestamp=1596144714487&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Ftypes%2Fdownload%2F%40babel%2Ftypes-7.11.0.tgz",
-          "integrity": "sha1-Kua/G6mujDxDgk5YYSaYcbIG6Q0=",
+          "version": "7.11.5",
+          "resolved": "https://registry.npm.taobao.org/@babel/types/download/@babel/types-7.11.5.tgz?cache=0&sync_timestamp=1598904272861&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Ftypes%2Fdownload%2F%40babel%2Ftypes-7.11.5.tgz",
+          "integrity": "sha1-2d5XfQElLXfGgAzuA57mT691Zi0=",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
@@ -1923,7 +1923,7 @@
     },
     "@rollup/plugin-commonjs": {
       "version": "11.1.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-11.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-11.1.0.tgz?cache=0&sync_timestamp=1597326192868&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fplugin-commonjs%2Fdownload%2F%40rollup%2Fplugin-commonjs-11.1.0.tgz",
       "integrity": "sha1-YGNsenIvVLQeQZ4XCd8FxyNFV+8=",
       "dev": true,
       "requires": {
@@ -1947,7 +1947,7 @@
     },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-node-resolve/download/@rollup/plugin-node-resolve-7.1.3.tgz?cache=0&sync_timestamp=1594594969145&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fplugin-node-resolve%2Fdownload%2F%40rollup%2Fplugin-node-resolve-7.1.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-node-resolve/download/@rollup/plugin-node-resolve-7.1.3.tgz?cache=0&sync_timestamp=1597328884850&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fplugin-node-resolve%2Fdownload%2F%40rollup%2Fplugin-node-resolve-7.1.3.tgz",
       "integrity": "sha1-gN44Tt+9e/yRARZJEPhgeBUaPso=",
       "dev": true,
       "requires": {
@@ -1966,7 +1966,7 @@
     },
     "@rollup/pluginutils": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/pluginutils/download/@rollup/pluginutils-3.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-3.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@rollup/pluginutils/download/@rollup/pluginutils-3.1.0.tgz?cache=0&sync_timestamp=1597328386643&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-3.1.0.tgz",
       "integrity": "sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=",
       "dev": true,
       "requires": {
@@ -2030,7 +2030,7 @@
     },
     "@types/estree": {
       "version": "0.0.39",
-      "resolved": "https://registry.npm.taobao.org/@types/estree/download/@types/estree-0.0.39.tgz?cache=0&sync_timestamp=1584727775273&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Festree%2Fdownload%2F%40types%2Festree-0.0.39.tgz",
+      "resolved": "https://registry.npm.taobao.org/@types/estree/download/@types/estree-0.0.39.tgz",
       "integrity": "sha1-4Xfmme4bjCLSMXTKqnQiZEOJUJ8=",
       "dev": true
     },
@@ -2097,7 +2097,7 @@
     },
     "@types/resolve": {
       "version": "0.0.8",
-      "resolved": "https://registry.npm.taobao.org/@types/resolve/download/@types/resolve-0.0.8.tgz",
+      "resolved": "https://registry.npm.taobao.org/@types/resolve/download/@types/resolve-0.0.8.tgz?cache=0&sync_timestamp=1596840738717&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fresolve%2Fdownload%2F%40types%2Fresolve-0.0.8.tgz",
       "integrity": "sha1-8mB00jjgJlnjI84aE9BB7uKA4ZQ=",
       "dev": true,
       "requires": {
@@ -2216,12 +2216,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npm.taobao.org/abab/download/abab-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fabab%2Fdownload%2Fabab-2.0.1.tgz",
       "integrity": "sha1-P6F3lwMrcUEOw3LhFmj0tP/IaoI=",
-      "dev": true
-    },
-    "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-7.4.0.tgz?cache=0&sync_timestamp=1596457241712&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.0.tgz",
-      "integrity": "sha1-4a1IbmxUUBY0xsOXxcEh2qODYHw=",
       "dev": true
     },
     "acorn-globals": {
@@ -4159,7 +4153,7 @@
     },
     "find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-4.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-4.1.0.tgz?cache=0&sync_timestamp=1597169795121&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffind-up%2Fdownload%2Ffind-up-4.1.0.tgz",
       "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "requires": {
@@ -7856,7 +7850,7 @@
     },
     "p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-4.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-4.1.0.tgz?cache=0&sync_timestamp=1597081369770&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fp-locate%2Fdownload%2Fp-locate-4.1.0.tgz",
       "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "requires": {
@@ -8293,6 +8287,15 @@
       "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.taobao.org/randombytes/download/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-16.9.0.tgz",
@@ -8714,14 +8717,21 @@
       }
     },
     "rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-1.32.1.tgz",
-      "integrity": "sha1-RIDlLZ2eKuS0a6DZ3erzFjlA+cQ=",
+      "version": "2.26.11",
+      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.11.tgz?cache=0&sync_timestamp=1599542640482&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.11.tgz",
+      "integrity": "sha1-T8Md6ce4PVCRb8g5X4w9JHMM2q4=",
       "dev": true,
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
+        "fsevents": "~2.1.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npm.taobao.org/fsevents/download/fsevents-2.1.3.tgz?cache=0&sync_timestamp=1588787369955&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffsevents%2Fdownload%2Ffsevents-2.1.3.tgz",
+          "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "rollup-plugin-progress": {
@@ -8734,15 +8744,15 @@
       }
     },
     "rollup-plugin-terser": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npm.taobao.org/rollup-plugin-terser/download/rollup-plugin-terser-5.3.0.tgz",
-      "integrity": "sha1-nA3TPVdx35YwzQJ9aiVZGH9liF4=",
+      "version": "5.3.1",
+      "resolved": "https://registry.npm.taobao.org/rollup-plugin-terser/download/rollup-plugin-terser-5.3.1.tgz?cache=0&sync_timestamp=1599267952414&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup-plugin-terser%2Fdownload%2Frollup-plugin-terser-5.3.1.tgz",
+      "integrity": "sha1-jGUAYsIqhCbGQmhUiVdGO/mBtBM=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "jest-worker": "^24.9.0",
         "rollup-pluginutils": "^2.8.2",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "terser": "^4.6.2"
       }
     },
@@ -8847,10 +8857,13 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/serialize-javascript/download/serialize-javascript-2.1.2.tgz?cache=0&sync_timestamp=1581860503528&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fserialize-javascript%2Fdownload%2Fserialize-javascript-2.1.2.tgz",
-      "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npm.taobao.org/serialize-javascript/download/serialize-javascript-4.0.0.tgz?cache=0&sync_timestamp=1599740689479&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fserialize-javascript%2Fdownload%2Fserialize-javascript-4.0.0.tgz",
+      "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -9406,7 +9419,7 @@
     },
     "terser": {
       "version": "4.8.0",
-      "resolved": "https://registry.npm.taobao.org/terser/download/terser-4.8.0.tgz?cache=0&sync_timestamp=1596288789413&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fterser%2Fdownload%2Fterser-4.8.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/terser/download/terser-4.8.0.tgz",
       "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
       "dev": true,
       "requires": {
@@ -9660,13 +9673,13 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz?cache=0&sync_timestamp=1599348641853&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fy18n%2Fdownload%2Fy18n-4.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz",
           "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
           "dev": true
         },
         "yargs": {
           "version": "13.3.2",
-          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-13.3.2.tgz?cache=0&sync_timestamp=1599709346664&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-13.3.2.tgz",
+          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-13.3.2.tgz?cache=0&sync_timestamp=1597809594304&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-13.3.2.tgz",
           "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
           "dev": true,
           "requires": {
@@ -9684,7 +9697,7 @@
         },
         "yargs-parser": {
           "version": "13.1.2",
-          "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-13.1.2.tgz?cache=0&sync_timestamp=1599672404544&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-13.1.2.tgz",
+          "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-13.1.2.tgz?cache=0&sync_timestamp=1596945842652&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-13.1.2.tgz",
           "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.1.0",
-    "@cocos/build-engine": "3.0.5",
+    "@cocos/build-engine": "3.0.6",
     "@cocos/typedoc-plugin-internal-external": "^1.0.0",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1258,11 +1258,6 @@
       "resolved": "https://registry.npm.taobao.org/@types/color-name/download/@types/color-name-1.1.1.tgz",
       "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA="
     },
-    "@types/estree": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npm.taobao.org/@types/estree/download/@types/estree-0.0.42.tgz",
-      "integrity": "sha1-jQwfSAM57+2z5GBw4i3WPgQw3RE="
-    },
     "@types/fs-extra": {
       "version": "8.0.1",
       "resolved": "https://registry.npm.taobao.org/@types/fs-extra/download/@types/fs-extra-8.0.1.tgz",
@@ -1300,11 +1295,6 @@
       "resolved": "https://registry.npm.taobao.org/@types/yargs-parser/download/@types/yargs-parser-15.0.0.tgz",
       "integrity": "sha1-yz+fdBhp4gzOMw/765JxWQSDiC0=",
       "dev": true
-    },
-    "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-7.1.0.tgz?cache=0&sync_timestamp=1574806921127&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.1.0.tgz",
-      "integrity": "sha1-lJ028sKSU12mAig1hsJHfFfrLWw="
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -1490,6 +1480,12 @@
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npm.taobao.org/fsevents/download/fsevents-2.1.3.tgz?cache=0&sync_timestamp=1588787369955&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffsevents%2Fdownload%2Ffsevents-2.1.3.tgz",
+      "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1887,13 +1883,11 @@
       }
     },
     "rollup": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-1.29.0.tgz?cache=0&sync_timestamp=1578478901756&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-1.29.0.tgz",
-      "integrity": "sha1-ahp57qQ8qdPXmpDBWhzuztxyCXs=",
+      "version": "2.26.11",
+      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.11.tgz?cache=0&sync_timestamp=1599542640482&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.11.tgz",
+      "integrity": "sha1-T8Md6ce4PVCRb8g5X4w9JHMM2q4=",
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
+        "fsevents": "~2.1.2"
       }
     },
     "rollup-plugin-progress": {

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {
@@ -16,7 +16,7 @@
     "@rollup/plugin-virtual": "^2.0.1",
     "fs-extra": "^8.1.0",
     "resolve": "^1.17.0",
-    "rollup": "^1.29.0",
+    "rollup": "^2.26.11",
     "rollup-plugin-progress": "^1.1.1",
     "rollup-plugin-terser": "^5.2.0",
     "yargs": "^15.1.0"
@@ -33,7 +33,8 @@
     "typescript": "^3.7.2"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "prepublish": "npm run build"
   },
   "author": "",
   "license": "MIT"

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -263,9 +263,9 @@ async function _doBuild ({
         babelHelpers: 'bundled',
         extensions: ['.js', '.ts'],
         highlightCode: true,
-        ignore: [
-            ps.join(options.engine, 'node_modules/@cocos/ammo/**'),
-            ps.join(options.engine, 'node_modules/@cocos/cannon/**'),
+        exclude: [
+            /@cocos[\/\\]ammo/g,
+            /@cocos[\/\\]cannon/g
         ],
         plugins: babelPlugins,
         presets: [


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Bump rollup to fix export alias issue; Bump @cocos/build-engine at 3.0.6

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
