### PR TITLE
Bump rollup@2.26.6(fixed); bump @cocos/build-engine@3.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1314,9 +1314,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-3.0.6.tgz?cache=0&sync_timestamp=1600154923095&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40cocos%2Fbuild-engine%2Fdownload%2F%40cocos%2Fbuild-engine-3.0.6.tgz",
-      "integrity": "sha1-RPci6c0ZX2BR80L7Wp7t6f5NxoM=",
+      "version": "3.0.8",
+      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-3.0.8.tgz?cache=0&sync_timestamp=1600163867028&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40cocos%2Fbuild-engine%2Fdownload%2F%40cocos%2Fbuild-engine-3.0.8.tgz",
+      "integrity": "sha1-Sae63bY/DQ5vG+IcgQ5Iq8MgP1A=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -1331,7 +1331,7 @@
         "@rollup/plugin-virtual": "^2.0.1",
         "fs-extra": "^8.1.0",
         "resolve": "^1.17.0",
-        "rollup": "^2.26.11",
+        "rollup": "2.26.6",
         "rollup-plugin-progress": "^1.1.1",
         "rollup-plugin-terser": "^5.2.0",
         "yargs": "^15.1.0"
@@ -8717,9 +8717,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.11",
-      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.11.tgz?cache=0&sync_timestamp=1599542640482&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.11.tgz",
-      "integrity": "sha1-T8Md6ce4PVCRb8g5X4w9JHMM2q4=",
+      "version": "2.26.6",
+      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.6.tgz?cache=0&sync_timestamp=1599542640482&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.6.tgz",
+      "integrity": "sha1-C0YMHaIkxq8SoelIooxROqEfK5M=",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.1.0",
-    "@cocos/build-engine": "3.0.6",
+    "@cocos/build-engine": "3.0.8",
     "@cocos/typedoc-plugin-internal-external": "^1.0.0",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "3.0.6",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1883,9 +1883,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.11",
-      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.11.tgz?cache=0&sync_timestamp=1599542640482&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.11.tgz",
-      "integrity": "sha1-T8Md6ce4PVCRb8g5X4w9JHMM2q4=",
+      "version": "2.26.6",
+      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.6.tgz?cache=0&sync_timestamp=1599542640482&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.6.tgz",
+      "integrity": "sha1-C0YMHaIkxq8SoelIooxROqEfK5M=",
       "requires": {
         "fsevents": "~2.1.2"
       }

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "3.0.6",
+  "version": "3.0.8",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {
@@ -16,7 +16,7 @@
     "@rollup/plugin-virtual": "^2.0.1",
     "fs-extra": "^8.1.0",
     "resolve": "^1.17.0",
-    "rollup": "^2.26.11",
+    "rollup": "2.26.6",
     "rollup-plugin-progress": "^1.1.1",
     "rollup-plugin-terser": "^5.2.0",
     "yargs": "^15.1.0"


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Bump `@cocos/build-engine@3.0.8`: lock `rollup@2.26.6`. See https://github.com/rollup/rollup/issues/3780 for reason.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
