### PR TITLE
fix prefab revert problem for render component

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -196,8 +196,6 @@ let Label = cc.Class({
     },
 
     properties: {
-        _useOriginalSize: true,
-        
         /**
          * !#en Content string of label.
          * !#zh 标签显示的文本内容。


### PR DESCRIPTION
Remove ununsed property to ensure prefab could be revert utterly