### PR TITLE
Fixed mesh sprite can't support flipX and fixY

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/mesh.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/mesh.js
@@ -117,6 +117,16 @@ export default class MeshSpriteAssembler extends Assembler2D {
                 local[offset + 1] = (originalHeight - y[i] - trimY) * scaleY - appy;
             }
         }
+        if (frame._flipX) {
+            for (let i = 0, l = this.verticesCount; i < l; i++) {
+                local[i * 2] =  - local[i * 2];
+            }
+        }
+        if (frame._flipY) {
+            for (let i = 0, l = this.verticesCount; i < l; i++) {
+                local[i * 2 + 1] =  - local[i * 2 + 1];
+            }
+        }
     }
 
     updateWorldVerts (sprite) {

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/mesh.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/mesh.js
@@ -119,12 +119,12 @@ export default class MeshSpriteAssembler extends Assembler2D {
         }
         if (frame._flipX) {
             for (let i = 0, l = this.verticesCount; i < l; i++) {
-                local[i * 2] =  - local[i * 2];
+                local[i * 2] = contentWidth - local[i * 2] - 2 * appx;
             }
         }
         if (frame._flipY) {
             for (let i = 0, l = this.verticesCount; i < l; i++) {
-                local[i * 2 + 1] =  - local[i * 2 + 1];
+                local[i * 2 + 1] = contentHeight - local[i * 2 + 1] - 2 * appy;
             }
         }
     }


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * Fixed mesh sprite can't support flipX and fixY