### PR TITLE
Optimize morph rendering

### DIFF
--- a/cocos/core/pipeline/define.ts
+++ b/cocos/core/pipeline/define.ts
@@ -369,6 +369,8 @@ export class UBOMorph {
 
     public static readonly OFFSET_OF_DISPLACEMENT_TEXTURE_HEIGHT = UBOMorph.OFFSET_OF_DISPLACEMENT_TEXTURE_WIDTH + 4;
 
+    public static readonly OFFSET_OF_VERTICES_COUNT = UBOMorph.OFFSET_OF_DISPLACEMENT_TEXTURE_HEIGHT + 4;
+
     public static readonly COUNT_BASE_4_BYTES = 4 * Math.ceil(UBOMorph.MAX_MORPH_TARGET_COUNT / 4) + 4;
 
     public static readonly SIZE = UBOMorph.COUNT_BASE_4_BYTES * 4;

--- a/editor/assets/chunks/morph.chunk
+++ b/editor/assets/chunks/morph.chunk
@@ -84,9 +84,9 @@ vec3 getVec3DisplacementFromTexture(sampler2D tex, int vertexIndex) {
     return fetchVec3ArrayFromTexture(tex, vertexIndex).rgb;
 #else
     vec3 result = vec3(0, 0, 0);
+    int nVertices = int(cc_displacementTextureInfo.z);
     for (int iTarget = 0; iTarget < CC_MORPH_TARGET_COUNT; ++iTarget) {
-        int dataPixelStart = int(fetchVec3ArrayFromTexture(tex, iTarget).r);
-        result += (fetchVec3ArrayFromTexture(tex, dataPixelStart + vertexIndex).rgb * getDisplacementWeight(iTarget));
+        result += (fetchVec3ArrayFromTexture(tex, nVertices * iTarget + vertexIndex).rgb * getDisplacementWeight(iTarget));
     }
     return result;
 #endif


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Do not sample `dataPixelStart`(https://github.com/cocos-creator/engine/pull/7436/files#diff-35b2158819cd4a28c3c9771b5ec390cbL88) from texture but simply calculate it.

Note, this optimization also fix some morph rendering errors on iOS(Safari, WebGL 1) caused by sampling big integer `dataPixelStart`s from texture(even texture float is enabled) encountered integer precision error.

For example, `dataPixelStart`s of model https://github.com/cocos-creator/test-cases-3d/tree/v1.2/assets/cases/animation/morph/morph_head are:
```
0: 10.5     ✔️
1: 403.5    ✔️
2: 796.5    ✔️
3: 1189.5   ❌
4: 1582.5   ✔️
5: 1975.5   ❌
6: 2368.5   ✔️
7: 2761.5   ❌
8: 3154.5   ✔️
9: 3547.5   ❌
```

Starting from 3, exceeds the `mediump` precision limit `2^10`:

![image](https://user-images.githubusercontent.com/28807867/93847471-94a27900-fcd9-11ea-8286-5a7eb81d034c.png)

You may prove this by attach `highp` precision specifier to `cc_PositionDisplacements`, you should see it works fine.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
