### PR TITLE
fix set font size invalid in rich text

### DIFF
--- a/cocos/ui/components/rich-text.ts
+++ b/cocos/ui/components/rich-text.ts
@@ -1083,9 +1083,7 @@ export class RichText extends UIComponent {
                 labelOutline.width = textStyle.outline.width;
             }
 
-            if (textStyle.size) {
-                label.fontSize = textStyle.size;
-            }
+            label.fontSize = textStyle.size || this._fontSize;
 
             labelSeg.clickHandler = '';
             labelSeg.clickParam = '';


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * fix set font size invalid in rich text