### PR TITLE
fix calculate delta time bug

### DIFF
--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -1000,7 +1000,7 @@ export class Director extends EventTarget {
         }
         else if (!this._invalid) {
             // calculate "global" dt
-            if (!EDITOR) {
+            if (!EDITOR || legacyCC.GAME_VIEW) {
                 this.calculateDeltaTime(time);
             }
             const dt = this._deltaTime;

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -1000,7 +1000,9 @@ export class Director extends EventTarget {
         }
         else if (!this._invalid) {
             // calculate "global" dt
-            this.calculateDeltaTime(time);
+            if (!EDITOR) {
+                this.calculateDeltaTime(time);
+            }
             const dt = this._deltaTime;
 
             // Update


### PR DESCRIPTION
there is no need to calculate Delta Time under the editor.

Re: cocos-creator/2d-tasks#

Changes:
 * there is no need to calculate Delta Time under the editor. 
