### PR TITLE
fixed tiled sprite can not rotate

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -267,38 +267,40 @@ export default class TiledAssembler extends Assembler2D {
 
                 if (rotated) {
                     if (yindex === 0) {
-                        tempYVerts[0] = uvSliced[0].u;
-                        tempYVerts[1] = uvSliced[0].u;
-                        tempYVerts[2] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
-                    } else if (yindex > 0 && yindex < (row - 1)) {
-                        tempYVerts[0] = uvSliced[4].u;
-                        tempYVerts[1] = uvSliced[4].u;
-                        tempYVerts[2] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
+                        tempXVerts[0] = uvSliced[0].u;
+                        tempXVerts[1] = uvSliced[0].u;
+                        tempXVerts[2] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
+                    } else if (yindex < (row - 1)) {
+                        tempXVerts[0] = uvSliced[4].u;
+                        tempXVerts[1] = uvSliced[4].u;
+                        tempXVerts[2] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
                     } else if (yindex === (row - 1)) {
-                        tempYVerts[0] = uvSliced[8].u;
-                        tempYVerts[1] = uvSliced[8].u;
-                        tempYVerts[2] = uvSliced[12].u;
+                        tempXVerts[0] = uvSliced[8].u;
+                        tempXVerts[1] = uvSliced[8].u;
+                        tempXVerts[2] = uvSliced[12].u;
                     }
                     if (xindex === 0) {
-                        tempXVerts[0] = uvSliced[0].v;
-                        tempXVerts[1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
-                        tempXVerts[2] = uvSliced[0].v;
-                    } else if (xindex > 0 && xindex < (col - 1)) {
-                        tempXVerts[0] = uvSliced[1].v;
-                        tempXVerts[1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
-                        tempXVerts[2] = uvSliced[1].v;
+                        tempYVerts[0] = uvSliced[0].v;
+                        tempYVerts[1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
+                        tempYVerts[2] = uvSliced[0].v;
+                    } else if (xindex < (col - 1)) {
+                        tempYVerts[0] = uvSliced[1].v;
+                        tempYVerts[1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
+                        tempYVerts[2] = uvSliced[1].v;
                     } else if (xindex === (col - 1)) {
-                        tempXVerts[0] = uvSliced[2].v;
-                        tempXVerts[1] = uvSliced[3].v;
-                        tempXVerts[2] = uvSliced[2].v;
+                        tempYVerts[0] = uvSliced[2].v;
+                        tempYVerts[1] = uvSliced[3].v;
+                        tempYVerts[2] = uvSliced[2].v;
                     }
+                    tempXVerts[3] = tempXVerts[2];
+                    tempYVerts[3] = tempYVerts[1];
                 }
                 else {
                     if (xindex === 0) {
                         tempXVerts[0] = uvSliced[0].u;
                         tempXVerts[1] = uvSliced[1].u + (uvSliced[2].u - uvSliced[1].u) * coefu;
                         tempXVerts[2] = uv[0];
-                    } else if (xindex > 0 && xindex < (col - 1)) {
+                    } else if (xindex < (col - 1)) {
                         tempXVerts[0] = uvSliced[1].u;
                         tempXVerts[1] = uvSliced[1].u + (uvSliced[2].u - uvSliced[1].u) * coefu;
                         tempXVerts[2] = uvSliced[1].u;
@@ -311,7 +313,7 @@ export default class TiledAssembler extends Assembler2D {
                         tempYVerts[0] = uvSliced[0].v;
                         tempYVerts[1] = uvSliced[0].v;
                         tempYVerts[2] = uvSliced[4].v + (uvSliced[8].v - uvSliced[4].v) * coefv;
-                    } else if (yindex > 0 && yindex < (row - 1)) {
+                    } else if (yindex < (row - 1)) {
                         tempYVerts[0] = uvSliced[4].v;
                         tempYVerts[1] = uvSliced[4].v;
                         tempYVerts[2] = uvSliced[4].v + (uvSliced[8].v - uvSliced[4].v) * coefv;
@@ -320,6 +322,8 @@ export default class TiledAssembler extends Assembler2D {
                         tempYVerts[1] = uvSliced[8].v;
                         tempYVerts[2] = uvSliced[12].v;
                     }
+                    tempXVerts[3] = tempXVerts[1];
+                    tempYVerts[3] = tempYVerts[2];
                 }
                 // lb
                 verts[uvOffset] = tempXVerts[0];
@@ -334,13 +338,8 @@ export default class TiledAssembler extends Assembler2D {
                 verts[uvOffset + 1] = tempYVerts[2];
                 uvOffset += floatsPerVert;
                 // rt
-                if (rotated) {
-                    verts[uvOffset] = verts[uvOffset - floatsPerVert];
-                    verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
-                } else {
-                    verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
-                    verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
-                }
+                verts[uvOffset] = tempXVerts[3];
+                verts[uvOffset + 1] = tempYVerts[3];
                 uvOffset += floatsPerVert;
             }
         }

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -297,22 +297,24 @@ export default class TiledAssembler extends Assembler2D {
                     else if (yindex === (row - 1)) {
                         verts[uvOffset] = uvSliced[8].u;
                     }
+                    var rBottomV = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
                     if (xindex === 0) {
-                        verts[uvOffset + 1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
+                        verts[uvOffset + 1] = rBottomV;
                     }
                     else if (xindex > 0 && xindex < (col - 1)) {
-                        verts[uvOffset + 1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
+                        verts[uvOffset + 1] = rBottomV;
                     }
                     else if (xindex === (col - 1)) {
                         verts[uvOffset + 1] = uvSliced[3].v;
                     }
                     uvOffset += floatsPerVert;
                     // lt
+                    var lTopU = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
                     if (yindex === 0) {
-                        verts[uvOffset] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
+                        verts[uvOffset] = lTopU;
                     }
                     else if (yindex > 0 && yindex < (row - 1)) {
-                        verts[uvOffset] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
+                        verts[uvOffset] = lTopU;
                     }
                     else if (yindex === (row - 1)){
                         verts[uvOffset] = uvSliced[12].u;
@@ -354,11 +356,12 @@ export default class TiledAssembler extends Assembler2D {
                     }
                     uvOffset += floatsPerVert;
                     // rb
+                    var rBottomU = uvSliced[1].u + (uvSliced[2].u - uvSliced[1].u) * coefu;
                     if (xindex === 0) {
-                        verts[uvOffset] = uvSliced[1].u + (uvSliced[2].u - uvSliced[1].u) * coefu;
+                        verts[uvOffset] = rBottomU;
                     }
                     else if (xindex > 0 && xindex < (col - 1)) {
-                        verts[uvOffset] = uvSliced[1].u + (uvSliced[2].u - uvSliced[1].u) * coefu;
+                        verts[uvOffset] = rBottomU;
                     }
                     else if (xindex === (col - 1)){
                         verts[uvOffset] = uvSliced[3].u;
@@ -383,11 +386,12 @@ export default class TiledAssembler extends Assembler2D {
                     else if (xindex === (col - 1)) {
                         verts[uvOffset] = uvSliced[2].u;
                     }
+                    var lTopV = uvSliced[4].v + (uvSliced[8].v - uvSliced[4].v) * coefv;
                     if (yindex === 0) {
-                        verts[uvOffset + 1] = uvSliced[4].v + (uvSliced[8].v - uvSliced[4].v) * coefv;
+                        verts[uvOffset + 1] = lTopV;
                     }
                     else if (yindex > 0 && yindex < (row - 1)) {
-                        verts[uvOffset + 1] = uvSliced[4].v + (uvSliced[8].v - uvSliced[4].v) * coefv;
+                        verts[uvOffset + 1] = lTopV;
                     }
                     else if (yindex === (row - 1)) {
                         verts[uvOffset + 1] = uvSliced[12].v;

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -268,16 +268,64 @@ export default class TiledAssembler extends Assembler2D {
                 // UV
                 if (rotated) {
                     // lb
-                    verts[uvOffset] = uv[0];
-                    verts[uvOffset + 1] = uv[1];
+                    if (yindex === 0) {
+                        verts[uvOffset] = uvSliced[0].u;
+                    }
+                    else if (yindex > 0 && yindex < (row - 1)) {
+                        verts[uvOffset] = uvSliced[4].u;
+                    }
+                    else if (yindex === (row - 1)) {
+                        verts[uvOffset] = uvSliced[8].u;
+                    }
+                    if (xindex === 0) {
+                        verts[uvOffset + 1] = uvSliced[0].v;
+                    }
+                    else if (xindex > 0 && xindex < (col - 1)) {
+                        verts[uvOffset + 1] = uvSliced[1].v;
+                    }
+                    else if (xindex === (col - 1)) {
+                        verts[uvOffset + 1] = uvSliced[2].v;
+                    }
                     uvOffset += floatsPerVert;
                     // rb
-                    verts[uvOffset] = uv[0];
-                    verts[uvOffset + 1] = uv[1] + (uv[7] - uv[1]) * coefu;
+                    if (yindex === 0) {
+                        verts[uvOffset] = uvSliced[0].u;
+                    }
+                    else if (yindex > 0 && yindex < (row - 1)) {
+                        verts[uvOffset] = uvSliced[4].u;
+                    }
+                    else if (yindex === (row - 1)) {
+                        verts[uvOffset] = uvSliced[8].u;
+                    }
+                    if (xindex === 0) {
+                        verts[uvOffset + 1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
+                    }
+                    else if (xindex > 0 && xindex < (col - 1)) {
+                        verts[uvOffset + 1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
+                    }
+                    else if (xindex === (col - 1)) {
+                        verts[uvOffset + 1] = uvSliced[3].v;
+                    }
                     uvOffset += floatsPerVert;
                     // lt
-                    verts[uvOffset] = uv[0] + (uv[6] - uv[0]) * coefv;
-                    verts[uvOffset + 1] = uv[1];
+                    if (yindex === 0) {
+                        verts[uvOffset] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
+                    }
+                    else if (yindex > 0 && yindex < (row - 1)) {
+                        verts[uvOffset] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
+                    }
+                    else if (yindex === (row - 1)){
+                        verts[uvOffset] = uvSliced[12].u;
+                    }
+                    if (xindex === 0) {
+                        verts[uvOffset + 1] = uvSliced[0].v;
+                    }
+                    else if (xindex > 0 && xindex < (col - 1)) {
+                        verts[uvOffset + 1] = uvSliced[1].v;
+                    }
+                    else if (xindex === (col - 1)) {
+                        verts[uvOffset + 1] = uvSliced[2].v;
+                    }
                     uvOffset += floatsPerVert;
                     // rt
                     verts[uvOffset] = verts[uvOffset - floatsPerVert];
@@ -287,7 +335,7 @@ export default class TiledAssembler extends Assembler2D {
                 else {
                     // lb
                     if (xindex === 0) {
-                        verts[uvOffset] = uv[0];
+                        verts[uvOffset] = uvSliced[0].u;
                     }
                     else if (xindex > 0 && xindex < (col - 1)) {
                         verts[uvOffset] = uvSliced[1].u;
@@ -327,7 +375,7 @@ export default class TiledAssembler extends Assembler2D {
                     uvOffset += floatsPerVert;
                     // lt
                     if (xindex === 0) {
-                        verts[uvOffset] = uv[0];
+                        verts[uvOffset] = uvSliced[0].u;
                     }
                     else if (xindex > 0 && xindex < (col - 1)) {
                         verts[uvOffset] = uvSliced[1].u;

--- a/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
+++ b/cocos2d/core/renderer/webgl/assemblers/sprite/2d/tiled.js
@@ -265,143 +265,83 @@ export default class TiledAssembler extends Assembler2D {
                     coefu = hRepeat;
                 }
 
-                // UV
                 if (rotated) {
-                    // lb
                     if (yindex === 0) {
-                        verts[uvOffset] = uvSliced[0].u;
-                    }
-                    else if (yindex > 0 && yindex < (row - 1)) {
-                        verts[uvOffset] = uvSliced[4].u;
-                    }
-                    else if (yindex === (row - 1)) {
-                        verts[uvOffset] = uvSliced[8].u;
+                        tempYVerts[0] = uvSliced[0].u;
+                        tempYVerts[1] = uvSliced[0].u;
+                        tempYVerts[2] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
+                    } else if (yindex > 0 && yindex < (row - 1)) {
+                        tempYVerts[0] = uvSliced[4].u;
+                        tempYVerts[1] = uvSliced[4].u;
+                        tempYVerts[2] = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
+                    } else if (yindex === (row - 1)) {
+                        tempYVerts[0] = uvSliced[8].u;
+                        tempYVerts[1] = uvSliced[8].u;
+                        tempYVerts[2] = uvSliced[12].u;
                     }
                     if (xindex === 0) {
-                        verts[uvOffset + 1] = uvSliced[0].v;
+                        tempXVerts[0] = uvSliced[0].v;
+                        tempXVerts[1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
+                        tempXVerts[2] = uvSliced[0].v;
+                    } else if (xindex > 0 && xindex < (col - 1)) {
+                        tempXVerts[0] = uvSliced[1].v;
+                        tempXVerts[1] = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
+                        tempXVerts[2] = uvSliced[1].v;
+                    } else if (xindex === (col - 1)) {
+                        tempXVerts[0] = uvSliced[2].v;
+                        tempXVerts[1] = uvSliced[3].v;
+                        tempXVerts[2] = uvSliced[2].v;
                     }
-                    else if (xindex > 0 && xindex < (col - 1)) {
-                        verts[uvOffset + 1] = uvSliced[1].v;
-                    }
-                    else if (xindex === (col - 1)) {
-                        verts[uvOffset + 1] = uvSliced[2].v;
-                    }
-                    uvOffset += floatsPerVert;
-                    // rb
-                    if (yindex === 0) {
-                        verts[uvOffset] = uvSliced[0].u;
-                    }
-                    else if (yindex > 0 && yindex < (row - 1)) {
-                        verts[uvOffset] = uvSliced[4].u;
-                    }
-                    else if (yindex === (row - 1)) {
-                        verts[uvOffset] = uvSliced[8].u;
-                    }
-                    var rBottomV = uvSliced[1].v + (uvSliced[2].v - uvSliced[1].v) * coefu;
-                    if (xindex === 0) {
-                        verts[uvOffset + 1] = rBottomV;
-                    }
-                    else if (xindex > 0 && xindex < (col - 1)) {
-                        verts[uvOffset + 1] = rBottomV;
-                    }
-                    else if (xindex === (col - 1)) {
-                        verts[uvOffset + 1] = uvSliced[3].v;
-                    }
-                    uvOffset += floatsPerVert;
-                    // lt
-                    var lTopU = uvSliced[4].u + (uvSliced[8].u - uvSliced[4].u) * coefv;
-                    if (yindex === 0) {
-                        verts[uvOffset] = lTopU;
-                    }
-                    else if (yindex > 0 && yindex < (row - 1)) {
-                        verts[uvOffset] = lTopU;
-                    }
-                    else if (yindex === (row - 1)){
-                        verts[uvOffset] = uvSliced[12].u;
-                    }
-                    if (xindex === 0) {
-                        verts[uvOffset + 1] = uvSliced[0].v;
-                    }
-                    else if (xindex > 0 && xindex < (col - 1)) {
-                        verts[uvOffset + 1] = uvSliced[1].v;
-                    }
-                    else if (xindex === (col - 1)) {
-                        verts[uvOffset + 1] = uvSliced[2].v;
-                    }
-                    uvOffset += floatsPerVert;
-                    // rt
-                    verts[uvOffset] = verts[uvOffset - floatsPerVert];
-                    verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
-                    uvOffset += floatsPerVert;
                 }
                 else {
-                    // lb
                     if (xindex === 0) {
-                        verts[uvOffset] = uvSliced[0].u;
-                    }
-                    else if (xindex > 0 && xindex < (col - 1)) {
-                        verts[uvOffset] = uvSliced[1].u;
-                    }
-                    else if(xindex === (col - 1)) {
-                        verts[uvOffset] = uvSliced[2].u;
+                        tempXVerts[0] = uvSliced[0].u;
+                        tempXVerts[1] = uvSliced[1].u + (uvSliced[2].u - uvSliced[1].u) * coefu;
+                        tempXVerts[2] = uv[0];
+                    } else if (xindex > 0 && xindex < (col - 1)) {
+                        tempXVerts[0] = uvSliced[1].u;
+                        tempXVerts[1] = uvSliced[1].u + (uvSliced[2].u - uvSliced[1].u) * coefu;
+                        tempXVerts[2] = uvSliced[1].u;
+                    } else if (xindex === (col - 1)) {
+                        tempXVerts[0] = uvSliced[2].u;
+                        tempXVerts[1] = uvSliced[3].u;
+                        tempXVerts[2] = uvSliced[2].u;
                     }
                     if (yindex === 0) {
-                        verts[uvOffset + 1] = uvSliced[0].v;
+                        tempYVerts[0] = uvSliced[0].v;
+                        tempYVerts[1] = uvSliced[0].v;
+                        tempYVerts[2] = uvSliced[4].v + (uvSliced[8].v - uvSliced[4].v) * coefv;
+                    } else if (yindex > 0 && yindex < (row - 1)) {
+                        tempYVerts[0] = uvSliced[4].v;
+                        tempYVerts[1] = uvSliced[4].v;
+                        tempYVerts[2] = uvSliced[4].v + (uvSliced[8].v - uvSliced[4].v) * coefv;
+                    } else if (yindex === (row - 1)) {
+                        tempYVerts[0] = uvSliced[8].v;
+                        tempYVerts[1] = uvSliced[8].v;
+                        tempYVerts[2] = uvSliced[12].v;
                     }
-                    else if (yindex > 0 && yindex < (row - 1)) {
-                        verts[uvOffset + 1] = uvSliced[4].v;
-                    }
-                    else if (yindex === (row - 1)) {
-                        verts[uvOffset + 1] = uvSliced[8].v;
-                    }
-                    uvOffset += floatsPerVert;
-                    // rb
-                    var rBottomU = uvSliced[1].u + (uvSliced[2].u - uvSliced[1].u) * coefu;
-                    if (xindex === 0) {
-                        verts[uvOffset] = rBottomU;
-                    }
-                    else if (xindex > 0 && xindex < (col - 1)) {
-                        verts[uvOffset] = rBottomU;
-                    }
-                    else if (xindex === (col - 1)){
-                        verts[uvOffset] = uvSliced[3].u;
-                    }
-                    if (yindex === 0) {
-                        verts[uvOffset + 1] = uvSliced[0].v;
-                    }
-                    else if (yindex > 0 && yindex < (row - 1)) {
-                        verts[uvOffset + 1] = uvSliced[4].v;
-                    }
-                    else if (yindex === (row - 1)) {
-                        verts[uvOffset + 1] = uvSliced[8].v;
-                    }
-                    uvOffset += floatsPerVert;
-                    // lt
-                    if (xindex === 0) {
-                        verts[uvOffset] = uvSliced[0].u;
-                    }
-                    else if (xindex > 0 && xindex < (col - 1)) {
-                        verts[uvOffset] = uvSliced[1].u;
-                    }
-                    else if (xindex === (col - 1)) {
-                        verts[uvOffset] = uvSliced[2].u;
-                    }
-                    var lTopV = uvSliced[4].v + (uvSliced[8].v - uvSliced[4].v) * coefv;
-                    if (yindex === 0) {
-                        verts[uvOffset + 1] = lTopV;
-                    }
-                    else if (yindex > 0 && yindex < (row - 1)) {
-                        verts[uvOffset + 1] = lTopV;
-                    }
-                    else if (yindex === (row - 1)) {
-                        verts[uvOffset + 1] = uvSliced[12].v;
-                    }
-                    uvOffset += floatsPerVert;
-                    // rt
+                }
+                // lb
+                verts[uvOffset] = tempXVerts[0];
+                verts[uvOffset + 1] = tempYVerts[0];
+                uvOffset += floatsPerVert;
+                // rb
+                verts[uvOffset] = tempXVerts[1];
+                verts[uvOffset + 1] = tempYVerts[1];
+                uvOffset += floatsPerVert;
+                // lt
+                verts[uvOffset] = tempXVerts[2];
+                verts[uvOffset + 1] = tempYVerts[2];
+                uvOffset += floatsPerVert;
+                // rt
+                if (rotated) {
+                    verts[uvOffset] = verts[uvOffset - floatsPerVert];
+                    verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert * 2];
+                } else {
                     verts[uvOffset] = verts[uvOffset - floatsPerVert * 2];
                     verts[uvOffset + 1] = verts[uvOffset + 1 - floatsPerVert];
-                    uvOffset += floatsPerVert;
                 }
+                uvOffset += floatsPerVert;
             }
         }
     }


### PR DESCRIPTION
Fixed an image display exception when using `Auto Atlas` and checking `Allow Rotation`.
![image](https://user-images.githubusercontent.com/35944775/95687920-29452a80-0c39-11eb-9677-af7a2ffbddb9.png)


before：
![Oct-12-2020 03-10-06](https://user-images.githubusercontent.com/35944775/95687796-7a085380-0c38-11eb-9899-453903cf8f4e.gif)

after：
![Oct-12-2020 03-09-37](https://user-images.githubusercontent.com/35944775/95687801-7ecd0780-0c38-11eb-86ba-bead6cf7d7a7.gif)
