### PR TITLE
Remove es5 cc class

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -362,6 +362,7 @@ Event manager only support scene graph priority for ui nodes which contain UICom
 
 ### 3600
 
+<!-- DEPRECATED -->
 cc.Class will automatically call super constructor of %s, you should not call it manually.
 
 ### 3601
@@ -430,6 +431,7 @@ Should not specify class name %s for Component which defines in project.
 
 ### 3617
 
+<!-- DEPRECATED -->
 Can not instantiate CCClass '%s' with arguments.
 
 ### 3618
@@ -438,18 +440,22 @@ ctor of '%s' can not be another CCClass
 
 ### 3619
 
+<!-- DEPRECATED -->
 ctor of '%s' must be function type
 
 ### 3620
 
+<!-- DEPRECATED -->
 this._super declared in '%s.%s' but no super method defined
 
 ### 3621
 
+<!-- DEPRECATED -->
 Unknown type of %s.%s, maybe you want is '%s'.
 
 ### 3622
 
+<!-- DEPRECATED -->
 Unknown type of %s.%s, property should be defined in 'properties' or 'ctor'
 
 ### 3623
@@ -458,6 +464,7 @@ Can not use 'editor' attribute, '%s' not inherits from Components.
 
 ### 3624
 
+<!-- DEPRECATED -->
 '%s' overrided '%s' but '%s' is defined as 'false' so the super method will not be called. You can set '%s' to null to disable this warning.
 
 ### 3625
@@ -505,10 +512,12 @@ Disallow to use '.' in property name
 
 ### 3635
 
+<!-- DEPRECATED -->
 Default array must be empty, set default value of %s.%s to [], and initialize in 'onLoad' or 'ctor' please. (just like 'this.%s = [...];')
 
 ### 3636
 
+<!-- DEPRECATED -->
 Do not set default value to non-empty object, unless the object defines its own 'clone' function. Set default value of %s.%s to null or {}, and initialize in 'onLoad' or 'ctor' please. (just like 'this.%s = {foo: bar};')
 
 ### 3637
@@ -517,6 +526,7 @@ Can not declare %s.%s, it is already defined in the prototype of %s
 
 ### 3638
 
+<!-- DEPRECATED -->
 '%s': the getter of '%s' is already defined!
 
 ### 3639
@@ -533,10 +543,12 @@ Can not construct %s because it contains object property.
 
 ### 3642
 
+<!-- DEPRECATED -->
 Cannot define %s.%s because static member name can not be '%s'.
 
 ### 3643
 
+<!-- DEPRECATED -->
 Can not define a member called 'constructor' in the class '%s', please use 'ctor' instead.
 
 ### 3644
@@ -561,6 +573,7 @@ Can not declare %s.%s method, it is already defined in the properties of %s.
 
 ### 3649
 
+<!-- DEPRECATED -->
 CCClass %s have conflict between its ctor and __ctor__.
 
 ### 3650
@@ -570,6 +583,7 @@ No need to specifiy "%s" attribute for "%s" property in "%s" class.
 
 ### 3651
 
+<!-- DEPRECATED -->
 Can not call `_super` or `prototype.ctor` in ES6 Classes "%s", use `super` instead please.
 
 ### 3652
@@ -663,6 +677,7 @@ export class Foo {            //  ↓
 
 ### 3661
 
+<!-- DEPRECATED -->
 Register a cc-class through `cc.Class({ /* ... */ })` is deprecated (when registering cc-class "%s"). Use ES6 class syntax and decorators for that purpose instead.
 
 ### 3700
@@ -1107,6 +1122,7 @@ The 'default' value of '%s.%s' can not be an constructor. Set default to null pl
 
 ### 5516
 
+<!-- DEPRECATED -->
 Property '%s.%s' must define at least one of 'default', 'get' or 'set'.
 
 ### 5517

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -448,7 +448,7 @@ export function CCClass<TFunction> (options: {
 
     const editor = options.editor;
     if (editor) {
-        if (typeof base === 'function' && js.isChildClassOf(base, legacyCC.Component)) {
+        if (js.isChildClassOf(base, legacyCC.Component)) {
             legacyCC.Component._registerEditorProps(cls, editor);
         }
         else if (DEV) {

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -44,16 +44,13 @@ import { BitMask } from '../value-types';
 import { Enum } from '../value-types/enum';
 import * as attributeUtils from './utils/attribute';
 import { IAcceptableAttributes } from './utils/attribute-defines';
-import { preprocessAttrs, validateMethodWithProps } from './utils/preprocess-class';
+import { preprocessAttrs } from './utils/preprocess-class';
 import * as RF from './utils/requiring-frame';
 import { error } from '../platform/debug';
 import { DEV, EDITOR, SUPPORT_JIT, TEST } from 'internal:constants';
 import { legacyCC } from '../global-exports';
 
 const DELIMETER = attributeUtils.DELIMETER;
-
-const BUILTIN_ENTRIES = ['name', 'extends', 'mixins', 'ctor', '__ctor__', 'properties', 'statics', 'editor', '__ES6__'];
-const INVALID_STATICS_DEV = ['name', '__ctors__', '__props__', 'arguments', 'call', 'apply', 'caller', 'length', 'prototype'];
 
 function pushUnique (array, item) {
     if (array.indexOf(item) < 0) {
@@ -121,30 +118,10 @@ function appendProp (cls, name) {
 }
 
 const tmpArray = [];
-function defineProp (cls, className, propName, val, es6) {
+function defineProp (cls, className, propName, val) {
     const defaultValue = val.default;
 
     if (DEV) {
-        if (!es6) {
-            // check default object value
-            if (typeof defaultValue === 'object' && defaultValue) {
-                if (Array.isArray(defaultValue)) {
-                    // check array empty
-                    if (defaultValue.length > 0) {
-                        errorID(3635, className, propName, propName);
-                        return;
-                    }
-                }
-                else if (!isPlainEmptyObj_DEV(defaultValue)) {
-                    // check cloneable
-                    if (!cloneable_DEV(defaultValue)) {
-                        errorID(3636, className, propName, propName);
-                        return;
-                    }
-                }
-            }
-        }
-
         // check base prototype to avoid name collision
         if (CCClass.getInheritanceChain(cls)
             .some(function (x) { return x.prototype.hasOwnProperty(propName); })) {
@@ -182,19 +159,13 @@ function defineProp (cls, className, propName, val, es6) {
     }
 }
 
-function defineGetSet (cls, name, propName, val, es6) {
+function defineGetSet (cls, name, propName, val) {
     const getter = val.get;
     const setter = val.set;
     const proto = cls.prototype;
     const d = Object.getOwnPropertyDescriptor(proto, propName);
-    const setterUndefined = !d;
 
     if (getter) {
-        if (DEV && !es6 && d && d.get) {
-            errorID(3638, name, propName);
-            return;
-        }
-
         const attrs = parseAttributes(cls, val, name, propName, true);
         for (let i = 0; i < attrs.length; i++) {
             attributeUtils.attr(cls, propName, attrs[i]);
@@ -208,22 +179,12 @@ function defineGetSet (cls, name, propName, val, es6) {
             appendProp(cls, propName);
         }
 
-        if (!es6) {
-            js.get(proto, propName, getter, setterUndefined, setterUndefined);
-        }
-
         if (EDITOR || DEV) {
             attributeUtils.setClassAttr(cls, propName, 'hasGetter', true); // 方便 editor 做判断
         }
     }
 
     if (setter) {
-        if (!es6) {
-            if (DEV && d && d.set) {
-                return errorID(3640, name, propName);
-            }
-            js.set(proto, propName, setter, setterUndefined, setterUndefined);
-        }
         if (EDITOR || DEV) {
             attributeUtils.setClassAttr(cls, propName, 'hasSetter', true); // 方便 editor 做判断
         }
@@ -257,83 +218,29 @@ function mixinWithInherited (dest, src, filter?) {
 }
 
 function doDefine (className, baseClass, mixins, options) {
-    let shouldAddProtoCtor;
-    const __ctor__ = options.__ctor__;
-    let ctor = options.ctor;
-    const __es6__ = options.__ES6__;
+    const ctor = options.ctor;
 
     if (DEV) {
         // check ctor
-        const ctorToUse = __ctor__ || ctor;
-        if (ctorToUse) {
-            if (CCClass._isCCClass(ctorToUse)) {
-                errorID(3618, className);
-            }
-            else if (typeof ctorToUse !== 'function') {
-                errorID(3619, className);
-            }
-            else {
-                if (baseClass && /\bprototype.ctor\b/.test(ctorToUse)) {
-                    if (__es6__) {
-                        errorID(3651, className || '');
-                    }
-                    else {
-                        warnID(3600, className || '');
-                        shouldAddProtoCtor = true;
-                    }
-                }
-            }
-            if (ctor) {
-                if (__ctor__) {
-                    errorID(3649, className);
-                }
-                else {
-                    ctor = options.ctor = _validateCtor_DEV(ctor, baseClass, className, options);
-                }
-            }
+        if (CCClass._isCCClass(ctor)) {
+            errorID(3618, className);
         }
     }
 
-    let ctors;
-    let fireClass;
-    if (__es6__) {
-        ctors = [ctor];
-        fireClass = ctor;
-    }
-    else {
-        ctors = __ctor__ ? [__ctor__] : _getAllCtors(baseClass, mixins, options);
-        fireClass = _createCtor(ctors, baseClass, className, options);
-
-        // extend - Create a new Class that inherits from this Class
-        js.value(fireClass, 'extend', function (this: any, options) {
-            options.extends = this;
-            return CCClass(options);
-        }, true);
-    }
+    const ctors = [ctor];
+    const fireClass = ctor;
 
     js.value(fireClass, '__ctors__', ctors.length > 0 ? ctors : null, true);
 
-    let prototype = fireClass.prototype;
+    const prototype = fireClass.prototype;
     if (baseClass) {
-        if (!__es6__) {
-            js.extend(fireClass, baseClass);        // 这里会把父类的 __props__ 复制给子类
-            prototype = fireClass.prototype;        // get extended prototype
-        }
         fireClass.$super = baseClass;
-        if (DEV && shouldAddProtoCtor) {
-            prototype.ctor = function () { };
-        }
     }
 
     if (mixins) {
         for (let m = mixins.length - 1; m >= 0; m--) {
             const mixin = mixins[m];
             mixinWithInherited(prototype, mixin.prototype);
-
-            // mixin statics (this will also copy editor attributes for component)
-            mixinWithInherited(fireClass, mixin, function (prop) {
-                return mixin.hasOwnProperty(prop) && (!DEV || INVALID_STATICS_DEV.indexOf(prop) < 0);
-            });
 
             // mixin attributes
             if (CCClass._isCCClass(mixin)) {
@@ -345,10 +252,6 @@ function doDefine (className, baseClass, mixins, options) {
         }
         // restore constuctor overridden by mixin
         prototype.constructor = fireClass;
-    }
-
-    if (!__es6__) {
-        prototype.__initProps__ = compileProps;
     }
 
     js.setClassName(className, fireClass);
@@ -371,11 +274,6 @@ function define (className, baseClass, mixins, options) {
         className = className || frame.script;
     }
 
-    if (DEV) {
-        if (!options.__ES6__) {
-            warnID(3661, className);
-        }
-    }
     const cls = doDefine(className, baseClass, mixins, options);
 
     // for RenderPipeline, RenderFlow, RenderStage
@@ -433,22 +331,6 @@ function define (className, baseClass, mixins, options) {
     return cls;
 }
 
-function normalizeClassName_DEV (className) {
-    const DefaultName = 'CCClass';
-    if (className) {
-        className = className.replace(/^[^$A-Za-z_]/, '_').replace(/[^0-9A-Za-z_$]/g, '_');
-        try {
-            // validate name
-            Function('function ' + className + '(){}')();
-            return className;
-        }
-        catch (e) {
-
-        }
-    }
-    return DefaultName;
-}
-
 function getNewValueTypeCodeJit (value) {
     const clsName = js.getClassName(value);
     const type = value.constructor;
@@ -479,382 +361,10 @@ function escapeForJS (s) {
         replace(/\u2029/g, '\\u2029');
 }
 
-function getInitPropsJit (attrs, propList) {
-    // functions for generated code
-    const F: any[] = [];
-    let func = '';
-
-    for (let i = 0; i < propList.length; i++) {
-        const prop = propList[i];
-        const attrKey = prop + DELIMETER + 'default';
-        if (attrKey in attrs) {  // getter does not have default
-            let statement;
-            if (IDENTIFIER_RE.test(prop)) {
-                statement = 'this.' + prop + '=';
-            }
-            else {
-                statement = 'this[' + escapeForJS(prop) + ']=';
-            }
-            let expression;
-            const def = attrs[attrKey];
-            if (typeof def === 'object' && def) {
-                if (def instanceof legacyCC.ValueType) {
-                    expression = getNewValueTypeCodeJit(def);
-                }
-                else if (Array.isArray(def)) {
-                    expression = '[]';
-                }
-                else {
-                    expression = '{}';
-                }
-            }
-            else if (typeof def === 'function') {
-                const index = F.length;
-                F.push(def);
-                expression = 'F[' + index + ']()';
-                if (EDITOR) {
-                    func += 'try {\n' + statement + expression + ';\n}\ncatch(e) {\ncc._throw(e);\n' + statement + 'undefined;\n}\n';
-                    continue;
-                }
-            }
-            else if (typeof def === 'string') {
-                expression = escapeForJS(def);
-            }
-            else {
-                // number, boolean, null, undefined
-                expression = def;
-            }
-            statement = statement + expression + ';\n';
-            func += statement;
-        }
-    }
-
-    // if (TEST && !isPhantomJS) {
-    //     console.log(func);
-    // }
-
-    let initProps;
-    if (F.length === 0) {
-        initProps = Function(func);
-    }
-    else {
-        initProps = Function('F', 'return (function(){\n' + func + '})')(F);
-    }
-
-    return initProps;
-}
-
-function getInitProps (attrs, propList) {
-    const advancedProps: any[] = [];
-    const advancedValues: any[] = [];
-    const simpleProps: any[] = [];
-    const simpleValues: any[] = [];
-
-    for (let i = 0; i < propList.length; ++i) {
-        const prop = propList[i];
-        const attrKey = prop + DELIMETER + 'default';
-        if (attrKey in attrs) { // getter does not have default
-            const def = attrs[attrKey];
-            if ((typeof def === 'object' && def) || typeof def === 'function') {
-                advancedProps.push(prop);
-                advancedValues.push(def);
-            }
-            else {
-                // number, boolean, null, undefined, string
-                simpleProps.push(prop);
-                simpleValues.push(def);
-            }
-        }
-    }
-
-    return function (this: any) {
-        for (let i = 0; i < simpleProps.length; ++i) {
-            this[simpleProps[i]] = simpleValues[i];
-        }
-        for (let i = 0; i < advancedProps.length; i++) {
-            const prop = advancedProps[i];
-            let expression;
-            const def = advancedValues[i];
-            if (typeof def === 'object') {
-                if (def instanceof legacyCC.ValueType) {
-                    expression = def.clone();
-                }
-                else if (Array.isArray(def)) {
-                    expression = [];
-                }
-                else {
-                    expression = {};
-                }
-            }
-            else {
-                // def is function
-                if (EDITOR) {
-                    try {
-                        expression = def();
-                    }
-                    catch (err) {
-                        legacyCC._throw(err);
-                        continue;
-                    }
-                }
-                else {
-                    expression = def();
-                }
-            }
-            this[prop] = expression;
-        }
-    };
-}
-
 // simple test variable name
 const IDENTIFIER_RE = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
 
-function compileProps (this: any, actualClass) {
-    // init deferred properties
-    const attrs = attributeUtils.getClassAttrs(actualClass);
-    let propList = actualClass.__props__;
-    if (propList === null) {
-        deferredInitializer.init();
-        propList = actualClass.__props__;
-    }
-
-    // Overwite __initProps__ to avoid compile again.
-    const initProps = SUPPORT_JIT ? getInitPropsJit(attrs, propList) : getInitProps(attrs, propList);
-    actualClass.prototype.__initProps__ = initProps;
-
-    // call instantiateProps immediately, no need to pass actualClass into it anymore
-    // (use call to manually bind `this` because `this` may not instanceof actualClass)
-    initProps.call(this);
-}
-
-const _createCtor = SUPPORT_JIT ? function (ctors, baseClass, className, options) {
-    const superCallBounded = baseClass && boundSuperCalls(baseClass, options, className);
-
-    const ctorName = DEV ? normalizeClassName_DEV(className) : 'CCClass';
-    let body = 'return function ' + ctorName + '(){\n';
-
-    if (superCallBounded) {
-        body += 'this._super=null;\n';
-    }
-
-    // instantiate props
-    body += 'this.__initProps__(' + ctorName + ');\n';
-
-    // call user constructors
-    const ctorLen = ctors.length;
-    if (ctorLen > 0) {
-        const useTryCatch = DEV && !(className && className.startsWith('cc.'));
-        if (useTryCatch) {
-            body += 'try{\n';
-        }
-        const SNIPPET = '].apply(this,arguments);\n';
-        if (ctorLen === 1) {
-            body += ctorName + '.__ctors__[0' + SNIPPET;
-        }
-        else {
-            body += 'var cs=' + ctorName + '.__ctors__;\n';
-            for (let i = 0; i < ctorLen; i++) {
-                body += 'cs[' + i + SNIPPET;
-            }
-        }
-        if (useTryCatch) {
-            body += '}catch(e){\n' +
-                'cc._throw(e);\n' +
-                '}\n';
-        }
-    }
-    body += '}';
-
-    return Function(body)();
-} : function (ctors, baseClass, className, options) {
-    const superCallBounded = baseClass && boundSuperCalls(baseClass, options, className);
-    const ctorLen = ctors.length;
-
-    let Class;
-
-    if (ctorLen > 0) {
-        if (superCallBounded) {
-            if (ctorLen === 2) {
-                // User Component
-                Class = function (this: any) {
-                    this._super = null;
-                    this.__initProps__(Class);
-                    ctors[0].apply(this, arguments);
-                    ctors[1].apply(this, arguments);
-                };
-            }
-            else {
-                Class = function (this: any) {
-                    this._super = null;
-                    this.__initProps__(Class);
-                    for (let i = 0; i < ctors.length; ++i) {
-                        ctors[i].apply(this, arguments);
-                    }
-                };
-            }
-        }
-        else {
-            if (ctorLen === 3) {
-                // Node
-                Class = function (this: any) {
-                    this.__initProps__(Class);
-                    ctors[0].apply(this, arguments);
-                    ctors[1].apply(this, arguments);
-                    ctors[2].apply(this, arguments);
-                };
-            }
-            else {
-                Class = function (this: any) {
-                    this.__initProps__(Class);
-                    const ctors = Class.__ctors__;
-                    for (let i = 0; i < ctors.length; ++i) {
-                        ctors[i].apply(this, arguments);
-                    }
-                };
-            }
-        }
-    }
-    else {
-        Class = function (this: any) {
-            if (superCallBounded) {
-                this._super = null;
-            }
-            this.__initProps__(Class);
-        };
-    }
-    return Class;
-};
-
-function _validateCtor_DEV (ctor, baseClass, className, options) {
-    if (EDITOR && baseClass) {
-        // check super call in constructor
-        const originCtor = ctor;
-        if (SuperCallReg.test(ctor)) {
-            if (options.__ES6__) {
-                errorID(3651, className);
-            }
-            else {
-                warnID(3600, className);
-                // suppresss super call
-                ctor = function (this: any) {
-                    this._super = function () { };
-                    const ret = originCtor.apply(this, arguments);
-                    this._super = null;
-                    return ret;
-                };
-            }
-        }
-    }
-
-    // check ctor
-    if (ctor.length > 0 && (!className || !className.startsWith('cc.'))) {
-        // To make a unified CCClass serialization process,
-        // we don't allow parameters for constructor when creating instances of CCClass.
-        // For advanced user, construct arguments can still get from 'arguments'.
-        warnID(3617, className);
-    }
-
-    return ctor;
-}
-
-function _getAllCtors (baseClass, mixins, options) {
-    // get base user constructors
-    function getCtors (cls) {
-        if (CCClass._isCCClass(cls)) {
-            return cls.__ctors__ || [];
-        }
-        else {
-            return [cls];
-        }
-    }
-
-    const ctors: any[] = [];
-    // if (options.__ES6__) {
-    //     if (mixins) {
-    //         let baseOrMixins = getCtors(baseClass);
-    //         for (let b = 0; b < mixins.length; b++) {
-    //             let mixin = mixins[b];
-    //             if (mixin) {
-    //                 let baseCtors = getCtors(mixin);
-    //                 for (let c = 0; c < baseCtors.length; c++) {
-    //                     if (baseOrMixins.indexOf(baseCtors[c]) < 0) {
-    //                         pushUnique(ctors, baseCtors[c]);
-    //                     }
-    //                 }
-    //             }
-    //         }
-    //     }
-    // }
-    // else {
-    const baseOrMixins = [baseClass].concat(mixins);
-    for (let b = 0; b < baseOrMixins.length; b++) {
-        const baseOrMixin = baseOrMixins[b];
-        if (baseOrMixin) {
-            const baseCtors = getCtors(baseOrMixin);
-            for (let c = 0; c < baseCtors.length; c++) {
-                pushUnique(ctors, baseCtors[c]);
-            }
-        }
-    }
-    // }
-
-    // append subclass user constructors
-    const ctor = options.ctor;
-    if (ctor) {
-        ctors.push(ctor);
-    }
-
-    return ctors;
-}
-
-const superCllRegCondition = /xyz/.test(function () { const xyz = 0; }.toString());
-const SuperCallReg = superCllRegCondition ? /\b\._super\b/ : /.*/;
-const SuperCallRegStrict = superCllRegCondition ? /this\._super\s*\(/ : /(NONE){99}/;
-function boundSuperCalls (baseClass, options, className) {
-    let hasSuperCall = false;
-    for (const funcName in options) {
-        if (BUILTIN_ENTRIES.indexOf(funcName) >= 0) {
-            continue;
-        }
-        const func = options[funcName];
-        if (typeof func !== 'function') {
-            continue;
-        }
-        const pd = js.getPropertyDescriptor(baseClass.prototype, funcName);
-        if (pd) {
-            const superFunc = pd.value;
-            // ignore pd.get, assume that function defined by getter is just for warnings
-            if (typeof superFunc === 'function') {
-                if (SuperCallReg.test(func)) {
-                    hasSuperCall = true;
-                    // boundSuperCall
-                    options[funcName] = (function (superFunc, func) {
-                        return function (this: any) {
-                            const tmp = this._super;
-
-                            // Add a new ._super() method that is the same method but on the super-Class
-                            this._super = superFunc;
-
-                            const ret = func.apply(this, arguments);
-
-                            // The method only need to be bound temporarily, so we remove it when we're done executing
-                            this._super = tmp;
-
-                            return ret;
-                        };
-                    })(superFunc, func);
-                }
-                continue;
-            }
-        }
-        if (DEV && SuperCallRegStrict.test(func)) {
-            warnID(3620, className, funcName);
-        }
-    }
-    return hasSuperCall;
-}
-
-function declareProperties (cls, className, properties, baseClass, mixins, es6?: boolean) {
+function declareProperties (cls, className, properties, baseClass, mixins) {
     cls.__props__ = [];
 
     if (baseClass && baseClass.__props__) {
@@ -874,15 +384,15 @@ function declareProperties (cls, className, properties, baseClass, mixins, es6?:
 
     if (properties) {
         // 预处理属性
-        preprocessAttrs(properties, className, cls, es6);
+        preprocessAttrs(properties, className, cls);
 
         for (const propName in properties) {
             const val = properties[propName];
             if ('default' in val) {
-                defineProp(cls, className, propName, val, es6);
+                defineProp(cls, className, propName, val);
             }
             else {
-                defineGetSet(cls, className, propName, val, es6);
+                defineGetSet(cls, className, propName, val);
             }
         }
     }
@@ -893,9 +403,14 @@ function declareProperties (cls, className, properties, baseClass, mixins, es6?:
     });
 }
 
-export function CCClass (options) {
-    options = options || {};
-
+export function CCClass<TFunction> (options: {
+    name?: string;
+    extends: null | (Function & { __props__?: any; _sealed?: boolean });
+    ctor: TFunction;
+    properties?: any;
+    mixins?: (Function & { __props__?: any })[];
+    editor?: any;
+}) {
     let name = options.name;
     const base = options.extends/* || CCObject*/;
     const mixins = options.mixins;
@@ -919,8 +434,8 @@ export function CCClass (options) {
             return x.__props__ === null;
         }))
     ) {
-        if (DEV && options.__ES6__) {
-            error('not yet implement deferred properties for ES6 Classes');
+        if (DEV) {
+            error('not yet implement deferred properties.');
         }
         else {
             deferredInitializer.push({ cls, props: properties, mixins });
@@ -928,42 +443,12 @@ export function CCClass (options) {
         }
     }
     else {
-        declareProperties(cls, name, properties, base, options.mixins, options.__ES6__);
-    }
-
-    // define statics
-    const statics = options.statics;
-    if (statics) {
-        let staticPropName;
-        if (DEV) {
-            for (staticPropName in statics) {
-                if (INVALID_STATICS_DEV.indexOf(staticPropName) !== -1) {
-                    errorID(3642, name, staticPropName,
-                        staticPropName);
-                }
-            }
-        }
-        for (staticPropName in statics) {
-            cls[staticPropName] = statics[staticPropName];
-        }
-    }
-
-    // define functions
-    for (const funcName in options) {
-        if (BUILTIN_ENTRIES.indexOf(funcName) >= 0) {
-            continue;
-        }
-        const func = options[funcName];
-        if (!validateMethodWithProps(func, funcName, name, cls, base)) {
-            continue;
-        }
-        // use value to redefine some super method defined as getter
-        js.value(cls.prototype, funcName, func, true, true);
+        declareProperties(cls, name, properties, base, options.mixins);
     }
 
     const editor = options.editor;
     if (editor) {
-        if (js.isChildClassOf(base, legacyCC.Component)) {
+        if (typeof base === 'function' && js.isChildClassOf(base, legacyCC.Component)) {
             legacyCC.Component._registerEditorProps(cls, editor);
         }
         else if (DEV) {

--- a/cocos/core/data/decorators/ccclass.ts
+++ b/cocos/core/data/decorators/ccclass.ts
@@ -10,8 +10,8 @@ import { doValidateMethodWithProps_DEV } from '../utils/preprocess-class';
 import { CACHE_KEY, makeSmartClassDecorator } from './utils';
 
 /**
- * @en Declare a standard ES6 or TS Class as a CCClass, please refer to the [document](https://docs.cocos.com/creator3d/manual/zh/scripting/ccclass.html)
- * @zh 将标准写法的 ES6 或者 TS Class 声明为 CCClass，具体用法请参阅[类型定义](https://docs.cocos.com/creator3d/manual/zh/scripting/ccclass.html)。
+ * @en Declare a standard class as a CCClass, please refer to the [document](https://docs.cocos.com/creator3d/manual/zh/scripting/ccclass.html)
+ * @zh 将标准写法的类声明为 CC 类，具体用法请参阅[类型定义](https://docs.cocos.com/creator3d/manual/zh/scripting/ccclass.html)。
  * @param name - The class name used for serialization.
  * @example
  * ```ts
@@ -41,7 +41,6 @@ export const ccclass: ((name?: string) => ClassDecorator) & ClassDecorator = mak
         name,
         extends: base,
         ctor: constructor,
-        __ES6__: true,
     };
     const cache = constructor[CACHE_KEY];
     if (cache) {

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -94,7 +94,7 @@ function getDefaultFromInitializer (initializer) {
     }
     else {
         // The default attribute will not be used in ES6 constructor actually,
-        // so we dont need to simplify into `{}` or `[]` or vec2 completely.
+        // so we don't need to simplify into `{}` or `[]` or vec2 completely.
         return initializer;
     }
 }

--- a/cocos/core/data/utils/preprocess-class.ts
+++ b/cocos/core/data/utils/preprocess-class.ts
@@ -42,13 +42,6 @@ const SerializableAttrs = {
     formerlySerializedAs: {},
 };
 
-const TYPO_TO_CORRECT_DEV = DEV && {
-    extend: 'extends',
-    property: 'properties',
-    static: 'statics',
-    constructor: 'ctor',
-};
-
 /**
  * 预处理 notify 等扩展属性
  */
@@ -268,7 +261,7 @@ export function getFullFormOfProperty (options, propname_dev?, classname_dev?) {
     return null;
 }
 
-export function preprocessAttrs (properties, className, cls, es6) {
+export function preprocessAttrs (properties, className, cls) {
     for (const propName in properties) {
         let val = properties[propName];
         const fullForm = getFullFormOfProperty(val, propName, className);
@@ -289,12 +282,6 @@ export function preprocessAttrs (properties, className, cls, es6) {
                         errorID(5515, className, propName);
                     }
                 }
-                else if (!val.get && !val.set) {
-                    const maybeTypeScript = es6;
-                    if (!maybeTypeScript) {
-                        errorID(5516, className, propName);
-                    }
-                }
             }
             if (DEV && !val.override && cls.__props__.indexOf(propName) !== -1) {
                 // check override
@@ -303,8 +290,8 @@ export function preprocessAttrs (properties, className, cls, es6) {
             }
             const notify = val.notify;
             if (notify) {
-                if (DEV && es6) {
-                    error('not yet support notify attribute for ES6 Classes');
+                if (DEV) {
+                    error('not yet support notify attributes.');
                 }
                 else {
                     parseNotify(val, propName, notify, properties);
@@ -341,38 +328,4 @@ export function doValidateMethodWithProps_DEV (func, funcName, className, cls, b
         // tslint:disable-next-line: max-line-length
         error(`Overwriting '${funcName}' function in '${className}' class without calling super is not allowed. Call the super function in '${funcName}' please.`);
     }
-}
-
-export function validateMethodWithProps (func, funcName, className, cls, base) {
-    if (DEV && funcName === 'constructor') {
-        errorID(3643, className);
-        return false;
-    }
-    if (typeof func === 'function' || func === null) {
-        if (DEV) {
-            doValidateMethodWithProps_DEV(func, funcName, className, cls, base);
-        }
-    }
-    else {
-        if (DEV) {
-            if (func === false && base && base.prototype) {
-                // check override
-                const overrided = base.prototype[funcName];
-                if (typeof overrided === 'function') {
-                    const baseFuc = js.getClassName(base) + '.' + funcName;
-                    const subFuc = className + '.' + funcName;
-                    warnID(3624, subFuc, baseFuc, subFuc, subFuc);
-                }
-            }
-            const correct = TYPO_TO_CORRECT_DEV[funcName];
-            if (correct) {
-                warnID(3621, className, funcName, correct);
-            }
-            else if (func) {
-                errorID(3622, className, funcName);
-            }
-        }
-        return false;
-    }
-    return true;
 }

--- a/cocos/core/utils/js-typed.ts
+++ b/cocos/core/utils/js-typed.ts
@@ -394,7 +394,7 @@ export function getSuper (constructor: Function) {
 /**
  * Checks whether subclass is child of superclass or equals to superclass.
  */
-export function isChildClassOf (subclass: Function, superclass: Function) {
+export function isChildClassOf (subclass: unknown, superclass: unknown) {
     if (subclass && superclass) {
         if (typeof subclass !== 'function') {
             return false;
@@ -409,7 +409,7 @@ export function isChildClassOf (subclass: Function, superclass: Function) {
             return true;
         }
         for (; ;) {
-            subclass = getSuper(subclass);
+            subclass = getSuper(subclass as Function);
             if (!subclass) {
                 return false;
             }

--- a/cocos/particle/animator/color-overtime.ts
+++ b/cocos/particle/animator/color-overtime.ts
@@ -48,8 +48,3 @@ export default class ColorOvertimeModule extends ParticleModuleBase {
         particle.color.multiply(this.color.evaluate(1.0 - particle.remainingLifetime / particle.startLifetime, pseudoRandom(particle.randomSeed + COLOR_OVERTIME_RAND_OFFSET)));
     }
 }
-
-// CCClass.fastDefine('cc.ColorOvertimeModule', ColorOvertimeModule, {
-//     enable: false,
-//     color: null
-// });

--- a/cocos/particle/animator/force-overtime.ts
+++ b/cocos/particle/animator/force-overtime.ts
@@ -103,12 +103,3 @@ export default class ForceOvertimeModule extends ParticleModuleBase {
         Vec3.copy(p.ultimateVelocity, p.velocity);
     }
 }
-
-// CCClass.fastDefine('cc.ForceOvertimeModule',ForceOvertimeModule,{
-//     enable : false,
-//     x : new CurveRange(),
-//     y : new CurveRange(),
-//     z : new CurveRange(),
-//     space : Space.Local,
-//     randomized : false
-// });

--- a/cocos/particle/animator/gradient-range.ts
+++ b/cocos/particle/animator/gradient-range.ts
@@ -124,15 +124,6 @@ export default class GradientRange {
     }
 }
 
-// CCClass.fastDefine('cc.GradientRange', GradientRange, {
-//     mode: Mode.Color,
-//     color: cc.Color.WHITE.clone(),
-//     colorMin: cc.Color.WHITE.clone(),
-//     colorMax: cc.Color.WHITE.clone(),
-//     gradient: new Gradient(),
-//     gradientMin: null,
-//     gradientMax: null
-// });
 function evaluateGradient (gr: GradientRange, time: number, index: number) {
     switch (gr.mode) {
         case Mode.Color:

--- a/cocos/particle/animator/gradient.ts
+++ b/cocos/particle/animator/gradient.ts
@@ -26,11 +26,6 @@ export class ColorKey {
     public time = 0;
 }
 
-// CCClass.fastDefine('cc.ColorKey', ColorKey, {
-//     color: cc.Color.WHITE.clone(),
-//     time: 0
-// });
-
 @ccclass('cc.AlphaKey')
 export class AlphaKey {
 
@@ -42,11 +37,6 @@ export class AlphaKey {
     @editable
     public time = 0;
 }
-
-// CCClass.fastDefine('cc.AlphaKey', AlphaKey, {
-//     alpha: 1,
-//     time: 0
-// });
 
 @ccclass('cc.Gradient')
 export default class Gradient {
@@ -157,9 +147,3 @@ export default class Gradient {
         }
     }
 }
-
-// CCClass.fastDefine('cc.Gradient', Gradient, {
-//     mode: Mode.Blend,
-//     colorKeys: [],
-//     alphaKeys: []
-// });

--- a/cocos/particle/animator/limit-velocity-overtime.ts
+++ b/cocos/particle/animator/limit-velocity-overtime.ts
@@ -153,18 +153,3 @@ function dampenBeyondLimit (vel: number, limit: number, dampen: number) {
     }
     return abs * sgn;
 }
-
-// CCClass.fastDefine('cc.LimitVelocityOvertimeModule', LimitVelocityOvertimeModule, {
-//     enable: false,
-//     limitX: null,
-//     limitY: null,
-//     limitZ: null,
-//     limit: null,
-//     dampen: null,
-//     separateAxes: false,
-//     space: Space.Local,
-//     // TODO:functions related to drag are temporarily not supported
-//     drag: null,
-//     multiplyDragByParticleSize: false,
-//     multiplyDragByParticleVelocity: false
-// });

--- a/cocos/particle/animator/rotation-overtime.ts
+++ b/cocos/particle/animator/rotation-overtime.ts
@@ -97,11 +97,3 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
         }
     }
 }
-
-// CCClass.fastDefine('cc.RotationOvertimeModule', RotationOvertimeModule, {
-//     enable: false,
-//     _separateAxes: false,
-//     x: new CurveRange(),
-//     y: new CurveRange(),
-//     z: new CurveRange()
-// });

--- a/cocos/particle/animator/size-overtime.ts
+++ b/cocos/particle/animator/size-overtime.ts
@@ -90,12 +90,3 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
         }
     }
 }
-
-// CCClass.fastDefine('cc.SizeOvertimeModule', SizeOvertimeModule, {
-//     enable: false,
-//     separateAxes: false,
-//     size: new CurveRange(),
-//     x: new CurveRange(),
-//     y: new CurveRange(),
-//     z: new CurveRange()
-// });

--- a/cocos/particle/animator/velocity-overtime.ts
+++ b/cocos/particle/animator/velocity-overtime.ts
@@ -114,12 +114,3 @@ export default class VelocityOvertimeModule extends ParticleModuleBase {
         Vec3.multiplyScalar(p.ultimateVelocity, p.ultimateVelocity, this.speedModifier.evaluate(1 - p.remainingLifetime / p.startLifetime, pseudoRandom(p.randomSeed + VELOCITY_X_OVERTIME_RAND_OFFSET))!);
     }
 }
-
-// CCClass.fastDefine('cc.VelocityOvertimeModule', VelocityOvertimeModule, {
-//     enable: false,
-//     x: new CurveRange(),
-//     y: new CurveRange(),
-//     z: new CurveRange(),
-//     speedModifier: new CurveRange(),
-//     space: Space.Local
-// });

--- a/cocos/particle/burst.ts
+++ b/cocos/particle/burst.ts
@@ -84,12 +84,3 @@ export default class Burst {
         return this.count.getMax() * Math.min(Math.ceil(psys.duration / this.repeatInterval), this.repeatCount);
     }
 }
-
-// CCClass.fastDefine('cc.Burst', Burst, {
-//     _time: 0,
-//     minCount: 30,
-//     maxCount: 30,
-//     _repeatCount: 1,
-//     repeatInterval: 1,
-//     count: new CurveRange
-// });

--- a/cocos/particle/emitter/shape-module.ts
+++ b/cocos/particle/emitter/shape-module.ts
@@ -448,25 +448,3 @@ function applyBoxThickness (pos, thickness) {
         pos[2] = clamp(pos[2], -0.5, 0.5);
     }
 }
-
-// CCClass.fastDefine('cc.ShapeModule', ShapeModule, {
-//     enable: false,
-//     shapeType: ShapeType.Box,
-//     emitFrom: EmitLocation.Base,
-//     _position: new Vec3(0, 0, 0),
-//     _rotation: new Vec3(0, 0, 0),
-//     _scale: new Vec3(0, 0, 0),
-//     alignToDirection: false,
-//     randomDirectionAmount: 0,
-//     sphericalDirectionAmount: 0,
-//     randomPositionAmount: 0,
-//     radius: 0,
-//     radiusThickness: 1,
-//     arc: 0,
-//     arcMode: ArcMode.Random,
-//     arcSpread: 0,
-//     arcSpeed: null,
-//     angle: 0,
-//     length: 0,
-//     boxThickness: new Vec3(0, 0, 0)
-// });


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Remove `CCClass()` style cc-class declaration.

@jareguo  Please review this.

In detail, I removed:

- `CCClass(options)`'s `options.__es6__`, `options.__ctor__`, `options.statics`.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
