### PR TITLE
do not need call beforeDraw in editor

### DIFF
--- a/cocos2d/core/camera/CCCamera.js
+++ b/cocos2d/core/camera/CCCamera.js
@@ -593,7 +593,10 @@ let Camera = cc.Class({
         this._updateProjection();
         this._updateStages();
         this._updateRect();
-        this.beforeDraw();
+
+        if (!CC_EDITOR) {
+            this.beforeDraw();
+        }
     },
 
     __preload () {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * do not need call beforeDraw in editor

