### PR TITLE
fixed _doDispatchEvent error

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -626,7 +626,7 @@ function _doDispatchEvent (owner, event) {
     event.eventPhase = 1;
     for (i = _cachedArray.length - 1; i >= 0; --i) {
         target = _cachedArray[i];
-        if (target._capturingListeners) {
+        if (target && target._capturingListeners) {
             event.currentTarget = target;
             // fire event
             target._capturingListeners.emit(event.type, event, _cachedArray);

--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -657,7 +657,7 @@ function _doDispatchEvent (owner, event) {
         event.eventPhase = 3;
         for (i = 0; i < _cachedArray.length; ++i) {
             target = _cachedArray[i];
-            if (target._bubblingListeners) {
+            if (target && target._bubblingListeners) {
                 event.currentTarget = target;
                 // fire event
                 target._bubblingListeners.emit(event.type, event);


### PR DESCRIPTION
之前处理过这个问题: https://github.com/cocos-creator/engine/pull/6816， 但是后面没复现就没处理了。
现在重新提交：

使用 pageView 嵌套 scrollview 能够复现问题。

[demo.zip](https://github.com/cocos-creator/engine/files/5407730/demo.zip)


由于 pageView 是继承自 scrollview 的，所以他们操作的 _cachedArray 是同一份数据。当两者嵌套使用的时候，_doDispatchEvent 的调用可能会使上次调用 _doDispatchEvent 且正在遍历的数组 _cachedArray 清空。

![image](https://user-images.githubusercontent.com/35944775/96564362-a46fa600-12f5-11eb-91af-8e5c6d7c624b.png)
有两个方案：
   * 每次执行 _doDispatchEvent 的时候，都拷贝一个 _cachedArray，这样就不会都是操作同一个数据
   * 判断 target 是否为空，保护代码执行

拷贝会消耗性能，所以就加个保护解决。