### PR TITLE
sync 2d playOnFocus default value

### DIFF
--- a/cocos/core/data/decorators/editable.ts
+++ b/cocos/core/data/decorators/editable.ts
@@ -65,7 +65,7 @@ export const menu: (path: string) => ClassDecorator =
  * ```
  */
 export const playOnFocus: ClassDecorator & ((yes?: boolean) => ClassDecorator) =
-    DEV ? makeSmartEditorClassDecorator<boolean>('playOnFocus') : emptySmartClassDecorator;
+    DEV ? makeSmartEditorClassDecorator<boolean>('playOnFocus', true) : emptySmartClassDecorator;
 
 /**
  * @en Use a customized inspector page in the **inspector**
@@ -107,7 +107,7 @@ export const icon: (url: string) => ClassDecorator =
     DEV ? makeEditorClassDecoratorFn('icon') : emptyDecoratorFn;
 
 /**
- * @en Define the help documentation url, if given, the component section in the **inspector** will have a help documentation icon reference to the web page given. 
+ * @en Define the help documentation url, if given, the component section in the **inspector** will have a help documentation icon reference to the web page given.
  * @zh 指定当前组件的帮助文档的 url，设置过后，在 **属性检查器** 中就会出现一个帮助图标，用户点击将打开指定的网页。
  * @param url The url of the help documentation
  * @example


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/pull/3568

https://github.com/cocos-creator/3d-tasks/issues/3962

Changes:
 * sync 2d playOnFocus default value

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
