### PR TITLE
fix texture preloading

### DIFF
--- a/cocos2d/core/asset-manager/depend-util.js
+++ b/cocos2d/core/asset-manager/depend-util.js
@@ -168,7 +168,7 @@ var dependUtil = {
             else {
                 try {
                     var asset = deserialize(json);
-                    out = this._parseDepsFromAsset(asset)
+                    out = this._parseDepsFromAsset(asset);
                     out.nativeDep && (out.nativeDep.uuid = uuid);
                     parsed.add(uuid + '@import', asset);
                 }

--- a/cocos2d/core/asset-manager/pack-manager.js
+++ b/cocos2d/core/asset-manager/pack-manager.js
@@ -99,7 +99,7 @@ var packManager = {
                         cc.errorID(4915);
                     }
                     for (let i = 0; i < pack.length; i++) {
-                        out[pack[i] + '@import'] = packCustomObjData(textureType, datas[i]);
+                        out[pack[i] + '@import'] = packCustomObjData(textureType, datas[i], true);
                     }
                 }
             }

--- a/cocos2d/core/platform/deserialize-compiled.ts
+++ b/cocos2d/core/platform/deserialize-compiled.ts
@@ -994,12 +994,12 @@ export function unpackJSONs (data: IPackedFileData, classFinder?: ClassFinder): 
     return sections;
 }
 
-export function packCustomObjData (type: string, data: IClassObjectData|OtherObjectData): IFileData {
+export function packCustomObjData (type: string, data: IClassObjectData|OtherObjectData, hasNativeDep?: boolean): IFileData {
     return [
         SUPPORT_MIN_FORMAT_VERSION, EMPTY_PLACEHOLDER, EMPTY_PLACEHOLDER,
         [type],
         EMPTY_PLACEHOLDER,
-        [data],
+        hasNativeDep ? [data, ~0] : [data],
         [0],
         EMPTY_PLACEHOLDER, [], [], []
     ];

--- a/test/qunit/unit-es5/test-pack-unpack.js
+++ b/test/qunit/unit-es5/test-pack-unpack.js
@@ -73,12 +73,12 @@
     var tex1 = new cc.Texture2D();
     tex1._uuid = '555AC';
     tex1._setRawAsset('.png');
-    var tex1Json = Editor.serializeCompiled(tex1, { stringify: false });
+    var tex1Json = Editor.serializeCompiled(tex1, { stringify: false, noNativeDep: false });
 
     var tex2 = new cc.Texture2D();
     tex2._uuid = '08T18';
     tex2._setRawAsset('.jare');
-    var tex2Json = Editor.serializeCompiled(tex2, { stringify: false });
+    var tex2Json = Editor.serializeCompiled(tex2, { stringify: false, noNativeDep: false });
 
     test('pack and unpack something', function () {
         var packer = new Editor.TextureAssetPacker();


### PR DESCRIPTION
Re: https://discuss.cocos2d-x.org/t/preloadscene-does-not-load-assets-used-by-scene-in-2-4-3/51820
Changes:
 * 修复预加载图片无效的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
