### PR TITLE
Bump @cocos/build-engine: fix box-2d integration problem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "cocos-creator-3d",
-  "version": "1.1.1",
+  "name": "cocos-creator",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1322,9 +1322,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.0.0-jsb.alpha.6",
-      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-4.0.0-jsb.alpha.6.tgz",
-      "integrity": "sha1-HeR4/FFCXTTm2i09p31YWEGDgdk=",
+      "version": "4.0.0-jsb.alpha.9",
+      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-4.0.0-jsb.alpha.9.tgz",
+      "integrity": "sha1-fbKTR0306qfnMHG4eqrezUNUA9c=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -1377,7 +1377,7 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-6.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-6.0.0.tgz?cache=0&sync_timestamp=1602861367442&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcliui%2Fdownload%2Fcliui-6.0.0.tgz",
           "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
           "dev": true,
           "requires": {
@@ -1403,7 +1403,7 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://registry.npm.taobao.org/emoji-regex/download/emoji-regex-8.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/emoji-regex/download/emoji-regex-8.0.0.tgz?cache=0&sync_timestamp=1603212180491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Femoji-regex%2Fdownload%2Femoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
           "dev": true
         },
@@ -1446,11 +1446,12 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npm.taobao.org/resolve/download/resolve-1.17.0.tgz",
-          "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+          "version": "1.18.1",
+          "resolved": "https://registry.npm.taobao.org/resolve/download/resolve-1.18.1.tgz?cache=0&sync_timestamp=1603313597183&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve%2Fdownload%2Fresolve-1.18.1.tgz",
+          "integrity": "sha1-AY/LLFsgfSpkJK7jYcWiZtqPQTA=",
           "dev": true,
           "requires": {
+            "is-core-module": "^2.0.0",
             "path-parse": "^1.0.6"
           }
         },
@@ -1493,13 +1494,13 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz?cache=0&sync_timestamp=1601576683926&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fy18n%2Fdownload%2Fy18n-4.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz",
           "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
           "dev": true
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1600660006050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1602805577427&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
           "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
           "dev": true,
           "requires": {
@@ -1905,12 +1906,12 @@
       },
       "dependencies": {
         "@babel/helper-module-imports": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npm.taobao.org/@babel/helper-module-imports/download/@babel/helper-module-imports-7.10.4.tgz",
-          "integrity": "sha1-TFxUvgS9MWcKc4J5fXW5+i5bViA=",
+          "version": "7.12.1",
+          "resolved": "https://registry.npm.taobao.org/@babel/helper-module-imports/download/@babel/helper-module-imports-7.12.1.tgz?cache=0&sync_timestamp=1602802634702&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fhelper-module-imports%2Fdownload%2F%40babel%2Fhelper-module-imports-7.12.1.tgz",
+          "integrity": "sha1-FkTAFZGhWi8ITdbQktlDDrHRIWw=",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.12.1"
           }
         },
         "@babel/helper-validator-identifier": {
@@ -1920,9 +1921,9 @@
           "dev": true
         },
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npm.taobao.org/@babel/types/download/@babel/types-7.11.5.tgz?cache=0&sync_timestamp=1598904272861&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Ftypes%2Fdownload%2F%40babel%2Ftypes-7.11.5.tgz",
-          "integrity": "sha1-2d5XfQElLXfGgAzuA57mT691Zi0=",
+          "version": "7.12.1",
+          "resolved": "https://registry.npm.taobao.org/@babel/types/download/@babel/types-7.12.1.tgz",
+          "integrity": "sha1-4QnZq5mo3nNb4ofuPWqZR6GQxK4=",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
@@ -5695,6 +5696,15 @@
         "ci-info": "^2.0.0"
       }
     },
+    "is-core-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/is-core-module/download/is-core-module-2.0.0.tgz?cache=0&sync_timestamp=1603133391687&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-core-module%2Fdownload%2Fis-core-module-2.0.0.tgz",
+      "integrity": "sha1-WFMbcK7R23wOjU6xoKLR3dZL0S0=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-0.1.4.tgz",
@@ -8740,7 +8750,7 @@
     },
     "rollup": {
       "version": "2.26.6",
-      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.6.tgz?cache=0&sync_timestamp=1602131520389&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.6.tgz",
+      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.6.tgz",
       "integrity": "sha1-C0YMHaIkxq8SoelIooxROqEfK5M=",
       "dev": true,
       "requires": {
@@ -9441,7 +9451,7 @@
     },
     "terser": {
       "version": "4.8.0",
-      "resolved": "https://registry.npm.taobao.org/terser/download/terser-4.8.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/terser/download/terser-4.8.0.tgz?cache=0&sync_timestamp=1603374108186&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fterser%2Fdownload%2Fterser-4.8.0.tgz",
       "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.1.0",
-    "@cocos/build-engine": "4.0.0-jsb.alpha.6",
+    "@cocos/build-engine": "4.0.0-jsb.alpha.9",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.0.0-jsb.alpha.7",
+  "version": "4.0.0-jsb.alpha.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.0.0-jsb.alpha.7",
+  "version": "4.0.0-jsb.alpha.9",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "author": "",
   "license": "MIT"

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -262,7 +262,6 @@ async function _doBuild ({
         extensions: ['.js', '.ts'],
         highlightCode: true,
         exclude: [
-            /node_modules[\/\\]/g,
         ],
         plugins: babelPlugins,
         presets: [
@@ -313,14 +312,9 @@ async function _doBuild ({
             preferConst: true,
         }),
 
-        rpBabel(babelOptions),
+        commonjs({}),
 
-        commonjs({
-            namedExports: {
-                '@cocos/ammo': ['Ammo'],
-                '@cocos/cannon': ['CANNON'],
-            },
-        }),
+        rpBabel(babelOptions),
     ];
 
     if (options.progress) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Solve that `@cocos/box2d` can not be used. This is due to misuse of `rollup`: the `@cocos/box2d` won't be transformed(since we used `exclude` option of babel, which is further because the plugin order issue of `rollup`. See https://github.com/rollup/plugins/issues/620 
 for more detail.).

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
