### PR TITLE
@cocos/build-engine now accepts the `loose` option

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,8 @@ module.exports = (api) => {
     return {
         presets: [
             [require('@babel/preset-env'), {
-                targets: { node: 'current', }
+                targets: { node: 'current', },
+                loose: true,
             }],
             [require('@cocos/babel-preset-cc'), {
                 allowDeclareFields: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1322,9 +1322,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.0.0-jsb.alpha.9",
-      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-4.0.0-jsb.alpha.9.tgz",
-      "integrity": "sha1-fbKTR0306qfnMHG4eqrezUNUA9c=",
+      "version": "4.0.0-jsb.alpha.10",
+      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-4.0.0-jsb.alpha.10.tgz",
+      "integrity": "sha1-kkiFaxS2pQBHnduxymALUqWB7PI=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -1494,7 +1494,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz?cache=0&sync_timestamp=1603639294538&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fy18n%2Fdownload%2Fy18n-4.0.0.tgz",
           "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.1.0",
-    "@cocos/build-engine": "4.0.0-jsb.alpha.9",
+    "@cocos/build-engine": "4.0.0-jsb.alpha.10",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.0.0-jsb.alpha.9",
+  "version": "4.0.0-jsb.alpha.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1233,6 +1233,12 @@
       "requires": {
         "@babel/types": "^7.0.0"
       }
+    },
+    "@types/babel__preset-env": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npm.taobao.org/@types/babel__preset-env/download/@types/babel__preset-env-7.9.1.tgz",
+      "integrity": "sha1-umvHO/qiBQylRZI1+3PhRtD2aqY=",
+      "dev": true
     },
     "@types/babel__template": {
       "version": "7.0.2",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.0.0-jsb.alpha.9",
+  "version": "4.0.0-jsb.alpha.10",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.3",
+    "@types/babel__preset-env": "^7.9.1",
     "@types/fs-extra": "^8.0.1",
     "@types/json5": "0.0.30",
     "@types/node": "^13.1.7",

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -6,8 +6,8 @@ import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser as rpTerser } from 'rollup-plugin-terser';
-// @ts-ignore
 import babelPresetEnv from '@babel/preset-env';
+import type { Options as babelPresetEnvOptions } from '@babel/preset-env';
 import babelPresetCc from '@cocos/babel-preset-cc';
 // @ts-ignore
 import babelPluginTransformForOf from '@babel/plugin-transform-for-of';
@@ -117,9 +117,14 @@ namespace build {
         progress?: boolean;
 
         /**
-         * `options.targets` of @babel/preset-env.
+         * BrowsersList targets.
          */
         targets?: string | string[] | Record<string, string>;
+
+        /**
+         * Enable loose compilation.
+         */
+        loose?: boolean;
 
         visualize?: boolean | {
             file?: string;
@@ -245,7 +250,9 @@ async function _doBuild ({
         console.debug(`Module source "cc":\n${rpVirtualOptions['cc']}`);
     }
 
-    const presetEnvOptions: any = {};
+    const presetEnvOptions: babelPresetEnvOptions = {
+        loose: options.loose ?? true,
+    };
     if (options.targets !== undefined) {
         presetEnvOptions.targets = options.targets;
     }
@@ -261,8 +268,6 @@ async function _doBuild ({
         babelHelpers: 'bundled',
         extensions: ['.js', '.ts'],
         highlightCode: true,
-        exclude: [
-        ],
         plugins: babelPlugins,
         presets: [
             [babelPresetEnv, presetEnvOptions],

--- a/scripts/build-engine/src/make-cc.ts
+++ b/scripts/build-engine/src/make-cc.ts
@@ -8,11 +8,11 @@ export function generateCCSource (moduleRequests: string[]) {
     return moduleRequests.map(moduleRequest => `export * from '${moduleRequest}';`).join('\n');
 }
 
-export async function generateCCSourceTransformed (moduleRequests: string[], moduleOption: ModuleOption) {
+export async function generateCCSourceTransformed (moduleRequests: string[], moduleOption: ModuleOption, loose?: boolean) {
     const babelFormat = moduleOptionsToBabelEnvModules(moduleOption);
     const source = generateCCSource(moduleRequests);
     const babelFileResult = await babel.transformAsync(source, {
-        presets: [[babelPresetEnv, {modules: babelFormat }]],
+        presets: [[babelPresetEnv, { modules: babelFormat, loose: loose ?? true }]],
     });
     if (!babelFileResult || !babelFileResult.code) {
         throw new Error(`Failed to transform!`);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * @cocos/build-engine now accepts the `loose` option

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
