### PR TITLE
@cocos/build-engine: add option to remove deprecated features

### DIFF
--- a/cocos/core/animation/deprecated.ts
+++ b/cocos/core/animation/deprecated.ts
@@ -3,7 +3,7 @@
  * @module animation
  */
 
-import { replaceProperty } from '../utils/deprecated';
+import { replaceProperty } from '../utils/x-deprecated';
 import { Animation } from './animation-component';
 import { SkeletalAnimation } from './skeletal-animation';
 import { AnimationClip } from './animation-clip';

--- a/cocos/core/deprecated.ts
+++ b/cocos/core/deprecated.ts
@@ -3,7 +3,7 @@
  * @hidden
  */
 
-import { replaceProperty, removeProperty } from './utils/deprecated';
+import { replaceProperty, removeProperty } from './utils/x-deprecated';
 import * as math from './math';
 import { Scheduler } from './scheduler';
 import { EventTouch } from './platform/event-manager/events';

--- a/cocos/core/geometry/deprecated.ts
+++ b/cocos/core/geometry/deprecated.ts
@@ -3,7 +3,7 @@
  * @hidden
  */
 
-import { replaceProperty, removeProperty } from '../utils/deprecated';
+import { replaceProperty, removeProperty } from '../utils/x-deprecated';
 import line from './line';
 import intersect from './intersect';
 

--- a/cocos/core/math/deprecated.ts
+++ b/cocos/core/math/deprecated.ts
@@ -3,7 +3,7 @@
  * @hidden
  */
 
-import { removeProperty, replaceProperty } from '../utils/deprecated';
+import { removeProperty, replaceProperty } from '../utils/x-deprecated';
 import { Color } from './color';
 import { Mat3 } from './mat3';
 import { Mat4 } from './mat4';

--- a/cocos/core/renderer/scene/deprecated.ts
+++ b/cocos/core/renderer/scene/deprecated.ts
@@ -1,4 +1,4 @@
-import { replaceProperty, removeProperty, markAsWarning } from '../../utils/deprecated';
+import { replaceProperty, removeProperty, markAsWarning } from '../../utils/x-deprecated';
 import { RenderScene } from './render-scene';
 import { Layers } from '../../scene-graph/layers';
 import { legacyCC } from '../../global-exports';

--- a/cocos/core/scene-graph/deprecated.ts
+++ b/cocos/core/scene-graph/deprecated.ts
@@ -4,7 +4,7 @@
  */
 
 import { BaseNode } from './base-node';
-import { replaceProperty, removeProperty } from '../utils/deprecated';
+import { replaceProperty, removeProperty } from '../utils/x-deprecated';
 import { Layers } from './layers';
 import { Node } from './node';
 import { Vec2 } from '../math/vec2';

--- a/cocos/core/utils/coordinates-converts-utils.ts
+++ b/cocos/core/utils/coordinates-converts-utils.ts
@@ -6,7 +6,7 @@
 import { Camera } from '../3d/framework/camera-component';
 import { Vec3 } from '../math';
 import { Node } from '../scene-graph';
-import { replaceProperty } from './deprecated';
+import { replaceProperty } from './x-deprecated';
 import { legacyCC } from '../global-exports';
 
 const _vec3 = new Vec3();

--- a/cocos/core/utils/index.ts
+++ b/cocos/core/utils/index.ts
@@ -36,7 +36,7 @@ import * as misc from './misc';
  */
 import * as path from './path';
 
-export * from './deprecated';
+export * from './x-deprecated';
 export * from './text-utils';
 export * from './html-text-parser';
 export * from './prefab-helper';

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -1,6 +1,7 @@
 /**
  * @packageDocumentation
  * @hidden
+ * Note, naming this file with prefix `x-` exclude it from regular deprecated modules.
  */
 
 import { error, warn } from '../platform/debug';

--- a/cocos/particle/deprecated.ts
+++ b/cocos/particle/deprecated.ts
@@ -3,7 +3,7 @@
  * @module particle
  */
 
-import { removeProperty } from '../core/utils/deprecated';
+import { removeProperty } from '../core/utils/x-deprecated';
 import Burst from './burst';
 import { ParticleSystem } from './particle-system';
 import { Billboard } from './billboard';

--- a/cocos/physics-2d/box2d/physics-world.ts
+++ b/cocos/physics-2d/box2d/physics-world.ts
@@ -6,7 +6,7 @@ import { IVec2Like, Vec3, Quat, toRadian, Vec2, toDegree, Rect, Node, game, CCOb
 import { PHYSICS_2D_PTM_RATIO, ERaycast2DType } from '../framework/physics-types';
 import { ERigidBody2DType } from '../framework/physics-types';
 import { array } from '../../core/utils/js';
-import { CanvasComponent, GraphicsComponent } from '../../../exports/ui';
+import { Canvas, Graphics } from '../../../exports/ui';
 
 import { b2RigidBody2D } from './rigid-body';
 import { PhysicsContactListener } from './platform/physics-contact-listener';
@@ -55,7 +55,7 @@ export class b2PhysicsWorld implements IPhysicsWorld {
         this._raycastQueryCallback = new PhysicsRayCastCallback();
     }
 
-    _debugGraphics: GraphicsComponent | null = null;
+    _debugGraphics: Graphics | null = null;
     _b2DebugDrawer: b2.Draw | null = null;
 
     _debugDrawFlags = 0;
@@ -84,14 +84,14 @@ export class b2PhysicsWorld implements IPhysicsWorld {
             let canvas = find('Canvas');
             if (!canvas) {
                 canvas = new Node('Canvas');
-                canvas.addComponent(CanvasComponent);
+                canvas.addComponent(Canvas);
                 canvas.parent = director.getScene() as any;
             }
 
             node.parent = canvas;
             node.worldPosition = Vec3.ZERO;
 
-            this._debugGraphics = node.addComponent(GraphicsComponent);
+            this._debugGraphics = node.addComponent(Graphics);
             this._debugGraphics.lineWidth = 2;
 
             let debugDraw = new PhysicsDebugDraw(this._debugGraphics);

--- a/cocos/physics-2d/box2d/platform/physics-debug-draw.ts
+++ b/cocos/physics-2d/box2d/platform/physics-debug-draw.ts
@@ -26,7 +26,7 @@
 import b2 from '@cocos/box2d';
 import { Color } from '../../../core';
 import { PHYSICS_2D_PTM_RATIO } from '../../framework';
-import { GraphicsComponent } from '../../../ui';
+import { Graphics } from '../../../ui';
 
 let _tmp_vec2 = new b2.Vec2();
 let _tmp_color = new Color();
@@ -35,12 +35,12 @@ let GREEN_COLOR = Color.GREEN;
 let RED_COLOR = Color.RED;
 
 export class PhysicsDebugDraw extends b2.Draw {
-    _drawer: GraphicsComponent | null = null;
+    _drawer: Graphics | null = null;
 
     _xf = new b2.Transform;
     _dxf = new b2.Transform;
 
-    constructor (drawer: GraphicsComponent) {
+    constructor (drawer: Graphics) {
         super();
         this._drawer = drawer;
     }

--- a/cocos/physics-2d/builtin/builtin-world.ts
+++ b/cocos/physics-2d/builtin/builtin-world.ts
@@ -1,8 +1,8 @@
 import { IPhysicsWorld } from '../spec/i-physics-world'
 import { EDITOR } from 'internal:constants';
-import { GraphicsComponent } from '../../ui';
+import { Graphics } from '../../ui';
 import { Node, CCObject, find, director, Vec3, Color, IVec2Like, Vec2, Rect } from '../../core';
-import { CanvasComponent } from '../../../exports/ui';
+import { Canvas } from '../../../exports/ui';
 import { BuiltinShape2D } from './shapes/shape-2d';
 import { BuiltinBoxShape } from './shapes/box-shape-2d';
 import { BuiltinCircleShape } from './shapes/circle-shape-2d';
@@ -17,7 +17,7 @@ let testIntersectResults: Collider2D[] = [];
 export class BuiltinPhysicsWorld implements IPhysicsWorld {
     private _contacts: BuiltinContact[] = [];
     private _shapes: BuiltinShape2D[] = [];
-    private _debugGraphics: GraphicsComponent | null = null;
+    private _debugGraphics: Graphics | null = null;
     private _debugDrawFlags = 0;
 
     get debugDrawFlags () {
@@ -170,14 +170,14 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
             let canvas = find('Canvas');
             if (!canvas) {
                 canvas = new Node('Canvas');
-                canvas.addComponent(CanvasComponent);
+                canvas.addComponent(Canvas);
                 canvas.parent = director.getScene() as any;
             }
 
             node.parent = canvas;
             node.worldPosition = Vec3.ZERO;
 
-            this._debugGraphics = node.addComponent(GraphicsComponent);
+            this._debugGraphics = node.addComponent(Graphics);
             this._debugGraphics.lineWidth = 2;
 
         }

--- a/cocos/physics/framework/deprecated.ts
+++ b/cocos/physics/framework/deprecated.ts
@@ -4,7 +4,7 @@
  */
 
 import { PhysicsSystem } from "./physics-system";
-import { replaceProperty, removeProperty } from "../../core/utils/deprecated";
+import { replaceProperty, removeProperty } from "../../core/utils/x-deprecated";
 import { BoxCollider } from "./components/colliders/box-collider";
 import { SphereCollider } from "./components/colliders/sphere-collider";
 import { CapsuleCollider } from "./components/colliders/capsule-collider";

--- a/docs/contribution/deprecated-features.md
+++ b/docs/contribution/deprecated-features.md
@@ -1,0 +1,59 @@
+
+
+# Deprecated features
+
+If you feel a "public" feature(API) is not needed anymore, mark it as deprecated before you can completely remove it from the engine.
+
+Don't take anything for granted: do not suppose that the features should not have been used by users. The publics is public once it was public. The publics for example are module exports, public class members, fields of public interfaces.
+
+## Things you should do
+
+You should take the following rules to mark a feature as deprecated.
+
+### JsDoc
+
+Mark the API as deprecated using JsDoc:
+
+```ts
+/**
+ * @deprecated Reason or detail.
+ */
+export function f () {}
+```
+
+Illustrate the version you deprecate it. An explanation couldn't be better.
+
+### Put it in an isolated module
+
+When building the engine, users may be allowed to remove a version range of deprecated features. Below is the common practice.
+
+Put a serials of deprecated features, with same deprecating date, in a module file with stem name as `deprecated-${version}`, the `version` is the version since where you deprecate them. `version` shall be a valid **semver version**. For example `1.2.0` instead of `1.2`. If the version is in the specific range, the module will be removed.
+
+You may also simplify the stem name as `deprecated`.
+In such cases, the module is removed regardless of the user specified range. But it's strongly not recommended.
+
+Such a name convention is applied to all module files of engine.
+The regular module file names should not starts with a `deprecated` or `deprecated-` prefix.
+
+The "removal" is implemented as if each of the module is replaced as an empty module: `export {};`. Due to this,
+you shall not do named import/export from deprecated modules
+in modules that would be included in the building. For example, the following is not permitted:
+
+```ts
+export { Deprecated } from './deprecated-1.2.0';
+```
+
+In most cases, the named import/export is not required. If it does, simply constructs an also-deprecated module and export it:
+
+```ts
+// Module select-deprecated-1.2.0
+export { Deprecated } from './deprecated-1.2.0';
+```
+
+and the importing module:
+
+```ts
+export * from './select-deprecated-1.2.0';
+```
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1322,9 +1322,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.0.0-jsb.alpha.10",
-      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-4.0.0-jsb.alpha.10.tgz",
-      "integrity": "sha1-kkiFaxS2pQBHnduxymALUqWB7PI=",
+      "version": "4.0.0-jsb.alpha.11",
+      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-4.0.0-jsb.alpha.11.tgz?cache=0&sync_timestamp=1603778114450&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40cocos%2Fbuild-engine%2Fdownload%2F%40cocos%2Fbuild-engine-4.0.0-jsb.alpha.11.tgz",
+      "integrity": "sha1-7RRNezr8aSMYNfMky48JBIjfTKM=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -1343,6 +1343,7 @@
         "rollup": "2.26.6",
         "rollup-plugin-progress": "^1.1.1",
         "rollup-plugin-terser": "^5.2.0",
+        "semver": "^7.3.2",
         "yargs": "^15.1.0"
       },
       "dependencies": {
@@ -1454,6 +1455,12 @@
             "is-core-module": "^2.0.0",
             "path-parse": "^1.0.6"
           }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-7.3.2.tgz",
+          "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.0",
@@ -1941,7 +1948,7 @@
     },
     "@rollup/plugin-commonjs": {
       "version": "11.1.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-11.1.0.tgz?cache=0&sync_timestamp=1600666088505&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fplugin-commonjs%2Fdownload%2F%40rollup%2Fplugin-commonjs-11.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-11.1.0.tgz",
       "integrity": "sha1-YGNsenIvVLQeQZ4XCd8FxyNFV+8=",
       "dev": true,
       "requires": {
@@ -1965,7 +1972,7 @@
     },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-node-resolve/download/@rollup/plugin-node-resolve-7.1.3.tgz?cache=0&sync_timestamp=1597328884850&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fplugin-node-resolve%2Fdownload%2F%40rollup%2Fplugin-node-resolve-7.1.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-node-resolve/download/@rollup/plugin-node-resolve-7.1.3.tgz?cache=0&sync_timestamp=1603765888985&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fplugin-node-resolve%2Fdownload%2F%40rollup%2Fplugin-node-resolve-7.1.3.tgz",
       "integrity": "sha1-gN44Tt+9e/yRARZJEPhgeBUaPso=",
       "dev": true,
       "requires": {
@@ -1984,7 +1991,7 @@
     },
     "@rollup/pluginutils": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/pluginutils/download/@rollup/pluginutils-3.1.0.tgz?cache=0&sync_timestamp=1597328386643&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-3.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@rollup/pluginutils/download/@rollup/pluginutils-3.1.0.tgz?cache=0&sync_timestamp=1603767889260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-3.1.0.tgz",
       "integrity": "sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.1.0",
-    "@cocos/build-engine": "4.0.0-jsb.alpha.10",
+    "@cocos/build-engine": "4.0.0-jsb.alpha.11",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.0.0-jsb.alpha.10",
+  "version": "4.0.0-jsb.alpha.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20,6 +20,13 @@
         "browserslist": "^4.9.1",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        }
       }
     },
     "@babel/core": {
@@ -96,6 +103,11 @@
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
         }
       }
     },
@@ -149,6 +161,13 @@
         "invariant": "^2.2.4",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        }
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -1057,6 +1076,11 @@
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
         }
       }
     },
@@ -1292,6 +1316,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npm.taobao.org/@types/semver/download/@types/semver-7.3.4.tgz?cache=0&sync_timestamp=1600115372478&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fsemver%2Fdownload%2F%40types%2Fsemver-7.3.4.tgz",
+      "integrity": "sha1-Q9cWj+xvoJiLsaUTppeykpZyGvs=",
+      "dev": true
     },
     "@types/yargs": {
       "version": "15.0.4",
@@ -1974,9 +2004,9 @@
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+      "version": "7.3.2",
+      "resolved": "https://registry.npm.taobao.org/semver/download/semver-7.3.2.tgz",
+      "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg="
     },
     "serialize-javascript": {
       "version": "2.1.2",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.0.0-jsb.alpha.10",
+  "version": "4.0.0-jsb.alpha.11",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {
@@ -20,6 +20,7 @@
     "rollup": "2.26.6",
     "rollup-plugin-progress": "^1.1.1",
     "rollup-plugin-terser": "^5.2.0",
+    "semver": "^7.3.2",
     "yargs": "^15.1.0"
   },
   "devDependencies": {
@@ -29,6 +30,7 @@
     "@types/json5": "0.0.30",
     "@types/node": "^13.1.7",
     "@types/resolve": "^1.17.1",
+    "@types/semver": "^7.3.4",
     "@types/yargs": "^15.0.4",
     "rollup-plugin-visualizer": "^4.0.4"
   },

--- a/scripts/build-engine/src/cli.ts
+++ b/scripts/build-engine/src/cli.ts
@@ -9,6 +9,9 @@ import {
 } from './index';
 
 async function main() {
+    yargs.parserConfiguration({
+        'boolean-negation': false,
+    });
     yargs.help();
     yargs.options('engine', {
         type: 'string',
@@ -36,6 +39,17 @@ async function main() {
     });
     yargs.option('ammojs-wasm', {
         choices: [true, 'fallback'],
+    });
+    yargs.option('no-deprecated-features', {
+        description: `Whether to remove deprecated features. You can specify boolean or a version string(in semver)`,
+        type: 'string',
+        coerce: (arg: string | boolean) => {
+            return typeof arg !== 'string' ?
+                arg :
+                ((arg === 'true' || arg.length === 0) ? true : (
+                    arg === 'false' ? false : arg
+                ));
+        },
     });
     yargs.option('destination', {
         type: 'string',
@@ -105,6 +119,8 @@ async function main() {
         flags,
     });
 
+    const noDeprecatedFeatures = yargs.argv.noDeprecatedFeatures as (boolean | string | undefined);
+
     const options: build.Options = {
         engine: yargs.argv.engine as string,
         split: yargs.argv.split as boolean,
@@ -115,6 +131,7 @@ async function main() {
         progress: yargs.argv.progress as (boolean | undefined),
         incremental: yargs.argv['watch-files'] as (string | undefined),
         ammoJsWasm: yargs.argv['ammojs-wasm'] as (boolean | undefined | 'fallback'),
+        noDeprecatedFeatures: noDeprecatedFeatures,
         buildTimeConstants,
     };
     if (yargs.argv.module) {

--- a/scripts/build-engine/src/remove-deprecated-features.ts
+++ b/scripts/build-engine/src/remove-deprecated-features.ts
@@ -1,0 +1,38 @@
+import * as rollup from 'rollup';
+import semver from 'semver';
+import ps from 'path';
+
+export default function removeDeprecatedFeatures (range?: string): rollup.Plugin {
+    const versionRange = range ? new semver.Range(range) : undefined;
+    return {
+        name: '@cocos/build-engine | remove-deprecated-features',
+
+        load: function (this, id: string) {
+            if (!ps.isAbsolute(id)) {
+                return null;
+            }
+
+            const stem = ps.basename(id, ps.extname(id));
+            const match = /^deprecated(-)?(.*)/.exec(stem);
+            if (!match) {
+                return null;
+            }
+
+            const versionString = match[2];
+            if (versionString.length !== 0) {
+                const parsedVersion = semver.parse(versionString);
+                if (!parsedVersion) {
+                    console.debug(`${id} looks like a deprecated module, but it contains an invalid version.`);
+                    return null;
+                }
+                
+                if (versionRange && !semver.satisfies(parsedVersion, versionRange)) {
+                    return null;
+                }
+            }
+
+            console.debug(`Exclude deprecated module ${id}`);
+            return `export {}`;
+        },
+    };
+}


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Add @cocos/build-engine option to remove deprecated features;
 * rename the `core/utils/deprecated.ts` to `core/utils/x-deprecated.ts`;
 * DO NOT use deprecated features in some of main modules; @2youyou2  Please review on this.
 * doc the deprecated-features contribution guide.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
