### PR TITLE
tweaks of deprecated&tween due to loose mode

### DIFF
--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -112,21 +112,24 @@ replaceProperty = (owner: object, ownerName: string, properties: IReplacement[])
                     set (this, v: any) {
                         replacePropertyLog(ownerName, item.name, targetName, newName, warn, id);
                         item.customSetter!.call(this, v);
-                    }
+                    },
+                    enumerable: false,
                 });
             } else if (hasSetter) {
                 Object.defineProperty(owner, item.name, {
                     set (this, v: any) {
                         replacePropertyLog(ownerName, item.name, targetName, newName, warn, id);
                         item.customSetter!.call(this, v);
-                    }
+                    },
+                    enumerable: false,
                 });
             } else if (hasGetter) {
                 Object.defineProperty(owner, item.name, {
                     get (this) {
                         replacePropertyLog(ownerName, item.name, targetName, newName, warn, id);
                         return item.customGetter!.call(this);
-                    }
+                    },
+                    enumerable: false,
                 });
             }
         } else {
@@ -142,7 +145,8 @@ replaceProperty = (owner: object, ownerName: string, properties: IReplacement[])
                     } else {
                         target[newName] = v;
                     }
-                }
+                },
+                enumerable: false,
             });
         }
     });
@@ -171,7 +175,8 @@ removeProperty = (owner: object, ownerName: string, properties: IRemoveItem[]) =
             },
             set (this) {
                 removePropertyLog(ownerName, item.name, error, id, item.suggest);
-            }
+            },
+            enumerable: false,
         });
     });
 };
@@ -209,10 +214,8 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
         const deprecatedProp = item.name;
         const descriptor = Object.getOwnPropertyDescriptor(owner, deprecatedProp);
         if (!descriptor) { return; }
-
         const id = messageID++;
         messageMap.set(id, { id, count: 0, logTimes: item.logTimes !== undefined ? item.logTimes : defaultLogTimes, });
-
         if (descriptor.value != null) {
             if (typeof descriptor.value === 'function') {
                 const oldValue = descriptor.value as Function;
@@ -226,6 +229,7 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
         } else {
             _defaultGetSet(descriptor, ownerName, deprecatedProp, warn, id, item.suggest);
         }
+        Object.defineProperty(owner, deprecatedProp, { enumerable: false });
     });
 };
 

--- a/cocos/tween/tween-action.ts
+++ b/cocos/tween/tween-action.ts
@@ -103,6 +103,11 @@ export class TweenAction extends ActionInterval {
 
         this._props = Object.create(null);
         for (let name in props) {
+            // filtering if
+            // - it was not own property
+            // - it was a function
+            // - it was undefined / null
+            if (!props.hasOwnProperty(name)) continue;
             let value = props[name];
             if (!value || typeof value === 'function') continue;
             // property may have custom easing or progress function
@@ -157,6 +162,8 @@ export class TweenAction extends ActionInterval {
                 }
 
                 for (var k in value) {
+                    // filtering if it not a number
+                    if (isNaN(_t[k])) continue;
                     prop.start[k] = _t[k];
                     prop.current[k] = _t[k];
                     prop.end[k] = relative ? _t[k] + value[k] : value[k];


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * disable enum deprecated property
 * add some filtering to tween

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
