### PR TITLE
fix mesh.struct for native

### DIFF
--- a/cocos/core/assets/mesh.ts
+++ b/cocos/core/assets/mesh.ts
@@ -863,7 +863,7 @@ export class Mesh extends Asset {
             worldMatrix!.getRotation(rotate);
         }
         if (!this._initialized) {
-            const struct = JSON.parse(JSON.stringify(mesh._struct)) as Mesh.IStruct;
+            const struct = mesh._struct;
             const data = mesh._data.slice();
             if (worldMatrix) {
                 if (struct.maxPosition && struct.minPosition) {

--- a/cocos/core/renderer/scene/submodel.ts
+++ b/cocos/core/renderer/scene/submodel.ts
@@ -98,7 +98,6 @@ export class SubModel {
     public destroy () {
         DSPool.free(SubModelPool.get(this._handle, SubModelView.DESCRIPTOR_SET));
         IAPool.free(SubModelPool.get(this._handle, SubModelView.INPUT_ASSEMBLER));
-        SubMeshPool.free(SubModelPool.get(this._handle, SubModelView.SUB_MESH));
         SubModelPool.free(this._handle);
 
         this._descriptorSet = null;


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#4842](https://github.com/cocos-creator/3d-tasks/issues/4842)

Changes:
 * fix mesh.struct for native since native jsb attribute enumerable property was defined on prototype rather than on object.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
