### PR TITLE
Optimize rAF, cAF

### DIFF
--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -235,7 +235,6 @@ export class Director extends EventTarget {
 
     public _compScheduler: ComponentScheduler;
     public _nodeActivator: NodeActivator;
-    public _maxParticleDeltaTime: number;
     private _invalid: boolean;
     private _paused: boolean;
     private _purgeDirectorInNextLoop: boolean;
@@ -270,9 +269,6 @@ export class Director extends EventTarget {
         this._lastUpdate = 0;
         this._deltaTime = 0.0;
         this._startTime = 0.0;
-
-        // ParticleSystem max step delta time
-        this._maxParticleDeltaTime = 0.0;
 
         // Scheduler for user registration update
         this._scheduler = new Scheduler();

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -331,6 +331,10 @@ export class Game extends EventTarget {
     public collisionMatrix = [];
     public groupList: any[] = [];
 
+    get frameTime () {
+        return this._frameTime;
+    }
+
     // @Methods
 
     //  @Game play control
@@ -642,7 +646,6 @@ export class Game extends EventTarget {
         this._lastTime = performance.now();
         const frameRate = this.config.frameRate;
         this._frameTime = 1000 / frameRate;
-        legacyCC.director._maxParticleDeltaTime = this._frameTime / 1000 * 2;
         if (JSB || RUNTIME_BASED) {
             // @ts-ignore
             jsb.setPreferredFramesPerSecond(frameRate);

--- a/cocos/particle-2d/particle-simulator-2d.ts
+++ b/cocos/particle-2d/particle-simulator-2d.ts
@@ -25,7 +25,6 @@
 import { Vec2, Vec3, Color } from '../core/math';
 import Pool from '../core/utils/pool';
 import { clampf, degreesToRadians, radiansToDegrees } from '../core/utils/misc';
-import { director } from '../core/director';
 import { vfmtPosUvColor, getAttributeFormatBytes } from '../core/renderer/ui/ui-vertex-format';
 import { PositionType, EmitterMode, START_SIZE_EQUAL_TO_END_SIZE, START_RADIUS_EQUAL_TO_END_RADIUS } from './define';
 import { legacyCC } from '../../cocos/core/global-exports';

--- a/cocos/particle-2d/particle-simulator-2d.ts
+++ b/cocos/particle-2d/particle-simulator-2d.ts
@@ -28,6 +28,7 @@ import { clampf, degreesToRadians, radiansToDegrees } from '../core/utils/misc';
 import { director } from '../core/director';
 import { vfmtPosUvColor, getAttributeFormatBytes } from '../core/renderer/ui/ui-vertex-format';
 import { PositionType, EmitterMode, START_SIZE_EQUAL_TO_END_SIZE, START_RADIUS_EQUAL_TO_END_RADIUS } from './define';
+import { legacyCC } from '../../cocos/core/global-exports';
 
 const ZERO_VEC2 = new Vec2(0, 0);
 const _pos = new Vec2();
@@ -320,7 +321,8 @@ export class Simulator {
     };
 
     public step (dt) {
-        dt = dt > director._maxParticleDeltaTime ? director._maxParticleDeltaTime : dt;
+        const maxParticleDeltaTime = legacyCC.game.frameTime / 1000 * 2;
+        dt = dt > maxParticleDeltaTime ? maxParticleDeltaTime : dt;
         const psys = this.sys;
         const node = psys.node;
         const particles = this.particles;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Optimize `_sTimeWithRaf`.

 * Global namespace pollution of `window.rAF`, `window.cAF` are dropped. Replaced with `Game.prototype.requestAnimationFrame` and `Game.prototype.cancelAnimationFrame`.


------------------------------

In draft stage, this PR is still based on https://github.com/cocos-creator/engine/pull/7713. Once it's ready for review. I will rebase it.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
