### PR TITLE
improve _underlineHeight init value to 2 in the label

### DIFF
--- a/cocos/ui/components/label.ts
+++ b/cocos/ui/components/label.ts
@@ -658,7 +658,7 @@ export class Label extends UIRenderable {
     @serializable
     protected _isUnderline = false;
     @serializable
-    protected _underlineHeight = 0;
+    protected _underlineHeight = 2;
     @serializable
     protected _cacheMode = CacheMode.NONE;
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/4851

Changes:
 * improve _underlineHeight init value to 2 in the label
