### PR TITLE
fix makeAtLeastOneToggleChecked invalid when the toggleContainer enabled

### DIFF
--- a/cocos2d/core/components/CCToggleContainer.js
+++ b/cocos2d/core/components/CCToggleContainer.js
@@ -65,6 +65,8 @@ var ToggleContainer = cc.Class({
             default: [],
             type: cc.Component.EventHandler
         },
+        
+        _hasMakeAtLeastOneToggleChecked: false,
     },
 
     updateToggles: function (toggle) {
@@ -106,19 +108,25 @@ var ToggleContainer = cc.Class({
                 toggleItems[0].check();
             }
         }
+        this._hasMakeAtLeastOneToggleChecked = true;
     },
 
     onEnable: function () {
+        if (!this._hasMakeAtLeastOneToggleChecked) {
+            this._makeAtLeastOneToggleChecked();
+        }
         this.node.on('child-added', this._allowOnlyOneToggleChecked, this);
         this.node.on('child-removed', this._makeAtLeastOneToggleChecked, this);
     },
 
     onDisable: function () {
+        this._hasMakeAtLeastOneToggleChecked = false;
         this.node.off('child-added', this._allowOnlyOneToggleChecked, this);
         this.node.off('child-removed', this._makeAtLeastOneToggleChecked, this);
     },
 
     start: function () {
+        this._hasMakeAtLeastOneToggleChecked = false;
         this._makeAtLeastOneToggleChecked();
     }
 });

--- a/cocos2d/core/components/CCToggleContainer.js
+++ b/cocos2d/core/components/CCToggleContainer.js
@@ -65,8 +65,6 @@ var ToggleContainer = cc.Class({
             default: [],
             type: cc.Component.EventHandler
         },
-        
-        _hasMakeAtLeastOneToggleChecked: false,
     },
 
     updateToggles: function (toggle) {
@@ -108,27 +106,18 @@ var ToggleContainer = cc.Class({
                 toggleItems[0].check();
             }
         }
-        this._hasMakeAtLeastOneToggleChecked = true;
     },
 
     onEnable: function () {
-        if (!this._hasMakeAtLeastOneToggleChecked) {
-            this._makeAtLeastOneToggleChecked();
-        }
+        this._makeAtLeastOneToggleChecked();
         this.node.on('child-added', this._allowOnlyOneToggleChecked, this);
         this.node.on('child-removed', this._makeAtLeastOneToggleChecked, this);
     },
 
     onDisable: function () {
-        this._hasMakeAtLeastOneToggleChecked = false;
         this.node.off('child-added', this._allowOnlyOneToggleChecked, this);
         this.node.off('child-removed', this._makeAtLeastOneToggleChecked, this);
     },
-
-    start: function () {
-        this._hasMakeAtLeastOneToggleChecked = false;
-        this._makeAtLeastOneToggleChecked();
-    }
 });
 
 /**


### PR DESCRIPTION
Re: https://forum.cocos.org/t/creator2-4-1toggle/100125/7

Changes:
 * fix makeAtLeastOneToggleChecked invalid when the toggleContainer enabled

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
