### PR TITLE
fixed password type editbox show error

### DIFF
--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -477,7 +477,7 @@ Object.assign(WebEditBoxImpl.prototype, {
         elem.style.active = 0;
         elem.style.outline = 'medium';
         elem.style.padding = '0';
-        elem.style.textTransform = 'uppercase';
+        elem.style.textTransform = 'none';
         elem.style.position = "absolute";
         elem.style.bottom = "0px";
         elem.style.left = LEFT_PADDING + "px";

--- a/cocos2d/core/components/editbox/WebEditBoxImpl.js
+++ b/cocos2d/core/components/editbox/WebEditBoxImpl.js
@@ -421,6 +421,7 @@ Object.assign(WebEditBoxImpl.prototype, {
         // begin to updateInputType
         if (inputFlag === InputFlag.PASSWORD) {
             elem.type = 'password';
+            elem.style.textTransform = 'none';
             return;
         }
     


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/3216
Changes:

The default value of `textTransform` should not be set to `uppercase`, it should be `none`