### PR TITLE
add an empty sub mesh to fix cc.geomUtils.intersect.rayMesh issue.

### DIFF
--- a/cocos2d/core/mesh/CCMesh.js
+++ b/cocos2d/core/mesh/CCMesh.js
@@ -168,6 +168,7 @@ let Mesh = cc.Class({
 
             if (CC_JSB && CC_NATIVERENDERER) {
                 meshData.vDirty = true;
+                this._subMeshes.push(new InputAssembler(null, null));
             } else {
                 let vbBuffer = new gfx.VertexBuffer(
                     renderer.device,


### PR DESCRIPTION
issue:
https://discuss.cocos2d-x.org/t/raymesh-on-native-always-return-infinity-2-4-3/51994/3

[rayMeshTest.zip](https://github.com/cocos-creator/engine/files/5841907/rayMeshTest.zip)
