### PR TITLE
fix editBox event  unregister

### DIFF
--- a/port/native/engine/jsb-editbox.js
+++ b/port/native/engine/jsb-editbox.js
@@ -108,9 +108,6 @@
 
             function onComplete (res) {
                 self.endEditing();
-                jsb.inputBox.offConfirm(onConfirm);
-                jsb.inputBox.offInput(onInput);
-                jsb.inputBox.offComplete(onComplete);
             }
 
             jsb.inputBox.onInput(onInput);
@@ -142,6 +139,9 @@
             if (!cc.sys.isMobile) {
                 this._delegate._showLabels();
             }
+            jsb.inputBox.offConfirm();
+            jsb.inputBox.offInput();
+            jsb.inputBox.offComplete();
             jsb.inputBox.hide();
             this._delegate._editBoxEditingDidEnded();
         }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/4910

Changes:
 * 修复 editbox 编辑状态下切换场景导致事件没有被反注册的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
