### PR TITLE
Introduce the `EXPORT_TO_GLOBAL`

### DIFF
--- a/@types/consts.d.ts
+++ b/@types/consts.d.ts
@@ -1,5 +1,13 @@
+declare module 'internal:constants' {
+    /**
+     * This constant is private and used for internal purpose only.
+     *
+     * If true, some of the constants of `internal:constants` would be also export to the global namespace.
+     * For example would set `CC_EDITOR` on `globalThis` as `EDITOR`.
+     * This is due to we at present inherits the way how Creator prior to 3.0 deploys the build time constants.
+     */
+    export const EXPORT_TO_GLOBAL: boolean;
 
-declare module "internal:constants" {
     /**
      * Running in published project.
      */
@@ -89,7 +97,7 @@ declare module "internal:constants" {
      * Running in the linksure's quick game.
      */
     export const LINKSURE: boolean;
-    
+
     /**
      * Running in mini game.
      */
@@ -99,7 +107,6 @@ declare module "internal:constants" {
      * Running in runtime environments.
      */
     export const RUNTIME_BASED: boolean;
-
 
     export const SUPPORT_JIT: boolean;
 }

--- a/cocos/core/default-constants.ts
+++ b/cocos/core/default-constants.ts
@@ -37,6 +37,8 @@ function tryDefineGlobal (name: string, value: boolean): boolean {
     }
 }
 
+// No export to global required since we have already done here.
+export const EXPORT_TO_GLOBAL = false;
 export const BUILD = tryDefineGlobal('CC_BUILD', false);
 export const TEST = tryDefineGlobal('CC_TEST', defined('tap') || defined('QUnit'));
 export const EDITOR = tryDefineGlobal('CC_EDITOR', defined('Editor') && defined('process') && ('electron' in process.versions));

--- a/cocos/core/global-exports.ts
+++ b/cocos/core/global-exports.ts
@@ -48,6 +48,7 @@ import {
     HUAWEI,
     OPPO,
     VIVO,
+    EXPORT_TO_GLOBAL,
 } from 'internal:constants';
 
 const _global = typeof window === 'undefined' ? global : window;
@@ -68,7 +69,7 @@ export const legacyCC: Record<string, any> & {
 // For internal usage
 legacyCC.internal = {};
 
-if (BUILD) {
+if (EXPORT_TO_GLOBAL) {
     // Supports dynamically access from external scripts such as adapters and debugger.
     // So macros should still defined in global even if inlined in engine.
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1444,9 +1444,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-4.0.0-beta.4.tgz",
-      "integrity": "sha1-Jh2vfGUl5iXJYwlL6la6TmQEOJs=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npm.taobao.org/@cocos/build-engine/download/@cocos/build-engine-4.0.1.tgz?cache=0&sync_timestamp=1605755224372&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40cocos%2Fbuild-engine%2Fdownload%2F%40cocos%2Fbuild-engine-4.0.1.tgz",
+      "integrity": "sha1-1BwuvJWf3ZZ/m69udssMIKIKWVk=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -1520,7 +1520,7 @@
         },
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-8.1.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-8.1.0.tgz?cache=0&sync_timestamp=1591229972229&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-8.1.0.tgz",
           "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
           "dev": true,
           "requires": {
@@ -9894,7 +9894,7 @@
     },
     "rollup": {
       "version": "2.26.6",
-      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.6.tgz?cache=0&sync_timestamp=1605363097629&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.6.tgz",
+      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.6.tgz?cache=0&sync_timestamp=1605677265137&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup%2Fdownload%2Frollup-2.26.6.tgz",
       "integrity": "sha1-C0YMHaIkxq8SoelIooxROqEfK5M=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.0.0-beta.4",
+    "@cocos/build-engine": "4.0.1",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.0.0-beta.4",
+  "version": "4.0.1",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -232,7 +232,10 @@ async function _doBuild ({
     );
 
     const rpVirtualOptions: Record<string, string> = {};
-    const vmInternalConstants = getModuleSourceInternalConstants(options.buildTimeConstants);
+    const vmInternalConstants = getModuleSourceInternalConstants({
+        EXPORT_TO_GLOBAL: true,
+        ...options.buildTimeConstants,
+    });
     console.debug(`Module source "internal-constants":\n${vmInternalConstants}`);
     rpVirtualOptions['internal:constants'] = vmInternalConstants;
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * There may be a situation that `@cocos/build-engine` is used to build a release for previewing. The `BUILD` and `PREVIEW` are conflict therefor.

Request review from @PPpro 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
