### PR TITLE
add CCTextureWithIndex macro

### DIFF
--- a/cocos2d/renderer/build/chunks/texture.inc
+++ b/cocos2d/renderer/build/chunks/texture.inc
@@ -25,3 +25,16 @@
     _color_.rgb *= _texture_##_tmp.rgb;                                         \
   #endif                                                            \
   #pragma // empty pragma trick to get rid of trailing semicolons at effect compile time
+
+#define CCTextureWithIndex(_texture_, _uv_, _color_, __index__)                             \
+  vec4 _texture_##_tmp##__index__ = texture(_texture_, _uv_);                      \
+  #if CC_USE_ALPHA_ATLAS_##_texture_                                  \
+      _texture_##_tmp##__index__.a *= texture(_texture_, _uv_ + vec2(0, 0.5)).r;   \
+  #endif                                                            \
+  #if INPUT_IS_GAMMA                                                \
+    _color_.rgb *= SRGBToLinear(_texture_##_tmp##__index__.rgb);                   \
+    _color_.a *= _texture_##_tmp##__index__.a;                                     \
+  #else                                                             \
+    _color_ *= _texture_##_tmp##__index__;                                         \
+  #endif                                                            \
+  #pragma // empty pragma trick to get rid of trailing semicolons at effect compile time


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * add CCTextureWithIndex macro, which support sampler sample texture multiple times

```js
CCTextureWithIndex(texture, v_uv0, o, 1);
CCTextureWithIndex(texture, v_uv0, o, 2);
```
