### PR TITLE
fix when dragging the program to switch between two screens at runtim…

### DIFF
--- a/port/native/engine/jsb-game.js
+++ b/port/native/engine/jsb-game.js
@@ -48,6 +48,8 @@ jsb.onResize = function (size) {
         width: size.width,
         height: size.height,
     };
+    size.width /= window.devicePixelRatio;
+    size.height /= window.devicePixelRatio;
     window.resize(size.width, size.height);
 };
 


### PR DESCRIPTION
…e, the click event is invalid.

Re: https://github.com/cocos-creator/3d-tasks/issues/5462

Changes:
 * When dragging the program to switch between two screens at runtime, the click event is invalid.
