### PR TITLE
Provide global touches and count getter in InputManager

### DIFF
--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -250,11 +250,11 @@ let inputManager = {
      * @returns {Array}
      */
     getSetOfTouchesEndOrCancel (touches) {
-        let selTouch, index, touchID, handleTouches = [], locTouches = this._touches, locTouchesIntDict = this._touchesIntegerDict;
+        let selTouch, index, touchID, handleTouches = [], locTouches = this._touches;
         for (let i = 0, len = touches.length; i< len; i ++) {
             selTouch = touches[i];
             touchID = selTouch.getID();
-            index = locTouchesIntDict[touchID];
+            index = this._touchesIntegerDict[touchID];
 
             if (index == null) {
                 continue;  //cc.log("if the index doesn't exist, it is an error");
@@ -264,7 +264,8 @@ let inputManager = {
                 locTouches[index]._setPrevPoint(selTouch._prevPoint);
                 handleTouches.push(locTouches[index]);
                 this._removeUsedIndexBit(index);
-                delete locTouchesIntDict[touchID];
+                delete this._touchesCache[touchID];
+                delete this._touchesIntegerDict[touchID];
             }
         }
         return handleTouches;

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -81,10 +81,10 @@ let inputManager = {
         let locTouchesCache = this._touchesCache;
 
         for (let i = 0; i < this._maxTouches; i++) {
-            let touch = locTouches[i];
-            if (now - touch._lastModified > timeout) {
+            const ccTouch = locTouches[i];
+            if (ccTouch && (now - ccTouch._lastModified > timeout)) {
                 this._removeUsedIndexBit(i);
-                const touchID = touch.getID();
+                const touchID = ccTouch.getID();
                 delete locTouchesIntDict[touchID];
                 delete locTouchesCache[touchID];
                 this._touchCount--;
@@ -276,10 +276,12 @@ let inputManager = {
             if (index == null) {
                 continue;  //cc.log("if the index doesn't exist, it is an error");
             }
-            if (locTouches[index]) {
-                locTouches[index]._setPoint(selTouch._point);
-                locTouches[index]._setPrevPoint(selTouch._prevPoint);
-                handleTouches.push(locTouches[index]);
+
+            const ccTouch = locTouches[index];
+            if (ccTouch) {
+                ccTouch._setPoint(selTouch._point);
+                ccTouch._setPrevPoint(selTouch._prevPoint);
+                handleTouches.push(ccTouch);
                 this._removeUsedIndexBit(index);
                 delete locTouchesIntDict[touchID];
                 delete locTouchesCache[touchID];
@@ -613,3 +615,4 @@ let inputManager = {
 
 
 module.exports = cc.internal.inputManager = inputManager;
+

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -44,14 +44,19 @@ let inputManager = {
     _preTouchPool: [],
     _preTouchPoolPointer: 0,
 
+    // All touches pool
     _touches: [],
-    _touchesIntegerDict:{},
-
-    _touchesCache: {},
-    _touchCount: 0,
-
-    _indexBitsUsed: 0,
+    // Maximum available touches, it's also the length of _touches array
     _maxTouches: 10,
+    // Global touches map with touch id as key and index in _touches as value 
+    _touchesIntegerDict:{},
+    // A bit mask for index of _touches, every bit indicates whether the correspond touch is currently valid
+    _indexBitsUsed: 0,
+
+    // A global touches map with touch id as key and touch object as value, only contains currently valid touches
+    _touchesCache: {},
+    // Current global touches count (only valid touches)
+    _touchCount: 0,
 
     _accelEnabled: false,
     _accelInterval: 1/5,
@@ -106,15 +111,7 @@ let inputManager = {
             temp >>= 1;
         }
 
-        // all bits are used
         return unused;
-    },
-
-    _removeUsedIndexBit (index) {
-        if (index < 0 || index >= this._maxTouches)
-            return;
-
-        this._indexBitsUsed &= ~(1 << index);
     },
 
     _glView: null,
@@ -295,6 +292,24 @@ let inputManager = {
         }
         return handleTouches;
     },
+
+    /**
+     * Gets the count of all currently valid touches.
+     * @method getGlobalTouchCount
+     * @return Current global touches count (only valid touches)
+     */
+    getGlobalTouchCount () {
+        return this._touchCount;
+    },
+
+    /**
+     * Gets global touches map, please do not modify the touches, otherwise all event listener will be affected
+     * @method getGlobalTouches
+     * @return A global touches map with touch id as key and touch object as value, only contains currently valid touches
+     */
+    getGlobalTouches () {
+        return this._touchesCache;
+    }
 
     /**
      * @method getPreTouch
@@ -607,14 +622,6 @@ let inputManager = {
         }
         this._accelCurTime += dt;
     },
-
-    getGlobalTouchCount () {
-        return this._touchCount;
-    },
-
-    getGlobalTouches () {
-        return this._touchesCache;
-    }
 
 };
 

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -150,7 +150,7 @@ let inputManager = {
             selTouch = touches[i];
             touchID = selTouch.getID();
 
-            index = locTouchIntDict[touchID];
+            index = this._touchesIntegerDict[touchID];
             if (index == null) {
                 let unusedIndex = this._getUnUsedIndex();
                 if (unusedIndex === -1) {

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -51,7 +51,7 @@ let inputManager = {
     _touchCount: 0,
 
     _indexBitsUsed: 0,
-    _maxTouches: 8,
+    _maxTouches: 10,
 
     _accelEnabled: false,
     _accelInterval: 1/5,

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -81,25 +81,29 @@ let inputManager = {
         let locTouchesCache = this._touchesCache;
 
         for (let i = 0; i < this._maxTouches; i++) {
-            const ccTouch = locTouches[i];
-            if (ccTouch && (now - ccTouch._lastModified > timeout)) {
-                this._removeUsedIndexBit(i);
-                const touchID = ccTouch.getID();
-                delete locTouchesIntDict[touchID];
-                delete locTouchesCache[touchID];
-                this._touchCount--;
-
-                if (unused === -1) {
+            if (!(temp & 0x00000001)) {
+                if (unused === -1){
                     unused = i;
                     this._indexBitsUsed |= (1 << i);
                 }
+            } else {
+                const ccTouch = locTouches[i];
+                if (ccTouch && (now - ccTouch._lastModified > timeout)) {
+                    const touchID = ccTouch.getID();
+                    delete locTouchesIntDict[touchID];
+                    delete locTouchesCache[touchID];
+                    this._touchCount--;
+
+                    if (unused === -1) {
+                        unused = i;
+                        this._indexBitsUsed |= (1 << i);
+                    } else {
+                        this._indexBitsUsed &= ~(1 << i);
+                    }
+                }
             }
 
-            if (unused === -1 && !(temp & 0x00000001)) {
-                unused = i;
-                this._indexBitsUsed |= (1 << i);
-                temp >>= 1;
-            }
+            temp >>= 1;
         }
 
         // all bits are used
@@ -282,10 +286,11 @@ let inputManager = {
                 ccTouch._setPoint(selTouch._point);
                 ccTouch._setPrevPoint(selTouch._prevPoint);
                 handleTouches.push(ccTouch);
-                this._removeUsedIndexBit(index);
                 delete locTouchesIntDict[touchID];
                 delete locTouchesCache[touchID];
                 this._touchCount--;
+
+                this._indexBitsUsed &= ~(1 << index);
             }
         }
         return handleTouches;
@@ -613,6 +618,4 @@ let inputManager = {
 
 };
 
-
 module.exports = cc.internal.inputManager = inputManager;
-

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -309,7 +309,7 @@ let inputManager = {
      */
     getGlobalTouches () {
         return this._touchesCache;
-    }
+    },
 
     /**
      * @method getPreTouch

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -606,7 +606,7 @@ let inputManager = {
         let _touchesCache = this._touchesCache;
         for (let touchID in _touchesCache) {
             let ccTouch = _touchesCache[touchID];
-            if (!ccTouch || now - touch._lastModified > timeout) {
+            if (!ccTouch || now - ccTouch._lastModified > timeout) {
                 delete _touchesCache[touchID];
                 this._touchCount--;
             }

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -222,18 +222,6 @@ let inputManager = {
      * @param {Array} touches
      */
     handleTouchesEnd (touches) {
-        let touchID;
-        let _touchesCache = this._touchesCache;
-        for (let i = 0, len = touches.length; i < len; i++) {
-            touchID = touches[i].getID();
-
-            let ccTouch = _touchesCache[touchID];
-            if (ccTouch) {
-                delete _touchesCache[touchID];
-                this._touchCount--;
-            }
-        }
-
         let handleTouches = this.getSetOfTouchesEndOrCancel(touches);
         if (handleTouches.length > 0) {
             this._glView._convertTouchesWithScale(handleTouches);
@@ -265,11 +253,19 @@ let inputManager = {
      * @returns {Array}
      */
     getSetOfTouchesEndOrCancel (touches) {
+        let _touchesCache = this._touchesCache;
+
         let selTouch, index, touchID, handleTouches = [], locTouches = this._touches, locTouchesIntDict = this._touchesIntegerDict;
         for (let i = 0, len = touches.length; i< len; i ++) {
             selTouch = touches[i];
             touchID = selTouch.getID();
             index = locTouchesIntDict[touchID];
+
+            let ccTouch = _touchesCache[touchID];
+            if (ccTouch) {
+                delete _touchesCache[touchID];
+                this._touchCount--;
+            }
 
             if (index == null) {
                 continue;  //cc.log("if the index doesn't exist, it is an error");
@@ -609,3 +605,4 @@ let inputManager = {
 
 
 module.exports = cc.internal.inputManager = inputManager;
+

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -593,6 +593,26 @@ let inputManager = {
         this._accelCurTime += dt;
     },
 
+    // (此处注释需要更新)
+    // 某些安卓手机有特殊的全屏多点触控手势, 这些手势会导致 cocos无法获得正确的 "在屏手指"数.
+    // 所以用户应该根据自己的需求 适时的调用这个方法.
+    //  比如在 touchStart时, 而且 timeout 应该传入一个比较小的毫秒值.
+    cleanTimeoutGlobalTouches (timeout) {
+        if (this._touchCount < 1) {
+            return;
+        }
+        timeout = timeout || TOUCH_TIMEOUT;
+        let now = cc.sys.now();
+        let _touchesCache = this._touchesCache;
+        for (let touchID in _touchesCache) {
+            let ccTouch = _touchesCache[touchID];
+            if (!ccTouch || now - touch._lastModified > timeout) {
+                delete _touchesCache[touchID];
+                this._touchCount--;
+            }
+        }
+    },
+
     getGlobalTouchCount () {
         return this._touchCount;
     },


### PR DESCRIPTION
增加了  getGlobalTouchCount()  和 getGlobalTouches() , 用来获取 此时此刻 还按在屏幕上的 "手指" 数量 和 相应的对象.

Re: cocos-creator/2d-tasks#

Changes:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
