### PR TITLE
Suppress no-initializer warns if the property is declared to have object type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,8 @@
     "eslint.validate": [
         "javascript",
         "typescript"
-    ]
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll": true,
+    },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,8 +14,5 @@
     "eslint.validate": [
         "javascript",
         "typescript"
-    ],
-    "editor.codeActionsOnSave": {
-        "source.fixAll": true,
-    },
+    ]
 }

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -433,11 +433,9 @@ export function CCClass<TFunction> (options: {
  * @return {Boolean}
  * @private
  */
-CCClass._isCCClass = function isCCClass (constructor): boolean {
-    // Does not support fastDefined class (ValueType).
-    // Use `instanceof ValueType` if necessary.
-    // eslint-disable-next-line no-prototype-builtins, @typescript-eslint/no-unsafe-return
-    return constructor?.hasOwnProperty?.('__ctors__');     // __ctors__ is not inherited
+CCClass._isCCClass = function (constructor) {
+    return constructor && constructor.hasOwnProperty &&
+        constructor.hasOwnProperty('__ctors__');     // is not inherited __ctors__
 };
 
 //
@@ -571,7 +569,7 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
 
     if ('default' in attributes) {
         (attrs || initAttrs())[`${propertyNamePrefix}default`] = attributes.default;
-    } else if (DEV && warnOnNoDefault && !(attributes.get || attributes.set)) {
+    } else if (((EDITOR && !window.Build) || TEST) && warnOnNoDefault && !(attributes.get || attributes.set)) {
         warnID(3654, className, propertyName);
     }
 

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -569,7 +569,7 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
         }
     }
 
-    if (Object.prototype.hasOwnProperty.call(attributes, 'default')) {
+    if ('default' in attributes) {
         (attrs || initAttrs())[`${propertyNamePrefix}default`] = attributes.default;
     } else if (DEV && warnOnNoDefault && !(attributes.get || attributes.set)) {
         warnID(3654, className, propertyName);

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -588,7 +588,7 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
 
     if (attributes.editorOnly) {
         if (DEV && usedInGetter) {
-            errorID(3613, 'editorOnly', name, propertyName);
+            errorID(3613, 'editorOnly', className, propertyName);
         }
         else {
             (attrs || initAttrs())[propertyNamePrefix + 'editorOnly'] = true;
@@ -613,7 +613,7 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
     } else {
         if (attributes.serializable === false) {
             if (DEV && usedInGetter) {
-                errorID(3613, 'serializable', name, propertyName);
+                errorID(3613, 'serializable', className, propertyName);
             }
             else {
                 (attrs || initAttrs())[propertyNamePrefix + 'serializable'] = false;

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -433,9 +433,11 @@ export function CCClass<TFunction> (options: {
  * @return {Boolean}
  * @private
  */
-CCClass._isCCClass = function (constructor) {
-    return constructor && constructor.hasOwnProperty &&
-        constructor.hasOwnProperty('__ctors__');     // is not inherited __ctors__
+CCClass._isCCClass = function isCCClass (constructor): boolean {
+    // Does not support fastDefined class (ValueType).
+    // Use `instanceof ValueType` if necessary.
+    // eslint-disable-next-line no-prototype-builtins, @typescript-eslint/no-unsafe-return
+    return constructor?.hasOwnProperty?.('__ctors__');     // __ctors__ is not inherited
 };
 
 //

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -117,8 +117,6 @@ function appendProp (cls, name) {
 }
 
 function defineProp (cls, className, propName, val) {
-    const defaultValue = val.default;
-
     if (DEV) {
         // check base prototype to avoid name collision
         if (CCClass.getInheritanceChain(cls)
@@ -127,9 +125,6 @@ function defineProp (cls, className, propName, val) {
             return;
         }
     }
-
-    // set default value
-    attributeUtils.setClassAttr(cls, propName, 'default', defaultValue);
 
     appendProp(cls, propName);
 
@@ -357,7 +352,7 @@ function declareProperties (cls, className, properties, baseClass, mixins) {
 
         for (const propName in properties) {
             const val = properties[propName];
-            if ('default' in val) {
+            if (!val.get && !val.set) {
                 defineProp(cls, className, propName, val);
             }
             else {
@@ -506,7 +501,13 @@ interface IParsedAttribute extends IAcceptableAttributes {
 type OnAfterProp = (constructor: Function, mainPropertyName: string) => void;
 const onAfterProps_ET: OnAfterProp[] = [];
 
-function parseAttributes (constructor: Function, attributes: IAcceptableAttributes, className: string, propertyName: string, usedInGetter) {
+interface AttributesRecord {
+    get?: unknown;
+    set?: unknown;
+    default?: unknown;
+}
+
+function parseAttributes (constructor: Function, attributes: IAcceptableAttributes & AttributesRecord, className: string, propertyName: string, usedInGetter) {
     const ERR_Type = DEV ? 'The %s of %s must be type %s' : '';
 
     let attrs: IParsedAttribute | null = null;
@@ -523,6 +524,8 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
     if ('type' in attributes && typeof attributes.type === 'undefined') {
         warnID(3660, propertyName, className);
     }
+
+    let warnOnNoDefault = true;
 
     const type = attributes.type;
     if (type) {
@@ -554,6 +557,8 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
                 errorID(3645, className, propertyName, type);
             }
         } else if (typeof type === 'function') {
+            // Do not warn missing-default if the type is object
+            warnOnNoDefault = false;
             (attrs || initAttrs())[propertyNamePrefix + 'type'] = 'Object';
             attrs![propertyNamePrefix + 'ctor'] = type;
             if (((EDITOR && !window.Build) || TEST) && !attributes._short) {
@@ -562,6 +567,12 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
         } else if (DEV) {
             errorID(3646, className, propertyName, type);
         }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(attributes, 'default')) {
+        (attrs || initAttrs())[`${propertyNamePrefix}default`] = attributes.default;
+    } else if (DEV && warnOnNoDefault && !(attributes.get || attributes.set)) {
+        warnID(3654, className, propertyName);
     }
 
     const parseSimpleAttribute = (attributeName: keyof IAcceptableAttributes, expectType: string) => {

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -176,35 +176,21 @@ function genProperty (
             return;
         }
 
-        let defaultValue: any;
-        let isDefaultValueSpecified = false;
         if (descriptor) {
             // In case of Babel, if an initializer is given for class field.
             // That initializer is passed to `descriptor.initializer`.
             // babel
             if (descriptor.initializer) {
-                defaultValue = getDefaultFromInitializer(descriptor.initializer);
-                isDefaultValueSpecified = true;
+                propertyRecord.default = getDefaultFromInitializer(descriptor.initializer);
             }
         } else {
             // In case of TypeScript, we can not directly capture the initializer.
             // We have to be hacking to extract the value.
             const actualDefaultValues = cache.default || (cache.default = extractActualDefaultValues(ctor));
             if (actualDefaultValues.hasOwnProperty(propertyKey)) {
-                defaultValue = actualDefaultValues[propertyKey];
-                isDefaultValueSpecified = true;
+                propertyRecord.default = actualDefaultValues[propertyKey];
             }
         }
-
-        if ((EDITOR && !window.Build) || TEST) {
-            if (!fullOptions && options && options.hasOwnProperty('default')) {
-                warnID(3653, propertyKey, js.getClassName(ctor));
-            } else if (!isDefaultValueSpecified) {
-                warnID(3654, js.getClassName(ctor), propertyKey);
-            }
-        }
-
-        propertyRecord.default = defaultValue;
     }
 
     properties[propertyKey] = propertyRecord;

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -191,6 +191,12 @@ function genProperty (
                 propertyRecord.default = actualDefaultValues[propertyKey];
             }
         }
+
+        if ((EDITOR && !window.Build) || TEST) {
+            if (!fullOptions && options && options.hasOwnProperty('default')) {
+                warnID(3653, propertyKey, js.getClassName(ctor));
+            }
+        }
     }
 
     properties[propertyKey] = propertyRecord;

--- a/tests/core/ccclass.test.ts
+++ b/tests/core/ccclass.test.ts
@@ -1,6 +1,6 @@
 import { ccclass } from 'cc.decorator';
 import { warnID } from '../../cocos/core';
-import { property } from '../../cocos/core/data/class-decorator';
+import { float, property } from '../../cocos/core/data/class-decorator';
 
 /**
  * Happened when:
@@ -32,4 +32,28 @@ test('explicit undefined type', () => {
     expect(warnID).toHaveBeenCalledTimes(2);
     expect(warnID).toHaveBeenNthCalledWith(1, 3660, 'property1', Foo.name);
     expect(warnID).toHaveBeenNthCalledWith(2, 3660, 'property2', Foo.name);
+});
+
+describe('ccclass warnings', () => {
+    const clearWarnID = () => {
+        // @ts-expect-error
+        warnID.mockClear();
+    };
+
+    test('Warn on no default value specified', () => {
+        clearWarnID();
+        { @ccclass class _ { @float p; } }
+        expect(warnID).toHaveBeenCalledTimes(1);
+        expect(warnID).toHaveBeenCalledWith(3654, '_', 'p');
+
+        clearWarnID();
+        { @ccclass class _ { @property p; } }
+        expect(warnID).toHaveBeenCalledTimes(1);
+        expect(warnID).toHaveBeenCalledWith(3654, '_', 'p');
+
+        clearWarnID();
+        @ccclass class C { }
+        { @ccclass class _ { @property(C) p; } }
+        expect(warnID).not.toHaveBeenCalled();
+    });
 });

--- a/tests/init.ts
+++ b/tests/init.ts
@@ -11,7 +11,7 @@ jest.mock('../cocos/core/platform/debug', () => {
         ...jest.requireActual('../cocos/core/platform/debug'),
     };
     if (result.warnID) {
-        result.warnID = jest.fn(result.warnID);
+        result.warnID = jest.fn();
     }
     return result;
 });


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Properties specified with object type(i.e non-primitive/non-enum type) are usually have no initializer. This PR allows to write:
```ts
class C {
  @property
  p: Node;
}
```
without warnings.

Otherwise, users have to write:
```ts
class C {
  @property
  p: Node | null = null;
}
```

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
