### PR TITLE
[sync to 3.0]fix : when destory node, 'this._siblingIndex' is not update

### DIFF
--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -1340,10 +1340,10 @@ export class BaseNode extends CCObject implements ISchedulable {
                 const childIndex = parent._children.indexOf(this);
                 parent._children.splice(childIndex, 1);
                 this._siblingIndex = 0;
+                parent._updateSiblingIndex();
                 if (parent.emit) {
                     parent.emit(SystemEventType.CHILD_REMOVED, this);
                 }
-                parent._updateSiblingIndex();
             }
         }
 

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -1343,6 +1343,7 @@ export class BaseNode extends CCObject implements ISchedulable {
                 if (parent.emit) {
                     parent.emit(SystemEventType.CHILD_REMOVED, this);
                 }
+                parent._updateSiblingIndex();
             }
         }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/5290