### PR TITLE
Add publish @cocos/build-engine workflow

### DIFF
--- a/.github/workflows/publish-build-engine.yml
+++ b/.github/workflows/publish-build-engine.yml
@@ -1,0 +1,24 @@
+name: publish-build-engine
+on:
+  push:
+    branches:
+      - 3d
+jobs:
+  publish-build-engine:
+    name: publish-build-engine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+        working-directory: ./scripts/build-engine
+      - id: publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: ./scripts/build-engine/package.json
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+      - if: steps.publish.outputs.type != 'none'
+        run: |
+          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
     "files.exclude": {
         ".git": true,
         "node_modules": true,
-        ".github": true
     },
     "search.exclude": {
         ".git": true,


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Add GitHub workflow to automatize publishing of `@cocos/build-engine`

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
