### PR TITLE
fix rich text no normal recycling of labels to the object pool

### DIFF
--- a/cocos/ui/components/rich-text.ts
+++ b/cocos/ui/components/rich-text.ts
@@ -849,7 +849,7 @@ export class RichText extends UIComponent {
         this._resetState();
 
         let lastEmptyLine = false;
-        let label: ILabelSegment;
+        let label: ISegment;
 
         for (let i = 0; i < this._textArray.length; ++i) {
             const richTextElement = this._textArray[i];

--- a/cocos/ui/components/rich-text.ts
+++ b/cocos/ui/components/rich-text.ts
@@ -29,7 +29,7 @@
  * @module ui
  */
 
-import { Font, SpriteAtlas, TTFFont } from '../../core/assets';
+import { Font, SpriteAtlas, SpriteFrame, TTFFont } from '../../core/assets';
 import { ccclass, executeInEditMode, executionOrder, help, menu, tooltip, multiline, type, serializable } from 'cc.decorator';
 import { assert, EventTouch, warnID } from '../../core/platform';
 import { BASELINE_RATIO, fragmentText, HtmlTextParser, IHtmlTextParserResultObj, IHtmlTextParserStack, isUnicodeCJK, isUnicodeSpace } from '../../core/utils';
@@ -52,18 +52,15 @@ const RichTextChildImageName = 'RICHTEXT_Image_CHILD';
 /**
  * 富文本池。<br/>
  */
-const pool = new Pool((labelSeg: ILabelSegment) => {
-    if (EDITOR) {
-        return false;
-    }
+const pool = new Pool((seg: ISegment) => {
     if (DEV) {
-        assert(!labelSeg.node.parent, 'Recycling node\'s parent should be null!');
+        assert(!seg.node.parent, 'Recycling node\'s parent should be null!');
     }
-    if (!legacyCC.isValid(labelSeg.node)) {
+    if (!legacyCC.isValid(seg.node)) {
         return false;
     }
-    else {
-        const outline = labelSeg.node.getComponent(LabelOutline);
+    else if (seg.type === RichTextChildName) {
+        const outline = seg.node.getComponent(LabelOutline);
         if (outline) {
             outline.width = 0;
         }
@@ -71,61 +68,63 @@ const pool = new Pool((labelSeg: ILabelSegment) => {
     return true;
 }, 20);
 
-// @ts-expect-error
-pool.get = function (str: string, richtext: RichText) {
-    let labelSeg = this._get();
-    if (!labelSeg) {
-        labelSeg = {
-            node: new PrivateNode(RichTextChildName),
-            comp: null,
-            lineCount: 0,
-            styleIndex: 0,
-            imageOffset: '',
-            clickParam: '',
-            clickHandler: '',
-        };
-    }
-
-    let labelNode = labelSeg.node;
-    if (!labelNode) {
-        labelNode = new PrivateNode(RichTextChildName);
-    }
-
-    let label = labelNode.getComponent(Label);
-    if (!label) {
-        label = labelNode.addComponent(Label)!;
-    }
-
-    label.string = str;
-    label.horizontalAlign = HorizontalTextAlignment.LEFT;
-    label.verticalAlign = VerticalTextAlignment.TOP;
-    // label._forceUseCanvas = true;
-
-    labelNode.setPosition(0, 0, 0);
-    const trans = labelNode._uiProps.uiTransformComp!;
-    trans.setAnchorPoint(0.5, 0.5);
-
-    const labelObj: ILabelSegment = {
-        node: labelNode,
-        comp: label,
+//
+function createSegment (type: string): ISegment {
+    return {
+        node: new PrivateNode(type),
+        comp: null,
         lineCount: 0,
         styleIndex: 0,
         imageOffset: '',
         clickParam: '',
         clickHandler: '',
+        type: type,
     };
+}
 
-    return labelObj;
+// @ts-expect-error
+pool.get = function (type: string, content: string | SpriteFrame) {
+    let seg = this._get() || createSegment(type);
+    let node = seg.node;
+    if (!node) {
+        node = new PrivateNode(type);
+    }
+
+    let component: Label | Sprite;
+    if (type === RichTextChildImageName) {
+        component = node.getComponent(Sprite) || node.addComponent(Sprite);
+        component.spriteFrame = content as SpriteFrame;
+        component.type = Sprite.Type.SLICED;
+        component.sizeMode = Sprite.SizeMode.CUSTOM;
+    } else { // RichTextChildName
+        component = node.getComponent(Label) || node.addComponent(Label);
+        component.string = content as string;
+        component.horizontalAlign = HorizontalTextAlignment.LEFT;
+        component.verticalAlign = VerticalTextAlignment.TOP;
+    }
+    node.setPosition(0, 0, 0);
+    const trans = node._uiProps.uiTransformComp!;
+    trans.setAnchorPoint(0.5, 0.5);
+
+    seg.node = node;
+    seg.comp = component;
+    seg.lineCount = 0;
+    seg.styleIndex = 0;
+    seg.imageOffset = '';
+    seg.clickParam = '';
+    seg.clickHandler = '';
+    return seg;
 };
 
-interface ILabelSegment {
+interface ISegment {
     node: PrivateNode;
-    comp: UIRenderable | null;
+    comp: Label | Sprite | null;
     lineCount: number;
     styleIndex: number;
     imageOffset: string;
     clickParam: string;
     clickHandler: string;
+    type: string,
 }
 
 /**
@@ -428,8 +427,8 @@ export class RichText extends UIComponent {
     protected _handleTouchEvent = true;
 
     protected _textArray: IHtmlTextParserResultObj[] = [];
-    protected _labelSegments: ILabelSegment[] = [];
-    protected _labelSegmentsCache: ILabelSegment[] = [];
+    protected _segments: ISegment[] = [];
+    protected _labelSegmentsCache: ISegment[] = [];
     protected _linesWidth: number[] = [];
     protected _lineCount = 1;
     protected _labelWidth = 0;
@@ -485,7 +484,7 @@ export class RichText extends UIComponent {
     }
 
     public onDestroy () {
-        for (const seg of this._labelSegments) {
+        for (const seg of this._segments) {
             seg.node.removeFromParent();
             pool.put(seg);
         }
@@ -502,14 +501,19 @@ export class RichText extends UIComponent {
     }
 
     protected _updateLabelSegmentTextAttributes () {
-        this._labelSegments.forEach((item) => {
+        this._segments.forEach((item) => {
             this._applyTextAttribute(item);
         });
     }
 
-    protected _createFontLabel (str: string): ILabelSegment {
+    protected _createFontLabel (str: string): ISegment {
         // @ts-expect-error
-        return pool.get(str, this)!;
+        return pool.get(RichTextChildName, str)!;
+    }
+
+    protected _createImage (spriteFrame: SpriteFrame): ISegment {
+        // @ts-expect-error
+        return pool.get(RichTextChildImageName, spriteFrame)!;
     }
 
     protected _onTTFLoaded () {
@@ -534,7 +538,7 @@ export class RichText extends UIComponent {
 
     protected _measureText (styleIndex: number, string?: string) {
         const func = (s: string) => {
-            let label: ILabelSegment;
+            let label: ISegment;
             if (this._labelSegmentsCache.length === 0) {
                 label = this._createFontLabel(s);
                 this._labelSegmentsCache.push(label);
@@ -559,7 +563,7 @@ export class RichText extends UIComponent {
     protected _onTouchEnded (event: EventTouch) {
         const components = this.node.getComponents(Component);
 
-        for (const seg of this._labelSegments) {
+        for (const seg of this._segments) {
             const clickHandler = seg.clickHandler;
             const clickParam = seg.clickParam;
             if (clickHandler && this._containsTouchLocation(seg, event.touch!.getUILocation())) {
@@ -574,7 +578,7 @@ export class RichText extends UIComponent {
         }
     }
 
-    protected _containsTouchLocation (label: ILabelSegment, point: Vec2) {
+    protected _containsTouchLocation (label: ISegment, point: Vec2) {
         const comp = label.node.getComponent(UITransform);
         if (!comp) {
             return false;
@@ -598,21 +602,16 @@ export class RichText extends UIComponent {
                     children.splice(i, 1);
                 }
 
-                if (child.name === RichTextChildName) {
-                    const index = this._labelSegments.findIndex((seg) => {
-                        return seg.node === child;
-                    });
-
-                    if (index !== -1) {
-                        pool.put(this._labelSegments[index]);
-                    }
-                }
+                const segment = createSegment(RichTextChildName);
+                segment.node = child;
+                segment.comp = RichTextChildName ? child.getComponent(Label) : child.getComponent(Sprite);
+                pool.put(segment);
             }
         }
         // Tolerate null parent child (upgrade issue may cause this special case)
         children.length = 0;
 
-        this._labelSegments.length = 0;
+        this._segments.length = 0;
         this._labelSegmentsCache.length = 0;
         this._linesWidth.length = 0;
         this._lineOffsetX = 0;
@@ -632,7 +631,7 @@ export class RichText extends UIComponent {
     }
 
     protected _addLabelSegment (stringToken: string, styleIndex: number) {
-        let labelSegment: ILabelSegment;
+        let labelSegment: ISegment;
         if (this._labelSegmentsCache.length === 0) {
             labelSegment = this._createFontLabel(stringToken);
         } else {
@@ -648,14 +647,14 @@ export class RichText extends UIComponent {
         labelSegment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 0);
         this._applyTextAttribute(labelSegment);
         this.node.addChild(labelSegment.node);
-        this._labelSegments.push(labelSegment);
+        this._segments.push(labelSegment);
 
         return labelSegment;
     }
 
     protected _updateRichTextWithMaxWidth (labelString: string, labelWidth: number, styleIndex: number) {
         let fragmentWidth = labelWidth;
-        let labelSegment: ILabelSegment;
+        let labelSegment: ISegment;
 
         if (this._lineOffsetX > 0 && fragmentWidth + this._lineOffsetX > this._maxWidth) {
             // concat previous line
@@ -771,36 +770,22 @@ export class RichText extends UIComponent {
         if (!spriteFrame) {
             warnID(4400);
         } else {
-            const spriteNode = new PrivateNode(RichTextChildImageName);
-            const sprite = spriteNode.addComponent(Sprite);
+            const segment = this._createImage(spriteFrame);
+            const sprite = segment.comp;
             switch (style.imageAlign) {
                 case 'top':
-                    spriteNode._uiProps.uiTransformComp!.setAnchorPoint(0, 1);
+                    segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 1);
                     break;
                 case 'center':
-                    spriteNode._uiProps.uiTransformComp!.setAnchorPoint(0, 0.5);
+                    segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 0.5);
                     break;
                 default:
-                    spriteNode._uiProps.uiTransformComp!.setAnchorPoint(0, 0);
+                    segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 0);
                     break;
             }
-            sprite.type = Sprite.Type.SLICED;
-            sprite.sizeMode = Sprite.SizeMode.CUSTOM;
 
-            // Why need to set spriteFrame before can add child ??
-            sprite.spriteFrame = spriteFrame;
-            this.node.addChild(spriteNode);
-            const obj: ILabelSegment = {
-                node: spriteNode,
-                comp: sprite,
-                lineCount: 0,
-                styleIndex: 0,
-                imageOffset: style.imageOffset || '',
-                clickParam: '',
-                clickHandler: '',
-            };
-            this._labelSegments.push(obj);
-
+            this.node.addChild(segment.node);
+            this._segments.push(segment);
 
             const spriteRect = spriteFrame.rect.clone();
             let scaleFactor = 1;
@@ -835,15 +820,15 @@ export class RichText extends UIComponent {
                     this._labelWidth = this._lineOffsetX;
                 }
             }
-            spriteNode._uiProps.uiTransformComp!.setContentSize(spriteWidth, spriteHeight);
-            obj.lineCount = this._lineCount;
+            segment.node._uiProps.uiTransformComp!.setContentSize(spriteWidth, spriteHeight);
+            segment.lineCount = this._lineCount;
 
-            obj.clickHandler = '';
-            obj.clickParam = '';
+            segment.clickHandler = '';
+            segment.clickParam = '';
             const event = style.event;
             if (event) {
-                obj.clickHandler = event['click'];
-                obj.clickParam = event['param'];
+                segment.clickHandler = event['click'];
+                segment.clickParam = event['param'];
             }
         }
     }
@@ -962,8 +947,8 @@ export class RichText extends UIComponent {
         const trans = this.node._uiProps.uiTransformComp!;
         const anchorX = trans.anchorX;
         const anchorY = trans.anchorY;
-        for (let i = 0; i < this._labelSegments.length; ++i) {
-            const segment = this._labelSegments[i];
+        for (let i = 0; i < this._segments.length; ++i) {
+            const segment = this._segments[i];
             const lineCount = segment.lineCount;
             if (lineCount > nextLineIndex) {
                 nextTokenX = 0;
@@ -1049,7 +1034,7 @@ export class RichText extends UIComponent {
         }
     }
 
-    protected _applyTextAttribute (labelSeg: ILabelSegment) {
+    protected _applyTextAttribute (labelSeg: ISegment) {
         const label = labelSeg.node.getComponent(Label);
         if (!label) {
             return;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/5618

Changes:
 * fix rich text no normal recycling of labels to the object pool

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
