### PR TITLE
Canvas split Camera

### DIFF
--- a/cocos/core/components/ui-base/canvas.ts
+++ b/cocos/core/components/ui-base/canvas.ts
@@ -365,20 +365,20 @@ export class Canvas extends Component {
     protected _onResizeCamera () {
         if (!this._alignCanvasWithScreen) { return; }
 
-        const camera = this._cameraComponent;
-        if (camera) {
+        const cameraComponent = this._cameraComponent;
+        if (cameraComponent) {
             if (this._targetTexture) {
                 const win = this._targetTexture.window;
-                camera.camera.setFixedSize(win!.width, win!.height);
-                camera.orthoHeight = visibleRect.height / 2;
+                cameraComponent.camera.setFixedSize(win!.width, win!.height);
+                cameraComponent.orthoHeight = visibleRect.height / 2;
             } else {
                 const size = game.canvas!;
-                camera.camera.resize(size.width, size.height);
-                camera.orthoHeight = game.canvas!.height / view.getScaleY() / 2;
+                cameraComponent.camera.resize(size.width, size.height);
+                cameraComponent.orthoHeight = game.canvas!.height / view.getScaleY() / 2;
             }
             this.node.getWorldPosition(_worldPos);
-            camera.node.setWorldPosition(_worldPos.x, _worldPos.y, 1000);
-            camera.camera.update();
+            cameraComponent.node.setWorldPosition(_worldPos.x, _worldPos.y, 1000);
+            cameraComponent.camera.update();
         }
     }
 
@@ -402,20 +402,20 @@ export class Canvas extends Component {
     protected _updateTargetTexture () {
         if (!this._cameraComponent) { return; }
 
-        const camera = this._cameraComponent;
-        if (!camera.camera) { return; }
+        const cameraComponent = this._cameraComponent;
+        if (!cameraComponent.camera) { return; }
 
         if (!this._targetTexture) {
-            camera.camera.changeTargetWindow();
-            camera.orthoHeight = game.canvas!.height / view.getScaleY() / 2;
-            camera.camera.isWindowSize = true;
+            cameraComponent.camera.changeTargetWindow();
+            cameraComponent.orthoHeight = game.canvas!.height / view.getScaleY() / 2;
+            cameraComponent.camera.isWindowSize = true;
         } else {
             const win = this._targetTexture.window;
-            camera.camera.changeTargetWindow(win);
-            camera.orthoHeight = visibleRect.height / 2;
-            camera.camera.isWindowSize = false;
+            cameraComponent.camera.changeTargetWindow(win);
+            cameraComponent.orthoHeight = visibleRect.height / 2;
+            cameraComponent.camera.isWindowSize = false;
         }
-        camera.camera.update();
+        cameraComponent.camera.update();
     }
 
     private _getViewPriority () {

--- a/cocos/core/components/ui-base/canvas.ts
+++ b/cocos/core/components/ui-base/canvas.ts
@@ -29,7 +29,8 @@
  * @module ui
  */
 
-import { ccclass, help, disallowMultiple, executeInEditMode, executionOrder, menu, requireComponent, tooltip, type, serializable } from 'cc.decorator';
+import { ccclass, help, disallowMultiple, executeInEditMode, executionOrder,
+    menu, requireComponent, tooltip, type, serializable } from 'cc.decorator';
 import { EDITOR } from 'internal:constants';
 import { Camera } from '../../3d/framework/camera-component';
 import { Widget } from '../../../ui/components/widget';
@@ -39,7 +40,6 @@ import { ClearFlag } from '../../gfx/define';
 import { Color, Vec3, Rect, Size } from '../../math';
 import { view } from '../../platform/view';
 import visibleRect from '../../platform/visible-rect';
-import { scene } from '../../renderer';
 import { Node } from '../../scene-graph/node';
 import { Enum } from '../../value-types';
 import { Component } from '../component';
@@ -47,6 +47,7 @@ import { UITransform } from './ui-transform';
 import { legacyCC } from '../../global-exports';
 import { RenderWindow } from '../../renderer/core/render-window';
 import { SystemEventType } from '../../platform/event-manager';
+import { Layers } from '../..';
 
 const _worldPos = new Vec3();
 
@@ -95,8 +96,8 @@ export class Canvas extends Component {
 
     set clearFlag (val) {
         this._clearFlag = val;
-        if (this._camera) {
-            this._camera.clearFlag = this._clearFlag;
+        if (this._cameraComponent) {
+            this._cameraComponent.clearFlags = this._clearFlag;
         }
     }
 
@@ -114,8 +115,8 @@ export class Canvas extends Component {
 
     set color (val) {
         Color.copy(this._color, val);
-        if (this._camera) {
-            this._camera.clearColor = val;
+        if (this._cameraComponent) {
+            this._cameraComponent.clearColor = val;
         }
     }
 
@@ -140,8 +141,8 @@ export class Canvas extends Component {
 
     set renderMode (val) {
         this._renderMode = val;
-        if (this._camera) {
-            this._camera.priority = this._getViewPriority();
+        if (this._cameraComponent) {
+            this._cameraComponent.priority = this._getViewPriority();
         }
     }
 
@@ -163,8 +164,8 @@ export class Canvas extends Component {
 
     set priority (val: number) {
         this._priority = val;
-        if (this._camera) {
-            this._camera.priority = this._getViewPriority();
+        if (this._cameraComponent) {
+            this._cameraComponent.priority = this._getViewPriority();
         }
 
         if (legacyCC.director.root && legacyCC.director.root.ui) {
@@ -197,15 +198,40 @@ export class Canvas extends Component {
     }
 
     get visibility () {
-        if (this._camera) {
-            return this._camera.view.visibility;
+        if (this._cameraComponent) {
+            return this._cameraComponent.visibility;
         }
 
         return -1;
     }
 
+    @type(Camera)
+    @tooltip('2D渲染相机')
+    get cameraComponent () {
+        return this._cameraComponent;
+    }
+
+    set cameraComponent (value) {
+        if (this._cameraComponent === value) { return; }
+
+        this._cameraComponent = value;
+
+        this._onResizeCamera();
+    }
+
+    @tooltip('是否自动为 camera 计算参数')
+    get alignCanvasWithScreen () {
+        return this._alignCanvasWithScreen;
+    }
+
+    set alignCanvasWithScreen (value) {
+        this._alignCanvasWithScreen = value;
+
+        this._onResizeCamera();
+    }
+
     get camera () {
-        return this._camera;
+        return this._cameraComponent?.camera;
     }
 
     // /**
@@ -224,12 +250,15 @@ export class Canvas extends Component {
     protected _color = new Color(0, 0, 0, 255);
     @type(RenderMode)
     protected _renderMode = RenderMode.OVERLAY;
+    @type(Camera)
+    protected _cameraComponent: Camera | null = null;
+    @serializable
+    protected _alignCanvasWithScreen = true;
 
     protected _thisOnCameraResized: () => void;
     // fit canvas node to design resolution
     protected _fitDesignResolution: (() => void) | undefined;
 
-    protected _camera: scene.Camera | null = null;
     private _pos = new Vec3();
 
     constructor () {
@@ -239,9 +268,9 @@ export class Canvas extends Component {
         if (EDITOR) {
             this._fitDesignResolution = () => {
                 // TODO: support paddings of locked widget
-                let nodeSize: Size; let designSize: Size;
+                let designSize: Size;
                 this.node.getPosition(this._pos);
-                nodeSize = designSize = view.getDesignResolutionSize();
+                const nodeSize = designSize = view.getDesignResolutionSize();
                 Vec3.set(_worldPos, designSize.width * 0.5, designSize.height * 0.5, 0);
 
                 if (!this._pos.equals(_worldPos)) {
@@ -267,27 +296,27 @@ export class Canvas extends Component {
             this._fitDesignResolution!();
         }
 
-        const cameraNode = new Node(`UICamera_${this.node.name}`);
-        cameraNode.setPosition(0, 0, 1000);
-        if (!EDITOR) {
-            this._camera = legacyCC.director.root!.createCamera() as scene.Camera;
-            this._camera.initialize({
-                name: `ui_${this.node.name}`,
-                node: cameraNode,
-                projection: Camera.ProjectionType.ORTHO,
-                priority: this._getViewPriority(),
-                flows: ['UIFlow'],
-            });
+        if (!this._cameraComponent) {
+            const cameraNode = new Node(`UICamera_${this.node.name}`);
+            this.node.addChild(cameraNode);
+            cameraNode.addComponent('cc.Camera');
+            this._cameraComponent = cameraNode.getComponent('cc.Camera') as Camera;
+            this._cameraComponent.name = `ui_${this.node.name}`;
+            this._cameraComponent.projection = Camera.ProjectionType.ORTHO;
+            this._cameraComponent.priority = this._getViewPriority();
+            this._cameraComponent.flows = ['UIFlow'];
+            this._cameraComponent.visibility = Layers.BitMask.DEFAULT | Layers.BitMask.UI_2D | Layers.BitMask.UI_3D;
 
-            this._camera.fov = 45;
-            this._camera.clearFlag = this.clearFlag;
-            this._camera.farClip = 2000;
-            this._camera.viewport = new Rect(0, 0, 1, 1);
-            this.color = this._color;
-
-            this._checkTargetTextureEvent(null);
-            this._updateTargetTexture();
+            this._cameraComponent.fov = 45.0;
+            this._cameraComponent.clearFlags = this.clearFlag;
+            this._cameraComponent.far = 2000.0;
+            this._cameraComponent.rect = new Rect(0, 0, 1, 1);
+            this._cameraComponent.clearColor = this._color;
+            this._cameraComponent.camera.update();
         }
+
+        this._checkTargetTextureEvent(null);
+        this._updateTargetTexture();
 
         if (EDITOR) {
             // Constantly align canvas node in edit mode
@@ -305,21 +334,21 @@ export class Canvas extends Component {
     }
 
     public onEnable () {
-        if (this._camera) {
-            legacyCC.director.root!.ui.renderScene.addCamera(this._camera);
+        if (this._cameraComponent) {
+            this._cameraComponent.onEnable();
         }
     }
 
     public onDisable () {
-        if (this._camera) {
-            legacyCC.director.root!.ui.renderScene.removeCamera(this._camera);
+        if (this._cameraComponent) {
+            this._cameraComponent.onDisable();
         }
     }
 
     public onDestroy () {
         legacyCC.director.root!.ui.removeScreen(this);
-        if (this._camera) {
-            legacyCC.director.root!.destroyCamera(this._camera);
+        if (this._cameraComponent) {
+            this._cameraComponent.onDestroy();
         }
 
         if (EDITOR) {
@@ -334,27 +363,30 @@ export class Canvas extends Component {
     }
 
     protected _onResizeCamera () {
-        const camera = this._camera;
+        if (!this._alignCanvasWithScreen) { return; }
+
+        const camera = this._cameraComponent;
         if (camera) {
             if (this._targetTexture) {
                 const win = this._targetTexture.window;
-                camera.setFixedSize(win!.width, win!.height);
+                camera.camera.setFixedSize(win!.width, win!.height);
                 camera.orthoHeight = visibleRect.height / 2;
             } else {
                 const size = game.canvas!;
-                camera.resize(size.width, size.height);
+                camera.camera.resize(size.width, size.height);
                 camera.orthoHeight = game.canvas!.height / view.getScaleY() / 2;
             }
             this.node.getWorldPosition(_worldPos);
-            camera.node.setPosition(_worldPos.x, _worldPos.y, 1000);
-            camera.update();
+            camera.node.setWorldPosition(_worldPos.x, _worldPos.y, 1000);
+            camera.camera.update();
         }
     }
 
     protected _checkTargetTextureEvent (old: RenderTexture | null) {
         const resizeFunc = (win: RenderWindow) => {
-            if (this._camera) {
-                this._camera.setFixedSize(win.width, win.height);
+            if (this._cameraComponent) {
+                this._cameraComponent.camera.setFixedSize(win.width, win.height);
+                this._cameraComponent.camera.update();
             }
         };
 
@@ -368,21 +400,22 @@ export class Canvas extends Component {
     }
 
     protected _updateTargetTexture () {
-        if (!this._camera) {
-            return;
-        }
+        if (!this._cameraComponent) { return; }
 
-        const camera = this._camera;
+        const camera = this._cameraComponent;
+        if (!camera.camera) { return; }
+
         if (!this._targetTexture) {
-            camera.changeTargetWindow();
+            camera.camera.changeTargetWindow();
             camera.orthoHeight = game.canvas!.height / view.getScaleY() / 2;
-            camera.isWindowSize = true;
+            camera.camera.isWindowSize = true;
         } else {
             const win = this._targetTexture.window;
-            camera.changeTargetWindow(win);
+            camera.camera.changeTargetWindow(win);
             camera.orthoHeight = visibleRect.height / 2;
-            camera.isWindowSize = false;
+            camera.camera.isWindowSize = false;
         }
+        camera.camera.update();
     }
 
     private _getViewPriority () {

--- a/cocos/core/renderer/ui/ui.ts
+++ b/cocos/core/renderer/ui/ui.ts
@@ -51,6 +51,7 @@ import { EffectAsset, RenderTexture, SpriteFrame } from '../../assets';
 import { programLib } from '../core/program-lib';
 import { TextureBase } from '../../assets/texture-base';
 import { sys } from '../../platform/sys';
+
 const _dsInfo = new DescriptorSetInfo(null!);
 
 /**
@@ -294,7 +295,7 @@ export class UI {
 
         let camera: Camera | null;
         for (let i = idx; i < this._screens.length; i++) {
-            camera = this._screens[i].camera;
+            camera = this._screens[i].camera!;
             if (camera) {
                 const matRecord = this._canvasMaterials.get(camera.view.visibility)!;
                 camera.view.visibility = Layers.BitMask.UI_2D | (i + 1);
@@ -312,11 +313,11 @@ export class UI {
         this._screens.sort(this._screenSort);
     }
 
-    public addUploadBuffersFunc(target: any, func: Function) {
+    public addUploadBuffersFunc (target: any, func: Function) {
         this._doUploadBuffersCall.set(target, func);
     }
 
-    public removeUploadBuffersFunc(target: any) {
+    public removeUploadBuffersFunc (target: any) {
         this._doUploadBuffersCall.delete(target);
     }
 
@@ -531,7 +532,7 @@ export class UI {
 
         const uiCanvas = this._currCanvas;
         const curDrawBatch = this._drawBatchPool.alloc();
-        curDrawBatch.camera = uiCanvas && uiCanvas.camera;
+        curDrawBatch.camera = uiCanvas && uiCanvas.camera!;
         curDrawBatch.model = model;
         curDrawBatch.bufferBatch = null;
         curDrawBatch.material = mat;
@@ -592,7 +593,7 @@ export class UI {
         }
 
         const curDrawBatch = this._currStaticRoot ? this._currStaticRoot._requireDrawBatch() : this._drawBatchPool.alloc();
-        curDrawBatch.camera = uiCanvas && uiCanvas.camera;
+        curDrawBatch.camera = uiCanvas && uiCanvas.camera!;
         curDrawBatch.bufferBatch = buffer;
         curDrawBatch.material = mat;
         curDrawBatch.texture = this._currTexture!;

--- a/cocos/core/renderer/ui/ui.ts
+++ b/cocos/core/renderer/ui/ui.ts
@@ -103,7 +103,7 @@ export class UI {
     private _uiMaterials: Map<number, UIMaterial> = new Map<number, UIMaterial>();
     private _canvasMaterials: Map<number, Map<number, number>> = new Map<number, Map<number, number>>();
     private _batches: CachedArray<UIDrawBatch>;
-    private _doUploadBuffersCall: Map<any, any> = new Map();
+    private _doUploadBuffersCall: Map<any, (ui: UI) => void> = new Map();
     private _uiModelPool: Pool<UIBatchModel> | null = null;
     private _modelInUse: CachedArray<UIBatchModel>;
     // batcher
@@ -313,7 +313,7 @@ export class UI {
         this._screens.sort(this._screenSort);
     }
 
-    public addUploadBuffersFunc (target: any, func: any) {
+    public addUploadBuffersFunc (target: any, func: (ui: UI) => void) {
         this._doUploadBuffersCall.set(target, func);
     }
 
@@ -398,7 +398,7 @@ export class UI {
             const calls = this._doUploadBuffersCall;
             for (const key of calls.keys()) {
                 const list = calls.get(key);
-                list.call(key, this);
+                list!.call(key, this);
             }
 
             const buffers = this._meshBuffers;

--- a/cocos/core/renderer/ui/ui.ts
+++ b/cocos/core/renderer/ui/ui.ts
@@ -103,7 +103,7 @@ export class UI {
     private _uiMaterials: Map<number, UIMaterial> = new Map<number, UIMaterial>();
     private _canvasMaterials: Map<number, Map<number, number>> = new Map<number, Map<number, number>>();
     private _batches: CachedArray<UIDrawBatch>;
-    private _doUploadBuffersCall: Map<any, Function> = new Map();
+    private _doUploadBuffersCall: Map<any, any> = new Map();
     private _uiModelPool: Pool<UIBatchModel> | null = null;
     private _modelInUse: CachedArray<UIBatchModel>;
     // batcher
@@ -313,7 +313,7 @@ export class UI {
         this._screens.sort(this._screenSort);
     }
 
-    public addUploadBuffersFunc (target: any, func: Function) {
+    public addUploadBuffersFunc (target: any, func: any) {
         this._doUploadBuffersCall.set(target, func);
     }
 
@@ -398,7 +398,7 @@ export class UI {
             const calls = this._doUploadBuffersCall;
             for (const key of calls.keys()) {
                 const list = calls.get(key);
-                list!.call(key, this);
+                list.call(key, this);
             }
 
             const buffers = this._meshBuffers;


### PR DESCRIPTION
# 需求
- [x]  2D 游戏能自由控制 Camera 类型和参数。
- [x]  Label 等 2D 组件在 3D 世界中渲染（比如头顶人名） #2261。
- [x]  华为 VR 的 UI 界面需要做出倾斜角，同一，需要允许对 UI 使用 3D Camera。
# 方案
- Canvas 应该只管 UI 排版的功能，包括 widget 功能和 camera 适应屏幕的功能
- Canvas 内部的 camera 由 scene.Camera 改为 Camera Component 并暴露为属性
- 创建 Canvas 的时候默认创建一个名叫 UI Camera 的节点挂到 child 上，并赋值到 camera 属性上
- Canvas 会接管自己的 Camera 部分控制权，包括为 Camera 计算出适应屏幕的 fov/orthSize
# 关联 issue
- https://github.com/cocos-creator/3d-tasks/issues/5010
