### PR TITLE
Optimize wasm fetching

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -52,6 +52,8 @@ rules:
     prefer-spread: off # we need ES5 to be fast too
     space-before-function-paren: [warn, always] # we require this explicitly
     radix: off # we sometimes do not need to pass a second parameter
+    quotes: [warn, single, { allowTemplateLiterals: true }] # force single, but allow template literal
+    no-else-return: off
 
     ##### AIRBNB-SPECIFIC RULE OVERRIDES #####
 

--- a/cocos/physics/ammo/ammo-instantiated.ts
+++ b/cocos/physics/ammo/ammo-instantiated.ts
@@ -88,4 +88,10 @@ export namespace waitForAmmoInstantiation {
      * True if the `'@cocos/ammo'` is the WebAssembly edition.
      */
     export const isWasm = (AmmoJs as any).isWasm;
+
+    /**
+     * The url to the WebAssembly binary.
+     * Either can be absolute or relative, depends on build options.
+     */
+    export const wasmBinaryURL = (AmmoJs as any).wasmBinaryURL;
 }

--- a/scripts/build-engine/.eslintrc.yaml
+++ b/scripts/build-engine/.eslintrc.yaml
@@ -1,0 +1,2 @@
+extends:
+    - ../../.eslintrc.yaml

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -18,17 +18,19 @@ import rpProgress from 'rollup-plugin-progress';
 import rpVirtual from '@rollup/plugin-virtual';
 import nodeResolve from 'resolve';
 import babelPluginDynamicImportVars from '@cocos/babel-plugin-dynamic-import-vars';
+import realFs from 'fs';
+import { URL, pathToFileURL, fileURLToPath } from 'url';
 import { ModuleOption, enumerateModuleOptionReps, parseModuleOption } from './module-option';
 import tsConfigPaths from './ts-paths';
 import { getPlatformConstantNames, IBuildTimeConstants } from './build-time-constants';
 import removeDeprecatedFeatures from './remove-deprecated-features';
-import realFs from 'fs';
 import { StatsQuery } from './stats-query';
 import { filePathToModuleRequest } from './utils';
+import { assetRef as rpAssetRef, pathToAssetRefURL } from './rollup-plugins/asset-ref';
 
 export { ModuleOption, enumerateModuleOptionReps, parseModuleOption };
 
-function equalPathIgnoreDriverLetterCase(lhs: string, rhs: string) {
+function equalPathIgnoreDriverLetterCase (lhs: string, rhs: string) {
     if (lhs.length !== rhs.length) {
         return false;
     }
@@ -51,11 +53,12 @@ function makePathEqualityKey (path: string) {
 
 async function build (options: build.Options) {
     console.debug(`Build-engine options: ${JSON.stringify(options, undefined, 2)}`);
-    return await _doBuild({
+    return doBuild({
         options,
     });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace build {
     export interface Options {
         /**
@@ -144,6 +147,11 @@ namespace build {
          */
         loose?: boolean;
 
+        /**
+         * How to generate the URL of external assets.
+         */
+        assetURLFormat?: rpAssetRef.Format;
+
         visualize?: boolean | {
             file?: string;
         };
@@ -166,7 +174,7 @@ namespace build {
         dependencyGraph?: Record<string, string[]>;
     }
 
-    export async function transform(code: string, moduleOption: ModuleOption, loose?: boolean) {
+    export async function transform (code: string, moduleOption: ModuleOption, loose?: boolean) {
         const babelFormat = moduleOptionsToBabelEnvModules(moduleOption);
         const babelFileResult = await babel.transformAsync(code, {
             presets: [[babelPresetEnv, { modules: babelFormat, loose: loose ?? true } as babelPresetEnv.Options]],
@@ -182,18 +190,18 @@ namespace build {
 
 export { build };
 
-async function _doBuild ({
+async function doBuild ({
     options,
 }: {
     options: build.Options;
 }): Promise<build.Result> {
     const realpath = typeof realFs.realpath.native === 'function' ? realFs.realpath.native : realFs.realpath;
     const realPath = (file: string) => new Promise<string>((resolve, reject) => {
-        realpath(file, function (err, path) {
+        realpath(file, (err, path) => {
             if (err && err.code !== 'ENOENT') {
                 reject(err);
             } else {
-                resolve(err ? file : path)
+                resolve(err ? file : path);
             }
         });
     });
@@ -230,8 +238,8 @@ async function _doBuild ({
         if (split !== true) {
             split = true;
             console.warn(
-                `You did not specify features which implies 'split: true'. ` +
-                `Explicitly set 'split: true' to suppress this warning.`
+                `You did not specify features which implies 'split: true'. `
+                + `Explicitly set 'split: true' to suppress this warning.`,
             );
         }
     }
@@ -239,7 +247,7 @@ async function _doBuild ({
     const moduleOverrides = Object.entries(statsQuery.evaluateModuleOverrides({
         mode: options.mode,
         platform: options.platform,
-    })).reduce((result, [k ,v]) => {
+    })).reduce((result, [k, v]) => {
         result[makePathEqualityKey(k)] = v;
         return result;
     }, {} as Record<string, string>);
@@ -347,6 +355,10 @@ async function _doBuild ({
     }
 
     rollupPlugins.push(
+        rpAssetRef({
+            format: options.assetURLFormat,
+        }),
+
         {
             name: '@cocos/build-engine|module-overrides',
             load (this, id: string) {
@@ -444,8 +456,10 @@ async function _doBuild ({
 
     const ammoJsAsmJsModule = await nodeResolveAsync('@cocos/ammo/builds/ammo.js');
     const ammoJsWasmModule = await nodeResolveAsync('@cocos/ammo/builds/ammo.wasm.js');
+    const wasmBinaryPath = ps.join(ammoJsWasmModule, '..', 'ammo.wasm.wasm');
     if (ammoJsWasm === 'fallback') {
         rpVirtualOptions['@cocos/ammo'] = `
+import wasmBinaryURL from '${pathToAssetRefURL(wasmBinaryPath)}';
 let ammo;
 let isWasm = false;
 if (typeof WebAssembly === 'undefined') {
@@ -455,14 +469,15 @@ if (typeof WebAssembly === 'undefined') {
     isWasm = true;
 }
 export default ammo.default;
-export { isWasm };
+export { isWasm, wasmBinaryURL };
 `;
     } else if (ammoJsWasm === true) {
         rpVirtualOptions['@cocos/ammo'] = `
+import wasmBinaryURL from '${pathToAssetRefURL(wasmBinaryPath)}';
 import Ammo from '${filePathToModuleRequest(ammoJsWasmModule)}';
 export default Ammo;
 const isWasm = true;
-export { isWasm };
+export { isWasm, wasmBinaryURL };
 `;
     }
 
@@ -514,26 +529,6 @@ export { isWasm };
 
     Object.assign(result.exports, validEntryChunks);
 
-    // // 构造模块 `"cc"`
-    // let ccModuleRequests: string[] | undefined;
-    // if (options.cc === 'bare') {
-    //     ccModuleRequests = [];
-    //     ccModuleRequests.push(...Object.keys(validEntryChunks));
-    // } else if (options.cc === 'unmapped') {
-    //     ccModuleRequests = [];
-    //     ccModuleRequests.push(...Object.values(validEntryChunks).map(fileName => `./${fileName}`));
-    // }
-    // if (ccModuleRequests !== undefined) {
-    //     let code = await makeModuleSourceCC(ccModuleRequests, moduleOption);
-    //     if (options.compress) {
-    //         code = terser.minify(code).code!;
-    //     }
-    //     const moduleCCFileName = 'cc.js';
-    //     await fs.ensureDir(options.out);
-    //     await fs.writeFile(ps.join(options.out, moduleCCFileName), code);
-    //     result.exports['cc'] = moduleCCFileName;
-    // }
-
     result.dependencyGraph = {};
     for (const output of rollupOutput.output) {
         if (output.type === 'chunk') {
@@ -541,21 +536,7 @@ export { isWasm };
         }
     }
 
-    if (ammoJsWasm === 'fallback' || ammoJsWasm === true) {
-        await fs.copy(
-            ps.join(ammoJsWasmModule, '..', 'ammo.wasm.wasm'),
-            ps.join(options.out, 'ammo.wasm.wasm'),
-        );
-    }
-
     return result;
-
-    async function copy (src: string) {
-        const rel = ps.relative(options.engine, src);
-        const target = ps.join(options.out, rel);
-        await fs.ensureDir(ps.dirname(target));
-        await fs.copy(src, target);
-    }
 
     async function nodeResolveAsync (specifier: string) {
         return new Promise<string>((r, reject) => {
@@ -578,6 +559,7 @@ function moduleOptionsToRollupFormat (moduleOptions: ModuleOption): rollup.Modul
     case ModuleOption.esm: return 'esm';
     case ModuleOption.system: return 'system';
     case ModuleOption.iife: return 'iife';
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     default: throw new Error(`Unknown module format ${moduleOptions}`);
     }
 }
@@ -588,14 +570,14 @@ function moduleOptionsToBabelEnvModules (moduleOptions: ModuleOption):
 | 'amd'
 | 'umd'
 | 'systemjs'
-| 'auto'
-{
+| 'auto' {
     switch (moduleOptions) {
-        case ModuleOption.cjs: return 'commonjs';
-        case ModuleOption.system: return 'systemjs';
-        case ModuleOption.iife:
-        case ModuleOption.esm: return false;
-        default: throw new Error(`Unknown module format ${moduleOptions}`);
+    case ModuleOption.cjs: return 'commonjs';
+    case ModuleOption.system: return 'systemjs';
+    case ModuleOption.iife:
+    case ModuleOption.esm: return false;
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    default: throw new Error(`Unknown module format ${moduleOptions}`);
     }
 }
 

--- a/scripts/build-engine/src/rollup-plugins/asset-ref.ts
+++ b/scripts/build-engine/src/rollup-plugins/asset-ref.ts
@@ -1,0 +1,95 @@
+import type * as rollup from 'rollup';
+import { URL, fileURLToPath, pathToFileURL } from 'url';
+import fs from 'fs-extra';
+import ps from 'path';
+
+/**
+ * This plugin enable to locate non-code assets in their path or URLs:
+ * ```ts
+ * import wasm from `asset-ref-url-to-C:/foo.wasm`;
+ * ```
+ * is equivalent to, for example:
+ * ```ts
+ * const wasm = 'path-to-<C:/foo.wasm>-relative-to-<outDir>-after-bundle';
+ * ```
+ * You can call `pathToAssetRefURL()` to convert file path to asset ref URL.
+ */
+export function assetRef (options: assetRef.Options): rollup.Plugin {
+    return {
+        name: '@cocos/build-engine|load-asset',
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async resolveId (this, source, importer) {
+            if (source.startsWith(assetPrefix)) {
+                return source;
+            }
+            return null;
+        },
+
+        async load (id) {
+            if (id.startsWith(assetPrefix)) {
+                const pathname = id.substr(assetPrefix.length);
+                const path = fileURLToPath(`file://${pathname}`);
+                const referenceId = this.emitFile({
+                    type: 'asset',
+                    name: ps.basename(path),
+                    // fileName: path,
+                    source: await fs.readFile(path),
+                });
+                return `export default import.meta.ROLLUP_FILE_URL_${referenceId};`;
+            }
+            return null;
+        },
+
+        // Generates the `import.meta.ROLLUP_FILE_URL_referenceId`.
+        resolveFileUrl ({
+            // > The path and file name of the emitted asset, relative to `output.dir` without a leading `./`.
+            fileName,
+            // > The path and file name of the emitted file,
+            // > relative to the chunk the file is referenced from.
+            // > This will path will contain no leading `./` but may contain a leading `../`.
+            relativePath,
+        }) {
+            switch (options.format) {
+            case 'relative-from-chunk':
+                return `'${relativePath}'`;
+            case 'relative-from-out':
+                return `'${fileName}'`;
+            case 'runtime-resolved': default:
+                return undefined; // return `new URL('${fileName}', import.meta.url).href`;
+            }
+        },
+    };
+}
+
+export declare namespace assetRef {
+    export interface Options {
+        format?: Format;
+    }
+
+    /**
+     * How to generate the reference to external assets:
+     * - `'relative-from-out'`
+     * Generate the path relative from `out` directory, does not contain the leading './'.
+     *
+     * - `'relative-from-chunk'`
+     * Generate the path relative from the referencing output chunk.
+     *
+     * - `'dynamic'`(default)
+     * Use runtime `URL` API to resolve the absolute URL.
+     * This requires `URL` and `import.meta.url` to be valid.
+     */
+    export type Format =
+        | 'relative-from-out'
+        | 'relative-from-chunk'
+        | 'runtime-resolved';
+}
+
+/**
+ * Convert the file path to asset ref URL.
+ * @param file File path in absolute.
+ */
+export function pathToAssetRefURL (file: string) {
+    return `${assetPrefix}${pathToFileURL(file).pathname}`;
+}
+
+const assetPrefix = 'asset:';

--- a/scripts/build-engine/tsconfig.json
+++ b/scripts/build-engine/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "dist"
   },
   "exclude": [
-      "dist"
+      "dist",
+      "out"
   ]
 }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Optimize `.wasm` files fetching.

Details:
1. The url(path) to ammo's wasm file is not hard-coded anymore.
2. `@cocos/build-engine` now accepts a option `assetURLFormat` to control how to generate url to ammo's wasm file. In implementation, it will obby rollup's rule to emit wasm files. The url can be visited through `waitForAmmoInstantiation.wasmBinaryURL`.

Request review from @JayceLai @yanOO1497 @PPpro 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
