### PR TITLE
improve onLoadedMetadata in jsb-videoplayer

### DIFF
--- a/platforms/native/engine/jsb-videoplayer.js
+++ b/platforms/native/engine/jsb-videoplayer.js
@@ -81,6 +81,19 @@ if (cc.internal.VideoPlayer) {
             this.video.addEventListener('ended', this.onEnded.bind(this));
         }
 
+        onLoadedMetadata() {
+            this._loadedMeta = true;
+            this._forceUpdate = true;
+            if (this._visible) {
+                this.enable();
+            } else {
+                this.disable();
+            }
+            this.dispatchEvent(EventType.META_LOADED);
+            this.delayedFullScreen();
+            this.delayedPlay();
+        }
+
         createVideoPlayer(url) {
             this._video = new jsb.VideoPlayer();
             this._bindEvent();


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * improve onLoadedMetadata in jsb-videoplayer. (fix event target is undefined error)

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
