### PR TITLE
unused scripts should be able to deserialize lazily

### DIFF
--- a/cocos2d/core/asset-manager/pack-manager.js
+++ b/cocos2d/core/asset-manager/pack-manager.js
@@ -80,7 +80,7 @@ var packManager = {
         
         if (Array.isArray(json)) {
 
-            json = unpackJSONs(json, cc._MissingScript.safeFindClass);
+            json = unpackJSONs(json);
 
             if (json.length !== pack.length) {
                 cc.errorID(4915);

--- a/test/qunit/unit-es5/test-pack-unpack.js
+++ b/test/qunit/unit-es5/test-pack-unpack.js
@@ -40,11 +40,48 @@
         ok(res.indices.indexOf(KEY1) !== -1 && res.indices.indexOf(KEY2) !== -1, 'should generate index data when packing');
 
         cc.assetManager.packManager.unpack(res.indices, JSON.parse(res.data), '.json', null, function (err, data) {
+            // ignore headers
             JSON1[0] = data[KEY1 + '@import'][0];
             JSON2[0] = data[KEY2 + '@import'][0];
+
             deepEqual(data[KEY1 + '@import'], JSON1, 'should unpack JSON1');
             deepEqual(data[KEY2 + '@import'], JSON2, 'should unpack JSON2');
         });
+    });
+
+    test('unpack unused script', function () {
+        var KEY1 = 'amitafasbha';
+        let Class1 = cc.Class({
+            name: KEY1
+        });
+        var KEY2 = 'hallelujafsdh';
+        let Class2 = cc.Class({
+            name: KEY2
+        });
+        var JSON1 = Editor.serializeCompiled(new Class1(), { stringify: false });
+        var JSON2 = Editor.serializeCompiled(new Class2(), { stringify: false });
+
+        var packer = new Editor.JsonPacker();
+        packer.add(KEY1, JSON.parse(JSON.stringify(JSON1)));
+        packer.add(KEY2, JSON.parse(JSON.stringify(JSON2)));
+        var res = packer.pack();
+
+        cc.js.unregisterClass(Class2);
+
+        cc.assetManager.packManager.unpack(res.indices, JSON.parse(res.data), '.json', null, function (err, data) {
+            let json1 = data[KEY1 + '@import'];
+            let json2 = data[KEY2 + '@import'];
+
+            let { deserialize: deserializeCompiled } = cc._Test.deserializeCompiled;
+            let obj1 = deserializeCompiled(json1);
+            ok(obj1 instanceof Class1, 'Could deserialize json1 when other script not loaded');
+
+            cc.js._setClassId(KEY2, Class2);
+            let obj2 = deserializeCompiled(json2);
+            ok(obj2 instanceof Class2, 'Could deserialize json2 once script loaded lazily');
+        });
+
+        cc.js.unregisterClass(Class1, Class2);
     });
 })();
 


### PR DESCRIPTION
Changes:
 * 修复子包中的 Prefab 被主包复用时，运行时有可能导致组件脚本丢失的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
