### PR TITLE
fix: _initEvents() called twice

### DIFF
--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -530,10 +530,6 @@ export class Game extends EventTarget {
     public run (onStart?: Game.OnStart): Promise<void>;
 
     public run (configOrCallback?: Game.OnStart | IGameConfig, onStart?: Game.OnStart) {
-        if (!EDITOR) {
-            this._initEvents();
-        }
-
         // To compatible with older version,
         // we allow the `run(config, onstart?)` form. But it's deprecated.
         let initPromise: Promise<boolean> | undefined;


### PR DESCRIPTION
Changes:

移除重复的visibilitychange事件监听。
_initEvents()在game.init()中已经调用过一次，在game.run()中调用会重复监听visibilitychange。
