### PR TITLE
fix mask state change bug

### DIFF
--- a/cocos/2d/renderer/stencil-manager.ts
+++ b/cocos/2d/renderer/stencil-manager.ts
@@ -90,8 +90,7 @@ export class StencilManager {
         this._maskStack.pop();
         if (this._maskStack.length === 0) {
             this.stage = Stage.DISABLED;
-        }
-        else {
+        } else {
             this.stageOld = Stage.EXIT_LEVEL;
             this.stage = Stage.ENABLED;
         }
@@ -182,7 +181,7 @@ export class StencilManager {
         const stencilState = pass.depthStencilState;
         const pattern = this._stencilPattern;
 
-        if(comp) {
+        if (comp) {
             if (comp.stencilStage === this.stage && pattern.ref === stencilState.stencilRefFront) {
                 return false;
             } else {
@@ -191,12 +190,12 @@ export class StencilManager {
             }
         }
 
-        if (pattern.stencilTest !== stencilState.stencilTestFront ||
-            pattern.func !== stencilState.stencilFuncFront ||
-            pattern.failOp !== stencilState.stencilFailOpFront ||
-            pattern.stencilMask !== stencilState.stencilReadMaskFront ||
-            pattern.writeMask !== stencilState.stencilWriteMaskFront ||
-            pattern.ref !== stencilState.stencilRefFront) {
+        if (pattern.stencilTest !== stencilState.stencilTestFront
+            || pattern.func !== stencilState.stencilFuncFront
+            || pattern.failOp !== stencilState.stencilFailOpFront
+            || pattern.stencilMask !== stencilState.stencilReadMaskFront
+            || pattern.writeMask !== stencilState.stencilWriteMaskFront
+            || pattern.ref !== stencilState.stencilRefFront) {
             return true;
         }
 

--- a/cocos/2d/renderer/stencil-manager.ts
+++ b/cocos/2d/renderer/stencil-manager.ts
@@ -92,6 +92,7 @@ export class StencilManager {
             this.stage = Stage.DISABLED;
         }
         else {
+            this.stageOld = Stage.EXIT_LEVEL;
             this.stage = Stage.ENABLED;
         }
     }
@@ -176,8 +177,13 @@ export class StencilManager {
     }
 
     private _changed (pass: Pass, comp?: UIRenderable) {
+        // only ui-model use this code
+        // Notice: Not all state
+        const stencilState = pass.depthStencilState;
+        const pattern = this._stencilPattern;
+
         if(comp) {
-            if (comp.stencilStage === this.stage) {
+            if (comp.stencilStage === this.stage && pattern.ref === stencilState.stencilRefFront) {
                 return false;
             } else {
                 comp.stencilStage = this.stage;
@@ -185,10 +191,6 @@ export class StencilManager {
             }
         }
 
-        // only ui-model use this code
-        // Notice: Not all state
-        const stencilState = pass.depthStencilState;
-        const pattern = this._stencilPattern;
         if (pattern.stencilTest !== stencilState.stencilTestFront ||
             pattern.func !== stencilState.stencilFuncFront ||
             pattern.failOp !== stencilState.stencilFailOpFront ||


### PR DESCRIPTION
Changes:
 * fix StencilManager state change bug 

when nesting cc.mask，stencil.ref value not update correctly

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
