### PR TITLE
Fix empty scene bug & dragonbones rendering bug

### DIFF
--- a/platforms/native/engine/jsb-editor-support.js
+++ b/platforms/native/engine/jsb-editor-support.js
@@ -56,6 +56,7 @@
             let srcVertexFloatCount = srcVertexCount * nativeFormat;
             
             let buffer = renderer.acquireBufferBatch(jsFormat);
+            buffer.reset();
             const isRecreate = buffer.request(srcVertexCount, srcIndicesCount);
             if (!isRecreate) {
                 buffer = renderer.currBufferBatch;
@@ -70,6 +71,10 @@
             vBuf.set(srcVBuf.subarray(0, srcVertexFloatCount), 0);
             iBuf.set(srcIBuf.subarray(0, srcIndicesCount), 0);
 
+            // forbid js upload data, call by middleware
+            buffer.uploadBuffers();
+            buffer.byteOffset = 0;
+            
             // forbid auto merge, because of it's meanless
             buffer.indicesOffset = 0;
             renderInfoLookup[nativeFormat][i] = buffer;


### PR DESCRIPTION
-修复了空场景导致reset未正确执行的bug
related issue: cocos-creator/3d-tasks#5752

-修复了dragonbones渲染多出来一块的bug
related issue: cocos-creator/3d-tasks#5746 (comment)