### PR TITLE
Fix change scene will crash in dragonbones

### DIFF
--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -782,6 +782,7 @@ export class ArmatureDisplay extends UIRenderable {
     }
 
     onDestroy () {
+        this._materialInstances = this._materialInstances.filter(instance => !!instance);
         super.onDestroy();
         this._inited = false;
 

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -782,7 +782,7 @@ export class ArmatureDisplay extends UIRenderable {
     }
 
     onDestroy () {
-        this._materialInstances = this._materialInstances.filter(instance => !!instance);
+        this._materialInstances = this._materialInstances.filter((instance) => !!instance);
         super.onDestroy();
         this._inited = false;
 


### PR DESCRIPTION
问题: 
在runtime平台点击fire时切换场景会报错, 经排查, 是ui-renderable.ts中onDestroy()没有对_materialInstances中的null元素进行检查.
为修复该问题, 我在ArmatureDisplay.ts的onDestroy()中进行提前判断.  

相关issue: https://github.com/cocos-creator/3d-tasks/issues/5672
