### PR TITLE
Fix timeScale button invalid in Spine

### DIFF
--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -354,9 +354,15 @@ export class Skeleton extends UIRenderable {
      * !#zh 当前骨骼中所有动画的时间缩放率。
      */
     @serializable
+    private _timeScale = 1;
     @tooltip('i18n:COMPONENT.skeleton.time_scale')
     @editable
-    public timeScale = 1;
+    get timeScale () { return this._timeScale; }
+    set timeScale (value) {
+        if (value !== this._timeScale) {
+            this._timeScale = value;
+        }
+    }
 
     /**
      * !#en Indicates whether open debug slots.
@@ -726,8 +732,7 @@ export class Skeleton extends UIRenderable {
         if (EDITOR) return;
         if (this.paused) return;
 
-        dt *= this.timeScale * timeScale;
-
+        dt *= this._timeScale * timeScale;
         if (this.isAnimationCached()) {
             // Cache mode and has animation queue.
             if (this._isAniComplete) {


### PR DESCRIPTION
问题: test-case-3d/SpineBoy点击Time Scale，人物动作没有变慢
相关issue: https://github.com/cocos-creator/3d-tasks/issues/5769#
原因: TS引擎中的timescale没有成功传入原生.
修改: 在cocos/spine/skeleton.ts添加了timeScale的get/set方法 



