### PR TITLE
Remove current() and ratio() setters

### DIFF
--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -291,27 +291,11 @@ export class AnimationState extends Playable {
     }
 
     /**
-     * @en Sets the time progress, in seconds.
-     * @zh 设置动画的时间进度，单位为秒。
-     */
-    set current (value) {
-        this.setTime(value);
-    }
-
-    /**
      * @en Gets the playback ratio.
      * @zh 获取动画播放的比例时间。
      */
     get ratio () {
         return this.current / this.duration;
-    }
-
-    /**
-     * @en Sets the playback ratio.
-     * @zh 设置动画播放的比例时间。
-     */
-    set ratio (value) {
-        this.current = this.duration * value;
     }
 
     /**


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * In https://github.com/cocos-creator/engine/pull/8037 we added `.current` and `.ratio` accessors to provide convenient accesses to "current time progress"(which lays in `[0, duration]`). Now we decide to remove the setters and keep only the getters since the need of reverse calculation of "accumulated time" from 'current time'. https://github.com/cocos-creator/engine/pull/8037 is not a released change so we do not need migration here.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
