### PR TITLE
update default prefab meta ver to 1.1.27 and fbx var to 2.0.10

### DIFF
--- a/editor/assets/default_prefab/3d/Capsule.prefab
+++ b/editor/assets/default_prefab/3d/Capsule.prefab
@@ -72,7 +72,10 @@
     },
     "_shadowCastingMode": 0,
     "_receiveShadows": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "da90XzlDpMAYZdnNEoKl+n",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "da90XzlDpMAYZdnNEoKl+n"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "79dw5Ftk1ApLmqTwrc+k7C"
   }
 ]

--- a/editor/assets/default_prefab/3d/Capsule.prefab.meta
+++ b/editor/assets/default_prefab/3d/Capsule.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "73ce1f7f-d1f4-4942-ad93-66ca3b3041ab",

--- a/editor/assets/default_prefab/3d/Cone.prefab
+++ b/editor/assets/default_prefab/3d/Cone.prefab
@@ -72,7 +72,10 @@
     },
     "_shadowCastingMode": 0,
     "_receiveShadows": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "71iiGASwNCApxqLqH+wIbn",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "71iiGASwNCApxqLqH+wIbn"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "f1ipRw5aRJRZ9C2iZg62pq"
   }
 ]

--- a/editor/assets/default_prefab/3d/Cone.prefab.meta
+++ b/editor/assets/default_prefab/3d/Cone.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "6350d660-e888-4acf-a552-f3b719ae9110",

--- a/editor/assets/default_prefab/3d/Cube.prefab
+++ b/editor/assets/default_prefab/3d/Cube.prefab
@@ -72,7 +72,10 @@
     },
     "_shadowCastingMode": 0,
     "_receiveShadows": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "18p7R2TC1PDpDQlq3lim9E",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "18p7R2TC1PDpDQlq3lim9E"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e8DOT5UJ1F/ZgplWYyCxRs"
   }
 ]

--- a/editor/assets/default_prefab/3d/Cube.prefab.meta
+++ b/editor/assets/default_prefab/3d/Cube.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "30da77a1-f02d-4ede-aa56-403452ee7fde",

--- a/editor/assets/default_prefab/3d/Cylinder.prefab
+++ b/editor/assets/default_prefab/3d/Cylinder.prefab
@@ -72,7 +72,10 @@
     },
     "_shadowCastingMode": 0,
     "_receiveShadows": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "33oEQpEV9OVK/ZqTytUy5k",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "33oEQpEV9OVK/ZqTytUy5k"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "b8R46AvAVAcJdQNHs3AvR2"
   }
 ]

--- a/editor/assets/default_prefab/3d/Cylinder.prefab.meta
+++ b/editor/assets/default_prefab/3d/Cylinder.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "ab3e16f9-671e-48a7-90b7-d0884d9cbb85",

--- a/editor/assets/default_prefab/3d/Plane.prefab
+++ b/editor/assets/default_prefab/3d/Plane.prefab
@@ -72,7 +72,10 @@
     },
     "_shadowCastingMode": 0,
     "_receiveShadows": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "a4McGKwcFCoYngMEkhGE/8",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "a4McGKwcFCoYngMEkhGE/8"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e0uHCYkZ1D1I9glcT6oLf2"
   }
 ]

--- a/editor/assets/default_prefab/3d/Plane.prefab.meta
+++ b/editor/assets/default_prefab/3d/Plane.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "40563723-f8fc-4216-99ea-a81636435c10",

--- a/editor/assets/default_prefab/3d/Quad.prefab
+++ b/editor/assets/default_prefab/3d/Quad.prefab
@@ -72,7 +72,10 @@
     },
     "_shadowCastingMode": 0,
     "_receiveShadows": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "f7nu3miDhBqIw9jKCaQ84w",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "f7nu3miDhBqIw9jKCaQ84w"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "cf0e2Ddb1LaZRmljaFideC"
   }
 ]

--- a/editor/assets/default_prefab/3d/Quad.prefab.meta
+++ b/editor/assets/default_prefab/3d/Quad.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "34a07346-9f62-4a84-90ae-cb83f7a426c1",

--- a/editor/assets/default_prefab/3d/Sphere.prefab
+++ b/editor/assets/default_prefab/3d/Sphere.prefab
@@ -72,7 +72,10 @@
     },
     "_shadowCastingMode": 0,
     "_receiveShadows": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "a0eltv8s1AU6XwR/2b0+3P",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "a0eltv8s1AU6XwR/2b0+3P"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "492SVdw3ZPdre+amT+eLU6"
   }
 ]

--- a/editor/assets/default_prefab/3d/Sphere.prefab.meta
+++ b/editor/assets/default_prefab/3d/Sphere.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "655c9519-1a37-472b-bae6-29fefac0b550",

--- a/editor/assets/default_prefab/3d/Torus.prefab
+++ b/editor/assets/default_prefab/3d/Torus.prefab
@@ -72,7 +72,10 @@
     },
     "_shadowCastingMode": 0,
     "_receiveShadows": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "3eSHLLgglMw5XPGA//qFqs",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "3eSHLLgglMw5XPGA//qFqs"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "f5ai5YKCpGMp+t5Pa+yXBj"
   }
 ]

--- a/editor/assets/default_prefab/3d/Torus.prefab.meta
+++ b/editor/assets/default_prefab/3d/Torus.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "d47f5d5e-c931-4ff4-987b-cc818a728b82",

--- a/editor/assets/default_prefab/Camera.prefab
+++ b/editor/assets/default_prefab/Camera.prefab
@@ -87,7 +87,10 @@
     },
     "_targetDisplay": 0,
     "_id": "",
-    "_visibility": 1822425087
+    "_visibility": 1822425087,
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -97,11 +100,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "f8Nyw5r0hH9Zz+WrOqK1x/",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "f8Nyw5r0hH9Zz+WrOqK1x/"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "dbCiGR9T1E0oZwxclTRFEj"
   }
 ]

--- a/editor/assets/default_prefab/Camera.prefab.meta
+++ b/editor/assets/default_prefab/Camera.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "bb0a6472-cd67-4afb-a031-94fca8f4cc92",

--- a/editor/assets/default_prefab/Terrain.prefab
+++ b/editor/assets/default_prefab/Terrain.prefab
@@ -66960,7 +66960,10 @@
         "__id__": 4
       }
     ],
-    "_id": "cbqSAfqt9PBb18GTThCTUP"
+    "_id": "cbqSAfqt9PBb18GTThCTUP",
+    "__prefab": {
+      "__id__": 6
+    }
   },
   {
     "__type__": "cc.TerrainInfo",
@@ -66989,11 +66992,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "0cVtTfa61GVq2E3ZL5+7Tf",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "0cVtTfa61GVq2E3ZL5+7Tf"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "af82Rx80RL5J4w+bDUekBo"
   }
 ]

--- a/editor/assets/default_prefab/Terrain.prefab.meta
+++ b/editor/assets/default_prefab/Terrain.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "90e8b0d4-12dc-412d-9156-ea1fdb18c15b",

--- a/editor/assets/default_prefab/effects/Particle System.prefab
+++ b/editor/assets/default_prefab/effects/Particle System.prefab
@@ -154,7 +154,10 @@
     "_prewarm": false,
     "_capacity": 100,
     "_simulationSpace": 1,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 53
+    }
   },
   {
     "__type__": "cc.GradientRange",
@@ -610,11 +613,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "d8TRONhORDRpCXbQBSi+LM",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "d8TRONhORDRpCXbQBSi+LM"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "0b7a7v3FVOCpzmec7amMlB"
   }
 ]

--- a/editor/assets/default_prefab/effects/Particle System.prefab.meta
+++ b/editor/assets/default_prefab/effects/Particle System.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "f09a0597-10e6-49e5-8759-a148b5e85395",

--- a/editor/assets/default_prefab/light/Directional Light.prefab
+++ b/editor/assets/default_prefab/light/Directional Light.prefab
@@ -72,7 +72,10 @@
     "_useColorTemperature": false,
     "_colorTemperature": 6550,
     "_intensity": 65000,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -82,11 +85,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "aeyMch0nJBEbV/mk9CXYkW",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "aeyMch0nJBEbV/mk9CXYkW"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "1fmNgOipdOha90C8NNkXEN"
   }
 ]

--- a/editor/assets/default_prefab/light/Directional Light.prefab.meta
+++ b/editor/assets/default_prefab/light/Directional Light.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "a0e9756d-9128-4f49-8097-e041c8b733b8",

--- a/editor/assets/default_prefab/light/Sphere Light.prefab
+++ b/editor/assets/default_prefab/light/Sphere Light.prefab
@@ -74,7 +74,10 @@
     "_intensity": 1700,
     "_size": 0.15,
     "_range": 2,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -84,11 +87,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "59eikBZx5K9aR06hUuVC37",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "59eikBZx5K9aR06hUuVC37"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "5b6a86+adN0IKor4mk41YN"
   }
 ]

--- a/editor/assets/default_prefab/light/Sphere Light.prefab.meta
+++ b/editor/assets/default_prefab/light/Sphere Light.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "4182ee46-ffa0-4de2-b66b-c93cc6c7e9b8",

--- a/editor/assets/default_prefab/light/Spot Light.prefab
+++ b/editor/assets/default_prefab/light/Spot Light.prefab
@@ -75,7 +75,10 @@
     "_size": 0.3,
     "_range": 5,
     "_spotAngle": 30,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 4
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -85,11 +88,10 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "35C2xAi5dG/btOADE1TC8p",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "35C2xAi5dG/btOADE1TC8p"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "42FuKkPeBOSLyZuICQqfaf"
   }
 ]

--- a/editor/assets/default_prefab/light/Spot Light.prefab.meta
+++ b/editor/assets/default_prefab/light/Spot Light.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "7a49aa24-bd7a-40a8-b31a-b2a9da85abcd",

--- a/editor/assets/default_prefab/ui/Button.prefab
+++ b/editor/assets/default_prefab/ui/Button.prefab
@@ -132,7 +132,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 10
+    }
   },
   {
     "__type__": "cc.Label",
@@ -168,7 +171,10 @@
     "_isBold": false,
     "_isUnderline": false,
     "_cacheMode": 0,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 11
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -178,12 +184,7 @@
     "asset": {
       "__uuid__": "90bdd2a9-2838-4888-b66c-e94c8b7a5169"
     },
-    "fileId": "99oRe7NgdNvrQe2oNkTmkx",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "99oRe7NgdNvrQe2oNkTmkx"
   },
   {
     "__type__": "cc.UITransform",
@@ -204,7 +205,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 12
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -239,7 +243,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 13
+    }
   },
   {
     "__type__": "cc.Button",
@@ -297,7 +304,10 @@
     "_target": {
       "__id__": 1
     },
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 14
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -307,8 +317,26 @@
     "asset": {
       "__uuid__": "90bdd2a9-2838-4888-b66c-e94c8b7a5169"
     },
-    "fileId": "80LJYphSdNMqbi3XYDUm5q",
-    "sync": false,
-    "_synced": true
+    "fileId": "80LJYphSdNMqbi3XYDUm5q"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "07QMd0h1dLcYd/vjigaip6"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "ee3IZdy2dLIaAWpjI7P0FL"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "98TYGMtwRBTYZZn4EZmhzJ"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "77BcV1zfNHo4LI4KRqZupe"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "2fOwBXUwBNvaJ4NyyrOq4C"
   }
 ]

--- a/editor/assets/default_prefab/ui/Button.prefab.meta
+++ b/editor/assets/default_prefab/ui/Button.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "90bdd2a9-2838-4888-b66c-e94c8b7a5169",

--- a/editor/assets/default_prefab/ui/Canvas.prefab
+++ b/editor/assets/default_prefab/ui/Canvas.prefab
@@ -155,7 +155,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 8
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -177,7 +179,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 9
+    },
     "_cameraComponent": {
       "__id__": 3
     },
@@ -192,7 +196,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 10
+    },
     "_alignFlags": 45,
     "_target": null,
     "_left": 0,
@@ -222,5 +228,17 @@
       "__uuid__": "f773db21-62b8-4540-956a-29bacf5ddbf5"
     },
     "fileId": "5f6AJl30pDQId35UqIfQJ/"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "0dngp/9gNO34wUQjZfN/CX"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "3f2oTdCepERZdpmIfLsrhd"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e8a+bU/8dPDbbJguUzLdoF"
   }
 ]

--- a/editor/assets/default_prefab/ui/Canvas.prefab.meta
+++ b/editor/assets/default_prefab/ui/Canvas.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "f773db21-62b8-4540-956a-29bacf5ddbf5",

--- a/editor/assets/default_prefab/ui/EditBox.prefab
+++ b/editor/assets/default_prefab/ui/EditBox.prefab
@@ -135,7 +135,10 @@
       "y": 1
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 14
+    }
   },
   {
     "__type__": "cc.Label",
@@ -171,7 +174,10 @@
     "_isBold": false,
     "_isUnderline": false,
     "_cacheMode": 0,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 15
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -181,12 +187,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "e02jnMmZxAGZlJs5fq9NJo",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "e02jnMmZxAGZlJs5fq9NJo"
   },
   {
     "__type__": "cc.Node",
@@ -256,7 +257,10 @@
       "y": 1
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 16
+    }
   },
   {
     "__type__": "cc.Label",
@@ -292,7 +296,10 @@
     "_isBold": false,
     "_isUnderline": false,
     "_cacheMode": 0,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 17
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -302,12 +309,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "c4xCQrIDRL0pjg6mrIks7k",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "c4xCQrIDRL0pjg6mrIks7k"
   },
   {
     "__type__": "cc.UITransform",
@@ -328,7 +330,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 18
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -363,7 +368,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 19
+    }
   },
   {
     "__type__": "cc.EditBox",
@@ -406,7 +414,10 @@
       "a": 255
     },
     "_stayOnTop": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 20
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -416,11 +427,34 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "028Ule0PtAPqB/Osb42WnZ",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "028Ule0PtAPqB/Osb42WnZ"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "779kAXGTtMZKXfYlOg0Tfd"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "ddIY+NJvlDTIQAg7PLVrGo"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "d07wQj4whCUqYGJH1lEpVp"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "8fhi7qRLFJbK0abIJuXmCW"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "1fhJOVuOVAGYSYZoiE25Uz"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "43qH95z3VGeYelCElKd6FW"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "1bCHrwPGZOPrbmPh93kwpe"
   }
 ]

--- a/editor/assets/default_prefab/ui/EditBox.prefab.meta
+++ b/editor/assets/default_prefab/ui/EditBox.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "05e79121-8675-4551-9ad7-1b901a4025db",

--- a/editor/assets/default_prefab/ui/Graphics.prefab
+++ b/editor/assets/default_prefab/ui/Graphics.prefab
@@ -64,7 +64,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 5
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -86,7 +88,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 6
+    },
     "_visFlags": 0,
     "_customMaterial": null,
     "_srcBlendFactor": 2,
@@ -126,11 +130,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "ecuOmM2MBGcJr6Soj9eWHR",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "ecuOmM2MBGcJr6Soj9eWHR"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "c3dMMH5KBHA7aaNq/gxfrr"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "b72j61fNtG9IH3vOo7HXe7"
   }
 ]

--- a/editor/assets/default_prefab/ui/Graphics.prefab.meta
+++ b/editor/assets/default_prefab/ui/Graphics.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "c96e159e-43ea-4a16-8279-05bc39119d1a",

--- a/editor/assets/default_prefab/ui/Label.prefab
+++ b/editor/assets/default_prefab/ui/Label.prefab
@@ -75,7 +75,10 @@
       "x": 0.5,
       "y": 0.5
     },
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 5
+    }
   },
   {
     "__type__": "cc.Label",
@@ -111,7 +114,10 @@
     "_isBold": false,
     "_isUnderline": false,
     "_cacheMode": 0,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 6
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -121,11 +127,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "85tZs04QNDoJ8Zw+ovirTw",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "85tZs04QNDoJ8Zw+ovirTw"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "c68UOAlNhN171Umca6yVvF"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "2frm37uaJHQr0AEEaYyM82"
   }
 ]

--- a/editor/assets/default_prefab/ui/Label.prefab.meta
+++ b/editor/assets/default_prefab/ui/Label.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "36008810-7ad3-47c0-8112-e30aee089e45",

--- a/editor/assets/default_prefab/ui/Layout.prefab
+++ b/editor/assets/default_prefab/ui/Layout.prefab
@@ -75,7 +75,10 @@
       "x": 0.5,
       "y": 0.5
     },
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 5
+    }
   },
   {
     "__type__": "cc.Layout",
@@ -102,7 +105,10 @@
     "_horizontalDirection": 0,
     "_affectedByScale": false,
     "_id": "",
-    "_layoutType": 0
+    "_layoutType": 0,
+    "__prefab": {
+      "__id__": 6
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -112,11 +118,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "708rGaUe1FubBlr3fE3DYE",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "708rGaUe1FubBlr3fE3DYE"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "71F9vsVsZH7ZFd+PpN0azA"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "eaGEkmlCpANK+GS6CImtZa"
   }
 ]

--- a/editor/assets/default_prefab/ui/Layout.prefab.meta
+++ b/editor/assets/default_prefab/ui/Layout.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "a9ef7dfc-ea8b-4cf8-918e-36da948c4de0",

--- a/editor/assets/default_prefab/ui/Mask.prefab
+++ b/editor/assets/default_prefab/ui/Mask.prefab
@@ -76,7 +76,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 5
+    }
   },
   {
     "__type__": "cc.Mask",
@@ -98,7 +101,10 @@
     "_sharedMaterial": null,
     "_type": 0,
     "_segments": 64,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 6
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -108,8 +114,14 @@
     "asset": {
       "__uuid__": "7fa63aed-f3e2-46a5-8a7c-c1a1adf6cea6"
     },
-    "fileId": "dcqbd5AqtAAa0hfeX2B3/Y",
-    "sync": false,
-    "_synced": true
+    "fileId": "dcqbd5AqtAAa0hfeX2B3/Y"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "85Rkr8igNOB6QSD/HtnhgH"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "90TR3hptxAq7K974GgvafO"
   }
 ]

--- a/editor/assets/default_prefab/ui/Mask.prefab.meta
+++ b/editor/assets/default_prefab/ui/Mask.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "7fa63aed-f3e2-46a5-8a7c-c1a1adf6cea6",

--- a/editor/assets/default_prefab/ui/ParticleSystem2D.prefab
+++ b/editor/assets/default_prefab/ui/ParticleSystem2D.prefab
@@ -64,7 +64,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 5
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -86,7 +88,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 6
+    },
     "_visFlags": 0,
     "_customMaterial": null,
     "_srcBlendFactor": 2,
@@ -192,11 +196,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "366F5dFQ5Mrpf1fc4rgmf8",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "366F5dFQ5Mrpf1fc4rgmf8"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "52j42auLRKAqKHqVwKrYR+"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "7aW/vBOFFJYZIJQ4frUfp7"
   }
 ]

--- a/editor/assets/default_prefab/ui/ParticleSystem2D.prefab.meta
+++ b/editor/assets/default_prefab/ui/ParticleSystem2D.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "f396261e-3e06-41ec-bdd6-9a8b6d99026f",

--- a/editor/assets/default_prefab/ui/ProgressBar.prefab
+++ b/editor/assets/default_prefab/ui/ProgressBar.prefab
@@ -132,7 +132,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 10
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -167,7 +170,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 11
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -177,12 +183,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "41M8shm3JNAZH4s8uu8rgG",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "41M8shm3JNAZH4s8uu8rgG"
   },
   {
     "__type__": "cc.UITransform",
@@ -203,7 +204,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 12
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -238,7 +242,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 13
+    }
   },
   {
     "__type__": "cc.ProgressBar",
@@ -255,7 +262,10 @@
     "_totalLength": 300,
     "_progress": 0.5,
     "_reverse": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 14
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -265,11 +275,26 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "57OgHuVgZMi7YjfxaBX7ok",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "57OgHuVgZMi7YjfxaBX7ok"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "80SdIywIVFupwJOwCni0ux"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e00niSjJdHzqQfr6Uq+1as"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "0a4TUb2bBHBa3wO6MCw2d2"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e3LBidlN9MdpNxB8lzYZv7"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "3f/uAXDzRCkYMASuN3GC61"
   }
 ]

--- a/editor/assets/default_prefab/ui/ProgressBar.prefab.meta
+++ b/editor/assets/default_prefab/ui/ProgressBar.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "0d9353c4-6fb9-49bb-bc62-77f1750078c2",

--- a/editor/assets/default_prefab/ui/RichText.prefab
+++ b/editor/assets/default_prefab/ui/RichText.prefab
@@ -120,7 +120,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 4
+      "__id__": 19
     },
     "_priority": 0,
     "_contentSize": {
@@ -136,7 +136,7 @@
     "_id": "6e4/YFEbFHzZBehWqOktUl"
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "2e5gEZK7JEv6t/lN+cudVF"
   },
   {
@@ -148,7 +148,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 6
+      "__id__": 20
     },
     "_visFlags": 0,
     "_customMaterial": null,
@@ -181,7 +181,7 @@
     "_id": "7aViHQO/JMT5W88a+35F5h"
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "b58BtkmEREfLcahhaxkiSf"
   },
   {
@@ -256,7 +256,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 10
+      "__id__": 21
     },
     "_priority": 0,
     "_contentSize": {
@@ -272,7 +272,7 @@
     "_id": "63Udn/+qJJGZgy9VR1u6JL"
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "8fB1K+zqFDm6KLLi/2Tbxt"
   },
   {
@@ -284,7 +284,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 12
+      "__id__": 22
     },
     "_visFlags": 0,
     "_customMaterial": null,
@@ -317,7 +317,7 @@
     "_id": "bdTdPOjbRBFK1zYN9pkSl1"
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "08TnEzpqFCOK/MDNdWrYro"
   },
   {
@@ -344,7 +344,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 15
+      "__id__": 23
     },
     "_priority": 0,
     "_contentSize": {
@@ -360,7 +360,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "78TiFTq9pPVbHywzr3HwuF"
   },
   {
@@ -372,7 +372,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 17
+      "__id__": 24
     },
     "_lineHeight": 40,
     "_string": "<color=#00ff00>Rich</color><color=#0fffff>Text</color>",
@@ -389,7 +389,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "95NxRt8ExMwbEuH92a6KWX"
   },
   {
@@ -400,11 +400,30 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "ddu3l1uz1AJ7G5NFjjOoPp",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "ddu3l1uz1AJ7G5NFjjOoPp"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e9RnBvol9I/LTEOHmUV8HW"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "47B31pTwRFw57GhzKn35Ha"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "83GI+Q3olL7aDBXgnPxDms"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "8asfnZ9LhD4YCtcfGdgdsw"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "4bf4SjaRxP4KcluNxRvaJw"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "b5LFduq8VJWo/DE4BRFmBn"
   }
 ]

--- a/editor/assets/default_prefab/ui/RichText.prefab.meta
+++ b/editor/assets/default_prefab/ui/RichText.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "fc6bfcfa-8086-4326-809b-0ba1226bac7d",

--- a/editor/assets/default_prefab/ui/ScrollView.prefab
+++ b/editor/assets/default_prefab/ui/ScrollView.prefab
@@ -180,7 +180,9 @@
       "__id__": 3
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 27
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -203,7 +205,9 @@
     },
     "_enabled": true,
     "_materials": [],
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 28
+    },
     "_visFlags": 0,
     "_srcBlendFactor": 2,
     "_dstBlendFactor": 4,
@@ -240,12 +244,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "37iH41l99AV7W0A5uz+YvA",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "37iH41l99AV7W0A5uz+YvA"
   },
   {
     "__type__": "cc.UITransform",
@@ -255,7 +254,9 @@
       "__id__": 2
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 29
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -278,7 +279,9 @@
     },
     "_enabled": true,
     "_materials": [],
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 30
+    },
     "_visFlags": 0,
     "_srcBlendFactor": 2,
     "_dstBlendFactor": 4,
@@ -315,7 +318,9 @@
       "__id__": 2
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 31
+    },
     "_alignFlags": 37,
     "_target": null,
     "_left": 0,
@@ -344,7 +349,9 @@
       "__id__": 2
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 32
+    },
     "_scrollView": {
       "__id__": 11
     },
@@ -364,7 +371,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 33
+    },
     "bounceDuration": 0.23,
     "brake": 0.75,
     "elastic": true,
@@ -491,7 +500,9 @@
       "__id__": 13
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 34
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -514,7 +525,9 @@
     },
     "_enabled": true,
     "_materials": [],
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 35
+    },
     "_visFlags": 0,
     "_srcBlendFactor": 2,
     "_dstBlendFactor": 4,
@@ -538,12 +551,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "e31+R9dbtKeoazXpaYbIbx",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "e31+R9dbtKeoazXpaYbIbx"
   },
   {
     "__type__": "cc.Node",
@@ -601,7 +609,9 @@
       "__id__": 17
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 36
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -624,7 +634,9 @@
     },
     "_enabled": true,
     "_materials": [],
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 37
+    },
     "_visFlags": 0,
     "_srcBlendFactor": 2,
     "_dstBlendFactor": 4,
@@ -661,12 +673,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "e75Yn6okpGsaAv7P/g74uT",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "e75Yn6okpGsaAv7P/g74uT"
   },
   {
     "__type__": "cc.UITransform",
@@ -676,7 +683,9 @@
       "__id__": 12
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 38
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -698,12 +707,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "50I0290rZBKYwdU731WBvs",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "50I0290rZBKYwdU731WBvs"
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -713,12 +717,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "6fbAJyq7xOYbcFlZbaG/yl",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "6fbAJyq7xOYbcFlZbaG/yl"
   },
   {
     "__type__": "cc.UITransform",
@@ -728,7 +727,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 39
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -751,7 +752,9 @@
     },
     "_enabled": true,
     "_materials": [],
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 40
+    },
     "_visFlags": 0,
     "_srcBlendFactor": 2,
     "_dstBlendFactor": 4,
@@ -788,11 +791,62 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "ddcO5JFkdFA4VJz3MwozPj",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "ddcO5JFkdFA4VJz3MwozPj"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "95oWyE8aJJxJ5UvVmOXyZU"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "02Vchn8fFF/77B+7pVCQuQ"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "17lQPXOPpO0b6Z/3qQRAz3"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "9dLJe/n0BKVoGauB1wT/Tc"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "88/VBmjEBOMLWb2cOiN0kU"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "f4i77UV0dH4pcD0KQOXx7c"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "a8UaPDxYhIX5MrqvKGMJdR"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "adVJjE6iNG9YcIKwDKe/zq"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "4eIg29oQZFVLk+NZnwDdlk"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "3d8stlV6pL/KRLrvrUs0F9"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "17Ae0SAyNCRLoyUTsE6naB"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "99yn0cfL9MmZYfJbPmK9qL"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "71kmounFRG/K27WWBbH2RB"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "8ce2Xg/B9GhY0DNafD/vxa"
   }
 ]

--- a/editor/assets/default_prefab/ui/ScrollView.prefab.meta
+++ b/editor/assets/default_prefab/ui/ScrollView.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "c1baa707-78d6-4b89-8d5d-0b7fdf0c39bc",

--- a/editor/assets/default_prefab/ui/Slider.prefab
+++ b/editor/assets/default_prefab/ui/Slider.prefab
@@ -135,7 +135,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 11
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -172,7 +175,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 12
+    }
   },
   {
     "__type__": "cc.Button",
@@ -224,7 +230,10 @@
       "__id__": 2
     },
     "_clickEvents": [],
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 13
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -234,12 +243,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "c99I/lNulB7bHkE13WGbdB",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "c99I/lNulB7bHkE13WGbdB"
   },
   {
     "__type__": "cc.UITransform",
@@ -260,7 +264,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 14
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -297,7 +304,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 15
+    }
   },
   {
     "__type__": "cc.Slider",
@@ -313,7 +323,10 @@
     "_direction": 0,
     "_progress": 0.1,
     "_slideEvents": [],
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 16
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -323,11 +336,30 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "338FzIbp1AD445tFsve9M7",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "338FzIbp1AD445tFsve9M7"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "13QJLCXqxP1Il0fUQIF50F"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "70944AM5hNwKBMkwzEOckA"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "9eUkB/MkNDvohDk817OV44"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "07sDRP1gxKtb3urHSdnuDY"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "36Am8fYc5AZodP1DolQQ0j"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "d072tlidJJc4WAM3bGih0d"
   }
 ]

--- a/editor/assets/default_prefab/ui/Slider.prefab.meta
+++ b/editor/assets/default_prefab/ui/Slider.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "2bd7e5b6-cd8c-41a1-8136-ddb8efbf6326",

--- a/editor/assets/default_prefab/ui/Sprite.prefab
+++ b/editor/assets/default_prefab/ui/Sprite.prefab
@@ -75,7 +75,10 @@
       "x": 0.5,
       "y": 0.5
     },
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 5
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -111,7 +114,10 @@
     "_isTrimmedMode": true,
     "_useGrayscale": false,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 6
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -121,11 +127,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "aaJ6tvsWNHC4pk5TDYmpFa",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "aaJ6tvsWNHC4pk5TDYmpFa"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "f7NISe7HdAD68SLfhnddy8"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e71ctEmpxFC4KlSYRZNz/a"
   }
 ]

--- a/editor/assets/default_prefab/ui/Sprite.prefab.meta
+++ b/editor/assets/default_prefab/ui/Sprite.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "9db8cd0b-cbe4-42e7-96a9-a239620c0a9d",

--- a/editor/assets/default_prefab/ui/SpriteSplash.prefab
+++ b/editor/assets/default_prefab/ui/SpriteSplash.prefab
@@ -65,7 +65,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 3
+      "__id__": 7
     },
     "_priority": 0,
     "_contentSize": {
@@ -81,7 +81,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "94Ki8oOf5BApUAVjddk12n"
   },
   {
@@ -93,7 +93,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 5
+      "__id__": 8
     },
     "_visFlags": 0,
     "_customMaterial": null,
@@ -125,7 +125,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "62gb5XootOJqH7yKP7GfB0"
   },
   {
@@ -136,11 +136,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "2auWFC5gdLdawQHv2TQRjx",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "2auWFC5gdLdawQHv2TQRjx"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "55pCbtzR5GbojKMArZkfim"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "20UGQn4U9GUoln0NJQTkbG"
   }
 ]

--- a/editor/assets/default_prefab/ui/SpriteSplash.prefab.meta
+++ b/editor/assets/default_prefab/ui/SpriteSplash.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "e5f21aad-3a69-4011-ac62-b74352ac025e",

--- a/editor/assets/default_prefab/ui/TiledMap.prefab
+++ b/editor/assets/default_prefab/ui/TiledMap.prefab
@@ -65,7 +65,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 3
+      "__id__": 7
     },
     "_priority": 0,
     "_contentSize": {
@@ -81,7 +81,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "a7PFP2zJtI6ITn7h8/nh2Z"
   },
   {
@@ -93,7 +93,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 5
+      "__id__": 8
     },
     "_tmxFile": null,
     "_enableCulling": true,
@@ -101,7 +101,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "bcLty6YUdDK7yX23lAP8eP"
   },
   {
@@ -112,11 +112,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "2105AkR79NcIYqFsVLNWzz",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "2105AkR79NcIYqFsVLNWzz"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "a2UFag3ptKgoD5Gu9Hc2u7"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "c9daWXSp1NHY7B0DcUp3vj"
   }
 ]

--- a/editor/assets/default_prefab/ui/TiledMap.prefab.meta
+++ b/editor/assets/default_prefab/ui/TiledMap.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "3139fa4f-8c42-4ce6-98be-15e848d9734c",

--- a/editor/assets/default_prefab/ui/Toggle.prefab
+++ b/editor/assets/default_prefab/ui/Toggle.prefab
@@ -130,7 +130,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 10
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -166,7 +169,10 @@
     "_isTrimmedMode": true,
     "_useGrayscale": false,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 11
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -176,12 +182,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "cdqABDPm1CNrPwkOTXQcNW",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "cdqABDPm1CNrPwkOTXQcNW"
   },
   {
     "__type__": "cc.UITransform",
@@ -202,7 +203,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 12
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -238,7 +242,10 @@
     "_isTrimmedMode": true,
     "_useGrayscale": false,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 13
+    }
   },
   {
     "__type__": "cc.Toggle",
@@ -296,7 +303,10 @@
     "_checkMark": {
       "__id__": 4
     },
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 14
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -306,11 +316,26 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "eaBmd9z1dGd5Mi/sTp4eCJ",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "eaBmd9z1dGd5Mi/sTp4eCJ"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e4k6OSwohL75lyfsntvPC5"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "25nHiyhlVLhbUiFI4JJ9Sn"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "a7yxb8GDhNnIT24rnD3lO4"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "3a4GKzsKZCNLuWHErVRJ1B"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "58GFHdMmJFBa4quSrrbzsk"
   }
 ]

--- a/editor/assets/default_prefab/ui/Toggle.prefab.meta
+++ b/editor/assets/default_prefab/ui/Toggle.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "0e89afe7-56de-4f99-96a1-cba8a75bedd2",

--- a/editor/assets/default_prefab/ui/ToggleContainer.prefab
+++ b/editor/assets/default_prefab/ui/ToggleContainer.prefab
@@ -188,7 +188,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 31
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -223,7 +226,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 32
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -233,12 +239,7 @@
     "asset": {
       "__uuid__": "2af73429-41d1-4346-9062-7798e42945dd"
     },
-    "fileId": "1dpH2l0LVHMo74pGALaWwb",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "1dpH2l0LVHMo74pGALaWwb"
   },
   {
     "__type__": "cc.UITransform",
@@ -259,7 +260,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 33
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -294,7 +298,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 34
+    }
   },
   {
     "__type__": "cc.Toggle",
@@ -354,7 +361,10 @@
     "_checkMark": {
       "__id__": 5
     },
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 35
+    }
   },
   {
     "__type__": "cc.ToggleContainer",
@@ -366,7 +376,10 @@
     "_enabled": true,
     "checkEvents": [],
     "_allowSwitchOff": false,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 36
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -376,12 +389,7 @@
     "asset": {
       "__uuid__": "2af73429-41d1-4346-9062-7798e42945dd"
     },
-    "fileId": "21XFZBsytE2bK6WHJkITcc",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "21XFZBsytE2bK6WHJkITcc"
   },
   {
     "__type__": "cc.Node",
@@ -507,7 +515,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 37
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -542,7 +553,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 38
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -552,12 +566,7 @@
     "asset": {
       "__uuid__": "2af73429-41d1-4346-9062-7798e42945dd"
     },
-    "fileId": "eb4g26NFpGh4wdfLABIdYV",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "eb4g26NFpGh4wdfLABIdYV"
   },
   {
     "__type__": "cc.UITransform",
@@ -578,7 +587,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 39
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -613,7 +625,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 40
+    }
   },
   {
     "__type__": "cc.Toggle",
@@ -673,7 +688,10 @@
     "_checkMark": {
       "__id__": 15
     },
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 41
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -683,12 +701,7 @@
     "asset": {
       "__uuid__": "2af73429-41d1-4346-9062-7798e42945dd"
     },
-    "fileId": "02WTSZFlRJ24FoUt5WpMow",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "02WTSZFlRJ24FoUt5WpMow"
   },
   {
     "__type__": "cc.Node",
@@ -814,7 +827,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 42
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -849,7 +865,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 43
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -859,12 +878,7 @@
     "asset": {
       "__uuid__": "2af73429-41d1-4346-9062-7798e42945dd"
     },
-    "fileId": "d9N37MSTRFepYAaUzF+wlO",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "d9N37MSTRFepYAaUzF+wlO"
   },
   {
     "__type__": "cc.UITransform",
@@ -885,7 +899,10 @@
       "y": 0.5
     },
     "_id": "",
-    "_priority": 0
+    "_priority": 0,
+    "__prefab": {
+      "__id__": 44
+    }
   },
   {
     "__type__": "cc.Sprite",
@@ -920,7 +937,10 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 45
+    }
   },
   {
     "__type__": "cc.Toggle",
@@ -980,21 +1000,9 @@
     "_checkMark": {
       "__id__": 24
     },
-    "_id": ""
-  },
-  {
-    "__type__": "cc.PrefabInfo",
-    "root": {
-      "__id__": 1
-    },
-    "asset": {
-      "__uuid__": "2af73429-41d1-4346-9062-7798e42945dd"
-    },
-    "fileId": "b9MEAVEjRMUbpyfVJTxhUS",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
+    "_id": "",
+    "__prefab": {
+      "__id__": 46
     }
   },
   {
@@ -1005,8 +1013,80 @@
     "asset": {
       "__uuid__": "2af73429-41d1-4346-9062-7798e42945dd"
     },
-    "fileId": "0abpGdRJZFr6tOhit0x6yB",
-    "sync": false,
-    "_synced": true
+    "fileId": "b9MEAVEjRMUbpyfVJTxhUS"
+  },
+  {
+    "__type__": "cc.PrefabInfo",
+    "root": {
+      "__id__": 1
+    },
+    "asset": {
+      "__uuid__": "2af73429-41d1-4346-9062-7798e42945dd"
+    },
+    "fileId": "0abpGdRJZFr6tOhit0x6yB"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "769r8PnWVBcKxoQ/tBgxxJ"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "feLMgPl9lI7psUYhi9QZnd"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "7eWgLqN4BJYKFxZT9fh0Dg"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "05YCOqjrpMLJpWYS4SFuRX"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "9b8IW1c0BB3rLtFXFfDwtM"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "352Lg0yJ1CEY+vaR56K/O8"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "689DN305dFGJTCMmQOfwAD"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "faDtNLU2xM7aWAk+Ipet86"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "2408xx9KlDjpgL7oVDU/d8"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "f5MaVV0MdBMIwcasBnu/Ri"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "62dIBI9rRNWoWNm6Z4N1Xu"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "eeq2vO+dJBn5KOb1dAA5F3"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "70FX1MVxdNeLTwMFd50cKW"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "32AvB2MYZMpaTyU7uqXecV"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "1abJcRoRFGWLtnvEy6fR2T"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "dbO+2TKn5Ku4d/ME4S+Grh"
   }
 ]

--- a/editor/assets/default_prefab/ui/ToggleContainer.prefab.meta
+++ b/editor/assets/default_prefab/ui/ToggleContainer.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "2af73429-41d1-4346-9062-7798e42945dd",

--- a/editor/assets/default_prefab/ui/VideoPlayer.prefab
+++ b/editor/assets/default_prefab/ui/VideoPlayer.prefab
@@ -65,7 +65,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 3
+      "__id__": 7
     },
     "_priority": 0,
     "_contentSize": {
@@ -81,7 +81,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "84IWCQmzxOwqmg8nEmFTNt"
   },
   {
@@ -93,7 +93,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 5
+      "__id__": 8
     },
     "_resourceType": 1,
     "_remoteURL": "",
@@ -112,7 +112,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "4ef/bMt1pLt5NzRNACjJwQ"
   },
   {
@@ -123,11 +123,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "88MH35CSlBl5HUFQvHLFlY",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "88MH35CSlBl5HUFQvHLFlY"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "03+tBKn75Dm5MWRbRZIMdF"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "6epnKYgbtL0Ze/OlJGICQj"
   }
 ]

--- a/editor/assets/default_prefab/ui/VideoPlayer.prefab.meta
+++ b/editor/assets/default_prefab/ui/VideoPlayer.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "7e089eaf-fa97-40d7-8a20-741a152585df",

--- a/editor/assets/default_prefab/ui/WebView.prefab
+++ b/editor/assets/default_prefab/ui/WebView.prefab
@@ -65,7 +65,7 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 3
+      "__id__": 7
     },
     "_priority": 0,
     "_contentSize": {
@@ -81,7 +81,7 @@
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "f8vvYOuJJPMpDZ0V7jUnx7"
   },
   {
@@ -93,14 +93,14 @@
     },
     "_enabled": true,
     "__prefab": {
-      "__id__": 5
+      "__id__": 8
     },
     "_url": "https://cocos.com",
     "webviewEvents": [],
     "_id": ""
   },
   {
-    "__type__": "cc.CompPrefabInfo ",
+    "__type__": "cc.CompPrefabInfo",
     "fileId": "56z0QooUVAnqSSs975NkzA"
   },
   {
@@ -111,11 +111,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "02LVpQNydBDY4ip8CPqdof",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "02LVpQNydBDY4ip8CPqdof"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "a1D+jicHZPDJe8HsX34jia"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "abdA5skhVLkY1+gRdDYTFK"
   }
 ]

--- a/editor/assets/default_prefab/ui/WebView.prefab.meta
+++ b/editor/assets/default_prefab/ui/WebView.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "9c541fa2-1dc8-4d8b-813a-aec89133f5b1",

--- a/editor/assets/default_prefab/ui/Widget.prefab
+++ b/editor/assets/default_prefab/ui/Widget.prefab
@@ -75,7 +75,10 @@
       "x": 0.5,
       "y": 0.5
     },
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 5
+    }
   },
   {
     "__type__": "cc.Widget",
@@ -101,7 +104,10 @@
     "_originalWidth": 0,
     "_originalHeight": 0,
     "_alignMode": 2,
-    "_id": ""
+    "_id": "",
+    "__prefab": {
+      "__id__": 6
+    }
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -111,11 +117,14 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "578WJabBZMg7E4k78zGTBW",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "578WJabBZMg7E4k78zGTBW"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "15MbuX4VNHPLpqzglWCixn"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "2ac45cT6BHwqitY1b17iCp"
   }
 ]

--- a/editor/assets/default_prefab/ui/Widget.prefab.meta
+++ b/editor/assets/default_prefab/ui/Widget.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "36ed4422-3542-4cc4-bf02-dc4bfc590836",

--- a/editor/assets/default_prefab/ui/pageView.prefab
+++ b/editor/assets/default_prefab/ui/pageView.prefab
@@ -232,7 +232,9 @@
       "__id__": 4
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 30
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -254,7 +256,9 @@
       "__id__": 4
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 31
+    },
     "_visFlags": 0,
     "_customMaterial": null,
     "_srcBlendFactor": 2,
@@ -292,12 +296,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "420fEzKrZE7oOsyr/lpDSv",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "420fEzKrZE7oOsyr/lpDSv"
   },
   {
     "__type__": "cc.Node",
@@ -355,7 +354,9 @@
       "__id__": 8
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 32
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -377,7 +378,9 @@
       "__id__": 8
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 33
+    },
     "_visFlags": 0,
     "_customMaterial": null,
     "_srcBlendFactor": 2,
@@ -415,12 +418,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "650lXdebtHaYLYZ6nM+I3J",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "650lXdebtHaYLYZ6nM+I3J"
   },
   {
     "__type__": "cc.Node",
@@ -478,7 +476,9 @@
       "__id__": 12
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 34
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -500,7 +500,9 @@
       "__id__": 12
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 35
+    },
     "_visFlags": 0,
     "_customMaterial": null,
     "_srcBlendFactor": 2,
@@ -538,12 +540,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "f17hrIT+RHcoUg4sbj1e6a",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "f17hrIT+RHcoUg4sbj1e6a"
   },
   {
     "__type__": "cc.UITransform",
@@ -553,7 +550,9 @@
       "__id__": 3
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 36
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -575,7 +574,9 @@
       "__id__": 3
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 37
+    },
     "_resizeMode": 1,
     "_cellSize": {
       "__type__": "cc.Size",
@@ -603,12 +604,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "420lQGg8RP6bVfGctaKLB8",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "420lQGg8RP6bVfGctaKLB8"
   },
   {
     "__type__": "cc.UITransform",
@@ -618,7 +614,9 @@
       "__id__": 2
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 38
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -640,7 +638,9 @@
       "__id__": 2
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 39
+    },
     "_visFlags": 0,
     "_customMaterial": null,
     "_srcBlendFactor": 2,
@@ -667,12 +667,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "b02pLdLTlDzpSu2HI2+8J1",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "b02pLdLTlDzpSu2HI2+8J1"
   },
   {
     "__type__": "cc.Node",
@@ -730,7 +725,9 @@
       "__id__": 22
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 40
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -752,7 +749,9 @@
       "__id__": 22
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 41
+    },
     "spacing": 10,
     "_spriteFrame": {
       "__uuid__": "afc47931-f066-46b0-90be-9fe61f213428@f9941"
@@ -773,12 +772,7 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "50/xjxY5pJ0Y0dRLDLkTGz",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "50/xjxY5pJ0Y0dRLDLkTGz"
   },
   {
     "__type__": "cc.UITransform",
@@ -788,7 +782,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 42
+    },
     "_priority": 0,
     "_contentSize": {
       "__type__": "cc.Size",
@@ -810,7 +806,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 43
+    },
     "_visFlags": 0,
     "_customMaterial": null,
     "_srcBlendFactor": 2,
@@ -848,7 +846,9 @@
       "__id__": 1
     },
     "_enabled": true,
-    "__prefab": null,
+    "__prefab": {
+      "__id__": 44
+    },
     "bounceDuration": 1,
     "brake": 0.5,
     "elastic": true,
@@ -882,11 +882,66 @@
     "asset": {
       "__id__": 0
     },
-    "fileId": "6eq+AK+UZHBpcOVwZfbLaD",
-    "sync": false,
-    "_synced": {
-      "default": false,
-      "serializable": false
-    }
+    "fileId": "6eq+AK+UZHBpcOVwZfbLaD"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "b5sM9g3kJDEq9eoxtvjd92"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "caphIITHFPSpbjE921BKQI"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "02+/HUMNxNUY1fwvhTLA22"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "0eZkXz1VZNRL+M2aQouICH"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "5daLkUbwVMXqDJa9hAUZR0"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "047maJVOpAKbNYJDzt5Hhe"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "09MiESWllLZaRdasGJ/zf+"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "d65L7G5HtO4Ib0ND5kWAd5"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "27sL1UK1tKbZofFl3ceFso"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "9b/WuWM39KzZfKN7y3t1Mq"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "e4APRgXX5GnYn+jIdNYZQY"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "06eKp4lNtKN6/xsyQf1TUr"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "f6HCKBPf1AgYk/vD8DtAzy"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "59Wq4+gGtAdbm0iHKljE25"
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "9aISCZ7W9H7bSr3VKT9Epv"
   }
 ]

--- a/editor/assets/default_prefab/ui/pageView.prefab.meta
+++ b/editor/assets/default_prefab/ui/pageView.prefab.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.26",
+  "ver": "1.1.27",
   "importer": "prefab",
   "imported": true,
   "uuid": "20a5d8cb-ccad-4543-a937-fccd98c9f3de",

--- a/editor/assets/primitives.fbx.meta
+++ b/editor/assets/primitives.fbx.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "2.0.7",
+  "ver": "2.0.10",
   "importer": "fbx",
   "imported": true,
   "uuid": "1263d74c-8167-4928-91a6-4e2672411f47",
@@ -163,7 +163,7 @@
       "displayName": "",
       "id": "aae0f",
       "name": "primitives.prefab",
-      "ver": "1.0.11",
+      "ver": "1.0.12",
       "imported": true,
       "files": [
         ".json"


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

Changes:
 * update default prefab meta ver to 1.1.27 and fbx var to 2.0.10

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
