### PR TITLE
ban VAO on some runtime platforms

### DIFF
--- a/cocos/core/gfx/webgl/webgl-device.ts
+++ b/cocos/core/gfx/webgl/webgl-device.ts
@@ -382,7 +382,7 @@ export class WebGLDevice extends Device {
                 // VAO implementations doesn't work well on some runtime platforms
                 if (LINKSURE || QTT || COCOSPLAY || HUAWEI) {
                     this._OES_vertex_array_object = null;
-                }                
+                }
             }
 
             // some earlier version of iOS and android wechat implement gl.detachShader incorrectly

--- a/cocos/core/gfx/webgl/webgl-device.ts
+++ b/cocos/core/gfx/webgl/webgl-device.ts
@@ -23,7 +23,7 @@
  THE SOFTWARE.
  */
 
-import { ALIPAY, RUNTIME_BASED, BYTEDANCE, WECHAT, VIVO } from 'internal:constants';
+import { ALIPAY, RUNTIME_BASED, BYTEDANCE, WECHAT, LINKSURE, QTT, COCOSPLAY, HUAWEI } from 'internal:constants';
 import { macro, warnID, warn } from '../../platform';
 import { sys } from '../../platform/sys';
 import { DescriptorSet, DescriptorSetInfo } from '../descriptor-set';
@@ -378,13 +378,11 @@ export class WebGLDevice extends Device {
                 this._WEBGL_depth_texture = null;
             }
 
-            // earlier runtime VAO implementations doesn't work
-            if (RUNTIME_BASED && !VIVO) {
-                // @ts-expect-error
-                if (typeof loadRuntime !== 'function' || !loadRuntime() || typeof loadRuntime().getFeature !== 'function' || loadRuntime()
-                    .getFeature('webgl.extensions.oes_vertex_array_object.revision') <= 0) {
+            if (RUNTIME_BASED) {
+                // VAO implementations doesn't work well on some runtime platforms
+                if (LINKSURE || QTT || COCOSPLAY || HUAWEI) {
                     this._OES_vertex_array_object = null;
-                }
+                }                
             }
 
             // some earlier version of iOS and android wechat implement gl.detachShader incorrectly


### PR DESCRIPTION
resolve: https://github.com/cocos-creator/3d-tasks/issues/5309

![WechatIMG8](https://user-images.githubusercontent.com/17872773/104411709-da938d80-55a5-11eb-9db1-6af2cb30a57a.png)

目前统计到 的情况：
- VAO 的 实现在  华为，连尚，趣头条 和 COCOSPLAY 这些平台上有问题，需要 手动禁用掉
- VAO 在 vivo 上不支持，可以通过  `gl.getExtension('OES_vertex_array_object')` 接口判断
- `loadRuntime().getFeature('webgl.extensions.oes_vertex_array_object.revision')`  这个查询接口不是所有 runtime 平台都通用, 且没有一个标准的 返回值

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
