### PR TITLE
Fix: builtin standard effect should respect to alpha channel of vertex color

### DIFF
--- a/editor/assets/chunks/general-vs.chunk
+++ b/editor/assets/chunks/general-vs.chunk
@@ -7,7 +7,7 @@ precision highp float;
 #include <cc-fog>
 #include <cc-shadow-map-vs>
 
-in vec3 a_color;
+in vec4 a_color;
 #if HAS_SECOND_UV
   in vec2 a_texCoord1;
 #endif
@@ -18,7 +18,7 @@ out vec3 v_tangent;
 out vec3 v_bitangent;
 out vec2 v_uv;
 out vec2 v_uv1;
-out vec3 v_color;
+out vec4 v_color;
 out float factor_fog;
 
 vec4 vert () {

--- a/editor/assets/effects/builtin-standard.effect
+++ b/editor/assets/effects/builtin-standard.effect
@@ -219,7 +219,7 @@ CCProgram standard-fs %{
   void surf (out StandardSurface s) {
     vec4 baseColor = albedo;
     #if USE_VERTEX_COLOR
-      baseColor.rgba *= v_color;
+      baseColor *= v_color;
     #endif
     #if USE_ALBEDO_MAP
       vec4 texColor = texture(albedoMap, ALBEDO_UV);

--- a/editor/assets/effects/builtin-standard.effect
+++ b/editor/assets/effects/builtin-standard.effect
@@ -102,8 +102,8 @@ CCProgram standard-vs %{
   #include <cc-shadow-map-vs>
 
   #if USE_VERTEX_COLOR
-    in vec3 a_color;
-    out vec3 v_color;
+    in vec4 a_color;
+    out vec4 v_color;
   #endif
 
   out vec3 v_position;
@@ -180,7 +180,7 @@ CCProgram standard-fs %{
   in float v_fog_factor;
 
   #if USE_VERTEX_COLOR
-    in vec3 v_color;
+    in vec4 v_color;
   #endif
 
   #if USE_ALBEDO_MAP
@@ -219,7 +219,7 @@ CCProgram standard-fs %{
   void surf (out StandardSurface s) {
     vec4 baseColor = albedo;
     #if USE_VERTEX_COLOR
-      baseColor.rgb *= v_color;
+      baseColor.rgba *= v_color;
     #endif
     #if USE_ALBEDO_MAP
       vec4 texColor = texture(albedoMap, ALBEDO_UV);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
