### PR TITLE
fix file size storage  exceeded  on Bytedance

### DIFF
--- a/platforms/minigame/common/cache-manager.js
+++ b/platforms/minigame/common/cache-manager.js
@@ -22,12 +22,11 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
-const { getUserDataPath, readJsonSync, makeDirSync, writeFileSync, copyFile, downloadFile, deleteFile, rmdirSync, unzip } = window.fsUtils;
+const { getUserDataPath, readJsonSync, makeDirSync, writeFileSync, copyFile, downloadFile, deleteFile, rmdirSync, unzip, isOutOfStorage } = window.fsUtils;
 
 var checkNextPeriod = false;
 var writeCacheFileList = null;
 var cleaning = false;
-var errTest = /the maximum size of the file storage/;
 var suffix = 0;
 const REGEX = /^https?:\/\/.*/;
 
@@ -126,7 +125,7 @@ var cacheManager = {
             
         function callback (err) {
             if (err)  {
-                if (errTest.test(err.message)) {
+                if (isOutOfStorage(err.message)) {
                     self.outOfStorage = true;
                     self.autoClear && self.clearLRU();
                     return;
@@ -243,7 +242,7 @@ var cacheManager = {
         unzip(zipFilePath, targetPath, function (err) {
             if (err) {
                 rmdirSync(targetPath, true);
-                if (errTest.test(err.message)) {
+                if (isOutOfStorage(err.message)) {
                     self.outOfStorage = true;
                     self.autoClear && self.clearLRU();
                 }

--- a/platforms/minigame/platforms/alipay/wrapper/fs-utils.js
+++ b/platforms/minigame/platforms/alipay/wrapper/fs-utils.js
@@ -23,10 +23,15 @@
  THE SOFTWARE.
  ****************************************************************************/
 var fs = my.getFileSystemManager ? my.getFileSystemManager() : null;
+var outOfStorageRegExp = /the maximum size of the file storage/;  // not exactly right
 
 var fsUtils = {
 
     fs,
+
+    isOutOfStorage (errMsg) {
+        return outOfStorageRegExp.test(errMsg);
+    },
 
     getUserDataPath () {
         return my.env.USER_DATA_PATH;

--- a/platforms/minigame/platforms/baidu/wrapper/fs-utils.js
+++ b/platforms/minigame/platforms/baidu/wrapper/fs-utils.js
@@ -23,10 +23,15 @@
  THE SOFTWARE.
  ****************************************************************************/
 var fs = swan.getFileSystemManager ? swan.getFileSystemManager() : null;
+var outOfStorageRegExp = /file size over/;
 
 var fsUtils = {
 
     fs,
+
+    isOutOfStorage (errMsg) {
+        return outOfStorageRegExp.test(errMsg);
+    },
 
     getUserDataPath () {
         return swan.env.USER_DATA_PATH;

--- a/platforms/minigame/platforms/bytedance/wrapper/fs-utils.js
+++ b/platforms/minigame/platforms/bytedance/wrapper/fs-utils.js
@@ -23,10 +23,15 @@
  THE SOFTWARE.
  ****************************************************************************/
 var fs = tt.getFileSystemManager ? tt.getFileSystemManager() : null;
+var outOfStorageRegExp = /size.*limit.*exceeded/;
 
 var fsUtils = {
 
     fs,
+
+    isOutOfStorage (errMsg) {
+        return outOfStorageRegExp.test(errMsg);
+    },
 
     getUserDataPath () {
         return tt.env.USER_DATA_PATH;

--- a/platforms/minigame/platforms/wechat/wrapper/fs-utils.js
+++ b/platforms/minigame/platforms/wechat/wrapper/fs-utils.js
@@ -23,10 +23,15 @@
  THE SOFTWARE.
  ****************************************************************************/
 var fs = wx.getFileSystemManager ? wx.getFileSystemManager() : null;
+var outOfStorageRegExp = /the maximum size of the file storage/;
 
 var fsUtils = {
 
     fs,
+
+    isOutOfStorage (errMsg) {
+        return outOfStorageRegExp.test(errMsg);
+    },
 
     getUserDataPath () {
         return wx.env.USER_DATA_PATH;

--- a/platforms/minigame/platforms/xiaomi/wrapper/fs-utils.js
+++ b/platforms/minigame/platforms/xiaomi/wrapper/fs-utils.js
@@ -23,10 +23,15 @@
  THE SOFTWARE.
  ****************************************************************************/
 var fs = qg.getFileSystemManager ? qg.getFileSystemManager() : null;
+var outOfStorageRegExp = /the maximum size of the file storage/;  // not exactly right
 
 var fsUtils = {
 
     fs,
+
+    isOutOfStorage (errMsg) {
+        return outOfStorageRegExp.test(errMsg);
+    },
 
     getUserDataPath () {
         return qg.env.USER_DATA_PATH;


### PR DESCRIPTION
resolve https://github.com/cocos-creator/3d-tasks/issues/5240

Changes:
 * fs 提供 isOutOfStorage  接口，用来判断缓存/解压操作是否超出缓存空间。这次修复主要 针对字节和百度平台，其他平台行为保持不变

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
