### PR TITLE
fix bitmap font addLetterDefinitions is null error

### DIFF
--- a/cocos2d/core/assets/CCBitmapFont.js
+++ b/cocos2d/core/assets/CCBitmapFont.js
@@ -111,8 +111,11 @@ var BitmapFont = cc.Class({
 
     onLoad () {
         let spriteFrame = this.spriteFrame;
-        if (!this._fontDefDictionary && spriteFrame) {
-            this._fontDefDictionary = new FontAtlas(spriteFrame._texture);
+        if (!this._fontDefDictionary) {
+            this._fontDefDictionary = new FontAtlas();
+            if (spriteFrame) {
+                this._fontDefDictionary._texture = spriteFrame._texture;
+            }
         }
 
         let fntConfig = this._fntConfig;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/3255

Changelog:
 * 修复 BMFont 资源导入时，没有导入关联图片出现报错 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
