### PR TITLE
Fixed-Mac-Safari-14.x-FPS-drop

### DIFF
--- a/cocos2d/core/renderer/webgl/mesh-buffer.js
+++ b/cocos2d/core/renderer/webgl/mesh-buffer.js
@@ -25,8 +25,7 @@
 
 import gfx from '../../../renderer/gfx';
 
-const FIX_IOS14_BUFFER = (cc.sys.os === cc.sys.OS_IOS || cc.sys.os === cc.sys.MACOS) && cc.sys.isBrowser 
-    && /(Mac OS X 1[0-9])|(OS 1[4-9])/.test(window.navigator.userAgent) && /(Version\/1[4-9])/.test(window.navigator.userAgent);
+const FIX_IOS14_BUFFER = (cc.sys.os === cc.sys.OS_IOS || cc.sys.os === cc.sys.MACOS) && cc.sys.isBrowser && /(OS 1[4-9])|(Version\/1[4-9])/.test(window.navigator.userAgent);
 
 let MeshBuffer = cc.Class({
     name: 'cc.MeshBuffer',

--- a/cocos2d/core/renderer/webgl/mesh-buffer.js
+++ b/cocos2d/core/renderer/webgl/mesh-buffer.js
@@ -25,7 +25,8 @@
 
 import gfx from '../../../renderer/gfx';
 
-const FIX_IOS14_BUFFER = cc.sys.os === cc.sys.OS_IOS && cc.sys.isBrowser && /(OS 1[4-9])|(Version\/1[4-9])/.test(window.navigator.userAgent);
+const FIX_IOS14_BUFFER = (cc.sys.os === cc.sys.OS_IOS || cc.sys.os === cc.sys.MACOS) && cc.sys.isBrowser 
+    && /(Mac OS X 1[0-9])|(OS 1[4-9])/.test(window.navigator.userAgent) && /(Version\/1[4-9])/.test(window.navigator.userAgent);
 
 let MeshBuffer = cc.Class({
     name: 'cc.MeshBuffer',


### PR DESCRIPTION
出现问题的 mac safari userAgent：Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Safari/605.1.15

未出现问题的 mac chrome userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36

```
const FIX_IOS14_BUFFER = (cc.sys.os === cc.sys.OS_IOS || cc.sys.os === cc.sys.MACOS) && cc.sys.isBrowser && /(OS 1[4-9])|(Version\/1[4-9])/.test(window.navigator.userAgent);
 ```
 
 只匹配有问题的 mac safari