### PR TITLE
Fixed-Mac-Safari-14.x-FPS-drop-again

### DIFF
--- a/cocos2d/core/renderer/webgl/mesh-buffer.js
+++ b/cocos2d/core/renderer/webgl/mesh-buffer.js
@@ -25,7 +25,7 @@
 
 import gfx from '../../../renderer/gfx';
 
-const FIX_IOS14_BUFFER = (cc.sys.os === cc.sys.OS_IOS || cc.sys.os === cc.sys.MACOS) && cc.sys.isBrowser && /(OS 1[4-9])|(Version\/1[4-9])/.test(window.navigator.userAgent);
+const FIX_IOS14_BUFFER = (cc.sys.os === cc.sys.OS_IOS || cc.sys.os === cc.sys.OS_OSX) && cc.sys.isBrowser && /(OS 1[4-9])|(Version\/1[4-9])/.test(window.navigator.userAgent);
 
 let MeshBuffer = cc.Class({
     name: 'cc.MeshBuffer',


### PR DESCRIPTION
因为 cc.sys.os === cc.sys.MACOS 在实际测试情况中并不会相等。OS_OSX 才可以。