### PR TITLE
fix native spine/dragonbones node move bug & node active bug

### DIFF
--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -2,7 +2,7 @@ import { EDITOR } from 'internal:constants';
 import { Armature, Bone, EventObject } from '@cocos/dragonbones-js';
 import { ccclass, executeInEditMode, help, menu } from '../core/data/class-decorator';
 import { Renderable2D } from '../2d/framework/renderable-2d';
-import { Node, EventTarget, CCClass, Color, Enum, PrivateNode, ccenum, errorID, Texture2D, js, CCObject, SystemEventType } from '../core';
+import { Node, EventTarget, CCClass, Color, Enum, PrivateNode, ccenum, errorID, Texture2D, js, CCObject } from '../core';
 import { BlendFactor } from '../core/gfx';
 import { displayName, editable, override, serializable, tooltip, type, visible } from '../core/data/decorators';
 import { AnimationCache, ArmatureCache, ArmatureFrame } from './ArmatureCache';
@@ -715,20 +715,6 @@ export class ArmatureDisplay extends Renderable2D {
             this._factory!._dragonBones.clock.add(this._armature);
         }
         this._flushAssembler();
-    }
-
-    public _onSyncTransform () {
-        this.node.on(SystemEventType.TRANSFORM_CHANGED, this.syncTransform, this);
-        this.node.on(SystemEventType.SIZE_CHANGED, this.syncTransform, this);
-    }
-
-    public _offSyncTransform () {
-        this.node.off(SystemEventType.TRANSFORM_CHANGED, this.syncTransform, this);
-        this.node.off(SystemEventType.SIZE_CHANGED, this.syncTransform, this);
-    }
-
-    private syncTransform () {
-
     }
 
     onDisable () {

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -564,12 +564,15 @@ export class ArmatureDisplay extends Renderable2D {
     protected _render (ui: Batcher2D) {
         if (this._meshRenderDataArray) {
             for (let i = 0; i < this._meshRenderDataArray.length; i++) {
+                // HACK
+                const mat = this.material;
                 this._meshRenderDataArrayIdx = i;
                 const m = this._meshRenderDataArray[i];
                 this.material = m.renderData.material;
                 if (m.texture) {
                     ui.commitComp(this, m.texture, this._assembler, null);
                 }
+                this.material = mat;
             }
         }
     }

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -5,7 +5,7 @@ import SkeletonCache, { AnimationCache, AnimationFrame } from './skeleton-cache'
 import { AttachUtil } from './attach-util';
 import { ccclass, executeInEditMode, help, menu } from '../core/data/class-decorator';
 import { Renderable2D } from '../2d/framework/renderable-2d';
-import { Node, CCClass, CCObject, Color, Enum, Material, PrivateNode, Texture2D, builtinResMgr, ccenum, errorID, logID, warn, SystemEventType } from '../core';
+import { Node, CCClass, CCObject, Color, Enum, Material, PrivateNode, Texture2D, builtinResMgr, ccenum, errorID, logID, warn } from '../core';
 import { displayName, displayOrder, editable, override, serializable, tooltip, type, visible } from '../core/data/decorators';
 import { SkeletonData } from './skeleton-data';
 import { VertexEffectDelegate } from './vertex-effect-delegate';
@@ -1252,20 +1252,6 @@ export class Skeleton extends Renderable2D {
     public onEnable () {
         super.onEnable();
         this._flushAssembler();
-    }
-
-    public _onSyncTransform () {
-        this.node.on(SystemEventType.TRANSFORM_CHANGED, this.syncTransform, this);
-        this.node.on(SystemEventType.SIZE_CHANGED, this.syncTransform, this);
-    }
-
-    public _offSyncTransform () {
-        this.node.off(SystemEventType.TRANSFORM_CHANGED, this.syncTransform, this);
-        this.node.off(SystemEventType.SIZE_CHANGED, this.syncTransform, this);
-    }
-
-    private syncTransform () {
-
     }
 
     public onDestroy () {

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -1254,6 +1254,10 @@ export class Skeleton extends Renderable2D {
         this._flushAssembler();
     }
 
+    public onDisable () {
+        super.onDisable();
+    }
+
     public onDestroy () {
         this._cleanMaterialCache();
         this.destroyRenderData();
@@ -1342,6 +1346,8 @@ export class Skeleton extends Renderable2D {
     protected _render (ui: Batcher2D) {
         if (this._meshRenderDataArray) {
             for (let i = 0; i < this._meshRenderDataArray.length; i++) {
+                // HACK
+                const mat = this.material;
                 this._meshRenderDataArrayIdx = i;
                 const m = this._meshRenderDataArray[i];
                 if (m.renderData.material) {
@@ -1350,6 +1356,7 @@ export class Skeleton extends Renderable2D {
                 if (m.texture) {
                     ui.commitComp(this, m.texture, this._assembler, null);
                 }
+                this.material = mat;
             }
             // this.node._static = true;
         }

--- a/platforms/native/engine/jsb-dragonbones.js
+++ b/platforms/native/engine/jsb-dragonbones.js
@@ -519,7 +519,6 @@ const cacheManager = require('./jsb-cache-manager');
         if (this._armature && !this.isAnimationCached()) {
             this._factory.add(this._armature);
         }
-        this._onSyncTransform();
         this.syncTransform(true);
         this._flushAssembler();
         middleware.retain();
@@ -531,7 +530,6 @@ const cacheManager = require('./jsb-cache-manager');
         if (this._armature && !this.isAnimationCached()) {
             this._factory.remove(this._armature);
         }
-        this._offSyncTransform();
         middleware.release();
     };
 
@@ -585,26 +583,28 @@ const cacheManager = require('./jsb-cache-manager');
 
         let paramsBuffer = this._paramsBuffer;
         if (!paramsBuffer) return;
-     
-        // sync node world matrix to native
-        node.updateWorldTransform();
-        let worldMat = node._mat;
-        paramsBuffer[1]  = worldMat.m00;
-        paramsBuffer[2]  = worldMat.m01;
-        paramsBuffer[3]  = worldMat.m02;
-        paramsBuffer[4]  = worldMat.m03;
-        paramsBuffer[5]  = worldMat.m04;
-        paramsBuffer[6]  = worldMat.m05;
-        paramsBuffer[7]  = worldMat.m06;
-        paramsBuffer[8]  = worldMat.m07;
-        paramsBuffer[9]  = worldMat.m08;
-        paramsBuffer[10] = worldMat.m09;
-        paramsBuffer[11] = worldMat.m10;
-        paramsBuffer[12] = worldMat.m11;
-        paramsBuffer[13] = worldMat.m12;
-        paramsBuffer[14] = worldMat.m13;
-        paramsBuffer[15] = worldMat.m14;
-        paramsBuffer[16] = worldMat.m15;
+
+        if (force || node.hasChangedFlags) {
+            // sync node world matrix to native
+            node.updateWorldTransform();
+            let worldMat = node._mat;
+            paramsBuffer[1]  = worldMat.m00;
+            paramsBuffer[2]  = worldMat.m01;
+            paramsBuffer[3]  = worldMat.m02;
+            paramsBuffer[4]  = worldMat.m03;
+            paramsBuffer[5]  = worldMat.m04;
+            paramsBuffer[6]  = worldMat.m05;
+            paramsBuffer[7]  = worldMat.m06;
+            paramsBuffer[8]  = worldMat.m07;
+            paramsBuffer[9]  = worldMat.m08;
+            paramsBuffer[10] = worldMat.m09;
+            paramsBuffer[11] = worldMat.m10;
+            paramsBuffer[12] = worldMat.m11;
+            paramsBuffer[13] = worldMat.m12;
+            paramsBuffer[14] = worldMat.m13;
+            paramsBuffer[15] = worldMat.m14;
+            paramsBuffer[16] = worldMat.m15;
+        }
     };
 
     armatureDisplayProto.setAnimationCacheMode = function (cacheMode) {
@@ -621,7 +621,7 @@ const cacheManager = require('./jsb-cache-manager');
     }
 
 
-    armatureDisplayProto.update = function () {
+    armatureDisplayProto.lateUpdate = function () {
         let nativeDisplay = this._nativeDisplay;
         if (!nativeDisplay) return;
 
@@ -635,6 +635,7 @@ const cacheManager = require('./jsb-cache-manager');
             middleware.renderOrder++;
         }
 
+        this.syncTransform();
 
         if (this.__preColor__ === undefined || !this.color.equals(this.__preColor__)) {
             let compColor = this.color;

--- a/platforms/native/engine/jsb-dragonbones.js
+++ b/platforms/native/engine/jsb-dragonbones.js
@@ -620,8 +620,9 @@ const cacheManager = require('./jsb-cache-manager');
         }
     }
 
-
+    const _lateUpdate = armatureDisplayProto.lateUpdate;
     armatureDisplayProto.lateUpdate = function () {
+        if(_lateUpdate) _lateUpdate.call(this);
         let nativeDisplay = this._nativeDisplay;
         if (!nativeDisplay) return;
 

--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -431,7 +431,9 @@ const cacheManager = require('./jsb-cache-manager');
         }
     };
 
+    const _lateUpdate = skeletonDataProto.lateUpdate;
     skeleton.lateUpdate = function () {
+        if (_lateUpdate) _lateUpdate.call(this);
         let nativeSkeleton = this._nativeSkeleton;
         if (!nativeSkeleton) return;
 

--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -378,7 +378,6 @@ const cacheManager = require('./jsb-cache-manager');
     let _onEnable = skeleton.onEnable;
     skeleton.onEnable = function () {
         _onEnable.call(this);
-        this._onSyncTransform();
         this.syncTransform(true);
 
         if (this._nativeSkeleton) {
@@ -390,8 +389,6 @@ const cacheManager = require('./jsb-cache-manager');
     let _onDisable = skeleton.onDisable;
     skeleton.onDisable = function () {
         _onDisable.call(this);
-        this._offSyncTransform();
-        
         if (this._nativeSkeleton) {
             this._nativeSkeleton.onDisable();
         }
@@ -411,28 +408,30 @@ const cacheManager = require('./jsb-cache-manager');
         let paramsBuffer = this._paramsBuffer;
         if (!paramsBuffer) return;
         
-        // sync node world matrix to native
-        node.updateWorldTransform();
-        let worldMat = node._mat;
-        paramsBuffer[1]  = worldMat.m00;
-        paramsBuffer[2]  = worldMat.m01;
-        paramsBuffer[3]  = worldMat.m02;
-        paramsBuffer[4]  = worldMat.m03;
-        paramsBuffer[5]  = worldMat.m04;
-        paramsBuffer[6]  = worldMat.m05;
-        paramsBuffer[7]  = worldMat.m06;
-        paramsBuffer[8]  = worldMat.m07;
-        paramsBuffer[9]  = worldMat.m08;
-        paramsBuffer[10] = worldMat.m09;
-        paramsBuffer[11] = worldMat.m10;
-        paramsBuffer[12] = worldMat.m11;
-        paramsBuffer[13] = worldMat.m12;
-        paramsBuffer[14] = worldMat.m13;
-        paramsBuffer[15] = worldMat.m14;
-        paramsBuffer[16] = worldMat.m15;
+        if (force || node.hasChangedFlags) {
+            // sync node world matrix to native
+            node.updateWorldTransform();
+            let worldMat = node._mat;
+            paramsBuffer[1]  = worldMat.m00;
+            paramsBuffer[2]  = worldMat.m01;
+            paramsBuffer[3]  = worldMat.m02;
+            paramsBuffer[4]  = worldMat.m03;
+            paramsBuffer[5]  = worldMat.m04;
+            paramsBuffer[6]  = worldMat.m05;
+            paramsBuffer[7]  = worldMat.m06;
+            paramsBuffer[8]  = worldMat.m07;
+            paramsBuffer[9]  = worldMat.m08;
+            paramsBuffer[10] = worldMat.m09;
+            paramsBuffer[11] = worldMat.m10;
+            paramsBuffer[12] = worldMat.m11;
+            paramsBuffer[13] = worldMat.m12;
+            paramsBuffer[14] = worldMat.m13;
+            paramsBuffer[15] = worldMat.m14;
+            paramsBuffer[16] = worldMat.m15;
+        }
     };
 
-    skeleton.update = function () {
+    skeleton.lateUpdate = function () {
         let nativeSkeleton = this._nativeSkeleton;
         if (!nativeSkeleton) return;
 
@@ -446,6 +445,7 @@ const cacheManager = require('./jsb-cache-manager');
             middleware.renderOrder++;
         }
 
+        this.syncTransform();
 
         if (this.__preColor__ === undefined || !this.color.equals(this.__preColor__)) {
             let compColor = this.color;


### PR DESCRIPTION
因为之前native spine和dragonbones的node更新是通过调用update, 这就使在director.ts中mainloop更新的时机过早,以至于当要setPostion信息在其之后,而在下一轮loop时setPosition信息又被clear掉导致失效.
修改后把spine/ dragonbones节点的更新从之前的update改为了lateUpdate, 以确保在setPostion信息之后做更新