### PR TITLE
Fix the persistNode is unavailable after switching scenes

### DIFF
--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -436,15 +436,16 @@ cc.Director.prototype = {
         for (let i = 0; i < persistNodeList.length; i++) {
             let node = persistNodeList[i];
             var existNode = scene.getChildByUuid(node.uuid);
+            var index = -1;
             if (existNode) {
-                // scene also contains the persist node, select the old one
-                var index = existNode.getSiblingIndex();
-                existNode._destroyImmediate();
-                scene.insertChild(node, index);
+                // scene also contains the persist node, remove the old one
+                existNode.removeFromParent(false);
+                index = existNode.getSiblingIndex();
             }
             else {
-                node.parent = scene;
+                index = node.getSiblingIndex();
             }
+            scene.insertChild(node, index);
         }
         CC_BUILD && CC_DEBUG && console.timeEnd('AttachPersist');
 

--- a/test/qunit/unit-es5/test-load-scene.js
+++ b/test/qunit/unit-es5/test-load-scene.js
@@ -87,7 +87,7 @@ test('persist node should replace existing node in scene', function () {
     cc.director.runSceneImmediate(newScene);
 
     ok(oldNode.parent === newScene, 'persist node should add to new scene');
-    strictEqual(oldNode.getSiblingIndex(), 1, 'persist node should restore sibling index');
+    strictEqual(oldNode.getSiblingIndex(), 0, 'persist node should restore sibling index');
     ok(newNode.parent === null, 'existing node should not in new scene');
 
     cc.game.step(); // ensure sgNode sorted


### PR DESCRIPTION
测试用例：
[example-cases.zip](https://github.com/cocos-creator/engine/files/6014378/example-cases.zip)

测试步骤：
1、使用 2.4.4 打开用例，打开场景 screen0，使用浏览器预览
2、点击 “点击” 按钮，label 节点能显示 “我是常驻节点“ 的字样，点击跳转，跳转到场景 sceen1。
3、可以看到方块依然在位移和旋转。此时点击跳转，跳转到 sceen0。方块依然在正常位移和旋转。
4、再次点击 ”点击“ 按钮，abel 节点能显示 “我是常驻节点“ 的字样。
5、测试结束。

修复前的效果示范：
![20210220002](https://user-images.githubusercontent.com/35944775/108588116-77f69400-7392-11eb-81b1-ff556d356dd9.gif)

修复后的效果示范：
![20210220001](https://user-images.githubusercontent.com/35944775/108588053-2b12bd80-7392-11eb-9c3b-fd1e9c64e9ee.gif)
