### PR TITLE
optimize Label black border on bytedance platform

### DIFF
--- a/platforms/minigame/platforms/bytedance/wrapper/engine/Label.js
+++ b/platforms/minigame/platforms/bytedance/wrapper/engine/Label.js
@@ -22,4 +22,23 @@ if (cc && cc.LabelComponent) {
             }
         });
     });
+
+    // need to fix ttf font black border at the sdk verion lower than 2.0.0
+    let sysInfo = tt.getSystemInfoSync();
+    if (Number.parseInt(sysInfo.SDKVersion[0]) < 2) {
+        let _originUpdateBlendFunc = Label.prototype._updateBlendFunc;
+        let gfxBlendFactor = cc.gfx.BlendFactor;
+        Object.assign(Label.prototype, {
+            _updateBlendFunc () {
+                _originUpdateBlendFunc.call(this);
+                // only fix when srcBlendFactor is SRC_ALPHA
+                if (this.srcBlendFactor !== gfxBlendFactor.SRC_ALPHA
+                    || isDevTool || this.font instanceof cc.BitmapFont) {
+                    return;
+                }
+                // Premultiplied alpha on runtime when sdk verion is lower than 2.0.0
+                this.srcBlendFactor = gfxBlendFactor.ONE;
+            },
+        });
+    }
 }


### PR DESCRIPTION
Changelog:
 * 优化字节的文字黑边问题的处理

说明：
- 字节 SDKVersion < 2.0.0 的情况下，默认是开启预乘的，此时如果用户配置 Label 组件的 srcBlendFactor 为 SRC_ALPHA 时，引擎应该帮用户改为 ONE 才是符合用户预期的
- 字节 2.0.0 版本后修复了预乘问题，这时候就不需要这部分修复了

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
