### PR TITLE
Fix the error when deactive node in onLoad.

### DIFF
--- a/cocos/core/scene-graph/component-scheduler.ts
+++ b/cocos/core/scene-graph/component-scheduler.ts
@@ -80,7 +80,7 @@ function stableRemoveInactive (iterator, flagToClear) {
     let next = iterator.i + 1;
     while (next < array.length) {
         const comp = array[next];
-        if (comp._enabled && comp.node._activeInHierarchy) {
+        if (comp.node._activeInHierarchy) {
             ++next;
         } else {
             iterator.removeAt(next);

--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -674,22 +674,13 @@ export class ParticleSystem2D extends Renderable2D {
     public declare _simulator: Simulator;
 
     /**
-     * @en Play particle in edit mode.
-     * @zh 在编辑器模式下预览粒子，启用后选中粒子时，粒子将自动播放。
-     */
-    @serializable
-    @editable
-    @tooltip('i18n:particle_system.preview')
-    private preview = true;
-
-    /**
      * @en If set to true, the particle system will automatically start playing on onLoad.
      * @zh 如果设置为 true 运行时会自动发射粒子。
      */
     @serializable
     @editable
     @tooltip('i18n:particle_system.playOnLoad')
-    private playOnLoad = true;
+    public playOnLoad = true;
 
     /**
      * @en Indicate whether the owner node will be auto-removed when it has no particles left.
@@ -698,8 +689,16 @@ export class ParticleSystem2D extends Renderable2D {
     @serializable
     @editable
     @tooltip('i18n:particle_system.autoRemoveOnFinish')
-    private autoRemoveOnFinish = false;
+    public autoRemoveOnFinish = false;
 
+    /**
+     * @en Play particle in edit mode.
+     * @zh 在编辑器模式下预览粒子，启用后选中粒子时，粒子将自动播放。
+     */
+    @serializable
+    @editable
+    @tooltip('i18n:particle_system.preview')
+    private preview = true;
     @serializable
     private _custom = false;
     @serializable


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/6377

Changelog:
 
 1. 在 onLoad 中对节点执行 node.active = false，禁用节点，会导致其他未禁用但是组件 enable 为 false 的节点没有执行 onLoad，后续再直接启用组件出现错误。
 
 2. 开放两个 Particle2D 的属性。
 
 