### PR TITLE
support for 2.x particles, textureUuid field

### DIFF
--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -37,6 +37,7 @@ import { warnID, errorID, error } from '../core/platform/debug';
 import { Simulator } from './particle-simulator-2d';
 import { SpriteFrame } from '../2d/assets/sprite-frame';
 import { ImageAsset } from '../core/assets/image-asset';
+import { Texture2D } from '../core/assets/texture-2d';
 import { ParticleAsset } from './particle-asset';
 import { BlendFactor } from '../core/gfx';
 import { path } from '../core/utils';
@@ -923,7 +924,22 @@ export class ParticleSystem2D extends Renderable2D {
                     this.spriteFrame = spriteFrame;
                 }
             });
-        } else {
+        }
+        else if (dict.textureUuid) {
+            const textureUuid = dict.textureUuid;
+            assetManager.loadAny(textureUuid, (err: Error, texture: Texture2D) => {
+                if (err) {
+                    dict.textureUuid = undefined;
+                    this._initTextureWithDictionary(dict);
+                    error(err);
+                } else {
+                    const spf = new SpriteFrame();
+                    spf.texture = texture;
+                    this.spriteFrame = spf;
+                }
+            });
+        }
+        else {
             // texture
             const imgPath = path.changeBasename(this._plistFile, dict.textureFileName || '');
             if (dict.textureFileName) {

--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -924,8 +924,7 @@ export class ParticleSystem2D extends Renderable2D {
                     this.spriteFrame = spriteFrame;
                 }
             });
-        }
-        else if (dict.textureUuid) {
+        } else if (dict.textureUuid) {
             const textureUuid = dict.textureUuid;
             assetManager.loadAny(textureUuid, (err: Error, texture: Texture2D) => {
                 if (err) {
@@ -938,8 +937,7 @@ export class ParticleSystem2D extends Renderable2D {
                     this.spriteFrame = spf;
                 }
             });
-        }
-        else {
+        } else {
             // texture
             const imgPath = path.changeBasename(this._plistFile, dict.textureFileName || '');
             if (dict.textureFileName) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * support for 2.x particles, textureUuid field

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
