### PR TITLE
Repair of the same frame to play audio, registered callback end, pause and resume play, leading to the end of the pullback in advance trigger.

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -66,7 +66,7 @@ Audio.State = {
     /**
      * @property {Number} ERROR
      */
-    ERROR : -1,
+    ERROR: -1,
     /**
      * @property {Number} INITIALZING
      */
@@ -456,10 +456,13 @@ let WebAudioElement = function (buffer, audio) {
         // If more than the duration of the audio, Need to take the remainder
         this.playedLength %= this._buffer.duration;
         let audio = this._currentSource;
+        if (audio) {
+            audio.onended = null;
+            audio.stop(0);
+        }
         this._currentSource = null;
         this._startTime = -1;
-        if (audio)
-            audio.stop(0);
+
     };
 
     Object.defineProperty(proto, 'paused', {

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -457,7 +457,10 @@ let WebAudioElement = function (buffer, audio) {
         this.playedLength %= this._buffer.duration;
         let audio = this._currentSource;
         if (audio) {
-            audio.onended = null;
+            if(audio.onended){
+                audio.onended._binded = false;
+                audio.onended = null;
+            }
             audio.stop(0);
         }
         this._currentSource = null;

--- a/cocos2d/renderer/gfx/program.js
+++ b/cocos2d/renderer/gfx/program.js
@@ -1,6 +1,9 @@
 let _genID = 0;
 
 function _parseError(out, type, errorLog) {
+  if(!errorLog){
+    return;
+  }
   errorLog.split('\n').forEach(msg => {
     if (msg.length < 5) {
       return;


### PR DESCRIPTION
Repair of the same frame to play audio, registered callback end, pause and resume play, leading to the end of the pullback in advance trigger.

Re: https://github.com/cocos-creator/engine/issues/7701