### PR TITLE
Mark an attribute to be shallow readonly

### DIFF
--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -576,7 +576,7 @@ function parseAttributes (constructor: Function, attributes: IAcceptableAttribut
         parseSimpleAttribute('multiline', 'boolean');
         parseSimpleAttribute('radian', 'boolean');
         if (attributes.readonly) {
-            (attrs || initAttrs())[`${propertyNamePrefix}readonly`] = true;
+            (attrs || initAttrs())[`${propertyNamePrefix}readonly`] = attributes.readonly;
         }
         parseSimpleAttribute('tooltip', 'string');
         parseSimpleAttribute('slide', 'boolean');

--- a/cocos/core/data/utils/attribute-defines.ts
+++ b/cocos/core/data/utils/attribute-defines.ts
@@ -56,8 +56,18 @@ export interface IExposedAttributes {
 
     /**
      * 指定该属性是否为可读的。
+     * 将 `readonly` 指定为 `true` 或选项对象时都将标记为该属性是可读的；
+     * 当指定为 `true` 时将应用所有默认的只读性质。
+     * @default false
      */
-    readonly?: boolean;
+    readonly?: boolean | {
+        /**
+         * 如果该属性是对象或数组，指定该对象的属性或该数组的元素是否是只读的。
+         * 若为 `true`，递归的所有属性或元素都将是只读的。
+         * @default true
+         */
+        deep?: boolean;
+    };
 
     /**
      * 当该属性为数值类型时，指定了该属性允许的最小值。


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Sometimes we expect the array's elements to be editable but its length to be immutable.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
