### PR TITLE
mat4 uniform setting up fix

### DIFF
--- a/cocos2d/renderer/types.js
+++ b/cocos2d/renderer/types.js
@@ -69,7 +69,7 @@ export let enums2default = {
     [enums.PARAM_FLOAT2]: new Float32Array([0, 0]),
     [enums.PARAM_FLOAT3]: new Float32Array([0, 0, 0]),
     [enums.PARAM_FLOAT4]: new Float32Array([0, 0, 0, 0]),
-    [enums.PARAM_MAT4]: cc.mat4().m,
+    [enums.PARAM_MAT4]: new Float32Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
     [enums.PARAM_TEXTURE_2D]: null,
     
     number: 0,


### PR DESCRIPTION
This pull request fixes type of mat4 uniform property to Float32Array. It ensures that WebGLRenderingContext.uniformMatrix4fv() always gets Float32Array as a value parameter as required by specification: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/uniformMatrix . 

Particularly it fixes setting up mat4 parameters on Chrome 66.0.3359.181.
