### PR TITLE
make assert() as valid assertion function

### DIFF
--- a/cocos/core/platform/debug.ts
+++ b/cocos/core/platform/debug.ts
@@ -109,7 +109,7 @@ export function error (message?: any, ...optionalParams: any[]) {
  * @param optionalParams - JavaScript objects with which to replace substitution strings within msg.
  * This gives you additional control over the format of the output.
  */
-export function assert (value: any, message?: string, ...optionalParams: any[]) {
+export function assert (value: any, message?: string, ...optionalParams: any[]): asserts value {
     return ccAssert(value, message, ...optionalParams);
 }
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * make `cc.assert()` as valid assertion function, ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
