### PR TITLE
Fix cc.ImageAsset memory leaks (new legacyCC.Texture2D())

### DIFF
--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -233,7 +233,7 @@ export class ImageAsset extends Asset {
     }
 
     public destroy () {
-        if (this._tex && this._tex.image == this && this._tex.destroy) {
+        if (this._tex && this._tex.image === this) {
             this._tex.destroy()
         } 
         if (this.data && this.data instanceof HTMLImageElement) {

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -233,6 +233,9 @@ export class ImageAsset extends Asset {
     }
 
     public destroy () {
+        if (this._tex && this._tex.image == this && this._tex.destroy) {
+            this._tex.destroy()
+        } 
         if (this.data && this.data instanceof HTMLImageElement) {
             this.data.src = '';
             this._setRawAsset('');

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -55,7 +55,7 @@ export interface IMemoryImageSource {
  */
 export type ImageSource = HTMLCanvasElement | HTMLImageElement | IMemoryImageSource | ImageBitmap;
 
-function isImageBitmap (imageSource: any): imageSource is ImageBitmap {
+function isImageBitmap (imageSource: any): boolean {
     return legacyCC.sys.capabilities.imageBitmap && imageSource instanceof ImageBitmap;
 }
 
@@ -156,7 +156,7 @@ export class ImageAsset extends Asset {
         this._tex = tex;
     }
 
-    get _texture () {
+    get _texture () : legacyCC.Texture2D | null {
         if (!this._tex) {
             const tex = new legacyCC.Texture2D();
             tex.name = this.nativeUrl;
@@ -249,7 +249,7 @@ export class ImageAsset extends Asset {
 
     // SERIALIZATION
 
-    public _serialize () {
+    public _serialize () : any {
         if (EDITOR || TEST) {
             let targetExtensions = this._exportedExts;
             if (!targetExtensions && this._native) {
@@ -272,6 +272,7 @@ export class ImageAsset extends Asset {
             }
             return { fmt: extensionIndices.join('_'), w: this.width, h: this.height };
         }
+        return '';
     }
 
     public _deserialize (data: any) {
@@ -341,7 +342,7 @@ export class ImageAsset extends Asset {
 
 function _getGlobalDevice (): Device | null {
     if (legacyCC.director.root) {
-        return legacyCC.director.root.device;
+        return legacyCC.director.root.device as Device;;
     }
     return null;
 }

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -56,7 +56,7 @@ export interface IMemoryImageSource {
 export type ImageSource = HTMLCanvasElement | HTMLImageElement | IMemoryImageSource | ImageBitmap;
 
 function isImageBitmap (imageSource: any): boolean {
-    return legacyCC.sys.capabilities.imageBitmap && imageSource instanceof ImageBitmap;
+    return (legacyCC.sys.capabilities.imageBitmap && imageSource instanceof ImageBitmap) == true;
 }
 
 function fetchImageSource (imageSource: ImageSource) {
@@ -156,7 +156,7 @@ export class ImageAsset extends Asset {
         this._tex = tex;
     }
 
-    get _texture () : legacyCC.Texture2D | null {
+    get _texture () : any {
         if (!this._tex) {
             const tex = new legacyCC.Texture2D();
             tex.name = this.nativeUrl;
@@ -342,7 +342,7 @@ export class ImageAsset extends Asset {
 
 function _getGlobalDevice (): Device | null {
     if (legacyCC.director.root) {
-        return legacyCC.director.root.device as Device;;
+        return legacyCC.director.root.device as Device;
     }
     return null;
 }

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -233,9 +233,9 @@ export class ImageAsset extends Asset {
     }
 
     public destroy () {
-        if (this._tex && this._tex.image == this && this._tex.destroy) {
-            this._tex.destroy()
-        } 
+        if (this._tex && this._tex.image === this) {
+            this._tex.destroy();
+        }
         if (this.data && this.data instanceof HTMLImageElement) {
             this.data.src = '';
             this._setRawAsset('');

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -156,14 +156,14 @@ export class ImageAsset extends Asset {
         this._tex = tex;
     }
 
-    get _texture () : any {
+    get _texture () : legacyCC.Texture2D | null {
         if (!this._tex) {
             const tex = new legacyCC.Texture2D();
             tex.name = this.nativeUrl;
             tex.image = this;
             this._tex = tex;
         }
-        return this._tex;
+        return this._tex as legacyCC.Texture2D;
     }
 
     private static extnames = ['.png', '.jpg', '.jpeg', '.bmp', '.webp', '.pvr', '.pkm', '.astc'];


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

unload spine asset will be leaked,  the `GFX Texture Mem(M)` on the web mobile platform will be increased by loaded and released repeatedly! because this code will new a Texture, but not released on destroy().

```ts
    get _texture () {
        if (!this._tex) {
            const tex = new legacyCC.Texture2D();
            tex.name = this.nativeUrl;
            tex.image = this;
            this._tex = tex;
        }
        return this._tex;
    }
```

Changelog:
 * Fix cc.ImageAsset memory leaks 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
