### PR TITLE
fix animaiton failure

### DIFF
--- a/cocos/tiledmap/tiled-map.ts
+++ b/cocos/tiledmap/tiled-map.ts
@@ -629,5 +629,10 @@ export class TiledMap extends Component {
             }
             texGrids.set(aniGID, frame.grid!);
         }
+        for (const layer of this.getLayers()) {
+            if (layer.hasAnimation()) {
+                layer.markForUpdateRenderData();
+            }
+        }
     }
 }


### PR DESCRIPTION
https://forum.cocos.org/t/topic/109704
tilemap的动画在2.4有动效 在3.0动不了了 
问题在于3.0tilemap的updateRenderData()的逻辑在2.4是写到fillbuffer里面的 在3.0是单独写在updateRenderData() 但是不是逐帧调用的.
解决办法: 在Tiled-layer的父节点TileMap的update中保证子tiled-layer有动画时置dirty位更新


