### PR TITLE
add lock to label under button by default

### DIFF
--- a/editor/assets/default_prefab/ui/Button.prefab
+++ b/editor/assets/default_prefab/ui/Button.prefab
@@ -21,20 +21,19 @@
       }
     ],
     "_active": true,
-    "_level": 2,
     "_components": [
       {
-        "__id__": 6
-      },
-      {
-        "__id__": 7
-      },
-      {
         "__id__": 8
+      },
+      {
+        "__id__": 10
+      },
+      {
+        "__id__": 12
       }
     ],
     "_prefab": {
-      "__id__": 9
+      "__id__": 14
     },
     "_lpos": {
       "__type__": "cc.Vec3",
@@ -67,23 +66,22 @@
   {
     "__type__": "cc.Node",
     "_name": "Label",
-    "_objFlags": 0,
+    "_objFlags": 512,
     "_parent": {
       "__id__": 1
     },
     "_children": [],
     "_active": true,
-    "_level": 3,
     "_components": [
       {
         "__id__": 3
       },
       {
-        "__id__": 4
+        "__id__": 5
       }
     ],
     "_prefab": {
-      "__id__": 5
+      "__id__": 7
     },
     "_lpos": {
       "__type__": "cc.Vec3",
@@ -121,6 +119,9 @@
       "__id__": 2
     },
     "_enabled": true,
+    "__prefab": {
+      "__id__": 4
+    },
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 100,
@@ -131,11 +132,11 @@
       "x": 0.5,
       "y": 0.5
     },
-    "_id": "",
-    "_priority": 0,
-    "__prefab": {
-      "__id__": 10
-    }
+    "_id": ""
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "07QMd0h1dLcYd/vjigaip6"
   },
   {
     "__type__": "cc.Label",
@@ -145,6 +146,11 @@
       "__id__": 2
     },
     "_enabled": true,
+    "__prefab": {
+      "__id__": 6
+    },
+    "_visFlags": 0,
+    "_customMaterial": null,
     "_srcBlendFactor": 2,
     "_dstBlendFactor": 4,
     "_color": {
@@ -154,8 +160,6 @@
       "b": 0,
       "a": 255
     },
-    "_sharedMaterial": null,
-    "_useOriginalSize": true,
     "_string": "button",
     "_horizontalAlign": 1,
     "_verticalAlign": 1,
@@ -170,11 +174,13 @@
     "_isItalic": false,
     "_isBold": false,
     "_isUnderline": false,
+    "_underlineHeight": 2,
     "_cacheMode": 0,
-    "_id": "",
-    "__prefab": {
-      "__id__": 11
-    }
+    "_id": ""
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "ee3IZdy2dLIaAWpjI7P0FL"
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -182,7 +188,7 @@
       "__id__": 1
     },
     "asset": {
-      "__uuid__": "90bdd2a9-2838-4888-b66c-e94c8b7a5169"
+      "__id__": 0
     },
     "fileId": "99oRe7NgdNvrQe2oNkTmkx"
   },
@@ -194,6 +200,9 @@
       "__id__": 1
     },
     "_enabled": true,
+    "__prefab": {
+      "__id__": 9
+    },
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 100,
@@ -204,11 +213,11 @@
       "x": 0.5,
       "y": 0.5
     },
-    "_id": "",
-    "_priority": 0,
-    "__prefab": {
-      "__id__": 12
-    }
+    "_id": ""
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "98TYGMtwRBTYZZn4EZmhzJ"
   },
   {
     "__type__": "cc.Sprite",
@@ -218,6 +227,11 @@
       "__id__": 1
     },
     "_enabled": true,
+    "__prefab": {
+      "__id__": 11
+    },
+    "_visFlags": 0,
+    "_customMaterial": null,
     "_srcBlendFactor": 2,
     "_dstBlendFactor": 4,
     "_color": {
@@ -227,7 +241,6 @@
       "b": 255,
       "a": 255
     },
-    "_sharedMaterial": null,
     "_spriteFrame": {
       "__uuid__": "20835ba4-6145-4fbc-a58a-051ce700aa3e@f9941"
     },
@@ -242,11 +255,13 @@
     "_fillStart": 0,
     "_fillRange": 0,
     "_isTrimmedMode": true,
+    "_useGrayscale": false,
     "_atlas": null,
-    "_id": "",
-    "__prefab": {
-      "__id__": 13
-    }
+    "_id": ""
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "77BcV1zfNHo4LI4KRqZupe"
   },
   {
     "__type__": "cc.Button",
@@ -256,6 +271,9 @@
       "__id__": 1
     },
     "_enabled": true,
+    "__prefab": {
+      "__id__": 13
+    },
     "clickEvents": [],
     "_interactable": true,
     "_transition": 2,
@@ -273,7 +291,7 @@
       "b": 211,
       "a": 255
     },
-    "_pressColor": {
+    "_pressedColor": {
       "__type__": "cc.Color",
       "r": 255,
       "g": 255,
@@ -304,10 +322,11 @@
     "_target": {
       "__id__": 1
     },
-    "_id": "",
-    "__prefab": {
-      "__id__": 14
-    }
+    "_id": ""
+  },
+  {
+    "__type__": "cc.CompPrefabInfo",
+    "fileId": "2fOwBXUwBNvaJ4NyyrOq4C"
   },
   {
     "__type__": "cc.PrefabInfo",
@@ -315,28 +334,8 @@
       "__id__": 1
     },
     "asset": {
-      "__uuid__": "90bdd2a9-2838-4888-b66c-e94c8b7a5169"
+      "__id__": 0
     },
     "fileId": "80LJYphSdNMqbi3XYDUm5q"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "07QMd0h1dLcYd/vjigaip6"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "ee3IZdy2dLIaAWpjI7P0FL"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "98TYGMtwRBTYZZn4EZmhzJ"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "77BcV1zfNHo4LI4KRqZupe"
-  },
-  {
-    "__type__": "cc.CompPrefabInfo",
-    "fileId": "2fOwBXUwBNvaJ4NyyrOq4C"
   }
 ]


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * add lock to label under button by default

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
