### PR TITLE
Fix some internal deprecated usages

### DIFF
--- a/cocos/core/pipeline/deferred/lighting-stage.ts
+++ b/cocos/core/pipeline/deferred/lighting-stage.ts
@@ -42,7 +42,7 @@ import { PlanarShadowQueue } from '../planar-shadow-queue';
 import { Material } from '../../assets/material';
 import { ShaderPool } from '../../renderer/core/memory-pools';
 import { PipelineStateManager } from '../pipeline-state-manager';
-import { sphere, intersect } from '../../geometry';
+import { intersect, Sphere } from '../../geometry';
 import { Vec3, Vec4 } from '../../math';
 import { SRGBToLinear } from '../pipeline-funcs';
 import { Pass } from '../../renderer/core/pass';
@@ -95,7 +95,7 @@ export class LightingStage extends RenderStage {
 
         const sphereLights = camera.scene!.sphereLights;
         const spotLights = camera.scene!.spotLights;
-        const _sphere = sphere.create(0, 0, 0, 1);
+        const _sphere = Sphere.create(0, 0, 0, 1);
         const _vec4Array = new Float32Array(4);
         const exposure = camera.exposure;
 
@@ -105,7 +105,7 @@ export class LightingStage extends RenderStage {
 
         for (let i = 0; i < sphereLights.length && idx < this._maxDeferredLights; i++, ++idx) {
             const light = sphereLights[i];
-            sphere.set(_sphere, light.position.x, light.position.y, light.position.z, light.range);
+            Sphere.set(_sphere, light.position.x, light.position.y, light.position.z, light.range);
             if (intersect.sphereFrustum(_sphere, camera.frustum)) {
                 // cc_lightPos
                 Vec3.toArray(_vec4Array, light.position);
@@ -139,7 +139,7 @@ export class LightingStage extends RenderStage {
 
         for (let i = 0; i < spotLights.length && idx < this._maxDeferredLights; i++, ++idx) {
             const light = spotLights[i];
-            sphere.set(_sphere, light.position.x, light.position.y, light.position.z, light.range);
+            Sphere.set(_sphere, light.position.x, light.position.y, light.position.z, light.range);
             if (intersect.sphereFrustum(_sphere, camera.frustum)) {
                 // cc_lightPos
                 Vec3.toArray(_vec4Array, light.position);

--- a/cocos/core/scene-graph/index.ts
+++ b/cocos/core/scene-graph/index.ts
@@ -37,5 +37,5 @@ export { Node } from './node';
 export { Scene } from './scene';
 export { Layers } from './layers';
 export { find } from './find';
-export { PrivateNode } from './deprecated';
+export * from './deprecated';
 export { default as NodeActivator } from './node-activator';


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Engine should not internally rely on deprecated codes.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
