### PR TITLE
fix window 'keydown' event swallow EditBox input event on Web

### DIFF
--- a/pal/input/web/keyboard.ts
+++ b/pal/input/web/keyboard.ts
@@ -13,8 +13,9 @@ export class KeyboardInputSource {
     }
 
     private _registerEvent () {
-        window.addEventListener('keydown', this._createCallback(SystemEventType.KEY_DOWN));
-        window.addEventListener('keyup', this._createCallback(SystemEventType.KEY_UP));
+        const canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
+        canvas?.addEventListener('keypress', this._createCallback(SystemEventType.KEY_DOWN));
+        canvas?.addEventListener('keyup', this._createCallback(SystemEventType.KEY_UP));
     }
 
     private _createCallback (eventType: string) {

--- a/pal/input/web/mouse.ts
+++ b/pal/input/web/mouse.ts
@@ -78,6 +78,9 @@ export class MouseInputSource {
             };
             event.stopPropagation();
             event.preventDefault();
+            if (event.type === 'mousedown') {
+                this._canvas?.focus();
+            }
             // emit web mouse event
             this._eventTarget.emit(eventType, inputEvent);
         };

--- a/pal/input/web/touch.ts
+++ b/pal/input/web/touch.ts
@@ -61,6 +61,9 @@ export class TouchInputSource {
             };
             event.stopPropagation();
             event.preventDefault();
+            if (event.type === 'touchstart') {
+                this._canvas?.focus();
+            }
             this._eventTarget.emit(eventType, inputEvent);
         };
     }


### PR DESCRIPTION
fix: 
https://github.com/cocos-creator/3d-tasks/issues/7032
https://github.com/cocos-creator/3d-tasks/issues/7108
https://github.com/cocos-creator/3d-tasks/issues/7107
https://github.com/cocos-creator/3d-tasks/issues/7006
https://github.com/cocos-creator/3d-tasks/issues/7005

Changelog:
 * fix window 'keydown' event swallow EditBox input event on Web

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
