### PR TITLE
use  windowHeight to handle  touch event on minigame platform

### DIFF
--- a/pal/input/minigame/touch.ts
+++ b/pal/input/minigame/touch.ts
@@ -32,7 +32,7 @@ export class TouchInputSource {
                 const touchData: TouchData = {
                     identifier: touch.identifier,
                     x: location.x,
-                    y: sysInfo.screenHeight - location.y,
+                    y: sysInfo.windowHeight - location.y,
                     force: touch.force,
                 };
                 touchDataList.push(touchData);

--- a/pal/minigame/alipay.ts
+++ b/pal/minigame/alipay.ts
@@ -52,13 +52,6 @@ minigame.onTouchCancel = function (cb) {
     });
 };
 
-minigame.getSystemInfoSync = function (): SystemInfo {
-    const sys = my.getSystemInfoSync() as SystemInfo;
-    sys.screenWidth = sys.windowWidth;
-    sys.screenHeight = sys.windowHeight;
-    return sys;
-};
-
 minigame.createInnerAudioContext = function (): InnerAudioContext {
     const audio: InnerAudioContext = my.createInnerAudioContext();
     // @ts-expect-error InnerAudioContext has onCanPlay


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/6958

Changelog:
 * fix qtt touch event

<img width="637" alt="1" src="https://user-images.githubusercontent.com/17872773/115991544-92035b80-a5fb-11eb-9469-41dad3ba2d33.png">

windowHeight  是去掉刘海屏高度后的数值

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
