### PR TITLE
resume onEnable when audioSource paused on disable

### DIFF
--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -51,6 +51,10 @@ export class AudioSource extends Component {
         return AudioPlayer.maxAudioChannel;
     }
     public static AudioState = AudioState;
+    // This is a synchronous audio state. It's different with the `audioPlayer.state`
+    // `audioPlayer.state` points to the real state of native audio.
+    // `audioSource.state` means that when you called `audioSource.play()`, then it should be on PLAYING state.
+    private _state: AudioState = AudioState.INIT;
 
     @type(AudioClip)
     protected _clip: AudioClip | null = null;
@@ -225,6 +229,7 @@ export class AudioSource extends Component {
      * 如果音频处于暂停状态，则会继续播放音频。
      */
     public play () {
+        this._state = AudioState.PLAYING;
         if (!this._isLoaded) {
             this._operationsBeforeLoading.push('play');
             return;
@@ -252,6 +257,7 @@ export class AudioSource extends Component {
      * 暂停播放。
      */
     public pause () {
+        this._state = AudioState.PAUSED;
         if (!this._isLoaded) {
             this._operationsBeforeLoading.push('pause');
             return;
@@ -268,6 +274,7 @@ export class AudioSource extends Component {
      * 停止播放。
      */
     public stop () {
+        this._state = AudioState.STOPPED;
         if (!this._isLoaded) {
             this._operationsBeforeLoading.push('stop');
             return;
@@ -357,7 +364,7 @@ export class AudioSource extends Component {
      * 获取当前音频状态。
      */
     get state (): AudioState {
-        return this._player ? this._player.state : AudioState.INIT;
+        return this._state;
     }
 
     /**

--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -70,6 +70,7 @@ export class AudioSource extends Component {
     private _isLoaded = false;
 
     private _lastSetClip?: AudioClip;
+    private _shouldResumeOnEnable = false;
     /**
      * @en
      * The default AudioClip to be played for this audio source.
@@ -193,20 +194,26 @@ export class AudioSource extends Component {
     }
 
     public onEnable () {
-        // audio source component may be played before
-        if (this._playOnAwake && !this.playing) {
+        if (this._shouldResumeOnEnable) {
+            this._resumeOnEnable();
+        } else if (this._playOnAwake && !this.playing) {
+            // audio source component may be played before
             this.play();
         }
     }
 
     public onDisable () {
-        this.pause();
+        this._pauseOnDisable();
     }
 
     public onDestroy () {
         this.stop();
     }
 
+    private _resumeOnEnable () {
+        this._shouldResumeOnEnable = false;
+        this.play();
+    }
     /**
      * @en
      * Play the clip.<br>
@@ -232,6 +239,12 @@ export class AudioSource extends Component {
         }).catch((e) => {});
     }
 
+    private _pauseOnDisable () {
+        if (this.playing) {
+            this._shouldResumeOnEnable = true;
+        }
+        this.pause();
+    }
     /**
      * @en
      * Pause the clip.


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7704

Changelog:
 * resume onEnable when audioSource paused on disable
 * optimize audioSource state

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
