### PR TITLE
把 releaseAssets 方法的 force 参数暴露出来, 给开发者更多选择

### DIFF
--- a/cocos2d/core/asset-manager/CCAssetManager.js
+++ b/cocos2d/core/asset-manager/CCAssetManager.js
@@ -727,10 +727,10 @@ AssetManager.prototype = {
      * @typescript
      * releaseAsset(asset: cc.Asset): void
      */
-    releaseAsset (asset) {
-        releaseManager.tryRelease(asset, true);
+    releaseAsset (asset, force) {
+        releaseManager.tryRelease(asset, force !== false);
     },
-
+    
     /**
      * !#en 
      * Release all unused assets. Refer to {{#crossLink "AssetManager/releaseAsset:method"}}{{/crossLink}} for detailed informations.


### PR DESCRIPTION
这个PR, 暴露了 force, 而且默认就是 true, 不会对已有代码造成破坏