### PR TITLE
support debuging dynamic-atlas in release mode

### DIFF
--- a/cocos2d/core/renderer/utils/dynamic-atlas/manager.js
+++ b/cocos2d/core/renderer/utils/dynamic-atlas/manager.js
@@ -194,7 +194,7 @@ let dynamicAtlasManager = {
      * @param {Boolean} show
      * @return {Node}
      */
-    showDebug: CC_DEBUG && function (show) {
+    showDebug (show) {
         if (show) {
             if (!_debugNode || !_debugNode.isValid) {
                 let width = cc.visibleRect.width;


### PR DESCRIPTION
很多 cocos的开发者相关的api 都是 非DEBUG , 比如看 drawcall 和 fps的那个.

没必要单独禁止这个api.

禁止这个API在普通模式下使用 会给开发调试带来困难. 比如要在微信小游戏里 测试调试.

Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
