### PR TITLE
asynchronous Audio operation on Wechat platform

### DIFF
--- a/pal/minigame/wechat.ts
+++ b/pal/minigame/wechat.ts
@@ -75,12 +75,70 @@ minigame.startAccelerometer = function (res: any) {
 };
 // #endregion Accelerometer
 
-minigame.createInnerAudioContext = createInnerAudioContextPolyfill(wx, {
-    onPlay: true,
-    onPause: true,
-    onStop: true,
-    onSeek: false,
-});
+// minigame.createInnerAudioContext = createInnerAudioContextPolyfill(wx, {
+//     onPlay: true,
+//     onPause: true,
+//     onStop: true,
+//     onSeek: false,
+// });
+
+// TODO: move to createInnerAudioContextPolyfill()
+minigame.createInnerAudioContext = function () {
+    const audioContext: InnerAudioContext = wx.createInnerAudioContext();
+
+    // add polyfill if onPlay method doesn't work this platform
+    const originalPlay = audioContext.play;
+    let _onPlayCB: (()=> void) | null = null;
+    Object.defineProperty(audioContext, 'onPlay', {
+        value (cb: ()=> void) {
+            _onPlayCB = cb;
+        },
+    });
+    Object.defineProperty(audioContext, 'play', {
+        value () {
+            originalPlay.call(audioContext);
+            if (_onPlayCB) {
+                setTimeout(_onPlayCB, 0);
+            }
+        },
+    });
+
+    // add polyfill if onPause method doesn't work this platform
+    const originalPause = audioContext.pause;
+    let _onPauseCB: (()=> void) | null = null;
+    Object.defineProperty(audioContext, 'onPause', {
+        value (cb: ()=> void) {
+            _onPauseCB = cb;
+        },
+    });
+    Object.defineProperty(audioContext, 'pause', {
+        value () {
+            originalPause.call(audioContext);
+            if (_onPauseCB) {
+                setTimeout(_onPauseCB, 0);
+            }
+        },
+    });
+
+    // add polyfill if onStop method doesn't work on this platform
+    const originalStop = audioContext.stop;
+    let _onStopCB: (()=> void) | null = null;
+    Object.defineProperty(audioContext, 'onStop', {
+        value (cb: ()=> void) {
+            _onStopCB = cb;
+        },
+    });
+    Object.defineProperty(audioContext, 'stop', {
+        value () {
+            originalStop.call(audioContext);
+            if (_onStopCB) {
+                setTimeout(_onStopCB, 0);
+            }
+        },
+    });
+
+    return audioContext;
+};
 
 // safeArea
 // origin point on the top-left corner


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7192

## NOTE
问题在于同一帧内执行了多次 Audio 操作，结果是不确定的
之前的原因是 AudioSource 执行了 stop play 操作，最终结果是 stop

## FIX
引擎侧只能保证同一帧内 对 AudioSource 的所有操作，按调用顺序依次分布到每一帧里执行，至于结果还是没办法保障的

## 目前的测试情况
1. asset-bundle、asset-bundle-zip  测试例，音频都能正常播放
2. AudioChannel 这个测试例比较极端，这个测试例在一帧之内做了如下压力测试
```
        // 测试播放队列
        this.source1.stop();
        this.source1.pause();
        this.source1.play();
        this.source1.stop();
        this.source1.stop();
        this.source1.pause();
        this.source1.play();
        this.source1.pause();
        this.source1.play();
        this.source1.play();
        this.source1.play();
        this.source1.stop();
        this.source1.play();
```
表现的结果是
- 安卓端 会播放一段时间，停止，又播放一段时间
- iOS 端直接就不播放了，这个可以作为已知问题处理

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
