### PR TITLE
fix accelerometer bug on QQ browser and WeChat iOS end

### DIFF
--- a/pal/input/web/accelerometer.ts
+++ b/pal/input/web/accelerometer.ts
@@ -21,7 +21,7 @@ export class AccelerometerInputSource {
         // init event name
         this._globalEventClass = window.DeviceMotionEvent || window.DeviceOrientationEvent;
         // TODO fix DeviceMotionEvent bug on QQ Browser version 4.1 and below.
-        if (system.browserType === BrowserType.QQ) {
+        if (system.browserType === BrowserType.MOBILE_QQ) {
             this._globalEventClass = window.DeviceOrientationEvent;
         }
         this._deviceEventName = this._globalEventClass === window.DeviceMotionEvent ? 'devicemotion' : 'deviceorientation';

--- a/pal/minigame/baidu.ts
+++ b/pal/minigame/baidu.ts
@@ -30,40 +30,38 @@ Object.defineProperty(minigame, 'orientation', {
 // #endregion SystemInfo
 
 // #region Accelerometer
-let _accelerometerCb: AccelerometerChangeCallback | undefined;
+let _customAccelerometerCb: AccelerometerChangeCallback | undefined;
+let _innerAccelerometerCb: AccelerometerChangeCallback | undefined;
 minigame.onAccelerometerChange = function (cb: AccelerometerChangeCallback) {
-    minigame.offAccelerometerChange();
-    // onAccelerometerChange would start accelerometer
-    // so we won't call this method here
-    _accelerometerCb = (res: any) => {
-        let x = res.x;
-        let y = res.y;
-        if (minigame.isLandscape) {
-            const orientationFactor = (landscapeOrientation === Orientation.LANDSCAPE_RIGHT ? 1 : -1);
-            const tmp = x;
-            x = -y * orientationFactor;
-            y = tmp * orientationFactor;
-        }
+    // swan.offAccelerometerChange() is not supported.
+    // so we can only register AccelerometerChange callback, but can't unregister.
+    if (!_innerAccelerometerCb) {
+        _innerAccelerometerCb = (res: any) => {
+            let x = res.x;
+            let y = res.y;
+            if (minigame.isLandscape) {
+                const orientationFactor = (landscapeOrientation === Orientation.LANDSCAPE_RIGHT ? 1 : -1);
+                const tmp = x;
+                x = -y * orientationFactor;
+                y = tmp * orientationFactor;
+            }
 
-        const resClone = {
-            x,
-            y,
-            z: res.z,
+            const resClone = {
+                x,
+                y,
+                z: res.z,
+            };
+            _customAccelerometerCb?.(resClone);
         };
-        cb(resClone);
-    };
+        swan.onAccelerometerChange(_innerAccelerometerCb);
+        // onAccelerometerChange would start accelerometer, need to stop it mannually
+        swan.stopAccelerometer({});
+    }
+    _customAccelerometerCb = cb;
 };
 minigame.offAccelerometerChange = function (cb?: AccelerometerChangeCallback) {
-    if (_accelerometerCb) {
-        swan.offAccelerometerChange(_accelerometerCb);
-        _accelerometerCb = undefined;
-    }
-};
-minigame.startAccelerometer = function (res: any) {
-    if (_accelerometerCb) {
-        swan.onAccelerometerChange(_accelerometerCb);
-    }
-    swan.startAccelerometer(res);
+    // swan.offAccelerometerChange() is not supported.
+    _customAccelerometerCb = undefined;
 };
 // #endregion Accelerometer
 

--- a/pal/minigame/wechat.ts
+++ b/pal/minigame/wechat.ts
@@ -14,7 +14,11 @@ minigame.isDevTool = (systemInfo.platform === 'devtools');
 // NOTE: size and orientation info is wrong at the init phase, especially on iOS device
 Object.defineProperty(minigame, 'isLandscape', {
     get () {
-        return systemInfo.deviceOrientation ? (systemInfo.deviceOrientation === 'landscape') : (systemInfo.screenWidth > systemInfo.screenHeight);
+        // NOTE: wrong deviceOrientation on iOS end before app launched.
+        const locSystemInfo = minigame.getSystemInfoSync();
+        return locSystemInfo.deviceOrientation
+            ? (locSystemInfo.deviceOrientation === 'landscape')
+            : (locSystemInfo.screenWidth > locSystemInfo.screenHeight);
     },
 });
 // init landscapeOrientation as LANDSCAPE_RIGHT


### PR DESCRIPTION
fix https://github.com/cocos-creator/3d-tasks/issues/6929
fix https://github.com/cocos-creator/3d-tasks/issues/7310
fix https://github.com/cocos-creator/3d-tasks/issues/7347

Changelog:
- 修复手机 qq 浏览器加速计方向不正确问题
- 修复微信小游戏 iOS 端加速计无法开启问题
- 修复百度小游戏加速计无法开启的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
