### PR TITLE
fix stopping audio won't seek to 0  when audio is paused on Xiaomi

### DIFF
--- a/pal/minigame/xiaomi.ts
+++ b/pal/minigame/xiaomi.ts
@@ -88,12 +88,28 @@ minigame.offAccelerometerChange = function (cb?: AccelerometerChangeCallback) {
 };
 // #endregion Accelerometer
 
+// #region InnerAudioContext
 minigame.createInnerAudioContext = createInnerAudioContextPolyfill(qg, {
     onPlay: true,
     onPause: true,
     onStop: true,
     onSeek: false,
 });
+const originalCreateInnerAudioContext = minigame.createInnerAudioContext;
+minigame.createInnerAudioContext = function () {
+    const audioContext = originalCreateInnerAudioContext.call(minigame);
+    const originalStop = audioContext.stop;
+    Object.defineProperty(audioContext, 'stop', {
+        configurable: true,
+        value () {
+            // NOTE: stop won't seek to 0 when audio is paused on Xiaomi platform.
+            audioContext.seek(0);
+            originalStop.call(audioContext);
+        },
+    });
+    return audioContext;
+};
+// #endregion InnerAudioContext
 
 minigame.getSafeArea = function () {
     console.warn('getSafeArea is not supported on this platform');

--- a/pal/utils.ts
+++ b/pal/utils.ts
@@ -32,11 +32,13 @@ export function createInnerAudioContextPolyfill (minigameEnv: any, polyfillConfi
             const originalPlay = audioContext.play;
             let _onPlayCB: (()=> void) | null = null;
             Object.defineProperty(audioContext, 'onPlay', {
+                configurable: true,
                 value (cb: ()=> void) {
                     _onPlayCB = cb;
                 },
             });
             Object.defineProperty(audioContext, 'play', {
+                configurable: true,
                 value () {
                     originalPlay.call(audioContext);
                     _onPlayCB?.();
@@ -49,11 +51,13 @@ export function createInnerAudioContextPolyfill (minigameEnv: any, polyfillConfi
             const originalPause = audioContext.pause;
             let _onPauseCB: (()=> void) | null = null;
             Object.defineProperty(audioContext, 'onPause', {
+                configurable: true,
                 value (cb: ()=> void) {
                     _onPauseCB = cb;
                 },
             });
             Object.defineProperty(audioContext, 'pause', {
+                configurable: true,
                 value () {
                     originalPause.call(audioContext);
                     _onPauseCB?.();
@@ -66,11 +70,13 @@ export function createInnerAudioContextPolyfill (minigameEnv: any, polyfillConfi
             const originalStop = audioContext.stop;
             let _onStopCB: (()=> void) | null = null;
             Object.defineProperty(audioContext, 'onStop', {
+                configurable: true,
                 value (cb: ()=> void) {
                     _onStopCB = cb;
                 },
             });
             Object.defineProperty(audioContext, 'stop', {
+                configurable: true,
                 value () {
                     originalStop.call(audioContext);
                     _onStopCB?.();
@@ -83,11 +89,13 @@ export function createInnerAudioContextPolyfill (minigameEnv: any, polyfillConfi
             const originalSeek = audioContext.seek;
             let _onSeekCB: (()=> void) | null = null;
             Object.defineProperty(audioContext, 'onSeeked', {
+                configurable: true,
                 value (cb: ()=> void) {
                     _onSeekCB = cb;
                 },
             });
             Object.defineProperty(audioContext, 'seek', {
+                configurable: true,
                 value (time: number) {
                     originalSeek.call(audioContext, time);
                     _onSeekCB?.();


### PR DESCRIPTION
fix https://github.com/cocos-creator/3d-tasks/issues/7222

Changelog:
 * 修复小米平台音频 pause 之后，无法 stop 的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
