### PR TITLE
deprecate 'sys.IPHONE' and 'sys.IPAD', not remove it

### DIFF
--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -142,9 +142,22 @@ replaceProperty(sys, 'sys',
     })));
 
 // remove platform field
+replaceProperty(sys, 'sys', [
+    {
+        name: 'IPHONE',
+        newName: 'IOS',
+        target: sys.Platform,
+        targetName: 'sys.Platform',
+    },
+    {
+        name: 'IPAD',
+        newName: 'IOS',
+        target: sys.Platform,
+        targetName: 'sys.Platform',
+    },
+]);
 removeProperty(sys, 'sys',
-    ['LINUX',  'IPHONE', 'IPAD', 'BLACKBERRY',
-        'NACL', 'EMSCRIPTEN', 'TIZEN', 'WINRT', 'WP8',
-        'QQ_PLAY', 'FB_PLAYABLE_ADS'].map((item) => ({
+    ['LINUX', 'BLACKBERRY', 'NACL', 'EMSCRIPTEN', 'TIZEN',
+        'WINRT', 'WP8', 'QQ_PLAY', 'FB_PLAYABLE_ADS'].map((item) => ({
         name: item,
     })));


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 

<img width="632" alt="1" src="https://user-images.githubusercontent.com/17872773/117392079-e70c6f00-af23-11eb-8079-e6ee5613bf67.png">

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
