### PR TITLE
Suppress rollup warning about non-exported isWasm & wasmBinaryURL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,9 +1767,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.2.7",
-      "resolved": "https://registry.nlark.com/@cocos/build-engine/download/@cocos/build-engine-4.2.7.tgz",
-      "integrity": "sha1-rSp/20O9hL94+kOv//yfpQ39G3Q=",
+      "version": "4.2.8",
+      "resolved": "https://registry.nlark.com/@cocos/build-engine/download/@cocos/build-engine-4.2.8.tgz",
+      "integrity": "sha1-zShiKAfMXEP5ZhEQL1mk93IFo18=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.13.10",
@@ -1856,7 +1856,7 @@
         },
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-8.1.0.tgz?cache=0&sync_timestamp=1611075413359&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-8.1.0.tgz",
+          "resolved": "https://registry.nlark.com/fs-extra/download/fs-extra-8.1.0.tgz",
           "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
           "dev": true,
           "requires": {
@@ -1989,7 +1989,7 @@
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.nlark.com/yargs/download/yargs-15.4.1.tgz",
+          "resolved": "https://registry.nlark.com/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1620086465147&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
           "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
           "dev": true,
           "requires": {
@@ -3206,18 +3206,18 @@
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npm.taobao.org/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.12.11.tgz?cache=0&sync_timestamp=1608076995361&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fhelper-validator-identifier%2Fdownload%2F%40babel%2Fhelper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha1-yaHwIZF9y1zPDU5FPjmQIpgfye0=",
+          "version": "7.14.0",
+          "resolved": "https://registry.nlark.com/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.14.0.tgz?cache=0&sync_timestamp=1619727412592&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40babel%2Fhelper-validator-identifier%2Fdownload%2F%40babel%2Fhelper-validator-identifier-7.14.0.tgz",
+          "integrity": "sha1-0mytikfGUoaxXfFUcxml0Lzycog=",
           "dev": true
         },
         "@babel/types": {
-          "version": "7.13.17",
-          "resolved": "https://registry.nlark.com/@babel/types/download/@babel/types-7.13.17.tgz",
-          "integrity": "sha1-SAEKEVyfunWItEN91oyUaQErOLQ=",
+          "version": "7.14.1",
+          "resolved": "https://registry.nlark.com/@babel/types/download/@babel/types-7.14.1.tgz",
+          "integrity": "sha1-CVvRLxwIq2Pv9uj3dF+nycwVqds=",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
+            "@babel/helper-validator-identifier": "^7.14.0",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -3225,7 +3225,7 @@
     },
     "@rollup/plugin-commonjs": {
       "version": "11.1.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-11.1.0.tgz",
+      "resolved": "https://registry.nlark.com/@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-11.1.0.tgz",
       "integrity": "sha1-YGNsenIvVLQeQZ4XCd8FxyNFV+8=",
       "dev": true,
       "requires": {
@@ -3249,7 +3249,7 @@
     },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-node-resolve/download/@rollup/plugin-node-resolve-7.1.3.tgz",
+      "resolved": "https://registry.nlark.com/@rollup/plugin-node-resolve/download/@rollup/plugin-node-resolve-7.1.3.tgz",
       "integrity": "sha1-gN44Tt+9e/yRARZJEPhgeBUaPso=",
       "dev": true,
       "requires": {
@@ -12382,7 +12382,7 @@
     },
     "open": {
       "version": "7.4.2",
-      "resolved": "https://registry.npm.taobao.org/open/download/open-7.4.2.tgz?cache=0&sync_timestamp=1618549241971&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fopen%2Fdownload%2Fopen-7.4.2.tgz",
+      "resolved": "https://registry.nlark.com/open/download/open-7.4.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fopen%2Fdownload%2Fopen-7.4.2.tgz",
       "integrity": "sha1-uBR+Jtzz5CYxbHMAif1x7dKcIyE=",
       "dev": true,
       "optional": true,
@@ -13344,7 +13344,7 @@
     },
     "rollup": {
       "version": "2.26.6",
-      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.6.tgz",
+      "resolved": "https://registry.nlark.com/rollup/download/rollup-2.26.6.tgz",
       "integrity": "sha1-C0YMHaIkxq8SoelIooxROqEfK5M=",
       "dev": true,
       "requires": {
@@ -13391,18 +13391,18 @@
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npm.taobao.org/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.12.11.tgz?cache=0&sync_timestamp=1608076995361&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fhelper-validator-identifier%2Fdownload%2F%40babel%2Fhelper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha1-yaHwIZF9y1zPDU5FPjmQIpgfye0=",
+          "version": "7.14.0",
+          "resolved": "https://registry.nlark.com/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.14.0.tgz?cache=0&sync_timestamp=1619727412592&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40babel%2Fhelper-validator-identifier%2Fdownload%2F%40babel%2Fhelper-validator-identifier-7.14.0.tgz",
+          "integrity": "sha1-0mytikfGUoaxXfFUcxml0Lzycog=",
           "dev": true
         },
         "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npm.taobao.org/@babel/highlight/download/@babel/highlight-7.13.10.tgz",
-          "integrity": "sha1-qLKmYUj1sn1maxXYF3Q0enMdUtE=",
+          "version": "7.14.0",
+          "resolved": "https://registry.nlark.com/@babel/highlight/download/@babel/highlight-7.14.0.tgz?cache=0&sync_timestamp=1619727182056&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40babel%2Fhighlight%2Fdownload%2F%40babel%2Fhighlight-7.14.0.tgz",
+          "integrity": "sha1-MZfjdXEe9r+DTmfQ2uyI5PRhE88=",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
+            "@babel/helper-validator-identifier": "^7.14.0",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
@@ -13539,7 +13539,7 @@
         },
         "yargs": {
           "version": "16.2.0",
-          "resolved": "https://registry.nlark.com/yargs/download/yargs-16.2.0.tgz",
+          "resolved": "https://registry.nlark.com/yargs/download/yargs-16.2.0.tgz?cache=0&sync_timestamp=1620086465147&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fyargs%2Fdownload%2Fyargs-16.2.0.tgz",
           "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
           "dev": true,
           "optional": true,
@@ -14556,7 +14556,7 @@
         },
         "yargs": {
           "version": "13.3.2",
-          "resolved": "https://registry.nlark.com/yargs/download/yargs-13.3.2.tgz",
+          "resolved": "https://registry.nlark.com/yargs/download/yargs-13.3.2.tgz?cache=0&sync_timestamp=1620086465147&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fyargs%2Fdownload%2Fyargs-13.3.2.tgz",
           "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.2.7",
+    "@cocos/build-engine": "4.2.8",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -518,6 +518,14 @@ export default Ammo;
 const isWasm = true;
 export { isWasm, wasmBinaryURL };
 `;
+    } else {
+        rpVirtualOptions['@cocos/ammo'] = `
+import Ammo from '${filePathToModuleRequest(ammoJsAsmJsModule)}';
+export default Ammo;
+const isWasm = false;
+const wasmBinaryURL = '';
+export { isWasm, wasmBinaryURL };
+`;
     }
 
     const rollupBuild = await rollup.rollup(rollupOptions);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#7346

Changelog:
 * Suppress rollup warning about non-exported isWasm & wasmBinaryURL

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
