### PR TITLE
Revert "fix widget align bug when isRoot (#8438)"

### DIFF
--- a/cocos/ui/widget-manager.ts
+++ b/cocos/ui/widget-manager.ts
@@ -91,11 +91,11 @@ function align (node: Node, widget: Widget) {
         } else {
             localLeft = -targetAnchor.x * targetWidth;
             localRight = localLeft + targetWidth;
-
-            // adjust borders according to offsets
-            localLeft += widget.isAbsoluteLeft ? widget.left : widget.left * targetWidth;
-            localRight -= widget.isAbsoluteRight ? widget.right : widget.right * targetWidth;
         }
+
+        // adjust borders according to offsets
+        localLeft += widget.isAbsoluteLeft ? widget.left : widget.left * targetWidth;
+        localRight -= widget.isAbsoluteRight ? widget.right : widget.right * targetWidth;
 
         if (hasTarget) {
             localLeft += inverseTranslate.x;
@@ -148,11 +148,11 @@ function align (node: Node, widget: Widget) {
         } else {
             localBottom = -targetAnchor.y * targetHeight;
             localTop = localBottom + targetHeight;
-
-            // adjust borders according to offsets
-            localBottom += widget.isAbsoluteBottom ? widget.bottom : widget.bottom * targetHeight;
-            localTop -= widget.isAbsoluteTop ? widget.top : widget.top * targetHeight;
         }
+
+        // adjust borders according to offsets
+        localBottom += widget.isAbsoluteBottom ? widget.bottom : widget.bottom * targetHeight;
+        localTop -= widget.isAbsoluteTop ? widget.top : widget.top * targetHeight;
 
         if (hasTarget) {
             // transform


### PR DESCRIPTION
This reverts commit 0001d0de17dafa78f7afce84a3f787ebedb14933.

NOTE: 
之前的 commit 会导致 Widget 无法运行时修改 canvas 节点的尺寸，safe-area 无法正常工作

之前的提交需要 @LinYunMo 思考下其他修复方式

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
