### PR TITLE
cache system info on LINK_SURE platform

### DIFF
--- a/pal/minigame/runtime.ts
+++ b/pal/minigame/runtime.ts
@@ -40,6 +40,23 @@ Object.defineProperty(minigame, 'orientation', {
         return minigame.isLandscape ? landscapeOrientation : Orientation.PORTRAIT;
     },
 });
+
+if (VIVO) {
+    // TODO: need to be handled in ral lib.
+    minigame.getSystemInfoSync = function () {
+        const sys = ral.getSystemInfoSync() as SystemInfo;
+        // on VIVO, windowWidth should be windowHeight when it is landscape
+        sys.windowWidth = sys.screenWidth;
+        sys.windowHeight = sys.screenHeight;
+        return sys;
+    };
+} else if (LINKSURE) {
+    // TODO: update system info when view resized, currently the resize callback is not supported.
+    const cachedSystemInfo = ral.getSystemInfoSync() as SystemInfo;
+    minigame.getSystemInfoSync = function () {
+        return cachedSystemInfo;
+    };
+}
 // #endregion SystemInfo
 
 // #region Accelerometer
@@ -88,16 +105,5 @@ minigame.getSafeArea = function () {
     }
     return { top, left, bottom, right, width, height };
 };
-
-if (VIVO) {
-    // TODO: need to be handled in ral lib.
-    minigame.getSystemInfoSync = function () {
-        const sys = ral.getSystemInfoSync() as SystemInfo;
-        // on VIVO, windowWidth should be windowHeight when it is landscape
-        sys.windowWidth = sys.screenWidth;
-        sys.windowHeight = sys.screenHeight;
-        return sys;
-    };
-}
 
 export { minigame };


### PR DESCRIPTION
fix: https://github.com/cocos-creator/3d-tasks/issues/7390
> changeLog
- 修复连尚平台，触摸事件回调导致在 荣耀v9 上卡顿的问题

> NOTE

ral.getSystemInfoSync() 在连尚平台的损耗太高了，touch 事件里太频繁调用，导致 荣耀 v9 卡顿

<img width="1003" alt="1" src="https://user-images.githubusercontent.com/17872773/117754157-5b108500-b24c-11eb-9f17-524fcbcfc596.png">

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
