### PR TITLE
Fixed accuracy issues with sineIn, backIn, backOut, backOutIn in boundary cases

### DIFF
--- a/cocos/core/animation/easing.ts
+++ b/cocos/core/animation/easing.ts
@@ -101,6 +101,9 @@ export function quintInOut (k: number) {
 }
 
 export function sineIn (k: number) {
+    if (k === 1) {
+        return 1;
+    }
     return 1 - Math.cos(k * Math.PI / 2);
 }
 
@@ -213,11 +216,17 @@ export function elasticInOut (k: number) {
 }
 
 export function backIn (k: number) {
+    if (k === 1) {
+        return 1;
+    }
     const s = 1.70158;
     return k * k * ((s + 1) * k - s);
 }
 
 export function backOut (k: number) {
+    if (k === 0) {
+        return 0;
+    }
     const s = 1.70158;
     return --k * k * ((s + 1) * k + s) + 1;
 }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
修复sineIn,backIn,backOut,backOutIn在k为0与1时返回值不正确的bug

问题描述:
sineIn,backIn,backOut,backOutIn在k为0或1时返回值非0和1

测试代码:
```ts
import * as easing from './easing'
const ignore = ['constant']
for (const key in easing) {
    if(ignore.includes(key)) {
        continue;
    }
    const func = (easing as any)[key];
    if (func(0) !== 0 || func(1) !== 1) {
        console.log(key, func(0), func(1));
    }
}
```

测试结果:
sineIn 0 0.9999999999999999
backIn -0 0.9999999999999998
backOut 2.220446049250313e-16 1
backOutIn 1.1102230246251565e-16 0.9999999999999999
