### PR TITLE
fix input support info on Web platform

### DIFF
--- a/pal/input/web/accelerometer.ts
+++ b/pal/input/web/accelerometer.ts
@@ -16,7 +16,7 @@ export class AccelerometerInputSource {
     private _didAccelerateFunc: (event: DeviceMotionEvent | DeviceOrientationEvent) => void;
 
     constructor () {
-        this.support = true;
+        this.support = (window.DeviceMotionEvent !== undefined || window.DeviceOrientationEvent !== undefined);
 
         // init event name
         this._globalEventClass = window.DeviceMotionEvent || window.DeviceOrientationEvent;

--- a/pal/input/web/keyboard.ts
+++ b/pal/input/web/keyboard.ts
@@ -8,7 +8,7 @@ export class KeyboardInputSource {
     private _eventTarget: EventTarget = new EventTarget();
 
     constructor () {
-        this.support = !system.isMobile;
+        this.support = document.documentElement.onkeyup !== undefined;
         this._registerEvent();
     }
 

--- a/pal/input/web/mouse.ts
+++ b/pal/input/web/mouse.ts
@@ -16,7 +16,7 @@ export class MouseInputSource {
     private _preMousePos: Vec2 = new Vec2();
 
     constructor () {
-        this.support = !system.isMobile && !EDITOR;
+        this.support = !EDITOR && document.documentElement.onmouseup !== undefined;
         if (this.support) {
             this._canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
             if (!this._canvas && !TEST) {

--- a/pal/input/web/touch.ts
+++ b/pal/input/web/touch.ts
@@ -12,7 +12,7 @@ export class TouchInputSource {
     private _eventTarget: EventTarget = new EventTarget();
 
     constructor () {
-        this.support = system.isMobile;
+        this.support = (document.documentElement.ontouchstart !== undefined || document.ontouchstart !== undefined || navigator.msPointerEnabled);
         if (this.support) {
             this._canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
             if (!this._canvas && !TEST) {


### PR DESCRIPTION
fix: https://discuss.cocos2d-x.org/t/cocos-creator-3-1-0-released/53555/2

> NOTE

the iPad device is kind of special. the `cc.sys.isMobile` returns `false` because of its special userAgent
![WechatIMG321](https://user-images.githubusercontent.com/17872773/118218467-0bc79000-b4aa-11eb-8707-66632c14f5f0.png)

> CHANGE LOG
- This commit fix the issue that the touch event doesn't work on iPad device.
- But still remain a known issue:  the `cc.sys.isMobile` returns `false` on iPad device


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
