### PR TITLE
Fix clip equivalence in Animation component

### DIFF
--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -105,9 +105,11 @@ export class Animation extends Eventify(Component) {
     /**
      * @en
      * Gets or sets the default clip.
+     * Two clips that both have same non-empty UUID are treat as equivalent.
      * @en
      * 获取或设置默认剪辑。
      * 设置时，若指定的剪辑不在 `this.clips` 中则会被自动添加至 `this.clips`。
+     * 具有相同的非空 UUID 的两个动画剪辑将被视为是相同的。
      * @see [[playOnLoad]]
      */
     @type(AnimationClip)
@@ -498,5 +500,5 @@ function equalClips (clip1: AnimationClip | null, clip2: AnimationClip | null) {
     if (clip1 === clip2) {
         return true;
     }
-    return !!clip1 && !!clip2 && (clip1.name === clip2.name || clip1._uuid === clip2._uuid);
+    return !!clip1 && !!clip2 && (clip1._uuid === clip2._uuid) && clip1._uuid;
 }

--- a/tests/animation/animation-component.test.ts
+++ b/tests/animation/animation-component.test.ts
@@ -1,0 +1,37 @@
+import { AnimationClip } from '../../cocos/core';
+import { Animation } from '../../cocos/core/animation/animation-component';
+
+describe('Animation Component', () => {
+    describe('Sync default clip into clips array(clip equivalence)', () => {
+        test('Clips are keyed by non-empty UUID', () => {
+            const component = new Animation();
+
+            const clipFoo = new AnimationClip('foo');
+            clipFoo._uuid = 'uuid';
+            component.defaultClip = clipFoo;
+            expect(component.clips).toHaveLength(1);
+            expect(component.clips[0]).toBe(clipFoo);
+
+            const anotherClipFoo = new AnimationClip();
+            anotherClipFoo._uuid = 'uuid';
+            component.defaultClip = anotherClipFoo;
+            expect(component.clips).toHaveLength(1);
+            expect(component.clips[0]).toBe(clipFoo);
+        });
+
+        test('Especially, clips are not keyed by their name', () => {
+            const component = new Animation();
+
+            const clipFoo = new AnimationClip('foo');
+            component.defaultClip = clipFoo;
+            expect(component.clips).toHaveLength(1);
+            expect(component.clips[0]).toBe(clipFoo);
+
+            const anotherClipFoo = new AnimationClip('foo');
+            component.defaultClip = anotherClipFoo;
+            expect(component.clips).toHaveLength(2);
+            expect(component.clips[0]).toBe(clipFoo);
+            expect(component.clips[1]).toBe(anotherClipFoo);
+        });
+    });
+});


### PR DESCRIPTION
Closes cocos-creator/3d-tasks#7379

Changelog:
 * Fix clip equivalence in Animation component: Two clips with same name are no longer treated as same.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
