### PR TITLE
optimize SystemEventType and NodeEventType

### DIFF
--- a/@types/pal/input.d.ts
+++ b/@types/pal/input.d.ts
@@ -3,7 +3,7 @@ declare module 'pal/input' {
         /**
          * Type of the input event used to quickly distinguish between event types.
          */
-        readonly type: string;
+        readonly type: import('../../cocos/core/platform/event-manager/event-enum').SystemEventType;
         /**
          * Timestamp when the input event is triggered.
          */

--- a/@types/pal/input.d.ts
+++ b/@types/pal/input.d.ts
@@ -145,6 +145,12 @@ declare module 'pal/input' {
          */
         public onDown (cb: KeyboardCallback);
         /**
+         * Register the key pressing event callback.
+         * NOTE: Compability for the deprecated KEY_DOWN event type. It should be removed in the future.
+         * @param cb 
+         */
+        public onPressing (cb: KeyboardCallback);
+        /**
          * Register the key up event callback.
          * @param cb 
          */

--- a/@types/pal/input.d.ts
+++ b/@types/pal/input.d.ts
@@ -3,7 +3,7 @@ declare module 'pal/input' {
         /**
          * Type of the input event used to quickly distinguish between event types.
          */
-        readonly type: import('../../cocos/core/platform/event-manager/event-enum').SystemEventType;
+        readonly type: import('../../cocos/core/platform/event-manager/event-enum').SystemEventTypeUnion;
         /**
          * Timestamp when the input event is triggered.
          */

--- a/cocos/2d/components/mask.ts
+++ b/cocos/2d/components/mask.ts
@@ -32,7 +32,7 @@
 import { ccclass, help, executionOrder, menu, tooltip, displayOrder, type, visible, override, serializable, range, slide } from 'cc.decorator';
 import { InstanceMaterialType, Renderable2D } from '../framework/renderable-2d';
 import { clamp, Color, Mat4, Vec2, Vec3 } from '../../core/math';
-import { SystemEventType, warnID } from '../../core/platform';
+import { warnID } from '../../core/platform';
 import { Batcher2D } from '../renderer/batcher-2d';
 import { ccenum } from '../../core/value-types/enum';
 import { Graphics } from './graphics';

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -32,7 +32,7 @@
 import { ccclass, executeInEditMode, executionOrder, help, menu, tooltip, multiline, type, serializable } from 'cc.decorator';
 import { DEV, EDITOR } from 'internal:constants';
 import { Font, SpriteAtlas, TTFFont, SpriteFrame } from '../assets';
-import { assert, EventTouch, SystemEventType, warnID } from '../../core/platform';
+import { assert, EventTouch, warnID } from '../../core/platform';
 import { BASELINE_RATIO, fragmentText, isUnicodeCJK, isUnicodeSpace } from '../utils/text-utils';
 import { HtmlTextParser, IHtmlTextParserResultObj, IHtmlTextParserStack } from '../utils/html-text-parser';
 import Pool from '../../core/utils/pool';
@@ -46,6 +46,7 @@ import { legacyCC } from '../../core/global-exports';
 import { Component } from '../../core/components';
 import assetManager from '../../core/asset-manager/asset-manager';
 import { CCObject } from '../../core';
+import { NodeEventType } from '../../core/scene-graph/node-event';
 
 const _htmlTextParser = new HtmlTextParser();
 const RichTextChildName = 'RICHTEXT_CHILD';
@@ -458,7 +459,7 @@ export class RichText extends UIComponent {
     }
 
     public onLoad () {
-        this.node.on(SystemEventType.LAYER_CHANGED, this._applyLayer, this);
+        this.node.on(NodeEventType.LAYER_CHANGED, this._applyLayer, this);
     }
 
     public onEnable () {
@@ -480,7 +481,7 @@ export class RichText extends UIComponent {
 
     public start () {
         this._onTTFLoaded();
-        this.node.on(Node.EventType.ANCHOR_CHANGED, this._updateRichTextPosition, this);
+        this.node.on(NodeEventType.ANCHOR_CHANGED, this._updateRichTextPosition, this);
     }
 
     public onRestore () {
@@ -508,16 +509,16 @@ export class RichText extends UIComponent {
             }
         }
 
-        this.node.off(Node.EventType.ANCHOR_CHANGED, this._updateRichTextPosition, this);
-        this.node.off(SystemEventType.LAYER_CHANGED, this._applyLayer, this);
+        this.node.off(NodeEventType.ANCHOR_CHANGED, this._updateRichTextPosition, this);
+        this.node.off(NodeEventType.LAYER_CHANGED, this._applyLayer, this);
     }
 
     protected _addEventListeners () {
-        this.node.on(Node.EventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.on(NodeEventType.TOUCH_END, this._onTouchEnded, this);
     }
 
     protected _removeEventListeners () {
-        this.node.off(Node.EventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.off(NodeEventType.TOUCH_END, this._onTouchEnded, this);
     }
 
     protected _updateLabelSegmentTextAttributes () {

--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -33,7 +33,6 @@ import { ccclass, help, executionOrder, menu, tooltip, displayOrder, type, range
 import { EDITOR } from 'internal:constants';
 import { SpriteAtlas } from '../assets/sprite-atlas';
 import { SpriteFrame } from '../assets/sprite-frame';
-import { SystemEventType } from '../../core/platform/event-manager/event-enum';
 import { Vec2 } from '../../core/math';
 import { ccenum } from '../../core/value-types/enum';
 import { clamp } from '../../core/math/utils';
@@ -42,7 +41,8 @@ import { Renderable2D, InstanceMaterialType } from '../framework/renderable-2d';
 import { legacyCC } from '../../core/global-exports';
 import { PixelFormat } from '../../core/assets/asset-enum';
 import { TextureBase } from '../../core/assets/texture-base';
-import { Material, RenderTexture } from '../../core';
+import { Material, Node, RenderTexture } from '../../core';
+import { NodeEventType } from '../../core/scene-graph/node-event';
 
 /**
  * @en
@@ -479,7 +479,7 @@ export class Sprite extends Renderable2D {
 
         if (EDITOR) {
             this._resized();
-            this.node.on(SystemEventType.SIZE_CHANGED, this._resized, this);
+            this.node.on(NodeEventType.SIZE_CHANGED, this._resized, this);
         }
 
         if (this._spriteFrame) {
@@ -516,7 +516,7 @@ export class Sprite extends Renderable2D {
     public onDestroy () {
         this.destroyRenderData();
         if (EDITOR) {
-            this.node.off(SystemEventType.SIZE_CHANGED, this._resized, this);
+            this.node.off(NodeEventType.SIZE_CHANGED, this._resized, this);
         }
 
         if (this._spriteFrame && !this._spriteFrame.loaded) {

--- a/cocos/2d/framework/canvas.ts
+++ b/cocos/2d/framework/canvas.ts
@@ -38,10 +38,11 @@ import { game } from '../../core/game';
 import { Vec3 } from '../../core/math';
 import { view } from '../../core/platform/view';
 import { legacyCC } from '../../core/global-exports';
-import { SystemEventType } from '../../core/platform/event-manager';
 import { Enum } from '../../core/value-types/enum';
 import visibleRect from '../../core/platform/visible-rect';
 import { RenderRoot2D } from './render-root-2d';
+import { Node } from '../../core';
+import { NodeEventType } from '../../core/scene-graph/node-event';
 
 const _worldPos = new Vec3();
 
@@ -189,7 +190,7 @@ export class Canvas extends RenderRoot2D {
             this._objFlags |= legacyCC.Object.Flags.IsPositionLocked | legacyCC.Object.Flags.IsSizeLocked | legacyCC.Object.Flags.IsAnchorLocked;
         }
 
-        this.node.on(SystemEventType.TRANSFORM_CHANGED, this._thisOnCameraResized);
+        this.node.on(NodeEventType.TRANSFORM_CHANGED, this._thisOnCameraResized);
     }
 
     public onDestroy () {
@@ -199,7 +200,7 @@ export class Canvas extends RenderRoot2D {
             legacyCC.director.off(legacyCC.Director.EVENT_AFTER_UPDATE, this._fitDesignResolution!, this);
         }
 
-        this.node.off(SystemEventType.TRANSFORM_CHANGED, this._thisOnCameraResized);
+        this.node.off(NodeEventType.TRANSFORM_CHANGED, this._thisOnCameraResized);
     }
 
     protected _onResizeCamera () {

--- a/cocos/2d/framework/renderable-2d.ts
+++ b/cocos/2d/framework/renderable-2d.ts
@@ -31,7 +31,6 @@ import { EDITOR } from 'internal:constants';
 import { ccclass, executeInEditMode, requireComponent, disallowMultiple, tooltip,
     type, displayOrder, serializable, override, visible, displayName } from 'cc.decorator';
 import { Color } from '../../core/math';
-import { SystemEventType } from '../../core/platform/event-manager/event-enum';
 import { ccenum } from '../../core/value-types/enum';
 import { builtinResMgr } from '../../core/builtin';
 import { Material } from '../../core/assets';
@@ -47,6 +46,7 @@ import { RenderableComponent } from '../../core/components/renderable-component'
 import { Stage } from '../renderer/stencil-manager';
 import { warnID } from '../../core/platform/debug';
 import { legacyCC } from '../../core/global-exports';
+import { NodeEventType } from '../../core/scene-graph/node-event';
 
 // hack
 ccenum(BlendFactor);
@@ -254,7 +254,7 @@ export class Renderable2D extends RenderableComponent {
         this._colorDirty = true;
         if (EDITOR) {
             const clone = value.clone();
-            this.node.emit(SystemEventType.COLOR_CHANGED, clone);
+            this.node.emit(NodeEventType.COLOR_CHANGED, clone);
         }
     }
 
@@ -330,8 +330,8 @@ export class Renderable2D extends RenderableComponent {
     }
 
     public onEnable () {
-        this.node.on(SystemEventType.ANCHOR_CHANGED, this._nodeStateChange, this);
-        this.node.on(SystemEventType.SIZE_CHANGED, this._nodeStateChange, this);
+        this.node.on(NodeEventType.ANCHOR_CHANGED, this._nodeStateChange, this);
+        this.node.on(NodeEventType.SIZE_CHANGED, this._nodeStateChange, this);
         this.updateMaterial();
         this._renderFlag = this._canRender();
     }
@@ -343,8 +343,8 @@ export class Renderable2D extends RenderableComponent {
     }
 
     public onDisable () {
-        this.node.off(SystemEventType.ANCHOR_CHANGED, this._nodeStateChange, this);
-        this.node.off(SystemEventType.SIZE_CHANGED, this._nodeStateChange, this);
+        this.node.off(NodeEventType.ANCHOR_CHANGED, this._nodeStateChange, this);
+        this.node.off(NodeEventType.SIZE_CHANGED, this._nodeStateChange, this);
         this._renderFlag = false;
     }
 

--- a/cocos/2d/framework/ui-transform.ts
+++ b/cocos/2d/framework/ui-transform.ts
@@ -31,7 +31,6 @@
 import { ccclass, help, executeInEditMode, executionOrder, menu, tooltip, displayOrder, serializable, disallowMultiple, visible } from 'cc.decorator';
 import { EDITOR } from 'internal:constants';
 import { Component } from '../../core/components';
-import { SystemEventType } from '../../core/platform/event-manager/event-enum';
 import { EventListener } from '../../core/platform/event-manager/event-listener';
 import { Mat4, Rect, Size, Vec2, Vec3 } from '../../core/math';
 import { AABB } from '../../core/geometry';
@@ -39,6 +38,7 @@ import { Node } from '../../core/scene-graph';
 import { legacyCC } from '../../core/global-exports';
 import { Director, director } from '../../core/director';
 import { warnID } from '../../core/platform/debug';
+import { NodeEventType } from '../../core/scene-graph/node-event';
 
 const _vec2a = new Vec2();
 const _vec2b = new Vec2();
@@ -88,9 +88,9 @@ export class UITransform extends Component {
         this._contentSize.set(value);
         if (EDITOR) {
             // @ts-expect-error EDITOR condition
-            this.node.emit(SystemEventType.SIZE_CHANGED, clone);
+            this.node.emit(NodeEventType.SIZE_CHANGED, clone);
         } else {
-            this.node.emit(SystemEventType.SIZE_CHANGED);
+            this.node.emit(NodeEventType.SIZE_CHANGED);
         }
     }
 
@@ -111,9 +111,9 @@ export class UITransform extends Component {
         this._contentSize.width = value;
         if (EDITOR) {
             // @ts-expect-error EDITOR condition
-            this.node.emit(SystemEventType.SIZE_CHANGED, clone);
+            this.node.emit(NodeEventType.SIZE_CHANGED, clone);
         } else {
-            this.node.emit(SystemEventType.SIZE_CHANGED);
+            this.node.emit(NodeEventType.SIZE_CHANGED);
         }
     }
 
@@ -134,9 +134,9 @@ export class UITransform extends Component {
         this._contentSize.height = value;
         if (EDITOR) {
             // @ts-expect-error EDITOR condition
-            this.node.emit(SystemEventType.SIZE_CHANGED, clone);
+            this.node.emit(NodeEventType.SIZE_CHANGED, clone);
         } else {
-            this.node.emit(SystemEventType.SIZE_CHANGED);
+            this.node.emit(NodeEventType.SIZE_CHANGED);
         }
     }
 
@@ -160,7 +160,7 @@ export class UITransform extends Component {
         }
 
         this._anchorPoint.set(value);
-        this.node.emit(SystemEventType.ANCHOR_CHANGED, this._anchorPoint);
+        this.node.emit(NodeEventType.ANCHOR_CHANGED, this._anchorPoint);
     }
 
     get anchorX () {
@@ -173,7 +173,7 @@ export class UITransform extends Component {
         }
 
         this._anchorPoint.x = value;
-        this.node.emit(SystemEventType.ANCHOR_CHANGED, this._anchorPoint);
+        this.node.emit(NodeEventType.ANCHOR_CHANGED, this._anchorPoint);
     }
 
     get anchorY () {
@@ -186,7 +186,7 @@ export class UITransform extends Component {
         }
 
         this._anchorPoint.y = value;
-        this.node.emit(SystemEventType.ANCHOR_CHANGED, this._anchorPoint);
+        this.node.emit(NodeEventType.ANCHOR_CHANGED, this._anchorPoint);
     }
 
     /**
@@ -239,7 +239,7 @@ export class UITransform extends Component {
         return camera ? camera.priority : 0;
     }
 
-    public static EventType = SystemEventType;
+    public static EventType = NodeEventType;
 
     @serializable
     protected _contentSize = new Size(100, 100);
@@ -257,11 +257,11 @@ export class UITransform extends Component {
     }
 
     public onEnable () {
-        this.node.on(SystemEventType.PARENT_CHANGED, this._parentChanged, this);
+        this.node.on(NodeEventType.PARENT_CHANGED, this._parentChanged, this);
     }
 
     public onDisable () {
-        this.node.off(SystemEventType.PARENT_CHANGED, this._parentChanged, this);
+        this.node.off(NodeEventType.PARENT_CHANGED, this._parentChanged, this);
     }
 
     public onDestroy () {
@@ -331,9 +331,9 @@ export class UITransform extends Component {
 
         if (EDITOR) {
             // @ts-expect-error EDITOR condition
-            this.node.emit(SystemEventType.SIZE_CHANGED, clone);
+            this.node.emit(NodeEventType.SIZE_CHANGED, clone);
         } else {
-            this.node.emit(SystemEventType.SIZE_CHANGED);
+            this.node.emit(NodeEventType.SIZE_CHANGED);
         }
     }
 
@@ -382,7 +382,7 @@ export class UITransform extends Component {
 
         // this.setLocalDirty(LocalDirtyFlag.POSITION);
         // if (this._eventMask & ANCHOR_ON) {
-        this.node.emit(SystemEventType.ANCHOR_CHANGED, this._anchorPoint);
+        this.node.emit(NodeEventType.ANCHOR_CHANGED, this._anchorPoint);
 
         // }
     }

--- a/cocos/core/event/event.ts
+++ b/cocos/core/event/event.ts
@@ -30,6 +30,7 @@
  */
 
 import { legacyCC } from '../global-exports';
+import { SystemEventType } from '../platform/event-manager/event-enum';
 
 /**
  * @en
@@ -39,50 +40,6 @@ import { legacyCC } from '../global-exports';
  * 所有事件对象的基类，包含事件相关基本信息。
  */
 export default class Event {
-    // Event types
-
-    /**
-     * @en
-     * Code for event without type.
-     *
-     * @zh
-     * 没有类型的事件。
-     */
-    public static NO_TYPE = 'no_type';
-
-    /**
-     * @en
-     * The type code of Touch event.
-     *
-     * @zh
-     * 触摸事件类型。
-     */
-    public static TOUCH = 'touch';
-    /**
-     * @en
-     * The type code of Mouse event.
-     *
-     * @zh
-     * 鼠标事件类型。
-     */
-    public static MOUSE = 'mouse';
-    /**
-     * @en
-     * The type code of Keyboard event.
-     *
-     * @zh
-     * 键盘事件类型。
-     */
-    public static KEYBOARD = 'keyboard';
-    /**
-     * @en
-     * The type code of Acceleration event.
-     *
-     * @zh
-     * 加速器事件类型。
-     */
-    public static ACCELERATION = 'acceleration';
-
     // Event phases
 
     /**
@@ -126,12 +83,12 @@ export default class Event {
 
     /**
      * @en
-     * The name of the event (case-sensitive), e.g. "click", "fire", or "submit".
+     * The name of the event
      *
      * @zh
      * 事件类型。
      */
-    public type: string;
+    public type: SystemEventType;
 
     /**
      * @en
@@ -199,7 +156,7 @@ export default class Event {
      * @param type - The name of the event (case-sensitive), e.g. "click", "fire", or "submit"
      * @param bubbles - A boolean indicating whether the event bubbles up through the tree or not
      */
-    constructor (type: string, bubbles?: boolean) {
+    constructor (type: SystemEventType, bubbles?: boolean) {
         this.type = type;
         this.bubbles = !!bubbles;
     }
@@ -212,7 +169,7 @@ export default class Event {
      * 重置事件对象以便在对象池中存储。
      */
     public unuse () {
-        this.type = Event.NO_TYPE;
+        this.type = SystemEventType.NO_TYPE;
         this.target = null;
         this.currentTarget = null;
         this.eventPhase = Event.NONE;
@@ -228,7 +185,7 @@ export default class Event {
      * @param type - The name of the event (case-sensitive), e.g. "click", "fire", or "submit"
      * @param bubbles - A boolean indicating whether the event bubbles up through the tree or not
      */
-    public reuse (type: string, bubbles?: boolean) {
+    public reuse (type: SystemEventType, bubbles?: boolean) {
         this.type = type;
         this.bubbles = bubbles || false;
     }

--- a/cocos/core/event/event.ts
+++ b/cocos/core/event/event.ts
@@ -30,7 +30,7 @@
  */
 
 import { legacyCC } from '../global-exports';
-import { SystemEventType } from '../platform/event-manager/event-enum';
+import { DeviceEvent, KeyboardEvent, MouseEvent, SystemEventType, SystemEventTypeUnion, TouchEvent } from '../platform/event-manager/event-enum';
 
 /**
  * @en
@@ -142,7 +142,7 @@ export default class Event {
      * @zh
      * 事件类型。
      */
-    public type: SystemEventType;
+    public type: SystemEventTypeUnion;
 
     /**
      * @en
@@ -210,7 +210,7 @@ export default class Event {
      * @param type - The name of the event (case-sensitive), e.g. "click", "fire", or "submit"
      * @param bubbles - A boolean indicating whether the event bubbles up through the tree or not
      */
-    constructor (type: SystemEventType, bubbles?: boolean) {
+    constructor (type: SystemEventTypeUnion, bubbles?: boolean) {
         this.type = type;
         this.bubbles = !!bubbles;
     }
@@ -239,7 +239,7 @@ export default class Event {
      * @param type - The name of the event (case-sensitive), e.g. "click", "fire", or "submit"
      * @param bubbles - A boolean indicating whether the event bubbles up through the tree or not
      */
-    public reuse (type: SystemEventType, bubbles?: boolean) {
+    public reuse (type: SystemEventTypeUnion, bubbles?: boolean) {
         this.type = type;
         this.bubbles = bubbles || false;
     }

--- a/cocos/core/event/event.ts
+++ b/cocos/core/event/event.ts
@@ -40,6 +40,60 @@ import { SystemEventType } from '../platform/event-manager/event-enum';
  * 所有事件对象的基类，包含事件相关基本信息。
  */
 export default class Event {
+    // Event types
+
+    /**
+     * @en
+     * Code for event without type.
+     *
+     * @zh
+     * 没有类型的事件。
+     *
+     * @deprecated since v3.3, please use SystemEvent.EventType.NO_TYPE instead
+     */
+    public static NO_TYPE = 'no_type';
+
+    /**
+     * @en
+     * The type code of Touch event.
+     *
+     * @zh
+     * 触摸事件类型。
+     *
+     * @deprecated since v3.3, please use SystemEvent.EventType.TOUCH_START, SystemEvent.EventType.TOUCH_MOVE, SystemEvent.EventType.TOUCH_END and SystemEvent.EventType.TOUCH_CANCEL instead
+     */
+    public static TOUCH = 'touch';
+    /**
+     * @en
+     * The type code of Mouse event.
+     *
+     * @zh
+     * 鼠标事件类型。
+     *
+     * @deprecated since v3.3, please use SystemEvent.EventType.MOUSE_DOWN, SystemEvent.EventType.MOUSE_MOVE, SystemEvent.EventType.MOUSE_UP, SystemEvent.EventType.MOUSE_WHEEL, Node.EventType.MOUSE_ENTER and Node.EventType.MOUSE_LEAVE instead
+     */
+    public static MOUSE = 'mouse';
+    /**
+     * @en
+     * The type code of Keyboard event.
+     *
+     * @zh
+     * 键盘事件类型。
+     *
+     * @deprecated since v3.3, please use SystemEvent.EventType.KEYBOARD_DOWN and SystemEvent.EventType.KEYBOARD_UP instead
+     */
+    public static KEYBOARD = 'keyboard';
+    /**
+     * @en
+     * The type code of Acceleration event.
+     *
+     * @zh
+     * 加速器事件类型。
+     *
+     * @deprecated since v3.3, please use SystemEvent.EventType.DEVICEMOTION instead
+     */
+    public static ACCELERATION = 'acceleration';
+
     // Event phases
 
     /**

--- a/cocos/core/event/event.ts
+++ b/cocos/core/event/event.ts
@@ -49,7 +49,7 @@ export default class Event {
      * @zh
      * 没有类型的事件。
      *
-     * @deprecated since v3.3, please use SystemEvent.EventType.NO_TYPE instead
+     * @deprecated since v3.3, please use SystemEventType.NO_TYPE instead
      */
     public static NO_TYPE = 'no_type';
 
@@ -60,7 +60,7 @@ export default class Event {
      * @zh
      * 触摸事件类型。
      *
-     * @deprecated since v3.3, please use SystemEvent.EventType.TOUCH_START, SystemEvent.EventType.TOUCH_MOVE, SystemEvent.EventType.TOUCH_END and SystemEvent.EventType.TOUCH_CANCEL instead
+     * @deprecated since v3.3, please use SystemEvent.TouchEvent.TOUCH_START, SystemEvent.TouchEvent.TOUCH_MOVE, SystemEvent.TouchEvent.TOUCH_END and SystemEvent.TouchEvent.TOUCH_CANCEL instead
      */
     public static TOUCH = 'touch';
     /**
@@ -70,7 +70,7 @@ export default class Event {
      * @zh
      * 鼠标事件类型。
      *
-     * @deprecated since v3.3, please use SystemEvent.EventType.MOUSE_DOWN, SystemEvent.EventType.MOUSE_MOVE, SystemEvent.EventType.MOUSE_UP, SystemEvent.EventType.MOUSE_WHEEL, Node.EventType.MOUSE_ENTER and Node.EventType.MOUSE_LEAVE instead
+     * @deprecated since v3.3, please use SystemEvent.MouseEvent.MOUSE_DOWN, SystemEvent.MouseEvent.MOUSE_MOVE, SystemEvent.MouseEvent.MOUSE_UP, SystemEvent.MouseEvent.MOUSE_WHEEL, Node.EventType.MOUSE_ENTER and Node.EventType.MOUSE_LEAVE instead
      */
     public static MOUSE = 'mouse';
     /**
@@ -80,7 +80,7 @@ export default class Event {
      * @zh
      * 键盘事件类型。
      *
-     * @deprecated since v3.3, please use SystemEvent.EventType.KEYBOARD_DOWN and SystemEvent.EventType.KEYBOARD_UP instead
+     * @deprecated since v3.3, please use SystemEvent.KeyboardEvent.KEY_DOWN and SystemEvent.KeyboardEvent.KEY_UP instead
      */
     public static KEYBOARD = 'keyboard';
     /**
@@ -90,7 +90,7 @@ export default class Event {
      * @zh
      * 加速器事件类型。
      *
-     * @deprecated since v3.3, please use SystemEvent.EventType.DEVICEMOTION instead
+     * @deprecated since v3.3, please use SystemEvent.DeviceEvent.DEVICEMOTION instead
      */
     public static ACCELERATION = 'acceleration';
 

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -24,7 +24,7 @@
  */
 
 import { removeProperty, replaceProperty } from '../utils';
-import { EventMouse, EventTouch, SystemEvent } from './event-manager';
+import { EventMouse, EventTouch, SystemEvent, SystemEventType } from './event-manager';
 import { sys } from './sys';
 import { View } from './view';
 
@@ -161,3 +161,22 @@ removeProperty(sys, 'sys',
         'WINRT', 'WP8', 'QQ_PLAY', 'FB_PLAYABLE_ADS'].map((item) => ({
         name: item,
     })));
+
+// deprecate KEY event
+replaceProperty(SystemEventType, 'SystemEventType', [
+    {
+        name: 'KEY_DOWN',
+        newName: 'KEYBOARD_DOWN',
+        suggest: 'the KEY_DOWN event will be continuously dispatched in the key pressed state, it\'s not a good API design for developers.',
+        customGetter () {
+            return 'keydown';
+        },
+    },
+    {
+        name: 'KEY_UP',
+        newName: 'KEYBOARD_UP',
+        customGetter () {
+            return 'keyup';
+        },
+    },
+]);

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -132,6 +132,7 @@ replaceProperty(EventTouch, 'EventTouch', [
 replaceProperty(EventTouch.prototype, 'EventTouch.prototype', [
     {
         name: 'getEventCode',
+        newName: 'type',
         customFunction () {
             // @ts-expect-error this points to an EventTouch instance.
             return this.type as SystemEventType;

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -24,7 +24,8 @@
  */
 
 import { removeProperty, replaceProperty } from '../utils';
-import { EventMouse, EventTouch, SystemEvent, SystemEventType } from './event-manager';
+import { Event } from '../event';
+import { EventKeyboard, EventMouse, EventTouch, SystemEvent, SystemEventType } from './event-manager';
 import { sys } from './sys';
 import { View } from './view';
 
@@ -39,7 +40,40 @@ removeProperty(View.prototype, 'View.prototype', [
     },
 ]);
 
-// depracate EventMouse static property
+// deprecate Event property
+replaceProperty(Event, 'Event', [
+    {
+        name: 'NO_TYPE',
+        target: SystemEvent.EventType,
+        targetName: 'SystemEvent.EventType',
+    },
+    {
+        name: 'ACCELERATION',
+        newName: 'DEVICEMOTION',
+        target: SystemEvent.EventType,
+        targetName: 'SystemEvent.EventType',
+    },
+    {
+        name: 'TOUCH',
+        customGetter () {
+            return 'touch';
+        },
+    },
+    {
+        name: 'MOUSE',
+        customGetter () {
+            return 'mouse';
+        },
+    },
+    {
+        name: 'KEYBOARD',
+        customGetter () {
+            return 'keyboard';
+        },
+    },
+]);
+
+// depracate EventMouse property
 replaceProperty(EventMouse, 'EventMouse',
     ['DOWN', 'UP', 'MOVE'].map((item) => ({
         name: item,
@@ -55,8 +89,14 @@ replaceProperty(EventMouse, 'EventMouse', [
         targetName: 'SystemEvent.EventType',
     },
 ]);
+replaceProperty(EventMouse.prototype, 'EventMouse.prototype', [
+    {
+        name: 'eventType',
+        newName: 'type',
+    },
+]);
 
-// depracate EventTouch static property
+// depracate EventTouch property
 replaceProperty(EventTouch, 'EventTouch', [
     {
         name: 'BEGAN',
@@ -87,6 +127,27 @@ replaceProperty(EventTouch, 'EventTouch', [
         newName: 'TOUCH_CANCEL',
         target: SystemEvent.EventType,
         targetName: 'SystemEvent.EventType',
+    },
+]);
+replaceProperty(EventTouch.prototype, 'EventTouch.prototype', [
+    {
+        name: 'getEventCode',
+        customFunction () {
+            // @ts-expect-error this points to an EventTouch instance.
+            return this.type as SystemEventType;
+        },
+    },
+]);
+
+// deprecated EventKeyboard property
+replaceProperty(EventKeyboard.prototype, 'EventKeyboard.prototype', [
+    {
+        name: 'isPressed',
+        suggest: 'use Event.prototype.type !== SystemEventType.KEYBOARD_UP instead',
+        customGetter () {
+            // @ts-expect-error this points to an EventKeyboard intance.
+            return this.type !== SystemEventType.KEYBOARD_UP;
+        },
     },
 ]);
 

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -134,14 +134,10 @@ markAsWarning(EventTouch.prototype, 'EventTouch.prototype', [
 ]);
 
 // deprecated EventKeyboard property
-replaceProperty(EventKeyboard.prototype, 'EventKeyboard.prototype', [
+markAsWarning(EventKeyboard.prototype, 'EventKeyboard.prototype', [
     {
         name: 'isPressed',
-        suggest: 'use Event.prototype.type !== SystemEventType.KEYBOARD_UP instead',
-        customGetter () {
-            // @ts-expect-error this points to an EventKeyboard intance.
-            return this.type !== SystemEventType.KEYBOARD_UP;
-        },
+        suggest: 'use EventKeyboard.prototype.type !== SystemEventType.KEYBOARD_UP instead',
     },
 ]);
 

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -45,14 +45,14 @@ removeProperty(View.prototype, 'View.prototype', [
 replaceProperty(Event, 'Event', [
     {
         name: 'NO_TYPE',
-        target: SystemEvent.EventType,
-        targetName: 'SystemEvent.EventType',
+        target: SystemEventType,
+        targetName: 'SystemEventType',
     },
     {
         name: 'ACCELERATION',
         newName: 'DEVICEMOTION',
-        target: SystemEvent.EventType,
-        targetName: 'SystemEvent.EventType',
+        target: SystemEvent.DeviceEvent,
+        targetName: 'SystemEvent.DeviceEvent',
     },
 ]);
 
@@ -76,15 +76,15 @@ replaceProperty(EventMouse, 'EventMouse',
     ['DOWN', 'UP', 'MOVE'].map((item) => ({
         name: item,
         newName: `MOUSE_${item}`,
-        target: SystemEvent.EventType,
-        targetName: 'SystemEvent.EventType',
+        target: SystemEvent.MouseEvent,
+        targetName: 'SystemEvent.MouseEvent',
     })));
 replaceProperty(EventMouse, 'EventMouse', [
     {
         name: 'SCROLL',
         newName: 'MOUSE_WHEEL',
-        target: SystemEvent.EventType,
-        targetName: 'SystemEvent.EventType',
+        target: SystemEvent.MouseEvent,
+        targetName: 'SystemEvent.MouseEvent',
     },
 ]);
 markAsWarning(EventMouse.prototype, 'EventMouse.prototype', [
@@ -99,32 +99,32 @@ replaceProperty(EventTouch, 'EventTouch', [
     {
         name: 'BEGAN',
         newName: 'TOUCH_START',
-        target: SystemEvent.EventType,
-        targetName: 'SystemEvent.EventType',
+        target: SystemEvent.TouchEvent,
+        targetName: 'SystemEvent.TouchEvent',
     },
 ]);
 replaceProperty(EventTouch, 'EventTouch', [
     {
         name: 'MOVED',
         newName: 'TOUCH_MOVE',
-        target: SystemEvent.EventType,
-        targetName: 'SystemEvent.EventType',
+        target: SystemEvent.TouchEvent,
+        targetName: 'SystemEvent.TouchEvent',
     },
 ]);
 replaceProperty(EventTouch, 'EventTouch', [
     {
         name: 'ENDED',
         newName: 'TOUCH_END',
-        target: SystemEvent.EventType,
-        targetName: 'SystemEvent.EventType',
+        target: SystemEvent.TouchEvent,
+        targetName: 'SystemEvent.TouchEvent',
     },
 ]);
 replaceProperty(EventTouch, 'EventTouch', [
     {
         name: 'CANCELLED',
         newName: 'TOUCH_CANCEL',
-        target: SystemEvent.EventType,
-        targetName: 'SystemEvent.EventType',
+        target: SystemEvent.TouchEvent,
+        targetName: 'SystemEvent.TouchEvent',
     },
 ]);
 markAsWarning(EventTouch.prototype, 'EventTouch.prototype', [

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -28,6 +28,7 @@ import { Event } from '../event';
 import { EventKeyboard, EventMouse, EventTouch, SystemEvent, SystemEventType } from './event-manager';
 import { sys } from './sys';
 import { View } from './view';
+import { Node } from '../scene-graph';
 
 removeProperty(View.prototype, 'View.prototype', [
     {
@@ -137,7 +138,7 @@ markAsWarning(EventTouch.prototype, 'EventTouch.prototype', [
 markAsWarning(EventKeyboard.prototype, 'EventKeyboard.prototype', [
     {
         name: 'isPressed',
-        suggest: 'use EventKeyboard.prototype.type !== SystemEventType.KEYBOARD_UP instead',
+        suggest: 'use EventKeyboard.prototype.type !== SystemEvent.KeyboardEvent.KEY_UP instead',
     },
 ]);
 
@@ -214,20 +215,33 @@ removeProperty(sys, 'sys',
     })));
 
 // deprecate KEY event
-replaceProperty(SystemEventType, 'SystemEventType', [
+markAsWarning(SystemEventType, 'SystemEventType', [
     {
         name: 'KEY_DOWN',
-        newName: 'KEYBOARD_DOWN',
-        suggest: 'the KEY_DOWN event will be continuously dispatched in the key pressed state, it\'s not a good API design for developers.',
-        customGetter () {
-            return 'keydown';
-        },
+        suggest: 'please use SystemEvent.KeyboardEvent.KEY_DOWN instead. The SystemEventType.KEY_DOWN event will be continuously dispatched in the key pressed state, it\'s not a good API design for developers.',
     },
     {
         name: 'KEY_UP',
-        newName: 'KEYBOARD_UP',
-        customGetter () {
-            return 'keyup';
-        },
+        suggest: 'please use SystemEvent.KeyboardEvent.KEY_UP instead.',
     },
 ]);
+
+replaceProperty(SystemEventType, 'SystemEventType', [
+    'MOUSE_ENTER',
+    'MOUSE_LEAVE',
+    'TRANSFORM_CHANGED',
+    'SCENE_CHANGED_FOR_PERSISTS',
+    'SIZE_CHANGED',
+    'ANCHOR_CHANGED',
+    'COLOR_CHANGED',
+    'CHILD_ADDED',
+    'CHILD_REMOVED',
+    'PARENT_CHANGED',
+    'NODE_DESTROYED',
+    'LAYER_CHANGED',
+    'SIBLING_ORDER_CHANGED',
+].map((name: string) => ({
+    name,
+    target: Node.EventType,
+    targetName: 'Node.EventType',
+})));

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -59,15 +59,15 @@ replaceProperty(Event, 'Event', [
 markAsWarning(Event, 'Event', [
     {
         name: 'TOUCH',
-        suggest: 'please use SystemEvent.EventType.TOUCH_START, SystemEvent.EventType.TOUCH_MOVE, SystemEvent.EventType.TOUCH_END and SystemEvent.EventType.TOUCH_CANCEL instead',
+        suggest: 'please use SystemEvent.TouchEvent.TOUCH_START, SystemEvent.TouchEvent.TOUCH_MOVE, SystemEvent.TouchEvent.TOUCH_END and SystemEvent.TouchEvent.TOUCH_CANCEL instead',
     },
     {
         name: 'MOUSE',
-        suggest: 'please use SystemEvent.EventType.MOUSE_DOWN, SystemEvent.EventType.MOUSE_MOVE, SystemEvent.EventType.MOUSE_UP, SystemEvent.EventType.MOUSE_WHEEL, Node.EventType.MOUSE_ENTER and Node.EventType.MOUSE_LEAVE instead',
+        suggest: 'please use SystemEvent.MouseEvent.MOUSE_DOWN, SystemEvent.MouseEvent.MOUSE_MOVE, SystemEvent.MouseEvent.MOUSE_UP, SystemEvent.MouseEvent.MOUSE_WHEEL, Node.EventType.MOUSE_ENTER and Node.EventType.MOUSE_LEAVE instead',
     },
     {
         name: 'KEYBOARD',
-        suggest: 'please use SystemEvent.EventType.KEYBOARD_DOWN and SystemEvent.EventType.KEYBOARD_UP instead',
+        suggest: 'please use SystemEvent.KeyboardEvent.KEY_DOWN and SystemEvent.KeyboardEvent.KEY_UP instead',
     },
 ]);
 

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -126,14 +126,10 @@ replaceProperty(EventTouch, 'EventTouch', [
         targetName: 'SystemEvent.EventType',
     },
 ]);
-replaceProperty(EventTouch.prototype, 'EventTouch.prototype', [
+markAsWarning(EventTouch.prototype, 'EventTouch.prototype', [
     {
         name: 'getEventCode',
-        newName: 'type',
-        customFunction () {
-            // @ts-expect-error this points to an EventTouch instance.
-            return this.type as SystemEventType;
-        },
+        suggest: 'please use EventTouch.prototype.type instead',
     },
 ]);
 

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -245,3 +245,21 @@ replaceProperty(SystemEventType, 'SystemEventType', [
     target: Node.EventType,
     targetName: 'Node.EventType',
 })));
+
+replaceProperty(Node.EventType, 'Node.EventType', [
+    {
+        name: 'DEVICEMOTION',
+        target: SystemEventType,
+        targetName: 'SystemEventType',
+    },
+    {
+        name: 'KEY_DOWN',
+        target: SystemEventType,
+        targetName: 'SystemEventType',
+    },
+    {
+        name: 'KEY_UP',
+        target: SystemEventType,
+        targetName: 'SystemEventType',
+    },
+]);

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -86,10 +86,10 @@ replaceProperty(EventMouse, 'EventMouse', [
         targetName: 'SystemEvent.EventType',
     },
 ]);
-replaceProperty(EventMouse.prototype, 'EventMouse.prototype', [
+markAsWarning(EventMouse.prototype, 'EventMouse.prototype', [
     {
         name: 'eventType',
-        newName: 'type',
+        suggest: 'please use EventMouse.prototype.type instead',
     },
 ]);
 

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -23,7 +23,7 @@
  THE SOFTWARE.
  */
 
-import { removeProperty, replaceProperty } from '../utils';
+import { markAsWarning, removeProperty, replaceProperty } from '../utils';
 import { Event } from '../event';
 import { EventKeyboard, EventMouse, EventTouch, SystemEvent, SystemEventType } from './event-manager';
 import { sys } from './sys';
@@ -53,23 +53,20 @@ replaceProperty(Event, 'Event', [
         target: SystemEvent.EventType,
         targetName: 'SystemEvent.EventType',
     },
+]);
+
+markAsWarning(Event, 'Event', [
     {
         name: 'TOUCH',
-        customGetter () {
-            return 'touch';
-        },
+        suggest: 'please use SystemEvent.EventType.TOUCH_START, SystemEvent.EventType.TOUCH_MOVE, SystemEvent.EventType.TOUCH_END and SystemEvent.EventType.TOUCH_CANCEL instead',
     },
     {
         name: 'MOUSE',
-        customGetter () {
-            return 'mouse';
-        },
+        suggest: 'please use SystemEvent.EventType.MOUSE_DOWN, SystemEvent.EventType.MOUSE_MOVE, SystemEvent.EventType.MOUSE_UP, SystemEvent.EventType.MOUSE_WHEEL, Node.EventType.MOUSE_ENTER and Node.EventType.MOUSE_LEAVE instead',
     },
     {
         name: 'KEYBOARD',
-        customGetter () {
-            return 'keyboard';
-        },
+        suggest: 'please use SystemEvent.EventType.KEYBOARD_DOWN and SystemEvent.EventType.KEYBOARD_UP instead',
     },
 ]);
 

--- a/cocos/core/platform/event-manager/event-enum.ts
+++ b/cocos/core/platform/event-manager/event-enum.ts
@@ -125,14 +125,16 @@ export enum SystemEventType {
     MOUSE_LEAVE = 'mouse-leave',
 
     /**
-     * @en The event type for press the key down event
-     * @zh 当按下按键时触发的事件
+     * @en The event type for press the key down event, the event will be continuously dispatched in the key pressed state
+     * @zh 当按下按键时触发的事件, 该事件在按下状态会持续派发
+     * @deprecated since v3.1.1
      */
     KEY_DOWN = 'keydown',
 
     /**
      * @en The event type for press the key up event
      * @zh 当松开按键时触发的事件
+     * @deprecated since v3.1.1
      */
     KEY_UP = 'keyup',
 

--- a/cocos/core/platform/event-manager/event-enum.ts
+++ b/cocos/core/platform/event-manager/event-enum.ts
@@ -136,14 +136,14 @@ export enum SystemEventType {
     /**
      * @en The event type for press the key down event, the event will be continuously dispatched in the key pressed state
      * @zh 当按下按键时触发的事件, 该事件在按下状态会持续派发
-     * @deprecated since v3.1.1
+     * @deprecated since v3.1.1, please use KEYBOARD_DOWN instead
      */
     KEY_DOWN = 'keydown',
 
     /**
      * @en The event type for press the key up event
      * @zh 当松开按键时触发的事件
-     * @deprecated since v3.1.1
+     * @deprecated since v3.1.1, please use KEYBOARD_UP instead
      */
     KEY_UP = 'keyup',
 

--- a/cocos/core/platform/event-manager/event-enum.ts
+++ b/cocos/core/platform/event-manager/event-enum.ts
@@ -37,7 +37,7 @@ import { legacyCC } from '../../global-exports';
 export enum SystemEventType {
     /**
      * @en
-     * The event type for touch start event, you can use its value directly: 'touchstart'.
+     * The event type for touch start event
      *
      * @zh
      * 手指开始触摸事件。
@@ -46,7 +46,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for touch move event, you can use its value directly: 'touchmove'.
+     * The event type for touch move event
      *
      * @zh
      * 当手指在屏幕上移动时。
@@ -55,7 +55,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for touch end event, you can use its value directly: 'touchend'.
+     * The event type for touch end event
      *
      * @zh
      * 手指结束触摸事件。
@@ -64,7 +64,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for touch end event, you can use its value directly: 'touchcancel'.
+     * The event type for touch end event
      *
      * @zh
      * 当手指在目标节点区域外离开屏幕时。
@@ -73,7 +73,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for mouse down events, you can use its value directly: 'mousedown'.
+     * The event type for mouse down events
      *
      * @zh
      * 当鼠标按下时触发一次。
@@ -82,7 +82,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for mouse move events, you can use its value directly: 'mousemove'.
+     * The event type for mouse move events
      *
      * @zh
      * 当鼠标在目标节点在目标节点区域中移动时，不论是否按下。
@@ -91,7 +91,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for mouse up events, you can use its value directly: 'mouseup'.
+     * The event type for mouse up events
      *
      * @zh
      * 当鼠标从按下状态松开时触发一次。
@@ -100,7 +100,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for mouse wheel events, you can use its value directly: 'mousewheel'.
+     * The event type for mouse wheel events
      *
      * @zh 手指开始触摸事件
      */
@@ -108,7 +108,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for mouse leave target events, you can use its value directly: 'mouseleave'.
+     * The event type for mouse leave target events
      *
      * @zh
      * 当鼠标移入目标节点区域时，不论是否按下.
@@ -117,7 +117,7 @@ export enum SystemEventType {
 
     /**
      * @en
-     * The event type for mouse leave target events, you can use its value directly: 'mouseleave'.
+     * The event type for mouse leave target events
      *
      * @zh
      * 当鼠标移出目标节点区域时，不论是否按下。
@@ -125,20 +125,20 @@ export enum SystemEventType {
     MOUSE_LEAVE = 'mouse-leave',
 
     /**
-     * @en The event type for press the key down event, you can use its value directly: 'keydown'
+     * @en The event type for press the key down event
      * @zh 当按下按键时触发的事件
      */
     KEY_DOWN = 'keydown',
 
     /**
-     * @en The event type for press the key up event, you can use its value directly: 'keyup'
+     * @en The event type for press the key up event
      * @zh 当松开按键时触发的事件
      */
     KEY_UP = 'keyup',
 
     /**
      * @en
-     * The event type for press the devicemotion event, you can use its value directly: 'devicemotion'
+     * The event type for press the devicemotion event
      *
      * @zh
      * 重力感应

--- a/cocos/core/platform/event-manager/event-enum.ts
+++ b/cocos/core/platform/event-manager/event-enum.ts
@@ -37,6 +37,15 @@ import { legacyCC } from '../../global-exports';
 export enum SystemEventType {
     /**
      * @en
+     * Code for event without type.
+     *
+     * @zh
+     * 没有类型的事件。
+     */
+    NO_TYPE = 'no_type',
+
+    /**
+     * @en
      * The event type for touch start event
      *
      * @zh

--- a/cocos/core/platform/event-manager/event-enum.ts
+++ b/cocos/core/platform/event-manager/event-enum.ts
@@ -139,6 +139,18 @@ export enum SystemEventType {
     KEY_UP = 'keyup',
 
     /**
+     * @en The event type for press the key down event
+     * @zh 当按下按键时触发的事件
+     */
+    KEYBOARD_DOWN = 'keyboarddown',  // NOTE: different value with KEY_DOWN event
+
+     /**
+      * @en The event type for press the key up event
+      * @zh 当松开按键时触发的事件
+      */
+    KEYBOARD_UP = 'keyup',  // NOTE: same value with KEY_UP event
+
+    /**
      * @en
      * The event type for press the devicemotion event
      *

--- a/cocos/core/platform/event-manager/event-enum.ts
+++ b/cocos/core/platform/event-manager/event-enum.ts
@@ -136,14 +136,14 @@ export enum SystemEventType {
     /**
      * @en The event type for press the key down event, the event will be continuously dispatched in the key pressed state
      * @zh 当按下按键时触发的事件, 该事件在按下状态会持续派发
-     * @deprecated since v3.1.1, please use KEYBOARD_DOWN instead
+     * @deprecated since v3.3, please use KEYBOARD_DOWN instead
      */
     KEY_DOWN = 'keydown',
 
     /**
      * @en The event type for press the key up event
      * @zh 当松开按键时触发的事件
-     * @deprecated since v3.1.1, please use KEYBOARD_UP instead
+     * @deprecated since v3.3, please use KEYBOARD_UP instead
      */
     KEY_UP = 'keyup',
 

--- a/cocos/core/platform/event-manager/event-enum.ts
+++ b/cocos/core/platform/event-manager/event-enum.ts
@@ -39,7 +39,7 @@ export enum TouchEvent {
      * @zh
      * 手指开始触摸事件。
      */
-     TOUCH_START = 'touch-start',
+    TOUCH_START = 'touch-start',
 
      /**
       * @en
@@ -48,7 +48,7 @@ export enum TouchEvent {
       * @zh
       * 当手指在屏幕上移动时。
       */
-     TOUCH_MOVE = 'touch-move',
+    TOUCH_MOVE = 'touch-move',
 
      /**
       * @en
@@ -57,7 +57,7 @@ export enum TouchEvent {
       * @zh
       * 手指结束触摸事件。
       */
-     TOUCH_END = 'touch-end',
+    TOUCH_END = 'touch-end',
 
      /**
       * @en
@@ -66,44 +66,44 @@ export enum TouchEvent {
       * @zh
       * 当手指在目标节点区域外离开屏幕时。
       */
-     TOUCH_CANCEL = 'touch-cancel',
+    TOUCH_CANCEL = 'touch-cancel',
 }
 
 export enum MouseEvent {
-  /**
-   * @en
-   * The event type for mouse down events
-   *
-   * @zh
-   * 当鼠标按下时触发一次。
-   */
-  MOUSE_DOWN = 'mouse-down',
+    /**
+     * @en
+     * The event type for mouse down events
+     *
+     * @zh
+     * 当鼠标按下时触发一次。
+     */
+    MOUSE_DOWN = 'mouse-down',
 
-  /**
-   * @en
-   * The event type for mouse move events
-   *
-   * @zh
-   * 当鼠标在目标节点在目标节点区域中移动时，不论是否按下。
-   */
-  MOUSE_MOVE = 'mouse-move',
+    /**
+     * @en
+     * The event type for mouse move events
+     *
+     * @zh
+     * 当鼠标在目标节点在目标节点区域中移动时，不论是否按下。
+     */
+    MOUSE_MOVE = 'mouse-move',
 
-  /**
-   * @en
-   * The event type for mouse up events
-   *
-   * @zh
-   * 当鼠标从按下状态松开时触发一次。
-   */
-  MOUSE_UP = 'mouse-up',
+    /**
+     * @en
+     * The event type for mouse up events
+     *
+     * @zh
+     * 当鼠标从按下状态松开时触发一次。
+     */
+    MOUSE_UP = 'mouse-up',
 
-  /**
-   * @en
-   * The event type for mouse wheel events
-   *
-   * @zh 手指开始触摸事件
-   */
-  MOUSE_WHEEL = 'mouse-wheel',
+    /**
+     * @en
+     * The event type for mouse wheel events
+     *
+     * @zh 手指开始触摸事件
+     */
+    MOUSE_WHEEL = 'mouse-wheel',
 }
 
 export enum KeyboardEvent {
@@ -111,7 +111,7 @@ export enum KeyboardEvent {
      * @en The event type for press the key down event
      * @zh 当按下按键时触发的事件
      */
-     KEY_DOWN = 'keyboarddown',  // NOTE: different value with SystemEventType.KEY_DOWN
+    KEY_DOWN = 'keyboarddown',  // NOTE: different value with SystemEventType.KEY_DOWN
 
      /**
       * @en The event type for press the key up event
@@ -128,9 +128,9 @@ export enum DeviceEvent {
      * @zh
      * 重力感应
      */
-     DEVICEMOTION = 'devicemotion',
+    DEVICEMOTION = 'devicemotion',
 
-     // TODO: add resize, orientation changed event
+    // TODO: add resize, orientation changed event
 }
 
 /**

--- a/cocos/core/platform/event-manager/event-listener.ts
+++ b/cocos/core/platform/event-manager/event-listener.ts
@@ -497,8 +497,9 @@ export class AccelerationEventListener extends EventListener {
 
 // Keyboard
 export class KeyboardEventListener extends EventListener {
-    public onKeyPressed: Function | null = null;
-    public onKeyReleased: Function | null = null;
+    public onKeyDown?: Function = undefined;
+    public onKeyPressed?: Function = undefined;  // deprecated
+    public onKeyReleased?: Function = undefined;
 
     constructor () {
         super(EventListener.KEYBOARD, ListenerID.KEYBOARD, null);
@@ -506,24 +507,31 @@ export class KeyboardEventListener extends EventListener {
     }
 
     public _callback (event: EventKeyboard) {
-        if (event.isPressed) {
-            if (this.onKeyPressed) {
-                this.onKeyPressed(event.keyCode, event);
-            }
-        } else if (this.onKeyReleased) {
-            this.onKeyReleased(event.keyCode, event);
+        switch (event.type) {
+        case SystemEventType.KEYBOARD_DOWN:
+            this.onKeyDown?.(event.keyCode, event);
+            break;
+        case 'keydown':  // SystemEventType.KEY_DOWN
+            this.onKeyPressed?.(event.keyCode, event);
+            break;
+        case SystemEventType.KEYBOARD_UP:
+            this.onKeyReleased?.(event.keyCode, event);
+            break;
+        default:
+            break;
         }
     }
 
     public clone () {
         const eventListener = new KeyboardEventListener();
+        eventListener.onKeyDown = this.onKeyDown;
         eventListener.onKeyPressed = this.onKeyPressed;
         eventListener.onKeyReleased = this.onKeyReleased;
         return eventListener;
     }
 
     public checkAvailable () {
-        if (this.onKeyPressed === null && this.onKeyReleased === null) {
+        if (this.onKeyDown === null && this.onKeyPressed === null && this.onKeyReleased === null) {
             logID(1800);
             return false;
         }

--- a/cocos/core/platform/event-manager/event-listener.ts
+++ b/cocos/core/platform/event-manager/event-listener.ts
@@ -360,7 +360,7 @@ export class MouseEventListener extends EventListener {
     }
 
     public _callback (event: EventMouse) {
-        switch (event.eventType) {
+        switch (event.type) {
         case SystemEventType.MOUSE_DOWN:
             if (this.onMouseDown) {
                 this.onMouseDown(event);

--- a/cocos/core/platform/event-manager/event-listener.ts
+++ b/cocos/core/platform/event-manager/event-listener.ts
@@ -34,7 +34,7 @@ import { EventKeyboard, EventAcceleration, EventMouse } from './events';
 import { Component } from '../../components';
 import { legacyCC } from '../../global-exports';
 import { logID, assertID } from '../debug';
-import { SystemEventType } from './event-enum';
+import { SystemEvent } from './system-event';
 
 export interface IEventListenerCreateInfo {
     event?: number;
@@ -361,22 +361,22 @@ export class MouseEventListener extends EventListener {
 
     public _callback (event: EventMouse) {
         switch (event.type) {
-        case SystemEventType.MOUSE_DOWN:
+        case SystemEvent.MouseEvent.MOUSE_DOWN:
             if (this.onMouseDown) {
                 this.onMouseDown(event);
             }
             break;
-        case SystemEventType.MOUSE_UP:
+        case SystemEvent.MouseEvent.MOUSE_UP:
             if (this.onMouseUp) {
                 this.onMouseUp(event);
             }
             break;
-        case SystemEventType.MOUSE_MOVE:
+        case SystemEvent.MouseEvent.MOUSE_MOVE:
             if (this.onMouseMove) {
                 this.onMouseMove(event);
             }
             break;
-        case SystemEventType.MOUSE_WHEEL:
+        case SystemEvent.MouseEvent.MOUSE_WHEEL:
             if (this.onMouseScroll) {
                 this.onMouseScroll(event);
             }
@@ -508,13 +508,13 @@ export class KeyboardEventListener extends EventListener {
 
     public _callback (event: EventKeyboard) {
         switch (event.type) {
-        case SystemEventType.KEYBOARD_DOWN:
+        case SystemEvent.KeyboardEvent.KEY_DOWN:
             this.onKeyDown?.(event.keyCode, event);
             break;
         case 'keydown':  // SystemEventType.KEY_DOWN
             this.onKeyPressed?.(event.keyCode, event);
             break;
-        case SystemEventType.KEYBOARD_UP:
+        case SystemEvent.KeyboardEvent.KEY_UP:
             this.onKeyReleased?.(event.keyCode, event);
             break;
         default:

--- a/cocos/core/platform/event-manager/event-listener.ts
+++ b/cocos/core/platform/event-manager/event-listener.ts
@@ -35,6 +35,7 @@ import { Component } from '../../components';
 import { legacyCC } from '../../global-exports';
 import { logID, assertID } from '../debug';
 import { SystemEvent } from './system-event';
+import { KeyboardEvent, MouseEvent } from './event-enum';
 
 export interface IEventListenerCreateInfo {
     event?: number;
@@ -361,22 +362,22 @@ export class MouseEventListener extends EventListener {
 
     public _callback (event: EventMouse) {
         switch (event.type) {
-        case SystemEvent.MouseEvent.MOUSE_DOWN:
+        case MouseEvent.MOUSE_DOWN:
             if (this.onMouseDown) {
                 this.onMouseDown(event);
             }
             break;
-        case SystemEvent.MouseEvent.MOUSE_UP:
+        case MouseEvent.MOUSE_UP:
             if (this.onMouseUp) {
                 this.onMouseUp(event);
             }
             break;
-        case SystemEvent.MouseEvent.MOUSE_MOVE:
+        case MouseEvent.MOUSE_MOVE:
             if (this.onMouseMove) {
                 this.onMouseMove(event);
             }
             break;
-        case SystemEvent.MouseEvent.MOUSE_WHEEL:
+        case MouseEvent.MOUSE_WHEEL:
             if (this.onMouseScroll) {
                 this.onMouseScroll(event);
             }
@@ -508,13 +509,13 @@ export class KeyboardEventListener extends EventListener {
 
     public _callback (event: EventKeyboard) {
         switch (event.type) {
-        case SystemEvent.KeyboardEvent.KEY_DOWN:
+        case KeyboardEvent.KEY_DOWN:
             this.onKeyDown?.(event.keyCode, event);
             break;
         case 'keydown':  // SystemEventType.KEY_DOWN
             this.onKeyPressed?.(event.keyCode, event);
             break;
-        case SystemEvent.KeyboardEvent.KEY_UP:
+        case KeyboardEvent.KEY_UP:
             this.onKeyReleased?.(event.keyCode, event);
             break;
         default:

--- a/cocos/core/platform/event-manager/event-manager.ts
+++ b/cocos/core/platform/event-manager/event-manager.ts
@@ -47,6 +47,10 @@ function checkUINode (node) {
     return false;
 }
 
+const touchEvents = [SystemEventType.TOUCH_START, SystemEventType.TOUCH_MOVE, SystemEventType.TOUCH_END, SystemEventType.TOUCH_CANCEL];
+const mouseEvents = [SystemEventType.MOUSE_DOWN, SystemEventType.MOUSE_MOVE, SystemEventType.MOUSE_DOWN, SystemEventType.MOUSE_WHEEL];
+const keyboardEvents = [SystemEventType.KEYBOARD_DOWN, SystemEventType.KEYBOARD_UP, 'keydown'];
+
 class _EventListenerVector {
     public gt0Index = 0;
     private _fixedListeners: EventListener[] = [];
@@ -91,18 +95,17 @@ class _EventListenerVector {
 }
 
 function __getListenerID (event: Event) {
-    const eventType = Event;
     const type = event.type;
-    if (type === eventType.ACCELERATION) {
+    if (type === SystemEventType.DEVICEMOTION) {
         return ListenerID.ACCELERATION;
     }
-    if (type === eventType.KEYBOARD) {
+    if (keyboardEvents.includes(type)) {
         return ListenerID.KEYBOARD;
     }
-    if (type.startsWith(eventType.MOUSE)) {
+    if (mouseEvents.includes(type)) {
         return ListenerID.MOUSE;
     }
-    if (type.startsWith(eventType.TOUCH)) {
+    if (touchEvents.includes(type)) {
         // Touch listener is very special, it contains two kinds of listeners:
         // EventListenerTouchOneByOne and EventListenerTouchAllAtOnce.
         // return UNKNOWN instead.
@@ -569,7 +572,7 @@ class EventManager {
             errorID(3511);
             return;
         }
-        if (event.getType().startsWith(legacyCC.Event.TOUCH)) {
+        if (touchEvents.includes(event.getType())) {
             this._dispatchTouchEvent(event as EventTouch);
             this._inDispatch--;
             return;

--- a/cocos/core/platform/event-manager/event-manager.ts
+++ b/cocos/core/platform/event-manager/event-manager.ts
@@ -952,8 +952,8 @@ class EventManager {
 
         let isClaimed = false;
         let removedIdx = -1;
-        const eventCode = event.getEventCode();
-        if (eventCode === SystemEventType.TOUCH_START) {
+        const eventType = event.type;
+        if (eventType === SystemEventType.TOUCH_START) {
             if (!macro.ENABLE_MULTI_TOUCH && eventManager._currentTouch) {
                 const node = eventManager._currentTouchListener._node;
                 if (!node || node.activeInHierarchy) {
@@ -978,9 +978,9 @@ class EventManager {
                 if (!macro.ENABLE_MULTI_TOUCH && eventManager._currentTouch && eventManager._currentTouch !== selTouch) {
                     return false;
                 }
-                if (eventCode === SystemEventType.TOUCH_MOVE && listener.onTouchMoved) {
+                if (eventType === SystemEventType.TOUCH_MOVE && listener.onTouchMoved) {
                     listener.onTouchMoved(selTouch, event);
-                } else if (eventCode === SystemEventType.TOUCH_END) {
+                } else if (eventType === SystemEventType.TOUCH_END) {
                     if (listener.onTouchEnded) {
                         listener.onTouchEnded(selTouch, event);
                     }
@@ -993,7 +993,7 @@ class EventManager {
                     }
 
                     eventManager._currentTouchListener = null;
-                } else if (eventCode === SystemEventType.TOUCH_CANCEL) {
+                } else if (eventType === SystemEventType.TOUCH_CANCEL) {
                     if (listener.onTouchCancelled) {
                         listener.onTouchCancelled(selTouch, event);
                     }
@@ -1073,15 +1073,15 @@ class EventManager {
 
         const event = callbackParams.event;
         const touches = callbackParams.touches;
-        const eventCode = event.getEventCode();
+        const eventType = event.type;
         event.currentTarget = listener._getSceneGraphPriority();
-        if (eventCode === SystemEventType.TOUCH_START && listener.onTouchesBegan) {
+        if (eventType === SystemEventType.TOUCH_START && listener.onTouchesBegan) {
             listener.onTouchesBegan(touches, event);
-        } else if (eventCode === SystemEventType.TOUCH_MOVE && listener.onTouchesMoved) {
+        } else if (eventType === SystemEventType.TOUCH_MOVE && listener.onTouchesMoved) {
             listener.onTouchesMoved(touches, event);
-        } else if (eventCode === SystemEventType.TOUCH_END && listener.onTouchesEnded) {
+        } else if (eventType === SystemEventType.TOUCH_END && listener.onTouchesEnded) {
             listener.onTouchesEnded(touches, event);
-        } else if (eventCode === SystemEventType.TOUCH_CANCEL && listener.onTouchesCancelled) {
+        } else if (eventType === SystemEventType.TOUCH_CANCEL && listener.onTouchesCancelled) {
             listener.onTouchesCancelled(touches, event);
         }
 

--- a/cocos/core/platform/event-manager/event-manager.ts
+++ b/cocos/core/platform/event-manager/event-manager.ts
@@ -36,7 +36,7 @@ import { Node } from '../../scene-graph';
 import { macro } from '../macro';
 import { legacyCC } from '../../global-exports';
 import { errorID, warnID, logID, assertID } from '../debug';
-import { SystemEventType } from './event-enum';
+import { SystemEvent } from './system-event';
 
 const ListenerID = EventListener.ListenerID;
 
@@ -47,9 +47,9 @@ function checkUINode (node) {
     return false;
 }
 
-const touchEvents = [SystemEventType.TOUCH_START, SystemEventType.TOUCH_MOVE, SystemEventType.TOUCH_END, SystemEventType.TOUCH_CANCEL];
-const mouseEvents = [SystemEventType.MOUSE_DOWN, SystemEventType.MOUSE_MOVE, SystemEventType.MOUSE_DOWN, SystemEventType.MOUSE_WHEEL];
-const keyboardEvents = [SystemEventType.KEYBOARD_DOWN, SystemEventType.KEYBOARD_UP, 'keydown'];
+const touchEvents: string[] = [SystemEvent.TouchEvent.TOUCH_START, SystemEvent.TouchEvent.TOUCH_MOVE, SystemEvent.TouchEvent.TOUCH_END, SystemEvent.TouchEvent.TOUCH_CANCEL];
+const mouseEvents: string[] = [SystemEvent.MouseEvent.MOUSE_DOWN, SystemEvent.MouseEvent.MOUSE_MOVE, SystemEvent.MouseEvent.MOUSE_DOWN, SystemEvent.MouseEvent.MOUSE_WHEEL];
+const keyboardEvents: string[] = [SystemEvent.KeyboardEvent.KEY_DOWN, SystemEvent.KeyboardEvent.KEY_UP, 'keydown'];
 
 class _EventListenerVector {
     public gt0Index = 0;
@@ -96,7 +96,7 @@ class _EventListenerVector {
 
 function __getListenerID (event: Event) {
     const type = event.type;
-    if (type === SystemEventType.DEVICEMOTION) {
+    if (type === SystemEvent.DeviceEvent.DEVICEMOTION) {
         return ListenerID.ACCELERATION;
     }
     if (keyboardEvents.includes(type)) {
@@ -953,7 +953,7 @@ class EventManager {
         let isClaimed = false;
         let removedIdx = -1;
         const eventType = event.type;
-        if (eventType === SystemEventType.TOUCH_START) {
+        if (eventType === SystemEvent.TouchEvent.TOUCH_START) {
             if (!macro.ENABLE_MULTI_TOUCH && eventManager._currentTouch) {
                 const node = eventManager._currentTouchListener._node;
                 if (!node || node.activeInHierarchy) {
@@ -978,9 +978,9 @@ class EventManager {
                 if (!macro.ENABLE_MULTI_TOUCH && eventManager._currentTouch && eventManager._currentTouch !== selTouch) {
                     return false;
                 }
-                if (eventType === SystemEventType.TOUCH_MOVE && listener.onTouchMoved) {
+                if (eventType === SystemEvent.TouchEvent.TOUCH_MOVE && listener.onTouchMoved) {
                     listener.onTouchMoved(selTouch, event);
-                } else if (eventType === SystemEventType.TOUCH_END) {
+                } else if (eventType === SystemEvent.TouchEvent.TOUCH_END) {
                     if (listener.onTouchEnded) {
                         listener.onTouchEnded(selTouch, event);
                     }
@@ -993,7 +993,7 @@ class EventManager {
                     }
 
                     eventManager._currentTouchListener = null;
-                } else if (eventType === SystemEventType.TOUCH_CANCEL) {
+                } else if (eventType === SystemEvent.TouchEvent.TOUCH_CANCEL) {
                     if (listener.onTouchCancelled) {
                         listener.onTouchCancelled(selTouch, event);
                     }
@@ -1075,13 +1075,13 @@ class EventManager {
         const touches = callbackParams.touches;
         const eventType = event.type;
         event.currentTarget = listener._getSceneGraphPriority();
-        if (eventType === SystemEventType.TOUCH_START && listener.onTouchesBegan) {
+        if (eventType === SystemEvent.TouchEvent.TOUCH_START && listener.onTouchesBegan) {
             listener.onTouchesBegan(touches, event);
-        } else if (eventType === SystemEventType.TOUCH_MOVE && listener.onTouchesMoved) {
+        } else if (eventType === SystemEvent.TouchEvent.TOUCH_MOVE && listener.onTouchesMoved) {
             listener.onTouchesMoved(touches, event);
-        } else if (eventType === SystemEventType.TOUCH_END && listener.onTouchesEnded) {
+        } else if (eventType === SystemEvent.TouchEvent.TOUCH_END && listener.onTouchesEnded) {
             listener.onTouchesEnded(touches, event);
-        } else if (eventType === SystemEventType.TOUCH_CANCEL && listener.onTouchesCancelled) {
+        } else if (eventType === SystemEvent.TouchEvent.TOUCH_CANCEL && listener.onTouchesCancelled) {
             listener.onTouchesCancelled(touches, event);
         }
 

--- a/cocos/core/platform/event-manager/event-manager.ts
+++ b/cocos/core/platform/event-manager/event-manager.ts
@@ -37,6 +37,7 @@ import { macro } from '../macro';
 import { legacyCC } from '../../global-exports';
 import { errorID, warnID, logID, assertID } from '../debug';
 import { SystemEvent } from './system-event';
+import { KeyboardEvent, MouseEvent, TouchEvent } from './event-enum';
 
 const ListenerID = EventListener.ListenerID;
 
@@ -47,9 +48,9 @@ function checkUINode (node) {
     return false;
 }
 
-const touchEvents: string[] = [SystemEvent.TouchEvent.TOUCH_START, SystemEvent.TouchEvent.TOUCH_MOVE, SystemEvent.TouchEvent.TOUCH_END, SystemEvent.TouchEvent.TOUCH_CANCEL];
-const mouseEvents: string[] = [SystemEvent.MouseEvent.MOUSE_DOWN, SystemEvent.MouseEvent.MOUSE_MOVE, SystemEvent.MouseEvent.MOUSE_DOWN, SystemEvent.MouseEvent.MOUSE_WHEEL];
-const keyboardEvents: string[] = [SystemEvent.KeyboardEvent.KEY_DOWN, SystemEvent.KeyboardEvent.KEY_UP, 'keydown'];
+const touchEvents: string[] = [TouchEvent.TOUCH_START, TouchEvent.TOUCH_MOVE, TouchEvent.TOUCH_END, TouchEvent.TOUCH_CANCEL];
+const mouseEvents: string[] = [MouseEvent.MOUSE_DOWN, MouseEvent.MOUSE_MOVE, MouseEvent.MOUSE_DOWN, MouseEvent.MOUSE_WHEEL];
+const keyboardEvents: string[] = [KeyboardEvent.KEY_DOWN, KeyboardEvent.KEY_UP, 'keydown'];
 
 class _EventListenerVector {
     public gt0Index = 0;
@@ -953,7 +954,7 @@ class EventManager {
         let isClaimed = false;
         let removedIdx = -1;
         const eventType = event.type;
-        if (eventType === SystemEvent.TouchEvent.TOUCH_START) {
+        if (eventType === TouchEvent.TOUCH_START) {
             if (!macro.ENABLE_MULTI_TOUCH && eventManager._currentTouch) {
                 const node = eventManager._currentTouchListener._node;
                 if (!node || node.activeInHierarchy) {
@@ -978,9 +979,9 @@ class EventManager {
                 if (!macro.ENABLE_MULTI_TOUCH && eventManager._currentTouch && eventManager._currentTouch !== selTouch) {
                     return false;
                 }
-                if (eventType === SystemEvent.TouchEvent.TOUCH_MOVE && listener.onTouchMoved) {
+                if (eventType === TouchEvent.TOUCH_MOVE && listener.onTouchMoved) {
                     listener.onTouchMoved(selTouch, event);
-                } else if (eventType === SystemEvent.TouchEvent.TOUCH_END) {
+                } else if (eventType === TouchEvent.TOUCH_END) {
                     if (listener.onTouchEnded) {
                         listener.onTouchEnded(selTouch, event);
                     }
@@ -993,7 +994,7 @@ class EventManager {
                     }
 
                     eventManager._currentTouchListener = null;
-                } else if (eventType === SystemEvent.TouchEvent.TOUCH_CANCEL) {
+                } else if (eventType === TouchEvent.TOUCH_CANCEL) {
                     if (listener.onTouchCancelled) {
                         listener.onTouchCancelled(selTouch, event);
                     }
@@ -1075,13 +1076,13 @@ class EventManager {
         const touches = callbackParams.touches;
         const eventType = event.type;
         event.currentTarget = listener._getSceneGraphPriority();
-        if (eventType === SystemEvent.TouchEvent.TOUCH_START && listener.onTouchesBegan) {
+        if (eventType === TouchEvent.TOUCH_START && listener.onTouchesBegan) {
             listener.onTouchesBegan(touches, event);
-        } else if (eventType === SystemEvent.TouchEvent.TOUCH_MOVE && listener.onTouchesMoved) {
+        } else if (eventType === TouchEvent.TOUCH_MOVE && listener.onTouchesMoved) {
             listener.onTouchesMoved(touches, event);
-        } else if (eventType === SystemEvent.TouchEvent.TOUCH_END && listener.onTouchesEnded) {
+        } else if (eventType === TouchEvent.TOUCH_END && listener.onTouchesEnded) {
             listener.onTouchesEnded(touches, event);
-        } else if (eventType === SystemEvent.TouchEvent.TOUCH_CANCEL && listener.onTouchesCancelled) {
+        } else if (eventType === TouchEvent.TOUCH_CANCEL && listener.onTouchesCancelled) {
             listener.onTouchesCancelled(touches, event);
         }
 

--- a/cocos/core/platform/event-manager/event-manager.ts
+++ b/cocos/core/platform/event-manager/event-manager.ts
@@ -36,8 +36,7 @@ import { Node } from '../../scene-graph';
 import { macro } from '../macro';
 import { legacyCC } from '../../global-exports';
 import { errorID, warnID, logID, assertID } from '../debug';
-import { SystemEvent } from './system-event';
-import { KeyboardEvent, MouseEvent, TouchEvent } from './event-enum';
+import { DeviceEvent, KeyboardEvent, MouseEvent, TouchEvent } from './event-enum';
 
 const ListenerID = EventListener.ListenerID;
 
@@ -97,7 +96,7 @@ class _EventListenerVector {
 
 function __getListenerID (event: Event) {
     const type = event.type;
-    if (type === SystemEvent.DeviceEvent.DEVICEMOTION) {
+    if (type === DeviceEvent.DEVICEMOTION) {
         return ListenerID.ACCELERATION;
     }
     if (keyboardEvents.includes(type)) {

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -391,10 +391,10 @@ export class EventTouch extends Event {
      * @param bubbles - Indicate whether the event bubbles up through the hierarchy or not.
      * @param eventType - The type of the event
      */
-    constructor (changedTouches: Touch[], bubbles: boolean, eventType: SystemEventType, touches: Touch[]) {
+    constructor (changedTouches: Touch[], bubbles: boolean, eventType: SystemEventType, touches: Touch[] = []) {
         super(eventType, bubbles);
         this._touches = changedTouches || [];
-        this._allTouches = touches || [];
+        this._allTouches = touches;
     }
 
     /**

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -382,6 +382,8 @@ export class EventTouch extends Event {
      */
     public simulate = false;
 
+    private _eventCode: SystemEventType;  // deprecated since v3.3
+
     private _touches: Touch[];
 
     private _allTouches: Touch[];
@@ -393,8 +395,19 @@ export class EventTouch extends Event {
      */
     constructor (changedTouches: Touch[], bubbles: boolean, eventType: SystemEventType, touches: Touch[] = []) {
         super(eventType, bubbles);
+        this._eventCode = eventType;
         this._touches = changedTouches || [];
         this._allTouches = touches;
+    }
+
+    /**
+     * @en Returns event type code.
+     * @zh 获取触摸事件类型。
+     *
+     * @deprecated since v3.3, please use EventTouch.prototype.type instead.
+     */
+    public getEventCode () {
+        return this._eventCode;
     }
 
     /**

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -621,7 +621,7 @@ export class EventKeyboard extends Event {
      * @en Indicates whether the current key is being pressed
      * @zh 表示当前按键是否正在被按下
      *
-     * @deprecated since v3.3, please use Event.prototype.type !== SystemEvent.EventType.KEYBOARD_UP instead
+     * @deprecated since v3.3, please use Event.prototype.type !== SystemEvent.KeyboardEvent.KEY_UP instead
      */
     public get isPressed () {
         return this._isPressed;

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -34,7 +34,8 @@ import { Vec2 } from '../../math/vec2';
 import { Touch } from './touch';
 import { Acceleration } from './acceleration';
 import { legacyCC } from '../../global-exports';
-import { SystemEventType } from './event-enum';
+import { SystemEventTypeUnion } from './event-enum';
+import { SystemEvent } from './system-event';
 
 const _vec2 = new Vec2();
 
@@ -109,7 +110,7 @@ export class EventMouse extends Event {
      */
     public movementY = 0;
 
-    private _eventType: SystemEventType;
+    private _eventType: SystemEventTypeUnion;
     /**
      * @en The type of the event
      * @zh 鼠标事件类型
@@ -138,7 +139,7 @@ export class EventMouse extends Event {
      * @param eventType - The type of the event
      * @param bubbles - Indicate whether the event bubbles up through the hierarchy or not.
      */
-    constructor (eventType: SystemEventType, bubbles?: boolean, prevLoc?: Vec2) {
+    constructor (eventType: SystemEventTypeUnion, bubbles?: boolean, prevLoc?: Vec2) {
         super(eventType, bubbles);
         this._eventType = eventType;
         if (prevLoc) {
@@ -394,7 +395,7 @@ export class EventTouch extends Event {
      */
     public simulate = false;
 
-    private _eventCode: SystemEventType;  // deprecated since v3.3
+    private _eventCode: SystemEventTypeUnion;  // deprecated since v3.3
 
     private _touches: Touch[];
 
@@ -405,7 +406,7 @@ export class EventTouch extends Event {
      * @param bubbles - Indicate whether the event bubbles up through the hierarchy or not.
      * @param eventType - The type of the event
      */
-    constructor (changedTouches: Touch[], bubbles: boolean, eventType: SystemEventType, touches: Touch[] = []) {
+    constructor (changedTouches: Touch[], bubbles: boolean, eventType: SystemEventTypeUnion, touches: Touch[] = []) {
         super(eventType, bubbles);
         this._eventCode = eventType;
         this._touches = changedTouches || [];
@@ -584,7 +585,7 @@ export class EventAcceleration extends Event {
      * @param bubbles - Indicate whether the event bubbles up through the hierarchy or not.
      */
     constructor (acc: Acceleration, bubbles?: boolean) {
-        super(SystemEventType.DEVICEMOTION, bubbles);
+        super(SystemEvent.DeviceEvent.DEVICEMOTION, bubbles);
         this.acc = acc;
     }
 }
@@ -637,15 +638,14 @@ export class EventKeyboard extends Event {
      * @param eventType - The type of the event
      * @param bubbles - Indicates whether the event bubbles up through the hierarchy or not.
      */
-    constructor (keyCode: number | KeyboardEvent, eventType: SystemEventType, bubbles?: boolean);
-    constructor (keyCode: number | KeyboardEvent, eventType: SystemEventType | boolean, bubbles?: boolean) {
+    constructor (keyCode: number | KeyboardEvent, eventType: SystemEventTypeUnion, bubbles?: boolean);
+    constructor (keyCode: number | KeyboardEvent, eventType: SystemEventTypeUnion | boolean, bubbles?: boolean) {
         if (typeof eventType === 'boolean') {
             const isPressed = eventType;
-            // @ts-expect-error Compability for legacy implementation.
-            eventType = isPressed ? 'keydown' : SystemEventType.KEYBOARD_UP;
+            eventType = isPressed ? 'keydown' : SystemEvent.KeyboardEvent.KEY_UP;
         }
-        super(<SystemEventType>eventType, bubbles);
-        this._isPressed = eventType !== SystemEventType.KEYBOARD_UP;
+        super(eventType, bubbles);
+        this._isPressed = eventType !== SystemEvent.KeyboardEvent.KEY_UP;
 
         if (typeof keyCode === 'number') {
             this.keyCode = keyCode;

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -109,6 +109,17 @@ export class EventMouse extends Event {
      */
     public movementY = 0;
 
+    private _eventType: SystemEventType;
+    /**
+     * @en The type of the event
+     * @zh 鼠标事件类型
+     *
+     * @deprecated since v3.3, please use EventMouse.prototype.type instead.
+     */
+    public get eventType () {
+        return this._eventType;
+    }
+
     private _button: number = EventMouse.BUTTON_MISSING;
 
     private _x = 0;
@@ -129,6 +140,7 @@ export class EventMouse extends Event {
      */
     constructor (eventType: SystemEventType, bubbles?: boolean, prevLoc?: Vec2) {
         super(eventType, bubbles);
+        this._eventType = eventType;
         if (prevLoc) {
             this._prevX = prevLoc.x;
             this._prevY = prevLoc.y;

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -34,7 +34,7 @@ import { Vec2 } from '../../math/vec2';
 import { Touch } from './touch';
 import { Acceleration } from './acceleration';
 import { legacyCC } from '../../global-exports';
-import { SystemEventTypeUnion } from './event-enum';
+import { KeyboardEvent, SystemEventTypeUnion } from './event-enum';
 import { SystemEvent } from './system-event';
 
 const _vec2 = new Vec2();
@@ -639,13 +639,13 @@ export class EventKeyboard extends Event {
      * @param bubbles - Indicates whether the event bubbles up through the hierarchy or not.
      */
     constructor (keyCode: number | KeyboardEvent, eventType: SystemEventTypeUnion, bubbles?: boolean);
-    constructor (keyCode: number | KeyboardEvent, eventType: SystemEventTypeUnion | boolean, bubbles?: boolean) {
+    constructor (keyCode: any, eventType: SystemEventTypeUnion | boolean, bubbles?: boolean) {
         if (typeof eventType === 'boolean') {
             const isPressed = eventType;
-            eventType = isPressed ? 'keydown' : SystemEvent.KeyboardEvent.KEY_UP;
+            eventType = isPressed ? 'keydown' : KeyboardEvent.KEY_UP;
         }
         super(eventType, bubbles);
-        this._isPressed = eventType !== SystemEvent.KeyboardEvent.KEY_UP;
+        this._isPressed = eventType !== KeyboardEvent.KEY_UP;
 
         if (typeof keyCode === 'number') {
             this.keyCode = keyCode;

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -34,8 +34,7 @@ import { Vec2 } from '../../math/vec2';
 import { Touch } from './touch';
 import { Acceleration } from './acceleration';
 import { legacyCC } from '../../global-exports';
-import { KeyboardEvent, SystemEventTypeUnion } from './event-enum';
-import { SystemEvent } from './system-event';
+import { DeviceEvent, KeyboardEvent, SystemEventTypeUnion } from './event-enum';
 
 const _vec2 = new Vec2();
 
@@ -585,7 +584,7 @@ export class EventAcceleration extends Event {
      * @param bubbles - Indicate whether the event bubbles up through the hierarchy or not.
      */
     constructor (acc: Acceleration, bubbles?: boolean) {
-        super(SystemEvent.DeviceEvent.DEVICEMOTION, bubbles);
+        super(DeviceEvent.DEVICEMOTION, bubbles);
         this.acc = acc;
     }
 }

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -613,6 +613,17 @@ export class EventKeyboard extends Event {
      */
     public rawEvent?: KeyboardEvent;
 
+    private _isPressed: boolean;
+    /**
+     * @en Indicates whether the current key is being pressed
+     * @zh 表示当前按键是否正在被按下
+     *
+     * @deprecated since v3.3, please use Event.prototype.type !== SystemEvent.EventType.KEYBOARD_UP instead
+     */
+    public get isPressed () {
+        return this._isPressed;
+    }
+
     /**
      * @param keyCode - The key code of the current key or the DOM KeyboardEvent
      * @param isPressed - Indicates whether the current key is being pressed, this is the DEPRECATED parameter.
@@ -632,6 +643,7 @@ export class EventKeyboard extends Event {
             eventType = isPressed ? 'keydown' : SystemEventType.KEYBOARD_UP;
         }
         super(<SystemEventType>eventType, bubbles);
+        this._isPressed = eventType !== SystemEventType.KEYBOARD_UP;
 
         if (typeof keyCode === 'number') {
             this.keyCode = keyCode;

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -610,6 +610,8 @@ export class EventKeyboard extends Event {
     /**
      * @en Raw DOM KeyboardEvent.
      * @zh 原始 DOM KeyboardEvent 事件对象
+     *
+     * @deprecated since v3.3, can't access rawEvent anymore
      */
     public rawEvent?: KeyboardEvent;
 

--- a/cocos/core/platform/event-manager/index.ts
+++ b/cocos/core/platform/event-manager/index.ts
@@ -36,4 +36,4 @@ export * from './input-manager';
 export * from './system-event';
 export * from './events';
 export * from './touch';
-export * from './event-enum';
+export { SystemEventType } from './event-enum';

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -433,7 +433,7 @@ class InputManager {
     }
 
     private _registerKeyboardEvent () {
-        input._keyboard.onDown((inputEvent)  => {
+        input._keyboard.onPressing((inputEvent)  => {
             eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, true));
         });
         input._keyboard.onUp((inputEvent)  => {

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -433,11 +433,14 @@ class InputManager {
     }
 
     private _registerKeyboardEvent () {
+        input._keyboard.onDown((inputEvent) => {
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'down'));
+        });
         input._keyboard.onPressing((inputEvent)  => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, true));
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'pressing'));
         });
         input._keyboard.onUp((inputEvent)  => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, false));
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'up'));
         });
     }
 

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -434,13 +434,14 @@ class InputManager {
 
     private _registerKeyboardEvent () {
         input._keyboard.onDown((inputEvent) => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'down'));
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEventType.KEYBOARD_DOWN));
         });
         input._keyboard.onPressing((inputEvent)  => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'pressing'));
+            // @ts-expect-error Compability for KEY_DOWN event
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'keydown'));
         });
         input._keyboard.onUp((inputEvent)  => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'up'));
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEventType.KEYBOARD_UP));
         });
     }
 

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -38,7 +38,7 @@ import { Touch } from './touch';
 import { legacyCC } from '../../global-exports';
 import { logID } from '../debug';
 import { Acceleration } from './acceleration';
-import { SystemEventType } from './event-enum';
+import { SystemEvent } from './system-event';
 
 const TOUCH_TIMEOUT = macro.TOUCH_TIMEOUT;
 
@@ -99,7 +99,7 @@ class InputManager {
         }
         if (handleTouches.length > 0) {
             // this._glView!._convertTouchesWithScale(handleTouches);
-            const touchEvent = new EventTouch(handleTouches, false, SystemEventType.TOUCH_START, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
+            const touchEvent = new EventTouch(handleTouches, false, SystemEvent.TouchEvent.TOUCH_START, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
             eventManager.dispatchEvent(touchEvent);
         }
     }
@@ -127,7 +127,7 @@ class InputManager {
             }
         }
         if (handleTouches.length > 0) {
-            const touchEvent = new EventTouch(handleTouches, false, SystemEventType.TOUCH_MOVE, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
+            const touchEvent = new EventTouch(handleTouches, false, SystemEvent.TouchEvent.TOUCH_MOVE, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
             eventManager.dispatchEvent(touchEvent);
         }
     }
@@ -135,7 +135,7 @@ class InputManager {
     public handleTouchesEnd (touches: Touch[]) {
         const handleTouches = this.getSetOfTouchesEndOrCancel(touches);
         if (handleTouches.length > 0) {
-            const touchEvent = new EventTouch(handleTouches, false, SystemEventType.TOUCH_END, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
+            const touchEvent = new EventTouch(handleTouches, false, SystemEvent.TouchEvent.TOUCH_END, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
             eventManager.dispatchEvent(touchEvent);
         }
         this._preTouchPool.length = 0;
@@ -144,7 +144,7 @@ class InputManager {
     public handleTouchesCancel (touches: Touch[]) {
         const handleTouches = this.getSetOfTouchesEndOrCancel(touches);
         if (handleTouches.length > 0) {
-            const touchEvent = new EventTouch(handleTouches, false, SystemEventType.TOUCH_CANCEL, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
+            const touchEvent = new EventTouch(handleTouches, false, SystemEvent.TouchEvent.TOUCH_CANCEL, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
             eventManager.dispatchEvent(touchEvent);
         }
         this._preTouchPool.length = 0;
@@ -434,14 +434,14 @@ class InputManager {
 
     private _registerKeyboardEvent () {
         input._keyboard.onDown((inputEvent) => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEventType.KEYBOARD_DOWN));
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEvent.KeyboardEvent.KEY_DOWN));
         });
         input._keyboard.onPressing((inputEvent)  => {
             // @ts-expect-error Compability for KEY_DOWN event
             eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'keydown'));
         });
         input._keyboard.onUp((inputEvent)  => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEventType.KEYBOARD_UP));
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEvent.KeyboardEvent.KEY_UP));
         });
     }
 

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -39,6 +39,7 @@ import { legacyCC } from '../../global-exports';
 import { logID } from '../debug';
 import { Acceleration } from './acceleration';
 import { SystemEvent } from './system-event';
+import { KeyboardEvent, TouchEvent } from './event-enum';
 
 const TOUCH_TIMEOUT = macro.TOUCH_TIMEOUT;
 
@@ -99,7 +100,7 @@ class InputManager {
         }
         if (handleTouches.length > 0) {
             // this._glView!._convertTouchesWithScale(handleTouches);
-            const touchEvent = new EventTouch(handleTouches, false, SystemEvent.TouchEvent.TOUCH_START, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
+            const touchEvent = new EventTouch(handleTouches, false, TouchEvent.TOUCH_START, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
             eventManager.dispatchEvent(touchEvent);
         }
     }
@@ -127,7 +128,7 @@ class InputManager {
             }
         }
         if (handleTouches.length > 0) {
-            const touchEvent = new EventTouch(handleTouches, false, SystemEvent.TouchEvent.TOUCH_MOVE, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
+            const touchEvent = new EventTouch(handleTouches, false, TouchEvent.TOUCH_MOVE, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
             eventManager.dispatchEvent(touchEvent);
         }
     }
@@ -135,7 +136,7 @@ class InputManager {
     public handleTouchesEnd (touches: Touch[]) {
         const handleTouches = this.getSetOfTouchesEndOrCancel(touches);
         if (handleTouches.length > 0) {
-            const touchEvent = new EventTouch(handleTouches, false, SystemEvent.TouchEvent.TOUCH_END, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
+            const touchEvent = new EventTouch(handleTouches, false, TouchEvent.TOUCH_END, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
             eventManager.dispatchEvent(touchEvent);
         }
         this._preTouchPool.length = 0;
@@ -144,7 +145,7 @@ class InputManager {
     public handleTouchesCancel (touches: Touch[]) {
         const handleTouches = this.getSetOfTouchesEndOrCancel(touches);
         if (handleTouches.length > 0) {
-            const touchEvent = new EventTouch(handleTouches, false, SystemEvent.TouchEvent.TOUCH_CANCEL, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
+            const touchEvent = new EventTouch(handleTouches, false, TouchEvent.TOUCH_CANCEL, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
             eventManager.dispatchEvent(touchEvent);
         }
         this._preTouchPool.length = 0;
@@ -434,14 +435,13 @@ class InputManager {
 
     private _registerKeyboardEvent () {
         input._keyboard.onDown((inputEvent) => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEvent.KeyboardEvent.KEY_DOWN));
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, KeyboardEvent.KEY_DOWN));
         });
         input._keyboard.onPressing((inputEvent)  => {
-            // @ts-expect-error Compability for KEY_DOWN event
             eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'keydown'));
         });
         input._keyboard.onUp((inputEvent)  => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEvent.KeyboardEvent.KEY_UP));
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, KeyboardEvent.KEY_UP));
         });
     }
 

--- a/cocos/core/platform/event-manager/system-event.ts
+++ b/cocos/core/platform/event-manager/system-event.ts
@@ -105,7 +105,7 @@ export class SystemEvent extends EventTarget {
         inputManager.setAccelerometerInterval(interval);
     }
 
-    public on (type: SystemEventType.KEY_DOWN | SystemEventType.KEY_UP, callback: (event: EventKeyboard) => void, target?: unknown): typeof callback;
+    public on (type: SystemEventType.KEY_DOWN | SystemEventType.KEY_UP | SystemEventType.KEYBOARD_DOWN | SystemEventType.KEYBOARD_UP, callback: (event: EventKeyboard) => void, target?: unknown): typeof callback;
     public on (type: SystemEventType.MOUSE_DOWN | SystemEventType.MOUSE_ENTER | SystemEventType.MOUSE_LEAVE |
                      SystemEventType.MOUSE_MOVE | SystemEventType.MOUSE_UP | SystemEventType.MOUSE_WHEEL,
                callback: (event: EventMouse) => void, target?: unknown): typeof callback;
@@ -129,17 +129,18 @@ export class SystemEvent extends EventTarget {
         super.on(type, callback, target, once);
 
         // Keyboard
-        if (type === 'keydown' || type === 'keyup') {
+        if (type === SystemEventType.KEYBOARD_DOWN || type === 'keydown' || type === SystemEventType.KEYBOARD_UP) {
             if (!keyboardListener) {
                 keyboardListener = EventListener.create({
                     event: EventListener.KEYBOARD,
-                    onKeyPressed (keyCode: number, event: EventKeyboard) {
-                        event.type = 'keydown';
+                    onKeyDown (keyCode: number, event: EventKeyboard) {
                         systemEvent.emit(event.type, event);
                     },
                     // deprecated
+                    onKeyPressed (keyCode: number, event: EventKeyboard) {
+                        systemEvent.emit(event.type, event);
+                    },
                     onKeyReleased (keyCode: number, event: EventKeyboard) {
-                        event.type = 'keyup';
                         systemEvent.emit(event.type, event);
                     },
                 });
@@ -243,10 +244,11 @@ export class SystemEvent extends EventTarget {
         super.off(type, callback, target);
 
         // Keyboard
-        if (keyboardListener && (type === 'keydown' || type === 'keyup')) {
-            const hasKeyDownEventListener = this.hasEventListener('keydown');
-            const hasKeyUpEventListener = this.hasEventListener('keyup');
-            if (!hasKeyDownEventListener && !hasKeyUpEventListener) {
+        if (keyboardListener && (type === SystemEventType.KEYBOARD_DOWN || type === 'keydown' || type === SystemEventType.KEYBOARD_UP)) {
+            const hasKeyDownEventListener = this.hasEventListener(SystemEventType.KEYBOARD_DOWN);
+            const hasKeyPressingEventListener = this.hasEventListener('keydown');  // SystemEventType.KEY_DOWN
+            const hasKeyUpEventListener = this.hasEventListener(SystemEventType.KEYBOARD_UP);
+            if (!hasKeyDownEventListener && !hasKeyPressingEventListener && !hasKeyUpEventListener) {
                 eventManager.removeListener(keyboardListener);
                 keyboardListener = null;
             }

--- a/cocos/core/platform/event-manager/system-event.ts
+++ b/cocos/core/platform/event-manager/system-event.ts
@@ -129,16 +129,17 @@ export class SystemEvent extends EventTarget {
         super.on(type, callback, target, once);
 
         // Keyboard
-        if (type === SystemEventType.KEY_DOWN || type === SystemEventType.KEY_UP) {
+        if (type === 'keydown' || type === 'keyup') {
             if (!keyboardListener) {
                 keyboardListener = EventListener.create({
                     event: EventListener.KEYBOARD,
                     onKeyPressed (keyCode: number, event: EventKeyboard) {
-                        event.type = SystemEventType.KEY_DOWN;
+                        event.type = 'keydown';
                         systemEvent.emit(event.type, event);
                     },
+                    // deprecated
                     onKeyReleased (keyCode: number, event: EventKeyboard) {
-                        event.type = SystemEventType.KEY_UP;
+                        event.type = 'keyup';
                         systemEvent.emit(event.type, event);
                     },
                 });
@@ -242,9 +243,9 @@ export class SystemEvent extends EventTarget {
         super.off(type, callback, target);
 
         // Keyboard
-        if (keyboardListener && (type === SystemEventType.KEY_DOWN || type === SystemEventType.KEY_UP)) {
-            const hasKeyDownEventListener = this.hasEventListener(SystemEventType.KEY_DOWN);
-            const hasKeyUpEventListener = this.hasEventListener(SystemEventType.KEY_UP);
+        if (keyboardListener && (type === 'keydown' || type === 'keyup')) {
+            const hasKeyDownEventListener = this.hasEventListener('keydown');
+            const hasKeyUpEventListener = this.hasEventListener('keyup');
             if (!hasKeyDownEventListener && !hasKeyUpEventListener) {
                 eventManager.removeListener(keyboardListener);
                 keyboardListener = null;

--- a/cocos/core/platform/event-manager/system-event.ts
+++ b/cocos/core/platform/event-manager/system-event.ts
@@ -154,7 +154,6 @@ export class SystemEvent extends EventTarget {
                 accelerationListener = EventListener.create({
                     event: EventListener.ACCELERATION,
                     callback (acc: any, event: EventAcceleration) {
-                        event.type = SystemEventType.DEVICEMOTION;
                         legacyCC.systemEvent.emit(event.type, event);
                     },
                 });
@@ -172,20 +171,16 @@ export class SystemEvent extends EventTarget {
                 touchListener = EventListener.create({
                     event: EventListener.TOUCH_ONE_BY_ONE,
                     onTouchBegan (touch: Touch, event: EventTouch) {
-                        event.type = SystemEventType.TOUCH_START;
                         legacyCC.systemEvent.emit(event.type, touch, event);
                         return true;
                     },
                     onTouchMoved (touch: Touch, event: EventTouch) {
-                        event.type = SystemEventType.TOUCH_MOVE;
                         legacyCC.systemEvent.emit(event.type, touch, event);
                     },
                     onTouchEnded (touch: Touch, event: EventTouch) {
-                        event.type = SystemEventType.TOUCH_END;
                         legacyCC.systemEvent.emit(event.type, touch, event);
                     },
                     onTouchCancelled (touch: Touch, event: EventTouch) {
-                        event.type = SystemEventType.TOUCH_CANCEL;
                         legacyCC.systemEvent.emit(event.type, touch, event);
                     },
                 });
@@ -203,19 +198,15 @@ export class SystemEvent extends EventTarget {
                 mouseListener = EventListener.create({
                     event: EventListener.MOUSE,
                     onMouseDown (event: EventMouse) {
-                        event.type = SystemEventType.MOUSE_DOWN;
                         legacyCC.systemEvent.emit(event.type, event);
                     },
                     onMouseMove (event:EventMouse) {
-                        event.type = SystemEventType.MOUSE_MOVE;
                         legacyCC.systemEvent.emit(event.type, event);
                     },
                     onMouseUp (event: EventMouse) {
-                        event.type = SystemEventType.MOUSE_UP;
                         legacyCC.systemEvent.emit(event.type, event);
                     },
                     onMouseScroll (event: EventMouse) {
-                        event.type = SystemEventType.MOUSE_WHEEL;
                         legacyCC.systemEvent.emit(event.type, event);
                     },
                 });

--- a/cocos/core/platform/event-manager/system-event.ts
+++ b/cocos/core/platform/event-manager/system-event.ts
@@ -32,7 +32,7 @@
 import { EDITOR } from 'internal:constants';
 import { EventTarget } from '../../event/event-target';
 import { EventAcceleration, EventKeyboard, EventMouse, EventTouch } from './events';
-import { SystemEventType } from './event-enum';
+import { DeviceEvent, KeyboardEvent, MouseEvent, SystemEventType, TouchEvent } from './event-enum';
 import { EventListener } from './event-listener';
 import eventManager from './event-manager';
 import inputManager from './input-manager';
@@ -61,7 +61,19 @@ let mouseListener: EventListener | null = null;
 */
 
 export class SystemEvent extends EventTarget {
+    /**
+     * @en The event type supported by SystemEvent and Node events
+     * @zh SystemEvent 支持的事件类型以及节点事件类型
+     *
+     * @deprecated since v3.3, please use SystemEvent.TouchEvent, SystemEvent.MouseEvent, SystemEvent.KeyboardEvent, SystemEvent.DeviceEvent and Node.EventType instead
+     */
     public static EventType = SystemEventType;
+
+    public static TouchEvent = TouchEvent;
+    public static MouseEvent = MouseEvent;
+    public static KeyboardEvent = KeyboardEvent;
+    public static DeviceEvent = DeviceEvent;
+
     constructor () {
         super();
     }
@@ -105,13 +117,12 @@ export class SystemEvent extends EventTarget {
         inputManager.setAccelerometerInterval(interval);
     }
 
-    public on (type: SystemEventType.KEY_DOWN | SystemEventType.KEY_UP | SystemEventType.KEYBOARD_DOWN | SystemEventType.KEYBOARD_UP, callback: (event: EventKeyboard) => void, target?: unknown): typeof callback;
-    public on (type: SystemEventType.MOUSE_DOWN | SystemEventType.MOUSE_ENTER | SystemEventType.MOUSE_LEAVE |
-                     SystemEventType.MOUSE_MOVE | SystemEventType.MOUSE_UP | SystemEventType.MOUSE_WHEEL,
+    public on (type: SystemEventType.KEY_DOWN | SystemEventType.KEY_UP | KeyboardEvent.KEY_DOWN | KeyboardEvent.KEY_UP, callback: (event: EventKeyboard) => void, target?: unknown): typeof callback;
+    public on (type: MouseEvent.MOUSE_DOWN | MouseEvent.MOUSE_MOVE | MouseEvent.MOUSE_UP | MouseEvent.MOUSE_WHEEL,
                callback: (event: EventMouse) => void, target?: unknown): typeof callback;
-    public on (type: SystemEventType.TOUCH_START | SystemEventType.TOUCH_MOVE | SystemEventType.TOUCH_END | SystemEventType.TOUCH_CANCEL,
+    public on (type: TouchEvent.TOUCH_START | TouchEvent.TOUCH_MOVE | TouchEvent.TOUCH_END | TouchEvent.TOUCH_CANCEL,
                callback: (touch: Touch, event: EventTouch) => void, target?: unknown): typeof callback;
-    public on (type: SystemEventType.DEVICEMOTION, callback: (event: EventAcceleration) => void, target?: unknown): typeof callback;
+    public on (type: DeviceEvent.DEVICEMOTION, callback: (event: EventAcceleration) => void, target?: unknown): typeof callback;
     /**
      * @en
      * Register an callback of a specific system event type.
@@ -129,7 +140,7 @@ export class SystemEvent extends EventTarget {
         super.on(type, callback, target, once);
 
         // Keyboard
-        if (type === SystemEventType.KEYBOARD_DOWN || type === 'keydown' || type === SystemEventType.KEYBOARD_UP) {
+        if (type === KeyboardEvent.KEY_DOWN || type === 'keydown' || type === KeyboardEvent.KEY_UP) {
             if (!keyboardListener) {
                 keyboardListener = EventListener.create({
                     event: EventListener.KEYBOARD,
@@ -149,7 +160,7 @@ export class SystemEvent extends EventTarget {
         }
 
         // Acceleration
-        if (type === SystemEventType.DEVICEMOTION) {
+        if (type === DeviceEvent.DEVICEMOTION) {
             if (!accelerationListener) {
                 accelerationListener = EventListener.create({
                     event: EventListener.ACCELERATION,
@@ -162,10 +173,10 @@ export class SystemEvent extends EventTarget {
         }
 
         // touch
-        if (type === SystemEventType.TOUCH_START
-            || type === SystemEventType.TOUCH_MOVE
-            || type === SystemEventType.TOUCH_END
-            || type === SystemEventType.TOUCH_CANCEL
+        if (type === TouchEvent.TOUCH_START
+            || type === TouchEvent.TOUCH_MOVE
+            || type === TouchEvent.TOUCH_END
+            || type === TouchEvent.TOUCH_CANCEL
         ) {
             if (!touchListener) {
                 touchListener = EventListener.create({
@@ -189,10 +200,10 @@ export class SystemEvent extends EventTarget {
         }
 
         // mouse
-        if (type === SystemEventType.MOUSE_DOWN
-            || type === SystemEventType.MOUSE_MOVE
-            || type === SystemEventType.MOUSE_UP
-            || type === SystemEventType.MOUSE_WHEEL
+        if (type === MouseEvent.MOUSE_DOWN
+            || type === MouseEvent.MOUSE_MOVE
+            || type === MouseEvent.MOUSE_UP
+            || type === MouseEvent.MOUSE_WHEEL
         ) {
             if (!mouseListener) {
                 mouseListener = EventListener.create({
@@ -235,10 +246,10 @@ export class SystemEvent extends EventTarget {
         super.off(type, callback, target);
 
         // Keyboard
-        if (keyboardListener && (type === SystemEventType.KEYBOARD_DOWN || type === 'keydown' || type === SystemEventType.KEYBOARD_UP)) {
-            const hasKeyDownEventListener = this.hasEventListener(SystemEventType.KEYBOARD_DOWN);
+        if (keyboardListener && (type === KeyboardEvent.KEY_DOWN || type === 'keydown' || type === KeyboardEvent.KEY_UP)) {
+            const hasKeyDownEventListener = this.hasEventListener(KeyboardEvent.KEY_DOWN);
             const hasKeyPressingEventListener = this.hasEventListener('keydown');  // SystemEventType.KEY_DOWN
-            const hasKeyUpEventListener = this.hasEventListener(SystemEventType.KEYBOARD_UP);
+            const hasKeyUpEventListener = this.hasEventListener(KeyboardEvent.KEY_UP);
             if (!hasKeyDownEventListener && !hasKeyPressingEventListener && !hasKeyUpEventListener) {
                 eventManager.removeListener(keyboardListener);
                 keyboardListener = null;
@@ -246,31 +257,31 @@ export class SystemEvent extends EventTarget {
         }
 
         // Acceleration
-        if (accelerationListener && type === SystemEventType.DEVICEMOTION) {
+        if (accelerationListener && type === DeviceEvent.DEVICEMOTION) {
             eventManager.removeListener(accelerationListener);
             accelerationListener = null;
         }
 
-        if (touchListener && (type === SystemEventType.TOUCH_START || type === SystemEventType.TOUCH_MOVE
-            || type === SystemEventType.TOUCH_END || type === SystemEventType.TOUCH_CANCEL)
+        if (touchListener && (type === TouchEvent.TOUCH_START || type === TouchEvent.TOUCH_MOVE
+            || type === TouchEvent.TOUCH_END || type === TouchEvent.TOUCH_CANCEL)
         ) {
-            const hasTouchStart = this.hasEventListener(SystemEventType.TOUCH_START);
-            const hasTouchMove = this.hasEventListener(SystemEventType.TOUCH_MOVE);
-            const hasTouchEnd = this.hasEventListener(SystemEventType.TOUCH_END);
-            const hasTouchCancel = this.hasEventListener(SystemEventType.TOUCH_CANCEL);
+            const hasTouchStart = this.hasEventListener(TouchEvent.TOUCH_START);
+            const hasTouchMove = this.hasEventListener(TouchEvent.TOUCH_MOVE);
+            const hasTouchEnd = this.hasEventListener(TouchEvent.TOUCH_END);
+            const hasTouchCancel = this.hasEventListener(TouchEvent.TOUCH_CANCEL);
             if (!hasTouchStart && !hasTouchMove && !hasTouchEnd && !hasTouchCancel) {
                 eventManager.removeListener(touchListener);
                 touchListener = null;
             }
         }
 
-        if (mouseListener && (type === SystemEventType.MOUSE_DOWN || type === SystemEventType.MOUSE_MOVE
-            || type === SystemEventType.MOUSE_UP || type === SystemEventType.MOUSE_WHEEL)
+        if (mouseListener && (type === MouseEvent.MOUSE_DOWN || type === MouseEvent.MOUSE_MOVE
+            || type === MouseEvent.MOUSE_UP || type === MouseEvent.MOUSE_WHEEL)
         ) {
-            const hasMouseDown = this.hasEventListener(SystemEventType.MOUSE_DOWN);
-            const hasMouseMove = this.hasEventListener(SystemEventType.MOUSE_MOVE);
-            const hasMouseUp = this.hasEventListener(SystemEventType.MOUSE_UP);
-            const hasMouseWheel = this.hasEventListener(SystemEventType.MOUSE_WHEEL);
+            const hasMouseDown = this.hasEventListener(MouseEvent.MOUSE_DOWN);
+            const hasMouseMove = this.hasEventListener(MouseEvent.MOUSE_MOVE);
+            const hasMouseUp = this.hasEventListener(MouseEvent.MOUSE_UP);
+            const hasMouseWheel = this.hasEventListener(MouseEvent.MOUSE_WHEEL);
             if (!hasMouseDown && !hasMouseMove && !hasMouseUp && !hasMouseWheel) {
                 eventManager.removeListener(mouseListener);
                 mouseListener = null;

--- a/cocos/core/platform/event-manager/system-event.ts
+++ b/cocos/core/platform/event-manager/system-event.ts
@@ -55,8 +55,8 @@ let mouseListener: EventListener | null = null;
 * @example
 * ```
 * import { systemEvent, SystemEvent } from 'cc';
-* systemEvent.on(SystemEvent.EventType.DEVICEMOTION, this.onDeviceMotionEvent, this);
-* systemEvent.off(SystemEvent.EventType.DEVICEMOTION, this.onDeviceMotionEvent, this);
+* systemEvent.on(SystemEvent.DeviceEvent.DEVICEMOTION, this.onDeviceMotionEvent, this);
+* systemEvent.off(SystemEvent.DeviceEvent.DEVICEMOTION, this.onDeviceMotionEvent, this);
 * ```
 */
 

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -35,7 +35,6 @@ import { property } from '../data/decorators/property';
 import { CCObject } from '../data/object';
 import { Event } from '../event';
 import { errorID, warnID, error, log, getError } from '../platform/debug';
-import { SystemEventType } from '../platform/event-manager/event-enum';
 import { ISchedulable } from '../scheduler';
 import IdGenerator from '../utils/id-generator';
 import * as js from '../utils/js';
@@ -44,6 +43,7 @@ import { legacyCC } from '../global-exports';
 import { Node } from './node';
 import type { Scene } from './scene';
 import { PrefabInfo } from '../utils/prefab/prefab-info';
+import { NodeEventType } from './node-event';
 
 const Destroying = CCObject.Flags.Destroying;
 const DontDestroy = CCObject.Flags.DontDestroy;
@@ -72,12 +72,12 @@ function getConstructor<T> (typeOrClassName: string | Constructor<T>): Construct
  * @en The base class for [[Node]], it:
  * - maintains scene hierarchy and life cycle logic
  * - provides EventTarget ability
- * - emits events if some properties changed, ref: [[SystemEventType]]
+ * - emits events if some properties changed, ref: [[Node.EventType]]
  * - manages components
  * @zh [[Node]] 的基类，他会负责：
  * - 维护场景树以及节点生命周期管理
  * - 提供 EventTarget 的事件管理和注册能力
- * - 派发节点状态相关的事件，参考：[[SystemEventType]]
+ * - 派发节点状态相关的事件，参考：[[Node.EventType]]
  * - 管理组件
  */
 @ccclass('cc.BaseNode')
@@ -425,7 +425,7 @@ export class BaseNode extends CCObject implements ISchedulable {
         this._onSetParent(oldParent, keepWorldTransform);
 
         if (this.emit) {
-            this.emit(SystemEventType.PARENT_CHANGED, oldParent);
+            this.emit(NodeEventType.PARENT_CHANGED, oldParent);
         }
 
         if (oldParent) {
@@ -438,7 +438,7 @@ export class BaseNode extends CCObject implements ISchedulable {
                 oldParent._children.splice(removeAt, 1);
                 oldParent._updateSiblingIndex();
                 if (oldParent.emit) {
-                    oldParent.emit(SystemEventType.CHILD_REMOVED, this);
+                    oldParent.emit(NodeEventType.CHILD_REMOVED, this);
                 }
             }
         }
@@ -450,7 +450,7 @@ export class BaseNode extends CCObject implements ISchedulable {
             newParent._children.push(this);
             this._siblingIndex = newParent._children.length - 1;
             if (newParent.emit) {
-                newParent.emit(SystemEventType.CHILD_ADDED, this);
+                newParent.emit(NodeEventType.CHILD_ADDED, this);
             }
         }
 
@@ -1062,15 +1062,15 @@ export class BaseNode extends CCObject implements ISchedulable {
      * @return - Just returns the incoming callback so you can save the anonymous function easier.
      * @example
      * ```ts
-     * this.node.on(SystemEventType.TOUCH_START, this.memberFunction, this);  // if "this" is component and the "memberFunction" declared in CCClass.
-     * node.on(SystemEventType.TOUCH_START, callback, this);
-     * node.on(SystemEventType.TOUCH_MOVE, callback, this);
-     * node.on(SystemEventType.TOUCH_END, callback, this);
+     * this.node.on(NodeEventType.TOUCH_START, this.memberFunction, this);  // if "this" is component and the "memberFunction" declared in CCClass.
+     * node.on(NodeEventType.TOUCH_START, callback, this);
+     * node.on(NodeEventType.TOUCH_MOVE, callback, this);
+     * node.on(NodeEventType.TOUCH_END, callback, this);
      * ```
      */
-    public on (type: string | SystemEventType, callback: AnyFunction, target?: unknown, useCapture: any = false) {
+    public on (type: string | NodeEventType, callback: AnyFunction, target?: unknown, useCapture: any = false) {
         switch (type) {
-        case SystemEventType.TRANSFORM_CHANGED:
+        case NodeEventType.TRANSFORM_CHANGED:
             this._eventMask |= TRANSFORM_ON;
             break;
         default:
@@ -1090,8 +1090,8 @@ export class BaseNode extends CCObject implements ISchedulable {
      * @param useCapture - When set to true, the listener will be triggered at capturing phase which is ahead of the final target emit, otherwise it will be triggered during bubbling phase.
      * @example
      * ```ts
-     * this.node.off(SystemEventType.TOUCH_START, this.memberFunction, this);
-     * node.off(SystemEventType.TOUCH_START, callback, this.node);
+     * this.node.off(NodeEventType.TOUCH_START, this.memberFunction, this);
+     * node.off(NodeEventType.TOUCH_START, callback, this.node);
      * ```
      */
     public off (type: string, callback?: AnyFunction, target?: unknown, useCapture: any = false) {
@@ -1101,7 +1101,7 @@ export class BaseNode extends CCObject implements ISchedulable {
         // All listener removed
         if (!hasListeners) {
             switch (type) {
-            case SystemEventType.TRANSFORM_CHANGED:
+            case NodeEventType.TRANSFORM_CHANGED:
                 this._eventMask &= ~TRANSFORM_ON;
                 break;
             default:
@@ -1179,7 +1179,7 @@ export class BaseNode extends CCObject implements ISchedulable {
     public targetOff (target: string | unknown) {
         this._eventProcessor.targetOff(target);
         // Check for event mask reset
-        if ((this._eventMask & TRANSFORM_ON) && !this._eventProcessor.hasEventListener(SystemEventType.TRANSFORM_CHANGED)) {
+        if ((this._eventMask & TRANSFORM_ON) && !this._eventProcessor.hasEventListener(NodeEventType.TRANSFORM_CHANGED)) {
             this._eventMask &= ~TRANSFORM_ON;
         }
     }
@@ -1233,7 +1233,7 @@ export class BaseNode extends CCObject implements ISchedulable {
             this._children[i]._siblingIndex = i;
         }
 
-        this.emit(SystemEventType.SIBLING_ORDER_CHANGED);
+        this.emit(NodeEventType.SIBLING_ORDER_CHANGED);
     }
 
     protected _onSetParent (oldParent: this | null, keepWorldTransform = false) {
@@ -1343,20 +1343,20 @@ export class BaseNode extends CCObject implements ISchedulable {
         if (!destroyByParent) {
             // remove from parent
             if (parent) {
-                this.emit(SystemEventType.PARENT_CHANGED, this);
+                this.emit(NodeEventType.PARENT_CHANGED, this);
                 // During destroy process, sibling index is not reliable
                 const childIndex = parent._children.indexOf(this);
                 parent._children.splice(childIndex, 1);
                 this._siblingIndex = 0;
                 parent._updateSiblingIndex();
                 if (parent.emit) {
-                    parent.emit(SystemEventType.CHILD_REMOVED, this);
+                    parent.emit(NodeEventType.CHILD_REMOVED, this);
                 }
             }
         }
 
         // emit node destroy event (this should before event processor destroy)
-        this.emit(SystemEventType.NODE_DESTROYED, this);
+        this.emit(NodeEventType.NODE_DESTROYED, this);
 
         // Destroy node event processor
         this._eventProcessor.destroy();

--- a/cocos/core/scene-graph/deprecated.ts
+++ b/cocos/core/scene-graph/deprecated.ts
@@ -39,25 +39,6 @@ import { Size } from '../math/size';
 import { legacyCC } from '../global-exports';
 import { CCObject } from '../data/object';
 import { warnID } from '../platform/debug';
-import { SystemEventType } from '../platform';
-
-replaceProperty(Node.EventType, 'Node.EventType', [
-    {
-        name: 'DEVICEMOTION',
-        target: SystemEventType,
-        targetName: 'SystemEventType',
-    },
-    {
-        name: 'KEY_DOWN',
-        target: SystemEventType,
-        targetName: 'SystemEventType',
-    },
-    {
-        name: 'KEY_UP',
-        target: SystemEventType,
-        targetName: 'SystemEventType',
-    },
-]);
 
 replaceProperty(BaseNode.prototype, 'BaseNode', [
     {

--- a/cocos/core/scene-graph/deprecated.ts
+++ b/cocos/core/scene-graph/deprecated.ts
@@ -39,6 +39,25 @@ import { Size } from '../math/size';
 import { legacyCC } from '../global-exports';
 import { CCObject } from '../data/object';
 import { warnID } from '../platform/debug';
+import { SystemEventType } from '../platform';
+
+replaceProperty(Node.EventType, 'Node.EventType', [
+    {
+        name: 'DEVICEMOTION',
+        target: SystemEventType,
+        targetName: 'SystemEventType',
+    },
+    {
+        name: 'KEY_DOWN',
+        target: SystemEventType,
+        targetName: 'SystemEventType',
+    },
+    {
+        name: 'KEY_UP',
+        target: SystemEventType,
+        targetName: 'SystemEventType',
+    },
+]);
 
 replaceProperty(BaseNode.prototype, 'BaseNode', [
     {

--- a/cocos/core/scene-graph/node-event-processor.ts
+++ b/cocos/core/scene-graph/node-event-processor.ts
@@ -72,7 +72,7 @@ function _touchStartHandler (this: EventListener, touch: Touch, event: EventTouc
     touch.getUILocation(pos);
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.TOUCH_START.toString();
+        event.type = SystemEventType.TOUCH_START;
         event.touch = touch;
         event.bubbles = true;
         node.dispatchEvent(event);
@@ -88,7 +88,7 @@ function _touchMoveHandler (this: EventListener, touch: Touch, event: EventTouch
         return false;
     }
 
-    event.type = SystemEventType.TOUCH_MOVE.toString();
+    event.type = SystemEventType.TOUCH_MOVE;
     event.touch = touch;
     event.bubbles = true;
     node.dispatchEvent(event);
@@ -104,9 +104,9 @@ function _touchEndHandler (this: EventListener, touch: Touch, event: EventTouch)
     touch.getUILocation(pos);
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.TOUCH_END.toString();
+        event.type = SystemEventType.TOUCH_END;
     } else {
-        event.type = SystemEventType.TOUCH_CANCEL.toString();
+        event.type = SystemEventType.TOUCH_CANCEL;
     }
     event.touch = touch;
     event.bubbles = true;
@@ -119,7 +119,7 @@ function _touchCancelHandler (this: EventListener, touch: Touch, event: EventTou
         return;
     }
 
-    event.type = SystemEventType.TOUCH_CANCEL.toString();
+    event.type = SystemEventType.TOUCH_CANCEL;
     event.touch = touch;
     event.bubbles = true;
     node.dispatchEvent(event);
@@ -134,7 +134,7 @@ function _mouseDownHandler (this: EventListener, event: EventMouse) {
     pos = event.getUILocation();
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.MOUSE_DOWN.toString();
+        event.type = SystemEventType.MOUSE_DOWN;
         event.bubbles = true;
         node.dispatchEvent(event);
     }
@@ -160,15 +160,15 @@ function _mouseMoveHandler (this: EventListener, event: EventMouse) {
                 }
             }
             _currentHovered = node;
-            event.type = SystemEventType.MOUSE_ENTER.toString();
+            event.type = SystemEventType.MOUSE_ENTER;
             node.dispatchEvent(event);
             this._previousIn = true;
         }
-        event.type = SystemEventType.MOUSE_MOVE.toString();
+        event.type = SystemEventType.MOUSE_MOVE;
         event.bubbles = true;
         node.dispatchEvent(event);
     } else if (this._previousIn) {
-        event.type = SystemEventType.MOUSE_LEAVE.toString();
+        event.type = SystemEventType.MOUSE_LEAVE;
         node.dispatchEvent(event);
         this._previousIn = false;
         _currentHovered = null;
@@ -191,7 +191,7 @@ function _mouseUpHandler (this: EventListener, event: EventMouse) {
     pos = event.getUILocation();
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.MOUSE_UP.toString();
+        event.type = SystemEventType.MOUSE_UP;
         event.bubbles = true;
         node.dispatchEvent(event);
         // event.propagationStopped = true;
@@ -208,7 +208,7 @@ function _mouseWheelHandler (this: EventListener, event: EventMouse) {
     pos = event.getUILocation();
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.MOUSE_WHEEL.toString();
+        event.type = SystemEventType.MOUSE_WHEEL;
         event.bubbles = true;
         node.dispatchEvent(event);
         // event.propagationStopped = true;

--- a/cocos/core/scene-graph/node-event-processor.ts
+++ b/cocos/core/scene-graph/node-event-processor.ts
@@ -30,7 +30,6 @@
 
 import Event from '../event/event';
 import { Vec2 } from '../math/vec2';
-import { SystemEventType } from '../platform/event-manager/event-enum';
 import { EventListener } from '../platform/event-manager/event-listener';
 import { eventManager } from '../platform/event-manager/event-manager';
 import { EventMouse, EventTouch } from '../platform/event-manager/events';
@@ -41,25 +40,26 @@ import { CallbacksInvoker } from '../event/callbacks-invoker';
 import { errorID } from '../platform/debug';
 import { legacyCC } from '../global-exports';
 import { Component } from '../components/component';
+import { NodeEventType } from './node-event';
 
 const _cachedArray = new Array<BaseNode>(16);
 let _currentHovered: BaseNode | null = null;
 let pos = new Vec2();
 
 const _touchEvents = [
-    SystemEventType.TOUCH_START.toString(),
-    SystemEventType.TOUCH_MOVE.toString(),
-    SystemEventType.TOUCH_END.toString(),
-    SystemEventType.TOUCH_CANCEL.toString(),
+    NodeEventType.TOUCH_START,
+    NodeEventType.TOUCH_MOVE,
+    NodeEventType.TOUCH_END,
+    NodeEventType.TOUCH_CANCEL,
 ];
 
 const _mouseEvents = [
-    SystemEventType.MOUSE_DOWN.toString(),
-    SystemEventType.MOUSE_ENTER.toString(),
-    SystemEventType.MOUSE_MOVE.toString(),
-    SystemEventType.MOUSE_LEAVE.toString(),
-    SystemEventType.MOUSE_UP.toString(),
-    SystemEventType.MOUSE_WHEEL.toString(),
+    NodeEventType.MOUSE_DOWN,
+    NodeEventType.MOUSE_ENTER,
+    NodeEventType.MOUSE_MOVE,
+    NodeEventType.MOUSE_LEAVE,
+    NodeEventType.MOUSE_UP,
+    NodeEventType.MOUSE_WHEEL,
 ];
 
 // TODO: rearrange event
@@ -72,7 +72,7 @@ function _touchStartHandler (this: EventListener, touch: Touch, event: EventTouc
     touch.getUILocation(pos);
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.TOUCH_START;
+        event.type = NodeEventType.TOUCH_START;
         event.touch = touch;
         event.bubbles = true;
         node.dispatchEvent(event);
@@ -88,7 +88,7 @@ function _touchMoveHandler (this: EventListener, touch: Touch, event: EventTouch
         return false;
     }
 
-    event.type = SystemEventType.TOUCH_MOVE;
+    event.type = NodeEventType.TOUCH_MOVE;
     event.touch = touch;
     event.bubbles = true;
     node.dispatchEvent(event);
@@ -104,9 +104,9 @@ function _touchEndHandler (this: EventListener, touch: Touch, event: EventTouch)
     touch.getUILocation(pos);
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.TOUCH_END;
+        event.type = NodeEventType.TOUCH_END;
     } else {
-        event.type = SystemEventType.TOUCH_CANCEL;
+        event.type = NodeEventType.TOUCH_CANCEL;
     }
     event.touch = touch;
     event.bubbles = true;
@@ -119,7 +119,7 @@ function _touchCancelHandler (this: EventListener, touch: Touch, event: EventTou
         return;
     }
 
-    event.type = SystemEventType.TOUCH_CANCEL;
+    event.type = NodeEventType.TOUCH_CANCEL;
     event.touch = touch;
     event.bubbles = true;
     node.dispatchEvent(event);
@@ -134,7 +134,7 @@ function _mouseDownHandler (this: EventListener, event: EventMouse) {
     pos = event.getUILocation();
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.MOUSE_DOWN;
+        event.type = NodeEventType.MOUSE_DOWN;
         event.bubbles = true;
         node.dispatchEvent(event);
     }
@@ -153,22 +153,22 @@ function _mouseMoveHandler (this: EventListener, event: EventMouse) {
         if (!this._previousIn) {
             // Fix issue when hover node switched, previous hovered node won't get MOUSE_LEAVE notification
             if (_currentHovered && _currentHovered.eventProcessor.mouseListener) {
-                event.type = SystemEventType.MOUSE_LEAVE;
+                event.type = NodeEventType.MOUSE_LEAVE;
                 _currentHovered.dispatchEvent(event);
                 if (_currentHovered.eventProcessor.mouseListener) {
                     _currentHovered.eventProcessor.mouseListener._previousIn = false;
                 }
             }
             _currentHovered = node;
-            event.type = SystemEventType.MOUSE_ENTER;
+            event.type = NodeEventType.MOUSE_ENTER;
             node.dispatchEvent(event);
             this._previousIn = true;
         }
-        event.type = SystemEventType.MOUSE_MOVE;
+        event.type = NodeEventType.MOUSE_MOVE;
         event.bubbles = true;
         node.dispatchEvent(event);
     } else if (this._previousIn) {
-        event.type = SystemEventType.MOUSE_LEAVE;
+        event.type = NodeEventType.MOUSE_LEAVE;
         node.dispatchEvent(event);
         this._previousIn = false;
         _currentHovered = null;
@@ -191,7 +191,7 @@ function _mouseUpHandler (this: EventListener, event: EventMouse) {
     pos = event.getUILocation();
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.MOUSE_UP;
+        event.type = NodeEventType.MOUSE_UP;
         event.bubbles = true;
         node.dispatchEvent(event);
         // event.propagationStopped = true;
@@ -208,7 +208,7 @@ function _mouseWheelHandler (this: EventListener, event: EventMouse) {
     pos = event.getUILocation();
 
     if (node._uiProps.uiTransformComp.isHit(pos, this)) {
-        event.type = SystemEventType.MOUSE_WHEEL;
+        event.type = NodeEventType.MOUSE_WHEEL;
         event.bubbles = true;
         node.dispatchEvent(event);
         // event.propagationStopped = true;

--- a/cocos/core/scene-graph/node-event-processor.ts
+++ b/cocos/core/scene-graph/node-event-processor.ts
@@ -430,7 +430,7 @@ export class NodeEventProcessor {
      * this.node.on(Node.EventType.ANCHOR_CHANGED, callback);
      * ```
      */
-    public on (type: string, callback: AnyFunction, target?: unknown, useCapture?: boolean) {
+    public on (type: NodeEventType, callback: AnyFunction, target?: unknown, useCapture?: boolean) {
         const forDispatch = this._checknSetupSysEvent(type);
         if (forDispatch) {
             return this._onDispatch(type, callback, target, useCapture);
@@ -479,7 +479,7 @@ export class NodeEventProcessor {
      * node.once(Node.EventType.ANCHOR_CHANGED, callback);
      * ```
      */
-    public once (type: string, callback: AnyFunction, target?: unknown, useCapture?: boolean) {
+    public once (type: NodeEventType, callback: AnyFunction, target?: unknown, useCapture?: boolean) {
         const forDispatch = this._checknSetupSysEvent(type);
 
         let listeners: CallbacksInvoker;
@@ -512,7 +512,7 @@ export class NodeEventProcessor {
      * node.off(Node.EventType.ANCHOR_CHANGED, callback, this);
      * ```
      */
-    public off (type: string, callback?: AnyFunction, target?: unknown, useCapture?: boolean) {
+    public off (type: NodeEventType, callback?: AnyFunction, target?: unknown, useCapture?: boolean) {
         const touchEvent = _touchEvents.indexOf(type) !== -1;
         const mouseEvent = !touchEvent && _mouseEvents.indexOf(type) !== -1;
         if (touchEvent || mouseEvent) {
@@ -673,7 +673,7 @@ export class NodeEventProcessor {
 
     // EVENT TARGET
 
-    private _checknSetupSysEvent (type: string) {
+    private _checknSetupSysEvent (type: NodeEventType) {
         let newAdded = false;
         let forDispatch = false;
         // just for ui

--- a/cocos/core/scene-graph/node-event.ts
+++ b/cocos/core/scene-graph/node-event.ts
@@ -1,154 +1,4 @@
-/*
- Copyright (c) 2020 Xiamen Yaji Software Co., Ltd.
-
- https://www.cocos.com/
-
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated engine source code (the "Software"), a limited,
- worldwide, royalty-free, non-assignable, revocable and non-exclusive license
- to use Cocos Creator solely to develop games on your target platforms. You shall
- not use Cocos Creator software for developing other software or tools that's
- used for developing games. You are not granted to publish, distribute,
- sublicense, and/or sell copies of Cocos Creator.
-
- The software or tools in this License Agreement are licensed, not sold.
- Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
-
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
- */
-
-/**
- * @packageDocumentation
- * @module event
- */
-import { ccenum } from '../../value-types/enum';
-import { legacyCC } from '../../global-exports';
-import { NodeEventType } from '../../scene-graph/node-event';
-
-export enum TouchEvent {
-    /**
-     * @en
-     * The event type for touch start event
-     *
-     * @zh
-     * 手指开始触摸事件。
-     */
-     TOUCH_START = 'touch-start',
-
-     /**
-      * @en
-      * The event type for touch move event
-      *
-      * @zh
-      * 当手指在屏幕上移动时。
-      */
-     TOUCH_MOVE = 'touch-move',
-
-     /**
-      * @en
-      * The event type for touch end event
-      *
-      * @zh
-      * 手指结束触摸事件。
-      */
-     TOUCH_END = 'touch-end',
-
-     /**
-      * @en
-      * The event type for touch end event
-      *
-      * @zh
-      * 当手指在目标节点区域外离开屏幕时。
-      */
-     TOUCH_CANCEL = 'touch-cancel',
-}
-
-export enum MouseEvent {
-  /**
-   * @en
-   * The event type for mouse down events
-   *
-   * @zh
-   * 当鼠标按下时触发一次。
-   */
-  MOUSE_DOWN = 'mouse-down',
-
-  /**
-   * @en
-   * The event type for mouse move events
-   *
-   * @zh
-   * 当鼠标在目标节点在目标节点区域中移动时，不论是否按下。
-   */
-  MOUSE_MOVE = 'mouse-move',
-
-  /**
-   * @en
-   * The event type for mouse up events
-   *
-   * @zh
-   * 当鼠标从按下状态松开时触发一次。
-   */
-  MOUSE_UP = 'mouse-up',
-
-  /**
-   * @en
-   * The event type for mouse wheel events
-   *
-   * @zh 手指开始触摸事件
-   */
-  MOUSE_WHEEL = 'mouse-wheel',
-}
-
-export enum KeyboardEvent {
-    /**
-     * @en The event type for press the key down event
-     * @zh 当按下按键时触发的事件
-     */
-     KEY_DOWN = 'keyboarddown',  // NOTE: different value with SystemEventType.KEY_DOWN
-
-     /**
-      * @en The event type for press the key up event
-      * @zh 当松开按键时触发的事件
-      */
-    KEY_UP = 'keyup',  // NOTE: same value with SystemEventType.KEY_UP
-}
-
-export enum DeviceEvent {
-    /**
-     * @en
-     * The event type for press the devicemotion event
-     *
-     * @zh
-     * 重力感应
-     */
-     DEVICEMOTION = 'devicemotion',
-
-     // TODO: add resize, orientation changed event
-}
-
-/**
- * @en The event type supported by SystemEvent and Node events
- * @zh SystemEvent 支持的事件类型以及节点事件类型
- *
- * @deprecated since v3.3, please use SystemEvent.TouchEvent, SystemEvent.MouseEvent, SystemEvent.KeyboardEvent, SystemEvent.DeviceEvent and Node.EventType instead
- */
-export enum SystemEventType {
-    /**
-     * @en
-     * Code for event without type.
-     *
-     * @zh
-     * 没有类型的事件。
-     */
-    NO_TYPE = 'no_type',
-
+export enum NodeEventType {
     /**
      * @en
      * The event type for touch start event
@@ -226,8 +76,6 @@ export enum SystemEventType {
      *
      * @zh
      * 当鼠标移入目标节点区域时，不论是否按下.
-     *
-     * @deprecated since v3.3, please use Node.EventType.MOUSE_ENTER instead.
      */
     MOUSE_ENTER = 'mouse-enter',
 
@@ -237,22 +85,20 @@ export enum SystemEventType {
      *
      * @zh
      * 当鼠标移出目标节点区域时，不论是否按下。
-     *
-     * @deprecated since v3.3, please use Node.EventType.MOUSE_LEAVE instead.
      */
     MOUSE_LEAVE = 'mouse-leave',
 
     /**
      * @en The event type for press the key down event, the event will be continuously dispatched in the key pressed state
      * @zh 当按下按键时触发的事件, 该事件在按下状态会持续派发
-     * @deprecated since v3.3, please use SystemEvent.KeyboardEvent.KEY_DOWN instead. The SystemEventType.KEY_DOWN event will be continuously dispatched in the key pressed state, it's not a good API design for developers.
+     * @deprecated since v3.3, please use SystemEventType.KEY_DOWN instead
      */
     KEY_DOWN = 'keydown',
 
     /**
      * @en The event type for press the key up event
      * @zh 当松开按键时触发的事件
-     * @deprecated since v3.3, please use SystemEvent.KeyboardEvent.KEY_UP instead
+     * @deprecated since v3.3, please use SystemEventType.KEY_UP instead
      */
     KEY_UP = 'keyup',
 
@@ -262,6 +108,8 @@ export enum SystemEventType {
      *
      * @zh
      * 重力感应
+     *
+     * @deprecated since v3.3, please use SystemEventType.DEVICEMOTION instead
      */
     DEVICEMOTION = 'devicemotion',
 
@@ -279,16 +127,12 @@ export enum SystemEventType {
      *   }
      * }, this);
      * ```
-     *
-     * @deprecated since v3.3, please use Node.EventType.TRANSFORM_CHANGED instead
      */
     TRANSFORM_CHANGED = 'transform-changed',
 
     /**
      * @en The event type for notifying the host scene has been changed for a persist node.
      * @zh 当场景常驻节点的场景发生改变时触发的事件，一般在切换场景过程中触发。
-     *
-     * @deprecated since v3.3, please use Node.EventType.SCENE_CHANGED_FOR_PERSISTS instead
      */
     SCENE_CHANGED_FOR_PERSISTS = 'scene-changed-for-persists',
 
@@ -301,8 +145,6 @@ export enum SystemEventType {
      * @zh
      * 当节点尺寸改变时触发的事件。
      * 性能警告：这个事件会在每次对应的属性被修改时触发，如果事件回调损耗较高，有可能对性能有很大的负面影响，请尽量避免这种情况。
-     *
-     * @deprecated since v3.3, please use Node.EventType.SIZE_CHANGED instead
      */
     SIZE_CHANGED = 'size-changed',
 
@@ -315,8 +157,6 @@ export enum SystemEventType {
      * @zh
      * 当节点的 UITransform 锚点改变时触发的事件。
      * 性能警告：这个事件会在每次对应的属性被修改时触发，如果事件回调损耗较高，有可能对性能有很大的负面影响，请尽量避免这种情况。
-     *
-     * @deprecated since v3.3, please use Node.EventType.ANCHOR_CHANGED instead
      */
     ANCHOR_CHANGED = 'anchor-changed',
 
@@ -329,8 +169,6 @@ export enum SystemEventType {
      * @zh
      * 当节点的 UI 渲染组件颜色属性改变时触发的事件。
      * 性能警告：这个事件会在每次对应的属性被修改时触发，如果事件回调损耗较高，有可能对性能有很大的负面影响，请尽量避免这种情况。
-     *
-     * @deprecated since v3.3, please use Node.EventType.COLOR_CHANGED instead
      */
     COLOR_CHANGED = 'color-changed',
 
@@ -340,8 +178,6 @@ export enum SystemEventType {
      *
      * @zh
      * 给目标节点添加子节点时触发的事件。
-     *
-     * @deprecated since v3.3, please use Node.EventType.CHILD_ADDED instead
      */
     CHILD_ADDED = 'child-added',
 
@@ -351,46 +187,30 @@ export enum SystemEventType {
      *
      * @zh
      * 给目标节点移除子节点时触发的事件。
-     *
-     * @deprecated since v3.3, please use Node.EventType.CHILD_REMOVED instead
      */
     CHILD_REMOVED = 'child-removed',
 
     /**
      * @en The event type for changing the parent of the target node
      * @zh 目标节点的父节点改变时触发的事件。
-     *
-     * @deprecated since v3.3, please use Node.EventType.PARENT_CHANGED instead
      */
     PARENT_CHANGED = 'parent-changed',
 
     /**
      * @en The event type for destroying the target node
      * @zh 目标节点被销毁时触发的事件。
-     *
-     * @deprecated since v3.3, please use Node.EventType.NODE_DESTROYED instead
      */
     NODE_DESTROYED = 'node-destroyed',
 
     /**
      * @en The event type for node layer change events.
      * @zh 节点 layer 改变时触发的事件。
-     *
-     * @deprecated since v3.3, please use Node.EventType.LAYER_CHANGED instead
      */
     LAYER_CHANGED = 'layer-changed',
 
     /**
      * @en The event type for node's sibling order changed.
      * @zh 当节点在兄弟节点中的顺序发生变化时触发的事件。
-     *
-     * @deprecated since v3.3, please use Node.EventType.SIBLING_ORDER_CHANGED instead
      */
     SIBLING_ORDER_CHANGED = 'sibling-order-changed',
 }
-
-ccenum(SystemEventType);
-
-export type SystemEventTypeUnion = SystemEventType.NO_TYPE | TouchEvent | MouseEvent | KeyboardEvent | DeviceEvent | 'keydown' | NodeEventType;
-
-legacyCC.SystemEventType = SystemEventType;

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -34,7 +34,6 @@ import {
 import { JSB } from 'internal:constants';
 import { Layers } from './layers';
 import { NodeUIProperties } from './node-ui-properties';
-import { SystemEventType } from '../platform/event-manager/event-enum';
 import { eventManager } from '../platform/event-manager/event-manager';
 import { legacyCC } from '../global-exports';
 import { BaseNode, TRANSFORM_ON } from './base-node';
@@ -47,6 +46,7 @@ import { applyMountedChildren, applyMountedComponents, applyRemovedComponents,
 import { Component } from '../components';
 import { NativeNode } from '../renderer/scene/native-scene';
 import { FloatArray } from '../math/type-define';
+import { NodeEventType } from './node-event';
 
 const v3_a = new Vec3();
 const q_a = new Quat();
@@ -88,7 +88,7 @@ export class Node extends BaseNode {
      * @en Event types emitted by Node
      * @zh 节点可能发出的事件类型
      */
-    public static EventType = SystemEventType;
+    public static EventType = NodeEventType;
 
     /**
      * @en Coordinates space
@@ -104,8 +104,8 @@ export class Node extends BaseNode {
     public static TransformDirtyBit = TransformBit;
 
     /**
-     * @en Bit masks for Node transformation parts, can be used to determine which part changed in [[SystemEventType.TRANSFORM_CHANGED]] event
-     * @zh 节点变换更新的具体部分，可用于判断 [[SystemEventType.TRANSFORM_CHANGED]] 事件的具体类型
+     * @en Bit masks for Node transformation parts, can be used to determine which part changed in [[NodeEventType.TRANSFORM_CHANGED]] event
+     * @zh 节点变换更新的具体部分，可用于判断 [[NodeEventType.TRANSFORM_CHANGED]] 事件的具体类型
      */
     public static TransformBit = TransformBit;
 
@@ -278,7 +278,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.ROTATION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
         }
     }
 
@@ -332,7 +332,7 @@ export class Node extends BaseNode {
         this.invalidateChildren(TransformBit.TRS);
         this._eulerDirty = true;
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.TRS);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.TRS);
         }
     }
 
@@ -371,7 +371,7 @@ export class Node extends BaseNode {
         if (JSB) {
             this._nativeLayer[0] = this._layer;
         }
-        this.emit(SystemEventType.LAYER_CHANGED, this._layer);
+        this.emit(NodeEventType.LAYER_CHANGED, this._layer);
     }
 
     get layer () {
@@ -512,7 +512,7 @@ export class Node extends BaseNode {
         }
         this.invalidateChildren(TransformBit.POSITION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.POSITION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.POSITION);
         }
     }
 
@@ -538,7 +538,7 @@ export class Node extends BaseNode {
         this._eulerDirty = true;
         this.invalidateChildren(TransformBit.ROTATION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
         }
     }
 
@@ -672,7 +672,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.POSITION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.POSITION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.POSITION);
         }
     }
 
@@ -716,7 +716,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.ROTATION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
         }
     }
 
@@ -751,7 +751,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.ROTATION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
         }
     }
 
@@ -795,7 +795,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.SCALE);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.SCALE);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.SCALE);
         }
     }
 
@@ -873,7 +873,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.POSITION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.POSITION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.POSITION);
         }
     }
 
@@ -924,7 +924,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.ROTATION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
         }
     }
 
@@ -947,7 +947,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.ROTATION);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.ROTATION);
         }
     }
 
@@ -1005,7 +1005,7 @@ export class Node extends BaseNode {
 
         this.invalidateChildren(TransformBit.SCALE);
         if (this._eventMask & TRANSFORM_ON) {
-            this.emit(SystemEventType.TRANSFORM_CHANGED, TransformBit.SCALE);
+            this.emit(NodeEventType.TRANSFORM_CHANGED, TransformBit.SCALE);
         }
     }
 
@@ -1092,7 +1092,7 @@ export class Node extends BaseNode {
         if (dirtyBit) {
             this.invalidateChildren(dirtyBit);
             if (this._eventMask & TRANSFORM_ON) {
-                this.emit(SystemEventType.TRANSFORM_CHANGED, dirtyBit);
+                this.emit(NodeEventType.TRANSFORM_CHANGED, dirtyBit);
             }
         }
     }

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -246,7 +246,7 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
         const id = messageID++;
         messageMap.set(id, { id, count: 0, logTimes: item.logTimes !== undefined ? item.logTimes : defaultLogTimes });
         const suggest = item.suggest ? `(${item.suggest})` : '';
-        if (descriptor.value != null) {
+        if (typeof descriptor.value !== 'undefined') {
             if (typeof descriptor.value === 'function') {
                 const oldValue = descriptor.value as Function;
                 owner[deprecatedProp] = function (this) {
@@ -254,7 +254,17 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
                     return oldValue.call(this, ...arguments);
                 };
             } else {
-                _defaultGetSet(descriptor, ownerName, deprecatedProp, warn, id, suggest);
+                let oldValue = descriptor.value;
+                Object.defineProperty(owner, deprecatedProp, {
+                    get () {
+                        markAsWarningLog(ownerName, deprecatedProp, warn, id, suggest);
+                        return oldValue;
+                    },
+                    set (v) {
+                        markAsWarningLog(ownerName, deprecatedProp, warn, id, suggest);
+                        oldValue = v;
+                    },
+                });
             }
         } else {
             _defaultGetSet(descriptor, ownerName, deprecatedProp, warn, id, suggest);

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -222,37 +222,21 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
     if (owner == null) return;
 
     const _defaultGetSet = (d: PropertyDescriptor, n: string, dp: string, f: Function, id: number, s: string) => {
-        if (typeof d.value !== 'undefined') {
-            if (typeof d.get === 'undefined' && typeof d.set === 'undefined') {
-                let oldValue = d.value;
-                Object.defineProperty(owner, dp, {
-                    get () {
-                        markAsWarningLog(n, dp, f, id, s);
-                        return oldValue;
-                    },
-                    set (v) {
-                        markAsWarningLog(n, dp, f, id, s);
-                        oldValue = v;
-                    },
-                });
-            }
-        } else {
-            if (d.get) {
-                const oldGet = d.get;
-                d.get = function (this) {
-                    markAsWarningLog(n, dp, f, id, s);
-                    return oldGet.call(this);
-                };
-            }
-            if (d.set) {
-                const oldSet = d.set;
-                d.set = function (this, v: any) {
-                    markAsWarningLog(n, dp, f, id, s);
-                    oldSet.call(this, v);
-                };
-            }
-            Object.defineProperty(owner, dp, d);
+        if (d.get) {
+            const oldGet = d.get;
+            d.get = function (this) {
+                markAsWarningLog(n, dp, f, id, s);
+                return oldGet.call(this);
+            };
         }
+        if (d.set) {
+            const oldSet = d.set;
+            d.set = function (this, v: any) {
+                markAsWarningLog(n, dp, f, id, s);
+                oldSet.call(this, v);
+            };
+        }
+        Object.defineProperty(owner, dp, d);
     };
 
     properties.forEach((item: IMarkItem) => {

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -254,17 +254,7 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
                     return oldValue.call(this, ...arguments);
                 };
             } else {
-                let oldValue = descriptor.value;
-                Object.defineProperty(owner, deprecatedProp, {
-                    get () {
-                        return oldValue;
-                    },
-                    set (v) {
-                        oldValue = v;
-                    },
-                });
-                let getsetDescriptor = Object.getOwnPropertyDescriptor(owner, deprecatedProp)!;
-                _defaultGetSet(getsetDescriptor, ownerName, deprecatedProp, warn, id, suggest);
+                _defaultGetSet(descriptor, ownerName, deprecatedProp, warn, id, suggest);
             }
         } else {
             _defaultGetSet(descriptor, ownerName, deprecatedProp, warn, id, suggest);

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -254,7 +254,17 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
                     return oldValue.call(this, ...arguments);
                 };
             } else {
-                _defaultGetSet(descriptor, ownerName, deprecatedProp, warn, id, suggest);
+                let oldValue = descriptor.value;
+                Object.defineProperty(owner, deprecatedProp, {
+                    get () {
+                        return oldValue;
+                    },
+                    set (v) {
+                        oldValue = v;
+                    },
+                });
+                let getsetDescriptor = Object.getOwnPropertyDescriptor(owner, deprecatedProp)!;
+                _defaultGetSet(getsetDescriptor, ownerName, deprecatedProp, warn, id, suggest);
             }
         } else {
             _defaultGetSet(descriptor, ownerName, deprecatedProp, warn, id, suggest);

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -256,15 +256,20 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
             } else {
                 let oldValue = descriptor.value;
                 Object.defineProperty(owner, deprecatedProp, {
+                    configurable: true,
                     get () {
                         markAsWarningLog(ownerName, deprecatedProp, warn, id, suggest);
                         return oldValue;
                     },
-                    set (v) {
-                        markAsWarningLog(ownerName, deprecatedProp, warn, id, suggest);
-                        oldValue = v;
-                    },
                 });
+                if (descriptor.writable) {
+                    Object.defineProperty(owner, deprecatedProp, {
+                        set (value) {
+                            markAsWarningLog(ownerName, deprecatedProp, warn, id, suggest);
+                            oldValue = value;
+                        },
+                    });
+                }
             }
         } else {
             _defaultGetSet(descriptor, ownerName, deprecatedProp, warn, id, suggest);

--- a/cocos/dragon-bones/CCFactory.ts
+++ b/cocos/dragon-bones/CCFactory.ts
@@ -5,7 +5,7 @@
 
 import { EDITOR } from 'internal:constants';
 import { Armature, BaseObject, Animation, BaseFactory, DragonBones } from '@cocos/dragonbones-js';
-import { Component, director, Game, game, ISchedulable, Node, RenderTexture, Scheduler, systemEvent, SystemEventType } from '../core';
+import { Component, director, Game, game, ISchedulable, Node, RenderTexture, Scheduler } from '../core';
 import { ccclass } from '../core/data/class-decorator';
 import { CCTextureAtlasData } from './CCTextureData';
 import { TextureBase } from '../core/assets/texture-base';

--- a/cocos/physics-2d/box2d/joints/mouse-joint.ts
+++ b/cocos/physics-2d/box2d/joints/mouse-joint.ts
@@ -7,8 +7,9 @@ import { IMouseJoint } from '../../spec/i-physics-joint';
 import { b2Joint } from './joint-2d';
 import { MouseJoint2D, PhysicsSystem2D, Joint2D } from '../../framework';
 import { PHYSICS_2D_PTM_RATIO } from '../../framework/physics-types';
-import { IVec2Like, systemEvent, SystemEventType, Touch, Vec2, find } from '../../../core';
+import { IVec2Like, Touch, Vec2, find } from '../../../core';
 import { b2PhysicsWorld } from '../physics-world';
+import { NodeEventType } from '../../../core/scene-graph/node-event';
 
 const tempB2Vec2 = new b2.Vec2();
 
@@ -54,10 +55,10 @@ export class b2MouseJoint extends b2Joint implements IMouseJoint {
 
         const canvas = find('Canvas');
         if (canvas) {
-            canvas.on(SystemEventType.TOUCH_START, this.onTouchBegan, this);
-            canvas.on(SystemEventType.TOUCH_MOVE, this.onTouchMove, this);
-            canvas.on(SystemEventType.TOUCH_END, this.onTouchEnd, this);
-            canvas.on(SystemEventType.TOUCH_CANCEL, this.onTouchEnd, this);
+            canvas.on(NodeEventType.TOUCH_START, this.onTouchBegan, this);
+            canvas.on(NodeEventType.TOUCH_MOVE, this.onTouchMove, this);
+            canvas.on(NodeEventType.TOUCH_END, this.onTouchEnd, this);
+            canvas.on(NodeEventType.TOUCH_CANCEL, this.onTouchEnd, this);
         }
     }
 

--- a/cocos/physics-2d/box2d/rigid-body.ts
+++ b/cocos/physics-2d/box2d/rigid-body.ts
@@ -13,6 +13,7 @@ import { PHYSICS_2D_PTM_RATIO, ERigidBody2DType } from '../framework/physics-typ
 
 import { Node } from '../../core/scene-graph/node';
 import { Collider2D } from '../framework';
+import { NodeEventType } from '../../core/scene-graph/node-event';
 
 const tempVec3 = new Vec3();
 
@@ -64,12 +65,12 @@ export class b2RigidBody2D implements IRigidBody2D {
 
     _registerNodeEvents () {
         const node = this.rigidBody.node;
-        node.on(Node.EventType.TRANSFORM_CHANGED, this._onNodeTransformChanged, this);
+        node.on(NodeEventType.TRANSFORM_CHANGED, this._onNodeTransformChanged, this);
     }
 
     _unregisterNodeEvents () {
         const node = this.rigidBody.node;
-        node.off(Node.EventType.TRANSFORM_CHANGED, this._onNodeTransformChanged, this);
+        node.off(NodeEventType.TRANSFORM_CHANGED, this._onNodeTransformChanged, this);
     }
 
     _onNodeTransformChanged (type) {

--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -37,7 +37,7 @@ import { Renderable2D } from '../2d/framework/renderable-2d';
 import { SpriteFrame } from '../2d/assets/sprite-frame';
 import { Component } from '../core/components';
 import { TMXMapInfo } from './tmx-xml-parser';
-import { Color, IVec2Like, Mat4, Size, SystemEventType, Texture2D, Vec2, Vec3, Node, warn, logID, CCBoolean, director } from '../core';
+import { Color, IVec2Like, Mat4, Size, Texture2D, Vec2, Vec3, Node, warn, logID, CCBoolean, director } from '../core';
 import { TiledTile } from './tiled-tile';
 import { MeshRenderData } from '../2d/renderer/render-data';
 import { Batcher2D } from '../2d/renderer/batcher-2d';
@@ -46,6 +46,7 @@ import {
     GIDFlags, TiledGrid, TiledAnimationType, PropertiesInfo, TMXLayerInfo,
 } from './tiled-types';
 import { fillTextureGrids, loadAllTextures } from './tiled-utils';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 const _mat4_temp = new Mat4();
 const _vec2_temp = new Vec2();
@@ -229,8 +230,8 @@ export class TiledLayer extends Renderable2D {
         this._positionToRowCol(_vec2_temp.x, _vec2_temp.y, _tempRowCol);
         this._addUserNodeToGrid(dataComp, _tempRowCol);
         this._updateCullingOffsetByUserNode(node);
-        node.on(SystemEventType.TRANSFORM_CHANGED, this._userNodePosChange, dataComp);
-        node.on(SystemEventType.SIZE_CHANGED, this._userNodeSizeChange, dataComp);
+        node.on(NodeEventType.TRANSFORM_CHANGED, this._userNodePosChange, dataComp);
+        node.on(NodeEventType.SIZE_CHANGED, this._userNodeSizeChange, dataComp);
         return true;
     }
 
@@ -247,8 +248,8 @@ export class TiledLayer extends Renderable2D {
             warn('CCTiledLayer:removeUserNode node is not exist');
             return false;
         }
-        node.off(SystemEventType.TRANSFORM_CHANGED, this._userNodePosChange, dataComp);
-        node.off(SystemEventType.SIZE_CHANGED, this._userNodeSizeChange, dataComp);
+        node.off(NodeEventType.TRANSFORM_CHANGED, this._userNodePosChange, dataComp);
+        node.off(NodeEventType.SIZE_CHANGED, this._userNodeSizeChange, dataComp);
         this._removeUserNodeFromGrid(dataComp);
         delete this._userNodeMap[node.uuid];
         node._removeComponent(dataComp);
@@ -394,11 +395,11 @@ export class TiledLayer extends Renderable2D {
 
     onEnable () {
         super.onEnable();
-        this.node.on(SystemEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
-        this.node.on(SystemEventType.TRANSFORM_CHANGED, this.updateCulling, this);
-        this.node.on(SystemEventType.SIZE_CHANGED, this.updateCulling, this);
-        this.node.parent!.on(SystemEventType.TRANSFORM_CHANGED, this.updateCulling, this);
-        this.node.parent!.on(SystemEventType.SIZE_CHANGED, this.updateCulling, this);
+        this.node.on(NodeEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
+        this.node.on(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
+        this.node.on(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
+        this.node.parent!.on(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
+        this.node.parent!.on(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
         this.markForUpdateRenderData();
         // delay 1 frame, since camera's matrix data is dirty
         this.scheduleOnce(this.updateCulling.bind(this));
@@ -406,11 +407,11 @@ export class TiledLayer extends Renderable2D {
 
     onDisable () {
         super.onDisable();
-        this.node.parent!.off(SystemEventType.SIZE_CHANGED, this.updateCulling, this);
-        this.node.parent!.off(SystemEventType.TRANSFORM_CHANGED, this.updateCulling, this);
-        this.node.off(SystemEventType.SIZE_CHANGED, this.updateCulling, this);
-        this.node.off(SystemEventType.TRANSFORM_CHANGED, this.updateCulling, this);
-        this.node.off(SystemEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
+        this.node.parent!.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
+        this.node.parent!.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
+        this.node.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
+        this.node.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
+        this.node.off(NodeEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
     }
 
     protected _syncAnchorPoint () {

--- a/cocos/tiledmap/tiled-map.ts
+++ b/cocos/tiledmap/tiled-map.ts
@@ -40,8 +40,9 @@ import { TiledObjectGroup } from './tiled-object-group';
 import { TiledMapAsset } from './tiled-map-asset';
 import { Sprite } from '../2d/components/sprite';
 import { fillTextureGrids, loadAllTextures } from './tiled-utils';
-import { Size, SystemEventType, Vec2, Node, logID, Color, sys } from '../core';
+import { Size, Vec2, Node, logID, Color, sys } from '../core';
 import { SpriteFrame } from '../2d/assets';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 interface ImageExtendedNode extends Node {
     layerInfo: TMXImageLayerInfo;
@@ -315,11 +316,11 @@ export class TiledMap extends Component {
     }
 
     onEnable () {
-        this.node.on(SystemEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
+        this.node.on(NodeEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
     }
 
     onDisable () {
-        this.node.off(SystemEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
+        this.node.off(NodeEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
     }
 
     _applyFile () {

--- a/cocos/ui/block-input-events.ts
+++ b/cocos/ui/block-input-events.ts
@@ -32,11 +32,11 @@
 import { ccclass, help, menu } from 'cc.decorator';
 import { Component } from '../core/components/component';
 import { Event } from '../core/event';
-import { SystemEventType } from '../core/platform/event-manager/event-enum';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
-const BlockEvents = [SystemEventType.TOUCH_START, SystemEventType.TOUCH_END, SystemEventType.TOUCH_MOVE,
-    SystemEventType.MOUSE_DOWN, SystemEventType.MOUSE_MOVE, SystemEventType.MOUSE_UP,
-    SystemEventType.MOUSE_ENTER, SystemEventType.MOUSE_LEAVE, SystemEventType.MOUSE_WHEEL];
+const BlockEvents = [NodeEventType.TOUCH_START, NodeEventType.TOUCH_END, NodeEventType.TOUCH_MOVE,
+    NodeEventType.MOUSE_DOWN, NodeEventType.MOUSE_MOVE, NodeEventType.MOUSE_UP,
+    NodeEventType.MOUSE_ENTER, NodeEventType.MOUSE_LEAVE, NodeEventType.MOUSE_WHEEL];
 
 function stopPropagation (event: Event) {
     event.propagationStopped = true;

--- a/cocos/ui/button.ts
+++ b/cocos/ui/button.ts
@@ -34,7 +34,7 @@ import { EDITOR } from 'internal:constants';
 import { SpriteFrame } from '../2d/assets';
 import { Component, EventHandler as ComponentEventHandler } from '../core/components';
 import { UITransform, Renderable2D } from '../2d/framework';
-import { EventMouse, EventTouch, SystemEventType } from '../core/platform';
+import { EventMouse, EventTouch } from '../core/platform';
 import { Color, Vec3 } from '../core/math';
 import { ccenum } from '../core/value-types/enum';
 import { lerp } from '../core/math/utils';
@@ -42,6 +42,7 @@ import { Node } from '../core/scene-graph/node';
 import { Sprite } from '../2d/components/sprite';
 import { legacyCC } from '../core/global-exports';
 import { TransformBit } from '../core/scene-graph/node-enum';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 const _tempColor = new Color();
 
@@ -672,39 +673,39 @@ export class Button extends Component {
     }
 
     protected _registerNodeEvent () {
-        this.node.on(SystemEventType.TOUCH_START, this._onTouchBegan, this);
-        this.node.on(SystemEventType.TOUCH_MOVE, this._onTouchMove, this);
-        this.node.on(SystemEventType.TOUCH_END, this._onTouchEnded, this);
-        this.node.on(SystemEventType.TOUCH_CANCEL, this._onTouchCancel, this);
+        this.node.on(NodeEventType.TOUCH_START, this._onTouchBegan, this);
+        this.node.on(NodeEventType.TOUCH_MOVE, this._onTouchMove, this);
+        this.node.on(NodeEventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.on(NodeEventType.TOUCH_CANCEL, this._onTouchCancel, this);
 
-        this.node.on(SystemEventType.MOUSE_ENTER, this._onMouseMoveIn, this);
-        this.node.on(SystemEventType.MOUSE_LEAVE, this._onMouseMoveOut, this);
+        this.node.on(NodeEventType.MOUSE_ENTER, this._onMouseMoveIn, this);
+        this.node.on(NodeEventType.MOUSE_LEAVE, this._onMouseMoveOut, this);
     }
 
     protected _registerTargetEvent (target) {
         if (EDITOR && !legacyCC.GAME_VIEW) {
             target.on(Sprite.EventType.SPRITE_FRAME_CHANGED, this._onTargetSpriteFrameChanged, this);
-            target.on(SystemEventType.COLOR_CHANGED, this._onTargetColorChanged, this);
+            target.on(NodeEventType.COLOR_CHANGED, this._onTargetColorChanged, this);
         }
-        target.on(SystemEventType.TRANSFORM_CHANGED, this._onTargetTransformChanged, this);
+        target.on(NodeEventType.TRANSFORM_CHANGED, this._onTargetTransformChanged, this);
     }
 
     protected _unregisterNodeEvent () {
-        this.node.off(SystemEventType.TOUCH_START, this._onTouchBegan, this);
-        this.node.off(SystemEventType.TOUCH_MOVE, this._onTouchMove, this);
-        this.node.off(SystemEventType.TOUCH_END, this._onTouchEnded, this);
-        this.node.off(SystemEventType.TOUCH_CANCEL, this._onTouchCancel, this);
+        this.node.off(NodeEventType.TOUCH_START, this._onTouchBegan, this);
+        this.node.off(NodeEventType.TOUCH_MOVE, this._onTouchMove, this);
+        this.node.off(NodeEventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.off(NodeEventType.TOUCH_CANCEL, this._onTouchCancel, this);
 
-        this.node.off(SystemEventType.MOUSE_ENTER, this._onMouseMoveIn, this);
-        this.node.off(SystemEventType.MOUSE_LEAVE, this._onMouseMoveOut, this);
+        this.node.off(NodeEventType.MOUSE_ENTER, this._onMouseMoveIn, this);
+        this.node.off(NodeEventType.MOUSE_LEAVE, this._onMouseMoveOut, this);
     }
 
     protected _unregisterTargetEvent (target) {
         if (EDITOR && !legacyCC.GAME_VIEW) {
             target.off(Sprite.EventType.SPRITE_FRAME_CHANGED);
-            target.off(SystemEventType.COLOR_CHANGED);
+            target.off(NodeEventType.COLOR_CHANGED);
         }
-        target.off(SystemEventType.TRANSFORM_CHANGED);
+        target.off(NodeEventType.TRANSFORM_CHANGED);
     }
 
     protected _getTargetSprite (target: Node | null) {

--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -37,7 +37,6 @@ import { Component } from '../../core/components/component';
 import { EventHandler as ComponentEventHandler } from '../../core/components/component-event-handler';
 import { Color, Size, Vec3 } from '../../core/math';
 import { EventTouch } from '../../core/platform';
-import { SystemEventType } from '../../core/platform/event-manager/event-enum';
 import { Node } from '../../core/scene-graph/node';
 import { Label, VerticalTextAlignment } from '../../2d/components/label';
 import { Sprite } from '../../2d/components/sprite';
@@ -46,6 +45,7 @@ import { EditBoxImplBase } from './edit-box-impl-base';
 import { InputFlag, InputMode, KeyboardReturnType } from './types';
 import { sys } from '../../core/platform/sys';
 import { legacyCC } from '../../core/global-exports';
+import { NodeEventType } from '../../core/scene-graph/node-event';
 
 const LEFT_PADDING = 2;
 
@@ -511,7 +511,7 @@ export class EditBox extends Component {
         this._updatePlaceholderLabel();
         this._updateTextLabel();
         this._isLabelVisible = true;
-        this.node.on(SystemEventType.SIZE_CHANGED, this._resizeChildNodes, this);
+        this.node.on(NodeEventType.SIZE_CHANGED, this._resizeChildNodes, this);
 
         const impl = this._impl = new EditBox._EditBoxImpl();
         impl.init(this);
@@ -657,13 +657,13 @@ export class EditBox extends Component {
     }
 
     protected _registerEvent () {
-        this.node.on(SystemEventType.TOUCH_START, this._onTouchBegan, this);
-        this.node.on(SystemEventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.on(NodeEventType.TOUCH_START, this._onTouchBegan, this);
+        this.node.on(NodeEventType.TOUCH_END, this._onTouchEnded, this);
     }
 
     protected _unregisterEvent () {
-        this.node.off(SystemEventType.TOUCH_START, this._onTouchBegan, this);
-        this.node.off(SystemEventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.off(NodeEventType.TOUCH_START, this._onTouchBegan, this);
+        this.node.off(NodeEventType.TOUCH_END, this._onTouchEnded, this);
     }
 
     protected _updateLabelPosition (size: Size) {

--- a/cocos/ui/layout.ts
+++ b/cocos/ui/layout.ts
@@ -34,12 +34,11 @@ import { Component } from '../core/components/component';
 import { Rect, Size, Vec2, Vec3 } from '../core/math';
 import { ccenum } from '../core/value-types/enum';
 import { UITransform } from '../2d/framework/ui-transform';
-import { SystemEventType } from '../core/platform/event-manager/event-enum';
 import { director, Director } from '../core/director';
 import { TransformBit } from '../core/scene-graph/node-enum';
 import { Node, warn } from '../core';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
-const NodeEvent = SystemEventType;
 /**
  * @en Layout type.
  *
@@ -712,22 +711,22 @@ export class Layout extends Component {
 
     protected _addEventListeners () {
         director.on(Director.EVENT_AFTER_UPDATE, this.updateLayout, this);
-        this.node.on(NodeEvent.SIZE_CHANGED, this._resized, this);
-        this.node.on(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
-        this.node.on(NodeEvent.CHILD_ADDED, this._childAdded, this);
-        this.node.on(NodeEvent.CHILD_REMOVED, this._childRemoved, this);
-        this.node.on(NodeEvent.SIBLING_ORDER_CHANGED, this._childrenChanged, this);
+        this.node.on(NodeEventType.SIZE_CHANGED, this._resized, this);
+        this.node.on(NodeEventType.ANCHOR_CHANGED, this._doLayoutDirty, this);
+        this.node.on(NodeEventType.CHILD_ADDED, this._childAdded, this);
+        this.node.on(NodeEventType.CHILD_REMOVED, this._childRemoved, this);
+        this.node.on(NodeEventType.SIBLING_ORDER_CHANGED, this._childrenChanged, this);
         this.node.on('childrenSiblingOrderChanged', this.updateLayout, this);
         this._addChildrenEventListeners();
     }
 
     protected _removeEventListeners () {
         director.off(Director.EVENT_AFTER_UPDATE, this.updateLayout, this);
-        this.node.off(NodeEvent.SIZE_CHANGED, this._resized, this);
-        this.node.off(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
-        this.node.off(NodeEvent.CHILD_ADDED, this._childAdded, this);
-        this.node.off(NodeEvent.CHILD_REMOVED, this._childRemoved, this);
-        this.node.off(NodeEvent.SIBLING_ORDER_CHANGED, this._childrenChanged, this);
+        this.node.off(NodeEventType.SIZE_CHANGED, this._resized, this);
+        this.node.off(NodeEventType.ANCHOR_CHANGED, this._doLayoutDirty, this);
+        this.node.off(NodeEventType.CHILD_ADDED, this._childAdded, this);
+        this.node.off(NodeEventType.CHILD_REMOVED, this._childRemoved, this);
+        this.node.off(NodeEventType.SIBLING_ORDER_CHANGED, this._childrenChanged, this);
         this.node.off('childrenSiblingOrderChanged', this.updateLayout, this);
         this._removeChildrenEventListeners();
     }
@@ -736,9 +735,9 @@ export class Layout extends Component {
         const children = this.node.children;
         for (let i = 0; i < children.length; ++i) {
             const child = children[i];
-            child.on(NodeEvent.SIZE_CHANGED, this._doLayoutDirty, this);
-            child.on(NodeEvent.TRANSFORM_CHANGED, this._transformDirty, this);
-            child.on(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
+            child.on(NodeEventType.SIZE_CHANGED, this._doLayoutDirty, this);
+            child.on(NodeEventType.TRANSFORM_CHANGED, this._transformDirty, this);
+            child.on(NodeEventType.ANCHOR_CHANGED, this._doLayoutDirty, this);
             child.on('active-in-hierarchy-changed', this._childrenChanged, this);
         }
     }
@@ -747,25 +746,25 @@ export class Layout extends Component {
         const children = this.node.children;
         for (let i = 0; i < children.length; ++i) {
             const child = children[i];
-            child.off(NodeEvent.SIZE_CHANGED, this._doLayoutDirty, this);
-            child.off(NodeEvent.TRANSFORM_CHANGED, this._transformDirty, this);
-            child.off(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
+            child.off(NodeEventType.SIZE_CHANGED, this._doLayoutDirty, this);
+            child.off(NodeEventType.TRANSFORM_CHANGED, this._transformDirty, this);
+            child.off(NodeEventType.ANCHOR_CHANGED, this._doLayoutDirty, this);
             child.off('active-in-hierarchy-changed', this._childrenChanged, this);
         }
     }
 
     protected _childAdded (child: Node) {
-        child.on(NodeEvent.SIZE_CHANGED, this._doLayoutDirty, this);
-        child.on(NodeEvent.TRANSFORM_CHANGED, this._transformDirty, this);
-        child.on(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
+        child.on(NodeEventType.SIZE_CHANGED, this._doLayoutDirty, this);
+        child.on(NodeEventType.TRANSFORM_CHANGED, this._transformDirty, this);
+        child.on(NodeEventType.ANCHOR_CHANGED, this._doLayoutDirty, this);
         child.on('active-in-hierarchy-changed', this._childrenChanged, this);
         this._childrenChanged();
     }
 
     protected _childRemoved (child: Node) {
-        child.off(NodeEvent.SIZE_CHANGED, this._doLayoutDirty, this);
-        child.off(NodeEvent.TRANSFORM_CHANGED, this._transformDirty, this);
-        child.off(NodeEvent.ANCHOR_CHANGED, this._doLayoutDirty, this);
+        child.off(NodeEventType.SIZE_CHANGED, this._doLayoutDirty, this);
+        child.off(NodeEventType.TRANSFORM_CHANGED, this._transformDirty, this);
+        child.off(NodeEventType.ANCHOR_CHANGED, this._doLayoutDirty, this);
         child.off('active-in-hierarchy-changed', this._childrenChanged, this);
         this._childrenChanged();
     }

--- a/cocos/ui/page-view.ts
+++ b/cocos/ui/page-view.ts
@@ -31,7 +31,7 @@
 import { ccclass, help, executionOrder, menu, tooltip, type, slide, range, visible, override, serializable, editable } from 'cc.decorator';
 import { EDITOR } from 'internal:constants';
 import { EventHandler as ComponentEventHandler } from '../core/components';
-import { EventTouch, SystemEventType } from '../core/platform';
+import { EventTouch } from '../core/platform';
 import { Vec2, Vec3 } from '../core/math';
 import { ccenum } from '../core/value-types/enum';
 import { Layout } from './layout';
@@ -42,6 +42,7 @@ import { warnID, logID } from '../core/platform/debug';
 import { extendsEnum } from '../core/data/utils/extends-enum';
 import { Node } from '../core/scene-graph';
 import { legacyCC } from '../core/global-exports';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 const _tempVec2 = new Vec2();
 
@@ -324,7 +325,7 @@ export class PageView extends ScrollView {
 
     public onEnable () {
         super.onEnable();
-        this.node.on(SystemEventType.SIZE_CHANGED, this._updateAllPagesSize, this);
+        this.node.on(NodeEventType.SIZE_CHANGED, this._updateAllPagesSize, this);
         if (!EDITOR || legacyCC.GAME_VIEW) {
             this.node.on(PageView.EventType.SCROLL_ENG_WITH_THRESHOLD, this._dispatchPageTurningEvent, this);
         }
@@ -332,7 +333,7 @@ export class PageView extends ScrollView {
 
     public onDisable () {
         super.onDisable();
-        this.node.off(SystemEventType.SIZE_CHANGED, this._updateAllPagesSize, this);
+        this.node.off(NodeEventType.SIZE_CHANGED, this._updateAllPagesSize, this);
         if (!EDITOR || legacyCC.GAME_VIEW) {
             this.node.off(PageView.EventType.SCROLL_ENG_WITH_THRESHOLD, this._dispatchPageTurningEvent, this);
         }

--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -34,7 +34,7 @@ import { EDITOR } from 'internal:constants';
 import { EventHandler as ComponentEventHandler } from '../core/components/component-event-handler';
 import { UITransform } from '../2d/framework';
 import { Event } from '../core/event';
-import { EventMouse, EventTouch, Touch, logID } from '../core/platform';
+import { EventMouse, EventTouch, Touch, logID, SystemEventType } from '../core/platform';
 import { Size, Vec2, Vec3 } from '../core/math';
 import { Layout } from './layout';
 import { ScrollBar } from './scroll-bar';
@@ -1053,8 +1053,7 @@ export class ScrollView extends ViewGroup {
         if (deltaMove.length() > 7) {
             if (!this._touchMoved && event.target !== this.node) {
                 // Simulate touch cancel for target node
-                const cancelEvent = new EventTouch(event.getTouches(), event.bubbles);
-                cancelEvent.type = Node.EventType.TOUCH_CANCEL;
+                const cancelEvent = new EventTouch(event.getTouches(), event.bubbles, SystemEventType.TOUCH_CANCEL);
                 cancelEvent.touch = event.touch;
                 cancelEvent.simulate = true;
                 (event.target as Node).dispatchEvent(cancelEvent);

--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -34,7 +34,7 @@ import { EDITOR } from 'internal:constants';
 import { EventHandler as ComponentEventHandler } from '../core/components/component-event-handler';
 import { UITransform } from '../2d/framework';
 import { Event } from '../core/event';
-import { EventMouse, EventTouch, Touch, logID, TouchEvent } from '../core/platform';
+import { EventMouse, EventTouch, Touch, logID } from '../core/platform';
 import { Size, Vec2, Vec3 } from '../core/math';
 import { Layout } from './layout';
 import { ScrollBar } from './scroll-bar';
@@ -44,6 +44,7 @@ import { director, Director } from '../core/director';
 import { TransformBit } from '../core/scene-graph/node-enum';
 import { legacyCC } from '../core/global-exports';
 import { NodeEventType } from '../core/scene-graph/node-event';
+import { TouchEvent } from '../core/platform/event-manager/event-enum';
 
 const NUMBER_OF_GATHERED_TOUCHES_FOR_MOVE_SPEED = 5;
 const OUT_OF_BOUNDARY_BREAKING_FACTOR = 0.05;

--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -34,7 +34,7 @@ import { EDITOR } from 'internal:constants';
 import { EventHandler as ComponentEventHandler } from '../core/components/component-event-handler';
 import { UITransform } from '../2d/framework';
 import { Event } from '../core/event';
-import { EventMouse, EventTouch, Touch, logID, SystemEventType } from '../core/platform';
+import { EventMouse, EventTouch, Touch, logID, TouchEvent } from '../core/platform';
 import { Size, Vec2, Vec3 } from '../core/math';
 import { Layout } from './layout';
 import { ScrollBar } from './scroll-bar';
@@ -43,6 +43,7 @@ import { Node } from '../core/scene-graph/node';
 import { director, Director } from '../core/director';
 import { TransformBit } from '../core/scene-graph/node-enum';
 import { legacyCC } from '../core/global-exports';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 const NUMBER_OF_GATHERED_TOUCHES_FOR_MOVE_SPEED = 5;
 const OUT_OF_BOUNDARY_BREAKING_FACTOR = 0.05;
@@ -943,11 +944,11 @@ export class ScrollView extends ViewGroup {
         if (!EDITOR || legacyCC.GAME_VIEW) {
             this._registerEvent();
             if (this._content) {
-                this._content.on(Node.EventType.SIZE_CHANGED, this._calculateBoundary, this);
-                this._content.on(Node.EventType.TRANSFORM_CHANGED, this._scaleChanged, this);
+                this._content.on(NodeEventType.SIZE_CHANGED, this._calculateBoundary, this);
+                this._content.on(NodeEventType.TRANSFORM_CHANGED, this._scaleChanged, this);
                 if (this.view) {
-                    this.view.node.on(Node.EventType.TRANSFORM_CHANGED, this._scaleChanged, this);
-                    this.view.node.on(Node.EventType.SIZE_CHANGED, this._calculateBoundary, this);
+                    this.view.node.on(NodeEventType.TRANSFORM_CHANGED, this._scaleChanged, this);
+                    this.view.node.on(NodeEventType.SIZE_CHANGED, this._calculateBoundary, this);
                 }
             }
 
@@ -966,11 +967,11 @@ export class ScrollView extends ViewGroup {
         if (!EDITOR || legacyCC.GAME_VIEW) {
             this._unregisterEvent();
             if (this._content) {
-                this._content.off(Node.EventType.SIZE_CHANGED, this._calculateBoundary, this);
-                this._content.off(Node.EventType.TRANSFORM_CHANGED, this._scaleChanged, this);
+                this._content.off(NodeEventType.SIZE_CHANGED, this._calculateBoundary, this);
+                this._content.off(NodeEventType.TRANSFORM_CHANGED, this._scaleChanged, this);
                 if (this.view) {
-                    this.view.node.off(Node.EventType.TRANSFORM_CHANGED, this._scaleChanged, this);
-                    this.view.node.off(Node.EventType.SIZE_CHANGED, this._calculateBoundary, this);
+                    this.view.node.off(NodeEventType.TRANSFORM_CHANGED, this._scaleChanged, this);
+                    this.view.node.off(NodeEventType.SIZE_CHANGED, this._calculateBoundary, this);
                 }
             }
         }
@@ -980,19 +981,19 @@ export class ScrollView extends ViewGroup {
 
     // private methods
     protected _registerEvent () {
-        this.node.on(Node.EventType.TOUCH_START, this._onTouchBegan, this, true);
-        this.node.on(Node.EventType.TOUCH_MOVE, this._onTouchMoved, this, true);
-        this.node.on(Node.EventType.TOUCH_END, this._onTouchEnded, this, true);
-        this.node.on(Node.EventType.TOUCH_CANCEL, this._onTouchCancelled, this, true);
-        this.node.on(Node.EventType.MOUSE_WHEEL, this._onMouseWheel, this, true);
+        this.node.on(NodeEventType.TOUCH_START, this._onTouchBegan, this, true);
+        this.node.on(NodeEventType.TOUCH_MOVE, this._onTouchMoved, this, true);
+        this.node.on(NodeEventType.TOUCH_END, this._onTouchEnded, this, true);
+        this.node.on(NodeEventType.TOUCH_CANCEL, this._onTouchCancelled, this, true);
+        this.node.on(NodeEventType.MOUSE_WHEEL, this._onMouseWheel, this, true);
     }
 
     protected _unregisterEvent () {
-        this.node.off(Node.EventType.TOUCH_START, this._onTouchBegan, this, true);
-        this.node.off(Node.EventType.TOUCH_MOVE, this._onTouchMoved, this, true);
-        this.node.off(Node.EventType.TOUCH_END, this._onTouchEnded, this, true);
-        this.node.off(Node.EventType.TOUCH_CANCEL, this._onTouchCancelled, this, true);
-        this.node.off(Node.EventType.MOUSE_WHEEL, this._onMouseWheel, this, true);
+        this.node.off(NodeEventType.TOUCH_START, this._onTouchBegan, this, true);
+        this.node.off(NodeEventType.TOUCH_MOVE, this._onTouchMoved, this, true);
+        this.node.off(NodeEventType.TOUCH_END, this._onTouchEnded, this, true);
+        this.node.off(NodeEventType.TOUCH_CANCEL, this._onTouchCancelled, this, true);
+        this.node.off(NodeEventType.MOUSE_WHEEL, this._onMouseWheel, this, true);
     }
 
     protected _onMouseWheel (event: EventMouse, captureListeners?: Node[]) {
@@ -1053,7 +1054,7 @@ export class ScrollView extends ViewGroup {
         if (deltaMove.length() > 7) {
             if (!this._touchMoved && event.target !== this.node) {
                 // Simulate touch cancel for target node
-                const cancelEvent = new EventTouch(event.getTouches(), event.bubbles, SystemEventType.TOUCH_CANCEL);
+                const cancelEvent = new EventTouch(event.getTouches(), event.bubbles, TouchEvent.TOUCH_CANCEL);
                 cancelEvent.touch = event.touch;
                 cancelEvent.simulate = true;
                 (event.target as Node).dispatchEvent(cancelEvent);

--- a/cocos/ui/slider.ts
+++ b/cocos/ui/slider.ts
@@ -33,12 +33,13 @@ import { ccclass, help, executionOrder, menu, requireComponent, tooltip, type, s
 import { EDITOR } from 'internal:constants';
 import { Component, EventHandler } from '../core/components';
 import { UITransform } from '../2d/framework';
-import { EventTouch, SystemEventType, Touch } from '../core/platform';
+import { EventTouch, Touch } from '../core/platform';
 import { Vec3 } from '../core/math';
 import { ccenum } from '../core/value-types/enum';
 import { clamp01 } from '../core/math/utils';
 import { Sprite } from '../2d/components/sprite';
 import { legacyCC } from '../core/global-exports';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 const _tempPos = new Vec3();
 /**
@@ -186,26 +187,26 @@ export class Slider extends Component {
     public onEnable () {
         this._updateHandlePosition();
 
-        this.node.on(SystemEventType.TOUCH_START, this._onTouchBegan, this);
-        this.node.on(SystemEventType.TOUCH_MOVE, this._onTouchMoved, this);
-        this.node.on(SystemEventType.TOUCH_END, this._onTouchEnded, this);
-        this.node.on(SystemEventType.TOUCH_CANCEL, this._onTouchCancelled, this);
+        this.node.on(NodeEventType.TOUCH_START, this._onTouchBegan, this);
+        this.node.on(NodeEventType.TOUCH_MOVE, this._onTouchMoved, this);
+        this.node.on(NodeEventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.on(NodeEventType.TOUCH_CANCEL, this._onTouchCancelled, this);
         if (this._handle && this._handle.isValid) {
-            this._handle.node.on(SystemEventType.TOUCH_START, this._onHandleDragStart, this);
-            this._handle.node.on(SystemEventType.TOUCH_MOVE, this._onTouchMoved, this);
-            this._handle.node.on(SystemEventType.TOUCH_END, this._onTouchEnded, this);
+            this._handle.node.on(NodeEventType.TOUCH_START, this._onHandleDragStart, this);
+            this._handle.node.on(NodeEventType.TOUCH_MOVE, this._onTouchMoved, this);
+            this._handle.node.on(NodeEventType.TOUCH_END, this._onTouchEnded, this);
         }
     }
 
     public onDisable () {
-        this.node.off(SystemEventType.TOUCH_START, this._onTouchBegan, this);
-        this.node.off(SystemEventType.TOUCH_MOVE, this._onTouchMoved, this);
-        this.node.off(SystemEventType.TOUCH_END, this._onTouchEnded, this);
-        this.node.off(SystemEventType.TOUCH_CANCEL, this._onTouchCancelled, this);
+        this.node.off(NodeEventType.TOUCH_START, this._onTouchBegan, this);
+        this.node.off(NodeEventType.TOUCH_MOVE, this._onTouchMoved, this);
+        this.node.off(NodeEventType.TOUCH_END, this._onTouchEnded, this);
+        this.node.off(NodeEventType.TOUCH_CANCEL, this._onTouchCancelled, this);
         if (this._handle && this._handle.isValid) {
-            this._handle.node.off(SystemEventType.TOUCH_START, this._onHandleDragStart, this);
-            this._handle.node.off(SystemEventType.TOUCH_MOVE, this._onTouchMoved, this);
-            this._handle.node.off(SystemEventType.TOUCH_END, this._onTouchEnded, this);
+            this._handle.node.off(NodeEventType.TOUCH_START, this._onHandleDragStart, this);
+            this._handle.node.off(NodeEventType.TOUCH_MOVE, this._onTouchMoved, this);
+            this._handle.node.off(NodeEventType.TOUCH_END, this._onTouchEnded, this);
         }
     }
 

--- a/cocos/ui/sub-context-view.ts
+++ b/cocos/ui/sub-context-view.ts
@@ -42,7 +42,8 @@ import { ImageAsset } from '../core/assets/image-asset';
 import { Rect, Size } from '../core/math';
 
 import { legacyCC } from '../core/global-exports';
-import { CCObject, SystemEventType } from '../core';
+import { CCObject } from '../core';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 /**
  * @en SubContextView is a view component which controls open data context viewport in WeChat game platform.<br/>
@@ -227,15 +228,15 @@ export class SubContextView extends Component {
     }
 
     private _registerNodeEvent () {
-        this.node.on(Node.EventType.TRANSFORM_CHANGED, this._updateSubContextView, this);
-        this.node.on(Node.EventType.SIZE_CHANGED, this._updateSubContextView, this);
-        this.node.on(SystemEventType.LAYER_CHANGED, this._updateContentLayer, this);
+        this.node.on(NodeEventType.TRANSFORM_CHANGED, this._updateSubContextView, this);
+        this.node.on(NodeEventType.SIZE_CHANGED, this._updateSubContextView, this);
+        this.node.on(NodeEventType.LAYER_CHANGED, this._updateContentLayer, this);
     }
 
     private _unregisterNodeEvent () {
-        this.node.off(Node.EventType.TRANSFORM_CHANGED, this._updateSubContextView, this);
-        this.node.off(Node.EventType.SIZE_CHANGED, this._updateSubContextView, this);
-        this.node.off(SystemEventType.LAYER_CHANGED, this._updateContentLayer, this);
+        this.node.off(NodeEventType.TRANSFORM_CHANGED, this._updateSubContextView, this);
+        this.node.off(NodeEventType.SIZE_CHANGED, this._updateSubContextView, this);
+        this.node.off(NodeEventType.LAYER_CHANGED, this._updateContentLayer, this);
     }
 
     private _updateContentLayer () {

--- a/cocos/ui/toggle-container.ts
+++ b/cocos/ui/toggle-container.ts
@@ -33,7 +33,7 @@ import { ccclass, help, executeInEditMode, executionOrder, menu, tooltip, type, 
 import { Component, EventHandler as ComponentEventHandler } from '../core/components';
 import { Toggle } from './toggle';
 import { legacyCC } from '../core/global-exports';
-import { SystemEventType } from '../core/platform/event-manager';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 /**
  * @en
@@ -103,13 +103,13 @@ export class ToggleContainer extends Component {
 
     public onEnable () {
         this.ensureValidState();
-        this.node.on(SystemEventType.CHILD_ADDED, this.ensureValidState, this);
-        this.node.on(SystemEventType.CHILD_REMOVED, this.ensureValidState, this);
+        this.node.on(NodeEventType.CHILD_ADDED, this.ensureValidState, this);
+        this.node.on(NodeEventType.CHILD_REMOVED, this.ensureValidState, this);
     }
 
     public onDisable () {
-        this.node.off(SystemEventType.CHILD_ADDED, this.ensureValidState, this);
-        this.node.off(SystemEventType.CHILD_REMOVED, this.ensureValidState, this);
+        this.node.off(NodeEventType.CHILD_ADDED, this.ensureValidState, this);
+        this.node.off(NodeEventType.CHILD_REMOVED, this.ensureValidState, this);
     }
 
     public activeToggles () {

--- a/cocos/ui/widget.ts
+++ b/cocos/ui/widget.ts
@@ -35,7 +35,6 @@ import { Component } from '../core/components';
 import { UITransform } from '../2d/framework/ui-transform';
 import { Size, Vec2, Vec3 } from '../core/math';
 import { errorID, warnID } from '../core/platform/debug';
-import { SystemEventType } from '../core/platform/event-manager/event-enum';
 import { View } from '../core/platform/view';
 import visibleRect from '../core/platform/visible-rect';
 import { Scene } from '../core/scene-graph';
@@ -43,6 +42,7 @@ import { Node } from '../core/scene-graph/node';
 import { ccenum } from '../core/value-types/enum';
 import { TransformBit } from '../core/scene-graph/node-enum';
 import { legacyCC } from '../core/global-exports';
+import { NodeEventType } from '../core/scene-graph/node-event';
 
 const _tempScale = new Vec2();
 
@@ -845,29 +845,29 @@ export class Widget extends Component {
 
     protected _registerEvent () {
         if (EDITOR && !legacyCC.GAME_VIEW) {
-            this.node.on(SystemEventType.TRANSFORM_CHANGED, this._adjustWidgetToAllowMovingInEditor, this);
-            this.node.on(SystemEventType.SIZE_CHANGED, this._adjustWidgetToAllowResizingInEditor, this);
+            this.node.on(NodeEventType.TRANSFORM_CHANGED, this._adjustWidgetToAllowMovingInEditor, this);
+            this.node.on(NodeEventType.SIZE_CHANGED, this._adjustWidgetToAllowResizingInEditor, this);
         } else {
-            this.node.on(SystemEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
-            this.node.on(SystemEventType.SIZE_CHANGED, this._setDirtyByMode, this);
+            this.node.on(NodeEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
+            this.node.on(NodeEventType.SIZE_CHANGED, this._setDirtyByMode, this);
         }
-        this.node.on(SystemEventType.ANCHOR_CHANGED, this._adjustWidgetToAnchorChanged, this);
-        this.node.on(SystemEventType.PARENT_CHANGED, this._adjustTargetToParentChanged, this);
+        this.node.on(NodeEventType.ANCHOR_CHANGED, this._adjustWidgetToAnchorChanged, this);
+        this.node.on(NodeEventType.PARENT_CHANGED, this._adjustTargetToParentChanged, this);
     }
 
     protected _unregisterEvent () {
         if (EDITOR && !legacyCC.GAME_VIEW) {
-            this.node.off(SystemEventType.TRANSFORM_CHANGED, this._adjustWidgetToAllowMovingInEditor, this);
-            this.node.off(SystemEventType.SIZE_CHANGED, this._adjustWidgetToAllowResizingInEditor, this);
+            this.node.off(NodeEventType.TRANSFORM_CHANGED, this._adjustWidgetToAllowMovingInEditor, this);
+            this.node.off(NodeEventType.SIZE_CHANGED, this._adjustWidgetToAllowResizingInEditor, this);
         } else {
-            this.node.off(SystemEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
-            this.node.off(SystemEventType.SIZE_CHANGED, this._setDirtyByMode, this);
+            this.node.off(NodeEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
+            this.node.off(NodeEventType.SIZE_CHANGED, this._setDirtyByMode, this);
         }
-        this.node.off(SystemEventType.ANCHOR_CHANGED, this._adjustWidgetToAnchorChanged, this);
+        this.node.off(NodeEventType.ANCHOR_CHANGED, this._adjustWidgetToAnchorChanged, this);
     }
 
     protected _removeParentEvent () {
-        this.node.off(SystemEventType.PARENT_CHANGED, this._adjustTargetToParentChanged, this);
+        this.node.off(NodeEventType.PARENT_CHANGED, this._adjustTargetToParentChanged, this);
     }
 
     protected _autoChangedValue (flag: AlignFlags, isAbs: boolean) {
@@ -900,8 +900,8 @@ export class Widget extends Component {
         const target = this._target || this.node.parent;
         if (target) {
             if (target.getComponent(UITransform)) {
-                target.on(SystemEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
-                target.on(SystemEventType.SIZE_CHANGED, this._setDirtyByMode, this);
+                target.on(NodeEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
+                target.on(NodeEventType.SIZE_CHANGED, this._setDirtyByMode, this);
             }
         }
     }
@@ -909,16 +909,16 @@ export class Widget extends Component {
     protected _unregisterTargetEvents () {
         const target = this._target || this.node.parent;
         if (target) {
-            target.off(SystemEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
-            target.off(SystemEventType.SIZE_CHANGED, this._setDirtyByMode, this);
+            target.off(NodeEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
+            target.off(NodeEventType.SIZE_CHANGED, this._setDirtyByMode, this);
         }
     }
 
     protected _unregisterOldParentEvents (oldParent: Node) {
         const target = this._target || oldParent;
         if (target) {
-            target.off(SystemEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
-            target.off(SystemEventType.SIZE_CHANGED, this._setDirtyByMode, this);
+            target.off(NodeEventType.TRANSFORM_CHANGED, this._setDirtyByMode, this);
+            target.off(NodeEventType.SIZE_CHANGED, this._setDirtyByMode, this);
         }
     }
 

--- a/pal/input/minigame/accelerometer.ts
+++ b/pal/input/minigame/accelerometer.ts
@@ -1,6 +1,6 @@
 import { AccelerometerCallback, AccelerometerInputEvent } from 'pal/input';
 import { minigame, AccelerometerIntervalMode } from 'pal/minigame';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { DeviceEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 
 export class AccelerometerInputSource {
@@ -26,13 +26,13 @@ export class AccelerometerInputSource {
 
     private _didAccelerate (event: AccelerometerData) {
         const accelerometer: AccelerometerInputEvent = {
-            type: SystemEventType.DEVICEMOTION,
+            type: DeviceEvent.DEVICEMOTION,
             x: event.x,
             y: event.y,
             z: event.z,
             timestamp: performance.now(),
         };
-        this._eventTarget.emit(SystemEventType.DEVICEMOTION, accelerometer);
+        this._eventTarget.emit(DeviceEvent.DEVICEMOTION, accelerometer);
     }
 
     public start () {
@@ -71,6 +71,6 @@ export class AccelerometerInputSource {
         }
     }
     public onChange (cb: AccelerometerCallback) {
-        this._eventTarget.on(SystemEventType.DEVICEMOTION, cb);
+        this._eventTarget.on(DeviceEvent.DEVICEMOTION, cb);
     }
 }

--- a/pal/input/minigame/keyboard.ts
+++ b/pal/input/minigame/keyboard.ts
@@ -11,10 +11,15 @@ export class KeyboardInputSource {
     }
 
     public onDown (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEY_DOWN, cb);
+        this._eventTarget.on(SystemEventType.KEYBOARD_DOWN, cb);
+    }
+
+    public onPressing (cb: KeyboardCallback) {
+        this._eventTarget.on('keydown', cb);
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEY_UP, cb);
+        this._eventTarget.on('keyup', cb);
+        this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
     }
 }

--- a/pal/input/minigame/keyboard.ts
+++ b/pal/input/minigame/keyboard.ts
@@ -19,7 +19,6 @@ export class KeyboardInputSource {
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on('keyup', cb);
         this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
     }
 }

--- a/pal/input/minigame/keyboard.ts
+++ b/pal/input/minigame/keyboard.ts
@@ -1,5 +1,5 @@
 import { KeyboardCallback, KeyboardInputEvent } from 'pal/input';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { KeyboardEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 
 export class KeyboardInputSource {
@@ -11,7 +11,7 @@ export class KeyboardInputSource {
     }
 
     public onDown (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEYBOARD_DOWN, cb);
+        this._eventTarget.on(KeyboardEvent.KEY_DOWN, cb);
     }
 
     public onPressing (cb: KeyboardCallback) {
@@ -19,6 +19,6 @@ export class KeyboardInputSource {
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
+        this._eventTarget.on(KeyboardEvent.KEY_UP, cb);
     }
 }

--- a/pal/input/minigame/mouse.ts
+++ b/pal/input/minigame/mouse.ts
@@ -1,7 +1,7 @@
 import { MouseCallback, MouseInputEvent, MouseWheelCallback, MouseWheelInputEvent } from 'pal/input';
 import { EventMouse } from '../../../cocos/core/platform/event-manager/events';
 import { EventTarget } from '../../../cocos/core/event/event-target';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { MouseEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 
 export class MouseInputSource {
     public support: boolean;
@@ -12,15 +12,15 @@ export class MouseInputSource {
     }
 
     onDown (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_DOWN, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_DOWN, cb);
     }
     onMove (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_MOVE, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_MOVE, cb);
     }
     onUp (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_UP, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_UP, cb);
     }
     onWheel (cb: MouseWheelCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_WHEEL, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_WHEEL, cb);
     }
 }

--- a/pal/input/minigame/touch.ts
+++ b/pal/input/minigame/touch.ts
@@ -21,7 +21,7 @@ export class TouchInputSource {
         minigame.onTouchCancel(this._createCallback(SystemEventType.TOUCH_CANCEL));
     }
 
-    private _createCallback (eventType: string) {
+    private _createCallback (eventType: SystemEventType) {
         return (event: TouchEvent) => {
             const sysInfo = minigame.getSystemInfoSync();
             const touchDataList: TouchData[] = [];

--- a/pal/input/minigame/touch.ts
+++ b/pal/input/minigame/touch.ts
@@ -2,8 +2,7 @@ import { TouchCallback, TouchData, TouchInputEvent } from 'pal/input';
 import { minigame } from 'pal/minigame';
 import { Vec2 } from '../../../cocos/core/math';
 import { EventTarget } from '../../../cocos/core/event/event-target';
-import { EventTouch } from '../../../cocos/core/platform/event-manager/events';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { TouchEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 
 export class TouchInputSource {
     public support: boolean;
@@ -15,14 +14,14 @@ export class TouchInputSource {
     }
 
     private _registerEvent () {
-        minigame.onTouchStart(this._createCallback(SystemEventType.TOUCH_START));
-        minigame.onTouchMove(this._createCallback(SystemEventType.TOUCH_MOVE));
-        minigame.onTouchEnd(this._createCallback(SystemEventType.TOUCH_END));
-        minigame.onTouchCancel(this._createCallback(SystemEventType.TOUCH_CANCEL));
+        minigame.onTouchStart(this._createCallback(TouchEvent.TOUCH_START));
+        minigame.onTouchMove(this._createCallback(TouchEvent.TOUCH_MOVE));
+        minigame.onTouchEnd(this._createCallback(TouchEvent.TOUCH_END));
+        minigame.onTouchCancel(this._createCallback(TouchEvent.TOUCH_CANCEL));
     }
 
-    private _createCallback (eventType: SystemEventType) {
-        return (event: TouchEvent) => {
+    private _createCallback (eventType: TouchEvent) {
+        return (event: any) => {
             const sysInfo = minigame.getSystemInfoSync();
             const touchDataList: TouchData[] = [];
             const length = event.changedTouches.length;
@@ -51,15 +50,15 @@ export class TouchInputSource {
     }
 
     public onStart (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_START, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_START, cb);
     }
     public onMove (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_MOVE, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_MOVE, cb);
     }
     public onEnd (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_END, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_END, cb);
     }
     public onCancel (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_CANCEL, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_CANCEL, cb);
     }
 }

--- a/pal/input/native/accelerometer.ts
+++ b/pal/input/native/accelerometer.ts
@@ -1,6 +1,6 @@
 import { AccelerometerCallback, AccelerometerInputEvent } from 'pal/input';
 import { system } from 'pal/system';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { DeviceEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { Orientation, OS } from '../../system/enum-type';
 
@@ -44,14 +44,14 @@ export class AccelerometerInputSource {
             y = -y;
         }
         const accelerometer: AccelerometerInputEvent = {
-            type: SystemEventType.DEVICEMOTION,
+            type: DeviceEvent.DEVICEMOTION,
             x,
             y,
             z,
             timestamp: performance.now(),
         };
 
-        this._eventTarget.emit(SystemEventType.DEVICEMOTION, accelerometer);
+        this._eventTarget.emit(DeviceEvent.DEVICEMOTION, accelerometer);
     }
 
     public start () {
@@ -81,6 +81,6 @@ export class AccelerometerInputSource {
         }
     }
     public onChange (cb: AccelerometerCallback) {
-        this._eventTarget.on(SystemEventType.DEVICEMOTION, cb);
+        this._eventTarget.on(DeviceEvent.DEVICEMOTION, cb);
     }
 }

--- a/pal/input/native/keyboard.ts
+++ b/pal/input/native/keyboard.ts
@@ -13,11 +13,11 @@ export class KeyboardInputSource {
     }
 
     private _registerEvent () {
-        jsb.onKeyDown = this._createCallback('keydown');
-        jsb.onKeyUp =  this._createCallback('keyup');
+        jsb.onKeyDown = this._createCallback(SystemEventType.KEYBOARD_DOWN);
+        jsb.onKeyUp =  this._createCallback(SystemEventType.KEYBOARD_UP);
     }
 
-    private _createCallback (eventType: string) {
+    private _createCallback (eventType: SystemEventType) {
         return (event: jsb.KeyboardEvent) => {
             const inputEvent: KeyboardInputEvent = {
                 type: eventType,

--- a/pal/input/native/keyboard.ts
+++ b/pal/input/native/keyboard.ts
@@ -13,8 +13,8 @@ export class KeyboardInputSource {
     }
 
     private _registerEvent () {
-        jsb.onKeyDown = this._createCallback(SystemEventType.KEY_DOWN);
-        jsb.onKeyUp =  this._createCallback(SystemEventType.KEY_UP);
+        jsb.onKeyDown = this._createCallback('keydown');
+        jsb.onKeyUp =  this._createCallback('keyup');
     }
 
     private _createCallback (eventType: string) {
@@ -29,10 +29,15 @@ export class KeyboardInputSource {
     }
 
     public onDown (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEY_DOWN, cb);
+        this._eventTarget.on(SystemEventType.KEYBOARD_DOWN, cb);
+    }
+
+    public onPressing (cb: KeyboardCallback) {
+        this._eventTarget.on('keydown', cb);
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEY_UP, cb);
+        this._eventTarget.on('keyup', cb);
+        this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
     }
 }

--- a/pal/input/native/keyboard.ts
+++ b/pal/input/native/keyboard.ts
@@ -37,7 +37,6 @@ export class KeyboardInputSource {
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on('keyup', cb);
         this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
     }
 }

--- a/pal/input/native/keyboard.ts
+++ b/pal/input/native/keyboard.ts
@@ -7,25 +7,45 @@ export class KeyboardInputSource {
     public support: boolean;
     private _eventTarget: EventTarget = new EventTarget();
 
+    // On native platform, KeyboardEvent.repeat is always false, so we need a map to manage the key state.
+    private _keyStateMap: Record<number, boolean> = {};
+
     constructor () {
         this.support = !system.isMobile;
         this._registerEvent();
     }
 
     private _registerEvent () {
-        jsb.onKeyDown = this._createCallback(SystemEventType.KEYBOARD_DOWN);
-        jsb.onKeyUp =  this._createCallback(SystemEventType.KEYBOARD_UP);
-    }
-
-    private _createCallback (eventType: SystemEventType) {
-        return (event: jsb.KeyboardEvent) => {
+        jsb.onKeyDown = (event: jsb.KeyboardEvent) => {
+            const keyCode = event.keyCode;
+            if (!this._keyStateMap[keyCode]) {
+                const keyDownInputEvent = this._getInputEvent(event, SystemEventType.KEYBOARD_DOWN);
+                this._eventTarget.emit(SystemEventType.KEYBOARD_DOWN, keyDownInputEvent);
+            }
+            // @ts-expect-error Compability for key pressing callback
+            const keyPressingInputEvent = this._getInputEvent(event, 'keydown');
+            this._eventTarget.emit('keydown', keyPressingInputEvent);
+            this._keyStateMap[keyCode] = true;
+        };
+        jsb.onKeyUp =  (event: jsb.KeyboardEvent) => {
+            const keyCode = event.keyCode;
             const inputEvent: KeyboardInputEvent = {
-                type: eventType,
-                code: event.keyCode,
+                type: SystemEventType.KEYBOARD_UP,
+                code: keyCode,
                 timestamp: performance.now(),
             };
-            this._eventTarget.emit(eventType, inputEvent);
+            this._keyStateMap[keyCode] = false;
+            this._eventTarget.emit(SystemEventType.KEYBOARD_UP, inputEvent);
         };
+    }
+
+    private _getInputEvent (event: jsb.KeyboardEvent, eventType: SystemEventType) {
+        const inputEvent: KeyboardInputEvent = {
+            type: eventType,
+            code: event.keyCode,  // TODO: keyCode is deprecated on Web standard
+            timestamp: performance.now(),
+        };
+        return inputEvent;
     }
 
     public onDown (cb: KeyboardCallback) {

--- a/pal/input/native/keyboard.ts
+++ b/pal/input/native/keyboard.ts
@@ -1,6 +1,6 @@
 import { KeyboardCallback, KeyboardInputEvent } from 'pal/input';
 import { system } from 'pal/system';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { KeyboardEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 
 export class KeyboardInputSource {
@@ -19,8 +19,8 @@ export class KeyboardInputSource {
         jsb.onKeyDown = (event: jsb.KeyboardEvent) => {
             const keyCode = event.keyCode;
             if (!this._keyStateMap[keyCode]) {
-                const keyDownInputEvent = this._getInputEvent(event, SystemEventType.KEYBOARD_DOWN);
-                this._eventTarget.emit(SystemEventType.KEYBOARD_DOWN, keyDownInputEvent);
+                const keyDownInputEvent = this._getInputEvent(event, KeyboardEvent.KEY_DOWN);
+                this._eventTarget.emit(KeyboardEvent.KEY_DOWN, keyDownInputEvent);
             }
             // @ts-expect-error Compability for key pressing callback
             const keyPressingInputEvent = this._getInputEvent(event, 'keydown');
@@ -30,16 +30,16 @@ export class KeyboardInputSource {
         jsb.onKeyUp =  (event: jsb.KeyboardEvent) => {
             const keyCode = event.keyCode;
             const inputEvent: KeyboardInputEvent = {
-                type: SystemEventType.KEYBOARD_UP,
+                type: KeyboardEvent.KEY_UP,
                 code: keyCode,
                 timestamp: performance.now(),
             };
             this._keyStateMap[keyCode] = false;
-            this._eventTarget.emit(SystemEventType.KEYBOARD_UP, inputEvent);
+            this._eventTarget.emit(KeyboardEvent.KEY_UP, inputEvent);
         };
     }
 
-    private _getInputEvent (event: jsb.KeyboardEvent, eventType: SystemEventType) {
+    private _getInputEvent (event: jsb.KeyboardEvent, eventType: KeyboardEvent) {
         const inputEvent: KeyboardInputEvent = {
             type: eventType,
             code: event.keyCode,  // TODO: keyCode is deprecated on Web standard
@@ -49,7 +49,7 @@ export class KeyboardInputSource {
     }
 
     public onDown (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEYBOARD_DOWN, cb);
+        this._eventTarget.on(KeyboardEvent.KEY_DOWN, cb);
     }
 
     public onPressing (cb: KeyboardCallback) {
@@ -57,6 +57,6 @@ export class KeyboardInputSource {
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
+        this._eventTarget.on(KeyboardEvent.KEY_UP, cb);
     }
 }

--- a/pal/input/native/mouse.ts
+++ b/pal/input/native/mouse.ts
@@ -39,7 +39,7 @@ export class MouseInputSource {
         };
     }
 
-    private _createCallback (eventType: string) {
+    private _createCallback (eventType: SystemEventType) {
         return (event: jsb.MouseEvent) => {
             const location = this._getLocation(event);
             const viewSize = system.getViewSize();

--- a/pal/input/native/mouse.ts
+++ b/pal/input/native/mouse.ts
@@ -3,7 +3,7 @@ import { system } from 'pal/system';
 import { EventMouse } from '../../../cocos/core/platform/event-manager/events';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { Vec2 } from '../../../cocos/core/math';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { MouseEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 
 export class MouseInputSource {
     public support: boolean;
@@ -19,15 +19,15 @@ export class MouseInputSource {
     }
 
     private _registerEvent () {
-        jsb.onMouseDown = this._createCallback(SystemEventType.MOUSE_DOWN);
-        jsb.onMouseMove = this._createCallback(SystemEventType.MOUSE_MOVE);
-        jsb.onMouseUp =  this._createCallback(SystemEventType.MOUSE_UP);
+        jsb.onMouseDown = this._createCallback(MouseEvent.MOUSE_DOWN);
+        jsb.onMouseMove = this._createCallback(MouseEvent.MOUSE_MOVE);
+        jsb.onMouseUp =  this._createCallback(MouseEvent.MOUSE_UP);
         jsb.onMouseWheel = (event: jsb.MouseWheelEvent) => {
             const location = this._getLocation(event);
             const viewSize = system.getViewSize();
             const matchStandardFactor = 120;
             const inputEvent: MouseWheelInputEvent = {
-                type: SystemEventType.MOUSE_WHEEL,
+                type: MouseEvent.MOUSE_WHEEL,
                 x: location.x,
                 y: viewSize.height - location.y,
                 button: event.button,
@@ -35,11 +35,11 @@ export class MouseInputSource {
                 deltaY: event.wheelDeltaY * matchStandardFactor,
                 timestamp: performance.now(),
             };
-            this._eventTarget.emit(SystemEventType.MOUSE_WHEEL, inputEvent);
+            this._eventTarget.emit(MouseEvent.MOUSE_WHEEL, inputEvent);
         };
     }
 
-    private _createCallback (eventType: SystemEventType) {
+    private _createCallback (eventType: MouseEvent) {
         return (event: jsb.MouseEvent) => {
             const location = this._getLocation(event);
             const viewSize = system.getViewSize();
@@ -56,15 +56,15 @@ export class MouseInputSource {
     }
 
     onDown (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_DOWN, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_DOWN, cb);
     }
     onMove (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_MOVE, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_MOVE, cb);
     }
     onUp (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_UP, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_UP, cb);
     }
     onWheel (cb: MouseWheelCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_WHEEL, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_WHEEL, cb);
     }
 }

--- a/pal/input/native/touch.ts
+++ b/pal/input/native/touch.ts
@@ -22,7 +22,7 @@ export class TouchInputSource {
         jsb.onTouchCancel = this._createCallback(SystemEventType.TOUCH_CANCEL);
     }
 
-    private _createCallback (eventType: string) {
+    private _createCallback (eventType: SystemEventType) {
         return (touchList: TouchList) => {
             const touchDataList: TouchData[] = [];
             const length = touchList.length;

--- a/pal/input/native/touch.ts
+++ b/pal/input/native/touch.ts
@@ -4,7 +4,7 @@ import { Rect, Vec2 } from '../../../cocos/core/math';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { EventTouch } from '../../../cocos/core/platform/event-manager/events';
 import { legacyCC } from '../../../cocos/core/global-exports';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { TouchEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 
 export class TouchInputSource {
     public support: boolean;
@@ -16,13 +16,13 @@ export class TouchInputSource {
     }
 
     private _registerEvent () {
-        jsb.onTouchStart = this._createCallback(SystemEventType.TOUCH_START);
-        jsb.onTouchMove = this._createCallback(SystemEventType.TOUCH_MOVE);
-        jsb.onTouchEnd = this._createCallback(SystemEventType.TOUCH_END);
-        jsb.onTouchCancel = this._createCallback(SystemEventType.TOUCH_CANCEL);
+        jsb.onTouchStart = this._createCallback(TouchEvent.TOUCH_START);
+        jsb.onTouchMove = this._createCallback(TouchEvent.TOUCH_MOVE);
+        jsb.onTouchEnd = this._createCallback(TouchEvent.TOUCH_END);
+        jsb.onTouchCancel = this._createCallback(TouchEvent.TOUCH_CANCEL);
     }
 
-    private _createCallback (eventType: SystemEventType) {
+    private _createCallback (eventType: TouchEvent) {
         return (touchList: TouchList) => {
             const touchDataList: TouchData[] = [];
             const length = touchList.length;
@@ -54,15 +54,15 @@ export class TouchInputSource {
     }
 
     public onStart (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_START, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_START, cb);
     }
     public onMove (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_MOVE, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_MOVE, cb);
     }
     public onEnd (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_END, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_END, cb);
     }
     public onCancel (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_CANCEL, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_CANCEL, cb);
     }
 }

--- a/pal/input/web/accelerometer.ts
+++ b/pal/input/web/accelerometer.ts
@@ -1,9 +1,9 @@
 import { AccelerometerCallback, AccelerometerInputEvent } from 'pal/input';
 import { system } from 'pal/system';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { BrowserType, OS } from '../../system/enum-type';
 import { legacyCC } from '../../../cocos/core/global-exports';
+import { DeviceEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 
 export class AccelerometerInputSource {
     public support: boolean;
@@ -93,14 +93,14 @@ export class AccelerometerInputSource {
             y = -y;
         }
         const accelerometer: AccelerometerInputEvent = {
-            type: SystemEventType.DEVICEMOTION,
+            type: DeviceEvent.DEVICEMOTION,
             x,
             y,
             z,
             timestamp: performance.now(),
         };
 
-        this._eventTarget.emit(SystemEventType.DEVICEMOTION, accelerometer);
+        this._eventTarget.emit(DeviceEvent.DEVICEMOTION, accelerometer);
     }
 
     public start () {
@@ -113,6 +113,6 @@ export class AccelerometerInputSource {
         this._intervalInMileseconds = intervalInMileseconds;
     }
     public onChange (cb: AccelerometerCallback) {
-        this._eventTarget.on(SystemEventType.DEVICEMOTION, cb);
+        this._eventTarget.on(DeviceEvent.DEVICEMOTION, cb);
     }
 }

--- a/pal/input/web/keyboard.ts
+++ b/pal/input/web/keyboard.ts
@@ -13,21 +13,32 @@ export class KeyboardInputSource {
 
     private _registerEvent () {
         const canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
-        canvas?.addEventListener('keydown', this._createCallback('keydown'));
-        canvas?.addEventListener('keyup', this._createCallback('keyup'));
-    }
-
-    private _createCallback (eventType: string) {
-        return (event: KeyboardEvent) => {
-            const inputEvent: KeyboardInputEvent = {
-                type: eventType,
-                code: event.keyCode,  // TODO: keyCode is deprecated on Web standard
-                timestamp: performance.now(),
-            };
+        canvas?.addEventListener('keydown', (event: KeyboardEvent) => {
             event.stopPropagation();
             event.preventDefault();
-            this._eventTarget.emit(eventType, inputEvent);
+            if (!event.repeat) {
+                const keyDownInputEvent = this._getInputEvent(event, SystemEventType.KEYBOARD_DOWN);
+                this._eventTarget.emit(SystemEventType.KEYBOARD_DOWN, keyDownInputEvent);
+            }
+            // @ts-expect-error Compability for key pressing callback
+            const keyPressingInputEvent = this._getInputEvent(event, 'keydown');
+            this._eventTarget.emit('keydown', keyPressingInputEvent);
+        });
+        canvas?.addEventListener('keyup', (event: KeyboardEvent) => {
+            const inputEvent = this._getInputEvent(event, SystemEventType.KEYBOARD_UP);
+            event.stopPropagation();
+            event.preventDefault();
+            this._eventTarget.emit(SystemEventType.KEYBOARD_UP, inputEvent);
+        });
+    }
+
+    private _getInputEvent (event: KeyboardEvent, eventType: SystemEventType) {
+        const inputEvent: KeyboardInputEvent = {
+            type: eventType,
+            code: event.keyCode,  // TODO: keyCode is deprecated on Web standard
+            timestamp: performance.now(),
         };
+        return inputEvent;
     }
 
     public onDown (cb: KeyboardCallback) {
@@ -39,7 +50,6 @@ export class KeyboardInputSource {
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on('keyup', cb);
         this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
     }
 }

--- a/pal/input/web/keyboard.ts
+++ b/pal/input/web/keyboard.ts
@@ -1,5 +1,4 @@
 import { KeyboardCallback, KeyboardInputEvent } from 'pal/input';
-import { system } from 'pal/system';
 import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 
@@ -14,8 +13,8 @@ export class KeyboardInputSource {
 
     private _registerEvent () {
         const canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
-        canvas?.addEventListener('keydown', this._createCallback(SystemEventType.KEY_DOWN));
-        canvas?.addEventListener('keyup', this._createCallback(SystemEventType.KEY_UP));
+        canvas?.addEventListener('keydown', this._createCallback('keydown'));
+        canvas?.addEventListener('keyup', this._createCallback('keyup'));
     }
 
     private _createCallback (eventType: string) {
@@ -32,10 +31,15 @@ export class KeyboardInputSource {
     }
 
     public onDown (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEY_DOWN, cb);
+        this._eventTarget.on(SystemEventType.KEYBOARD_DOWN, cb);
+    }
+
+    public onPressing (cb: KeyboardCallback) {
+        this._eventTarget.on('keydown', cb);
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEY_UP, cb);
+        this._eventTarget.on('keyup', cb);
+        this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
     }
 }

--- a/pal/input/web/keyboard.ts
+++ b/pal/input/web/keyboard.ts
@@ -1,5 +1,5 @@
 import { KeyboardCallback, KeyboardInputEvent } from 'pal/input';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { KeyboardEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 
 export class KeyboardInputSource {
@@ -13,26 +13,26 @@ export class KeyboardInputSource {
 
     private _registerEvent () {
         const canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
-        canvas?.addEventListener('keydown', (event: KeyboardEvent) => {
+        canvas?.addEventListener('keydown', (event: any) => {
             event.stopPropagation();
             event.preventDefault();
             if (!event.repeat) {
-                const keyDownInputEvent = this._getInputEvent(event, SystemEventType.KEYBOARD_DOWN);
-                this._eventTarget.emit(SystemEventType.KEYBOARD_DOWN, keyDownInputEvent);
+                const keyDownInputEvent = this._getInputEvent(event, KeyboardEvent.KEY_DOWN);
+                this._eventTarget.emit(KeyboardEvent.KEY_DOWN, keyDownInputEvent);
             }
             // @ts-expect-error Compability for key pressing callback
             const keyPressingInputEvent = this._getInputEvent(event, 'keydown');
             this._eventTarget.emit('keydown', keyPressingInputEvent);
         });
-        canvas?.addEventListener('keyup', (event: KeyboardEvent) => {
-            const inputEvent = this._getInputEvent(event, SystemEventType.KEYBOARD_UP);
+        canvas?.addEventListener('keyup', (event: any) => {
+            const inputEvent = this._getInputEvent(event, KeyboardEvent.KEY_UP);
             event.stopPropagation();
             event.preventDefault();
-            this._eventTarget.emit(SystemEventType.KEYBOARD_UP, inputEvent);
+            this._eventTarget.emit(KeyboardEvent.KEY_UP, inputEvent);
         });
     }
 
-    private _getInputEvent (event: KeyboardEvent, eventType: SystemEventType) {
+    private _getInputEvent (event: any, eventType: KeyboardEvent) {
         const inputEvent: KeyboardInputEvent = {
             type: eventType,
             code: event.keyCode,  // TODO: keyCode is deprecated on Web standard
@@ -42,7 +42,7 @@ export class KeyboardInputSource {
     }
 
     public onDown (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEYBOARD_DOWN, cb);
+        this._eventTarget.on(KeyboardEvent.KEY_DOWN, cb);
     }
 
     public onPressing (cb: KeyboardCallback) {
@@ -50,6 +50,6 @@ export class KeyboardInputSource {
     }
 
     public onUp (cb: KeyboardCallback) {
-        this._eventTarget.on(SystemEventType.KEYBOARD_UP, cb);
+        this._eventTarget.on(KeyboardEvent.KEY_UP, cb);
     }
 }

--- a/pal/input/web/mouse.ts
+++ b/pal/input/web/mouse.ts
@@ -95,7 +95,7 @@ export class MouseInputSource {
         }
     }
 
-    private _createCallback (eventType: string) {
+    private _createCallback (eventType: SystemEventType) {
         return (event: MouseEvent) => {
             const canvasRect = this._getCanvasRect();
             const location = this._getLocation(event);

--- a/pal/input/web/mouse.ts
+++ b/pal/input/web/mouse.ts
@@ -1,11 +1,8 @@
 import { EDITOR, TEST } from 'internal:constants';
 import { MouseCallback, MouseInputEvent, MouseWheelCallback, MouseWheelInputEvent } from 'pal/input';
-import { system } from 'pal/system';
+import { MouseEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { Rect, Vec2 } from '../../../cocos/core/math';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
-
-type MouseEventNames = 'mousedown' | 'mouseup' | 'mousemove' | 'wheel';
 
 export class MouseInputSource {
     public support: boolean;
@@ -35,7 +32,7 @@ export class MouseInputSource {
         return new Rect(0, 0, 0, 0);
     }
 
-    private _getLocation (event: MouseEvent): Vec2 {
+    private _getLocation (event: any): Vec2 {
         return new Vec2(event.clientX, event.clientY);
     }
 
@@ -44,14 +41,14 @@ export class MouseInputSource {
         window.addEventListener('mousedown', () => {
             this._isPressed = true;
         });
-        this._canvas?.addEventListener('mousedown', this._createCallback(SystemEventType.MOUSE_DOWN));
+        this._canvas?.addEventListener('mousedown', this._createCallback(MouseEvent.MOUSE_DOWN));
 
         // register mouse move event
-        this._canvas?.addEventListener('mousemove', this._createCallback(SystemEventType.MOUSE_MOVE));
+        this._canvas?.addEventListener('mousemove', this._createCallback(MouseEvent.MOUSE_MOVE));
 
         // register mouse up event
-        window.addEventListener('mouseup', this._createCallback(SystemEventType.MOUSE_UP));
-        this._canvas?.addEventListener('mouseup', this._createCallback(SystemEventType.MOUSE_UP));
+        window.addEventListener('mouseup', this._createCallback(MouseEvent.MOUSE_UP));
+        this._canvas?.addEventListener('mouseup', this._createCallback(MouseEvent.MOUSE_UP));
 
         // register wheel event
         this._canvas?.addEventListener('wheel', (event: WheelEvent) => {
@@ -59,7 +56,7 @@ export class MouseInputSource {
             const location = this._getLocation(event);
             const wheelSensitivityFactor = 5;
             const inputEvent: MouseWheelInputEvent = {
-                type: SystemEventType.MOUSE_WHEEL,
+                type: MouseEvent.MOUSE_WHEEL,
                 x: location.x - canvasRect.x,
                 y: canvasRect.y + canvasRect.height - location.y,
                 button: event.button,  // TODO: what is the button when tracking mouse move ?
@@ -71,7 +68,7 @@ export class MouseInputSource {
             };
             event.stopPropagation();
             event.preventDefault();
-            this._eventTarget.emit(SystemEventType.MOUSE_WHEEL, inputEvent);
+            this._eventTarget.emit(MouseEvent.MOUSE_WHEEL, inputEvent);
         });
         this._registerPointerLockEvent();
     }
@@ -95,8 +92,8 @@ export class MouseInputSource {
         }
     }
 
-    private _createCallback (eventType: SystemEventType) {
-        return (event: MouseEvent) => {
+    private _createCallback (eventType: MouseEvent) {
+        return (event: any) => {
             const canvasRect = this._getCanvasRect();
             const location = this._getLocation(event);
             let button = event.button;
@@ -118,8 +115,8 @@ export class MouseInputSource {
             }
             const inputEvent: MouseInputEvent = {
                 type: eventType,
-                x: this._pointLocked ? (this._preMousePos.x + event.movementX) : (location.x - canvasRect.x),
-                y: this._pointLocked ? (this._preMousePos.y - event.movementY) : (canvasRect.y + canvasRect.height - location.y),
+                x: this._pointLocked ? (this._preMousePos.x + <number>event.movementX) : (location.x - canvasRect.x),
+                y: this._pointLocked ? (this._preMousePos.y - <number>event.movementY) : (canvasRect.y + canvasRect.height - location.y),
                 button,
                 timestamp: performance.now(),
                 // this is web only property
@@ -138,15 +135,15 @@ export class MouseInputSource {
     }
 
     onDown (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_DOWN, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_DOWN, cb);
     }
     onMove (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_MOVE, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_MOVE, cb);
     }
     onUp (cb: MouseCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_UP, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_UP, cb);
     }
     onWheel (cb: MouseWheelCallback) {
-        this._eventTarget.on(SystemEventType.MOUSE_WHEEL, cb);
+        this._eventTarget.on(MouseEvent.MOUSE_WHEEL, cb);
     }
 }

--- a/pal/input/web/touch.ts
+++ b/pal/input/web/touch.ts
@@ -30,7 +30,7 @@ export class TouchInputSource {
         this._canvas?.addEventListener('touchcancel', this._createCallback(SystemEventType.TOUCH_CANCEL));
     }
 
-    private _createCallback (eventType: string) {
+    private _createCallback (eventType: SystemEventType) {
         return (event: TouchEvent) => {
             const canvasRect = this._getCanvasRect();
             const touchDataList: TouchData[] = [];

--- a/pal/input/web/touch.ts
+++ b/pal/input/web/touch.ts
@@ -4,7 +4,7 @@ import { TEST } from 'internal:constants';
 import { Rect, Vec2 } from '../../../cocos/core/math';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { legacyCC } from '../../../cocos/core/global-exports';
-import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
+import { TouchEvent } from '../../../cocos/core/platform/event-manager/event-enum';
 
 export class TouchInputSource {
     public support: boolean;
@@ -24,14 +24,14 @@ export class TouchInputSource {
 
     private _registerEvent () {
         // IDEA: need to register on window ?
-        this._canvas?.addEventListener('touchstart', this._createCallback(SystemEventType.TOUCH_START));
-        this._canvas?.addEventListener('touchmove', this._createCallback(SystemEventType.TOUCH_MOVE));
-        this._canvas?.addEventListener('touchend', this._createCallback(SystemEventType.TOUCH_END));
-        this._canvas?.addEventListener('touchcancel', this._createCallback(SystemEventType.TOUCH_CANCEL));
+        this._canvas?.addEventListener('touchstart', this._createCallback(TouchEvent.TOUCH_START));
+        this._canvas?.addEventListener('touchmove', this._createCallback(TouchEvent.TOUCH_MOVE));
+        this._canvas?.addEventListener('touchend', this._createCallback(TouchEvent.TOUCH_END));
+        this._canvas?.addEventListener('touchcancel', this._createCallback(TouchEvent.TOUCH_CANCEL));
     }
 
-    private _createCallback (eventType: SystemEventType) {
-        return (event: TouchEvent) => {
+    private _createCallback (eventType: TouchEvent) {
+        return (event: any) => {
             const canvasRect = this._getCanvasRect();
             const touchDataList: TouchData[] = [];
             const length = event.changedTouches.length;
@@ -85,15 +85,15 @@ export class TouchInputSource {
     }
 
     public onStart (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_START, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_START, cb);
     }
     public onMove (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_MOVE, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_MOVE, cb);
     }
     public onEnd (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_END, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_END, cb);
     }
     public onCancel (cb: TouchCallback) {
-        this._eventTarget.on(SystemEventType.TOUCH_CANCEL, cb);
+        this._eventTarget.on(TouchEvent.TOUCH_CANCEL, cb);
     }
 }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7536
Re: https://github.com/cocos-creator/3d-tasks/issues/7529
Re: https://github.com/cocos-creator/3d-tasks/issues/7096
Re: https://forum.cocos.org/t/topic/111740/132

> ## NOTE

v3.1.0 废弃了 EventKeyboard 的 rawEvent 属性了。论坛用户反馈了一些相关的需求：
- [x] 需要访问 rawEvent.repeat 属性，防止 KEY_DOWN 事件重复触发  (该 pr 支持了新的 KEYBOARD_DOWN 事件)
- [ ] ~~需要访问 rawEvent.code 属性，用来区分 左右 ctrl shift~~ (不在这个 pr 里处理)
- [ ] ~~KeyboardEvent 不应该 preventDefault~~ (不合理的需求，不予处理)

> ## CHANGE LOG

 1. 支持 systemEvent 上注册 `SystemEvent.KeyboardEvent.KEY_DOWN` 和 `SystemEvent.KeyboardEvent.KEY_UP` 事件
 2. 废弃之前的 SystemEventType.KEY_DOWN 和 SystemEventType.KEY_UP 事件 (SystemEventType.KEY_DOWN 会持续派发 https://github.com/cocos-creator/3d-tasks/issues/7096)
 3. 废弃属性和方法：
    - Event.NO_TYPE, Event.TOUCH, Event.MOUSE, Event.KEYBOARD, Event.ACCELERATION
    - EventMouse.prototype.eventType
    - EventTouch.prototype.getEventCode()
    - EventKeyboard.prototype.isPressed
4. 将 SystemEventType 划分到 `SystemEvent.TouchEvent, SystemEvent.MouseEvent, SystemEvent.KeyboardEvent, SystemEvent.DeviceEvent, Node.EventType` 里
5. 修复 x-deprecate 工具，在废弃没有 getset 的属性时，无法输出 warning 的问题
> ## 说明
- EventTouch.prototype.getEventCode() 和 EventMouse.prototype.eventType 做的都是同一件事，获取具体的事件类型，这个直接访问 Event.prototype.type 就能解决了，完全没必要支持这些方法  
- EventKeyboard.prototype.isPressed 也可以通过 EventKeyboard.prototype.type !== SystemEventType.KEYBOARD_UP 判断

> ## 目前的接口划分情况
### NodeEventType
![NodeEventType](https://user-images.githubusercontent.com/17872773/120753363-a3664e80-c53d-11eb-82f0-a90faefc31c5.png)

### SystemEventType
![systemEventType](https://user-images.githubusercontent.com/17872773/120753372-abbe8980-c53d-11eb-95b1-834926b99e84.png)

### New System EventType
![new_event](https://user-images.githubusercontent.com/17872773/120753433-bb3dd280-c53d-11eb-97b8-2612d814a5e8.png)

