### PR TITLE
update deprecated usage of sy API

### DIFF
--- a/extensions/videoplayer/video-player-impl.js
+++ b/extensions/videoplayer/video-player-impl.js
@@ -82,7 +82,7 @@ let VideoPlayerImpl = cc.Class({
         let cbs = this.__eventListeners;
         cbs.loadedmetadata = function () {
             this._loadedmeta = true;
-            if (sys.os === sys.OS_IOS && sys.isBrowser) {
+            if (sys.os === sys.OS.IOS && sys.isBrowser) {
                 triggerFullScene(video, self._fullScreenEnabled);
             }
             self._dispatchEvent(VideoPlayerImpl.EventType.META_LOADED);
@@ -368,7 +368,7 @@ let VideoPlayerImpl = cc.Class({
         if (!video) {
             return;
         }
-        if (sys.os === sys.OS_IOS && sys.isBrowser) {
+        if (sys.os === sys.OS.IOS && sys.isBrowser) {
             this._fullScreenEnabled = enable;
             if (this._loadedmeta) {
                 triggerFullScene(video, enable);
@@ -557,14 +557,14 @@ if (sys.platform !== sys.WECHAT_GAME) {
         VideoPlayerImpl._polyfill.canPlayType.push(".webm");
 }
 
-if (sys.browserType === sys.BROWSER_TYPE_FIREFOX) {
+if (sys.browserType === sys.BrowserType.FIREFOX) {
     VideoPlayerImpl._polyfill.autoplayAfterOperation = true;
 }
 
 if (
     sys.OS_ANDROID === sys.os && (
-    sys.browserType === sys.BROWSER_TYPE_SOUGOU ||
-    sys.browserType === sys.BROWSER_TYPE_360
+    sys.browserType === sys.BrowserType.SOUGOU ||
+    sys.browserType === sys.BrowserType.BROWSER_360
 )
 ) {
     VideoPlayerImpl._polyfill.zoomInvalid = true;

--- a/platforms/minigame/common/engine/AssetManager.js
+++ b/platforms/minigame/common/engine/AssetManager.js
@@ -211,7 +211,7 @@ function downloadBundle (nameOrUrl, options, onComplete) {
                     // PATCH: for android alipay version before v10.1.95 (v10.1.95 included)
                     // to remove in the future
                     let sys = cc.sys;
-                    if (sys.platform === sys.ALIPAY_MINI_GAME && sys.os === sys.OS_ANDROID) {
+                    if (sys.platform === sys.Platform.ALIPAY_MINI_GAME && sys.os === sys.OS.ANDROID) {
                         let resPath = unzipPath + 'res/';
                         if (fs.accessSync({path: resPath})) {
                             data.base = resPath;

--- a/platforms/native/engine/jsb-reflection.js
+++ b/platforms/native/engine/jsb-reflection.js
@@ -29,9 +29,9 @@
 Object.defineProperty(jsb, "reflection", {
     get: function () {
         if (jsb.__bridge !== undefined) return jsb.__bridge;
-        if (window.JavascriptJavaBridge && cc.sys.os === cc.sys.OS_ANDROID) {
+        if (window.JavascriptJavaBridge && cc.sys.os === cc.sys.OS.ANDROID) {
             jsb.__bridge = new JavascriptJavaBridge();
-        } else if (window.JavaScriptObjCBridge && (cc.sys.os === cc.sys.OS_IOS || cc.sys.os === cc.sys.OS_OSX)) {
+        } else if (window.JavaScriptObjCBridge && (cc.sys.os === cc.sys.OS.IOS || cc.sys.os === cc.sys.OS.OSX)) {
             jsb.__bridge = new JavaScriptObjCBridge();
         }else   {
             jsb.__bridge = null;

--- a/tests/lib/spawn-runner.js
+++ b/tests/lib/spawn-runner.js
@@ -1,6 +1,6 @@
 // so as to run tests in page-level
 
-if (cc.sys.platform === cc.sys.EDITOR_CORE) {
+if (cc.sys.platform === cc.sys.Platform.EDITOR_CORE) {
     var Ipc = require('ipc');
     var Path = require('path');
     var Url = require('url');


### PR DESCRIPTION
Re: https://forum.cocos.org/t/topic/112871

Changelog:
 * 修复勾选 剔除废弃的引擎接口 后 jsb.reflection 无法使用的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
