### PR TITLE
change AnimationClip IEvent interface params support (number string boolean)

### DIFF
--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -96,7 +96,7 @@ export declare namespace AnimationClip {
     export interface IEvent {
         frame: number;
         func: string;
-        params: string[];
+        params: any[];
     }
 
     export namespace _impl {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 change the AnimationClip IEvent interface params string[] to any[] for support (number string boolean)




```
defaultClip.events.push({
                frame: 0.5, // trigger event on the 0.5 second
                func: "onflowAnimToYEnd", // name of event to be called
                params: [0], // parameters passed to `func`
})
(params: [0] error): Type 'number' is not assignable to type 'string'.ts(2322)
```



<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
