### PR TITLE
Fix that runtime change to useBakedAnimation stops the animation

### DIFF
--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -96,10 +96,12 @@ export class SkeletalAnimationState extends AnimationState {
         this._bakedDuration = this._frames / info.sample; // last key
     }
 
-    public onPlay () {
-        super.onPlay();
-        const baked = this._parent!.useBakedAnimation;
-        if (baked) {
+    /**
+     * @internal For internal usage only.
+     * @param enabled
+     */
+    public useBaked (enabled: boolean) {
+        if (enabled) {
             this._sampleCurves = this._sampleCurvesBaked;
             this.duration = this._bakedDuration;
             this._animInfoMgr.switchClip(this._animInfo!, this.clip);

--- a/cocos/3d/skeletal-animation/skeletal-animation.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation.ts
@@ -141,6 +141,14 @@ export class SkeletalAnimation extends Animation {
 
     set useBakedAnimation (val) {
         this._useBakedAnimation = val;
+
+        for (const stateName in this._nameToState) {
+            const state = this._nameToState[stateName];
+            if (state instanceof SkeletalAnimationState) {
+                state.useBaked(val);
+            }
+        }
+
         const comps = this.node.getComponentsInChildren(SkinnedMeshRenderer);
         for (let i = 0; i < comps.length; ++i) {
             const comp = comps[i];


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Fix that runtime change to useBakedAnimation stops the animation

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
