### PR TITLE
Optimize and refactor skeletal animation blending

### DIFF
--- a/cocos/core/animation/bound-target.ts
+++ b/cocos/core/animation/bound-target.ts
@@ -87,8 +87,7 @@ export function createBoundTarget (target: any, modifiers: TargetPath[], valueAd
     }
 }
 
-export function createBufferedTarget (target: any, modifiers: TargetPath[], valueAdapter?: IValueProxyFactory): null | IBufferedTarget {
-    const boundTarget = createBoundTarget(target, modifiers, valueAdapter);
+export function createBufferedTarget (boundTarget: IBoundTarget): null | IBufferedTarget {
     if (boundTarget === null) {
         return null;
     }

--- a/cocos/core/animation/cross-fade.ts
+++ b/cocos/core/animation/cross-fade.ts
@@ -69,13 +69,6 @@ export class CrossFade extends Playable {
         } else {
             this._calculateWeights(deltaTime);
         }
-
-        for (let iManagedState = 0; iManagedState < managedStates.length; ++iManagedState) {
-            const state = managedStates[iManagedState].state;
-            if (state && state.isMotionless) {
-                state.sample();
-            }
-        }
     }
 
     /**

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -694,7 +694,7 @@ export class Node extends BaseNode {
      * @zh 用四元数设置本地旋转
      * @param rotation Rotation in quaternion
      */
-    public setRotation (rotation: Quat): void;
+    public setRotation (rotation: Readonly<Quat>): void;
 
     /**
      * @en Set rotation in local coordinate system with a quaternion representing the rotation
@@ -706,9 +706,9 @@ export class Node extends BaseNode {
      */
     public setRotation (x: number, y: number, z: number, w: number): void;
 
-    public setRotation (val: Quat | number, y?: number, z?: number, w?: number) {
+    public setRotation (val: Readonly<Quat> | number, y?: number, z?: number, w?: number) {
         if (y === undefined || z === undefined || w === undefined) {
-            Quat.copy(this._lrot, val as Quat);
+            Quat.copy(this._lrot, val as Readonly<Quat>);
         } else {
             Quat.set(this._lrot, val as number, y, z, w);
         }

--- a/tests/animation/skeletal-animation-blending.test.ts
+++ b/tests/animation/skeletal-animation-blending.test.ts
@@ -1,0 +1,141 @@
+
+import { BlendStateBuffer, BlendStateWriter } from '../../cocos/3d/skeletal-animation/skeletal-animation-blending';
+import { Node, Quat, toRadian, Vec3 } from '../../cocos/core';
+
+describe('Skeletal animation blending', () => {
+    describe('Blending', () => {
+        const nodes = [
+            new Node('Node position affected by all nodes'),
+            new Node('Node rotation affected by all nodes'),
+            new Node('Node eulerAngles affected by all nodes'),
+            new Node('Node scale affected by all nodes'),
+            new Node('Node Scale affected by 1'),
+            new Node('Node Scale affected by 1 2'),
+        ];
+        const [
+            nodePosition_all,
+            nodeRotation_all,
+            nodeEulerAngles_all,
+            nodeScale_all,
+            nodeScale_1,
+            nodeScale_1_2,
+        ] = nodes;
+
+        function revertNodesTransforms () {
+            for (const node of nodes) {
+                node.setPosition(0.0, 0.0, 0.0);
+                node.setScale(1.0, 1.0, 1.0);
+                node.setRotation(Quat.IDENTITY);
+            }
+        }
+
+        const blendBuffer = new BlendStateBuffer();
+
+        const host1 = { weight: 0.0 };
+        const writers1 = {
+            nodePosition_all: blendBuffer.createWriter(nodePosition_all, 'position', host1, false),
+            nodeRotation_all: blendBuffer.createWriter(nodeRotation_all, 'rotation', host1, false),
+            nodeEulerAngles_all: blendBuffer.createWriter(nodeEulerAngles_all, 'eulerAngles', host1, false),
+            nodeScale_all: blendBuffer.createWriter(nodeScale_all, 'scale', host1, false),
+            nodeScale_1: blendBuffer.createWriter(nodeScale_1, 'scale', host1, false),
+            nodeScale_1_2: blendBuffer.createWriter(nodeScale_1_2, 'scale', host1, false),
+        };
+
+        const host2 = { weight: 0.0 };
+        const writers2 = {
+            nodePosition_all: blendBuffer.createWriter(nodePosition_all, 'position', host2, false),
+            nodeRotation_all: blendBuffer.createWriter(nodeRotation_all, 'rotation', host2, false),
+            nodeEulerAngles_all: blendBuffer.createWriter(nodeEulerAngles_all, 'eulerAngles', host2, false),
+            nodeScale_all: blendBuffer.createWriter(nodeScale_all, 'scale', host2, false),
+            nodeScale_1_2: blendBuffer.createWriter(nodeScale_1_2, 'scale', host2, false),
+        };
+
+        const host3 = { weight: 0.0 };
+        const writers3 = {
+            nodePosition_all: blendBuffer.createWriter(nodePosition_all, 'position', host3, false),
+            nodeRotation_all: blendBuffer.createWriter(nodeRotation_all, 'rotation', host3, false),
+            nodeEulerAngles_all: blendBuffer.createWriter(nodeEulerAngles_all, 'eulerAngles', host3, false),
+            nodeScale_all: blendBuffer.createWriter(nodeScale_all, 'scale', host3, false),
+        };
+
+        beforeEach(() => {
+            revertNodesTransforms();
+        });
+
+        test('Normalized blending ', () => {
+            host1.weight = 0.3;
+            host2.weight = 0.5;
+            host3.weight = 0.2;
+
+            writers1.nodePosition_all.setValue(new Vec3(0.2, 0.4, 0.6));
+            writers2.nodePosition_all.setValue(new Vec3(1.2, 1.4, 1.6));
+            writers3.nodePosition_all.setValue(new Vec3(7.0, 8.0, 9.0));
+
+            writers1.nodeRotation_all.setValue(Quat.fromEuler(new Quat(), toRadian(20.0), 0.0, 0.0));
+            writers2.nodeRotation_all.setValue(Quat.fromEuler(new Quat(), toRadian(30.0), 0.0, 0.0));
+            writers3.nodeRotation_all.setValue(Quat.fromEuler(new Quat(), toRadian(40.0), 0.0, 0.0));
+
+            writers1.nodeEulerAngles_all.setValue(new Vec3(toRadian(20.0), 0.0, 0.0));
+            writers2.nodeEulerAngles_all.setValue(new Vec3(toRadian(30.0), 0.0, 0.0));
+            writers3.nodeEulerAngles_all.setValue(new Vec3(toRadian(40.0), 0.0, 0.0));
+
+            writers1.nodeScale_all.setValue(new Vec3(0.2, 0.4, 0.6));
+            writers2.nodeScale_all.setValue(new Vec3(1.2, 1.4, 1.6));
+            writers3.nodeScale_all.setValue(new Vec3(7.0, 8.0, 9.0));
+
+            blendBuffer.apply();
+
+            expect(Vec3.equals(nodePosition_all.position, new Vec3(
+                0.2 * 0.3 + 1.2 * 0.5 + 7.0 * 0.2,
+                0.4 * 0.3 + 1.4 * 0.5 + 8.0 * 0.2,
+                0.6 * 0.3 + 1.6 * 0.5 + 9.0 * 0.2,
+            ))).toBe(true);
+
+            expect(Vec3.equals(nodeRotation_all.rotation, Quat.fromEuler(
+                new Quat(),
+                toRadian(20.0 * 0.3 + 30.0 * 0.5 + 40.0 * 0.2),
+                0.0,
+                0.0,
+            ))).toBe(true);
+
+            expect(Vec3.equals(nodeEulerAngles_all.eulerAngles, new Vec3(
+                toRadian(20.0 * 0.3 + 30.0 * 0.5 + 40.0 * 0.2),
+                0.0,
+                0.0,
+            ))).toBe(true);
+
+            expect(Vec3.equals(nodeScale_all.scale, new Vec3(
+                0.2 * 0.3 + 1.2 * 0.5 + 7.0 * 0.2,
+                0.4 * 0.3 + 1.4 * 0.5 + 8.0 * 0.2,
+                0.6 * 0.3 + 1.6 * 0.5 + 9.0 * 0.2,
+            ))).toBe(true);
+        });
+
+        test('If sum less than 1, current pose with be blended, with remain weight', () => {
+            host1.weight = 0.3;
+            host2.weight = 0.5;
+            host3.weight = 0.2;
+
+            writers1.nodeScale_1.setValue(new Vec3(1.2, 1.4, 1.6));
+            writers1.nodeScale_1_2.setValue(new Vec3(1.2, 1.4, 1.6));
+
+            writers2.nodeScale_1_2.setValue(new Vec3(3.0, 4.0, 5.0));
+
+            blendBuffer.apply();
+
+            // nodeScale_1.scale is only effect by host1
+            expect(Vec3.equals(nodeScale_1.scale, new Vec3(
+                1.2 * 0.3 + 1.0 * 0.7,
+                1.4 * 0.3 + 1.0 * 0.7,
+                1.6 * 0.3 + 1.0 * 0.7,
+            ))).toBe(true);
+
+            // nodeScale_1.scale is effect by both host1 and host2, even if their weights are not sum to 1
+            expect(Vec3.equals(nodeScale_1_2.scale, new Vec3(
+                1.2 * 0.3 + 3.0 * 0.5 + 1.0 * 0.2,
+                1.4 * 0.3 + 4.0 * 0.5 + 1.0 * 0.2,
+                1.6 * 0.3 + 5.0 * 0.5 + 1.0 * 0.2,
+            ))).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Optimize and refactor skeletal animation blending.
 
Now we are perfectly compatible with track-different-animations. In particular, we optimized the following case:
- Cross fade from/to paused/stopped animations.
- Blending between animations, where there may be a property not modified by all animation.

The core idea is: animations(blend state writer) contributes to blend state buffer by their weights. Before blend state buffer applied, if the property's weight sum less than 1. It would be blended with current node state, with remain weight.

Besides, I have supplied the unit tests for skeletal animation blending.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
