### PR TITLE
Store morph weights in mesh renderer

### DIFF
--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -318,7 +318,8 @@ export class MeshRenderer extends RenderableComponent {
     }
 
     /**
-     * Gets the weight at specified shape of specified sub mesh.
+     * @zh 获取子网格指定外形的权重。
+     * @en Gets the weight at specified shape of specified sub mesh.
      * @param subMeshIndex Index to the sub mesh.
      * @param shapeIndex Index to the shape of the sub mesh.
      * @returns The weight.
@@ -332,6 +333,10 @@ export class MeshRenderer extends RenderableComponent {
     }
 
     /**
+     * @zh
+     * 设置子网格所有外形的权重。
+     * `subMeshIndex` 是无效索引或 `weights` 的长度不匹配子网格的外形数量时，此方法不会生效。
+     * @en
      * Sets weights of each shape of specified sub mesh.
      * If takes no effect if
      * `subMeshIndex` out of bounds or
@@ -353,6 +358,10 @@ export class MeshRenderer extends RenderableComponent {
     }
 
     /**
+     * @zh
+     * 设置子网格指定外形的权重。
+     * `subMeshIndex` 或 `shapeIndex` 是无效索引时，此方法不会生效。
+     * @en
      * Sets the weight at specified shape of specified sub mesh.
      * If takes no effect if
      * `subMeshIndex` or `shapeIndex` out of bounds.

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -178,6 +178,9 @@ export class MeshRenderer extends RenderableComponent {
     @serializable
     protected _shadowReceivingMode = ModelShadowReceivingMode.ON;
 
+    // @serializable
+    private _subMeshShapesWeights: number[][] = [];
+
     /**
      * @en Shadow projection mode.
      * @zh 阴影投射方式。
@@ -211,8 +214,10 @@ export class MeshRenderer extends RenderableComponent {
     }
 
     /**
-     * @en The mesh of the model.
-     * @zh 模型的网格数据。
+     * @en Gets or sets the mesh of the model.
+     * Note, when set, all shape's weights would be reset to zero.
+     * @zh 获取或设置模型的网格数据。
+     * 注意，设置时，所有形状的权重都将归零。
      */
     @type(Mesh)
     @tooltip('i18n:model.mesh')
@@ -222,8 +227,9 @@ export class MeshRenderer extends RenderableComponent {
 
     set mesh (val) {
         const old = this._mesh;
-        this._mesh = val;
-        if (this._mesh) { this._mesh.initialize(); }
+        const mesh = this._mesh = val;
+        mesh?.initialize();
+        this._initSubMeshShapesWeights();
         this._watchMorphInMesh();
         this._onMeshChanged(old);
         this._updateModels();
@@ -271,6 +277,9 @@ export class MeshRenderer extends RenderableComponent {
 
     public onLoad () {
         if (this._mesh) { this._mesh.initialize(); }
+        if (!this._validateShapeWeights()) {
+            this._initSubMeshShapesWeights();
+        }
         this._watchMorphInMesh();
         this._updateModels();
         this._updateCastShadow();
@@ -308,10 +317,60 @@ export class MeshRenderer extends RenderableComponent {
         }
     }
 
+    /**
+     * Gets the weight at specified shape of specified sub mesh.
+     * @param subMeshIndex Index to the sub mesh.
+     * @param shapeIndex Index to the shape of the sub mesh.
+     * @returns The weight.
+     */
+    public getWeight (subMeshIndex: number, shapeIndex: number) {
+        const { _subMeshShapesWeights: subMeshShapesWeights } = this;
+        assertIsTrue(subMeshIndex < subMeshShapesWeights.length);
+        const shapeWeights = this._subMeshShapesWeights[subMeshIndex];
+        assertIsTrue(shapeIndex < shapeWeights.length);
+        return shapeWeights[shapeIndex];
+    }
+
+    /**
+     * Sets weights of each shape of specified sub mesh.
+     * If takes no effect if
+     * `subMeshIndex` out of bounds or
+     * `weights` has a different length with shapes count of the sub mesh.
+     * @param weights The weights.
+     * @param subMeshIndex Index to the sub mesh.
+     */
     public setWeights (weights: number[], subMeshIndex: number) {
-        if (this._morphInstance) {
-            this._morphInstance.setWeights(subMeshIndex, weights);
+        const { _subMeshShapesWeights: subMeshShapesWeights } = this;
+        if (subMeshIndex >= subMeshShapesWeights.length) {
+            return;
         }
+        const shapeWeights = subMeshShapesWeights[subMeshIndex];
+        if (shapeWeights.length !== weights.length) {
+            return;
+        }
+        subMeshShapesWeights[subMeshIndex] = weights.slice(0);
+        this._uploadSubMeshShapesWeights(subMeshIndex);
+    }
+
+    /**
+     * Sets the weight at specified shape of specified sub mesh.
+     * If takes no effect if
+     * `subMeshIndex` or `shapeIndex` out of bounds.
+     * @param weight The weight.
+     * @param subMeshIndex Index to the sub mesh.
+     * @param shapeIndex Index to the shape of the sub mesh.
+     */
+    public setWeight (weight: number, subMeshIndex: number, shapeIndex: number) {
+        const { _subMeshShapesWeights: subMeshShapesWeights } = this;
+        if (subMeshIndex >= subMeshShapesWeights.length) {
+            return;
+        }
+        const shapeWeights = subMeshShapesWeights[subMeshIndex];
+        if (shapeIndex >= shapeWeights.length) {
+            return;
+        }
+        shapeWeights[shapeIndex] = weight;
+        this._uploadSubMeshShapesWeights(subMeshIndex);
     }
 
     public setInstancedAttribute (name: string, value: ArrayLike<number>) {
@@ -511,19 +570,10 @@ export class MeshRenderer extends RenderableComponent {
             return;
         }
 
-        const { morph } = this._mesh.struct;
         this._morphInstance = this._mesh.morphRendering.createInstance();
         const nSubMeshes = this._mesh.struct.primitives.length;
         for (let iSubMesh = 0; iSubMesh < nSubMeshes; ++iSubMesh) {
-            const subMeshMorph = morph.subMeshMorphs[iSubMesh];
-            if (!subMeshMorph) {
-                continue;
-            }
-            const initialWeights = subMeshMorph.weights || morph.weights;
-            const weights = initialWeights
-                ? initialWeights.slice()
-                : new Array<number>(subMeshMorph.targets.length).fill(0);
-            this._morphInstance.setWeights(iSubMesh, weights);
+            this._uploadSubMeshShapesWeights(iSubMesh);
         }
 
         if (this._model && this._model instanceof MorphModel) {
@@ -531,15 +581,57 @@ export class MeshRenderer extends RenderableComponent {
         }
     }
 
-    private _syncMorphWeights (subMeshIndex: number) {
-        if (!this._morphInstance) {
+    private _initSubMeshShapesWeights () {
+        const { _mesh: mesh } = this;
+
+        this._subMeshShapesWeights.length = 0;
+
+        if (!mesh) {
             return;
         }
-        const subMeshMorphInstance = this._morphInstance[subMeshIndex];
-        if (!subMeshMorphInstance || !subMeshMorphInstance.renderResources) {
+
+        const morph = mesh.struct.morph;
+        if (!morph) {
             return;
         }
-        subMeshMorphInstance.renderResources.setWeights(subMeshMorphInstance.weights);
+
+        const commonWeights = morph.weights;
+        this._subMeshShapesWeights = morph.subMeshMorphs.map((subMeshMorph) => {
+            if (!subMeshMorph) {
+                return [];
+            } else if (subMeshMorph.weights) {
+                return subMeshMorph.weights.slice(0);
+            } else if (commonWeights) {
+                assertIsTrue(commonWeights.length === subMeshMorph.targets.length);
+                return commonWeights.slice(0);
+            } else {
+                return new Array<number>(subMeshMorph.targets.length).fill(0.0);
+            }
+        });
+    }
+
+    private _validateShapeWeights () {
+        const {
+            _mesh: mesh,
+            _subMeshShapesWeights: subMeshShapesWeights,
+        } = this;
+
+        if (!mesh || !mesh.struct.morph) {
+            return subMeshShapesWeights.length === 0;
+        }
+
+        const { morph } = mesh.struct;
+        if (morph.subMeshMorphs.length !== subMeshShapesWeights.length) {
+            return false;
+        }
+
+        return subMeshShapesWeights.every(
+            ({ length: shapeCount }, subMeshIndex) => (morph.subMeshMorphs[subMeshIndex]?.targets.length ?? 0) === shapeCount,
+        );
+    }
+
+    private _uploadSubMeshShapesWeights (subMeshIndex: number) {
+        this._morphInstance?.setWeights(subMeshIndex, this._subMeshShapesWeights[subMeshIndex]);
     }
 }
 

--- a/cocos/core/animation/value-proxy-factories/index.ts
+++ b/cocos/core/animation/value-proxy-factories/index.ts
@@ -30,4 +30,4 @@
 
 export * from './uniform';
 
-export { MorphWeightsValueProxy, MorphWeightsAllValueProxy  } from './morph-weights';
+export { MorphWeightValueProxy, MorphWeightsValueProxy, MorphWeightsAllValueProxy  } from './morph-weights';

--- a/cocos/core/animation/value-proxy-factories/morph-weights.ts
+++ b/cocos/core/animation/value-proxy-factories/morph-weights.ts
@@ -38,29 +38,29 @@ import { IValueProxyFactory } from '../value-proxy';
  * @zh
  * 用于设置模型组件目标上指定子网格的指定形状的形变权重的曲线值代理工厂。
  */
- @ccclass('cc.animation.MorphWeightValueProxy')
+@ccclass('cc.animation.MorphWeightValueProxy')
 export class MorphWeightValueProxy implements IValueProxyFactory {
-     /**
+    /**
       * @en Sub mesh index.
       * @zh 子网格索引。
       */
-     @serializable
-     public subMeshIndex = 0;
+    @serializable
+    public subMeshIndex = 0;
 
-     /**
+    /**
       * @en Shape Index.
       * @zh 形状索引。
       */
-     @serializable
-     public shapeIndex = 0;
+    @serializable
+    public shapeIndex = 0;
 
-     public forTarget (target: MeshRenderer) {
-         return {
-             set: (value: number) => {
-                 target.setWeight(value, this.subMeshIndex, this.shapeIndex);
-             },
-         };
-     }
+    public forTarget (target: MeshRenderer) {
+        return {
+            set: (value: number) => {
+                target.setWeight(value, this.subMeshIndex, this.shapeIndex);
+            },
+        };
+    }
 }
 
 /**

--- a/cocos/core/animation/value-proxy-factories/morph-weights.ts
+++ b/cocos/core/animation/value-proxy-factories/morph-weights.ts
@@ -36,6 +36,37 @@ import { IValueProxyFactory } from '../value-proxy';
  * @en
  * Value proxy factory for setting morph weights of specified sub-mesh on model component target.
  * @zh
+ * 用于设置模型组件目标上指定子网格的指定形状的形变权重的曲线值代理工厂。
+ */
+ @ccclass('cc.animation.MorphWeightValueProxy')
+export class MorphWeightValueProxy implements IValueProxyFactory {
+     /**
+      * @en Sub mesh index.
+      * @zh 子网格索引。
+      */
+     @serializable
+     public subMeshIndex = 0;
+
+     /**
+      * @en Shape Index.
+      * @zh 形状索引。
+      */
+     @serializable
+     public shapeIndex = 0;
+
+     public forTarget (target: MeshRenderer) {
+         return {
+             set: (value: number) => {
+                 target.setWeight(value, this.subMeshIndex, this.shapeIndex);
+             },
+         };
+     }
+}
+
+/**
+ * @en
+ * Value proxy factory for setting morph weights of specified sub-mesh on model component target.
+ * @zh
  * 用于设置模型组件目标上指定子网格形变权重的曲线值代理工厂。
  */
 @ccclass('cc.animation.MorphWeightsValueProxy')

--- a/tests/core/components/mesh-renderer.test.ts
+++ b/tests/core/components/mesh-renderer.test.ts
@@ -1,0 +1,137 @@
+// import { Mesh } from '../../../cocos/3d/assets';
+// import { MeshRenderer } from '../../../cocos/3d/framework/mesh-renderer';
+// import { Node } from '../../../cocos/core/scene-graph/node';
+
+// describe('Mesh Renderer', () => {
+//     test('Setting mesh resets weights', () => {
+//         const meshRenderer = createMeshRenderer();
+//         const mesh = new Mesh();
+//         mesh.struct.morph = {
+//             subMeshMorphs: [
+//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.2], },
+//             ],
+//         };
+//         meshRenderer.mesh = mesh;
+//         expect(meshRenderer.getWeight(0, 0)).toBe(0.2);
+//         meshRenderer.mesh = null;
+//         expect(() => meshRenderer.getWeight(0, 0)).toThrow();
+//     });
+
+//     test('Shape with default weights specified for sub mesh', () => {
+//         const meshRenderer = createMeshRenderer();
+//         const mesh = new Mesh();
+//         mesh.struct.morph = {
+//             weights: [0.85, 0.86],
+//             subMeshMorphs: [
+//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.61, 0.62], },
+//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.73, 0.74], },
+//             ],
+//         };
+//         meshRenderer.mesh = mesh;
+//         expect(meshRenderer.getWeight(0, 0)).toBe(0.61);
+//         expect(meshRenderer.getWeight(0, 1)).toBe(0.62);
+//         expect(meshRenderer.getWeight(1, 0)).toBe(0.73);
+//         expect(meshRenderer.getWeight(1, 1)).toBe(0.74);
+//     });
+
+//     test('Shape with default weights specified for each sub mesh', () => {
+//         const meshRenderer = createMeshRenderer();
+//         const mesh = new Mesh();
+//         mesh.struct.morph = {
+//             weights: [0.85, 0.86],
+//             subMeshMorphs: [
+//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.61, 0.62], },
+//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] }, // No default sub mesh shape weights
+//             ],
+//         };
+//         meshRenderer.mesh = mesh;
+//         expect(meshRenderer.getWeight(0, 0)).toBe(0.61);
+//         expect(meshRenderer.getWeight(0, 1)).toBe(0.62);
+//         expect(meshRenderer.getWeight(1, 0)).toBe(0.85);
+//         expect(meshRenderer.getWeight(1, 1)).toBe(0.86);
+//     });
+
+//     test('Shape without default weights specified', () => {
+//         const meshRenderer = createMeshRenderer();
+//         const mesh = new Mesh();
+//         mesh.struct.morph = {
+//             subMeshMorphs: [
+//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] },
+//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] },
+//             ],
+//         };
+//         meshRenderer.mesh = mesh;
+//         expect(meshRenderer.getWeight(0, 0)).toBe(0.0);
+//         expect(meshRenderer.getWeight(0, 1)).toBe(0.0);
+//         expect(meshRenderer.getWeight(1, 0)).toBe(0.0);
+//         expect(meshRenderer.getWeight(1, 1)).toBe(0.0);
+//     });
+
+//     test('SetWeights() param validation', () => {
+//         const meshRenderer = createMeshRenderer();
+//         meshRenderer.mesh = createMeshWithShapeCounts([3]);
+//         meshRenderer.setWeights([0.33, 0.44, 0.55], 0);
+
+//         // Invalid sub mesh index
+//         meshRenderer.setWeights([0.3, 0.4, 0.3], 1);
+//         expectNotEffect();
+
+//         // Invalid weights
+//         meshRenderer.setWeights([0.2, 0.7], 0);
+//         expectNotEffect();
+
+//         // Invalid weights 2
+//         meshRenderer.setWeights([0.2, 0.7, 0.9, 1.0], 0);
+//         expectNotEffect();
+
+//         function expectNotEffect() {
+//             expect(meshRenderer.getWeight(0, 0)).toBe(0.33);
+//             expect(meshRenderer.getWeight(0, 1)).toBe(0.44);
+//             expect(meshRenderer.getWeight(0, 2)).toBe(0.55);
+//         }
+//     });
+    
+//     test('SetWeighs() param validation', () => {
+//         const meshRenderer = createMeshRenderer();
+//         meshRenderer.mesh = createMeshWithShapeCounts([3]);
+//         meshRenderer.setWeights([0.33, 0.44, 0.55], 0);
+
+//         // Invalid sub mesh index
+//         meshRenderer.setWeight(0.1, 1, 0);
+//         expectNotEffect();
+
+//         // Invalid shape index
+//         meshRenderer.setWeight(0.1, 0, 3);
+//         expectNotEffect();
+
+//         function expectNotEffect() {
+//             expect(meshRenderer.getWeight(0, 0)).toBe(0.33);
+//             expect(meshRenderer.getWeight(0, 1)).toBe(0.44);
+//             expect(meshRenderer.getWeight(0, 2)).toBe(0.55);
+//         }
+//     });
+
+//     function createMeshRenderer (): MeshRenderer {
+//         const node = new Node();
+//         const meshRenderer = node.addComponent(MeshRenderer);
+//         // @ts-expect-error Error
+//         return meshRenderer;
+//     }
+
+//     function createMeshWithShapeCounts (shapesCounts: number[]): Mesh {
+//         const mesh = new Mesh();
+//         mesh.struct.morph = {
+//             subMeshMorphs: shapesCounts.map((shapeCount) => {
+//                 return {
+//                     targets: Array.from({ length: shapeCount }, (_, index) => {
+//                         return {
+//                             displacements: [],
+//                         };
+//                     }),
+//                     attributes: [],
+//                 };
+//             }),
+//         };
+//         return mesh;
+//     }
+// });

--- a/tests/core/components/mesh-renderer.test.ts
+++ b/tests/core/components/mesh-renderer.test.ts
@@ -1,137 +1,143 @@
-// import { Mesh } from '../../../cocos/3d/assets';
-// import { MeshRenderer } from '../../../cocos/3d/framework/mesh-renderer';
-// import { Node } from '../../../cocos/core/scene-graph/node';
+import { Mesh } from '../../../cocos/3d/assets';
+import { MeshRenderer } from '../../../cocos/3d/framework/mesh-renderer';
+import { Node } from '../../../cocos/core/scene-graph/node';
 
-// describe('Mesh Renderer', () => {
-//     test('Setting mesh resets weights', () => {
-//         const meshRenderer = createMeshRenderer();
-//         const mesh = new Mesh();
-//         mesh.struct.morph = {
-//             subMeshMorphs: [
-//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.2], },
-//             ],
-//         };
-//         meshRenderer.mesh = mesh;
-//         expect(meshRenderer.getWeight(0, 0)).toBe(0.2);
-//         meshRenderer.mesh = null;
-//         expect(() => meshRenderer.getWeight(0, 0)).toThrow();
-//     });
+describe('Mesh Renderer', () => {
+    // At least one test should be present.
+    // The following test cases can not run since we lack of rendering.
+    test('Dummy', () => {
 
-//     test('Shape with default weights specified for sub mesh', () => {
-//         const meshRenderer = createMeshRenderer();
-//         const mesh = new Mesh();
-//         mesh.struct.morph = {
-//             weights: [0.85, 0.86],
-//             subMeshMorphs: [
-//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.61, 0.62], },
-//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.73, 0.74], },
-//             ],
-//         };
-//         meshRenderer.mesh = mesh;
-//         expect(meshRenderer.getWeight(0, 0)).toBe(0.61);
-//         expect(meshRenderer.getWeight(0, 1)).toBe(0.62);
-//         expect(meshRenderer.getWeight(1, 0)).toBe(0.73);
-//         expect(meshRenderer.getWeight(1, 1)).toBe(0.74);
-//     });
+    });
 
-//     test('Shape with default weights specified for each sub mesh', () => {
-//         const meshRenderer = createMeshRenderer();
-//         const mesh = new Mesh();
-//         mesh.struct.morph = {
-//             weights: [0.85, 0.86],
-//             subMeshMorphs: [
-//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.61, 0.62], },
-//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] }, // No default sub mesh shape weights
-//             ],
-//         };
-//         meshRenderer.mesh = mesh;
-//         expect(meshRenderer.getWeight(0, 0)).toBe(0.61);
-//         expect(meshRenderer.getWeight(0, 1)).toBe(0.62);
-//         expect(meshRenderer.getWeight(1, 0)).toBe(0.85);
-//         expect(meshRenderer.getWeight(1, 1)).toBe(0.86);
-//     });
+    // test('Setting mesh resets weights', () => {
+    //     const meshRenderer = createMeshRenderer();
+    //     const mesh = new Mesh();
+    //     mesh.struct.morph = {
+    //         subMeshMorphs: [
+    //             { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.2], },
+    //         ],
+    //     };
+    //     meshRenderer.mesh = mesh;
+    //     expect(meshRenderer.getWeight(0, 0)).toBe(0.2);
+    //     meshRenderer.mesh = null;
+    //     expect(() => meshRenderer.getWeight(0, 0)).toThrow();
+    // });
 
-//     test('Shape without default weights specified', () => {
-//         const meshRenderer = createMeshRenderer();
-//         const mesh = new Mesh();
-//         mesh.struct.morph = {
-//             subMeshMorphs: [
-//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] },
-//                 { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] },
-//             ],
-//         };
-//         meshRenderer.mesh = mesh;
-//         expect(meshRenderer.getWeight(0, 0)).toBe(0.0);
-//         expect(meshRenderer.getWeight(0, 1)).toBe(0.0);
-//         expect(meshRenderer.getWeight(1, 0)).toBe(0.0);
-//         expect(meshRenderer.getWeight(1, 1)).toBe(0.0);
-//     });
+    // test('Shape with default weights specified for sub mesh', () => {
+    //     const meshRenderer = createMeshRenderer();
+    //     const mesh = new Mesh();
+    //     mesh.struct.morph = {
+    //         weights: [0.85, 0.86],
+    //         subMeshMorphs: [
+    //             { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.61, 0.62], },
+    //             { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.73, 0.74], },
+    //         ],
+    //     };
+    //     meshRenderer.mesh = mesh;
+    //     expect(meshRenderer.getWeight(0, 0)).toBe(0.61);
+    //     expect(meshRenderer.getWeight(0, 1)).toBe(0.62);
+    //     expect(meshRenderer.getWeight(1, 0)).toBe(0.73);
+    //     expect(meshRenderer.getWeight(1, 1)).toBe(0.74);
+    // });
 
-//     test('SetWeights() param validation', () => {
-//         const meshRenderer = createMeshRenderer();
-//         meshRenderer.mesh = createMeshWithShapeCounts([3]);
-//         meshRenderer.setWeights([0.33, 0.44, 0.55], 0);
+    // test('Shape with default weights specified for each sub mesh', () => {
+    //     const meshRenderer = createMeshRenderer();
+    //     const mesh = new Mesh();
+    //     mesh.struct.morph = {
+    //         weights: [0.85, 0.86],
+    //         subMeshMorphs: [
+    //             { attributes: [], targets: [{ displacements: [] }, { displacements: [] }], weights: [0.61, 0.62], },
+    //             { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] }, // No default sub mesh shape weights
+    //         ],
+    //     };
+    //     meshRenderer.mesh = mesh;
+    //     expect(meshRenderer.getWeight(0, 0)).toBe(0.61);
+    //     expect(meshRenderer.getWeight(0, 1)).toBe(0.62);
+    //     expect(meshRenderer.getWeight(1, 0)).toBe(0.85);
+    //     expect(meshRenderer.getWeight(1, 1)).toBe(0.86);
+    // });
 
-//         // Invalid sub mesh index
-//         meshRenderer.setWeights([0.3, 0.4, 0.3], 1);
-//         expectNotEffect();
+    // test('Shape without default weights specified', () => {
+    //     const meshRenderer = createMeshRenderer();
+    //     const mesh = new Mesh();
+    //     mesh.struct.morph = {
+    //         subMeshMorphs: [
+    //             { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] },
+    //             { attributes: [], targets: [{ displacements: [] }, { displacements: [] }] },
+    //         ],
+    //     };
+    //     meshRenderer.mesh = mesh;
+    //     expect(meshRenderer.getWeight(0, 0)).toBe(0.0);
+    //     expect(meshRenderer.getWeight(0, 1)).toBe(0.0);
+    //     expect(meshRenderer.getWeight(1, 0)).toBe(0.0);
+    //     expect(meshRenderer.getWeight(1, 1)).toBe(0.0);
+    // });
 
-//         // Invalid weights
-//         meshRenderer.setWeights([0.2, 0.7], 0);
-//         expectNotEffect();
+    // test('SetWeights() param validation', () => {
+    //     const meshRenderer = createMeshRenderer();
+    //     meshRenderer.mesh = createMeshWithShapeCounts([3]);
+    //     meshRenderer.setWeights([0.33, 0.44, 0.55], 0);
 
-//         // Invalid weights 2
-//         meshRenderer.setWeights([0.2, 0.7, 0.9, 1.0], 0);
-//         expectNotEffect();
+    //     // Invalid sub mesh index
+    //     meshRenderer.setWeights([0.3, 0.4, 0.3], 1);
+    //     expectNotEffect();
 
-//         function expectNotEffect() {
-//             expect(meshRenderer.getWeight(0, 0)).toBe(0.33);
-//             expect(meshRenderer.getWeight(0, 1)).toBe(0.44);
-//             expect(meshRenderer.getWeight(0, 2)).toBe(0.55);
-//         }
-//     });
+    //     // Invalid weights
+    //     meshRenderer.setWeights([0.2, 0.7], 0);
+    //     expectNotEffect();
+
+    //     // Invalid weights 2
+    //     meshRenderer.setWeights([0.2, 0.7, 0.9, 1.0], 0);
+    //     expectNotEffect();
+
+    //     function expectNotEffect() {
+    //         expect(meshRenderer.getWeight(0, 0)).toBe(0.33);
+    //         expect(meshRenderer.getWeight(0, 1)).toBe(0.44);
+    //         expect(meshRenderer.getWeight(0, 2)).toBe(0.55);
+    //     }
+    // });
     
-//     test('SetWeighs() param validation', () => {
-//         const meshRenderer = createMeshRenderer();
-//         meshRenderer.mesh = createMeshWithShapeCounts([3]);
-//         meshRenderer.setWeights([0.33, 0.44, 0.55], 0);
+    // test('SetWeighs() param validation', () => {
+    //     const meshRenderer = createMeshRenderer();
+    //     meshRenderer.mesh = createMeshWithShapeCounts([3]);
+    //     meshRenderer.setWeights([0.33, 0.44, 0.55], 0);
 
-//         // Invalid sub mesh index
-//         meshRenderer.setWeight(0.1, 1, 0);
-//         expectNotEffect();
+    //     // Invalid sub mesh index
+    //     meshRenderer.setWeight(0.1, 1, 0);
+    //     expectNotEffect();
 
-//         // Invalid shape index
-//         meshRenderer.setWeight(0.1, 0, 3);
-//         expectNotEffect();
+    //     // Invalid shape index
+    //     meshRenderer.setWeight(0.1, 0, 3);
+    //     expectNotEffect();
 
-//         function expectNotEffect() {
-//             expect(meshRenderer.getWeight(0, 0)).toBe(0.33);
-//             expect(meshRenderer.getWeight(0, 1)).toBe(0.44);
-//             expect(meshRenderer.getWeight(0, 2)).toBe(0.55);
-//         }
-//     });
+    //     function expectNotEffect() {
+    //         expect(meshRenderer.getWeight(0, 0)).toBe(0.33);
+    //         expect(meshRenderer.getWeight(0, 1)).toBe(0.44);
+    //         expect(meshRenderer.getWeight(0, 2)).toBe(0.55);
+    //     }
+    // });
 
-//     function createMeshRenderer (): MeshRenderer {
-//         const node = new Node();
-//         const meshRenderer = node.addComponent(MeshRenderer);
-//         // @ts-expect-error Error
-//         return meshRenderer;
-//     }
+    function createMeshRenderer (): MeshRenderer {
+        const node = new Node();
+        const meshRenderer = node.addComponent(MeshRenderer);
+        // @ts-expect-error Error
+        return meshRenderer;
+    }
 
-//     function createMeshWithShapeCounts (shapesCounts: number[]): Mesh {
-//         const mesh = new Mesh();
-//         mesh.struct.morph = {
-//             subMeshMorphs: shapesCounts.map((shapeCount) => {
-//                 return {
-//                     targets: Array.from({ length: shapeCount }, (_, index) => {
-//                         return {
-//                             displacements: [],
-//                         };
-//                     }),
-//                     attributes: [],
-//                 };
-//             }),
-//         };
-//         return mesh;
-//     }
-// });
+    function createMeshWithShapeCounts (shapesCounts: number[]): Mesh {
+        const mesh = new Mesh();
+        mesh.struct.morph = {
+            subMeshMorphs: shapesCounts.map((shapeCount) => {
+                return {
+                    targets: Array.from({ length: shapeCount }, (_, index) => {
+                        return {
+                            displacements: [],
+                        };
+                    }),
+                    attributes: [],
+                };
+            }),
+        };
+        return mesh;
+    }
+});


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Store morph weights in mesh renderer so users can access or modify the morph animation result.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
