### PR TITLE
fix morph instance reuse

### DIFF
--- a/cocos/3d/models/morph-model.ts
+++ b/cocos/3d/models/morph-model.ts
@@ -55,6 +55,11 @@ export class MorphModel extends Model {
         );
     }
 
+    public destroy () {
+        super.destroy();
+        this._morphRenderingInstance = null;
+    }
+
     public setSubModelMaterial (subModelIndex: number, material: Material) {
         return super.setSubModelMaterial(subModelIndex, this._launderMaterial(material));
     }


### PR DESCRIPTION
`Models` are reused after destroy and `MorphModel` has a fragile dependency on the existence of the member `_morphRenderingInstance` at initialization. This will incorrectly enable morph for models that instead have none after some rounds of destroy & init loop.