### PR TITLE
bug fix: cc.Color.fromHex, This interface color conversion exception

### DIFF
--- a/cocos2d/core/value-types/color.ts
+++ b/cocos2d/core/value-types/color.ts
@@ -205,10 +205,10 @@ export default class Color extends ValueType {
      * @deprecated
      */
     static fromHex (out: Color, hex: number): Color {
-        let r = ((hex >> 24)) / 255.0;
-        let g = ((hex >> 16) & 0xff) / 255.0;
-        let b = ((hex >> 8) & 0xff) / 255.0;
-        let a = ((hex) & 0xff) / 255.0;
+        let r = ((hex >> 24) & 0xff);
+        let g = ((hex >> 16) & 0xff);
+        let b = ((hex >> 8) & 0xff);
+        let a = ((hex) & 0xff);
 
         out.r = r;
         out.g = g;


### PR DESCRIPTION
When user use cc.Color.fromHex,  This interface color conversion exception.
Although this interface currently has a deprecation warning, the color conversion has the following problems
1 rgba's r will have negative values
2 rgba is always 0 or 1, expect 0~255

Re: 
https://github.com/cocos-creator/engine/issues/6706
https://github.com/cocos-creator/engine/issues/6910
