### PR TITLE
add editorExtras to CCObject

### DIFF
--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -441,7 +441,8 @@ prototype._deserialize = null;
 // @ts-expect-error
 prototype._onPreDestroy = null;
 
-CCClass.fastDefine('cc.Object', CCObject, { _name: '', _objFlags: 0 });
+CCClass.fastDefine('cc.Object', CCObject, { _name: '', _objFlags: 0, __editorExtras__: {} });
+CCClass.Attr.setClassAttr(CCObject, '__editorExtras__', 'editorOnly', true);
 
 /**
  * Bit mask that controls object states.


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * add editorExtras to CCObject to restore some editorOnly data

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
