### PR TITLE
Add editor extendable

### DIFF
--- a/cocos/core/data/editor-extendable.ts
+++ b/cocos/core/data/editor-extendable.ts
@@ -1,0 +1,60 @@
+import { EDITOR } from 'internal:constants';
+import { js } from '../utils/js';
+import { CCClass } from './class';
+import { EditorExtendableObject, editorExtrasTag } from './editor-extras-tag';
+
+// Functions and classes exposed from this module are useful to
+// make a class to be `EditorExtendableObject`.
+//
+// These helpers are used internally, don't expose them to user.
+
+/**
+ * Creates a mixin class which inherits from specific base class and implements the `EditorExtendableObject` interface.
+ * @param Base The base class.
+ * @param className Assign an optional cc class name. If the base class is not cc class, this param is required.
+ * @returns The mixin class.
+ */
+export function EditorExtendableMixin<T> (Base: new (...args: any[]) => T, className?: string) {
+    return editorExtendableInternal(Base);
+}
+
+/**
+ * Class which implements the `EditorExtendableObject` interface.
+ */
+export const EditorExtendable = editorExtendableInternal(Object);
+
+export type EditorExtendable = InstanceType<typeof EditorExtendable>;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+function editorExtendableInternal<T> (Base?: (new (...args: any[]) => T), className?: string) {
+    type ResultType = new (...args: any[]) => (T & EditorExtendableObject);
+
+    if (!EDITOR) {
+        return Base as unknown as ResultType;
+    }
+
+    let name: string;
+    if (className) {
+        name = className;
+    } else if (!Base) {
+        name = `cc.EditorExtendable`;
+    } else {
+        const baseName = js.getClassName(Base);
+        if (baseName) {
+            name = `cc.EditorExtendable/${baseName}`;
+        } else {
+            throw new Error(`You should supply a class name to EditorExtendable.`);
+        }
+    }
+
+    const EditorExtendable = Base ? class EditorExtendable extends (Base as unknown as any) implements EditorExtendableObject {
+        public [editorExtrasTag]!: unknown;
+    } : class EditorExtendable implements EditorExtendableObject {
+        public [editorExtrasTag]!: unknown;
+    };
+
+    CCClass.fastDefine(name, EditorExtendable, { [editorExtrasTag]: {} });
+    CCClass.Attr.setClassAttr(EditorExtendable, editorExtrasTag, 'editorOnly', true);
+
+    return EditorExtendable as unknown as ResultType;
+}

--- a/cocos/core/data/editor-extras-tag.ts
+++ b/cocos/core/data/editor-extras-tag.ts
@@ -1,0 +1,31 @@
+/**
+ * Tag to visit editor extras of an object.
+ */
+export const editorExtrasTag = '__editorExtras__';
+
+/**
+ * Engine classes with this kind of signatures are integrated with editor extendability.
+ */
+export interface EditorExtendableObject {
+    /**
+     * The editor extras on this object.
+     *
+     * BE CAREFUL: this property is currently governed by Cocos Creator Editor.
+     * Its definition is not visible and is unknown to both engine code or users codes,
+     * they SHALL NOT operates it.
+     *
+     * You should use editor extras tag to visit this property.
+     * @example
+     * ```ts
+     * import { editorExtrasTag } from 'cc';
+     * node[editorExtrasTag] = {};
+     * node[editorExtrasTag].someWhat;
+     * ```
+     * Even if you know `editorExtrasTag === '__editorExtras__'` in current,
+     * don't access the property through that:
+     * ```ts
+     * node.__editorExtras__ = {}; // Error: might be break in future.
+     * ```
+     */
+    [editorExtrasTag]: unknown;
+}

--- a/cocos/core/data/editor-extras-tag.ts
+++ b/cocos/core/data/editor-extras-tag.ts
@@ -1,5 +1,5 @@
 /**
- * Tag to visit editor extras of an object.
+ * Tag to visit editor extras of an object. Never concern about its value please.
  */
 export const editorExtrasTag = '__editorExtras__';
 

--- a/cocos/core/data/index.ts
+++ b/cocos/core/data/index.ts
@@ -40,3 +40,4 @@ export { Details } from './deserialize';
 export { instantiate } from './instantiate';
 export { CCInteger, CCFloat, CCBoolean, CCString } from './utils/attribute';
 export { CompactValueTypeArray } from './utils/compact-value-type-array';
+export { editorExtrasTag } from './editor-extras-tag';

--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -33,6 +33,7 @@ import * as js from '../utils/js';
 import { CCClass } from './class';
 import { errorID, warnID } from '../platform/debug';
 import { legacyCC } from '../global-exports';
+import { editorExtrasTag } from './editor-extras-tag';
 
 // definitions for CCObject.Flags
 
@@ -441,8 +442,8 @@ prototype._deserialize = null;
 // @ts-expect-error
 prototype._onPreDestroy = null;
 
-CCClass.fastDefine('cc.Object', CCObject, { _name: '', _objFlags: 0, __editorExtras__: {} });
-CCClass.Attr.setClassAttr(CCObject, '__editorExtras__', 'editorOnly', true);
+CCClass.fastDefine('cc.Object', CCObject, { _name: '', _objFlags: 0, [editorExtrasTag]: {} });
+CCClass.Attr.setClassAttr(CCObject, editorExtrasTag, 'editorOnly', true);
 
 /**
  * Bit mask that controls object states.

--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -33,7 +33,7 @@ import * as js from '../utils/js';
 import { CCClass } from './class';
 import { errorID, warnID } from '../platform/debug';
 import { legacyCC } from '../global-exports';
-import { editorExtrasTag } from './editor-extras-tag';
+import { EditorExtendableObject, editorExtrasTag } from './editor-extras-tag';
 
 // definitions for CCObject.Flags
 
@@ -169,7 +169,7 @@ function compileDestruct (obj, ctor) {
  * 大部分对象的基类。
  * @private
  */
-class CCObject {
+class CCObject implements EditorExtendableObject {
     public static _deferredDestroy () {
         const deleteCount = objectsToDestroy.length;
         for (let i = 0; i < deleteCount; ++i) {
@@ -190,6 +190,8 @@ class CCObject {
             deferredDestroyTimer = null;
         }
     }
+
+    public declare [editorExtrasTag]: unknown;
 
     public _objFlags: number;
     protected _name: string;

--- a/tests/core/editor-extendable.test.ts
+++ b/tests/core/editor-extendable.test.ts
@@ -1,0 +1,15 @@
+import { EditorExtendable, editorExtrasTag } from "../../cocos/core/data/editor-extendable";
+
+describe('Editor extendable', () => {
+    test('Serialize', () => {
+        class Foo extends EditorExtendable {
+
+        }
+
+        const foo = new Foo();
+
+        foo[editorExtrasTag] = {};
+
+        const extras = foo[editorExtrasTag];
+    });
+});


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Created a tag name, exposed as `editorExtrasTag`, to store editor specific property. Editor may use this tag to visit those properties. Classes declared with such property are expressed via interface `EditorExtendableObject`.

 * **For convinient**, **internal** class `EditorExtendableMixin` and **internal** function `EditorExtendable` are created to simplify the creation of `EditorExtendableObject`. I have documented that these utility function should not been exposed to users currently.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
