### PR TITLE
Check texture consistency before invoke _updateMaterial

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -504,20 +504,21 @@ var Sprite = cc.Class({
             oldFrame.off('load', this._applySpriteSize, this);
         }
 
-        this._updateMaterial();
         let spriteFrame = this._spriteFrame;
-        if (spriteFrame) {
-            let newTexture = spriteFrame.getTexture();
-            if (newTexture && newTexture.loaded) {
-                this._applySpriteSize();
-            }
-            else {
-                this.disableRender();
-                spriteFrame.once('load', this._applySpriteSize, this);
-            }
+        let newTexture = spriteFrame && spriteFrame.getTexture();
+
+        if (oldTexture !== newTexture) {
+            this._updateMaterial();
+        }
+
+        if (newTexture && newTexture.loaded) {
+            this._applySpriteSize();
         }
         else {
             this.disableRender();
+            if (spriteFrame) {
+                spriteFrame.once('load', this._applySpriteSize, this);
+            }
         }
 
         if (CC_EDITOR) {


### PR DESCRIPTION
只有 PR #8528 是不够的.
因为 即使 texture 不变, 也会调用 `BlendFunc.prototype._updateMaterial.call(this);` , 进而导致 effect变成dirty,  进而导致 重新计算hash.

此PR 保证 texture不变时,  不会调用 _updateMaterial.

Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
