### PR TITLE
support checkout-engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build-declaration": "gulp build-declarations",
     "build-api-json": "gulp build-api-json -i index.ts -o ./3d-api-docs/tempJson",
     "build-api": "npm run build-api-json && gulp build-3d-api -i index.ts -o ./3d-api-docs -j ./3d-api-docs/tempJson",
+    "checkout-engine-version": "node ./scripts/checkout-engine-version.js",
     "test": "gulp test"
   },
   "repository": {

--- a/scripts/checkout-engine-version.js
+++ b/scripts/checkout-engine-version.js
@@ -1,13 +1,12 @@
 const fs = require('fs');
-const yargs = require('yargs');
-const argv = yargs.usage('Options:')
-    .help('h').alias('h', 'help')
-    .string('e').alias('e', 'engine-version').describe('e', 'Specify the version of engine')
-    .demandOption(['engine-version'])
-    .version('1.0')
-    .argv;
+// for adding options
+// const argv = require('yargs/yargs')(process.argv.slice(3))
+//     .usage('npm run checkout-engine-version -- [engine-version] [options]')
+//     .help('h').alias('h', 'help')
+//     .version('1.0')
+//     .argv;
 
-const targetEngineVersion = argv['engine-version'];
+const targetEngineVersion = process.argv[2];
 const versionRegExp = /^\d+\.\d+\.\d+$/
 if (!targetEngineVersion) {
     throw new Error('please specify a target engine version');

--- a/scripts/checkout-engine-version.js
+++ b/scripts/checkout-engine-version.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const yargs = require('yargs');
+const argv = yargs.usage('Options:')
+    .help('h').alias('h', 'help')
+    .string('e').alias('e', 'engine-version').describe('e', 'Specify the version of engine')
+    .demandOption(['engine-version'])
+    .version('1.0')
+    .argv;
+
+const targetEngineVersion = argv['engine-version'];
+const versionRegExp = /\d[\d\.]*\d$/
+if (!targetEngineVersion) {
+    throw new Error('please specify a target engine version');
+} else if (!versionRegExp.test(targetEngineVersion)) {
+    throw new Error('please specify a valid engine version');
+}
+
+/**
+ * This is a map for file path to file handler,
+ * the parameter of each handler is the content of file,
+ * each handler needs to return the handle result.
+ */
+const fileHandlers = {
+    './package.json' (content) {
+        const versionRegExp = /"version": ".*"/;
+        content = content.replace(versionRegExp, `"version": "${targetEngineVersion}"`);
+        return content;
+    },
+
+    './cocos/core/global-exports.ts' (content) {
+        const versionRegExp = /engineVersion = '.*'/;
+        content = content.replace(versionRegExp, `engineVersion = '${targetEngineVersion}'`);
+        return content;
+    },
+};
+
+for (filePath in fileHandlers) {
+    let handler = fileHandlers[filePath];
+    let content = fs.readFileSync(filePath, 'utf8');
+    content = handler(content);
+    if (!content) {
+        throw new Error('file handler need to return the handle result');
+    }
+    fs.writeFileSync(filePath, content, 'utf8');
+}

--- a/scripts/checkout-engine-version.js
+++ b/scripts/checkout-engine-version.js
@@ -8,7 +8,7 @@ const argv = yargs.usage('Options:')
     .argv;
 
 const targetEngineVersion = argv['engine-version'];
-const versionRegExp = /\d[\d\.]*\d$/
+const versionRegExp = /^\d+\.\d+\.\d+$/
 if (!targetEngineVersion) {
     throw new Error('please specify a target engine version');
 } else if (!versionRegExp.test(targetEngineVersion)) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7879

Changelog:
 * 支持修改引擎版本工作流 

```
npm run checkout-engine-version -- [engine-version]
```

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
