### PR TITLE
support engine version validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build-api-json": "gulp build-api-json -i index.ts -o ./3d-api-docs/tempJson",
     "build-api": "npm run build-api-json && gulp build-3d-api -i index.ts -o ./3d-api-docs -j ./3d-api-docs/tempJson",
     "checkout-engine-version": "node ./scripts/checkout-engine-version.js",
+    "varify-engine-version": "node ./scripts/varify-engine-version.js",
     "test": "gulp test"
   },
   "repository": {

--- a/scripts/checkout-engine-version.js
+++ b/scripts/checkout-engine-version.js
@@ -9,9 +9,11 @@ const fs = require('fs');
 const targetEngineVersion = process.argv[2];
 const versionRegExp = /^\d+\.\d+\.\d+$/
 if (!targetEngineVersion) {
-    throw new Error('please specify a target engine version');
+    console.error('please specify a target engine version');
+    process.exit(1);
 } else if (!versionRegExp.test(targetEngineVersion)) {
-    throw new Error('please specify a valid engine version');
+    console.error('please specify a valid engine version');
+    process.exit(1);
 }
 
 /**
@@ -38,7 +40,10 @@ for (filePath in fileHandlers) {
     let content = fs.readFileSync(filePath, 'utf8');
     content = handler(content);
     if (!content) {
-        throw new Error('file handler need to return the handle result');
+        console.error('file handler need to return the handle result');
+        process.exit(1);
     }
     fs.writeFileSync(filePath, content, 'utf8');
 }
+console.log('Checkout engine version complete!')
+process.exit(0);

--- a/scripts/varify-engine-version.js
+++ b/scripts/varify-engine-version.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const vGit = require('v-git');
+
+const repo = vGit.init('../');
+const branchName = repo.branch;
+const branchRegExp = /^v?(\d+\.\d+\.\d+)(?:-.*)?$/
+const matchResult = branchName.match(branchRegExp);
+if (!(matchResult && matchResult[1])) {
+    console.warn(`Invalid branch name: "${branchName}", skip engine version validation.`)
+    process.exit(0);
+}
+const branchVersion = matchResult[1];
+
+const versionRegExpMap = {
+    './package.json': /"version": "(.*)"/,
+    './cocos/core/global-exports.ts': /engineVersion = '(.*)'/,
+};
+for (filePath in versionRegExpMap) {
+    const regExp = versionRegExpMap[filePath];
+    const content = fs.readFileSync(filePath, 'utf8');
+    const version = content.match(regExp)[1];
+    if (version !== branchVersion) {
+        console.error(`Wrong engine version "${version}" in file "${filePath}", need to match branch name "${branchName}".`);
+        process.exit(1);
+    }
+}
+
+console.log('Engine version validation complete!');
+process.exit(0);

--- a/scripts/varify-engine-version.js
+++ b/scripts/varify-engine-version.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
+const ps = require('path');
 const vGit = require('v-git');
 
-const repo = vGit.init('../');
+const repo = vGit.init(ps.join(__dirname, '../'));
 const branchName = repo.branch;
 const branchRegExp = /^v?(\d+\.\d+\.\d+)(?:-.*)?$/
 const matchResult = branchName.match(branchRegExp);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7879

Changelog:
 * 支持引擎版本与仓库分支校验
```
npm run varify-engine-version
```
 * checkout-engine-version 工作流返回退出码

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
