### PR TITLE
support passing engine version parameter to varify-engine-version util

### DIFF
--- a/scripts/varify-engine-version.js
+++ b/scripts/varify-engine-version.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
-const ps = require('path');
-const vGit = require('v-git');
 
-const repo = vGit.init(ps.join(__dirname, '../'));
-const branchName = repo.branch;
+const branchName = process.argv[2];
+if (typeof branchName === 'undefined') {
+    console.error('Need to specify the current branch name in git repository');
+    process.exit(1);
+}
 const branchRegExp = /^v?(\d+\.\d+\.\d+)(?:-.*)?$/
 const matchResult = branchName.match(branchRegExp);
 if (!(matchResult && matchResult[1])) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7879
https://github.com/cocos-creator/3d-tasks/issues/8108

Changelog:
 * 支持引擎版本校验传参
 ```
npm run varify-engine-version -- [engine version]
```

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
