### PR TITLE
Class decorator uniquelyReferenced

### DIFF
--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -24,6 +24,7 @@
  THE SOFTWARE.
 */
 
+export { unique } from './decorators/serializable';
 export { ccclass } from './decorators/ccclass';
 export { property } from './decorators/property';
 export { requireComponent, executionOrder, disallowMultiple } from './decorators/component';

--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -24,7 +24,7 @@
  THE SOFTWARE.
 */
 
-export { unique } from './decorators/serializable';
+export { uniquelyReferenced } from './decorators/serializable';
 export { ccclass } from './decorators/ccclass';
 export { property } from './decorators/property';
 export { requireComponent, executionOrder, disallowMultiple } from './decorators/component';

--- a/cocos/core/data/decorators/index.ts
+++ b/cocos/core/data/decorators/index.ts
@@ -29,7 +29,12 @@
 
 export { ccclass } from './ccclass';
 export * from './component';
-export * from './serializable';
+export {
+    serializable,
+    formerlySerializedAs,
+    editorOnly,
+    unique,
+} from './serializable';
 export * from './editable';
 export * from './type';
 export { override } from './override';

--- a/cocos/core/data/decorators/index.ts
+++ b/cocos/core/data/decorators/index.ts
@@ -33,7 +33,7 @@ export {
     serializable,
     formerlySerializedAs,
     editorOnly,
-    unique,
+    uniquelyReferenced,
 } from './serializable';
 export * from './editable';
 export * from './type';

--- a/cocos/core/data/decorators/serializable.ts
+++ b/cocos/core/data/decorators/serializable.ts
@@ -28,7 +28,7 @@
  * @module decorator
  */
 
-import { EDITOR } from 'internal:constants';
+import { EDITOR, TEST } from 'internal:constants';
 import { emptyDecorator, LegacyPropertyDecorator } from './utils';
 import { property, IPropertyOptions } from './property';
 import { getOrCreateSerializationMetadata } from '../serialization-metadata';
@@ -36,7 +36,7 @@ import { getOrCreateSerializationMetadata } from '../serialization-metadata';
 /**
  * True if serialization feature is enabled in current environment.
  */
-const WITH_SERIALIZATION = EDITOR;
+const WITH_SERIALIZATION = EDITOR || TEST;
 
 export const serializable: LegacyPropertyDecorator = (target, propertyKey, descriptor) => property(makeSerializable({ }))(target, propertyKey, descriptor);
 

--- a/cocos/core/data/decorators/serializable.ts
+++ b/cocos/core/data/decorators/serializable.ts
@@ -85,7 +85,7 @@ function makeSerializable (options: IPropertyOptions) {
  * `bar1` and `bar2` reference to the same `Foo` object.
  * However, after deserializing, `bar1.foo === bar2.foo` always evaluates to `false`.
  * @zh
- * 将目标类标记为“唯一”的，其意味着就序列化而言，不会有多个对象引用该类的同一实例。
+ * 将目标类标记为“被唯一引用”的，其意味着就序列化而言，不会有多个对象引用该类的同一实例。
  * 当序列化到该类的对象引用时，即使它们明面上指向同一对象，也会被当作是不同对象；
  * 而当反序列化后，这两个引用将指向截然不同的两个对象。
  * 例如：

--- a/cocos/core/data/decorators/serializable.ts
+++ b/cocos/core/data/decorators/serializable.ts
@@ -60,7 +60,7 @@ function makeSerializable (options: IPropertyOptions) {
 
 /**
  * @en
- * Marks the target class as "unique" which means, in the aspect of serialization,
+ * Marks the target class as "unique referenced" which means, in the aspect of serialization,
  * no more than one objects should reference to same instance of that class.
  * When serializing references to objects of such class,
  * they're treated as different object even they point to actually the same.
@@ -69,7 +69,7 @@ function makeSerializable (options: IPropertyOptions) {
  * ```ts
  * import { _decorator } from 'cc';
  * \@_decorator.ccclass
- * \@_decorator.unique
+ * \@_decorator.uniquelyReferenced
  * class Foo { }
  *
  * \@_decorator.ccclass
@@ -92,7 +92,7 @@ function makeSerializable (options: IPropertyOptions) {
  * ```ts
  * import { _decorator } from 'cc';
  * \@_decorator.ccclass
- * \@_decorator.unique
+ * \@_decorator.uniquelyReferenced
  * class Foo { }
  *
  * \@_decorator.ccclass
@@ -109,7 +109,7 @@ function makeSerializable (options: IPropertyOptions) {
  * 但在反序列化之后，`bar1.foo === bar2.foo` 永不成立。
  */
 // eslint-disable-next-line func-names, @typescript-eslint/ban-types
-export function unique<TFunction extends Function> (constructor: TFunction) {
+export function uniquelyReferenced<TFunction extends Function> (constructor: TFunction) {
     const metadata = getOrCreateSerializationMetadata(constructor);
-    metadata.unique = true;
+    metadata.uniquelyReferenced = true;
 }

--- a/cocos/core/data/decorators/serializable.ts
+++ b/cocos/core/data/decorators/serializable.ts
@@ -30,6 +30,7 @@
 
 import { LegacyPropertyDecorator } from './utils';
 import { property, IPropertyOptions } from './property';
+import { getOrCreateSerializationMetadata } from '../serialization-metadata';
 
 export const serializable: LegacyPropertyDecorator = (target, propertyKey, descriptor) => property(makeSerializable({ }))(target, propertyKey, descriptor);
 
@@ -55,4 +56,60 @@ function makeSerializable (options: IPropertyOptions) {
         options.serializable = true;
     }
     return options;
+}
+
+/**
+ * @en
+ * Marks the target class as "unique" which means, in the aspect of serialization,
+ * no more than one objects should reference to same instance of that class.
+ * When serializing references to objects of such class,
+ * they're treated as different object even they point to actually the same.
+ * While deserializing, these two references would point two distinct objects.
+ * For example:
+ * ```ts
+ * import { _decorator } from 'cc';
+ * \@_decorator.ccclass
+ * \@_decorator.unique
+ * class Foo { }
+ *
+ * \@_decorator.ccclass
+ * class Bar {
+ *   \@_decorator.property
+ *   public foo = new Foo();
+ * }
+ *
+ * const bar1 = new Bar();
+ * const bar2 = new Bar();
+ * bar2.foo = bar1.foo; // Programmatically let them reference to the same
+ * ```
+ * `bar1` and `bar2` reference to the same `Foo` object.
+ * However, after deserializing, `bar1.foo === bar2.foo` always evaluates to `false`.
+ * @zh
+ * 将目标类标记为“唯一”的，其意味着就序列化而言，不会有多个对象引用该类的同一实例。
+ * 当序列化到该类的对象引用时，即使它们明面上指向同一对象，也会被当作是不同对象；
+ * 而当反序列化后，这两个引用将指向截然不同的两个对象。
+ * 例如：
+ * ```ts
+ * import { _decorator } from 'cc';
+ * \@_decorator.ccclass
+ * \@_decorator.unique
+ * class Foo { }
+ *
+ * \@_decorator.ccclass
+ * class Bar {
+ *   \@_decorator.property
+ *   public foo = new Foo();
+ * }
+ *
+ * const bar1 = new Bar();
+ * const bar2 = new Bar();
+ * bar2.foo = bar1.foo; // 由程序逻辑让它们引用同一个对象
+ * ```
+ * `bar1` 和 `bar2` 引用同一个 `Foo` 对象。
+ * 但在反序列化之后，`bar1.foo === bar2.foo` 永不成立。
+ */
+// eslint-disable-next-line func-names, @typescript-eslint/ban-types
+export function unique<TFunction extends Function> (constructor: TFunction) {
+    const metadata = getOrCreateSerializationMetadata(constructor);
+    metadata.unique = true;
 }

--- a/cocos/core/data/decorators/serializable.ts
+++ b/cocos/core/data/decorators/serializable.ts
@@ -60,7 +60,7 @@ function makeSerializable (options: IPropertyOptions) {
 
 /**
  * @en
- * Marks the target class as "unique referenced" which means, in the aspect of serialization,
+ * Marks the target class as "uniquely referenced" which means, in the aspect of serialization,
  * no more than one objects should reference to same instance of that class.
  * When serializing references to objects of such class,
  * they're treated as different object even they point to actually the same.

--- a/cocos/core/data/decorators/serializable.ts
+++ b/cocos/core/data/decorators/serializable.ts
@@ -28,9 +28,15 @@
  * @module decorator
  */
 
-import { LegacyPropertyDecorator } from './utils';
+import { EDITOR } from 'internal:constants';
+import { emptyDecorator, LegacyPropertyDecorator } from './utils';
 import { property, IPropertyOptions } from './property';
 import { getOrCreateSerializationMetadata } from '../serialization-metadata';
+
+/**
+ * True if serialization feature is enabled in current environment.
+ */
+const WITH_SERIALIZATION = EDITOR;
 
 export const serializable: LegacyPropertyDecorator = (target, propertyKey, descriptor) => property(makeSerializable({ }))(target, propertyKey, descriptor);
 
@@ -108,8 +114,10 @@ function makeSerializable (options: IPropertyOptions) {
  * `bar1` 和 `bar2` 引用同一个 `Foo` 对象。
  * 但在反序列化之后，`bar1.foo === bar2.foo` 永不成立。
  */
-// eslint-disable-next-line func-names, @typescript-eslint/ban-types
-export function uniquelyReferenced<TFunction extends Function> (constructor: TFunction) {
-    const metadata = getOrCreateSerializationMetadata(constructor);
-    metadata.uniquelyReferenced = true;
-}
+export const uniquelyReferenced: ClassDecorator = !WITH_SERIALIZATION
+    ? emptyDecorator
+    // eslint-disable-next-line func-names, @typescript-eslint/ban-types
+    : function uniquelyReferenced<TFunction extends Function> (constructor: TFunction) {
+        const metadata = getOrCreateSerializationMetadata(constructor);
+        metadata.uniquelyReferenced = true;
+    };

--- a/cocos/core/data/index.ts
+++ b/cocos/core/data/index.ts
@@ -37,6 +37,8 @@ export { CCClass } from './class';
 export { CCObject, isValid } from './object';
 export { deserialize } from './deserialize';
 export { Details } from './deserialize';
+export { getSerializationMetadata } from './serialization-metadata';
+export type { SerializationMetadata } from './serialization-metadata';
 export { instantiate } from './instantiate';
 export { CCInteger, CCFloat, CCBoolean, CCString } from './utils/attribute';
 export { CompactValueTypeArray } from './utils/compact-value-type-array';

--- a/cocos/core/data/serialization-metadata.ts
+++ b/cocos/core/data/serialization-metadata.ts
@@ -19,7 +19,7 @@ export function getOrCreateSerializationMetadata (constructor: Function): Serial
  * For internal usage only. DO NOT USE IT IN YOUR CODES.
  */
 export interface SerializationMetadata {
-    unique?: boolean;
+    uniquelyReferenced?: boolean;
 }
 
 interface MayBeInjected {

--- a/cocos/core/data/serialization-metadata.ts
+++ b/cocos/core/data/serialization-metadata.ts
@@ -1,0 +1,27 @@
+const sMetadataTag = Symbol('cc:SerializationMetadata');
+
+/**
+ * For internal usage only. DO NOT USE IT IN YOUR CODES.
+ * @param constructor
+ * @returns
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function getSerializationMetadata (constructor: Function): SerializationMetadata | undefined {
+    return (constructor as MayBeInjected)[sMetadataTag];
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function getOrCreateSerializationMetadata (constructor: Function): SerializationMetadata {
+    return (constructor as MayBeInjected)[sMetadataTag] ??= {};
+}
+
+/**
+ * For internal usage only. DO NOT USE IT IN YOUR CODES.
+ */
+export interface SerializationMetadata {
+    unique?: boolean;
+}
+
+interface MayBeInjected {
+    [sMetadataTag]?: SerializationMetadata;
+}

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -1,0 +1,11 @@
+import { getSerializationMetadata } from '../../cocos/core/data/serialization-metadata';
+import { uniquelyReferenced } from '../../cocos/core/data/decorators/serializable';
+
+describe(`Decorators`, () => {
+    test('@uniquelyReferenced', () => {
+        @uniquelyReferenced
+        class Foo { }
+        
+        expect(getSerializationMetadata(Foo)?.uniquelyReferenced).toBe(true);
+    });
+});


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Introduces the class decorator unique to optimize serialization of "value type"s.

Engine side only register the option info. Implementation now resides in serialization in Editor: https://github.com/cocos-creator/editor-3d/pull/5739

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
