### PR TITLE
compability with AudioClip method since deprecated on v3.1.0

### DIFF
--- a/cocos/audio/audio-clip.ts
+++ b/cocos/audio/audio-clip.ts
@@ -31,11 +31,13 @@
 import {
     ccclass, type, serializable, override,
 } from 'cc.decorator';
+import { AudioPlayer, OneShotAudio } from 'pal/audio';
 import { Asset } from '../core/assets/asset';
 import { legacyCC } from '../core/global-exports';
-import { AudioType } from '../../pal/audio/type';
+import { AudioState, AudioType } from '../../pal/audio/type';
 
 export interface AudioMeta {
+    player: AudioPlayer,
     url: string;
     type: AudioType;
     duration: number;
@@ -64,6 +66,8 @@ export class AudioClip extends Asset {
 
     protected _meta: AudioMeta | null = null;
 
+    private _player?: AudioPlayer;
+
     constructor () {
         super();
         this.loaded = false;
@@ -74,6 +78,7 @@ export class AudioClip extends Asset {
         if (meta) {
             this.loaded = true;
             this._loadMode = meta.type;
+            this._player = meta.player;
             this.emit('load');
         } else {
             this._meta = null;
@@ -112,6 +117,93 @@ export class AudioClip extends Asset {
         }
         return this._meta ? this._meta.duration : 0;
     }
+
+    // #region deprecated method
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.state instead.
+     */
+    public get state () {
+        return this._player ? this._player.state : AudioState.INIT;
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.getCurrentTime() instead.
+     */
+    public getCurrentTime () {
+        return this._player ? this._player.currentTime : 0;
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.getVolume() instead.
+     */
+    public getVolume () {
+        return this._player ? this._player.volume : 0;
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.getLoop() instead.
+     */
+    public getLoop () {
+        return this._player ? this._player.loop : false;
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.setCurrentTime() instead.
+     */
+    public setCurrentTime (time: number) {
+        this._player?.seek(time).catch((e) => {});
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.setVolume() instead.
+     */
+    public setVolume (volume: number) {
+        if (this._player) {
+            this._player.volume = volume;
+        }
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.setLoop() instead.
+     */
+    public setLoop (loop: boolean) {
+        if (this._player) {
+            this._player.loop = loop;
+        }
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.play() instead.
+     */
+    public play () {
+        this._player?.play().catch((e) => {});
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.pause() instead.
+     */
+    public pause () {
+        this._player?.pause().catch((e) => {});
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.stop() instead.
+     */
+    public stop () {
+        this._player?.stop().catch((e) => {});
+    }
+
+    /**
+     * @deprecated since v3.1.0, please use AudioSource.prototype.playOneShot() instead.
+     */
+    public playOneShot (volume: number) {
+        if (this._nativeAsset) {
+            AudioPlayer.loadOneShotAudio(this._nativeAsset.url, volume).then((oneShotAudio) => {
+                oneShotAudio.play();
+            }).catch((e) => {});
+        }
+    }
+    // #endregion deprecated method
 }
 
 legacyCC.AudioClip = AudioClip;

--- a/cocos/audio/audio-downloader.ts
+++ b/cocos/audio/audio-downloader.ts
@@ -39,11 +39,11 @@ export function loadAudioPlayer (url: string, options: IDownloadParseOptions, on
         audioLoadMode: options.audioLoadMode,
     }).then((player) => {
         const audioMeta: AudioMeta = {
+            player,
             url,
             duration: player.duration,
             type: player.type,
         };
-        player.destroy();
         onComplete(null, audioMeta);
     }).catch((err) => {
         onComplete(err);

--- a/cocos/audio/deprecated.ts
+++ b/cocos/audio/deprecated.ts
@@ -29,9 +29,8 @@
  */
 
 import { AudioSource } from './audio-source';
-import { replaceProperty, removeProperty } from '../core/utils/x-deprecated';
+import { replaceProperty, removeProperty, markAsWarning } from '../core/utils/x-deprecated';
 import { AudioClip } from './audio-clip';
-import { AudioState } from '../../pal/audio/type';
 
 // remove AudioClip static property
 replaceProperty(AudioClip, 'AudioClip', [
@@ -43,45 +42,10 @@ replaceProperty(AudioClip, 'AudioClip', [
     },
 ]);
 
-// remove AudioClip property
-replaceProperty(AudioClip.prototype, 'AudioClip.prototype', [
-    {
-        name: 'state',
-        targetName: 'AudioSource.prototype',
-        customGetter () {
-            return AudioState.INIT;
-        },
-    },
-]);
-
-// remove AudioClip getter
-replaceProperty(AudioClip.prototype, 'AudioClip.prototype', [
-    {
-        name: 'getCurrentTime',
-        targetName: 'AudioSource.prototype',
-        customFunction () {
-            return 0;
-        },
-    },
-    {
-        name: 'getVolume',
-        targetName: 'AudioSource.prototype',
-        customFunction () {
-            return 0;
-        },
-    },
-    {
-        name: 'getLoop',
-        targetName: 'AudioSource.prototype',
-        customFunction () {
-            return false;
-        },
-    },
-]);
-
-// remove AudioClip setter and methods
-replaceProperty(AudioClip.prototype, 'AudioClip.prototype',
+// deprecate AudioClip property
+markAsWarning(AudioClip.prototype, 'AudioClip.prototype',
     [
+        'state',
         'play',
         'pause',
         'stop',
@@ -89,8 +53,10 @@ replaceProperty(AudioClip.prototype, 'AudioClip.prototype',
         'setCurrentTime',
         'setVolume',
         'setLoop',
-    ].map((methodName) => ({
-        name: methodName,
-        targetName: 'AudioSource.prototype',
-        customFunction () {},
+        'getCurrentTime',
+        'getVolume',
+        'getLoop',
+    ].map((item) => ({
+        name: item,
+        suggest: `please use AudioSource.prototype.${item} instead`,
     })));

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -64,11 +64,9 @@ export class AudioContextAgent {
         return sourceBufferNode;
     }
 
-    public createGain (volume?: number) {
+    public createGain (volume = 1) {
         const gainNode = this._context.createGain();
-        if (volume !== undefined) {
-            this.setGainValue(gainNode, volume);
-        }
+        this.setGainValue(gainNode, volume);
         return gainNode;
     }
 

--- a/platforms/minigame/common/engine/AssetManager.js
+++ b/platforms/minigame/common/engine/AssetManager.js
@@ -74,11 +74,11 @@ function loadInnerAudioContext (url) {
 function loadAudioPlayer (url, options, onComplete) {
     cc.AudioPlayer.load(url).then(player => {
         const audioMeta = {
+            player,
             url,
             duration: player.duration,
             type: player.type,
         };
-        player.destroy();
         onComplete(null, audioMeta);
     }).catch(err => {
         onComplete(err);

--- a/platforms/native/engine/jsb-loader.js
+++ b/platforms/native/engine/jsb-loader.js
@@ -248,11 +248,11 @@ downloader.downloadScript = downloadScript;
 function loadAudioPlayer (url, options, onComplete) {
     cc.AudioPlayer.load(url).then(player => {
         const audioMeta = {
+            player,
             url,
             duration: player.duration,
             type: player.type,
         };
-        player.destroy();
         onComplete(null, audioMeta);
     }).catch(err => {
         onComplete(err);

--- a/platforms/runtime/common/engine/asset-manager.js
+++ b/platforms/runtime/common/engine/asset-manager.js
@@ -51,11 +51,11 @@ function handleZip(url, options, onComplete) {
 function loadAudioPlayer (url, options, onComplete) {
     cc.AudioPlayer.load(url).then(player => {
         const audioMeta = {
+            player,
             url,
             duration: player.duration,
             type: player.type,
         };
-        player.destroy();
         onComplete(null, audioMeta);
     }).catch(err => {
         onComplete(err);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7944

Changelog:
 * 兼容 v3.1.0 废弃的 AudioClip 接口，v3.1.0-v3.2.0 版本都可以合并这个 pr
 
Note:
- 只是做项目升级兼容，这些仍是不推荐使用的接口

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
