### PR TITLE
still invoke callback even if the event has been emit

### DIFF
--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -447,8 +447,10 @@ export class Game extends EventTarget {
      */
     public on (type: string, callback: () => void, target?: any, once?: boolean): any {
         // Make sure EVENT_ENGINE_INITED callbacks to be invoked
-        if (this._engineInited && type === Game.EVENT_ENGINE_INITED) {
-            return callback.call(target);
+        if ((this._engineInited && type === Game.EVENT_ENGINE_INITED) || 
+        (this._inited && type === Game.EVENT_GAME_INITED) || 
+        (this._rendererInitialized && type === Game.EVENT_RENDERER_INITED)) {
+            callback.call(target);
         }
         return this.eventTargetOn(type, callback, target, once);
     }

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -447,9 +447,9 @@ export class Game extends EventTarget {
      */
     public on (type: string, callback: () => void, target?: any, once?: boolean): any {
         // Make sure EVENT_ENGINE_INITED callbacks to be invoked
-        if ((this._engineInited && type === Game.EVENT_ENGINE_INITED) || 
-        (this._inited && type === Game.EVENT_GAME_INITED) || 
-        (this._rendererInitialized && type === Game.EVENT_RENDERER_INITED)) {
+        if ((this._engineInited && type === Game.EVENT_ENGINE_INITED)
+        || (this._inited && type === Game.EVENT_GAME_INITED)
+        || (this._rendererInitialized && type === Game.EVENT_RENDERER_INITED)) {
             callback.call(target);
         }
         return this.eventTargetOn(type, callback, target, once);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7961

Changelog:
 * still invoke callback even if the event has been emit

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
