### PR TITLE
fix sys.getNetworkType() on native platform

### DIFF
--- a/pal/system/native/system.ts
+++ b/pal/system/native/system.ts
@@ -11,7 +11,9 @@ const orientationMap: Record<string, Orientation> = {
     180: Orientation.PORTRAIT_UPSIDE_DOWN,
 };
 const networkTypeMap: Record<string, NetworkType> = {
-    // TODO
+    0: NetworkType.NONE,
+    1: NetworkType.LAN,
+    2: NetworkType.WWAN,
 };
 const platformMap: Record<number, Platform> = {
     0: Platform.WIN32,


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 修复原生平台 sys.getNetworkType() 返回 undefined 的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
