### PR TITLE
fix EventMouse.movement on native and minigame platform

### DIFF
--- a/pal/input/minigame/mouse.ts
+++ b/pal/input/minigame/mouse.ts
@@ -1,6 +1,7 @@
 import { MouseCallback, MouseInputEvent, MouseWheelCallback, MouseWheelInputEvent } from 'pal/input';
 import { MouseEventData, MouseWheelEventData, minigame } from 'pal/minigame';
 import { SystemEvent } from '../../../cocos/core/platform/event-manager/system-event';
+import { Vec2 } from '../../../cocos/core/math';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { SystemEventType } from '../../../cocos/core/platform/event-manager/event-enum';
 
@@ -8,6 +9,7 @@ export class MouseInputSource {
     public support: boolean;
     private _eventTarget: EventTarget = new EventTarget();
     private _isPressed = false;
+    private _preMousePos: Vec2 = new Vec2();
 
     constructor () {
         this.support = typeof minigame.wx === 'object' && typeof minigame.wx.onMouseDown !== 'undefined';
@@ -55,13 +57,19 @@ export class MouseInputSource {
             default:
                 break;
             }
+            const locationX = event.x;
+            const locationY = sysInfo.screenHeight - event.y;
             const inputEvent: MouseInputEvent = {
                 type: eventType,
-                x: event.x,
-                y: sysInfo.screenHeight - event.y,
+                x: locationX,
+                y: locationY,
+                movementX: locationX - this._preMousePos.x,
+                movementY: this._preMousePos.y - locationY,
                 button,
                 timestamp: performance.now(),
             };
+            // update previous mouse position.
+            this._preMousePos.set(inputEvent.x, inputEvent.y);
             // emit web mouse event
             this._eventTarget.emit(eventType, inputEvent);
         };

--- a/pal/input/native/mouse.ts
+++ b/pal/input/native/mouse.ts
@@ -8,6 +8,7 @@ import { SystemEvent } from '../../../cocos/core/platform/event-manager/system-e
 export class MouseInputSource {
     public support: boolean;
     private _eventTarget: EventTarget = new EventTarget();
+    private _preMousePos: Vec2 = new Vec2();
 
     constructor () {
         this.support = !system.isMobile;
@@ -43,13 +44,19 @@ export class MouseInputSource {
         return (event: jsb.MouseEvent) => {
             const location = this._getLocation(event);
             const viewSize = system.getViewSize();
+            const locationX = location.x;
+            const locationY = viewSize.height - location.y;
             const inputEvent: MouseInputEvent = {
                 type: eventType,
-                x: location.x,
-                y: viewSize.height - location.y,
+                x: locationX,
+                y: locationY,
+                movementX: locationX - this._preMousePos.x,
+                movementY: this._preMousePos.y - locationY,
                 button: event.button,
                 timestamp: performance.now(),
             };
+            // update previous mouse position.
+            this._preMousePos.set(inputEvent.x, inputEvent.y);
             // emit web mouse event
             this._eventTarget.emit(eventType, inputEvent);
         };


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 修复原生和微信 pc 平台 EventMouse.movementX EventMouse.movementY 一直为 0 的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
