### PR TITLE
support inputManager.frameDispatchEvents() in main loop

### DIFF
--- a/@types/pal/input.d.ts
+++ b/@types/pal/input.d.ts
@@ -21,8 +21,8 @@ declare module 'pal/input' {
 
     interface TouchData {
         /**
-         * A unique identifier for this touch.  
-         * A given touch point will have the same identifier for the duration of its movement around the surface.  
+         * A unique identifier for this touch.
+         * A given touch point will have the same identifier for the duration of its movement around the surface.
          * This lets you ensure that you're tracking the same touch all the time.
          */
         readonly identifier: number;
@@ -52,22 +52,22 @@ declare module 'pal/input' {
     export class TouchInputSource extends BaseInputSource {
         /**
          * Register the touch start event callback.
-         * @param cb 
+         * @param cb
          */
         public onStart (cb: TouchCallback);
         /**
          * Register the touch move event callback.
-         * @param cb 
+         * @param cb
          */
         public onMove (cb: TouchCallback);
         /**
          * Register the touch end event callback.
-         * @param cb 
+         * @param cb
          */
         public onEnd (cb: TouchCallback);
         /**
          * Register the touch cancel event callback.
-         * @param cb 
+         * @param cb
          */
         public onCancel (cb: TouchCallback);
     }
@@ -82,11 +82,11 @@ declare module 'pal/input' {
          */
         readonly y: number;
         /**
-         * The pressed mouse button during the related mouse event.  
+         * The pressed mouse button during the related mouse event.
          * The valid value maybe `EventMouse.BUTTON_LEFT`, `EventMouse.BUTTON_RIGHT` and `EventMouse.BUTTON_MIDDLE`.
          */
         readonly button: number;
-        // this is web only property, should be removed in the futrure. 
+        // this is web only property, should be removed in the futrure.
         movementX?: number;
         movementY?: number;
     }
@@ -108,22 +108,22 @@ declare module 'pal/input' {
     export class MouseInputSource extends BaseInputSource {
         /**
          * Register the mouse down event callback.
-         * @param cb 
+         * @param cb
          */
         public onDown (cb: MouseCallback);
         /**
          * Register the mouse move event callback.
-         * @param cb 
+         * @param cb
          */
         public onMove (cb: MouseCallback);
         /**
          * Register the mouse up event callback.
-         * @param cb 
+         * @param cb
          */
         public onUp (cb: MouseCallback);
         /**
          * Register the mouse wheel event callback.
-         * @param cb 
+         * @param cb
          */
         public onWheel (cb: MouseWheelCallback);
     }
@@ -141,18 +141,18 @@ declare module 'pal/input' {
     export class KeyboardInputSource extends BaseInputSource {
         /**
          * Register the key down event callback.
-         * @param cb 
+         * @param cb
          */
         public onDown (cb: KeyboardCallback);
         /**
          * Register the key pressing event callback.
          * NOTE: Compability for the deprecated KEY_DOWN event type. It should be removed in the future.
-         * @param cb 
+         * @param cb
          */
         public onPressing (cb: KeyboardCallback);
         /**
          * Register the key up event callback.
-         * @param cb 
+         * @param cb
          */
         public onUp (cb: KeyboardCallback);
     }
@@ -184,24 +184,24 @@ declare module 'pal/input' {
      */
     export class AccelerometerInputSource extends BaseInputSource {
         /**
-         * Asynchronously start the accelerometer.  
+         * Asynchronously start the accelerometer.
          * TODO: return a promise.
          */
         public start ();
         /**
-         * Stop the accelerometer.  
+         * Stop the accelerometer.
          * TODO: return a promise.
          */
         public stop ();
         /**
-         * Set interval of the accelerometer callback.  
-         * The interval is in mileseconds.  
+         * Set interval of the accelerometer callback.
+         * The interval is in mileseconds.
          * @param intervalInMileseconds interval in mileseconds
          */
         public setInterval (intervalInMileseconds: number);
         /**
          * Register the accelerometer change event callback.
-         * @param cb 
+         * @param cb
          */
         public onChange (cb: AccelerometerCallback);
     }
@@ -221,12 +221,12 @@ declare module 'pal/input' {
         public hide (): Promise<void>;
         /**
          * Register the UI input box change event callback.
-         * @param cb 
+         * @param cb
          */
         public onChange (cb: ()=>void);
         /**
          * Register the UI input box complete event callback.
-         * @param cb 
+         * @param cb
          */
         public onComplete (cb: ()=>void);
         /**
@@ -242,19 +242,28 @@ declare module 'pal/input' {
     }
 
     /**
-     * Class designed to manage all input sources.  
-     * TODO: designed `pollEvent()` API
+     * Class designed to manage all input sources.
      */
     class Input {
-        public _touch: TouchInputSource;
-        public _mouse: MouseInputSource;
-        public _keyboard: KeyboardInputSource;
-        public _accelerometer: AccelerometerInputSource;
-        public _inputBox: InputBox;
+        private _touch: TouchInputSource;
+        private _mouse: MouseInputSource;
+        private _keyboard: KeyboardInputSource;
+        private _accelerometer: AccelerometerInputSource;
+        private _inputBox: InputBox;
 
-        // public startAccelerometer (): Promise<void>;
-        // public stopAccelerometer (): Promise<void>;
-        // public setAccelerometerInterval (intercal: number): void;
+        private _touchEvents: TouchInputEvent[];
+        private _mouseEvents: MouseInputEvent[];
+        private _keyboardEvents: KeyboardInputEvent[];
+        private _accelerometerEvents: AccelerometerInputEvent[];
+
+        public pollTouchEvents (): TouchInputEvent[];
+        public pollMouseEvents (): MouseInputEvent[];
+        public pollKeyboardEvents (): KeyboardInputEvent[];
+        public pollAccelerometerEvents (): AccelerometerInputEvent[];
+
+        public startAccelerometer (): void;
+        public stopAccelerometer (): void;
+        public setAccelerometerInterval (interval: number): void;
 
         // // input box
         // public showInputBox (): Promise<void>;

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -48,6 +48,7 @@ import { Scheduler } from './scheduler';
 import { js } from './utils';
 import { legacyCC } from './global-exports';
 import { errorID, error, assertID, warnID } from './platform/debug';
+import inputManager from './platform/event-manager/input-manager';
 
 // ----------------------------------------------------------------------------------------------------------------------
 
@@ -736,6 +737,9 @@ export class Director extends EventTarget {
             // Update
             if (!this._paused) {
                 this.emit(Director.EVENT_BEFORE_UPDATE);
+                if (!EDITOR) {
+                    inputManager.frameDispatchEvents();
+                }
                 // Call start for new added components
                 this._compScheduler.startPhase();
                 // Update for components

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -734,12 +734,12 @@ export class Director extends EventTarget {
     public tick (dt: number) {
         if (!this._invalid) {
             this.emit(Director.EVENT_BEGIN_FRAME);
+            if (!EDITOR) {
+                inputManager.frameDispatchEvents();
+            }
             // Update
             if (!this._paused) {
                 this.emit(Director.EVENT_BEFORE_UPDATE);
-                if (!EDITOR) {
-                    inputManager.frameDispatchEvents();
-                }
                 // Call start for new added components
                 this._compScheduler.startPhase();
                 // Update for components

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -39,7 +39,7 @@ import { CCObject } from './data/object';
 import { EventTarget } from './event/event-target';
 import { game, Game } from './game';
 import { v2, Vec2 } from './math';
-import eventManager from './platform/event-manager/event-manager';
+import { eventManager } from './platform/event-manager/event-manager';
 import { Root } from './root';
 import { Node, Scene } from './scene-graph';
 import { ComponentScheduler } from './scene-graph/component-scheduler';
@@ -58,7 +58,7 @@ import inputManager from './platform/event-manager/input-manager';
  * `director` is a singleton object which manage your game's logic flow.
  * Since the `director` is a singleton, you don't need to call any constructor or create functions,
  * the standard way to use it is by calling:
- * `director.methodName();` 
+ * `director.methodName();`
  * It creates and handle the main Window and manages how and when to execute the Scenes.
  *
  * @zh

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -131,11 +131,6 @@ export interface IGameConfig {
     /**
      * For internal use.
      */
-    registerSystemEvent?: boolean;
-
-    /**
-     * For internal use.
-     */
     jsList?: string[];
 
     /**
@@ -574,14 +569,7 @@ export class Game extends EventTarget {
             this.onStart = configOrCallback ?? null;
         }
 
-        return Promise.resolve(initPromise).then(() => {
-            // register system events
-            if (!EDITOR && game.config.registerSystemEvent) {
-                inputManager.registerSystemEvent();
-            }
-
-            return this._setRenderPipelineNShowSplash();
-        });
+        return Promise.resolve(initPromise).then(() => this._setRenderPipelineNShowSplash());
     }
 
     //  @ Persist root node section
@@ -761,9 +749,6 @@ export class Game extends EventTarget {
         const renderMode = config.renderMode;
         if (typeof renderMode !== 'number' || renderMode > 2 || renderMode < 0) {
             config.renderMode = 0;
-        }
-        if (typeof config.registerSystemEvent !== 'boolean') {
-            config.registerSystemEvent = true;
         }
         config.showFPS = !!config.showFPS;
 

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -327,7 +327,7 @@ export class Game extends EventTarget {
      * @en The delta time since last frame, unit: s.
      * @zh 获取上一帧的增量时间，以秒为单位。
      */
-     public get deltaTime () {
+    public get deltaTime () {
         return this._deltaTime;
     }
 
@@ -351,7 +351,7 @@ export class Game extends EventTarget {
      * @en The expected delta time of each frame
      * @zh 期望帧率对应的每帧时间
      */
-    public frameTime = 1000/60;
+    public frameTime = 1000 / 60;
 
     public collisionMatrix = [];
     public groupList: any[] = [];
@@ -427,6 +427,7 @@ export class Game extends EventTarget {
      */
     public resume () {
         if (!this._paused) { return; }
+        inputManager.clearEvents();
         if (this._intervalId) {
             window.cAF(this._intervalId);
             this._intervalId = 0;

--- a/cocos/core/platform/event-manager/event-manager.ts
+++ b/cocos/core/platform/event-manager/event-manager.ts
@@ -1238,7 +1238,3 @@ class EventManager {
  * @deprecated
  */
 export const eventManager = new EventManager();
-
-legacyCC.eventManager = eventManager;
-
-export default eventManager;

--- a/cocos/core/platform/event-manager/index.ts
+++ b/cocos/core/platform/event-manager/index.ts
@@ -31,7 +31,6 @@
 
 import './deprecated';
 
-export * from './event-manager';
 export * from './input-manager';
 export * from './system-event';
 export * from './events';

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -81,25 +81,29 @@ class InputManager {
     public frameDispatchEvents () {
         const mouseEvents = input.pollMouseEvents();
         // TODO: culling event queue
-        for (const mouseEvent of mouseEvents) {
+        for (let i = 0, length = mouseEvents.length; i < length; ++i) {
+            const mouseEvent = mouseEvents[i];
             this._dispatchMouseEvent(mouseEvent);
         }
 
         const touchEvents = input.pollTouchEvents();
         // TODO: culling event queue
-        for (const touchEvent of touchEvents) {
+        for (let i = 0, length = touchEvents.length; i < length; ++i) {
+            const touchEvent = touchEvents[i];
             this._dispatchTouchEvent(touchEvent);
         }
 
         const keyboardEvents = input.pollKeyboardEvents();
         // TODO: culling event queue
-        for (const keyboardEvent of keyboardEvents) {
+        for (let i = 0, length = keyboardEvents.length; i < length; ++i) {
+            const keyboardEvent = keyboardEvents[i];
             this._dispatchKeyboardEvent(keyboardEvent);
         }
 
         const accelerometerEvents = input.pollAccelerometerEvents();
         // TODO: culling event queue
-        for (const accelerometerEvent of accelerometerEvents) {
+        for (let i = 0, length = accelerometerEvents.length; i < length; ++i) {
+            const accelerometerEvent = accelerometerEvents[i];
             this._dispatchAccelerometerEvent(accelerometerEvent);
         }
     }

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -32,7 +32,7 @@
 import { AccelerometerInputEvent, input, MouseInputEvent, MouseWheelInputEvent, TouchInputEvent, KeyboardInputEvent } from 'pal/input';
 import { Vec2 } from '../../math/index';
 import { macro } from '../macro';
-import eventManager from './event-manager';
+import { eventManager } from './event-manager';
 import { EventAcceleration, EventKeyboard, EventMouse, EventTouch } from './events';
 import { Touch } from './touch';
 import { legacyCC } from '../../global-exports';

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -29,7 +29,7 @@
  * @hidden
  */
 
-import { AccelerometerInputEvent, input, MouseInputEvent, TouchInputEvent } from 'pal/input';
+import { AccelerometerInputEvent, input, MouseInputEvent, MouseWheelInputEvent, TouchInputEvent, KeyboardInputEvent } from 'pal/input';
 import { Vec2 } from '../../math/index';
 import { macro } from '../macro';
 import eventManager from './event-manager';
@@ -53,8 +53,6 @@ interface IView {
  *  This class manages all events of input. include: touch, mouse, accelerometer, keyboard
  */
 class InputManager {
-    private _isRegisterEvent = false;
-
     private _preTouchPoint = new Vec2();
     private _prevMousePoint = new Vec2();
 
@@ -70,8 +68,88 @@ class InputManager {
     // TODO: remove this property
     private _glView: IView | null = null;
 
+    public frameDispatchEvents () {
+        const mouseEvents = input.pollMouseEvents();
+        // TODO: culling event queue
+        for (const mouseEvent of mouseEvents) {
+            this._dispatchMouseEvent(mouseEvent);
+        }
+
+        const touchEvents = input.pollTouchEvents();
+        // TODO: culling event queue
+        for (const touchEvent of touchEvents) {
+            this._dispatchTouchEvent(touchEvent);
+        }
+
+        const keyboardEvents = input.pollKeyboardEvents();
+        // TODO: culling event queue
+        for (const keyboardEvent of keyboardEvents) {
+            this._dispatchKeyboardEvent(keyboardEvent);
+        }
+
+        const accelerometerEvents = input.pollAccelerometerEvents();
+        // TODO: culling event queue
+        for (const accelerometerEvent of accelerometerEvents) {
+            this._dispatchAccelerometerEvent(accelerometerEvent);
+        }
+    }
+
+    // #region Mouse Handle
+    private _dispatchMouseEvent (inputEvent: MouseInputEvent) {
+        let mouseEvent: EventMouse;
+        let touch: Touch;
+        switch (inputEvent.type) {
+        case SystemEventType.MOUSE_DOWN:
+            mouseEvent = this._getMouseEvent(inputEvent);
+            touch = this._getTouch(inputEvent);
+            this._handleTouchesStart([touch]);
+            eventManager.dispatchEvent(mouseEvent);
+            break;
+        case SystemEventType.MOUSE_MOVE:
+            mouseEvent = this._getMouseEvent(inputEvent);
+            touch = this._getTouch(inputEvent);
+            this._handleTouchesMove([touch]);
+            eventManager.dispatchEvent(mouseEvent);
+            break;
+        case SystemEventType.MOUSE_UP:
+            mouseEvent = this._getMouseEvent(inputEvent);
+            touch = this._getTouch(inputEvent);
+            this._handleTouchesEnd([touch]);
+            eventManager.dispatchEvent(mouseEvent);
+            break;
+        case SystemEventType.MOUSE_WHEEL:
+            mouseEvent = this._getMouseEvent(inputEvent);
+            mouseEvent.setScrollData((<MouseWheelInputEvent>inputEvent).deltaX, (<MouseWheelInputEvent>inputEvent).deltaY);
+            eventManager.dispatchEvent(mouseEvent);
+            break;
+        default:
+            break;
+        }
+    }
+    // #endregion Mouse Handle
+
     // #region Touch Handle
-    public handleTouchesBegin (touches: Touch[]) {
+    private _dispatchTouchEvent (inputEvent: TouchInputEvent) {
+        const touchList = this._getTouchList(inputEvent);
+        switch (inputEvent.type) {
+        case SystemEventType.TOUCH_START:
+            this._handleTouchesStart(touchList);
+            break;
+        case SystemEventType.TOUCH_MOVE:
+            this._handleTouchesMove(touchList);
+            break;
+        case SystemEventType.TOUCH_END:
+            this._handleTouchesEnd(touchList);
+            break;
+        case SystemEventType.TOUCH_CANCEL:
+            this._handleTouchesCancel(touchList);
+            break;
+        default:
+            break;
+        }
+    }
+
+    private _handleTouchesStart (touches: Touch[]) {
         const handleTouches: Touch[] = [];
         const locTouchIntDict = this._touchesIntegerDict;
         for (let i = 0; i < touches.length; ++i) {
@@ -103,7 +181,7 @@ class InputManager {
         }
     }
 
-    public handleTouchesMove (touches: Touch[]) {
+    private _handleTouchesMove (touches: Touch[]) {
         const handleTouches: Touch[] = [];
         const locTouches = this._touches;
         for (let i = 0; i < touches.length; ++i) {
@@ -131,7 +209,7 @@ class InputManager {
         }
     }
 
-    public handleTouchesEnd (touches: Touch[]) {
+    private _handleTouchesEnd (touches: Touch[]) {
         const handleTouches = this.getSetOfTouchesEndOrCancel(touches);
         if (handleTouches.length > 0) {
             const touchEvent = new EventTouch(handleTouches, false, SystemEventType.TOUCH_END, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
@@ -140,7 +218,7 @@ class InputManager {
         this._preTouchPool.length = 0;
     }
 
-    public handleTouchesCancel (touches: Touch[]) {
+    private _handleTouchesCancel (touches: Touch[]) {
         const handleTouches = this.getSetOfTouchesEndOrCancel(touches);
         if (handleTouches.length > 0) {
             const touchEvent = new EventTouch(handleTouches, false, SystemEventType.TOUCH_CANCEL, macro.ENABLE_MULTI_TOUCH ? this._getUsefulTouches() : handleTouches);
@@ -336,121 +414,52 @@ class InputManager {
     }
     // #endregion Touch Handle
 
+    // #region Keyboard Handle
+    private _dispatchKeyboardEvent (inputEvent: KeyboardInputEvent) {
+        switch (inputEvent.type) {
+        // TODO: to support in Input Module
+        // case 'keypress':
+        //     eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'keypress'));
+        //     break;
+        case SystemEventType.KEY_DOWN:
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEventType.KEY_DOWN));
+            break;
+        case SystemEventType.KEY_UP:
+            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEventType.KEY_UP));
+            break;
+        default:
+            break;
+        }
+    }
+    // #endregion Keyboard Handle
+
     // #region Accelerometer Handle
+    _dispatchAccelerometerEvent (inputEvent: AccelerometerInputEvent) {
+        if (inputEvent.type === SystemEventType.DEVICEMOTION) {
+            const { x, y, z, timestamp } = inputEvent;
+            eventManager.dispatchEvent(new EventAcceleration(new Acceleration(x, y, z, timestamp)));
+        }
+    }
     /**
      * Whether enable accelerometer event.
      */
     public setAccelerometerEnabled (isEnable: boolean) {
         if (isEnable) {
-            input._accelerometer.start();
+            input.startAccelerometer();
         } else {
-            input._accelerometer.stop();
+            input.stopAccelerometer();
         }
     }
 
     /**
-     * set accelerometer interval value in mileseconds
+     * set accelerometer interval value in mile seconds
      * @method setAccelerometerInterval
-     * @param {Number} intervalInMileseconds
+     * @param {Number} intervalInMileSeconds
      */
-    public setAccelerometerInterval (intervalInMileseconds) {
-        input._accelerometer.setInterval(intervalInMileseconds);
+    public setAccelerometerInterval (intervalInMileSeconds) {
+        input.setAccelerometerInterval(intervalInMileSeconds);
     }
     // #endregion Accelerometer Handle
-
-    // #region Event Register
-    public registerSystemEvent () {
-        if (this._isRegisterEvent) {
-            return;
-        }
-
-        this._glView = legacyCC.view;
-
-        // Register mouse events.
-        if (input._mouse.support) {
-            this._registerMouseEvents();
-        }
-
-        // Register touch events.
-        if (input._touch.support) {
-            this._registerTouchEvents();
-        }
-
-        if (input._keyboard.support) {
-            this._registerKeyboardEvent();
-        }
-
-        if (input._accelerometer.support) {
-            this._registerAccelerometerEvent();
-        }
-        this._isRegisterEvent = true;
-    }
-
-    private _registerMouseEvents () {
-        input._mouse.onDown((inputEvent) => {
-            const mouseEvent = this._getMouseEvent(inputEvent);
-            const touch =  this._getTouch(inputEvent);
-            this.handleTouchesBegin([touch]);
-            eventManager.dispatchEvent(mouseEvent);
-        });
-        input._mouse.onMove((inputEvent) => {
-            const mouseEvent = this._getMouseEvent(inputEvent);
-            const touch =  this._getTouch(inputEvent);
-            this.handleTouchesMove([touch]);
-            eventManager.dispatchEvent(mouseEvent);
-        });
-        input._mouse.onUp((inputEvent) => {
-            const mouseEvent = this._getMouseEvent(inputEvent);
-            const touch =  this._getTouch(inputEvent);
-            this.handleTouchesEnd([touch]);
-            eventManager.dispatchEvent(mouseEvent);
-        });
-        input._mouse.onWheel((inputEvent) => {
-            const mouseEvent = this._getMouseEvent(inputEvent);
-            mouseEvent.setScrollData(inputEvent.deltaX, inputEvent.deltaY);
-            eventManager.dispatchEvent(mouseEvent);
-        });
-    }
-
-    private _registerTouchEvents () {
-        input._touch.onStart((inputEvent) => {
-            const touchList = this._getTouchList(inputEvent);
-            this.handleTouchesBegin(touchList);
-        });
-        input._touch.onMove((inputEvent) => {
-            const touchList = this._getTouchList(inputEvent);
-            this.handleTouchesMove(touchList);
-        });
-        input._touch.onEnd((inputEvent) => {
-            const touchList = this._getTouchList(inputEvent);
-            this.handleTouchesEnd(touchList);
-        });
-        input._touch.onCancel((inputEvent) => {
-            const touchList = this._getTouchList(inputEvent);
-            this.handleTouchesCancel(touchList);
-        });
-    }
-
-    private _registerKeyboardEvent () {
-        // TODO: to support in Input Module
-        // input._keyboard.onDown((inputEvent) => {
-        //     eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, 'keypress'));
-        // });
-        input._keyboard.onPressing((inputEvent)  => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEventType.KEY_DOWN));
-        });
-        input._keyboard.onUp((inputEvent)  => {
-            eventManager.dispatchEvent(new EventKeyboard(inputEvent.code, SystemEventType.KEY_UP));
-        });
-    }
-
-    private _registerAccelerometerEvent () {
-        input._accelerometer.onChange((inputEvent: AccelerometerInputEvent) => {
-            const { x, y, z, timestamp } = inputEvent;
-            eventManager.dispatchEvent(new EventAcceleration(new Acceleration(x, y, z, timestamp)));
-        });
-    }
-    // #endregion Event Register
 }
 
 const inputManager = new InputManager();

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -68,6 +68,16 @@ class InputManager {
     // TODO: remove this property
     private _glView: IView | null = null;
 
+    /**
+     * Clear events when game is resumed.
+     */
+    public clearEvents () {
+        input.pollMouseEvents();
+        input.pollTouchEvents();
+        input.pollKeyboardEvents();
+        input.pollAccelerometerEvents();
+    }
+
     public frameDispatchEvents () {
         const mouseEvents = input.pollMouseEvents();
         // TODO: culling event queue

--- a/cocos/core/platform/event-manager/input-manager.ts
+++ b/cocos/core/platform/event-manager/input-manager.ts
@@ -294,6 +294,9 @@ class InputManager {
 
     // TODO: remove this private method
     private _getViewPixelRatio () {
+        if (!this._glView) {
+            this._glView = legacyCC.view;
+        }
         return this._glView ? this._glView._devicePixelRatio : 1;
     }
 

--- a/cocos/core/platform/event-manager/system-event.ts
+++ b/cocos/core/platform/event-manager/system-event.ts
@@ -34,7 +34,7 @@ import { EventTarget } from '../../event/event-target';
 import { EventAcceleration, EventKeyboard, EventMouse, EventTouch } from './events';
 import { SystemEventType } from './event-enum';
 import { EventListener } from './event-listener';
-import eventManager from './event-manager';
+import { eventManager } from './event-manager';
 import inputManager from './input-manager';
 import { Touch } from './touch';
 import { legacyCC } from '../../global-exports';

--- a/cocos/core/utils/array.ts
+++ b/cocos/core/utils/array.ts
@@ -191,7 +191,7 @@ export function contains<T> (array: T[], value: T) {
  */
 export function copy<T> (array: T[]) {
     const len = array.length;
-    const cloned = new Array(len);
+    const cloned = new Array<T>(len);
     for (let i = 0; i < len; i += 1) {
         cloned[i] = array[i];
     }

--- a/pal/input/minigame/index.ts
+++ b/pal/input/minigame/index.ts
@@ -1,5 +1,5 @@
-import { EDITOR } from 'internal:constants';
-import { BaseInputEvent } from 'pal/input';
+import { TouchInputEvent, MouseInputEvent, KeyboardInputEvent, AccelerometerInputEvent } from 'pal/input';
+import { js } from '../../../cocos/core/utils/js';
 import { AccelerometerInputSource } from './accelerometer';
 import { InputBox } from './input-box';
 import { KeyboardInputSource } from './keyboard';
@@ -12,50 +12,56 @@ export class Input {
     public _keyboard = new KeyboardInputSource();
     public _accelerometer = new AccelerometerInputSource();
     public _inputBox = new InputBox();
-    private _inputEventList: BaseInputEvent[] = [];
+
+    private _touchEvents: TouchInputEvent[] = [];
+    private _mouseEvents: MouseInputEvent[] = [];
+    private _keyboardEvents: KeyboardInputEvent[] = [];
+    private _accelerometerEvents: AccelerometerInputEvent[] = [];
 
     constructor () {
         this._registerEvent();
     }
 
     private _registerEvent () {
-        // if (EDITOR) {
-        //     return;
-        // }
-        // TODO: implement event main loop
-        // if (this._touch.support) {
-        //     this._touch.onStart(this._pushEvent);
-        //     this._touch.onMove(this._pushEvent);
-        //     this._touch.onEnd(this._pushEvent);
-        //     this._touch.onCancel(this._pushEvent);
-        // }
+        if (this._touch.support) {
+            const touchEvents = this._touchEvents;
+            this._touch.onStart((event) => { touchEvents.push(event); });
+            this._touch.onMove((event) => { touchEvents.push(event); });
+            this._touch.onEnd((event) => { touchEvents.push(event); });
+            this._touch.onCancel((event) => { touchEvents.push(event); });
+        }
 
-        // if (this._mouse.support) {
-        //     this._mouse.onDown(this._pushEvent);
-        //     this._mouse.onMove(this._pushEvent);
-        //     this._mouse.onUp(this._pushEvent);
-        //     this._mouse.onCancel(this._pushEvent);
-        //     this._mouse.onWheel(this._pushEvent);
-        // }
+        if (this._mouse.support) {
+            const mouseEvents = this._mouseEvents;
+            this._mouse.onDown((event) => { mouseEvents.push(event); });
+            this._mouse.onMove((event) => { mouseEvents.push(event); });
+            this._mouse.onUp((event) => { mouseEvents.push(event); });
+            this._mouse.onWheel((event) => { mouseEvents.push(event); });
+        }
 
-        // if (this._keyboard.support) {
-        //     this._keyboard.onDown(this._pushEvent);
-        //     this._keyboard.onUp(this._pushEvent);
-        // }
+        if (this._keyboard.support) {
+            const keyboardEvents = this._keyboardEvents;
+            // this._keyboard.onDown((event) => { keyboardEvents.push(event); });
+            this._keyboard.onPressing((event) => { keyboardEvents.push(event); });
+            this._keyboard.onUp((event) => { keyboardEvents.push(event); });
+        }
 
-        // if (this._accelerometer.support) {
-        //     this._accelerometer.onChange(this._pushEvent);
-        // }
+        if (this._accelerometer.support) {
+            const accelerometerEvents = this._accelerometerEvents;
+            this._accelerometer.onChange((event) => { accelerometerEvents.push(event); });
+        }
     }
 
-    private _pushEvent (inputEvent: BaseInputEvent) {
-        this._inputEventList.push(inputEvent);
+    // accelerometer
+    public startAccelerometer (): void {
+        this._accelerometer.start();
     }
-
-    // // accelerometer
-    // public startAccelerometer (): Promise<void>;
-    // public stopAccelerometer (): Promise<void>;
-    // public setAccelerometerInterval (intercal: number): void;
+    public stopAccelerometer (): void {
+        this._accelerometer.stop();
+    }
+    public setAccelerometerInterval (interval: number): void {
+        this._accelerometer.setInterval(interval);
+    }
 
     // // input box
     // public showInputBox (): Promise<void>;
@@ -63,8 +69,25 @@ export class Input {
     // public onInputBoxChange (cb: Function);
     // public onInputBoxComplete (cb: Function);
 
-    public pollEvent (): BaseInputEvent | undefined {
-        return this._inputEventList.shift();
+    public pollTouchEvents (): TouchInputEvent[] {
+        const events = js.array.copy(this._touchEvents);
+        this._touchEvents.length = 0;
+        return events;
+    }
+    public pollMouseEvents (): MouseInputEvent[] {
+        const events = js.array.copy(this._mouseEvents);
+        this._mouseEvents.length = 0;
+        return events;
+    }
+    public pollKeyboardEvents (): KeyboardInputEvent[] {
+        const events = js.array.copy(this._keyboardEvents);
+        this._keyboardEvents.length = 0;
+        return events;
+    }
+    public pollAccelerometerEvents (): AccelerometerInputEvent[] {
+        const events = js.array.copy(this._accelerometerEvents);
+        this._accelerometerEvents.length = 0;
+        return events;
     }
 }
 

--- a/pal/input/native/index.ts
+++ b/pal/input/native/index.ts
@@ -1,5 +1,5 @@
-import { EDITOR } from 'internal:constants';
-import { BaseInputEvent } from 'pal/input';
+import { TouchInputEvent, MouseInputEvent, KeyboardInputEvent, AccelerometerInputEvent } from 'pal/input';
+import { js } from '../../../cocos/core/utils/js';
 import { AccelerometerInputSource } from './accelerometer';
 import { InputBox } from './input-box';
 import { KeyboardInputSource } from './keyboard';
@@ -12,50 +12,56 @@ export class Input {
     public _keyboard = new KeyboardInputSource();
     public _accelerometer = new AccelerometerInputSource();
     public _inputBox = new InputBox();
-    private _inputEventList: BaseInputEvent[] = [];
+
+    private _touchEvents: TouchInputEvent[] = [];
+    private _mouseEvents: MouseInputEvent[] = [];
+    private _keyboardEvents: KeyboardInputEvent[] = [];
+    private _accelerometerEvents: AccelerometerInputEvent[] = [];
 
     constructor () {
         this._registerEvent();
     }
 
     private _registerEvent () {
-        // if (EDITOR) {
-        //     return;
-        // }
-        // TODO: implement event main loop
-        // if (this._touch.support) {
-        //     this._touch.onStart(this._pushEvent);
-        //     this._touch.onMove(this._pushEvent);
-        //     this._touch.onEnd(this._pushEvent);
-        //     this._touch.onCancel(this._pushEvent);
-        // }
+        if (this._touch.support) {
+            const touchEvents = this._touchEvents;
+            this._touch.onStart((event) => { touchEvents.push(event); });
+            this._touch.onMove((event) => { touchEvents.push(event); });
+            this._touch.onEnd((event) => { touchEvents.push(event); });
+            this._touch.onCancel((event) => { touchEvents.push(event); });
+        }
 
-        // if (this._mouse.support) {
-        //     this._mouse.onDown(this._pushEvent);
-        //     this._mouse.onMove(this._pushEvent);
-        //     this._mouse.onUp(this._pushEvent);
-        //     this._mouse.onCancel(this._pushEvent);
-        //     this._mouse.onWheel(this._pushEvent);
-        // }
+        if (this._mouse.support) {
+            const mouseEvents = this._mouseEvents;
+            this._mouse.onDown((event) => { mouseEvents.push(event); });
+            this._mouse.onMove((event) => { mouseEvents.push(event); });
+            this._mouse.onUp((event) => { mouseEvents.push(event); });
+            this._mouse.onWheel((event) => { mouseEvents.push(event); });
+        }
 
-        // if (this._keyboard.support) {
-        //     this._keyboard.onDown(this._pushEvent);
-        //     this._keyboard.onUp(this._pushEvent);
-        // }
+        if (this._keyboard.support) {
+            const keyboardEvents = this._keyboardEvents;
+            // this._keyboard.onDown((event) => { keyboardEvents.push(event); });
+            this._keyboard.onPressing((event) => { keyboardEvents.push(event); });
+            this._keyboard.onUp((event) => { keyboardEvents.push(event); });
+        }
 
-        // if (this._accelerometer.support) {
-        //     this._accelerometer.onChange(this._pushEvent);
-        // }
+        if (this._accelerometer.support) {
+            const accelerometerEvents = this._accelerometerEvents;
+            this._accelerometer.onChange((event) => { accelerometerEvents.push(event); });
+        }
     }
 
-    private _pushEvent (inputEvent: BaseInputEvent) {
-        this._inputEventList.push(inputEvent);
+    // accelerometer
+    public startAccelerometer (): void {
+        this._accelerometer.start();
     }
-
-    // // accelerometer
-    // public startAccelerometer (): Promise<void>;
-    // public stopAccelerometer (): Promise<void>;
-    // public setAccelerometerInterval (intercal: number): void;
+    public stopAccelerometer (): void {
+        this._accelerometer.stop();
+    }
+    public setAccelerometerInterval (interval: number): void {
+        this._accelerometer.setInterval(interval);
+    }
 
     // // input box
     // public showInputBox (): Promise<void>;
@@ -63,8 +69,25 @@ export class Input {
     // public onInputBoxChange (cb: Function);
     // public onInputBoxComplete (cb: Function);
 
-    public pollEvent (): BaseInputEvent | undefined {
-        return this._inputEventList.shift();
+    public pollTouchEvents (): TouchInputEvent[] {
+        const events = js.array.copy(this._touchEvents);
+        this._touchEvents.length = 0;
+        return events;
+    }
+    public pollMouseEvents (): MouseInputEvent[] {
+        const events = js.array.copy(this._mouseEvents);
+        this._mouseEvents.length = 0;
+        return events;
+    }
+    public pollKeyboardEvents (): KeyboardInputEvent[] {
+        const events = js.array.copy(this._keyboardEvents);
+        this._keyboardEvents.length = 0;
+        return events;
+    }
+    public pollAccelerometerEvents (): AccelerometerInputEvent[] {
+        const events = js.array.copy(this._accelerometerEvents);
+        this._accelerometerEvents.length = 0;
+        return events;
     }
 }
 

--- a/pal/input/web/index.ts
+++ b/pal/input/web/index.ts
@@ -1,5 +1,5 @@
-import { EDITOR } from 'internal:constants';
-import { BaseInputEvent } from 'pal/input';
+import { TouchInputEvent, MouseInputEvent, KeyboardInputEvent, AccelerometerInputEvent } from 'pal/input';
+import { js } from '../../../cocos/core/utils/js';
 import { AccelerometerInputSource } from './accelerometer';
 import { InputBox } from './input-box';
 import { KeyboardInputSource } from './keyboard';
@@ -12,50 +12,56 @@ export class Input {
     public _keyboard = new KeyboardInputSource();
     public _accelerometer = new AccelerometerInputSource();
     public _inputBox = new InputBox();
-    private _inputEventList: BaseInputEvent[] = [];
+
+    private _touchEvents: TouchInputEvent[] = [];
+    private _mouseEvents: MouseInputEvent[] = [];
+    private _keyboardEvents: KeyboardInputEvent[] = [];
+    private _accelerometerEvents: AccelerometerInputEvent[] = [];
 
     constructor () {
         this._registerEvent();
     }
 
     private _registerEvent () {
-        // if (EDITOR) {
-        //     return;
-        // }
-        // TODO: implement event main loop
-        // if (this._touch.support) {
-        //     this._touch.onStart(this._pushEvent);
-        //     this._touch.onMove(this._pushEvent);
-        //     this._touch.onEnd(this._pushEvent);
-        //     this._touch.onCancel(this._pushEvent);
-        // }
+        if (this._touch.support) {
+            const touchEvents = this._touchEvents;
+            this._touch.onStart((event) => { touchEvents.push(event); });
+            this._touch.onMove((event) => { touchEvents.push(event); });
+            this._touch.onEnd((event) => { touchEvents.push(event); });
+            this._touch.onCancel((event) => { touchEvents.push(event); });
+        }
 
-        // if (this._mouse.support) {
-        //     this._mouse.onDown(this._pushEvent);
-        //     this._mouse.onMove(this._pushEvent);
-        //     this._mouse.onUp(this._pushEvent);
-        //     this._mouse.onCancel(this._pushEvent);
-        //     this._mouse.onWheel(this._pushEvent);
-        // }
+        if (this._mouse.support) {
+            const mouseEvents = this._mouseEvents;
+            this._mouse.onDown((event) => { mouseEvents.push(event); });
+            this._mouse.onMove((event) => { mouseEvents.push(event); });
+            this._mouse.onUp((event) => { mouseEvents.push(event); });
+            this._mouse.onWheel((event) => { mouseEvents.push(event); });
+        }
 
-        // if (this._keyboard.support) {
-        //     this._keyboard.onDown(this._pushEvent);
-        //     this._keyboard.onUp(this._pushEvent);
-        // }
+        if (this._keyboard.support) {
+            const keyboardEvents = this._keyboardEvents;
+            // this._keyboard.onDown((event) => { keyboardEvents.push(event); });
+            this._keyboard.onPressing((event) => { keyboardEvents.push(event); });
+            this._keyboard.onUp((event) => { keyboardEvents.push(event); });
+        }
 
-        // if (this._accelerometer.support) {
-        //     this._accelerometer.onChange(this._pushEvent);
-        // }
+        if (this._accelerometer.support) {
+            const accelerometerEvents = this._accelerometerEvents;
+            this._accelerometer.onChange((event) => { accelerometerEvents.push(event); });
+        }
     }
 
-    private _pushEvent (inputEvent: BaseInputEvent) {
-        this._inputEventList.push(inputEvent);
+    // accelerometer
+    public startAccelerometer (): void {
+        this._accelerometer.start();
     }
-
-    // // accelerometer
-    // public startAccelerometer (): Promise<void>;
-    // public stopAccelerometer (): Promise<void>;
-    // public setAccelerometerInterval (intercal: number): void;
+    public stopAccelerometer (): void {
+        this._accelerometer.stop();
+    }
+    public setAccelerometerInterval (interval: number): void {
+        this._accelerometer.setInterval(interval);
+    }
 
     // // input box
     // public showInputBox (): Promise<void>;
@@ -63,8 +69,25 @@ export class Input {
     // public onInputBoxChange (cb: Function);
     // public onInputBoxComplete (cb: Function);
 
-    public pollEvent (): BaseInputEvent | undefined {
-        return this._inputEventList.shift();
+    public pollTouchEvents (): TouchInputEvent[] {
+        const events = js.array.copy(this._touchEvents);
+        this._touchEvents.length = 0;
+        return events;
+    }
+    public pollMouseEvents (): MouseInputEvent[] {
+        const events = js.array.copy(this._mouseEvents);
+        this._mouseEvents.length = 0;
+        return events;
+    }
+    public pollKeyboardEvents (): KeyboardInputEvent[] {
+        const events = js.array.copy(this._keyboardEvents);
+        this._keyboardEvents.length = 0;
+        return events;
+    }
+    public pollAccelerometerEvents (): AccelerometerInputEvent[] {
+        const events = js.array.copy(this._accelerometerEvents);
+        this._accelerometerEvents.length = 0;
+        return events;
     }
 }
 

--- a/tests/general/sealed-global-variables.json
+++ b/tests/general/sealed-global-variables.json
@@ -312,7 +312,6 @@
         "cc.easing",
         "cc.error",
         "cc.errorID",
-        "cc.eventManager",
         "cc.find",
         "cc.game",
         "cc.geometry",


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/6216

关联：https://github.com/cocos-creator/editor-3d/pull/5808

Changelog:
 - 在 pal/input 层支持 pollEvent 接口
 - 输入事件归拢到主循环当中处理
 - 对外移除 eventManager 模块

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
