### PR TITLE
fix Audio bug on v3.3

### DIFF
--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -218,6 +218,7 @@ export class AudioSource extends Component {
 
     public onDestroy () {
         this.stop();
+        this._player?.destroy();
     }
 
     private _getRootNode (): Node | null {

--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -35,6 +35,7 @@ import { Component } from '../core/components/component';
 import { clamp } from '../core/math';
 import { AudioClip } from './audio-clip';
 import { audioManager } from './audio-manager';
+import { Node } from '../core';
 
 enum AudioSourceEventType {
     STARTED = 'started',
@@ -208,11 +209,23 @@ export class AudioSource extends Component {
     }
 
     public onDisable () {
+        const rootNode = this._getRootNode();
+        if (rootNode?._persistNode) {
+            return;
+        }
         this.pause();
     }
 
     public onDestroy () {
         this.stop();
+    }
+
+    private _getRootNode (): Node | null {
+        let currentNode = this.node as Node | undefined | null;
+        while (currentNode?.parent?.parent !== null) {
+            currentNode = currentNode?.parent;
+        }
+        return currentNode;
     }
 
     /**

--- a/pal/audio/audio-timer.ts
+++ b/pal/audio/audio-timer.ts
@@ -1,0 +1,92 @@
+import { clamp } from '../../cocos/core/math/utils';
+
+/**
+ * Tool class to calculate audio current time.
+ * For some platforms where audio.currentTime doesn't work well or isn't implemented.
+ */
+
+interface IDuration {
+    duration: number;
+}
+
+export default class AudioTimer {
+    private _nativeAudio: IDuration;
+    private _startTime = 0;
+    private _startOffset = 0;
+    private _isPaused = true;
+
+    constructor (nativeAudio: IDuration) {
+        this._nativeAudio = nativeAudio;
+    }
+
+    public destroy () {
+        // @ts-expect-error Type 'undefined' is not assignable to type 'IDuration'
+        this._nativeAudio = undefined;
+    }
+
+    get duration () {
+        return this._nativeAudio.duration;
+    }
+
+    /**
+     * Get the current time of audio timer.
+     */
+    get currentTime () {
+        if (this._isPaused) {
+            return this._startOffset;
+        } else {
+            return this._calculateCurrentTime();
+        }
+    }
+
+    private _now () {
+        return performance.now() / 1000;
+    }
+
+    private _calculateCurrentTime () {
+        const timePassed = this._now() - this._startTime;
+        const currentTime = this._startOffset + timePassed;
+        if (currentTime >= this.duration) {
+            // timer loop
+            this._startTime = this._now();
+            this._startOffset = 0;
+        }
+        return currentTime % this.duration;
+    }
+
+    /**
+     * Start the audio timer.
+     * Call this method when audio is played.
+     */
+    start () {
+        this._isPaused = false;
+        this._startTime = this._now();
+    }
+
+    /**
+     * Pause the audio timer.
+     * Call this method when audio is paused or interrupted.
+     */
+    pause () {
+        this._isPaused = true;
+        this._startOffset = this._calculateCurrentTime();
+    }
+
+    /**
+     * Stop the audio timer.
+     * Call this method when audio playing ended or audio is stopped.
+     */
+    stop () {
+        this._isPaused = true;
+        this._startOffset = 0;
+    }
+
+    /**
+     * Seek the audio timer.
+     * Call this method when audio is seeked.
+     */
+    seek (time: number) {
+        this._startTime = this._now();
+        this._startOffset = clamp(time, 0, this.duration);
+    }
+}

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -86,7 +86,7 @@ export class AudioPlayerMinigame implements OperationQueueable {
         this._onSeeked = () => { eventTarget.emit(AudioEvent.SEEKED); };
         innerAudioContext.onSeeked(this._onSeeked);
         this._onEnded = () => {
-            this._audioTimer?.stop();
+            this._audioTimer.stop();
             this._state = AudioState.INIT;
             eventTarget.emit(AudioEvent.ENDED);
         };
@@ -216,15 +216,12 @@ export class AudioPlayerMinigame implements OperationQueueable {
             time = clamp(time, 0, this.duration);
             this._eventTarget.once(AudioEvent.SEEKED, resolve);
             this._innerAudioContext.seek(time);
-            this._audioTimer?.seek(time);
+            this._audioTimer.seek(time);
         });
     }
 
     @enqueueOperation
     play (): Promise<void> {
-        // NOTE: on WeChat platform, duration is 0 when audio is loaded.
-        // so we can't initiate audio timer on constructor.
-        this._audioTimer = this._audioTimer || new AudioTimer(this._innerAudioContext.duration);
         return new Promise((resolve) => {
             this._eventTarget.once(AudioEvent.PLAYED, resolve);
             this._innerAudioContext.play();

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -101,8 +101,8 @@ export class AudioPlayerMinigame implements OperationQueueable {
                 this._offEvent(event);
             });
             this._innerAudioContext.destroy();
-            // @ts-expect-error Type 'undefined' is not assignable to type 'InnerAudioContext'
-            this._innerAudioContext = undefined;
+            // @ts-expect-error Type 'null' is not assignable to type 'InnerAudioContext'
+            this._innerAudioContext = null;
         }
     }
     private _onHide () {
@@ -130,7 +130,7 @@ export class AudioPlayerMinigame implements OperationQueueable {
     private _offEvent (eventName: string) {
         if (this[`_on${eventName}`]) {
             this._innerAudioContext[`off${eventName}`](this[`_on${eventName}`]);
-            this[`_on${eventName}`] = undefined;
+            this[`_on${eventName}`] = null;
         }
     }
 

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -1,6 +1,7 @@
 import { minigame } from 'pal/minigame';
 import { systemInfo } from 'pal/system-info';
 import { clamp, clamp01, EventTarget } from '../../../cocos/core';
+import AudioTimer from '../audio-timer';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
 import { AudioEvent, AudioState, AudioType } from '../type';
 
@@ -58,9 +59,8 @@ export class AudioPlayerWeb implements OperationQueueable {
     private _gainNode: GainNode;
     private _volume = 1;
     private _loop = false;
-    private _startTime = 0;
-    private _playTimeOffset = 0;
     private _state: AudioState = AudioState.INIT;
+    private _audioTimer: AudioTimer;
 
     private static _audioBufferCacheMap: Record<string, AudioBuffer> = {};
 
@@ -70,6 +70,7 @@ export class AudioPlayerWeb implements OperationQueueable {
 
     constructor (audioBuffer: AudioBuffer, url: string) {
         this._audioBuffer = audioBuffer;
+        this._audioTimer = new AudioTimer(audioBuffer);
         this._gainNode = audioContext!.createGain();
         this._gainNode.connect(audioContext!.destination);
 
@@ -79,6 +80,7 @@ export class AudioPlayerWeb implements OperationQueueable {
         systemInfo.on('show', this._onShow, this);
     }
     destroy () {
+        this._audioTimer.destroy();
         if (this._audioBuffer) {
             // @ts-expect-error need to release AudioBuffer instance
             this._audioBuffer = undefined;
@@ -171,14 +173,13 @@ export class AudioPlayerWeb implements OperationQueueable {
         return this._audioBuffer.duration;
     }
     get currentTime (): number {
-        if (this._state !== AudioState.PLAYING) { return this._playTimeOffset; }
-        return (audioContext!.currentTime - this._startTime + this._playTimeOffset) % this._audioBuffer.duration;
+        return this._audioTimer.currentTime;
     }
 
     @enqueueOperation
     seek (time: number): Promise<void> {
         return new Promise((resolve) => {
-            this._playTimeOffset = clamp(time, 0, this._audioBuffer.duration);
+            this._audioTimer.seek(time);
             if (this._state === AudioState.PLAYING) {
                 // one AudioBufferSourceNode can't start twice
                 // need to create a new one to start from the offset
@@ -205,13 +206,12 @@ export class AudioPlayerWeb implements OperationQueueable {
             this._sourceNode.loop = this._loop;
             this._sourceNode.connect(this._gainNode);
 
-            this._sourceNode.start(0, this._playTimeOffset);
+            this._sourceNode.start(0, this._audioTimer.currentTime);
             this._state = AudioState.PLAYING;
-            this._startTime = audioContext!.currentTime;
+            this._audioTimer.start();
 
             this._sourceNode.onended = () => {
-                this._playTimeOffset = 0;
-                this._startTime = audioContext!.currentTime;
+                this._audioTimer.stop();
                 this._eventTarget.emit(AudioEvent.ENDED);
                 this._state = AudioState.INIT;
             };
@@ -235,7 +235,7 @@ export class AudioPlayerWeb implements OperationQueueable {
         if (this._state !== AudioState.PLAYING || !this._sourceNode) {
             return Promise.resolve();
         }
-        this._playTimeOffset = (audioContext!.currentTime - this._startTime + this._playTimeOffset) % this._audioBuffer.duration;
+        this._audioTimer.pause();
         this._state = AudioState.PAUSED;
         this._stopSourceNode();
         return Promise.resolve();
@@ -246,7 +246,7 @@ export class AudioPlayerWeb implements OperationQueueable {
         if (!this._sourceNode) {
             return Promise.resolve();
         }
-        this._playTimeOffset = 0;
+        this._audioTimer.stop();
         this._state = AudioState.STOPPED;
         this._stopSourceNode();
         return Promise.resolve();

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -83,7 +83,7 @@ export class AudioPlayerWeb implements OperationQueueable {
         this._audioTimer.destroy();
         if (this._audioBuffer) {
             // @ts-expect-error need to release AudioBuffer instance
-            this._audioBuffer = undefined;
+            this._audioBuffer = null;
         }
         systemInfo.off('hide', this._onHide, this);
         systemInfo.off('show', this._onShow, this);

--- a/pal/audio/native/player.ts
+++ b/pal/audio/native/player.ts
@@ -199,7 +199,7 @@ export class AudioPlayer implements OperationQueueable {
     play (): Promise<void> {
         return new Promise((resolve) => {
             if (this._isValid) {
-                if (this._state === AudioState.PAUSED) {
+                if (this._state === AudioState.PAUSED || this._state === AudioState.INTERRUPTED) {
                     audioEngine.resume(this._id);
                 } else if (this._state === AudioState.PLAYING) {
                     audioEngine.pause(this._id);

--- a/pal/audio/native/player.ts
+++ b/pal/audio/native/player.ts
@@ -59,7 +59,7 @@ export class AudioPlayer implements OperationQueueable {
     public _operationQueue: OperationInfo[] = [];
 
     private _beforePlaying = {
-        duration: 0, // wrong value before playing
+        duration: 1, // wrong value before playing
         loop: false,
         currentTime: 0,
         volume: 1,
@@ -184,7 +184,8 @@ export class AudioPlayer implements OperationQueueable {
     @enqueueOperation
     seek (time: number): Promise<void> {
         return new Promise((resolve) => {
-            time = clamp(time, 0, this.duration);
+            // Duration is invalid before player
+            // time = clamp(time, 0, this.duration);
             if (!this._isValid) {
                 this._beforePlaying.currentTime = time;
                 return resolve();
@@ -210,6 +211,7 @@ export class AudioPlayer implements OperationQueueable {
                 if (this._isValid) {
                     if (this._beforePlaying.currentTime !== 0) {
                         audioEngine.setCurrentTime(this._id, this._beforePlaying.currentTime);
+                        this._beforePlaying.currentTime = 0;
                     }
                     audioEngine.setFinishCallback(this._id, () => {
                         this._id = INVALID_AUDIO_ID;


### PR DESCRIPTION
Changelog:
 * 支持 AudioTimer
    - 修复百度平台音频返回的 currentTime 小数位为 0 的问题 https://github.com/cocos-creator/3d-tasks/issues/7349 
    - 修复微信 iOS 停止音频，currentTime 没有重置为 0 的问题 https://github.com/cocos-creator/3d-tasks/issues/7564
- 优化 Audio destroy，避免内存泄漏
- 修复常驻节点上的 AudioSource 切场景时会被暂停的问题 https://github.com/cocos-creator/3d-tasks/issues/7606
- 修复微信、字节、百度从后台切回来后，音频无法播放的问题 https://github.com/cocos-creator/3d-tasks/issues/7528
- 修复安卓端第二次进入后台，音频无法暂停播放的问题 https://github.com/cocos-creator/3d-tasks/issues/7039

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
