### PR TITLE
bug fix: when the node is destory, node._activeInHierarchy may be error

### DIFF
--- a/cocos2d/core/components/CCComponent.js
+++ b/cocos2d/core/components/CCComponent.js
@@ -196,7 +196,7 @@ var Component = cc.Class({
          */
         enabledInHierarchy: {
             get () {
-                return this._enabled && this.node._activeInHierarchy;
+                return this._enabled && this.node && this.node._activeInHierarchy;
             },
             visible: false
         },


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/4982

when the node is destory ,  to visit node._activeInHierarchy may be error