### PR TITLE
fix touch event not working after touch end on an inactive node

### DIFF
--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -157,8 +157,13 @@ var eventManager = {
         }
         var listeners = this._nodeListenersMap[node._id], i, len;
         if (listeners) {
-            for (i = 0, len = listeners.length; i < len; i++)
-                listeners[i]._setPaused(true);
+            for (i = 0, len = listeners.length; i < len; i++) {
+                const listener = listeners[i];
+                listener._setPaused(true);
+                if (listener._claimedTouches && listener._claimedTouches.includes(this._currentTouch)) {
+                    this._clearCurTouch();
+                }
+            }
         }
         if (recursive === true) {
             var locChildren = node._children;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/6996

Changelog:
 * 修复触摸节点，紧接着隐藏节点，释放触点后导致触摸事件全部失效的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
