### PR TITLE
fix bug remove all spine animations could cause a memory leak on native iOS

### DIFF
--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -114,6 +114,14 @@ export class Batcher2D {
                 }
             }
         }
+
+        // release the buffer to recycle pool --
+        const idx = this._bufferBatchPool.data.indexOf(buffer);
+        if (idx != -1) {
+            buffer.reset();
+            this._bufferBatchPool.removeAt(idx);
+        }
+        // ---
     }
 
     set currStaticRoot (value: UIStaticBatch | null) {

--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -117,7 +117,7 @@ export class Batcher2D {
 
         // release the buffer to recycle pool --
         const idx = this._bufferBatchPool.data.indexOf(buffer);
-        if (idx != -1) {
+        if (idx !== -1) {
             buffer.reset();
             this._bufferBatchPool.removeAt(idx);
         }

--- a/cocos/2d/renderer/mesh-buffer.ts
+++ b/cocos/2d/renderer/mesh-buffer.ts
@@ -105,8 +105,9 @@ export class MeshBuffer {
         this._iaInfo = new InputAssemblerInfo(this.attributes, this.vertexBuffers, this.indexBuffer);
 
         // for recycle pool using purpose --
-        if (!this.vData || !this.iData)
+        if (!this.vData || !this.iData) {
             this._reallocBuffer();
+        }
         // ----------
     }
 

--- a/cocos/2d/renderer/mesh-buffer.ts
+++ b/cocos/2d/renderer/mesh-buffer.ts
@@ -104,7 +104,10 @@ export class MeshBuffer {
         this._attributes = attrs;
         this._iaInfo = new InputAssemblerInfo(this.attributes, this.vertexBuffers, this.indexBuffer);
 
-        this._reallocBuffer();
+        // for recycle pool using purpose --
+        if (!this.vData || !this.iData)
+            this._reallocBuffer();
+        // ----------
     }
 
     public request (vertexCount = 4, indicesCount = 6) {
@@ -152,6 +155,9 @@ export class MeshBuffer {
         this._nextFreeIAHandle = 0;
 
         this._dirty = false;
+
+        this._initIDataCount = 256 * 6;
+        this._initVDataCount = 256 * this._vertexFormatBytes;
     }
 
     public destroy () {

--- a/cocos/2d/renderer/mesh-buffer.ts
+++ b/cocos/2d/renderer/mesh-buffer.ts
@@ -156,9 +156,6 @@ export class MeshBuffer {
         this._nextFreeIAHandle = 0;
 
         this._dirty = false;
-
-        this._initIDataCount = 256 * 6;
-        this._initVDataCount = 256 * this._vertexFormatBytes;
     }
 
     public destroy () {


### PR DESCRIPTION
Steps to reproduce the bug: 
1. create 2 buttons: one for adding a new spine, one for remove all spines on the scene.
2. keep doing the process several times: using the 2 buttons to create some spine animations and remove all.
Result on iOS native: the memory keep increasing very fast and never be released.

The issue comes from using recycle pool for MeshBuffer in batcher-2d.ts. Also need to modify some code in mesh-buffer.ts to make sure the process of using recycle pool is correct.