### PR TITLE
Allow custom effects to customize the inspector displayed in the material

### DIFF
--- a/editor/i18n/en/assets.js
+++ b/editor/i18n/en/assets.js
@@ -305,5 +305,8 @@ module.exports = {
             modeWarn:
                 "Warning: WebGL 1.0 platform doesn't support 'repeat' filter for non-power-of-two textures(runtime fallback to 'clamp-to-edge'), effectively disabling features like the 'tilingOffset' property in many materials.",
         },
+        material: {
+            'fail-to-load-custom-inspector': 'material: fail to load custom inspector of {effect}',
+        },
     },
 };

--- a/editor/i18n/en/assets.js
+++ b/editor/i18n/en/assets.js
@@ -307,6 +307,7 @@ module.exports = {
         },
         material: {
             'fail-to-load-custom-inspector': 'material: fail to load custom inspector of {effect}',
+            'illegal-inspector-url': "Inspector's URL is not valid",
         },
     },
 };

--- a/editor/i18n/zh/assets.js
+++ b/editor/i18n/zh/assets.js
@@ -299,7 +299,8 @@ module.exports = {
             '警告：WebGL 1.0 平台不支持非 2 次幂贴图的 repeat 过滤模式，运行时会自动改为 clamp-to-edge 模式，这会使材质的 tilingOffset 等属性完全失效。',
         },
         material: {
-            'fail-to-load-custom-inspector': 'material: 自定义材质 {effect} 的 inspector 加载失败',
+            'fail-to-load-custom-inspector': 'material: 自定义 effect {effect} 的 inspector 加载失败',
+            'illegal-inspector-url': "Inspector的路径不合法",
         },
     },
 };

--- a/editor/i18n/zh/assets.js
+++ b/editor/i18n/zh/assets.js
@@ -298,5 +298,8 @@ module.exports = {
             modeWarn:
             '警告：WebGL 1.0 平台不支持非 2 次幂贴图的 repeat 过滤模式，运行时会自动改为 clamp-to-edge 模式，这会使材质的 tilingOffset 等属性完全失效。',
         },
+        material: {
+            'fail-to-load-custom-inspector': 'material: 自定义材质 {effect} 的 inspector 加载失败',
+        },
     },
 };

--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -4,12 +4,13 @@
 
 const { materialTechniquePolyfill } = require('../utils/material');
 const { setDisabled, setReadonly, setHidden, loopSetAssetDumpDataReadonly } = require('../utils/prop');
-
+const { join, sep, normalize } = require('path');
 exports.style = `
 ui-button.location { flex: none; margin-left: 6px; }
 `;
 
-exports.template = `
+exports.template =
+/* html */`
 <header class="header">
     <ui-prop>
         <ui-label slot="label">Effect</ui-label>
@@ -23,6 +24,9 @@ exports.template = `
         <ui-select class="technique" slot="content"></ui-select>
     </ui-prop>
 </header>
+<section class="customSection">
+    <ui-panel class="customPanel"></ui-panel>
+</section>
 <section class="section">
     <ui-prop class="useInstancing" type="dump"></ui-prop>
     <ui-prop class="useBatching" type="dump"></ui-prop>
@@ -40,9 +44,19 @@ exports.$ = {
     materialDump: '.material-dump',
     useInstancing: '.useInstancing',
     useBatching: '.useBatching',
+    customSection: '.customSection',
+    customPanel: '.customPanel',
 };
 
 exports.methods = {
+    async getCustomInspector() {
+        const currentEffectInfo = this._effects.find(effect => { return effect.name === this.material.effect; });
+        if (currentEffectInfo && currentEffectInfo.uuid) {
+            const meta = await Editor.Message.request('asset-db', 'query-asset-meta', currentEffectInfo.uuid);
+            return meta && meta.userData && meta.userData.editor && meta.userData.editor.inspector;
+        }
+        return '';
+    },
     /**
      * Custom Save
      */
@@ -56,6 +70,25 @@ exports.methods = {
         this.dirtyData.uuid = '';
     },
 
+    async updateCustomInspector() {
+        this.$.customPanel.hidden = false;
+        this.$.section.hidden = true;
+        this.$.materialDump.hidden = true;
+        try {
+            const relatePath = normalize((await this.getCustomInspector()).replace('packages://', ''));
+            const name = relatePath.split(sep)[0];
+            const packagePath = Editor.Package.getPackages({ name, enable: true })[0].path;
+            const path = join(packagePath, relatePath.split(name)[1]);
+            if (this.$.customPanel.getAttribute('src') !== join(path)) {
+                this.$.customPanel.setAttribute('src', path);
+            }
+            this.$.customPanel.update(this.material, this.assetList, this.metaList);
+        } catch (error) {
+            console.error(error);
+            console.error(Editor.I18n.t('ENGINE.assets.material.fail-to-load-custom-inspector', { effect: this.material.effect }));
+            this.updatePasses();
+        }
+    },
     /**
      * Detection of data changes only determines the currently selected technique
      */
@@ -80,13 +113,14 @@ exports.methods = {
      * Update the pass data that is finally displayed in the panel
      */
     updatePasses() {
+        this.$.customPanel.hidden = true;
+        this.$.section.hidden = false;
+        this.$.materialDump.hidden = false;
         // Automatic rendering of content
         // The data in passes is not all the values that need to be rendered
         // So it's sorted here, but that doesn't make sense
         // The logical way to do it would be to return a normal dump when querying for material
-        if (!this.material.data[this.material.technique]) {
-            this.$.technique.value = this.material.technique = 0;
-        }
+
         const technique = materialTechniquePolyfill(this.material.data[this.material.technique]);
         this.technique = technique;
 
@@ -187,7 +221,6 @@ exports.methods = {
                                 $prop.$children[childName] = document.createElement('ui-prop');
                                 $prop.$children[childName].setAttribute('type', 'dump');
                                 $prop.$children[childName].render(dump.childMap[childName]);
-
                                 $prop.$children.appendChild($prop.$children[childName]);
                             }
 
@@ -268,24 +301,25 @@ exports.update = async function(assetList, metaList) {
         this.dirtyData.uuid = this.asset.uuid;
         this.dirtyData.origin = '';
     }
-
+    // set this.material.technique
     this.material = await Editor.Message.request('scene', 'query-material', this.asset.uuid);
-
     // effect <select> tag
     this.$.effect.value = this.material.effect;
     setDisabled(this.asset.readonly, this.$.effect);
-
     // technique <select> tag
     this.$.technique.value = this.material.technique;
     setDisabled(this.asset.readonly, this.$.technique);
 
     this.updateTechniqueOptions();
     this.setDirtyData();
-
-    // optimize calculate speed when edit multiple materials in node mode
-    requestIdleCallback(() => {
-        this.updatePasses();
-    });
+    if (await this.getCustomInspector()) {
+        this.updateCustomInspector();
+    } else {
+        // optimize calculate speed when edit multiple materials in node mode
+        requestIdleCallback(() => {
+            this.updatePasses();
+        });
+    }
 };
 
 /**
@@ -323,11 +357,17 @@ exports.ready = async function() {
     this.$.effect.addEventListener('change', async (event) => {
         this.material.effect = event.target.value;
         this.material.data = await Editor.Message.request('scene', 'query-effect', this.material.effect);
-
         this.updateTechniqueOptions();
-        this.$.technique.value = 0;
-
-        this.updatePasses();
+        if (!this.material.data[this.material.technique]) {
+            this.$.technique.value = this.material.technique = 0;
+        } else {
+            this.$.technique.value = this.material.technique;
+        }
+        if (await this.getCustomInspector()) {
+            this.updateCustomInspector();
+        } else {
+            this.updatePasses();
+        }
         this.setDirtyData();
         this.dispatch('change');
     });
@@ -342,8 +382,11 @@ exports.ready = async function() {
     // Event triggered when the technique being used is changed
     this.$.technique.addEventListener('change', async (event) => {
         this.material.technique = event.target.value;
-
-        this.updatePasses();
+        if (await this.getCustomInspector()) {
+            this.updateCustomInspector();
+        } else {
+            this.updatePasses();
+        }
         this.setDirtyData();
         this.dispatch('change');
     });
@@ -382,6 +425,10 @@ exports.ready = async function() {
         effectOption += `<option>${effect.name}</option>`;
     }
     this.$.effect.innerHTML = effectOption;
+    this.$.customPanel.addEventListener('change', () => {
+        this.setDirtyData();
+        this.dispatch('change');
+    });
 };
 
 exports.close = function() {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Now we can customize the presentation of the effect in the material's inspector like this.
  ![image](https://user-images.githubusercontent.com/59186205/125776141-5e90bd3c-2f8d-4ef1-9b80-b388636794a0.png)
Suppose we have an enabled extension named 'ss'
and there is a hack.js file in that plugin directory
This file is similar to the inspector,
but will get the currently used material in the first argument of the update method
example:
```js
// ss/hack.js
"use strict";
module.exports = Editor.Panel.define({
    template:
    /* html*/ `
    <ui-prop>
        <ui-label slot="label"></ui-label>
        <ui-checkbox slot="content"></ui-checkbox>
    </ui-prop>
    `,
    $: {
        checkbox: 'ui-checkbox',
        label: 'ui-label',
    },
    ready() {
        var _a;
        (_a = this.$.checkbox) === null || _a === void 0 ? void 0 : _a.addEventListener('change', (event) => {
            this.material.data[0].passes[0].defines[0].value = event.target.value;
            this.dispatch('change');
        });
    },
    update(material, assetList, metaList) {
        this.material = material;
        this.$.label.value = this.material.data[0].passes[0].defines[0].name;
        this.$.checkbox.value = this.material.data[0].passes[0].defines[0].value;
    },
});

```
 
![image](https://user-images.githubusercontent.com/59186205/125777443-826ba2d9-5878-41b6-9a5c-55590e8506ff.png)



<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
