### PR TITLE
Add flag to indicates if is targeting CCON

### DIFF
--- a/cocos/core/asset-manager/downloader.ts
+++ b/cocos/core/asset-manager/downloader.ts
@@ -100,7 +100,7 @@ const downloadCCON = (url: string, options: IDownloadParseOptions, onComplete: C
     });
 };
 
-const downloadCCOBN = (url: string, options: IDownloadParseOptions, onComplete: CompleteCallback<CCON>) => {
+const downloadCCONB = (url: string, options: IDownloadParseOptions, onComplete: CompleteCallback<CCON>) => {
     downloadArrayBuffer(url, options, (err, json) => {
         if (err) {
             onComplete(err);
@@ -272,7 +272,7 @@ export class Downloader {
         '.plist': downloadText,
 
         '.ccon': downloadCCON,
-        '.ccobn': downloadCCOBN,
+        '.cconb': downloadCCONB,
 
         '.fnt': downloadText,
 

--- a/cocos/core/data/custom-serializable.ts
+++ b/cocos/core/data/custom-serializable.ts
@@ -1,4 +1,4 @@
-import { assertIsTrue } from './utils/asserts';
+import { assertIsNonNullable, assertIsTrue } from './utils/asserts';
 
 /**
  * Tag to define the custom serialization method.
@@ -91,7 +91,7 @@ export const enableIfCCON: MethodDecorator = <T>(
     descriptor: TypedPropertyDescriptor<T>,
 ): TypedPropertyDescriptor<T> | void => {
     const original = descriptor.value;
-    assertIsTrue(original);
+    assertIsNonNullable(original);
     if (propertyKey === serializeTag) {
         return {
             ...descriptor,

--- a/cocos/core/data/custom-serializable.ts
+++ b/cocos/core/data/custom-serializable.ts
@@ -1,7 +1,15 @@
-import { TEST } from 'internal:constants';
+import { assertIsTrue } from './utils/asserts';
 
+/**
+ * Tag to define the custom serialization method.
+ * @internal
+ */
 export const serializeTag = Symbol('[[Serialize]]');
 
+/**
+ * Tag to define the custom deserialization method.
+ * @internal
+ */
 export const deserializeTag = Symbol('[[Deserialize]]');
 
 export interface SerializationInput {
@@ -49,12 +57,21 @@ export type SerializationContext = {
     root: unknown;
 
     /**
+     * True if the serialization procedure is targeting CCON.
+     */
+    toCCON: boolean;
+
+    /**
      * Customized arguments passed to serialization procedure.
      */
     customArguments: Record<PropertyKey, unknown>
 };
 
 export type DeserializationContext = {
+    /**
+     * True if the deserialization procedure is deserializing from CCON.
+     */
+    fromCCON: boolean;
 };
 
 export interface CustomSerializable {
@@ -62,3 +79,41 @@ export interface CustomSerializable {
 
     [deserializeTag]?(input: SerializationInput, context: DeserializationContext): void;
 }
+
+/**
+ * Enables the custom serialize/deserialize method only if the (de)serialize procedure is targeting CCON.
+ * @internal
+ */
+export const enableIfCCON: MethodDecorator = <T>(
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    _target: Object,
+    propertyKey: PropertyKey,
+    descriptor: TypedPropertyDescriptor<T>,
+): TypedPropertyDescriptor<T> | void => {
+    const original = descriptor.value;
+    assertIsTrue(original);
+    if (propertyKey === serializeTag) {
+        return {
+            ...descriptor,
+            value: function wrapSerialize (output: SerializationOutput, context: SerializationContext) {
+                if (!context.toCCON) {
+                    output.writeThis();
+                } else {
+                    (original as unknown as CustomSerializable[typeof serializeTag]).call(this, output, context);
+                }
+            },
+        } as unknown as TypedPropertyDescriptor<T>;
+    } else {
+        assertIsTrue(propertyKey === deserializeTag, '@enableIfCCON should be only applied to custom (de)serialize method');
+        return {
+            ...descriptor,
+            value: function wrapDeserialize (input: SerializationInput, context: DeserializationContext) {
+                if (!context.fromCCON) {
+                    input.readThis();
+                } else {
+                    (original as unknown as NonNullable<CustomSerializable[typeof deserializeTag]>).call(this, input, context);
+                }
+            },
+        } as unknown as TypedPropertyDescriptor<T>;
+    }
+};

--- a/cocos/core/data/deserialize-dynamic.ts
+++ b/cocos/core/data/deserialize-dynamic.ts
@@ -673,7 +673,7 @@ class _Deserializer {
         propName: string,
     ) {
         const id = (serializedField as Partial<SerializedObjectReference>).__id__;
-        if (id) {
+        if (typeof id === 'number') {
             const field = this.deserializedList[id];
             if (field) {
                 obj[propName] = field;
@@ -700,7 +700,7 @@ class _Deserializer {
 
     private _deserializeObjectField (serializedField: SerializedFieldObjectValue) {
         const id = (serializedField as Partial<SerializedObjectReference>).__id__;
-        if (id) {
+        if (typeof id === 'number') {
             const field = this.deserializedList[id];
             if (field) {
                 return field;
@@ -842,7 +842,7 @@ export function deserializeDynamic (data: SerializedData | CCON, details: Detail
 export function parseUuidDependenciesDynamic (serialized: unknown) {
     const depends = [];
     const parseDependRecursively = (data: any, out: string[]) => {
-        if (!data || typeof data !== 'object' || data.__id__) { return; }
+        if (!data || typeof data !== 'object' || typeof data.__id__ === 'number') { return; }
         const uuid = data.__uuid__;
         if (Array.isArray(data)) {
             for (let i = 0, l = data.length; i < l; i++) {

--- a/cocos/core/data/deserialize-dynamic.ts
+++ b/cocos/core/data/deserialize-dynamic.ts
@@ -453,7 +453,9 @@ class _Deserializer {
         }
 
         this._serializedData = jsonObj;
-        this._context.fromCCON = fromCCON;
+        this._context = {
+            fromCCON,
+        };
 
         const serializedRootObject = Array.isArray(jsonObj) ? jsonObj[0] : jsonObj;
 

--- a/cocos/core/data/deserialize-dynamic.ts
+++ b/cocos/core/data/deserialize-dynamic.ts
@@ -402,6 +402,7 @@ class _Deserializer {
     private _ignoreEditorOnly: any;
     private declare _mainBinChunk: Uint8Array;
     private declare _serializedData: SerializedObject | SerializedObject[];
+    private declare _context: DeserializationContext;
 
     constructor (result: Details, classFinder: ClassFinder, reportMissingClass: ReportMissingClass, customEnv: unknown, ignoreEditorOnly: unknown) {
         this.result = result;
@@ -438,8 +439,10 @@ class _Deserializer {
     }
 
     public deserialize (serializedData: SerializedData | CCON) {
+        let fromCCON = false;
         let jsonObj: SerializedData;
         if (serializedData instanceof CCON) {
+            fromCCON = true;
             jsonObj = serializedData.document as SerializedData;
             if (serializedData.chunks.length > 0) {
                 assertIsTrue(serializedData.chunks.length === 1);
@@ -450,6 +453,7 @@ class _Deserializer {
         }
 
         this._serializedData = jsonObj;
+        this._context.fromCCON = fromCCON;
 
         const serializedRootObject = Array.isArray(jsonObj) ? jsonObj[0] : jsonObj;
 
@@ -471,6 +475,7 @@ class _Deserializer {
 
         this._serializedData = undefined!;
         this._mainBinChunk = undefined!;
+        this._context = undefined!;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this.deserializedData;
@@ -645,10 +650,7 @@ class _Deserializer {
             },
         };
 
-        const context: DeserializationContext = {
-        };
-
-        object[deserializeTag]!(serializationInput, context);
+        object[deserializeTag]!(serializationInput, this._context);
     }
 
     private _deserializeFireClass (obj: Record<PropertyKey, unknown>, serialized: SerializedGeneralTypedObject, klass: CCClassConstructor<unknown>) {

--- a/tests/core/serialization/deserialize-ref-0.test.ts
+++ b/tests/core/serialization/deserialize-ref-0.test.ts
@@ -1,0 +1,19 @@
+
+import { property } from '../../../cocos/core/data/class-decorator';
+import { deserialize } from '../../../cocos/core/data/deserialize';
+import { js } from '../../../cocos/core/utils/js';
+import { ccclassAutoNamed } from './shared/utils';
+
+@ccclassAutoNamed(__dirname) class Foo {
+    @property
+    bar!: Foo;
+}
+
+// We once had a BUG when processing `__id__: 0`
+test(`Deserialize property reference __id__: 0`, () => {
+    const deserialized = deserialize([{
+        __type__: js.getClassName(Foo),
+        bar: { __id__: 0 }
+    }], undefined, undefined) as Foo;
+    expect(deserialized.bar).toBe(deserialized);
+});

--- a/tests/core/serialization/shared/__snapshots__/case-custom-serialize-ccon-flag_port-CCON.json
+++ b/tests/core/serialization/shared/__snapshots__/case-custom-serialize-ccon-flag_port-CCON.json
@@ -1,0 +1,9 @@
+{
+  "document": {
+    "__type__": "custom-serialize-ccon-flag.Foo",
+    "bar": 3.14
+  },
+  "chunks": [
+    []
+  ]
+}

--- a/tests/core/serialization/shared/__snapshots__/case-custom-serialize-ccon-flag_port-Dynamic.json
+++ b/tests/core/serialization/shared/__snapshots__/case-custom-serialize-ccon-flag_port-Dynamic.json
@@ -1,0 +1,3 @@
+{
+  "__type__": "custom-serialize-ccon-flag.Foo"
+}

--- a/tests/core/serialization/shared/cases/custom-serialize-ccon-flag.test.ts
+++ b/tests/core/serialization/shared/cases/custom-serialize-ccon-flag.test.ts
@@ -1,0 +1,42 @@
+import {
+    _decorator,
+    serializeTag,
+    deserializeTag,
+    CustomSerializable,
+    SerializationOutput,
+    SerializationInput,
+    SerializationContext,
+    DeserializationContext,
+} from 'cc';
+import { PORTS_BOTH_DYNAMIC_COMPILED, testEachPort } from "../port";
+import { ccclassAutoNamed, runTest } from '../utils';
+
+@ccclassAutoNamed(__filename)
+class Foo implements CustomSerializable {
+    declare bar: number;
+
+    [serializeTag](serializationOutput: SerializationOutput, _context: SerializationContext) {
+        if (_context.toCCON) {
+            serializationOutput.writeProperty('bar', 3.14);
+        }
+    }
+
+    [deserializeTag](serializationInput: SerializationInput, _context: DeserializationContext) {
+        if (_context.toCCON) {
+            this.bar = serializationInput.readProperty('bar');
+        }
+    }
+}
+
+export const value = new Foo();
+
+testEachPort(PORTS_BOTH_DYNAMIC_COMPILED, async (port) => {
+    await runTest(
+        __filename,
+        port,
+        value,
+        (serialized: typeof value) => {
+            expect(serialized.bar).toBe(3.14);
+        }
+    );
+});

--- a/tests/core/serialization/shared/cases/custom-serialize-ccon-flag.test.ts
+++ b/tests/core/serialization/shared/cases/custom-serialize-ccon-flag.test.ts
@@ -8,7 +8,7 @@ import {
     SerializationContext,
     DeserializationContext,
 } from 'cc';
-import { PORTS_BOTH_DYNAMIC_COMPILED, testEachPort } from "../port";
+import { PORTS_BOTH_DYNAMIC_COMPILED, PORT_CCOB, testEachPort } from "../port";
 import { ccclassAutoNamed, runTest } from '../utils';
 
 @ccclassAutoNamed(__filename)
@@ -22,7 +22,7 @@ class Foo implements CustomSerializable {
     }
 
     [deserializeTag](serializationInput: SerializationInput, _context: DeserializationContext) {
-        if (_context.toCCON) {
+        if (_context.fromCCON) {
             this.bar = serializationInput.readProperty('bar');
         }
     }
@@ -30,7 +30,7 @@ class Foo implements CustomSerializable {
 
 export const value = new Foo();
 
-testEachPort(PORTS_BOTH_DYNAMIC_COMPILED, async (port) => {
+testEachPort([PORT_CCOB], async (port) => {
     await runTest(
         __filename,
         port,


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Mark the `serializeTag` and `deserializeTag` as internal.

 * Add `DeserializationContext.fromCCON`, `SerializationContext.toCCON` to indicates if the input(output) document is CCON.

 * Add an internal utility decorator `@enableIfCCON`.

 * Rename downloader extension `.ccobn` -> `.cconb`.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
