### PR TITLE
[CHERRY-PICK] fix touch event not working after touch end on an inactive node

### DIFF
--- a/cocos/core/platform/event-manager/event-manager.ts
+++ b/cocos/core/platform/event-manager/event-manager.ts
@@ -158,9 +158,12 @@ class EventManager {
         }
         const listeners = this._nodeListenersMap[node.uuid];
         if (listeners) {
-            for (let i = 0; i < listeners.length; ++i) {
+            for (let i = 0, len = listeners.length; i < len; i++) {
                 const listener = listeners[i];
                 listener._setPaused(true);
+                if (listener instanceof TouchOneByOneEventListener && listener._claimedTouches.includes(this._currentTouch)) {
+                    this._clearCurTouch();
+                }
             }
         }
         if (recursive === true) {
@@ -1162,6 +1165,11 @@ class EventManager {
 
     private _sortNumberAsc (a: number, b: number) {
         return a - b;
+    }
+
+    private _clearCurTouch () {
+        this._currentTouchListener = null;
+        this._currentTouch = null;
     }
 
     private _removeListenerInCallback (listeners: EventListener[], callback) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/6996

Changelog:
 * 修复触摸节点，紧接着隐藏节点，释放触点后导致触摸事件全部失效的问题， 同步 pr https://github.com/cocos-creator/engine/pull/8969

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
