### PR TITLE
fix can't update default value when show keyboard on Xiaomi platform

### DIFF
--- a/platforms/minigame/platforms/xiaomi/wrapper/engine/Editbox.js
+++ b/platforms/minigame/platforms/xiaomi/wrapper/engine/Editbox.js
@@ -64,6 +64,8 @@
                     __globalAdapter.updateKeyboard({
                         value: delegate.string,
                     });
+                    // NOTE: need to delay the event registering on Xiaomi platform
+                    // the input event callback is invoked twice when show keyboard.
                     this._registerKeyboardEvent();
                     this._editing = true;
                     _currentEditBoxImpl = this;

--- a/platforms/minigame/platforms/xiaomi/wrapper/engine/Editbox.js
+++ b/platforms/minigame/platforms/xiaomi/wrapper/engine/Editbox.js
@@ -58,11 +58,17 @@
             }
             this._ensureKeyboardHide(() => {
                 let delegate = this._delegate;
-                this._showKeyboard();
-                this._registerKeyboardEvent();
-                this._editing = true;
-                _currentEditBoxImpl = this;
-                delegate._editBoxEditingDidBegan();
+                this._showKeyboard(() => {
+                    // NOTE: pass defaultValue when showKeyboard is invalid on Xiaomi platform
+                    // need to manually update the value
+                    __globalAdapter.updateKeyboard({
+                        value: delegate.string,
+                    });
+                    this._registerKeyboardEvent();
+                    this._editing = true;
+                    _currentEditBoxImpl = this;
+                    delegate._editBoxEditingDidBegan();
+                });
             });
         },
 
@@ -139,7 +145,7 @@
             }, KEYBOARD_HIDE_TIME);
         },
 
-        _showKeyboard () {
+        _showKeyboard (successCB) {
             let delegate = this._delegate;
             let multiline = (delegate.inputMode === EditBoxComp.InputMode.ANY);
             __globalAdapter.showKeyboard({
@@ -149,7 +155,7 @@
                 confirmHold: false,
                 confirmType: getKeyboardReturnType(delegate.returnType),
                 success (res) {
-
+                    successCB && successCB();
                 },
                 fail (res) {
                     cc.warn(res.errMsg);

--- a/platforms/minigame/platforms/xiaomi/wrapper/engine/Editbox.js
+++ b/platforms/minigame/platforms/xiaomi/wrapper/engine/Editbox.js
@@ -10,7 +10,6 @@
     const KEYBOARD_HIDE_TIME = 600;
     let _hideKeyboardTimeout = null;
     let _currentEditBoxImpl = null;
-    let _invalidInputCallbackCount = 2;
 
     function getKeyboardReturnType (type) {
         switch (type) {
@@ -79,10 +78,6 @@
             let cbs = this._eventListeners;
 
             cbs.onKeyboardInput = function (res) {
-                // NOTE: Input callback will be invoked twice when show keyboard on Xiaomi platform
-                if (_invalidInputCallbackCount-- > 0) {
-                    return;
-                }
                 if (delegate._string !== res.value) {
                     delegate._editBoxTextChanged(res.value);
                 }
@@ -147,7 +142,6 @@
         _showKeyboard () {
             let delegate = this._delegate;
             let multiline = (delegate.inputMode === EditBoxComp.InputMode.ANY);
-            _invalidInputCallbackCount = 2;
             __globalAdapter.showKeyboard({
                 defaultValue: delegate.string,
                 maxLength: delegate.maxLength < 0 ? MAX_VALUE : delegate.maxLength,
@@ -155,11 +149,7 @@
                 confirmHold: false,
                 confirmType: getKeyboardReturnType(delegate.returnType),
                 success (res) {
-                    // NOTE: pass defaultValue when showKeyboard is invalid on Xiaomi platform
-                    // need to manually update the value
-                    __globalAdapter.updateKeyboard({
-                        value: delegate.string,
-                    });
+
                 },
                 fail (res) {
                     cc.warn(res.errMsg);

--- a/platforms/minigame/platforms/xiaomi/wrapper/engine/Editbox.js
+++ b/platforms/minigame/platforms/xiaomi/wrapper/engine/Editbox.js
@@ -1,0 +1,172 @@
+(function () {
+    if (!(cc && cc.EditBoxComponent)) {
+        return;
+    }
+
+    const EditBoxComp = cc.EditBoxComponent;
+    const js = cc.js;
+    const KeyboardReturnType = EditBoxComp.KeyboardReturnType;
+    const MAX_VALUE = 65535;
+    const KEYBOARD_HIDE_TIME = 600;
+    let _hideKeyboardTimeout = null;
+    let _currentEditBoxImpl = null;
+
+    function getKeyboardReturnType (type) {
+        switch (type) {
+            case KeyboardReturnType.DEFAULT:
+            case KeyboardReturnType.DONE:
+                return 'done';
+            case KeyboardReturnType.SEND:
+                return 'send';
+            case KeyboardReturnType.SEARCH:
+                return 'search';
+            case KeyboardReturnType.GO:
+                return 'go';
+            case KeyboardReturnType.NEXT:
+                return 'next';
+        }
+        return 'done';
+    }
+
+    function MiniGameEditBoxImpl () {
+        this._delegate = null;
+        this._editing = false;
+
+        this._eventListeners = {
+            onKeyboardInput: null,
+            onKeyboardConfirm: null,
+            onKeyboardComplete: null,
+        };
+    }
+
+    js.extend(MiniGameEditBoxImpl, EditBoxComp._EditBoxImpl);
+    EditBoxComp._EditBoxImpl = MiniGameEditBoxImpl;
+
+    Object.assign(MiniGameEditBoxImpl.prototype, {
+        init (delegate) {
+            if (!delegate) {
+                cc.error('EditBox init failed');
+                return;
+            }
+            this._delegate = delegate;
+        },
+
+        beginEditing () {
+            // In case multiply register events
+            if (this._editing) {
+                return;
+            }
+            this._ensureKeyboardHide(() => {
+                let delegate = this._delegate;
+                this._showKeyboard();
+                this._registerKeyboardEvent();
+                this._editing = true;
+                _currentEditBoxImpl = this;
+                delegate._editBoxEditingDidBegan();
+            });
+        },
+
+        endEditing () {
+            this._hideKeyboard();
+            let cbs = this._eventListeners;
+            cbs.onKeyboardComplete && cbs.onKeyboardComplete();
+        },
+
+        _registerKeyboardEvent () {
+            let self = this;
+            let delegate = this._delegate;
+            let cbs = this._eventListeners;
+
+            cbs.onKeyboardInput = function (res) {
+                if (delegate._string !== res.value) {
+                    delegate._editBoxTextChanged(res.value);
+                }
+            }
+
+            cbs.onKeyboardConfirm = function (res) {
+                delegate._editBoxEditingReturn();
+                let cbs = self._eventListeners;
+                cbs.onKeyboardComplete && cbs.onKeyboardComplete();
+            }
+
+            cbs.onKeyboardComplete = function () {
+                self._editing = false;
+                _currentEditBoxImpl = null;
+                self._unregisterKeyboardEvent();
+                delegate._editBoxEditingDidEnded();
+            }
+
+            __globalAdapter.onKeyboardInput(cbs.onKeyboardInput);
+            __globalAdapter.onKeyboardConfirm(cbs.onKeyboardConfirm);
+            __globalAdapter.onKeyboardComplete(cbs.onKeyboardComplete);
+        },
+
+        _unregisterKeyboardEvent () {
+            let cbs = this._eventListeners;
+
+            if (cbs.onKeyboardInput) {
+                __globalAdapter.offKeyboardInput(cbs.onKeyboardInput);
+                cbs.onKeyboardInput = null;
+            }
+            if (cbs.onKeyboardConfirm) {
+                __globalAdapter.offKeyboardConfirm(cbs.onKeyboardConfirm);
+                cbs.onKeyboardConfirm = null;
+            }
+            if (cbs.onKeyboardComplete) {
+                __globalAdapter.offKeyboardComplete(cbs.onKeyboardComplete);
+                cbs.onKeyboardComplete = null;
+            }
+        },
+
+        _otherEditing () {
+            return !!_currentEditBoxImpl && _currentEditBoxImpl !== this && _currentEditBoxImpl._editing;
+        },
+
+        _ensureKeyboardHide (cb) {
+            let otherEditing = this._otherEditing();
+            if (!otherEditing && !_hideKeyboardTimeout) {
+                return cb();
+            }
+            if (_hideKeyboardTimeout) {
+                clearTimeout(_hideKeyboardTimeout);
+            }
+            if (otherEditing) {
+                _currentEditBoxImpl.endEditing();
+            }
+            _hideKeyboardTimeout = setTimeout(() => {
+                _hideKeyboardTimeout = null;
+                cb();
+            }, KEYBOARD_HIDE_TIME);
+        },
+
+        _showKeyboard () {
+            let delegate = this._delegate;
+            let multiline = (delegate.inputMode === EditBoxComp.InputMode.ANY);
+            __globalAdapter.showKeyboard({
+                defaultValue: delegate.string,
+                maxLength: delegate.maxLength < 0 ? MAX_VALUE : delegate.maxLength,
+                multiple: multiline,
+                confirmHold: false,
+                confirmType: getKeyboardReturnType(delegate.returnType),
+                success (res) {
+
+                },
+                fail (res) {
+                    cc.warn(res.errMsg);
+                }
+            });
+        },
+
+        _hideKeyboard () {
+            __globalAdapter.hideKeyboard({
+                success (res) {
+
+                },
+                fail (res) {
+                    cc.warn(res.errMsg);
+                },
+            });
+        },
+    });
+})();
+

--- a/platforms/minigame/platforms/xiaomi/wrapper/engine/index.js
+++ b/platforms/minigame/platforms/xiaomi/wrapper/engine/index.js
@@ -1,1 +1,2 @@
 require('./download-ttf');
+require('./Editbox');


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/6705

Changelog:
 * 修复小米平台 EditBox 开始输入时，显示的长度是上一次输入最大长度的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
