### PR TITLE
close screen.windowSize interface

### DIFF
--- a/cocos/core/platform/screen.ts
+++ b/cocos/core/platform/screen.ts
@@ -39,16 +39,17 @@ import { warnID } from './debug';
  * @zh screen 单例对象提供简单的方法来做屏幕管理相关的工作。
  */
 class Screen {
-    /**
-     * @en Get the size of current window.
-     * On Web platform, this should be the size of game frame.
-     * @zh 获取当前窗口尺寸。
-     * 在 Web 平台，这里应该是 game frame 的尺寸
-     * @returns {Size}
-     */
-    public get windowSize (): Size {
-        return screenAdapter.windowSize;
-    }
+    // TODO: windowSize should be physical size, and deprecate sys.windowPixelResolution
+    // /**
+    //  * @en Get the size of current window.
+    //  * On Web platform, this should be the size of game frame.
+    //  * @zh 获取当前窗口尺寸。
+    //  * 在 Web 平台，这里应该是 game frame 的尺寸
+    //  * @returns {Size}
+    //  */
+    // public get windowSize (): Size {
+    //     return screenAdapter.windowSize;
+    // }
 
     /**
      * @en Whether it supports full screen？

--- a/cocos/core/platform/sys.ts
+++ b/cocos/core/platform/sys.ts
@@ -35,9 +35,8 @@ import { Rect } from '../math/rect';
 import { warnID, log } from './debug';
 import { NetworkType, Language, OS, Platform, BrowserType } from '../../../pal/system-info/enum-type';
 import { Vec2 } from '../math';
-import { screen } from './screen';
 
-const windowSize = screen.windowSize;
+const windowSize = screenAdapter.windowSize;
 const pixelRatio = systemInfo.pixelRatio;
 
 /**
@@ -292,7 +291,7 @@ export const sys = {
     getSafeAreaRect () {
         const locView = legacyCC.view;
         const edge = screenAdapter.safeAreaEdge;
-        const windowSize = screen.windowSize;
+        const windowSize = screenAdapter.windowSize;
 
         // Get leftBottom and rightTop point in screen coordinates system.
         const leftBottom = new Vec2(edge.left, windowSize.height - edge.bottom);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 临时关闭 screen.windowSize 接口

这个接口是 3.3 加的 https://github.com/cocos-creator/engine/pull/8836
该接口应该返回正确的 物理尺寸，目前返回的只是 css 像素。
对修改做了一下评估，需要把 view 里的对 dpr 降采样的操作放到 pal 层，同时废弃 sys.windowPixelResolution
这里还会影响 safeArea 和 触摸事件的位置计算，不想影响第一轮提测，所以不在这个时间节点做这个调整了

暂时先关闭这个接口，等之后接口规范明确下来，再开放出去给用户

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
