### PR TITLE
fix label opacity change bug

### DIFF
--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -743,20 +743,12 @@ export class Label extends Renderable2D {
         render.commitComp(this, this._texture, this._assembler!, null);
     }
 
+    // Cannot use the base class methods directly because BMFont and CHAR cannot be updated in assambler with just color.
     protected _updateColor () {
-        // hack for all type
-        if (this._font instanceof BitmapFont) {
-            this._updateWorldAlpha();
+        this._updateWorldAlpha();
+        if (this._colorDirty) {
+            this.updateRenderData(false);
             this._colorDirty = false;
-        } else {
-            this._updateWorldAlpha();
-            if (this._colorDirty) {
-                this.updateRenderData(false);
-                this._colorDirty = false;
-            } else if ((this._cacheAlpha !== this.node._uiProps.opacity) && this._renderFlag && this._assembler && this._assembler.updateOpacity) {
-                this._assembler.updateOpacity(this);
-                this._cacheAlpha = this.node._uiProps.opacity;
-            }
         }
     }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/8152

由于 此 PR https://github.com/cocos-creator/engine/pull/8743 导致遗漏了 canRender 的计算，导致 alpha 为 0 变为 1 时 无法渲染