### PR TITLE
fix sprite opacity change bug when start zero

### DIFF
--- a/cocos/2d/framework/renderable-2d.ts
+++ b/cocos/2d/framework/renderable-2d.ts
@@ -453,9 +453,14 @@ export class Renderable2D extends RenderableComponent {
     protected _postCanRender () {}
 
     protected _updateColor () {
+        // Need update rendFlag when opacity changes from 0 to !0
+        const opacityZero = this._cacheAlpha <= 0;
         this._updateWorldAlpha();
         if (this._colorDirty && this._assembler && this._assembler.updateColor) {
             this._assembler.updateColor(this);
+            if (opacityZero) {
+                this._renderFlag = this._canRender();
+            }
             this._colorDirty = false;
         }
     }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/8152

Re: https://github.com/cocos-creator/engine/pull/9049

由于 此 PR #8743 导致遗漏了 canRender 的计算，导致 alpha 为 0 变为 1 时 无法渲染