### PR TITLE
CCONBinary: chunk align as 4->8

### DIFF
--- a/cocos/core/data/ccon.ts
+++ b/cocos/core/data/ccon.ts
@@ -4,6 +4,8 @@ const VERSION = 1;
 
 const MAGIC = 0x4E4F4343;
 
+const CHUNK_ALIGN_AS = 8;
+
 export class CCON {
     constructor (document: unknown, chunks: Uint8Array[]) {
         this._document = document;
@@ -63,7 +65,7 @@ export function encodeCCONBinary (ccon: CCON) {
     ccobBuilder.append(jsonBytes);
 
     for (const chunk of chunks) {
-        ccobBuilder.alignAs(4);
+        ccobBuilder.alignAs(CHUNK_ALIGN_AS);
         ccobBuilder.append(uint32Bytes(chunk.byteLength));
         ccobBuilder.append(chunk);
     }
@@ -121,8 +123,8 @@ export function decodeCCONBinary (bytes: Uint8Array) {
 
     const chunks: Uint8Array[] = [];
     while (chunksStart < dataView.byteLength) {
-        if (chunksStart % 4 !== 0) {
-            const padding = 4 - chunksStart % 4;
+        if (chunksStart % CHUNK_ALIGN_AS !== 0) {
+            const padding = CHUNK_ALIGN_AS - chunksStart % CHUNK_ALIGN_AS;
             chunksStart += padding;
         }
         const chunkDataLength = dataView.getUint32(chunksStart, true);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * This PR allow `Float64Array` to be used in CCON binary.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
