### PR TITLE
fix reading array buffer failed

### DIFF
--- a/platforms/minigame/platforms/bytedance/wrapper/fs-utils.js
+++ b/platforms/minigame/platforms/bytedance/wrapper/fs-utils.js
@@ -170,7 +170,7 @@ var fsUtils = {
     },
 
     readArrayBuffer (filePath, onComplete) {
-        fsUtils.readFile(filePath, '', onComplete);
+        fsUtils.readFile(filePath, undefined, onComplete);
     },
 
     readJson (filePath, onComplete) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/8212
Changelog:
 * 试了下 'binary' 也有问题，看起来只能传 undefined 了

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
