### PR TITLE
Deserialize: Should not explicitly export texture field in SpriteFrame data

### DIFF
--- a/cocos/2d/assets/sprite-frame.ts
+++ b/cocos/2d/assets/sprite-frame.ts
@@ -1169,7 +1169,7 @@ export class SpriteFrame extends Asset {
                 rotated: this._rotated,
                 capInsets: this._capInsets,
                 vertices,
-                texture,
+                texture: (!ctxForExporting && texture) || undefined,
                 packable: this._packable,
             };
 


### PR DESCRIPTION
This field will be serialized in compiled data. No special treatment required, otherwise the exported package size will be bigger. (Consistent with 2D)

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [x] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [x] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [x] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
