### PR TITLE
fix audio can't resume when enter foreground on ByteDance platform

### DIFF
--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -61,6 +61,7 @@ export class AudioPlayerWeb implements OperationQueueable {
     private _loop = false;
     private _state: AudioState = AudioState.INIT;
     private _audioTimer: AudioTimer;
+    private _readyToHandleOnShow = false;
 
     private static _audioBufferCacheMap: Record<string, AudioBuffer> = {};
 
@@ -92,16 +93,23 @@ export class AudioPlayerWeb implements OperationQueueable {
         if (this._state === AudioState.PLAYING) {
             this.pause().then(() => {
                 this._state = AudioState.INTERRUPTED;
+                this._readyToHandleOnShow = true;
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_BEGIN);
             }).catch((e) => {});
         }
     }
     private _onShow () {
+        // We don't know whether onShow or resolve callback in pause promise is called at first.
+        if (!this._readyToHandleOnShow) {
+            this._eventTarget.once(AudioEvent.INTERRUPTION_BEGIN, this._onShow, this);
+            return;
+        }
         if (this._state === AudioState.INTERRUPTED) {
             this.play().then(() => {
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_END);
             }).catch((e) => {});
         }
+        this._readyToHandleOnShow = false;
     }
     static load (url: string): Promise<AudioPlayerWeb> {
         return new Promise((resolve) => {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7528

Changelog:
 * 修复字节平台 iOS 端，从后台进入前台是，音乐没有继续播放的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
