### PR TITLE
Fix `AnimationClip.prototype.hash`

### DIFF
--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -172,9 +172,10 @@ export class AnimationClip extends Asset {
     get hash () {
         // hashes should already be computed offline, but if not, make one
         if (this._hash) { return this._hash; }
-        const data = this._nativeAsset;
-        const buffer = new Uint8Array(ArrayBuffer.isView(data) ? data.buffer : data);
-        return this._hash = murmurhash2_32_gc(buffer, 666);
+        // Only hash exotic animations(including skeletal animations imported from model file).
+        // The behavior is consistent with how `.hash` implemented prior to 3.3.
+        const hashString = `Exotic:${this._exoticAnimation?.toHashString() ?? ''}`;
+        return this._hash = murmurhash2_32_gc(hashString, 666);
     }
 
     /**

--- a/cocos/core/animation/exotic-animation/exotic-animation.ts
+++ b/cocos/core/animation/exotic-animation/exotic-animation.ts
@@ -49,6 +49,13 @@ export class ExoticAnimation {
         return newAnimation;
     }
 
+    /**
+     * @internal
+     */
+    public toHashString () {
+        return this._nodeAnimations.map((nodeAnimation) => nodeAnimation.toHashString()).join('\n');
+    }
+
     @serializable
     private _nodeAnimations: ExoticNodeAnimation[] = [];
 }
@@ -108,6 +115,16 @@ class ExoticNodeAnimation {
         return this._path;
     }
 
+    /**
+     * @internal
+     */
+    public toHashString (): string {
+        return `${this._path}\n${
+            this._position?.toHashString() ?? ''
+        }${this._scale?.toHashString() ?? ''
+        }${this._rotation?.toHashString() ?? ''}`;
+    }
+
     @serializable
     private _path = '';
 
@@ -119,6 +136,16 @@ class ExoticNodeAnimation {
 
     @serializable
     private _scale: ExoticVec3Track | null = null;
+}
+
+function floatToHashString (value: number) {
+    // Note: referenced to `Skeleton.prototype.hash`
+    return value.toPrecision(2);
+}
+
+function floatArrayToHashString (values: FloatArray) {
+    // @ts-expect-error Complex typing
+    return (values).map(floatToHashString).join(' ');
 }
 
 interface ExoticTrackValues<TValue> {
@@ -153,6 +180,18 @@ class ExoticVectorLikeTrackValues {
         assertIsTrue(!this._isQuantized);
         this._values = quantize(this._values as FloatArray, type);
         this._isQuantized = true;
+    }
+
+    /**
+     * @internal
+     */
+    public toHashString (): string {
+        const { _isQuantized: isQuantized, _values: values } = this;
+        return `${isQuantized} ${
+            isQuantized
+                ? (values as QuantizedFloatArray).toHashString()
+                : floatArrayToHashString(values as FloatArray)
+        }`;
     }
 
     @serializable
@@ -253,7 +292,7 @@ class ExoticQuatTrackValues extends ExoticVectorLikeTrackValues implements Exoti
 }
 
 @ccclass(`${CLASS_NAME_PREFIX_ANIM}ExoticTrack`)
-class ExoticTrack<TTrackValues> {
+class ExoticTrack<TTrackValues extends { toHashString(): string; }> {
     constructor (times: FloatArray, values: TTrackValues) {
         this.times = times;
         this.values = values;
@@ -264,6 +303,14 @@ class ExoticTrack<TTrackValues> {
 
     @serializable
     public values!: TTrackValues;
+
+    /**
+     * @internal
+     */
+    public toHashString (): string {
+        const { times, values } = this;
+        return `times: ${floatArrayToHashString(times)}; values: ${values.toHashString()}`;
+    }
 }
 
 type ExoticVec3Track = ExoticTrack<ExoticVec3TrackValues>;
@@ -752,6 +799,14 @@ class QuantizedFloatArray {
         this.values = values;
         this.extent = extent;
         this.min = min;
+    }
+
+    /**
+     * @internal
+     */
+    public toHashString (): string {
+        const { originalPrecision, min, extent, values } = this;
+        return `${originalPrecision} ${floatToHashString(min)} ${floatToHashString(extent)} ${values.join(' ')}`;
     }
 }
 


### PR DESCRIPTION
Closes: cocos-creator/3d-tasks#8406

Changelog:
 * Fix `Animation.prototype.hash` mis-implementation after animation clip refactoring in 3.3.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
