### PR TITLE
Use float64 on non-JSB platforms

### DIFF
--- a/cocos/core/math/math-base.ts
+++ b/cocos/core/math/math-base.ts
@@ -6,7 +6,7 @@ export const MATH_FLOAT_ARRAY = JSB ? Float32Array : Float64Array;
 
 export class MathBase extends ValueType {
     public static createFloatArray (size: number) {
-        return new MATH_FLOAT_ARRAY();
+        return new MATH_FLOAT_ARRAY(size);
     }
 
     /**

--- a/cocos/core/math/math-base.ts
+++ b/cocos/core/math/math-base.ts
@@ -2,15 +2,11 @@ import { JSB } from 'internal:constants';
 import { ValueType } from '../value-types/value-type';
 import { FloatArray } from './type-define';
 
-export const MATH_FLOAT_ARRAY = Float32Array;
+export const MATH_FLOAT_ARRAY = JSB ? Float32Array : Float64Array;
 
 export class MathBase extends ValueType {
-    public static createFloatArray (size: number) : FloatArray {
-        if (JSB) {
-            return new Float32Array(size);
-        } else {
-            return new Float64Array(size);
-        }
+    public static createFloatArray (size: number) {
+        return new MATH_FLOAT_ARRAY();
     }
 
     /**

--- a/cocos/core/math/math-base.ts
+++ b/cocos/core/math/math-base.ts
@@ -1,11 +1,16 @@
+import { JSB } from 'internal:constants';
 import { ValueType } from '../value-types/value-type';
 import { FloatArray } from './type-define';
 
 export const MATH_FLOAT_ARRAY = Float32Array;
 
 export class MathBase extends ValueType {
-    public static createFloatArray (size: number) {
-        return new MATH_FLOAT_ARRAY(size);
+    public static createFloatArray (size: number) : FloatArray {
+        if (JSB) {
+            return new Float32Array(size);
+        } else {
+            return new Float64Array(size);
+        }
     }
 
     /**


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/8262

Changelog:
 * 参照 2.x 做法, 在 web 等非原生平台, 数学库使用 `Float64Array`

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
