### PR TITLE
fix cannot read property '_uiProps’ of null

### DIFF
--- a/cocos/core/platform/event-manager/event-manager.ts
+++ b/cocos/core/platform/event-manager/event-manager.ts
@@ -766,8 +766,9 @@ class EventManager {
         const eventListeners = listeners.getSceneGraphPriorityListeners();
         eventListeners.forEach((listener) => {
             const node: any = listener._getSceneGraphPriority();
-            const trans = node._uiProps.uiTransformComp;
-            listener._cameraPriority = trans.cameraPriority;
+            // NOTE: listener maybe in dispatching but its sceneGraphPriority has been reset to null.
+            const trans = node?._uiProps.uiTransformComp;
+            listener._cameraPriority = trans ? trans.cameraPriority : 0;
         });
         eventListeners.sort(this._sortEventListenersOfSceneGraphPriorityDes);
     }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/8438

Changelog:
 * 修复派发事件时，报错 cannot read property '_uiProps’ of null

这个可以作为 3.2.1 的临时解决方案，实际上这个应该是 listener 的回收流程有问题，
listener 在 removeListener 时，状态被重置了，但是还在派发阶段，没法从数组中移除，导致下一次派发事件时，事件排序时报错了
这个需要之后优化一下 listener 的 remove 流程，应该从 数组中移除后，再重置 listener 状态

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
