### PR TITLE
fix:when skeleton data destory clean all data.

### DIFF
--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -66,7 +66,6 @@ const cacheManager = require('./jsb-cache-manager');
     let skeletonCacheMgr = spine.SkeletonCacheMgr.getInstance();
     spine.skeletonCacheMgr = skeletonCacheMgr;
     skeletonDataProto.destroy = function () {
-        this.removeRecordTexture();
         this.reset();
         skeletonCacheMgr.removeSkeletonCache(this._uuid);
         cc.Asset.prototype.destroy.call(this);
@@ -144,26 +143,6 @@ const cacheManager = require('./jsb-cache-manager');
             this.height = this._skeletonCache.getHeight();
         }        
     };
-    
-    skeletonDataProto.removeRecordTexture = function () {
-        let textures = this.textures;
-        if (!(textures && textures.length > 0)) {
-            return;
-        }
-        for (let i = 0; i < textures.length; ++i) {
-            let texture = textures[i];
-            if (!texture) return;
-
-            let index = texture.__textureIndex__;
-            if (index) {
-                let texKey = _textureKeyMap[index];
-                if (texKey && _textureMap.has(texKey)) {
-                    _textureMap.delete(texKey);
-                    delete _textureKeyMap[index];
-                }
-            }
-        }
-    }
 
     skeletonDataProto.recordTexture = function (texture) {
         let index = _gTextureIdx;

--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -96,15 +96,6 @@ const cacheManager = require('./jsb-cache-manager');
             return;
         }
 
-        // gfxTexture may not exist if this._skeletonCache == null
-        // let skeletonCache = spine.retainSkeletonData(uuid);
-        // if (skeletonCache) {
-        //     this._skeletonCache = skeletonCache;
-        //     this.width = this._skeletonCache.getWidth();
-        //     this.height = this._skeletonCache.getHeight();                 
-        //     return;
-        // }
-
         let atlasText = this.atlasText;
         if (!atlasText) {
             cc.errorID(7508, this.name);
@@ -122,7 +113,6 @@ const cacheManager = require('./jsb-cache-manager');
         for (let i = 0; i < textures.length; ++i) {
             let texture = textures[i];
             let textureIdx = this.recordTexture(texture);
-            texture.__textureIndex__ = textureIdx;
             let spTex = new middleware.Texture2D();
             spTex.setRealTextureIndex(textureIdx);
             spTex.setPixelsWide(texture.width);


### PR DESCRIPTION
previous version the info still exists in the data map,
this cause initializing skeleton failed second time.