### PR TITLE
fix cc.Graphics Bezier Curve overdraw

### DIFF
--- a/cocos2d/core/renderer/webgl/assemblers/graphics/index.js
+++ b/cocos2d/core/renderer/webgl/assemblers/graphics/index.js
@@ -402,6 +402,7 @@ export default class GraphicsAssembler extends Assembler {
 
     _calculateJoins (impl, w, lineJoin, miterLimit) {
         let iw = 0.0;
+        let w2 = w * w;
     
         if (w > 0.0) {
             iw = 1 / w;
@@ -458,8 +459,8 @@ export default class GraphicsAssembler extends Assembler {
                 // Check whether dm length is too long
                 let dmwx = p1.dmx * w;
                 let dmwy = p1.dmy * w;
-                let dmlen = dmwx*dmwx + dmwy*dmwy;
-                if (dmlen > (p1.len * p1.len) || dmlen > (p0.len * p0.len)) {
+                let dmlen2 = dmwx*dmwx + dmwy*dmwy;
+                if (dmlen2 > (p1.len * p1.len) + w2 && dmlen2 > (p0.len * p0.len) + w2) {
                     p1.flags |= PointFlags.PT_INNERBEVEL;
                 }
     


### PR DESCRIPTION
Drawing Bezier Curve with cc.Graphics cause some unnecessary overdraw in cc2.4.6, but this not happen in cc2.4.2
Issue detail: https://forum.cocos.org/t/topic/119268/29

The issue is introduced by following commit, which tries to fix sharp harsh in corner case. But that fix is overkilling.
https://github.com/cocos-creator/engine/pull/7780/commits/06320339dae5419a6e96058344a35254429862f1


![7eff859b5cdcf5bb7ad6305d15aa225](https://user-images.githubusercontent.com/4058573/129597123-ffffa1e0-4bee-4c22-b266-ea4f00025158.jpg)
看图理解：产生sharp harsh的原因是，左右两条线段都很短，导致dm点“裸露在线段外”。
dm点只和线段夹角有关，和线段长度无关。通常在夹角是小锐角时，dm点会离折点很远，也容易出现sharp harsh。

要计算dmlen的最大值，考虑线段|P-dm|、w、len组成的三角形。
极限情况时，三条线段组成直角三角形，w、len是三角形的直角边（看上图涂色部分）。此时dmlen是被允许的最大值。
dm只要被左右线段之一经过，就不会出现sharp harsh，所以用 && 而不是 ||
