### PR TITLE
fix htmlString maybe empty

### DIFF
--- a/cocos2d/core/utils/html-text-parser.js
+++ b/cocos2d/core/utils/html-text-parser.js
@@ -44,7 +44,7 @@ HtmlTextParser.prototype = {
     constructor: HtmlTextParser,
     parse: function(htmlString) {
         this._resultObjectArray = [];
-             if (!htmlString) {
+        if (!htmlString) {
             return this._resultObjectArray;
         }
         this._stack = [];

--- a/cocos2d/core/utils/html-text-parser.js
+++ b/cocos2d/core/utils/html-text-parser.js
@@ -44,6 +44,9 @@ HtmlTextParser.prototype = {
     constructor: HtmlTextParser,
     parse: function(htmlString) {
         this._resultObjectArray = [];
+             if (!htmlString) {
+            return this._resultObjectArray;
+        }
         this._stack = [];
 
         var startIndex = 0;


### PR DESCRIPTION
修复htmlString有可能为空，直接return个空数组，应用场景在使用bugly报错