### PR TITLE
fix vivo touching

### DIFF
--- a/pal/input/minigame/touch.ts
+++ b/pal/input/minigame/touch.ts
@@ -1,5 +1,6 @@
 import { TouchCallback, TouchData, TouchInputEvent } from 'pal/input';
 import { minigame } from 'pal/minigame';
+import { VIVO } from 'internal:constants';
 import { Vec2 } from '../../../cocos/core/math';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { SystemEvent } from '../../../cocos/core/platform/event-manager/system-event';
@@ -26,13 +27,19 @@ export class TouchInputSource {
             const sysInfo = minigame.getSystemInfoSync();
             const touchDataList: TouchData[] = [];
             const length = event.changedTouches.length;
+            let targetHeight;
+            if (VIVO) {
+                targetHeight = window.innerHeight;
+            } else {
+                targetHeight = sysInfo.windowHeight;
+            }
             for (let i = 0; i < length; ++i) {
                 const touch = event.changedTouches[i];
                 const location = this._getLocation(touch);
                 const touchData: TouchData = {
                     identifier: touch.identifier,
                     x: location.x,
-                    y: sysInfo.windowHeight - location.y,
+                    y: targetHeight - location.y,
                     force: touch.force,
                 };
                 touchDataList.push(touchData);


### PR DESCRIPTION
相关论坛反馈 https://forum.cocos.org/t/topic/119826

changeLog:
- 修复 vivo 刘海屏竖屏状态下，触摸位置偏下的问题
- 除了这个修复之外，还需要做一个处理：
    在构建出来的 vivo 项目里，把 web-adapter.js 里关于 window.innerHeight 的适配需要注释掉，使用 vivo 原生返回的 window.innerHeight
![1](https://user-images.githubusercontent.com/17872773/130408123-e9661449-ac1c-467f-9761-6120dc6c195d.png)
![2](https://user-images.githubusercontent.com/17872773/130408148-18c5c365-9cb1-4866-996f-2362de994e81.png)


NOTE:
这是临时的修复方案，主要原因是 vivo 接口返回的 screenHeight 算上了刘海屏的高度，而原生返回的 window.innerHeight 数据才是正确的

## 需要交由平台方修复这个问题