### PR TITLE
fix:when undo operation of move, spine disappear

### DIFF
--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -1322,6 +1322,14 @@ export class Skeleton extends Renderable2D {
         return inst;
     }
 
+    // For Redo, Undo
+    // call markForUpdateRenderData to make sure renderData will be re-built.
+    public onRestore () {
+        this.updateMaterial();
+        this._renderFlag = this._canRender();
+        this.markForUpdateRenderData();
+    }
+
     protected updateMaterial () {
         if (this._customMaterial) {
             this.setMaterial(this._customMaterial, 0);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#
* https://github.com/cocos-creator/3d-tasks/issues/8685

撤销移动操作后，destroyRenderData会被调用销毁_meshRenderDataArray被清空，
同时由于材质被清除，在set animation 函数中markForUpdateRenderData()无法标记_renderDataFlag为true
导致_meshRenderDataArray丢失