### PR TITLE
Mesh dynamic operation API

### DIFF
--- a/cocos/3d/assets/morph.ts
+++ b/cocos/3d/assets/morph.ts
@@ -33,48 +33,6 @@ import { Mesh } from './mesh';
 import { StdMorphRendering } from './morph-rendering';
 import { IMacroPatch } from '../../core/renderer';
 
-export interface Morph {
-    /**
-     * Morph data of each sub-mesh.
-     */
-    subMeshMorphs: (SubMeshMorph | null)[];
-
-    /**
-     * Common initial weights of each sub-mesh.
-     */
-    weights?: number[];
-
-    /**
-     * Name of each target of each sub-mesh morph.
-     * This field is only meaningful if every sub-mesh has the same number of targets.
-     */
-    targetNames?: string[];
-}
-
-export interface MorphTarget {
-    /**
-     * Displacement of each target attribute.
-     */
-    displacements: Mesh.IBufferView[];
-}
-
-export interface SubMeshMorph {
-    /**
-     * Attributes to morph.
-     */
-    attributes: AttributeName[];
-
-    /**
-     * Targets.
-     */
-    targets: MorphTarget[];
-
-    /**
-     * Initial weights of each target.
-     */
-    weights?: number[];
-}
-
 export function createMorphRendering (mesh: Mesh, gfxDevice: Device): MorphRendering | null {
     return new StdMorphRendering(mesh, gfxDevice);
 }

--- a/cocos/3d/models/skinning-model.ts
+++ b/cocos/3d/models/skinning-model.ts
@@ -122,7 +122,7 @@ export class SkinningModel extends MorphModel {
         if (!skeleton || !skinningRoot || !mesh) { return; }
         this.transform = skinningRoot;
         const boneSpaceBounds = mesh.getBoneSpaceBounds(skeleton);
-        const jointMaps = mesh.struct.jointMaps;
+        const jointMaps = mesh.jointMaps;
         this._ensureEnoughBuffers(jointMaps && jointMaps.length || 1);
         this._bufferIndices = mesh.jointBufferIndices;
         const nativeJoints: NativeJointInfo[] = [];

--- a/cocos/core/animation/value-proxy-factories/morph-weights.ts
+++ b/cocos/core/animation/value-proxy-factories/morph-weights.ts
@@ -98,7 +98,7 @@ export class MorphWeightsAllValueProxy implements IValueProxyFactory {
     public forTarget (target: MeshRenderer) {
         return {
             set: (value: number[]) => {
-                const nSubMeshes = target.mesh?.struct.primitives.length ?? 0;
+                const nSubMeshes = target.mesh?.subMeshes.length ?? 0;
                 for (let iSubMesh = 0; iSubMesh < nSubMeshes; ++iSubMesh) {
                     target.setWeights(value, iSubMesh);
                 }

--- a/cocos/core/geometry/intersect.ts
+++ b/cocos/core/geometry/intersect.ts
@@ -454,8 +454,8 @@ const rayMesh = (function () {
         minDis = 0;
         const opt = options === undefined ? deOpt : options;
         const length = mesh.renderingSubMeshes.length;
-        const min = mesh.struct.minPosition;
-        const max = mesh.struct.maxPosition;
+        const min = mesh.minPosition;
+        const max = mesh.maxPosition;
         if (min && max && !rayAABB2(ray, min, max)) return minDis;
         for (let i = 0; i < length; i++) {
             const sm = mesh.renderingSubMeshes[i];

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
     setupFiles: [
         './tests/init.ts',
     ],
+    setupFilesAfterEnv: ["jest-extended"],
     coverageDirectory: './test/report/',
     globals: {
         CC_DEV: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1836,7 +1836,7 @@
         },
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-8.1.0.tgz?cache=0&sync_timestamp=1611075413359&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-8.1.0.tgz",
+          "resolved": "https://registry.nlark.com/fs-extra/download/fs-extra-8.1.0.tgz",
           "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
           "dev": true,
           "requires": {
@@ -1969,7 +1969,7 @@
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.nlark.com/yargs/download/yargs-15.4.1.tgz",
+          "resolved": "https://registry.nlark.com/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1620086465147&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
           "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
           "dev": true,
           "requires": {
@@ -3795,7 +3795,7 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
@@ -9490,6 +9490,176 @@
         }
       }
     },
+    "jest-extended": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npm.taobao.org/jest-extended/download/jest-extended-0.11.5.tgz",
+      "integrity": "sha1-8GOz8eqtrY18E6AfDf4PU41JjM8=",
+      "dev": true,
+      "requires": {
+        "expect": "^24.1.0",
+        "jest-get-type": "^22.4.3",
+        "jest-matcher-utils": "^22.0.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "24.9.0",
+          "resolved": "https://registry.nlark.com/@jest/console/download/@jest/console-24.9.0.tgz?cache=0&sync_timestamp=1631520427543&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40jest%2Fconsole%2Fdownload%2F%40jest%2Fconsole-24.9.0.tgz",
+          "integrity": "sha1-ebG8Bvt0qM+wHL3t+UVYSxuXB/A=",
+          "dev": true,
+          "requires": {
+            "@jest/source-map": "^24.9.0",
+            "chalk": "^2.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "24.9.0",
+          "resolved": "https://registry.nlark.com/@jest/source-map/download/@jest/source-map-24.9.0.tgz",
+          "integrity": "sha1-DiY6lEML5LQdpoPMwea//ioZFxQ=",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.1.15",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "24.9.0",
+          "resolved": "https://registry.nlark.com/@jest/test-result/download/@jest/test-result-24.9.0.tgz?cache=0&sync_timestamp=1631520534996&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40jest%2Ftest-result%2Fdownload%2F%40jest%2Ftest-result-24.9.0.tgz",
+          "integrity": "sha1-EXluiqnb+I6gJXV7MVJZWtBroMo=",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/istanbul-lib-coverage": "^2.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "1.0.1",
+          "resolved": "https://registry.nlark.com/@types/stack-utils/download/@types/stack-utils-1.0.1.tgz",
+          "integrity": "sha1-CoUdO9lkmPolwzq3J47TvWXwbD4=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.nlark.com/ansi-regex/download/ansi-regex-3.0.0.tgz?cache=0&sync_timestamp=1631634988487&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fansi-regex%2Fdownload%2Fansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.nlark.com/escape-string-regexp/download/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
+          "dev": true
+        },
+        "expect": {
+          "version": "24.9.0",
+          "resolved": "https://registry.nlark.com/expect/download/expect-24.9.0.tgz?cache=0&sync_timestamp=1631520435105&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fexpect%2Fdownload%2Fexpect-24.9.0.tgz",
+          "integrity": "sha1-t1FltIFwdPpKFXeU9G/p8boVtso=",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-styles": "^3.2.0",
+            "jest-get-type": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-regex-util": "^24.9.0"
+          },
+          "dependencies": {
+            "jest-get-type": {
+              "version": "24.9.0",
+              "resolved": "https://registry.nlark.com/jest-get-type/download/jest-get-type-24.9.0.tgz?cache=0&sync_timestamp=1624900056951&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fjest-get-type%2Fdownload%2Fjest-get-type-24.9.0.tgz",
+              "integrity": "sha1-FoSgyKUPLkkBtmRK6GH1ee7S7w4=",
+              "dev": true
+            },
+            "jest-matcher-utils": {
+              "version": "24.9.0",
+              "resolved": "https://registry.nlark.com/jest-matcher-utils/download/jest-matcher-utils-24.9.0.tgz?cache=0&sync_timestamp=1631520532926&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fjest-matcher-utils%2Fdownload%2Fjest-matcher-utils-24.9.0.tgz",
+              "integrity": "sha1-9bNmHV5ijf/m3WUlHf2uDofDoHM=",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.0.1",
+                "jest-diff": "^24.9.0",
+                "jest-get-type": "^24.9.0",
+                "pretty-format": "^24.9.0"
+              }
+            }
+          }
+        },
+        "jest-get-type": {
+          "version": "22.4.3",
+          "resolved": "https://registry.nlark.com/jest-get-type/download/jest-get-type-22.4.3.tgz?cache=0&sync_timestamp=1624900056951&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fjest-get-type%2Fdownload%2Fjest-get-type-22.4.3.tgz",
+          "integrity": "sha1-46hQTYR5NC3UQgI2syKGnxiQDOQ=",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "22.4.3",
+          "resolved": "https://registry.nlark.com/jest-matcher-utils/download/jest-matcher-utils-22.4.3.tgz?cache=0&sync_timestamp=1631520532926&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fjest-matcher-utils%2Fdownload%2Fjest-matcher-utils-22.4.3.tgz",
+          "integrity": "sha1-RjL+Qo68c+vBlNPHtl03sWH3EP8=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          },
+          "dependencies": {
+            "pretty-format": {
+              "version": "22.4.3",
+              "resolved": "https://registry.nlark.com/pretty-format/download/pretty-format-22.4.3.tgz",
+              "integrity": "sha1-+HPXgIOanALpZkyKCC6e556qwW8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0",
+                "ansi-styles": "^3.2.0"
+              }
+            }
+          }
+        },
+        "jest-message-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.nlark.com/jest-message-util/download/jest-message-util-24.9.0.tgz?cache=0&sync_timestamp=1631520480618&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fjest-message-util%2Fdownload%2Fjest-message-util-24.9.0.tgz",
+          "integrity": "sha1-Un9UoeOA9eICqNEUmw7IcvQxGeM=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^2.0.1",
+            "micromatch": "^3.1.10",
+            "slash": "^2.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-regex-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.nlark.com/jest-regex-util/download/jest-regex-util-24.9.0.tgz?cache=0&sync_timestamp=1624900201901&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fjest-regex-util%2Fdownload%2Fjest-regex-util-24.9.0.tgz",
+          "integrity": "sha1-wT+zOAveIr9ldUMsST6o/jeWVjY=",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.nlark.com/slash/download/slash-2.0.0.tgz",
+          "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.nlark.com/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "stack-utils": {
+          "version": "1.0.5",
+          "resolved": "https://registry.nlark.com/stack-utils/download/stack-utils-1.0.5.tgz?cache=0&sync_timestamp=1631632508333&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fstack-utils%2Fdownload%2Fstack-utils-1.0.5.tgz",
+          "integrity": "sha1-oZsLAZR+ACnI5FHV1hpJj1uxRxs=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^2.0.0"
+          }
+        }
+      }
+    },
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-24.9.0.tgz?cache=0&sync_timestamp=1579655144842&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-get-type%2Fdownload%2Fjest-get-type-24.9.0.tgz",
@@ -11893,7 +12063,7 @@
     },
     "kind-of": {
       "version": "6.0.2",
-      "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-6.0.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-6.0.2.tgz",
       "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
       "dev": true
     },
@@ -12656,7 +12826,7 @@
     },
     "open": {
       "version": "7.4.2",
-      "resolved": "https://registry.nlark.com/open/download/open-7.4.2.tgz?cache=0&sync_timestamp=1621868447130&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fopen%2Fdownload%2Fopen-7.4.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/open/download/open-7.4.2.tgz?cache=0&sync_timestamp=1614759218873&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fopen%2Fdownload%2Fopen-7.4.2.tgz",
       "integrity": "sha1-uBR+Jtzz5CYxbHMAif1x7dKcIyE=",
       "dev": true,
       "optional": true,
@@ -13700,7 +13870,7 @@
     },
     "rollup-plugin-visualizer": {
       "version": "4.2.2",
-      "resolved": "https://registry.nlark.com/rollup-plugin-visualizer/download/rollup-plugin-visualizer-4.2.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/rollup-plugin-visualizer/download/rollup-plugin-visualizer-4.2.2.tgz?cache=0&sync_timestamp=1617262822404&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frollup-plugin-visualizer%2Fdownload%2Frollup-plugin-visualizer-4.2.2.tgz",
       "integrity": "sha1-7euLP8b0mzyV9sxmj066V8YRIJk=",
       "dev": true,
       "optional": true,
@@ -13787,7 +13957,7 @@
         },
         "string-width": {
           "version": "4.2.2",
-          "resolved": "https://registry.nlark.com/string-width/download/string-width-4.2.2.tgz",
+          "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-4.2.2.tgz?cache=0&sync_timestamp=1614522241573&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstring-width%2Fdownload%2Fstring-width-4.2.2.tgz",
           "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "optional": true,
@@ -14512,7 +14682,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -14801,7 +14971,7 @@
         },
         "yargs": {
           "version": "13.3.2",
-          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-13.3.2.tgz?cache=0&sync_timestamp=1616790495164&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-13.3.2.tgz",
+          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-13.3.2.tgz?cache=0&sync_timestamp=1618115316688&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-13.3.2.tgz",
           "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp": "^4.0.2",
     "http-server": "^0.12.3",
     "jest": "^26.6.3",
+    "jest-extended": "^0.11.5",
     "jest-matcher-deep-close-to": "^2.0.1",
     "path": "^0.12.7",
     "pngjs": "^6.0.0",

--- a/tests/assets/mesh.test.ts
+++ b/tests/assets/mesh.test.ts
@@ -1,0 +1,219 @@
+
+import { Mesh, SubMesh, VertexAttributeVec3View, VertexAttributeVec4View, VertexAttributeView } from '../../cocos/3d/assets/mesh';
+import { gfx, Vec3, Vec4 } from '../../cocos/core';
+import { Color } from '../../cocos/core/gfx';
+import '../utils/matcher-deep-close-to';
+import 'jest-extended';
+
+describe('Mesh', () => {
+    describe('Attribute view', () => {
+        const mesh = new Mesh();
+        const subMesh = mesh.addSubMesh();
+        subMesh.rearrange({
+            streams: [{
+                attributes: [{
+                    name: gfx.AttributeName.ATTR_POSITION,
+                    format: gfx.Format.RGB32F,
+                }, {
+                    name: gfx.AttributeName.ATTR_NORMAL,
+                    format: gfx.Format.RGB32F,
+                }],
+            }, {
+                attributes: [{
+                    name: gfx.AttributeName.ATTR_COLOR,
+                    format: gfx.Format.RGBA32F,
+                }],
+            }],
+        }, 3);
+
+        expect(subMesh.vertexCount).toBe(3);
+        expect(subMesh.hasAttribute(gfx.AttributeName.ATTR_POSITION));
+        expect(subMesh.hasAttribute(gfx.AttributeName.ATTR_NORMAL));
+        expect(subMesh.hasAttribute(gfx.AttributeName.ATTR_COLOR));
+
+        const positions = Array.from({ length: 3 * subMesh.vertexCount }, (_, index) => index * 0.1);
+        const normals = Array.from({ length: 3 * subMesh.vertexCount }, (_, index) => index * 1.2);
+        const colors = Array.from({ length: 3 * subMesh.vertexCount }, (_, index) => index * -3.6);
+
+        subMesh.viewAttribute(gfx.AttributeName.ATTR_POSITION).write(positions);
+        subMesh.viewAttribute(gfx.AttributeName.ATTR_NORMAL).write(normals);
+        subMesh.viewAttribute(gfx.AttributeName.ATTR_COLOR).write(colors);
+
+        test.each([
+            ['interleaved', {
+                attributeName: gfx.AttributeName.ATTR_NORMAL,
+                expectedComponentCount: 3,
+            }],
+            ['compact', {
+                attributeName: gfx.AttributeName.ATTR_COLOR,
+                expectedComponentCount: 4,
+            }],
+        ])('View on %s attribute', (_, { attributeName, expectedComponentCount }) => {
+            const view = subMesh.viewAttribute(attributeName);
+
+            expect(view.vertexCount).toBe(subMesh.vertexCount);
+            expect(view.componentCount).toBe(expectedComponentCount);
+    
+            // Set 3rd vertex's y component to 0.1 
+            view.setComponent(2, 1, 0.1);
+            expect(view.getComponent(2, 1)).toBeCloseTo(0.1);
+    
+            // Copy 3rd vertex's value into 2nd vertex
+            view.set(view.subarray(2), 1);
+            for (let i = 0; i < view.componentCount; ++i) {
+                expect(view.getComponent(2, i)).toBe(view.getComponent(1, i));
+            }
+    
+            // Read all vertices' normal
+            const normals = view.read() as Float32Array;
+            expect(normals).toBeInstanceOf(Float32Array);
+            expect(normals).toHaveLength(view.componentCount * view.vertexCount);
+            for (let iVertex = 0; iVertex < view.vertexCount; ++iVertex) {
+                for (let iComponent = 0; iComponent < view.componentCount; ++iComponent) {
+                    expect(view.getComponent(iVertex, iComponent)).toBe(normals[view.componentCount * iVertex + iComponent]);
+                }
+            }
+    
+            // Read only two vertices' normal
+            const normals2 = view.read(2);
+            expect(normals2).toBeInstanceOf(Float32Array);
+            expect(normals2).toHaveLength(view.componentCount * 2);
+            for (let iVertex = 0; iVertex < 2; ++iVertex) {
+                for (let iComponent = 0; iComponent < view.componentCount; ++iComponent) {
+                    expect(view.getComponent(iVertex, iComponent)).toBe(normals[view.componentCount * iVertex + iComponent]);
+                }
+            }
+    
+            // Read 3(all) vertices' normal and store by your preferred array constructor
+            const normals3 = view.read(3, Float64Array);
+            // Read all vertices' normal into specified array(and optionally specify a count)
+            const normals4 = view.read(new Float32Array(3 * 3), 3);
+        });
+
+        test('Vec3 view', () => {
+            // Operates on whole attribute
+            const normalViewVec3 = new VertexAttributeVec3View(subMesh.viewAttribute(gfx.AttributeName.ATTR_NORMAL));
+            // Set 2nd vertex's value to (0.0, 1.0, 0.0)
+            normalViewVec3.set(1, new Vec3(0.0, 1.0, 0.0));
+            expect(normalViewVec3.get(1, new Vec3())).toStrictEqual(new Vec3(0.0, 1.0, 0.0));
+        });
+
+        test('Vec4 view', () => {
+            // Operates in Color(Vec4)
+            const colorView = new VertexAttributeVec4View(subMesh.viewAttribute(gfx.AttributeName.ATTR_COLOR));
+            colorView.set(1, new Color(0.1, 0.2, 0.3, 0.4));
+            expect(colorView.get(1, new Vec4())).toBeDeepCloseTo(new Color(0.1, 0.2, 0.3, 0.4), 5);
+        });
+    });
+
+    describe(`Resize`, () => {
+        function createSimple() {
+            const mesh = new Mesh();
+            const subMesh = mesh.addSubMesh();
+            subMesh.rearrange({
+                streams: [{
+                    attributes: [{
+                        name: gfx.AttributeName.ATTR_POSITION,
+                        format: gfx.Format.RGB32F,
+                    }],
+                }],
+            }, 3);
+
+            const positions = new VertexAttributeVec3View(subMesh.viewAttribute(gfx.AttributeName.ATTR_POSITION));
+            for (let i = 0; i < 3; ++i) {
+                positions.set(i, new Vec3(i + 1.0));
+            }
+            return subMesh;
+        }
+
+        test(`Shrink`, () => {
+            const subMesh = createSimple();
+            subMesh.resize(2);
+            expect(subMesh.vertexCount).toBe(2);
+            const positions = new VertexAttributeVec3View(subMesh.viewAttribute(gfx.AttributeName.ATTR_POSITION));
+            expect(positions.get(0)).toBeDeepCloseTo(new Vec3(1.0));
+            expect(positions.get(1)).toBeDeepCloseTo(new Vec3(2.0));
+        });
+
+        test(`Expansion`, () => {
+            const subMesh = createSimple();
+            subMesh.resize(5);
+            expect(subMesh.vertexCount).toBe(5);
+            const positions = new VertexAttributeVec3View(subMesh.viewAttribute(gfx.AttributeName.ATTR_POSITION));
+            expect(positions.get(0)).toBeDeepCloseTo(new Vec3(1.0));
+            expect(positions.get(1)).toBeDeepCloseTo(new Vec3(2.0));
+            expect(positions.get(2)).toBeDeepCloseTo(new Vec3(3.0));
+            expect([3, 4]).toSatisfyAll((index) => positions.get(index).x === 0.0);
+        });
+    });
+
+    test(`Rearrange`, () => {
+        const mesh = new Mesh();
+        const subMesh = mesh.addSubMesh();
+        subMesh.rearrange({
+            streams: [{
+                attributes: [{
+                    name: gfx.AttributeName.ATTR_POSITION,
+                    format: gfx.Format.RGB32F,
+                }],
+            }],
+        }, 3);
+
+        subMesh.viewAttribute(gfx.AttributeName.ATTR_POSITION).write(
+            Array.from({ length: 3 * subMesh.vertexCount }, (_, index) => index));
+
+        subMesh.rearrange({
+            streams: [{
+                attributes: [{
+                    name: gfx.AttributeName.ATTR_POSITION,
+                    format: gfx.Format.RGB32F,
+                }, {
+                    name: gfx.AttributeName.ATTR_NORMAL,
+                    format: gfx.Format.RGB32F,
+                }],
+            }, {
+                attributes: [{
+                    name: gfx.AttributeName.ATTR_COLOR,
+                    format: gfx.Format.RGBA32F,
+                }],
+            }],
+        }, 6);
+
+        expect(subMesh.vertexCount).toBe(6);
+        expect(subMesh.hasAttribute(gfx.AttributeName.ATTR_POSITION));
+        expect(subMesh.hasAttribute(gfx.AttributeName.ATTR_NORMAL));
+        expect(subMesh.hasAttribute(gfx.AttributeName.ATTR_COLOR));
+        expect(subMesh.attributeNames).toSatisfyAll(
+            (attribute) => subMesh.viewAttribute(attribute).read().every((v) => v === 0.0));
+    });
+
+    describe(`Events`, () => {
+        test(`Rendering mesh reconstituted`, () => {
+            const recorder = jest.fn<void, []>();
+
+            const mesh = new Mesh();
+            mesh.initialize();
+            
+            mesh.on(Mesh.EventType.RENDERING_SUB_MESH_RECONSTITUTED, recorder);
+
+            const subMesh = mesh.addSubMesh();
+            mesh.flush();
+            mesh.flush();
+            expect(recorder).toBeCalledTimes(1);
+            recorder.mockClear();
+
+            subMesh.rearrange({
+                streams: [{
+                    attributes: [{
+                        name: gfx.AttributeName.ATTR_POSITION,
+                        format: gfx.Format.RGB32F,
+                    }],
+                }],
+            }, 3);
+            mesh.flush();
+            mesh.flush();
+            expect(recorder).toBeCalledTimes(1);
+            recorder.mockClear();
+        });
+    });
+});


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
  <See below>

- Drop the concept that `Mesh` is composed as "structure" + "binary".

- Deprecate the API: `Mesh.struct`, `Mesh.data`, `Mesh._nativeAsset`, `Mesh.reset`, the alternatives of old stuffs are:

  - `Mesh.struct.minPosition: Vec3 | undefined`/`Mesh.struct.maxPosition: Vec3 | undefined` -> `Mesh.minPosition: Vec3`/`Mesh.maxPosition: Vec3`. Min position is initialized to positive infinities, max position is intialized as negative infinities.

  - `Mesh.struct.primitives` and other stuffs -> Take a look at `Mesh.subMeshes`

- Introduce the `SubMesh` class. `SubMesh`s store polygons. A mesh contains zero or more sub meshes. Sub meshes are isolated from each-other. They do not share nothing.(As a comparison, legacy mesh data do).

- To manipulate any vertex vertex, you need to visit the sub mesh and call to the `viewAttribute()` which returns a `VertexAttributeView`. Vertex attribute view objects can proceed with any component of any vertex. If the vertex format is well-known to caller, you may wrap it in `VertexAttributeVec3View` or `VertexAttributeVec4View` to get bettern vector operation experience. It is worth mentioning that vertex attribute view are designed so it feel like JavaScript's typed array buffer view. You might also reference to the unit test in this PR to inspect the usage.

- Sub mesh also supplied the following methods to proceed with polygons:

  - `resize()` - Resize the number of vertices, without touch the vertex layout. Both shrinking and expansion are considered and having definitely behaviours.

  - `rearange()` - Adjust the vertex layout. After this method call, old mesh data is erased.

  - `clone()` - Clone the mesh.

- All attribute operations(for example `Mesh.readAttribute`) are implemented through sub mesh API. I did not mark them as deprecated but I'd suggest to do so.

- `Mesh.flush()` flushes all sub mesh data for rendering:

  - If only vertex attribute data is changed, it just siliently update the backend buffers.

  - Otherwise, for example, the vertex layout or the vertex count is changed, it dispatches a `Mesh.EventType.RENDERING_SUB_MESH_RECONSTITUTED`. `MeshRenderer` listened to this event and then refresh the model info.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
