### PR TITLE
Fix EditorExtendable when compile in babel loose

### DIFF
--- a/cocos/core/data/editor-extendable.ts
+++ b/cocos/core/data/editor-extendable.ts
@@ -20,6 +20,8 @@ export function EditorExtendableMixin<T> (Base: new (...args: any[]) => T, class
     return editorExtendableInternal(Base);
 }
 
+class Empty {}
+
 /**
  * Class which implements the `EditorExtendableObject` interface.
  */
@@ -36,7 +38,7 @@ function editorExtendableInternal<T> (Base?: (new (...args: any[]) => T), classN
     type ResultType = new (...args: any[]) => (T & EditorExtendableObject);
 
     if (!EDITOR) {
-        return (Base ?? Object) as unknown as ResultType;
+        return (Base ?? Empty) as unknown as ResultType;
     }
 
     let name: string;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
*

When compile to <ES5 using babel loose mode, the following fails during preview stage:

```ts
class S extends EditorExtendable {
}

console.log((new S()) instanceof S); // false
```

This is because `EditorExtendable` actually eval to `Object`. In babel loose mode, extending natives can not be perfectly processed. See:

- https://javascript.info/task/class-extend-object

- https://babeljs.io/docs/en/babel-plugin-transform-classes#caveats

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
