### PR TITLE
revert deprecate EventKeyboard.isPressed

### DIFF
--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -152,14 +152,6 @@ markAsWarning(EventTouch.prototype, 'EventTouch.prototype', [
     },
 ]);
 
-// deprecated EventKeyboard property
-markAsWarning(EventKeyboard.prototype, 'EventKeyboard.prototype', [
-    {
-        name: 'isPressed',
-        suggest: 'use EventKeyboard.prototype.type !== SystemEvent.EventType.KEY_UP instead',
-    },
-]);
-
 // deprecate languageCode field
 replaceProperty(sys, 'sys',
     ['UNKNOWN', 'ENGLISH', 'CHINESE', 'FRENCH', 'ITALIAN',

--- a/cocos/core/platform/event-manager/events.ts
+++ b/cocos/core/platform/event-manager/events.ts
@@ -615,8 +615,6 @@ export class EventKeyboard extends Event {
     /**
      * @en Indicates whether the current key is being pressed
      * @zh 表示当前按键是否正在被按下
-     *
-     * @deprecated since v3.3, please use Event.prototype.type !== SystemEvent.EventType.KEY_UP instead
      */
     public get isPressed () {
         return this._isPressed;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/8802

Changelog:
 * 回滚对 `EventKeyboard.isPressed` 属性的弃用

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
