### PR TITLE
2 subtle improvements

### DIFF
--- a/cocos/core/components/camera-component.ts
+++ b/cocos/core/components/camera-component.ts
@@ -580,18 +580,16 @@ export class Camera extends Component {
     }
 
     protected _checkTargetTextureEvent (old: RenderTexture | null) {
-        const resizeFunc = (window: RenderWindow) => {
-            if (this._camera) {
-                this._camera.setFixedSize(window.width, window.height);
-            }
-        };
-
         if (old) {
             old.off('resize');
         }
 
         if (this._targetTexture) {
-            this._targetTexture.on('resize', resizeFunc, this);
+            this._targetTexture.on('resize', (window: RenderWindow) => {
+                if (this._camera) {
+                    this._camera.setFixedSize(window.width, window.height);
+                }
+            }, this);
         }
     }
 

--- a/cocos/core/pipeline/render-pipeline.ts
+++ b/cocos/core/pipeline/render-pipeline.ts
@@ -171,8 +171,8 @@ export abstract class RenderPipeline extends Asset {
      * @param camera the camera
      * @returns
      */
-    public generateRenderArea (camera: Camera): Rect {
-        const res = new Rect();
+    public generateRenderArea (camera: Camera, out?: Rect): Rect {
+        const res = out || new Rect();
         const vp = camera.viewport;
         const sceneData = this.pipelineSceneData;
         // render area is not oriented


### PR DESCRIPTION
2 changes, and all they are subtle improvements:

1, add an `out` argument for `generateRenderArea` method, because this method is called a lot of times in a single frame tick (for example in `Render` method), this wastes memory, so i think an `out` parameter is supposed to be here..

2, do not create temp function when set `camera.targetTexture` as null, in this situation this temp function is redundant here.
