### PR TITLE
fix spine not be packed in, jsb error

### DIFF
--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -26,6 +26,7 @@ const cacheManager = require('./jsb-cache-manager');
 
 (function(){
     if (window.spine === undefined || window.middleware === undefined) return;
+    if (cc.internal.SpineSkeletonData === undefined) return;
     
 
     middleware.generateGetSet(spine);


### PR DESCRIPTION
* https://github.com/cocos-creator/3d-tasks/issues/9181

未选择spine时cc.internal.SpineSkeletonData为空
