### PR TITLE
fix dragonbone material miss

### DIFF
--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -565,7 +565,9 @@ export class ArmatureDisplay extends Renderable2D {
                 const mat = this.material;
                 this._meshRenderDataArrayIdx = i;
                 const m = this._meshRenderDataArray[i];
-                this.material = m.renderData.material;
+                if (m.renderData.material) {
+                    this.material = m.renderData.material;
+                }
                 if (m.texture) {
                     ui.commitComp(this, m.texture, this._assembler, null);
                 }


### PR DESCRIPTION
* https://github.com/cocos-creator/3d-tasks/issues/9216
材质丢失导致
