### PR TITLE
Add `playById(id)`: play audio by id

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -164,6 +164,24 @@ var audioEngine = {
     },
 
     /**
+     * !#en Play audio by audioID.
+     * !#zh 播放音频
+     * @method playById
+     * @param {Number} audioID - audio id.
+     * @return {Boolean} has played
+     * @example
+     *   var played = cc.audioEngine.playById(audioID);
+     */
+    playById: function (audioID) {
+        var audio = getAudioFromId(audioID);
+        if (audio) {
+            audio.play();
+            return true;
+        }
+        return false;
+    },
+
+    /**
      * !#en Set audio loop.
      * !#zh 设置音频是否循环。
      * @method setLoop


### PR DESCRIPTION
当开发者需要自己封装一个 音乐播放类, 并自己储存和维护 audioID 以及对应的 audio实例时,  非常需要这个方法.
否则每次  stop 音乐后,  再进行播放,  之前维护的 audioID 就无效了.
而且 当开发者想自己控制 audio实例个数时,  也非常依赖该方法.
