### PR TITLE
fix rigid-body miss processing sync Position and Rotation

### DIFF
--- a/cocos/physics-2d/box2d/rigid-body.ts
+++ b/cocos/physics-2d/box2d/rigid-body.ts
@@ -83,13 +83,12 @@ export class b2RigidBody2D implements IRigidBody2D {
             for (let i = 0; i < colliders.length; i++) {
                 colliders[i].apply();
             }
-        } else {
-            if (type & Node.TransformBit.POSITION) {
-                this.syncPositionToPhysics(true);
-            }
-            if (type & Node.TransformBit.ROTATION) {
-                this.syncRotationToPhysics(true);
-            }
+        }
+        if (type & Node.TransformBit.POSITION) {
+            this.syncPositionToPhysics(true);
+        }
+        if (type & Node.TransformBit.ROTATION) {
+            this.syncRotationToPhysics(true);
         }
     }
 


### PR DESCRIPTION
* https://github.com/cocos-creator/3d-tasks/issues/9176

_onNodeTransformChanged 函数中，Node.TransformBit.SCALE 分支未处理 POSITION ROTATION 更新逻辑