### PR TITLE
Add `setAutoRecycleOnEnded(audioID, enabled)` .

### DIFF
--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -45,7 +45,7 @@ let recycleAudio = function (audio) {
     audio.src = null;
     // In case repeatly recycle audio
     if (!_audioPool.includes(audio)) {
-        if (_audioPool.length < audioEngine._maxPoolSize) {
+        if (_audioPool.length < 32) {
             _audioPool.push(audio);
         }
         else {
@@ -128,7 +128,6 @@ var audioEngine = {
     AudioState: Audio.State,
 
     _maxAudioInstance: 24,
-    _maxPoolSize: 32,
 
     _id2audio: _id2audio,
 
@@ -177,20 +176,6 @@ var audioEngine = {
     setAutoRecycleOnEnded: function (audioID, enabled) {
         var audio = getAudioFromId(audioID);
         audio && (audio._autoRecycleOnEnded = enabled);
-    },
-
-    /**
-     * !#en Check that the audio whether valid (still be cached)
-     * !#zh audioID 对应的 Audio对象 是否有效(是否仍然被缓存着, 没有被销毁)。
-     * @method isValidAudio
-     * @param {Number} audioID - audio id.
-     * @return {Boolean} the audio whether valid (still be cached).
-     * @example
-     * const valid = cc.audioEngine.isValidAudio(id);
-     */
-    isValidAudio: function (audioID) {
-        var audio = getAudioFromId(audioID);
-        return !!audio;
     },
 
     /**

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -56,7 +56,7 @@ let recycleAudio = function (audio) {
 };
 
 let getAudioFromPath = function (path) {
-    var id = ++_instanceId;
+    var id = _instanceId++;
     var list = _url2id[path];
     if (!list) {
         list = _url2id[path] = [];

--- a/cocos2d/audio/CCAudioEngine.js
+++ b/cocos2d/audio/CCAudioEngine.js
@@ -29,7 +29,7 @@ const Audio = require('./CCAudio');
 const AudioClip = require('../core/assets/CCAudioClip');
 const js = cc.js;
 
-let _instanceId = 1;
+let _instanceId = 0;
 let _id2audio = js.createMap(true);
 let _url2id = {};
 let _audioPool = [];
@@ -56,7 +56,7 @@ let recycleAudio = function (audio) {
 };
 
 let getAudioFromPath = function (path) {
-    var id = _instanceId++;
+    var id = ++_instanceId;
     var list = _url2id[path];
     if (!list) {
         list = _url2id[path] = [];


### PR DESCRIPTION
设置 是否在audio结束后自动回收.

当前版本的 audioEngine 会在 音乐播放结束后, 自动回收音乐 , 导致之前通过play拿到的 audioID 无效.

在很多场景下 会给开发者造成困扰.

比如开发者要在自己的逻辑里 控制音频的 前进后退 静音 等操作是.
音乐播放结束时 开发者甚至都拿不到状态. 因为获得状态也需要通过 audioID, 而此时audioID 已经无效.

因为此PR 中  `_autoRecycleOnEnded`默认为 `true`,   所以并不会改变当前cocos的 audioEngine的默认逻辑.

Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
