### PR TITLE
remove block/buffer.count

### DIFF
--- a/cocos/core/assets/effect-asset.ts
+++ b/cocos/core/assets/effect-asset.ts
@@ -73,7 +73,6 @@ export declare namespace EffectAsset {
         binding: number;
         name: string;
         members: Uniform[];
-        count: number;
         stageFlags: ShaderStageFlags;
     }
     export interface ISamplerTextureInfo {
@@ -101,7 +100,6 @@ export declare namespace EffectAsset {
     export interface IBufferInfo {
         binding: number;
         name: string;
-        count: number;
         memoryAccess: MemoryAccess;
         stageFlags: ShaderStageFlags;
     }

--- a/cocos/core/renderer/core/program-lib.ts
+++ b/cocos/core/renderer/core/program-lib.ts
@@ -275,10 +275,10 @@ class ProgramLib {
             for (let i = 0; i < tmpl.buffers.length; i++) {
                 const buffer = tmpl.buffers[i];
                 tmplInfo.bindings.push(new DescriptorSetLayoutBinding(buffer.binding,
-                    DescriptorType.STORAGE_BUFFER, buffer.count, buffer.stageFlags));
+                    DescriptorType.STORAGE_BUFFER, 1, buffer.stageFlags));
                 tmplInfo.shaderInfo.buffers.push(new UniformStorageBuffer(
-                    SetIndex.MATERIAL, buffer.binding, buffer.name, buffer.count, buffer.memoryAccess,
-                ));
+                    SetIndex.MATERIAL, buffer.binding, buffer.name, 1, buffer.memoryAccess,
+                )); // effect compiler guarantees buffer count = 1
             }
             for (let i = 0; i < tmpl.images.length; i++) {
                 const image = tmpl.images[i];


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * effect compiler guarantees block/buffer.count = 1

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->