### PR TITLE
remove Widget dependency on SafeArea component

### DIFF
--- a/cocos/ui/safe-area.ts
+++ b/cocos/ui/safe-area.ts
@@ -70,14 +70,11 @@ export class SafeArea extends Component {
 
     public onEnable () {
         this.updateArea();
-        // IDEA: need to delay the callback on Native platform ?
-        screenAdapter.on('window-resize', this.updateArea, this);
-        screenAdapter.on('orientation-change', this.updateArea, this);
+        view.on('design-resolution-changed', this.updateArea, this);
     }
 
     public onDisable () {
-        screenAdapter.off('window-resize', this.updateArea, this);
-        screenAdapter.off('orientation-change', this.updateArea, this);
+        view.off('design-resolution-changed', this.updateArea, this);
     }
 
     /**

--- a/cocos/ui/safe-area.ts
+++ b/cocos/ui/safe-area.ts
@@ -30,7 +30,6 @@
 
 import { ccclass, help, executionOrder, menu, executeInEditMode, requireComponent } from 'cc.decorator';
 import { EDITOR } from 'internal:constants';
-import { screenAdapter } from 'pal/screen-adapter';
 import { Component } from '../core/components';
 import { UITransform } from '../2d/framework';
 import { view, sys } from '../core/platform';


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/7511

Changelog:
 * 移除 SafeArea 组件对 Widget 组件的依赖

自测平台：
- [x] web
- [x] 微信、字节  （微信有特殊机型问题，已经反馈给微信团队）
- [x] OPPO
- [x] 模拟器
- [ ] ~~Android、iOS~~ 跑不起来

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
