### PR TITLE
fix init bug when mountedChild is a PrefabInstance

### DIFF
--- a/cocos/core/assets/prefab.ts
+++ b/cocos/core/assets/prefab.ts
@@ -199,7 +199,7 @@ export class Prefab extends Asset {
 
     public onLoaded () {
         const rootNode = this.data as Node;
-        utils.expandPrefabInstanceNode(rootNode);
+        utils.expandNestedPrefabInstanceNode(rootNode);
         utils.applyTargetOverrides(rootNode);
     }
 }

--- a/cocos/core/scene-graph/scene.ts
+++ b/cocos/core/scene-graph/scene.ts
@@ -38,7 +38,7 @@ import { BaseNode } from './base-node';
 import { legacyCC } from '../global-exports';
 import { Component } from '../components/component';
 import { SceneGlobals } from './scene-globals';
-import { applyTargetOverrides, expandPrefabInstanceNode } from '../utils/prefab/utils';
+import { applyTargetOverrides, expandNestedPrefabInstanceNode } from '../utils/prefab/utils';
 import { NativeScene } from '../renderer/scene/native-scene';
 
 /**
@@ -275,7 +275,7 @@ export class Scene extends BaseNode {
                 assert(!this._activeInHierarchy, 'Should deactivate ActionManager by default');
             }
 
-            expandPrefabInstanceNode(this);
+            expandNestedPrefabInstanceNode(this);
             applyTargetOverrides(this);
             this._onBatchCreated(EDITOR && this._prefabSyncedInLiveReload);
             this._inited = true;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * fix init bug when mountedChild is a PrefabInstance

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
