### PR TITLE
replace utils function ,update "sortProp" function

### DIFF
--- a/editor/inspector/components/particle-system.js
+++ b/editor/inspector/components/particle-system.js
@@ -520,7 +520,7 @@ const uiElements = {
                     element.render(prop.dump);
                 }
                 element.hidden = !prop.dump.visible;
-            }));
+            });
         },
     },
 };

--- a/editor/inspector/components/particle-system.js
+++ b/editor/inspector/components/particle-system.js
@@ -514,7 +514,7 @@ const uiElements = {
     },
     customProps: {
         update() {
-            this.$.customProps.replaceChildren(...propUtils.getCustomPropElements(excludeList, this.dump, (element, prop) => {
+            propUtils.updateCustomPropElements(this.$.customProps, excludeList, this.dump, (element, prop) => {
                 element.className = 'customProp';
                 if (prop.dump.visible) {
                     element.render(prop.dump);

--- a/editor/inspector/components/widget.js
+++ b/editor/inspector/components/widget.js
@@ -964,14 +964,13 @@ const uiElements = {
             if (!this.$customProps) {
                 this.$customProps = this.$el.querySelector('#customProps');
             }
-            this.$customProps.replaceChildren(...propUtils.getCustomPropElements(excludeList, this.dump, (element, prop) => {
+            propUtils.updateCustomPropElements(this.$customProps, excludeList, this.dump, (element, prop) => {
                 element.className = 'customProp';
-                const isShow = prop.dump.visible;
-                if (isShow) {
+                if (prop.dump.visible) {
                     element.render(prop.dump);
                 }
-                element.style = isShow ? '' : 'display: none;';
-            }));
+                element.hidden = !prop.dump.visible;
+            });
         },
     },
 };


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:

replace utils function
-  "getCustomPropElements" -> "updateCustomPropElements"
this function is use to render custom node

update  "sortProp" function
- item may be null
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
