### PR TITLE
fix cached currentTime on native audio ended

### DIFF
--- a/pal/audio/native/player.ts
+++ b/pal/audio/native/player.ts
@@ -212,6 +212,7 @@ export class AudioPlayer implements OperationQueueable {
                         this._cachedState.currentTime = 0;
                     }
                     audioEngine.setFinishCallback(this._id, () => {
+                        this._cachedState.currentTime = 0;
                         this._id = INVALID_AUDIO_ID;
                         this._state = AudioState.INIT;
                         this._eventTarget.emit(AudioEvent.ENDED);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/9648

Changelog:
 * 修复 Win32 和 Mac 平台，音频播放结束后 currentTime 没有重置的问题

播放结束后，AudioID 就无效了，AudioEngine 无法通过 AudioID 获取到正确的 currentTime，所以之前这块做了一次缓存
这里是缓存出问题了

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
