### PR TITLE
fix camera pre-rotation adaptation

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -3023,6 +3023,10 @@ Should only one camera exists, please check your project.
 
 Camera does not support Canvas Mode.
 
+### 8302
+
+Camera.viewport is deprecated, please use setViewportInOrientedSpace instead.
+
 ### 8400
 
 Wrong type arguments, 'filePath' must be a String.

--- a/cocos/2d/framework/canvas.ts
+++ b/cocos/2d/framework/canvas.ts
@@ -221,12 +221,9 @@ export class Canvas extends RenderRoot2D {
     protected _onResizeCamera () {
         if (this._cameraComponent && this._alignCanvasWithScreen) {
             if (this._cameraComponent.targetTexture) {
-                const win = this._cameraComponent.targetTexture.window;
-                if (this._cameraComponent.camera) { this._cameraComponent.camera.setFixedSize(win!.width, win!.height); }
                 this._cameraComponent.orthoHeight = visibleRect.height / 2;
-            } else if (game.canvas) {
+            } else {
                 const size = screen.windowSize;
-                if (this._cameraComponent.camera) { this._cameraComponent.camera.resize(size.width, size.height); }
                 this._cameraComponent.orthoHeight = size.height / view.getScaleY() / 2;
             }
 

--- a/cocos/core/assets/texture-base.ts
+++ b/cocos/core/assets/texture-base.ts
@@ -170,15 +170,14 @@ export class TextureBase extends Asset {
      * @param wrapR R(W) coordinate wrap mode
      */
     public setWrapMode (wrapS: WrapMode, wrapT: WrapMode, wrapR?: WrapMode) {
+        if (wrapR === undefined) wrapR = wrapS; // wrap modes should be as consistent as possible for performance
+
         this._wrapS = wrapS;
         this._samplerInfo.addressU = wrapS as unknown as Address;
         this._wrapT = wrapT;
         this._samplerInfo.addressV = wrapT as unknown as Address;
-
-        if (wrapR !== undefined) {
-            this._wrapR = wrapR;
-            this._samplerInfo.addressW = wrapR as unknown as Address;
-        }
+        this._wrapR = wrapR;
+        this._samplerInfo.addressW = wrapR as unknown as Address;
 
         if (this._gfxDevice) {
             this._gfxSampler = this._gfxDevice.getSampler(this._samplerInfo);

--- a/cocos/core/components/camera-component.ts
+++ b/cocos/core/components/camera-component.ts
@@ -393,7 +393,7 @@ export class Camera extends Component {
 
     set rect (val) {
         this._rect = val;
-        if (this._camera) { this._camera.viewport = val; }
+        if (this._camera) { this._camera.setViewportInOrientedSpace(val); }
     }
 
     /**
@@ -543,7 +543,7 @@ export class Camera extends Component {
                 priority: this._priority,
             });
 
-            this._camera.viewport = this._rect;
+            this._camera.setViewportInOrientedSpace(this._rect);
             this._camera.fovAxis = this._fovAxis;
             this._camera.fov = toRadian(this._fov);
             this._camera.orthoHeight = this._orthoHeight;

--- a/cocos/core/pipeline/common/postprocess-stage.ts
+++ b/cocos/core/pipeline/common/postprocess-stage.ts
@@ -96,13 +96,13 @@ export class PostProcessStage extends RenderStage {
         pipeline.pipelineUBO.updateCameraUBO(camera);
 
         const vp = camera.viewport;
-        this._renderArea.x = vp.x * camera.width;
-        this._renderArea.y = vp.y * camera.height;
-        this._renderArea.width = vp.width * camera.width;
-        this._renderArea.height = vp.height * camera.height;
+        this._renderArea.x = vp.x * camera.window.width;
+        this._renderArea.y = vp.y * camera.window.height;
+        this._renderArea.width = vp.width * camera.window.width;
+        this._renderArea.height = vp.height * camera.window.height;
         const renderData = pipeline.getPipelineRenderData();
-        const framebuffer = camera.window!.framebuffer;
-        const swapchain = camera.window!.swapchain;
+        const framebuffer = camera.window.framebuffer;
+        const swapchain = camera.window.swapchain;
         const renderPass = swapchain ? pipeline.getRenderPass(camera.clearFlag, swapchain) : framebuffer.renderPass;
 
         if (camera.clearFlag & ClearFlagBit.COLOR) {
@@ -131,7 +131,7 @@ export class PostProcessStage extends RenderStage {
 
         cmdBuff.bindDescriptorSet(SetIndex.MATERIAL, pass.descriptorSet);
 
-        const inputAssembler = camera.window!.swapchain ? pipeline.quadIAOnscreen : pipeline.quadIAOffscreen;
+        const inputAssembler = camera.window.swapchain ? pipeline.quadIAOnscreen : pipeline.quadIAOffscreen;
         let pso: PipelineState | null = null;
         if (pass != null && shader != null && inputAssembler != null) {
             pso = PipelineStateManager.getOrCreatePipelineState(device, pass, shader, renderPass, inputAssembler);

--- a/cocos/core/pipeline/pipeline-ubo.ts
+++ b/cocos/core/pipeline/pipeline-ubo.ts
@@ -72,15 +72,13 @@ export class PipelineUBO {
         const sceneData = pipeline.pipelineSceneData;
         const ambient = sceneData.ambient;
         const fog = sceneData.fog;
-        const shadingWidth = Math.floor(root.mainWindow.width);
-        const shadingHeight = Math.floor(root.mainWindow.height);
         const cv = bufferView;
         const exposure = camera.exposure;
         const isHDR = sceneData.isHDR;
 
         // update camera ubo
-        cv[UBOCamera.SCREEN_SCALE_OFFSET] = camera.width / shadingWidth;
-        cv[UBOCamera.SCREEN_SCALE_OFFSET + 1] = camera.height / shadingHeight;
+        cv[UBOCamera.SCREEN_SCALE_OFFSET] = sceneData.shadingScale;
+        cv[UBOCamera.SCREEN_SCALE_OFFSET + 1] = sceneData.shadingScale;
         cv[UBOCamera.SCREEN_SCALE_OFFSET + 2] = 1.0 / cv[UBOCamera.SCREEN_SCALE_OFFSET];
         cv[UBOCamera.SCREEN_SCALE_OFFSET + 3] = 1.0 / cv[UBOCamera.SCREEN_SCALE_OFFSET + 1];
 

--- a/cocos/core/pipeline/render-pipeline.ts
+++ b/cocos/core/pipeline/render-pipeline.ts
@@ -326,10 +326,8 @@ export abstract class RenderPipeline extends Asset implements IPipelineEvent {
     public generateRenderArea (camera: Camera, out?: Rect): Rect {
         const res = out || new Rect();
         const vp = camera.viewport;
-        // render area is not oriented
-        const swapchain = camera.window!.swapchain;
-        const w = swapchain && swapchain.surfaceTransform % 2 ? camera.height : camera.width;
-        const h = swapchain && swapchain.surfaceTransform % 2 ? camera.width : camera.height;
+        const w = camera.window.width;
+        const h = camera.window.height;
         res.x = vp.x * w;
         res.y = vp.y * h;
         res.width = vp.width * w;
@@ -395,7 +393,7 @@ export abstract class RenderPipeline extends Asset implements IPipelineEvent {
             if (camera.scene) {
                 this.emit(PipelineEventType.RENDER_CAMERA_BEGIN, camera);
                 sceneCulling(this, camera);
-                this._pipelineUBO.updateGlobalUBO(camera.window!);
+                this._pipelineUBO.updateGlobalUBO(camera.window);
                 this._pipelineUBO.updateCameraUBO(camera);
                 for (let j = 0; j < this._flows.length; j++) {
                     this._flows[j].render(camera);

--- a/cocos/core/renderer/core/render-window.ts
+++ b/cocos/core/renderer/core/render-window.ts
@@ -53,16 +53,16 @@ const orientationMap: Record<Orientation, SurfaceTransform> = {
  */
 export class RenderWindow {
     /**
-     * @en Get window width.
-     * @zh 窗口宽度。
+     * @en Get window width. Pre-rotated (i.e. always in identity/portrait mode) if supported.
+     * @zh 窗口宽度。如果支持交换链预变换，返回值始终处于单位旋转（竖屏）坐标系下。
      */
     get width (): number {
         return this._width;
     }
 
     /**
-     * @en Get window height.
-     * @zh 窗口高度。
+     * @en Get window height. Pre-rotated (i.e. always in identity/portrait mode) if supported.
+     * @zh 窗口高度。如果支持交换链预变换，返回值始终处于单位旋转（竖屏）坐标系下。
      */
     get height (): number {
         return this._height;
@@ -219,9 +219,7 @@ export class RenderWindow {
         }
 
         for (const camera of this._cameras) {
-            if (camera.isWindowSize) {
-                camera.resize(width, height);
-            }
+            camera.resize(width, height);
         }
     }
 

--- a/cocos/core/renderer/core/render-window.ts
+++ b/cocos/core/renderer/core/render-window.ts
@@ -53,16 +53,18 @@ const orientationMap: Record<Orientation, SurfaceTransform> = {
  */
 export class RenderWindow {
     /**
-     * @en Get window width. Pre-rotated (i.e. always in identity/portrait mode) if supported.
-     * @zh 窗口宽度。如果支持交换链预变换，返回值始终处于单位旋转（竖屏）坐标系下。
+     * @en Get window width. Pre-rotated (i.e. rotationally invariant, always in identity/portrait mode) if possible.
+     * If you want to get oriented size instead, you should use [[Camera.width]] which corresponds to the current screen rotation.
+     * @zh 获取窗口宽度。如果支持交换链预变换，返回值将始终处于单位旋转（竖屏）坐标系下。如果需要获取旋转后的尺寸，请使用 [[Camera.width]]。
      */
     get width (): number {
         return this._width;
     }
 
     /**
-     * @en Get window height. Pre-rotated (i.e. always in identity/portrait mode) if supported.
-     * @zh 窗口高度。如果支持交换链预变换，返回值始终处于单位旋转（竖屏）坐标系下。
+     * @en Get window height. Pre-rotated (i.e. rotationally invariant, always in identity/portrait mode) if possible.
+     * If you want to get oriented size instead, you should use [[Camera.width]] which corresponds to the current screen rotation.
+     * @zh 获取窗口高度。如果支持交换链预变换，返回值将始终处于单位旋转（竖屏）坐标系下。如果需要获取旋转后的尺寸，请使用 [[Camera.height]]。
      */
     get height (): number {
         return this._height;

--- a/cocos/core/renderer/scene/camera.ts
+++ b/cocos/core/renderer/scene/camera.ts
@@ -36,6 +36,7 @@ import { legacyCC } from '../../global-exports';
 import { RenderWindow } from '../core/render-window';
 import { preTransforms } from '../../math/mat4';
 import { NativeCamera } from './native-scene';
+import { warnID } from '../../platform/debug';
 
 export enum CameraFOVAxis {
     VERTICAL,
@@ -205,6 +206,7 @@ export class Camera {
 
     private _updateAspect (oriented = true) {
         this._aspect = (this.window.width * this._viewport.width) / (this.window.height * this._viewport.height);
+        // window size/viewport is pre-rotated, but aspect should be oriented to acquire the correct projection
         if (oriented) {
             const swapchain = this.window.swapchain;
             const orientation = swapchain && swapchain.surfaceTransform || SurfaceTransform.IDENTITY;
@@ -461,13 +463,22 @@ export class Camera {
         return this._clearColor as IVec4Like;
     }
 
-    // Pre-rotated (i.e. always in identity/portrait mode) if supported.
+    /**
+     * Pre-rotated (i.e. always in identity/portrait mode) if possible.
+     */
     get viewport () {
         return this._viewport;
     }
 
-    // Oriented
     set viewport (val) {
+        warnID(8302);
+        this.setViewportInOrientedSpace(val);
+    }
+
+    /**
+     * Set the viewport in oriented space (local to screen rotations)
+     */
+    public setViewportInOrientedSpace (val: Rect) {
         const { x, width, height } = val;
         const y = this._device.capabilities.screenSpaceSignY < 0 ? 1 - val.y - height : val.y;
 

--- a/cocos/core/renderer/scene/camera.ts
+++ b/cocos/core/renderer/scene/camera.ts
@@ -203,6 +203,18 @@ export class Camera {
         }
     }
 
+    private _updateAspect (oriented = true) {
+        this._aspect = (this.window.width * this._viewport.width) / (this.window.height * this._viewport.height);
+        if (oriented) {
+            const swapchain = this.window.swapchain;
+            const orientation = swapchain && swapchain.surfaceTransform || SurfaceTransform.IDENTITY;
+            if (orientation % 2) this._aspect = 1 / this._aspect;
+        }
+        this._isProjDirty = true;
+
+        if (JSB) this._nativeObj!.aspect = this._aspect;
+    }
+
     protected _init (info: ICameraInfo) {
         if (JSB) {
             this._nativeObj = new NativeCamera();
@@ -248,7 +260,7 @@ export class Camera {
     public destroy () {
         if (this._window) {
             this._window.detachCamera(this);
-            this.window = null;
+            this.window = null!;
         }
         this._name = null;
         this._destroy();
@@ -269,20 +281,13 @@ export class Camera {
 
         this._setWidth(width);
         this._setHeight(height);
-        this._aspect = (width * this._viewport.width) / (height * this._viewport.height);
-        if (JSB) {
-            this._nativeObj!.aspect = this._aspect;
-        }
-        this._isProjDirty = true;
+        this._updateAspect();
     }
 
     public setFixedSize (width: number, height: number) {
         this._setWidth(width);
         this._setHeight(height);
-        this._aspect = (width * this._viewport.width) / (height * this._viewport.height);
-        if (JSB) {
-            this._nativeObj!.aspect = this._aspect;
-        }
+        this._updateAspect(false);
         this.isWindowSize = false;
     }
 
@@ -330,7 +335,7 @@ export class Camera {
                 Mat4.perspective(this._matProj, this._fov, this._aspect, this._nearClip, this._farClip,
                     this._fovAxis === CameraFOVAxis.VERTICAL, this._device.capabilities.clipSpaceMinZ, projectionSignY, orientation);
             } else {
-                const x = this._orthoHeight * this._aspect; // aspect is already oriented
+                const x = this._orthoHeight * this._aspect;
                 const y = this._orthoHeight;
                 Mat4.ortho(this._matProj, -x, x, -y, y, this._nearClip, this._farClip,
                     this._device.capabilities.clipSpaceMinZ, projectionSignY, orientation);
@@ -456,10 +461,12 @@ export class Camera {
         return this._clearColor as IVec4Like;
     }
 
+    // Pre-rotated (i.e. always in identity/portrait mode) if supported.
     get viewport () {
         return this._viewport;
     }
 
+    // Oriented
     set viewport (val) {
         const { x, width, height } = val;
         const y = this._device.capabilities.screenSpaceSignY < 0 ? 1 - val.y - height : val.y;
@@ -554,12 +561,12 @@ export class Camera {
     set window (val) {
         this._window = val;
         if (JSB && val) {
-            this._nativeObj!.window = this._window!.native;
+            this._nativeObj!.window = this._window.native;
         }
     }
 
     get window () {
-        return this._window;
+        return this._window!;
     }
 
     set forward (val) {
@@ -701,7 +708,12 @@ export class Camera {
         if (win) {
             win.attachCamera(this);
             this.window = win;
-            this.resize(win.width, win.height);
+
+            // window size is pre-rotated
+            const swapchain = win.swapchain;
+            const orientation = swapchain && swapchain.surfaceTransform || SurfaceTransform.IDENTITY;
+            if (orientation % 2) this.resize(win.height, win.width);
+            else this.resize(win.width, win.height);
         }
     }
 
@@ -717,8 +729,8 @@ export class Camera {
     public screenPointToRay (out: Ray, x: number, y: number): Ray {
         if (!this._node) return null!;
 
-        const width = this.width;
-        const height = this.height;
+        const width = this.window.width;
+        const height = this.window.height;
         const cx = this._viewport.x * width;
         const cy = this._viewport.y * height;
         const cw = this._viewport.width * width;
@@ -750,8 +762,8 @@ export class Camera {
      * transform a screen position (in oriented space) to world space
      */
     public screenToWorld (out: Vec3, screenPos: Vec3): Vec3 {
-        const width = this.width;
-        const height = this.height;
+        const width = this.window.width;
+        const height = this.window.height;
         const cx = this._viewport.x * width;
         const cy = this._viewport.y * height;
         const cw = this._viewport.width * width;
@@ -796,8 +808,8 @@ export class Camera {
      * transform a world space position to screen space
      */
     public worldToScreen (out: Vec3, worldPos: Vec3 | Readonly<Vec3>): Vec3 {
-        const width = this.width;
-        const height = this.height;
+        const width = this.window.width;
+        const height = this.window.height;
         const cx = this._viewport.x * width;
         const cy = this._viewport.y * height;
         const cw = this._viewport.width * width;

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -667,7 +667,7 @@ export class TerrainBlock {
      * @en 地形块的可见性
      * @zh block visible
      */
-     set visible (val) {
+    set visible (val) {
         if (this._renderable._model !== null) {
             if (val) {
                 if (this._renderable._model.scene == null) {

--- a/tests/assets/render-texture.test.ts
+++ b/tests/assets/render-texture.test.ts
@@ -8,7 +8,7 @@ describe('render-texture', () => {
         expect(rt.width).toBe(1);
         expect(rt.height).toBe(1);
         rt.initialize({ width: 256, height: 256 });
-        rt.setWrapMode(WrapMode.MIRRORED_REPEAT, WrapMode.CLAMP_TO_EDGE);
+        rt.setWrapMode(WrapMode.MIRRORED_REPEAT, WrapMode.CLAMP_TO_EDGE, WrapMode.REPEAT);
         rt.setFilters(Filter.LINEAR, Filter.NEAREST);
         expect(rt.getSamplerInfo()).toStrictEqual(new SamplerInfo(GFXFilter.LINEAR, GFXFilter.POINT, GFXFilter.NONE, Address.MIRROR, Address.CLAMP, Address.WRAP, 0));
         expect(rt.getGFXTexture().width).toBe(256);
@@ -31,7 +31,7 @@ describe('render-texture', () => {
         rt.name = 'test';
         rt.setAnisotropy(16);
         rt.setFilters(Filter.NEAREST, Filter.NEAREST);
-        rt.setWrapMode(WrapMode.CLAMP_TO_EDGE, WrapMode.CLAMP_TO_EDGE);
+        rt.setWrapMode(WrapMode.CLAMP_TO_EDGE, WrapMode.CLAMP_TO_EDGE, WrapMode.CLAMP_TO_EDGE);
         const rtData2 = rt._serialize(null);
         expect(rtData2).toStrictEqual({ base: '1,1,2,2,0,16', w: 256, h: 128, n: 'test' });
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#9570

`camera.width/height` is oriented.
`window.width/height` is pre-rotated. (i.e. not oriented, always in identity/portrait mode)

Changelog:
 * fix up camera pre-rotation adaptations

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->