### PR TITLE
Serialization of SpacingX

### DIFF
--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -351,7 +351,7 @@ export class Label extends Renderable2D {
      * The space of text characters. Currently only bitmap fonts are supported.
      *
      * @zh
-     * 文本字符之间的间距。当前只支持BitmapFont。
+     * 文本字符之间的间距。当前只支持 BitmapFont。
      */
     @visible(function (this: Label) {
         return this._font instanceof BitmapFont;

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -348,6 +348,31 @@ export class Label extends Renderable2D {
 
     /**
      * @en
+     * The space of text characters.
+     *
+     * @zh
+     * 文本字符之间的间距。
+     */
+    @visible(function (this: Label) {
+        return this._font instanceof BitmapFont;
+    })
+    @displayOrder(8)
+    @tooltip('i18n:label.spacing_x')
+    get spacingX () {
+        return this._spacingX;
+    }
+
+    set spacingX (value) {
+        if (this._spacingX === value) {
+            return;
+        }
+
+        this._spacingX = value;
+        this.updateRenderData();
+    }
+
+    /**
+     * @en
      * Overflow of label.
      *
      * @zh
@@ -607,19 +632,6 @@ export class Label extends Renderable2D {
 
     set fontAtlas (value) {
         this._fontAtlas = value;
-    }
-
-    get spacingX () {
-        return this._spacingX;
-    }
-
-    set spacingX (value) {
-        if (this._spacingX === value) {
-            return;
-        }
-
-        this._spacingX = value;
-        this.updateRenderData();
     }
 
     get _bmFontOriginalSize () {

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -348,10 +348,10 @@ export class Label extends Renderable2D {
 
     /**
      * @en
-     * The space of text characters.
+     * The space of text characters. Currently only bitmap fonts are supported.
      *
      * @zh
-     * 文本字符之间的间距。
+     * 文本字符之间的间距。当前只支持BitmapFont。
      */
     @visible(function (this: Label) {
         return this._font instanceof BitmapFont;

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -348,10 +348,10 @@ export class Label extends Renderable2D {
 
     /**
      * @en
-     * The space of text characters. Currently only bitmap fonts are supported.
+     * The spacing between text characters, only available in BMFont.
      *
      * @zh
-     * 文本字符之间的间距。当前只支持 BitmapFont。
+     * 文本字符之间的间距。仅在使用 BMFont 位图字体时生效。
      */
     @visible(function (this: Label) {
         return this._font instanceof BitmapFont;

--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -201,6 +201,7 @@ module.exports = {
         font_size: 'Font size, in points',
         font_family: 'Font family name',
         line_height: 'Line height, in points',
+        spacing_x: 'The space of text characters',
         overflow:
             'Text layout modes: \n 1. CLAMP: Text nodes outside the bounding box will be truncated. \n 2. SHRINK: Automatically shrink text box according to the constraint node. \n 3. RESIZE: Automatically updates the Node based on heightof the text.',
         wrap: 'Wrap text?',

--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -201,7 +201,7 @@ module.exports = {
         font_size: 'Font size, in points',
         font_family: 'Font family name',
         line_height: 'Line height, in points',
-        spacing_x: 'The space of text characters',
+        spacing_x: 'The spacing between text characters, only available in BMFont',
         overflow:
             'Text layout modes: \n 1. CLAMP: Text nodes outside the bounding box will be truncated. \n 2. SHRINK: Automatically shrink text box according to the constraint node. \n 3. RESIZE: Automatically updates the Node based on heightof the text.',
         wrap: 'Wrap text?',

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -197,7 +197,7 @@ module.exports = {
         font_size: '文字尺寸，以 point 为单位',
         font_family: '文字字体名字',
         line_height: '文字行高，以 point 为单位',
-        spacing_x: '文本字符之间的间距',
+        spacing_x: '文本字符之间的间距，仅在使用 BMFont 位图字体时生效',
         overflow:
             '文字排版模式，包括以下三种：\n 1. CLAMP: 节点约束框之外的文字会被截断 \n 2. SHRINK: 自动根据节点约束框缩小文字\n 3. RESIZE: 根据文本内容自动更新节点的 height 属性.',
         wrap: '是否允许自动换行',

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -197,6 +197,7 @@ module.exports = {
         font_size: '文字尺寸，以 point 为单位',
         font_family: '文字字体名字',
         line_height: '文字行高，以 point 为单位',
+        spacing_x: '文本字符之间的间距',
         overflow:
             '文字排版模式，包括以下三种：\n 1. CLAMP: 节点约束框之外的文字会被截断 \n 2. SHRINK: 自动根据节点约束框缩小文字\n 3. RESIZE: 根据文本内容自动更新节点的 height 属性.',
         wrap: '是否允许自动换行',


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#9187

Changelog:
 * 在Label的inspector面板上开放SpacingX属性
 * 因为目前只在bmFont上支持该属性的运用，所以用修饰器判断当前字体类型是否为bmFont以决定该属性是否展示

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
