### PR TITLE
cc.find() does not return scene, and be compatible with path which consists of empty string

### DIFF
--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -518,7 +518,7 @@ export class BaseNode extends CCObject implements ISchedulable {
         let lastNode: this = this;
         for (let i = 0; i < segments.length; ++i) {
             const segment = segments[i];
-            if (segment.length === 0) {
+            if (i === 0 && segment.length === 0) {
                 continue;
             }
             const next = lastNode.children.find((childNode) => childNode.name === segment);

--- a/tests/core/find.test.ts
+++ b/tests/core/find.test.ts
@@ -2,24 +2,28 @@ import { director } from "../../cocos/core/director";
 import { find, Node, Scene } from "../../cocos/core/scene-graph";
 
 test('cc.find', function () {
-    const scene = new Scene('');
+    const scene = new Scene('myScene');
     director.runSceneImmediate(scene);
 
-    const node = new Node('test');
-    scene.addChild(node);
+    const nodeFirst = new Node('test');
+    scene.addChild(nodeFirst);
+    expect(find('/test')).toBe(nodeFirst);
+    expect(find('test')).toBe(nodeFirst);
 
-    expect(find('/test')).toBe(node);
-    expect(find('test')).toBe(node);
+    const nodeSecond = new Node('');
+    nodeFirst.addChild(nodeSecond);
+    expect(find('/test/')).toBe(nodeSecond);
+    expect(find('/', nodeFirst)).toBe(nodeSecond);
+
+    const nodeThird = new Node('');
+    nodeSecond.addChild(nodeThird);
+    expect(find('//',nodeFirst)).toBe(nodeThird);
+    expect(find('/',nodeSecond)).toBe(nodeThird);
 
     const node2 = new Node('.赞');
     scene.addChild(node2);
     expect(find('/.赞')).toBe(node2);
     expect(find('.赞')).toBe(node2);
-
-    // const nodenode = new Node('');
-    // node.addChild(nodenode);
-    // expect(find('//')).toBe(nodenode);
-    // expect(find('/', node)).toBe(nodenode);
 
     const node2node2 = new Node('Jare Guo');
     node2.addChild(node2node2);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#9475

Changelog:
 * 处理了getChildByPath里不兼容空路径的问题
 * 增加了find.test.ts里的单元测试用例

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
