### PR TITLE
check if _nodeListenersMap[id] is valid

### DIFF
--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -128,7 +128,7 @@ var eventManager = {
     _setDirtyForNode: function (node) {
         // Mark the node dirty only when there is an event listener associated with it.
         let selListeners = this._nodeListenersMap[node._id];
-        if (selListeners !== undefined) {
+        if (selListeners) {
             for (let j = 0, len = selListeners.length; j < len; j++) {
                 let selListener = selListeners[j];
                 let listenerID = selListener._getListenerID();


### PR DESCRIPTION
这个文件里 其他地方用的都是非严格判断, 只有这个地方严格 很奇怪.

Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
