### PR TITLE
fix bug that causes autoScrolling is always triggered in v3.5

### DIFF
--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -1251,7 +1251,7 @@ export class ScrollView extends ViewGroup {
         const adjustedMove = this._flattenVectorByDirection(deltaMove);
         _tempVec3.set(this._getContentPosition());
         _tempVec3.add(adjustedMove);
-        _tempVec3.set(Math.floor(_tempVec3.x * TOLERANCE) * EPSILON, Math.floor(_tempVec3.y * TOLERANCE) * EPSILON, _tempVec3.z);
+        _tempVec3.set(Math.round(_tempVec3.x * TOLERANCE) * EPSILON, Math.round(_tempVec3.y * TOLERANCE) * EPSILON, _tempVec3.z);
         this._setContentPosition(_tempVec3);
         const outOfBoundary = this._getHowMuchOutOfBoundary();
         _tempVec2.set(outOfBoundary.x, outOfBoundary.y);
@@ -1303,16 +1303,20 @@ export class ScrollView extends ViewGroup {
         }
 
         const outOfBoundaryAmount = new Vec3();
-        if (this._getContentLeftBoundary() + addition.x > this._leftBoundary) {
-            outOfBoundaryAmount.x = this._leftBoundary - (this._getContentLeftBoundary() + addition.x);
-        } else if (this._getContentRightBoundary() + addition.x < this._rightBoundary) {
-            outOfBoundaryAmount.x = this._rightBoundary - (this._getContentRightBoundary() + addition.x);
+        const tempLeftBoundary: number = this._getContentLeftBoundary();
+        const tempRightBoundary: number  = this._getContentRightBoundary();
+        if (tempLeftBoundary + addition.x > this._leftBoundary) {
+            outOfBoundaryAmount.x = this._leftBoundary - (tempLeftBoundary + addition.x);
+        } else if (tempRightBoundary + addition.x < this._rightBoundary) {
+            outOfBoundaryAmount.x = this._rightBoundary - (tempRightBoundary + addition.x);
         }
 
-        if (this._getContentTopBoundary() + addition.y < this._topBoundary) {
-            outOfBoundaryAmount.y = this._topBoundary - (this._getContentTopBoundary() + addition.y);
-        } else if (this._getContentBottomBoundary() + addition.y > this._bottomBoundary) {
-            outOfBoundaryAmount.y = this._bottomBoundary - (this._getContentBottomBoundary() + addition.y);
+        const tempTopBoundary: number = this._getContentTopBoundary();
+        const tempBottomBoundary: number = this._getContentBottomBoundary();
+        if (tempTopBoundary + addition.y < this._topBoundary) {
+            outOfBoundaryAmount.y = this._topBoundary - (tempTopBoundary + addition.y);
+        } else if (tempBottomBoundary + addition.y > this._bottomBoundary) {
+            outOfBoundaryAmount.y = this._bottomBoundary - (tempBottomBoundary + addition.y);
         }
 
         if (addition.equals(Vec3.ZERO, EPSILON)) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#8443

Changelog:
 * _moveContent 方法里，每次将当前位置的 xy 坐标的 e-4 位向下取整，将其改为四舍五入（floor 改为 round）
 * _getHowMuchOutOfBoundary 方法里获取当前边界提取出来，减少多余计算
 
### Reason
* 使用Chrome调试发现以下几点：
** 从右向左回弹表现正常，最终 setContentPosition 位置可以回到-375（从-374.99xxx逐渐减小至-375）
** 而从左向右回弹表现不正常，最终 setContentPosition 位置只会回到-375.0001（从-375.00xxx逐渐增大至-375.0001）
![SetContentPosition](https://user-images.githubusercontent.com/32831993/139007690-d8d4ebfd-74f6-42b5-b61c-f1068855b978.png)
* 由于上述原因，在从左向右回弹的setContentPosition里，当this.contentPos到达-375.0001000003（浮点误差）以及参数到达-375.00020000xxx时，会直接return，**不会重新设置位置**和**设置回弹到位的标志位**_outOfBoundaryAmountDirty为true
* 进而导致下图中直接return当前的差值0.000200xxx，而不继续做逼近计算
![GetHowMuchOutOfBoundary](https://user-images.githubusercontent.com/32831993/139008386-19436eba-4645-4bdc-96b5-7f433afdeab2.png)
* 最终导致在判定是否回弹结束时，差值bounceBackAmount永不会小于误差阈值0.0001，而一直尝试回弹（上面说了不会再设置位置）
![StartBounceBackIfNeeded](https://user-images.githubusercontent.com/32831993/139009128-6bb27a84-8b58-4f9d-b6b3-2a947de0a70a.png)

### Solution
* 根本原因：每次设置位置时，在小数点后**第四位使用向下取整**的方案，在横轴上滑动相当于向左取整，故之前从右向左没有出现问题。
* 使用 **Math.round** 替代 **Math.floor** ，那么无论左右方向都会无限逼近于 resultPos （本案例中-375），直到当前位置等于 resultPos，那么使用回弹判定阈值EPSILON就不会有问题。
![MoveContent](https://user-images.githubusercontent.com/32831993/139009904-91eaf653-a4bb-41e2-bd54-57c88cf57b7d.png)

### Result
案例最终测试，第二行是从右向左回弹，第四行是从左向右回弹
![企业微信截图_16353058808923](https://user-images.githubusercontent.com/32831993/139009984-eb0da62e-d782-4490-9c99-1f2413ba8170.png)


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
