### PR TITLE
optimize scroll view offset annotations in v3.5

### DIFF
--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -679,7 +679,7 @@ export class ScrollView extends ViewGroup {
      * @zh
      * 视图内容在规定时间内将滚动到 ScrollView 相对左上角原点的偏移位置, 如果 timeInSecond 参数不传，则立即滚动到指定偏移位置。
      *
-     * @param offset - 移动后，视图窗口（viewport）于视图内容（content）的相对位置。
+     * @param offset - 滚动视图后，视图内容（content）相对于视图窗口（viewport）的位置。
      * @param timeInSecond - 滚动时间（s）。 如果超时，内容将立即跳到指定偏移量处。
      * @param attenuated - 滚动加速是否衰减，默认为 true。
      * @example
@@ -711,10 +711,10 @@ export class ScrollView extends ViewGroup {
 
     /**
      * @en
-     * Get the content position value corresponds to the viewport's top left boundary.
+     * Get the position of the scrolling view relative to the origin in the upper-left corner of the viewport.
      *
      * @zh
-     * 获取滚动视图于视图窗口的左上角原点的相对位置。
+     * 获取滚动视图相对于视图窗口左上角原点的位置。
      *
      * @return - 当前滚动偏移量。
      */

--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -679,7 +679,7 @@ export class ScrollView extends ViewGroup {
      * @zh
      * 视图内容在规定时间内将滚动到 ScrollView 相对左上角原点的偏移位置, 如果 timeInSecond 参数不传，则立即滚动到指定偏移位置。
      *
-     * @param offset - 指定移动偏移量。
+     * @param offset - 移动后，视图窗口（viewport）于视图内容（content）的相对位置。
      * @param timeInSecond - 滚动时间（s）。 如果超时，内容将立即跳到指定偏移量处。
      * @param attenuated - 滚动加速是否衰减，默认为 true。
      * @example
@@ -711,10 +711,10 @@ export class ScrollView extends ViewGroup {
 
     /**
      * @en
-     * Get the positive offset value corresponds to the content's top left boundary.
+     * Get the content position value corresponds to the viewport's top left boundary.
      *
      * @zh
-     * 获取滚动视图相对于左上角原点的当前滚动偏移。
+     * 获取滚动视图于视图窗口的左上角原点的相对位置。
      *
      * @return - 当前滚动偏移量。
      */


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#8625

Changelog:
 * 优化了scrollToOffset的参数offset的注释
 * 优化了getScrollOffset的注释

### Explanation
* 理解 scrollToOffset
1. 如下图所示，传入offset(500,0)
2. 可以理解为，移动后，原来在 (500,0) 位置的 p 点，移动到到后来的原点 (0,0)
3. 也可以理解为，移动后，视窗左上角相对于内容左上角的位置是 (500,0)
* 理解 getScrollOffset
实际就是拿到内容相对视口的位置 (-500,0)
![scrollview图解](https://user-images.githubusercontent.com/32831993/139040516-eeb57968-6661-4e2b-ba6f-79a083ddf6e0.png)
* 二者为何一正一负
针对代码理解
1. getScrollOffset 的减数 this._leftBoundary 是视窗viewport的位置，也就是结果是**以视窗为参考系**
![企业微信截图_16353277331199](https://user-images.githubusercontent.com/32831993/139042963-152b80d0-c53a-48de-a8b9-72d02cdf28db.png)
2. scrollToOffset 的参数offset最终是计算为内容content的anchor，也就是**以内容为参考系**
![image](https://user-images.githubusercontent.com/32831993/139043724-3eb54281-bd28-4ca0-b866-e0a687e1c6b3.png)
3. **二者互为参考系**，所以结果互为相反数

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
