### PR TITLE
fix bug that causes autoScrolling is always triggered in v3.4

### DIFF
--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -1251,7 +1251,7 @@ export class ScrollView extends ViewGroup {
         const adjustedMove = this._flattenVectorByDirection(deltaMove);
         _tempVec3.set(this._getContentPosition());
         _tempVec3.add(adjustedMove);
-        _tempVec3.set(Math.floor(_tempVec3.x * TOLERANCE) * EPSILON, Math.floor(_tempVec3.y * TOLERANCE) * EPSILON, _tempVec3.z);
+        _tempVec3.set(Math.round(_tempVec3.x * TOLERANCE) * EPSILON, Math.round(_tempVec3.y * TOLERANCE) * EPSILON, _tempVec3.z);
         this._setContentPosition(_tempVec3);
         const outOfBoundary = this._getHowMuchOutOfBoundary();
         _tempVec2.set(outOfBoundary.x, outOfBoundary.y);
@@ -1303,16 +1303,20 @@ export class ScrollView extends ViewGroup {
         }
 
         const outOfBoundaryAmount = new Vec3();
-        if (this._getContentLeftBoundary() + addition.x > this._leftBoundary) {
-            outOfBoundaryAmount.x = this._leftBoundary - (this._getContentLeftBoundary() + addition.x);
-        } else if (this._getContentRightBoundary() + addition.x < this._rightBoundary) {
-            outOfBoundaryAmount.x = this._rightBoundary - (this._getContentRightBoundary() + addition.x);
+        const tempLeftBoundary: number = this._getContentLeftBoundary();
+        const tempRightBoundary: number  = this._getContentRightBoundary();
+        if (tempLeftBoundary + addition.x > this._leftBoundary) {
+            outOfBoundaryAmount.x = this._leftBoundary - (tempLeftBoundary + addition.x);
+        } else if (tempRightBoundary + addition.x < this._rightBoundary) {
+            outOfBoundaryAmount.x = this._rightBoundary - (tempRightBoundary + addition.x);
         }
 
-        if (this._getContentTopBoundary() + addition.y < this._topBoundary) {
-            outOfBoundaryAmount.y = this._topBoundary - (this._getContentTopBoundary() + addition.y);
-        } else if (this._getContentBottomBoundary() + addition.y > this._bottomBoundary) {
-            outOfBoundaryAmount.y = this._bottomBoundary - (this._getContentBottomBoundary() + addition.y);
+        const tempTopBoundary: number = this._getContentTopBoundary();
+        const tempBottomBoundary: number = this._getContentBottomBoundary();
+        if (tempTopBoundary + addition.y < this._topBoundary) {
+            outOfBoundaryAmount.y = this._topBoundary - (tempTopBoundary + addition.y);
+        } else if (tempBottomBoundary + addition.y > this._bottomBoundary) {
+            outOfBoundaryAmount.y = this._bottomBoundary - (tempBottomBoundary + addition.y);
         }
 
         if (addition.equals(Vec3.ZERO, EPSILON)) {


### PR DESCRIPTION
(cherry picked from commit f22ffa7d4f706375ddfd743179760a68384bec44)

Re: cocos-creator/3d-tasks#8443

Changelog:
 * _moveContent 方法里，每次将当前位置的 xy 坐标的 e-4 位向下取整，将其改为四舍五入（floor 改为 round）
 * _getHowMuchOutOfBoundary 方法里获取当前边界提取出来，减少多余计算

关联PR in v3.5
https://github.com/cocos-creator/engine/pull/9548

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
