### PR TITLE
set active false if param is undefined or null

### DIFF
--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -28,7 +28,7 @@
  * @module scene-graph
  */
 
-import { boolean, ccclass, editable, serializable } from 'cc.decorator';
+import { ccclass, editable, serializable } from 'cc.decorator';
 import { DEV, DEBUG, EDITOR } from 'internal:constants';
 import { Component } from '../components/component';
 import { property } from '../data/decorators/property';
@@ -163,9 +163,7 @@ export class BaseNode extends CCObject implements ISchedulable {
         return this._active;
     }
     set active (isActive: boolean) {
-        if (isActive === undefined) {
-            isActive = false;
-        }
+        isActive = !!isActive;
 
         if (this._active !== isActive) {
             this._active = isActive;

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -28,7 +28,7 @@
  * @module scene-graph
  */
 
-import { ccclass, editable, serializable } from 'cc.decorator';
+import { boolean, ccclass, editable, serializable } from 'cc.decorator';
 import { DEV, DEBUG, EDITOR } from 'internal:constants';
 import { Component } from '../components/component';
 import { property } from '../data/decorators/property';
@@ -163,6 +163,10 @@ export class BaseNode extends CCObject implements ISchedulable {
         return this._active;
     }
     set active (isActive: boolean) {
+        if (isActive === undefined) {
+            isActive = false;
+        }
+
         if (this._active !== isActive) {
             this._active = isActive;
             const parent = this._parent;

--- a/tests/core/node.test.ts
+++ b/tests/core/node.test.ts
@@ -46,4 +46,15 @@ describe(`Node`, () => {
         expect(cb).toBeCalledTimes(3);
         expect(cb1).toBeCalledTimes(2);
     });
+
+    test('active-undefined', () => {
+        let scene = new Scene('temp');
+        let node = new Node();
+        node.parent = scene;
+        node.active = true;
+        node.active = undefined;
+        expect(node.active).toBe(false);
+        node.active = true;
+        expect(node.active).toBe(true);
+    });
 });

--- a/tests/core/node.test.ts
+++ b/tests/core/node.test.ts
@@ -51,9 +51,20 @@ describe(`Node`, () => {
         let scene = new Scene('temp');
         let node = new Node();
         node.parent = scene;
+        
         node.active = true;
         node.active = undefined;
         expect(node.active).toBe(false);
+
+        node.active = true;
+        node.active = null;
+        expect(node.active).toBe(false);
+
+        // // @ts-expect-error
+        // node.active = '' as boolean;
+        // // @ts-expect-error
+        // node.active = 0 as boolean;
+
         node.active = true;
         expect(node.active).toBe(true);
     });

--- a/tests/core/node.test.ts
+++ b/tests/core/node.test.ts
@@ -60,10 +60,10 @@ describe(`Node`, () => {
         node.active = null;
         expect(node.active).toBe(false);
 
-        // // @ts-expect-error
-        // node.active = '' as boolean;
-        // // @ts-expect-error
-        // node.active = 0 as boolean;
+        // @ts-expect-error
+        node.active = '' as boolean;
+        // @ts-expect-error
+        node.active = 0 as boolean;
 
         node.active = true;
         expect(node.active).toBe(true);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#9397

Changelog:
 * 当node.active被设置为undefined时，会认为设置为false
 * 在node.test.ts里添加了单元测试，已跑通

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
