### PR TITLE
optimize screen adaption on Web platform

### DIFF
--- a/@types/pal/screen-adapter.d.ts
+++ b/@types/pal/screen-adapter.d.ts
@@ -11,9 +11,10 @@ declare module 'pal/screen-adapter' {
          * Init the callback to rebuild frame buffer when update the resolution.
          * This method will also init the resolution.
          * This method should be called when the engine director.root is initiated.
+         * @param configOrientation The orientation from the builder configuration
          * @param cbToRebuildFrameBuffer
          */
-        public init (cbToRebuildFrameBuffer: () => void);
+        public init (configOrientation: number, cbToRebuildFrameBuffer: () => void);
         /**
          * On web mobile platform, sometimes we need to rotate the game frame.
          * This field record the rotate state of game frame, which is false by default.

--- a/@types/pal/screen-adapter.d.ts
+++ b/@types/pal/screen-adapter.d.ts
@@ -6,6 +6,8 @@ declare module 'pal/screen-adapter' {
         right: number;
     }
 
+    export type ConfigOrientation = 'auto' | 'landscape' | 'portrait';
+
     class ScreenAdapter {
         /**
          * Init the callback to rebuild frame buffer when update the resolution.
@@ -14,7 +16,7 @@ declare module 'pal/screen-adapter' {
          * @param configOrientation The orientation from the builder configuration
          * @param cbToRebuildFrameBuffer
          */
-        public init (configOrientation: number, cbToRebuildFrameBuffer: () => void);
+        public init (configOrientation: ConfigOrientation, cbToRebuildFrameBuffer: () => void);
         /**
          * On web mobile platform, sometimes we need to rotate the game frame.
          * This field record the rotate state of game frame, which is false by default.

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -3053,6 +3053,14 @@ texture size exceeds current device limits %d/%d
 <!-- DEPRECATED -->
 cc.view.enableAntiAlias is deprecated, please use cc.Texture2D.setFilters instead
 
+### 9201
+
+Cannot access game frame.
+
+### 9202
+
+Setting window size is not supported.
+
 ### 9300
 
 The current buffer beyond the limit in ui static component, please reduce the amount

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -28,7 +28,7 @@
  * @module core
  */
 
-import { EDITOR, JSB, PREVIEW, RUNTIME_BASED, TEST } from 'internal:constants';
+import { EDITOR, HTML5, JSB, PREVIEW, RUNTIME_BASED, TEST } from 'internal:constants';
 import { systemInfo } from 'pal/system-info';
 import { IAssetManagerOptions } from './asset-manager/asset-manager';
 import { EventTarget } from './event';
@@ -49,7 +49,6 @@ import { Layers } from './scene-graph';
 import { log2 } from './math/bits';
 import { garbageCollectionManager } from './data/garbage-collection';
 import { screen } from './platform/screen';
-import { Size } from './math';
 
 interface ISceneInfo {
     url: string;
@@ -172,6 +171,12 @@ export interface IGameConfig {
         container: HTMLDivElement,
         [x: string]: any,
     };
+    
+    /**
+     * The orientation from the builder configuration.
+     * Available value can be 'auto', 'landscape', 'portrait'.
+     */
+    orientation?: number;
 }
 
 /**
@@ -548,6 +553,11 @@ export class Game extends EventTarget {
      */
     public init (config: IGameConfig) {
         this._initConfig(config);
+        // TODO: unify the screen initialization workflow.
+        if (HTML5) {
+            // @ts-expect-error access private method.
+            screen._init(config.orientation || 'auto');
+        }
         // Init assetManager
         if (this.config.assetOptions) {
             legacyCC.assetManager.init(this.config.assetOptions);
@@ -594,8 +604,10 @@ export class Game extends EventTarget {
         garbageCollectionManager.init();
 
         return Promise.resolve(initPromise).then(() => this._setRenderPipelineNShowSplash()).then(() => {
-            // @ts-expect-error access private method.
-            screen._init();
+            if (!HTML5) {
+                // @ts-expect-error access private method.
+                screen._init('auto');
+            }
         });
     }
 

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -171,7 +171,7 @@ export interface IGameConfig {
         container: HTMLDivElement,
         [x: string]: any,
     };
-    
+
     /**
      * The orientation from the builder configuration.
      * Available value can be 'auto', 'landscape', 'portrait'.

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -30,6 +30,7 @@
 
 import { EDITOR, HTML5, JSB, PREVIEW, RUNTIME_BASED, TEST } from 'internal:constants';
 import { systemInfo } from 'pal/system-info';
+import { ConfigOrientation } from 'pal/screen-adapter';
 import { IAssetManagerOptions } from './asset-manager/asset-manager';
 import { EventTarget } from './event';
 import { input } from '../input';
@@ -176,7 +177,7 @@ export interface IGameConfig {
      * The orientation from the builder configuration.
      * Available value can be 'auto', 'landscape', 'portrait'.
      */
-    orientation?: number;
+    orientation?: ConfigOrientation;
 }
 
 /**

--- a/cocos/core/platform/screen.ts
+++ b/cocos/core/platform/screen.ts
@@ -29,7 +29,7 @@
  * @module core
  */
 
-import { screenAdapter } from 'pal/screen-adapter';
+import { ConfigOrientation, screenAdapter } from 'pal/screen-adapter';
 import { legacyCC } from '../global-exports';
 import { Size, Vec2 } from '../math';
 import { warnID } from './debug';
@@ -39,7 +39,7 @@ import { warnID } from './debug';
  * @zh screen 单例对象提供简单的方法来做屏幕管理相关的工作。
  */
 class Screen {
-    private _init (configOrientation: number) {
+    private _init (configOrientation: ConfigOrientation) {
         screenAdapter.init(configOrientation, () => {
             const director = legacyCC.director;
             if (!director.root?.pipeline) {

--- a/cocos/core/platform/screen.ts
+++ b/cocos/core/platform/screen.ts
@@ -39,8 +39,8 @@ import { warnID } from './debug';
  * @zh screen 单例对象提供简单的方法来做屏幕管理相关的工作。
  */
 class Screen {
-    private _init () {
-        screenAdapter.init(() => {
+    private _init (configOrientation: number) {
+        screenAdapter.init(configOrientation, () => {
             const director = legacyCC.director;
             if (!director.root?.pipeline) {
                 warnID(1220);

--- a/cocos/core/platform/view.ts
+++ b/cocos/core/platform/view.ts
@@ -138,6 +138,7 @@ export class View extends EventTarget {
         // For now, the engine UI is adapted to resolution size, instead of window size.
         screenAdapter.on('window-resize', this._updateAdaptResult, this);
         screenAdapter.on('orientation-change', this._updateAdaptResult, this);
+        screenAdapter.on('fullscreen-change', this._updateAdaptResult, this);
     }
 
     /**

--- a/pal/screen-adapter/minigame/screen-adapter.ts
+++ b/pal/screen-adapter/minigame/screen-adapter.ts
@@ -129,7 +129,7 @@ class ScreenAdapter extends EventTarget {
         // TODO: onResize or onOrientationChange is not supported well
     }
 
-    public init (cbToRebuildFrameBuffer: () => void) {
+    public init (configOrientation: number, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
         this._updateResolution();
     }

--- a/pal/screen-adapter/minigame/screen-adapter.ts
+++ b/pal/screen-adapter/minigame/screen-adapter.ts
@@ -1,6 +1,6 @@
 import { ALIPAY, BAIDU, COCOSPLAY, RUNTIME_BASED, VIVO } from 'internal:constants';
 import { minigame } from 'pal/minigame';
-import { SafeAreaEdge } from 'pal/screen-adapter';
+import { ConfigOrientation, SafeAreaEdge } from 'pal/screen-adapter';
 import { systemInfo } from 'pal/system-info';
 import { warnID } from '../../../cocos/core/platform/debug';
 import { EventTarget } from '../../../cocos/core/event/event-target';
@@ -129,7 +129,7 @@ class ScreenAdapter extends EventTarget {
         // TODO: onResize or onOrientationChange is not supported well
     }
 
-    public init (configOrientation: number, cbToRebuildFrameBuffer: () => void) {
+    public init (configOrientation: ConfigOrientation, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
         this._updateResolution();
     }

--- a/pal/screen-adapter/native/screen-adapter.ts
+++ b/pal/screen-adapter/native/screen-adapter.ts
@@ -95,7 +95,7 @@ class ScreenAdapter extends EventTarget {
         this._registerEvent();
     }
 
-    public init (cbToRebuildFrameBuffer: () => void) {
+    public init (configOrientation: number, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
         this._updateResolution();
     }

--- a/pal/screen-adapter/native/screen-adapter.ts
+++ b/pal/screen-adapter/native/screen-adapter.ts
@@ -1,4 +1,4 @@
-import { SafeAreaEdge } from 'pal/screen-adapter';
+import { ConfigOrientation, SafeAreaEdge } from 'pal/screen-adapter';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { Size } from '../../../cocos/core/math';
 import { Orientation } from '../enum-type';
@@ -95,7 +95,7 @@ class ScreenAdapter extends EventTarget {
         this._registerEvent();
     }
 
-    public init (configOrientation: number, cbToRebuildFrameBuffer: () => void) {
+    public init (configOrientation: ConfigOrientation, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
         this._updateResolution();
     }

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -1,4 +1,4 @@
-import { EDITOR, TEST } from 'internal:constants';
+import { TEST } from 'internal:constants';
 import { SafeAreaEdge } from 'pal/screen-adapter';
 import { systemInfo } from 'pal/system-info';
 import { warnID } from '../../../cocos/core/platform/debug';
@@ -13,17 +13,17 @@ const orientationMap = {
 };
 
 /**
- * On Web platform, the game window may points to defferent type of window.
+ * On Web platform, the game window may points to different type of window.
  */
 enum WindowType {
     /**
-     * Uknown window type.
+     * Unknown window type.
      */
     Unknown,
     /**
      * A SubFrame in BrowserWindow.
      * Need to set the frame size from an external editor option.
-     * Should only dispatch 'resize' event when the frame size chanaged.
+     * Should only dispatch 'resize' event when the frame size changed.
      * Setting window size is supported.
      */
     SubFrame,

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -6,6 +6,7 @@ import { EventTarget } from '../../../cocos/core/event/event-target';
 import { Size } from '../../../cocos/core/math';
 import { Orientation } from '../enum-type';
 
+const EVENT_TIMEOUT = 200;
 const OrientationMap: {
     [key in ConfigOrientation]: Orientation;
 } = {
@@ -130,7 +131,6 @@ class ScreenAdapter extends EventTarget {
     private _onFullscreenChange?: () => void;
     private _onFullscreenError?: () => void;
     // We need to set timeout to handle screen event.
-    private readonly _EVENT_TIMEOUT = 200;
     private _resizeTimeoutId = -1;
     private _orientationChangeTimeoutId = -1;
     private _cachedFrameSize = new Size(0, 0); // cache before enter fullscreen.
@@ -323,7 +323,7 @@ class ScreenAdapter extends EventTarget {
                     this.emit('window-resize');
                 }
                 this._resizeTimeoutId = -1;
-            }, this._EVENT_TIMEOUT);
+            }, EVENT_TIMEOUT);
         });
         if (typeof window.matchMedia === 'function') {
             const updateDPRChangeListener = () => {
@@ -348,7 +348,7 @@ class ScreenAdapter extends EventTarget {
                 this._resizeFrame();
                 this.emit('orientation-change');
                 this._orientationChangeTimeoutId = -1;
-            }, this._EVENT_TIMEOUT);
+            }, EVENT_TIMEOUT);
         });
         document.addEventListener(this._fn.fullscreenchange, () => {
             this._onFullscreenChange?.();

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -410,7 +410,7 @@ class ScreenAdapter extends EventTarget {
     private _getFullscreenTarget () {
         const windowType = this._windowType;
         if (windowType === WindowType.Fullscreen) {
-            return document[this._fn.fullscreenElement];
+            return document[this._fn.fullscreenElement] as HTMLElement;
         }
         if (windowType === WindowType.SubFrame) {
             return this._gameFrame;

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -6,6 +6,12 @@ import { Size } from '../../../cocos/core/math';
 import { OS } from '../../system-info/enum-type';
 import { Orientation } from '../enum-type';
 
+const orientationMap = {
+    'auto': Orientation.AUTO,
+    'landscape': Orientation.LANDSCAPE,
+    'portrait': Orientation.PORTRAIT,
+};
+
 interface IScreenFunctionName {
     requestFullscreen: string,
     exitFullscreen: string,
@@ -207,9 +213,10 @@ class ScreenAdapter extends EventTarget {
         this._registerEvent();
     }
 
-    public init (cbToRebuildFrameBuffer: () => void) {
+    public init (configOrientation: number, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
         this._resizeFrame(this._windowSizeInCssPixels);
+        this.orientation = orientationMap[configOrientation];
     }
 
     public requestFullScreen (): Promise<void> {

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -1,12 +1,14 @@
 import { TEST } from 'internal:constants';
-import { SafeAreaEdge } from 'pal/screen-adapter';
+import { ConfigOrientation, SafeAreaEdge } from 'pal/screen-adapter';
 import { systemInfo } from 'pal/system-info';
 import { warnID } from '../../../cocos/core/platform/debug';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import { Size } from '../../../cocos/core/math';
 import { Orientation } from '../enum-type';
 
-const orientationMap = {
+const OrientationMap: {
+    [key in ConfigOrientation]: Orientation;
+} = {
     auto: Orientation.AUTO,
     landscape: Orientation.LANDSCAPE,
     portrait: Orientation.PORTRAIT,
@@ -259,9 +261,9 @@ class ScreenAdapter extends EventTarget {
         this._registerEvent();
     }
 
-    public init (configOrientation: number, cbToRebuildFrameBuffer: () => void) {
+    public init (configOrientation: ConfigOrientation, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
-        this.orientation = orientationMap[configOrientation];
+        this.orientation = OrientationMap[configOrientation];
         this._resizeFrame();
     }
 

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -7,9 +7,9 @@ import { Size } from '../../../cocos/core/math';
 import { Orientation } from '../enum-type';
 
 const orientationMap = {
-    'auto': Orientation.AUTO,
-    'landscape': Orientation.LANDSCAPE,
-    'portrait': Orientation.PORTRAIT,
+    auto: Orientation.AUTO,
+    landscape: Orientation.LANDSCAPE,
+    portrait: Orientation.PORTRAIT,
 };
 
 /**
@@ -180,24 +180,28 @@ class ScreenAdapter extends EventTarget {
         if (TEST) {
             return new Size(window.innerWidth, window.innerHeight);
         }
+        let fullscreenTarget;
+        let width: number;
+        let height: number;
         switch (this._windowType) {
-            case WindowType.SubFrame:
-                if (!this._gameFrame) {
-                    warnID(9201);
-                    return new Size(0, 0);
-                }
-                return new Size(this._gameFrame.clientWidth, this._gameFrame.clientHeight);
-            case WindowType.Fullscreen:
-                const fullscreenTarget = this._getFullscreenTarget()!;
-                const fullscreenTargetWidth = this.isFrameRotated ? fullscreenTarget.clientHeight : fullscreenTarget.clientWidth;
-                const fullscreenTargetHeight = this.isFrameRotated ? fullscreenTarget.clientWidth : fullscreenTarget.clientHeight;
-                return new Size(fullscreenTargetWidth, fullscreenTargetHeight);
-            case WindowType.BrowserWindow:
-                const winWidth = this.isFrameRotated ? window.innerHeight : window.innerWidth;
-                const winHeight = this.isFrameRotated ? window.innerWidth : window.innerHeight; 
-                return new Size(winWidth, winHeight);
-            case WindowType.Unknown:
+        case WindowType.SubFrame:
+            if (!this._gameFrame) {
+                warnID(9201);
                 return new Size(0, 0);
+            }
+            return new Size(this._gameFrame.clientWidth, this._gameFrame.clientHeight);
+        case WindowType.Fullscreen:
+            fullscreenTarget = this._getFullscreenTarget()!;
+            width = this.isFrameRotated ? fullscreenTarget.clientHeight : fullscreenTarget.clientWidth;
+            height = this.isFrameRotated ? fullscreenTarget.clientWidth : fullscreenTarget.clientHeight;
+            return new Size(width, height);
+        case WindowType.BrowserWindow:
+            width = this.isFrameRotated ? window.innerHeight : window.innerWidth;
+            height = this.isFrameRotated ? window.innerWidth : window.innerHeight;
+            return new Size(width, height);
+        case WindowType.Unknown:
+        default:
+            return new Size(0, 0);
         }
     }
     private get _windowType (): WindowType {
@@ -208,7 +212,8 @@ class ScreenAdapter extends EventTarget {
             warnID(9201);
             return WindowType.Unknown;
         }
-        if (this._gameFrame.attributes['cc_exact_fit_screen']?.value === 'true') {
+        // @ts-expect-error Property 'cc_exact_fit_screen' does not exist on type 'NamedNodeMap'.
+        if (this._gameFrame.attributes.cc_exact_fit_screen?.value === 'true') {
             // Note: It doesn't work well to determine whether the frame exact fits the screen.
             // Need to specify the attribute from Editor.
             return WindowType.BrowserWindow;
@@ -216,8 +221,8 @@ class ScreenAdapter extends EventTarget {
             // A fallback case when the 'cc_exact_fit_screen' attribute is not specified.
             const body = document.body;
             const frame = this._gameFrame;
-            const bodyWidth = body.clientWidth, bodyHeight = body.clientHeight;
-            const frameWidth = frame.clientWidth, frameHeight = frame.clientHeight;
+            const bodyWidth = body.clientWidth; const bodyHeight = body.clientHeight;
+            const frameWidth = frame.clientWidth; const frameHeight = frame.clientHeight;
             if ((bodyWidth === frameWidth && bodyHeight === frameHeight)
                 || (this.isFrameRotated && bodyWidth === frameHeight && bodyHeight === frameWidth)) {
                 return WindowType.BrowserWindow;
@@ -371,7 +376,7 @@ class ScreenAdapter extends EventTarget {
             this._gameFrame.style.width = `${sizeInCssPixels.width}px`;
             this._gameFrame.style.height = `${sizeInCssPixels.height}px`;
         } else {
-            const winWidth = window.innerWidth, winHeight = window.innerHeight;
+            const winWidth = window.innerWidth; const winHeight = window.innerHeight;
             if (this.isFrameRotated) {
                 this._gameFrame.style['-webkit-transform'] = 'rotate(90deg)';
                 this._gameFrame.style.transform = 'rotate(90deg)';
@@ -390,7 +395,7 @@ class ScreenAdapter extends EventTarget {
                 this._gameFrame.style.width = `${winWidth}px`;
                 this._gameFrame.style.height = `${winHeight}px`;
             }
-        }  
+        }
     }
 
     private _updateResolution () {
@@ -441,8 +446,8 @@ class ScreenAdapter extends EventTarget {
         const width = window.innerWidth;
         const height = window.innerHeight;
         const isBrowserLandscape = width > height;
-        this.isFrameRotated = systemInfo.isMobile && 
-            ((isBrowserLandscape && orientation === Orientation.PORTRAIT) || (!isBrowserLandscape && orientation === Orientation.LANDSCAPE));
+        this.isFrameRotated = systemInfo.isMobile
+            && ((isBrowserLandscape && orientation === Orientation.PORTRAIT) || (!isBrowserLandscape && orientation === Orientation.LANDSCAPE));
     }
 }
 

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -7,9 +7,7 @@ import { Size } from '../../../cocos/core/math';
 import { Orientation } from '../enum-type';
 
 const EVENT_TIMEOUT = 200;
-const OrientationMap: {
-    [key in ConfigOrientation]: Orientation;
-} = {
+const orientationMap: Record<ConfigOrientation, Orientation> = {
     auto: Orientation.AUTO,
     landscape: Orientation.LANDSCAPE,
     portrait: Orientation.PORTRAIT,
@@ -263,7 +261,7 @@ class ScreenAdapter extends EventTarget {
 
     public init (configOrientation: ConfigOrientation, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
-        this.orientation = OrientationMap[configOrientation];
+        this.orientation = orientationMap[configOrientation];
         this._resizeFrame();
     }
 


### PR DESCRIPTION
相关 pr: 
https://github.com/cocos-creator/test-cases-3d/pull/534
https://github.com/cocos-creator/editor-3d/pull/6268

Changelog:
 * 优化 screen.init 的流程，这个改动只影响 web 端
 * 在 Web 端的 screen-adapter 里支持 WindowType https://github.com/cocos-creator/3d-tasks/issues/9641
 * 优化全屏的适配 https://github.com/cocos-creator/3d-tasks/issues/9619
 * 优化屏幕方向适配  https://github.com/cocos-creator/3d-tasks/issues/9642
 * 延迟屏幕事件的处理 （因为很多时候屏幕变动之后，DOM 的数据没那么快同步）

测试平台：
- [x] WebDesktop
- [x] WebMobile
- [x] Preview Mobile
- [x] Preview PC

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
