### PR TITLE
webgl: fix instance count predicate

### DIFF
--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -2511,7 +2511,7 @@ export function WebGLCmdFuncDraw (device: WebGLDevice, drawInfo: Readonly<DrawIn
                     }
                 } else {
                     for (let j = 0; j < indirects.drawCount; j++) {
-                        if (indirects.instances[j] > 1 && ia) {
+                        if (indirects.instances[j] && ia) {
                             ia.drawElementsInstancedANGLE(glPrimitive, indirects.counts[j],
                                 gpuInputAssembler.glIndexType, indirects.byteOffsets[j], indirects.instances[j]);
                         } else {
@@ -2534,14 +2534,14 @@ export function WebGLCmdFuncDraw (device: WebGLDevice, drawInfo: Readonly<DrawIn
                 }
             } else {
                 for (let j = 0; j < indirects.drawCount; j++) {
-                    if (indirects.instances[j] > 1 && ia) {
+                    if (indirects.instances[j] && ia) {
                         ia.drawArraysInstancedANGLE(glPrimitive, indirects.offsets[j], indirects.counts[j], indirects.instances[j]);
                     } else {
                         gl.drawArrays(glPrimitive, indirects.offsets[j], indirects.counts[j]);
                     }
                 }
             }
-        } else if (drawInfo.instanceCount > 1 && ia) {
+        } else if (drawInfo.instanceCount && ia) {
             if (indexBuffer) {
                 if (drawInfo.indexCount > 0) {
                     const offset = drawInfo.firstIndex * indexBuffer.stride;

--- a/cocos/core/gfx/webgl/webgl-gpu-objects.ts
+++ b/cocos/core/gfx/webgl/webgl-gpu-objects.ts
@@ -61,7 +61,7 @@ export class WebGLIndirectDrawInfos {
     public setDrawInfo (idx: number, info: DrawInfo) {
         this._ensureCapacity(idx);
         this.drawByIndex = info.indexCount > 0;
-        this.instancedDraw = info.instanceCount > 1;
+        this.instancedDraw = !!info.instanceCount;
         this.drawCount = Math.max(idx + 1, this.drawCount);
 
         if (this.drawByIndex) {

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -2436,7 +2436,7 @@ export function WebGL2CmdFuncDraw (device: WebGL2Device, drawInfo: DrawInfo) {
                     }
                 } else {
                     for (let j = 0; j < indirects.drawCount; j++) {
-                        if (indirects.instances[j] > 1) {
+                        if (indirects.instances[j]) {
                             gl.drawElementsInstanced(glPrimitive, indirects.counts[j],
                                 gpuInputAssembler.glIndexType, indirects.byteOffsets[j], indirects.instances[j]);
                         } else {
@@ -2459,7 +2459,7 @@ export function WebGL2CmdFuncDraw (device: WebGL2Device, drawInfo: DrawInfo) {
                 }
             } else {
                 for (let j = 0; j < indirects.drawCount; j++) {
-                    if (indirects.instances[j] > 1) {
+                    if (indirects.instances[j]) {
                         gl.drawArraysInstanced(glPrimitive, indirects.offsets[j], indirects.counts[j], indirects.instances[j]);
                     } else {
                         gl.drawArrays(glPrimitive, indirects.offsets[j], indirects.counts[j]);

--- a/cocos/core/gfx/webgl2/webgl2-gpu-objects.ts
+++ b/cocos/core/gfx/webgl2/webgl2-gpu-objects.ts
@@ -60,7 +60,7 @@ export class WebGL2IndirectDrawInfos {
     public setDrawInfo (idx: number, info: DrawInfo) {
         this._ensureCapacity(idx);
         this.drawByIndex = info.indexCount > 0;
-        this.instancedDraw = info.instanceCount > 1;
+        this.instancedDraw = !!info.instanceCount;
         this.drawCount = Math.max(idx + 1, this.drawCount);
 
         if (this.drawByIndex) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#9663

Changelog:
 * should use instance draw when instance count >= 1

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->