### PR TITLE
pass owns instanced/batched buffer

### DIFF
--- a/cocos/core/pipeline/batched-buffer.ts
+++ b/cocos/core/pipeline/batched-buffer.ts
@@ -52,15 +52,6 @@ export interface IBatchedItem {
 }
 
 export class BatchedBuffer {
-    private static _buffers = new Map<Pass, Record<number, BatchedBuffer>>();
-
-    public static get (pass: Pass, extraKey = 0) {
-        const buffers = BatchedBuffer._buffers;
-        if (!buffers.has(pass)) buffers.set(pass, {});
-        const record = buffers.get(pass)!;
-        return record[extraKey] || (record[extraKey] = new BatchedBuffer(pass));
-    }
-
     public batches: IBatchedItem[] = [];
     public dynamicOffsets: number[] = [];
     private _device: Device;

--- a/cocos/core/pipeline/deferred/gbuffer-stage.ts
+++ b/cocos/core/pipeline/deferred/gbuffer-stage.ts
@@ -114,7 +114,7 @@ export class GbufferStage extends RenderStage {
         this._renderQueues.forEach(renderQueueClearFunc);
 
         this._renderArea = pipeline.generateRenderArea(camera);
-        pipeline.updateQuadVertexData(this._renderArea, camera.window!);
+        pipeline.updateQuadVertexData(this._renderArea, camera.window);
 
         const renderObjects = pipeline.pipelineSceneData.renderObjects;
 
@@ -130,11 +130,11 @@ export class GbufferStage extends RenderStage {
                     if (pass.phase !== this._phaseID) continue;
                     const batchingScheme = pass.batchingScheme;
                     if (batchingScheme === BatchingSchemes.INSTANCING) {
-                        const instancedBuffer = InstancedBuffer.get(pass);
+                        const instancedBuffer = pass.getInstancedBuffer();
                         instancedBuffer.merge(subModel, ro.model.instancedAttributes, p);
                         this._instancedQueue.queue.add(instancedBuffer);
                     } else if (batchingScheme === BatchingSchemes.VB_MERGING) {
-                        const batchedBuffer = BatchedBuffer.get(pass);
+                        const batchedBuffer = pass.getBatchedBuffer();
                         batchedBuffer.merge(subModel, p, ro.model);
                         this._batchedQueue.queue.add(batchedBuffer);
                     } else {

--- a/cocos/core/pipeline/forward/forward-stage.ts
+++ b/cocos/core/pipeline/forward/forward-stage.ts
@@ -139,11 +139,11 @@ export class ForwardStage extends RenderStage {
                     if (pass.phase !== this._phaseID) continue;
                     const batchingScheme = pass.batchingScheme;
                     if (batchingScheme === BatchingSchemes.INSTANCING) {
-                        const instancedBuffer = InstancedBuffer.get(pass);
+                        const instancedBuffer = pass.getInstancedBuffer();
                         instancedBuffer.merge(subModel, ro.model.instancedAttributes, p);
                         this._instancedQueue.queue.add(instancedBuffer);
                     } else if (batchingScheme === BatchingSchemes.VB_MERGING) {
-                        const batchedBuffer = BatchedBuffer.get(pass);
+                        const batchedBuffer = pass.getBatchedBuffer();
                         batchedBuffer.merge(subModel, p, ro.model);
                         this._batchedQueue.queue.add(batchedBuffer);
                     } else {
@@ -166,7 +166,7 @@ export class ForwardStage extends RenderStage {
         this._planarQueue.gatherShadowPasses(camera, cmdBuff);
         const sceneData = pipeline.pipelineSceneData;
         this._renderArea = pipeline.generateRenderArea(camera);
-        pipeline.updateQuadVertexData(this._renderArea, camera.window!);
+        pipeline.updateQuadVertexData(this._renderArea, camera.window);
         if (camera.clearFlag & ClearFlagBit.COLOR) {
             colors[0].x = camera.clearColor.x;
             colors[0].y = camera.clearColor.y;
@@ -175,8 +175,8 @@ export class ForwardStage extends RenderStage {
 
         colors[0].w = camera.clearColor.w;
 
-        const swapchain = camera.window!.swapchain;
-        let framebuffer = camera.window!.framebuffer;
+        const swapchain = camera.window.swapchain;
+        let framebuffer = camera.window.framebuffer;
         let renderPass = framebuffer.renderPass;
         if (swapchain) {
             renderPass = pipeline.getRenderPass(camera.clearFlag & this._clearFlag, swapchain);

--- a/cocos/core/pipeline/instanced-buffer.ts
+++ b/cocos/core/pipeline/instanced-buffer.ts
@@ -50,15 +50,6 @@ const INITIAL_CAPACITY = 32;
 const MAX_CAPACITY = 1024;
 
 export class InstancedBuffer {
-    private static _buffers = new Map<Pass, Record<number, InstancedBuffer>>();
-
-    public static get (pass: Pass, extraKey = 0) {
-        const buffers = InstancedBuffer._buffers;
-        if (!buffers.has(pass)) buffers.set(pass, {});
-        const record = buffers.get(pass)!;
-        return record[extraKey] || (record[extraKey] = new InstancedBuffer(pass));
-    }
-
     public instances: IInstancedItem[] = [];
     public pass: Pass;
     public hasPendingModels = false;

--- a/cocos/core/pipeline/planar-shadow-queue.ts
+++ b/cocos/core/pipeline/planar-shadow-queue.ts
@@ -67,7 +67,7 @@ export class PlanarShadowQueue {
             const model = models[i];
             if (model.enabled && model.node && model.castShadow) { this._castModels.push(model); }
         }
-        const instancedBuffer = InstancedBuffer.get(shadows.instancingMaterial.passes[0]);
+        const instancedBuffer = shadows.instancingMaterial.passes[0].getInstancedBuffer();
         this._instancedQueue.queue.add(instancedBuffer);
 
         for (let i = 0; i < this._castModels.length; i++) {

--- a/cocos/core/pipeline/render-additive-light-queue.ts
+++ b/cocos/core/pipeline/render-additive-light-queue.ts
@@ -292,7 +292,7 @@ export class RenderAdditiveLightQueue {
         if (batchingScheme === BatchingSchemes.INSTANCING) {            // instancing
             for (let l = 0; l < _lightIndices.length; l++) {
                 const idx = _lightIndices[l];
-                const buffer = InstancedBuffer.get(pass, idx);
+                const buffer = pass.getInstancedBuffer(idx);
                 buffer.merge(subModel, model.instancedAttributes, lightPassIdx);
                 buffer.dynamicOffsets[0] = this._lightBufferStride * idx;
                 this._instancedQueue.queue.add(buffer);
@@ -300,7 +300,7 @@ export class RenderAdditiveLightQueue {
         } else if (batchingScheme === BatchingSchemes.VB_MERGING) {     // vb-merging
             for (let l = 0; l < _lightIndices.length; l++) {
                 const idx = _lightIndices[l];
-                const buffer = BatchedBuffer.get(pass, idx);
+                const buffer = pass.getBatchedBuffer(idx);
                 buffer.merge(subModel, lightPassIdx, model);
                 buffer.dynamicOffsets[0] = this._lightBufferStride * idx;
                 this._batchedQueue.queue.add(buffer);

--- a/cocos/core/pipeline/render-shadow-map-batched-queue.ts
+++ b/cocos/core/pipeline/render-shadow-map-batched-queue.ts
@@ -150,11 +150,11 @@ export class RenderShadowMapBatchedQueue {
             const batchingScheme = pass.batchingScheme;
 
             if (batchingScheme === BatchingSchemes.INSTANCING) {            // instancing
-                const buffer = InstancedBuffer.get(pass);
+                const buffer = pass.getInstancedBuffer();
                 buffer.merge(subModel, model.instancedAttributes, shadowPassIdx);
                 this._instancedQueue.queue.add(buffer);
             } else if (pass.batchingScheme === BatchingSchemes.VB_MERGING) { // vb-merging
-                const buffer = BatchedBuffer.get(pass);
+                const buffer = pass.getBatchedBuffer();
                 buffer.merge(subModel, shadowPassIdx, model);
                 this._batchedQueue.queue.add(buffer);
             } else {

--- a/cocos/core/renderer/scene/model.ts
+++ b/cocos/core/renderer/scene/model.ts
@@ -567,7 +567,7 @@ export class Model {
             attrs.views.push(typeViewArray);
             offset += info.size;
         }
-        if (pass.batchingScheme === BatchingSchemes.INSTANCING) { InstancedBuffer.get(pass).destroy(); } // instancing IA changed
+        if (pass.batchingScheme === BatchingSchemes.INSTANCING) { pass.getInstancedBuffer().destroy(); } // instancing IA changed
         this._setInstMatWorldIdx(this._getInstancedAttributeIndex(INST_MAT_WORLD));
         this._localDataUpdated = true;
 

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -639,10 +639,10 @@ export default class TrailModule {
         const indexBuffer = device.createBuffer(new BufferInfo(
             BufferUsageBit.INDEX | BufferUsageBit.TRANSFER_DST,
             MemoryUsageBit.HOST | MemoryUsageBit.DEVICE,
-            this._trailNum * 6 * Uint16Array.BYTES_PER_ELEMENT,
+            Math.max(1, this._trailNum) * 6 * Uint16Array.BYTES_PER_ELEMENT,
             Uint16Array.BYTES_PER_ELEMENT,
         ));
-        this._iBuffer = new Uint16Array(this._trailNum * 6);
+        this._iBuffer = new Uint16Array(Math.max(1, this._trailNum) * 6);
         indexBuffer.update(this._iBuffer);
 
         this._iaInfoBuffer = device.createBuffer(new BufferInfo(

--- a/editor/assets/default_file_content/effect
+++ b/editor/assets/default_file_content/effect
@@ -29,6 +29,8 @@ CCProgram unlit-fs %{
   #include <cc-fog-fs>
 
   in vec2 v_uv;
+  in vec3 v_position;
+
   uniform sampler2D mainTexture;
 
   uniform Constant {

--- a/editor/assets/primitives.fbx.meta
+++ b/editor/assets/primitives.fbx.meta
@@ -1,9 +1,11 @@
 {
-  "ver": "2.1.8",
+  "ver": "2.1.9",
   "importer": "fbx",
   "imported": true,
   "uuid": "1263d74c-8167-4928-91a6-4e2672411f47",
-  "files": [],
+  "files": [
+    "__original-animation-0.cconb"
+  ],
   "subMetas": {
     "17020": {
       "importer": "gltf-mesh",
@@ -141,6 +143,29 @@
         "gltfIndex": 7
       }
     },
+    "73b7f": {
+      "importer": "gltf-animation",
+      "uuid": "1263d74c-8167-4928-91a6-4e2672411f47@73b7f",
+      "displayName": "",
+      "id": "73b7f",
+      "name": "Take 001.animation",
+      "userData": {
+        "gltfIndex": 0,
+        "wrapMode": 2,
+        "sample": 30,
+        "span": {
+          "from": 0,
+          "to": 3.3333332538604736
+        },
+        "events": []
+      },
+      "ver": "1.0.16",
+      "imported": true,
+      "files": [
+        ".cconb"
+      ],
+      "subMetas": {}
+    },
     "aae0f": {
       "importer": "gltf-scene",
       "uuid": "1263d74c-8167-4928-91a6-4e2672411f47@aae0f",
@@ -197,6 +222,21 @@
     "tangents": 2,
     "imageMetas": [],
     "legacyFbxImporter": false,
+    "animationImportSettings": [
+      {
+        "name": "Take 001",
+        "duration": 3.3333332538604736,
+        "fps": 30,
+        "splits": [
+          {
+            "name": "Take 001",
+            "from": 0,
+            "to": 3.3333332538604736,
+            "wrapMode": 2
+          }
+        ]
+      }
+    ],
     "fbx": {
       "preferLocalTimeSpan": false
     }

--- a/editor/assets/primitives.fbx.meta
+++ b/editor/assets/primitives.fbx.meta
@@ -1,11 +1,9 @@
 {
-  "ver": "2.1.9",
+  "ver": "2.1.8",
   "importer": "fbx",
   "imported": true,
   "uuid": "1263d74c-8167-4928-91a6-4e2672411f47",
-  "files": [
-    "__original-animation-0.cconb"
-  ],
+  "files": [],
   "subMetas": {
     "17020": {
       "importer": "gltf-mesh",
@@ -143,29 +141,6 @@
         "gltfIndex": 7
       }
     },
-    "73b7f": {
-      "importer": "gltf-animation",
-      "uuid": "1263d74c-8167-4928-91a6-4e2672411f47@73b7f",
-      "displayName": "",
-      "id": "73b7f",
-      "name": "Take 001.animation",
-      "userData": {
-        "gltfIndex": 0,
-        "wrapMode": 2,
-        "sample": 30,
-        "span": {
-          "from": 0,
-          "to": 3.3333332538604736
-        },
-        "events": []
-      },
-      "ver": "1.0.16",
-      "imported": true,
-      "files": [
-        ".cconb"
-      ],
-      "subMetas": {}
-    },
     "aae0f": {
       "importer": "gltf-scene",
       "uuid": "1263d74c-8167-4928-91a6-4e2672411f47@aae0f",
@@ -222,21 +197,6 @@
     "tangents": 2,
     "imageMetas": [],
     "legacyFbxImporter": false,
-    "animationImportSettings": [
-      {
-        "name": "Take 001",
-        "duration": 3.3333332538604736,
-        "fps": 30,
-        "splits": [
-          {
-            "name": "Take 001",
-            "from": 0,
-            "to": 3.3333332538604736,
-            "wrapMode": 2
-          }
-        ]
-      }
-    ],
     "fbx": {
       "preferLocalTimeSpan": false
     }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#9793

https://github.com/cocos-creator/3d-tasks/issues/9885

https://github.com/cocos-creator/engine/issues/9497

Changelog:
 * pass now owns instanced/batched buffers

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->