### PR TITLE
[temp hack] use simple flag to pause splashScreen

### DIFF
--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -210,6 +210,7 @@ export class Director extends EventTarget {
     private _totalFrames: number;
     private _scheduler: Scheduler;
     private _systems: System[];
+
     constructor () {
         super();
 
@@ -235,7 +236,7 @@ export class Director extends EventTarget {
         this._nodeActivator = new NodeActivator();
 
         this._systems = [];
-        
+
         game.once(Game.EVENT_RENDERER_INITED, this._initOnRendererInitialized, this);
     }
 

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -210,7 +210,7 @@ export class Director extends EventTarget {
     private _totalFrames: number;
     private _scheduler: Scheduler;
     private _systems: System[];
-
+    private _needRender: boolean;
     constructor () {
         super();
 
@@ -218,6 +218,8 @@ export class Director extends EventTarget {
         // paused?
         this._paused = false;
 
+        //Need Render in tick loop
+        this._needRender = true;
         // root
         this._root = null;
 
@@ -236,7 +238,7 @@ export class Director extends EventTarget {
         this._nodeActivator = new NodeActivator();
 
         this._systems = [];
-
+        
         game.once(Game.EVENT_RENDERER_INITED, this._initOnRendererInitialized, this);
     }
 
@@ -656,7 +658,12 @@ export class Director extends EventTarget {
     public stopAnimation () {
         this._invalid = true;
     }
-
+    public pauseRender () {
+        this._needRender = false;
+    }
+    public resumeRender () {
+        this._needRender = true;
+    }
     /**
      * @en Run main loop of director
      * @zh 运行主循环
@@ -709,7 +716,8 @@ export class Director extends EventTarget {
             }
 
             this.emit(Director.EVENT_BEFORE_DRAW);
-            this._root!.frameMove(dt);
+            if(this._needRender)
+                this._root!.frameMove(dt);
             this.emit(Director.EVENT_AFTER_DRAW);
 
             Node.resetHasChangedFlags();

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -210,7 +210,6 @@ export class Director extends EventTarget {
     private _totalFrames: number;
     private _scheduler: Scheduler;
     private _systems: System[];
-    private _needRender: boolean;
     constructor () {
         super();
 
@@ -218,8 +217,6 @@ export class Director extends EventTarget {
         // paused?
         this._paused = false;
 
-        //Need Render in tick loop
-        this._needRender = true;
         // root
         this._root = null;
 
@@ -658,12 +655,7 @@ export class Director extends EventTarget {
     public stopAnimation () {
         this._invalid = true;
     }
-    public pauseRender () {
-        this._needRender = false;
-    }
-    public resumeRender () {
-        this._needRender = true;
-    }
+
     /**
      * @en Run main loop of director
      * @zh 运行主循环
@@ -716,8 +708,7 @@ export class Director extends EventTarget {
             }
 
             this.emit(Director.EVENT_BEFORE_DRAW);
-            if(this._needRender)
-                this._root!.frameMove(dt);
+            this._root!.frameMove(dt);
             this.emit(Director.EVENT_AFTER_DRAW);
 
             Node.resetHasChangedFlags();

--- a/cocos/core/splash-screen.ts
+++ b/cocos/core/splash-screen.ts
@@ -98,11 +98,11 @@ export class SplashScreen {
     private watermarkMat!: Material;
     private watermarkTexture!: Texture;
 
-    public pause(){
+    public pauseRendering(){
         this.isPause = true;
     }
 
-    public resume(){
+    public resumeRendering(){
         this.isPause = false;
     }
 

--- a/cocos/core/splash-screen.ts
+++ b/cocos/core/splash-screen.ts
@@ -73,7 +73,7 @@ export class SplashScreen {
     private callBack: (() => void) | null = null;
     private cancelAnimate = false;
     private startTime = -1;
-    private needRender = true;
+    private isPause = false;
     private _splashFinish = false;
     private _loadFinish = false;
     private _directCall = false;
@@ -98,12 +98,12 @@ export class SplashScreen {
     private watermarkMat!: Material;
     private watermarkTexture!: Texture;
 
-    public pauseRender(){
-        this.needRender = false;
+    public pause(){
+        this.isPause = true;
     }
 
-    public resumeRender(){
-        this.needRender = true;
+    public resume(){
+        this.isPause = false;
     }
 
     public main (root: Root) {
@@ -275,9 +275,10 @@ export class SplashScreen {
                 this.watermarkMat.setProperty('u_projection', this.projection);
                 this.watermarkMat.passes[0].update();
             }
-            if(this.needRender)
+            if(!this.isPause){
                 this.frame();
-            if (elapsedTime > settings.totalTime) this.splashFinish = true;
+                if (elapsedTime > settings.totalTime) this.splashFinish = true;
+            }
             requestAnimationFrame(animate);
         };
         legacyCC.game.pause();

--- a/cocos/core/splash-screen.ts
+++ b/cocos/core/splash-screen.ts
@@ -73,6 +73,7 @@ export class SplashScreen {
     private callBack: (() => void) | null = null;
     private cancelAnimate = false;
     private startTime = -1;
+    private needRender = true;
     private _splashFinish = false;
     private _loadFinish = false;
     private _directCall = false;
@@ -96,6 +97,14 @@ export class SplashScreen {
 
     private watermarkMat!: Material;
     private watermarkTexture!: Texture;
+
+    public pauseRender(){
+        this.needRender = false;
+    }
+
+    public resumeRender(){
+        this.needRender = true;
+    }
 
     public main (root: Root) {
         if (root == null) {
@@ -266,8 +275,8 @@ export class SplashScreen {
                 this.watermarkMat.setProperty('u_projection', this.projection);
                 this.watermarkMat.passes[0].update();
             }
-
-            this.frame();
+            if(this.needRender)
+                this.frame();
             if (elapsedTime > settings.totalTime) this.splashFinish = true;
             requestAnimationFrame(animate);
         };

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -95,11 +95,11 @@ class SystemInfo extends EventTarget {
     private _registerEvent () {
         jsb.onPause = () => {
             this.emit('hide');
-            legacyCC.internal.SplashScreen.instance.pause();
+            legacyCC.internal.SplashScreen.instance.pauseRendering();
         };
         jsb.onResume = () => {
             this.emit('show');
-            legacyCC.internal.SplashScreen.instance.resume();
+            legacyCC.internal.SplashScreen.instance.resumeRendering();
         };
         jsb.onClose = () => {
             this.emit('close');

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -1,5 +1,8 @@
 import { IFeatureMap } from 'pal/system-info';
+import { Director } from '../../../cocos/core';
 import { EventTarget } from '../../../cocos/core/event';
+import { SplashScreen } from '../../../cocos/core/splash-screen';
+import legacyCC from '../../../predefine';
 import { BrowserType, NetworkType, OS, Platform, Language, Feature } from '../enum-type';
 
 const networkTypeMap: Record<string, NetworkType> = {
@@ -93,9 +96,13 @@ class SystemInfo extends EventTarget {
     private _registerEvent () {
         jsb.onPause = () => {
             this.emit('hide');
+            legacyCC.director.pauseRender();
+            legacyCC.internal.SplashScreen.instance.pauseRender();
         };
         jsb.onResume = () => {
             this.emit('show');
+            legacyCC.director.resumeRender();
+            legacyCC.internal.SplashScreen.instance.resumeRender();
         };
         jsb.onClose = () => {
             this.emit('close');

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -96,13 +96,11 @@ class SystemInfo extends EventTarget {
     private _registerEvent () {
         jsb.onPause = () => {
             this.emit('hide');
-            legacyCC.director.pauseRender();
-            legacyCC.internal.SplashScreen.instance.pauseRender();
+            legacyCC.internal.SplashScreen.instance.pause();
         };
         jsb.onResume = () => {
             this.emit('show');
-            legacyCC.director.resumeRender();
-            legacyCC.internal.SplashScreen.instance.resumeRender();
+            legacyCC.internal.SplashScreen.instance.resume();
         };
         jsb.onClose = () => {
             this.emit('close');

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -1,5 +1,4 @@
 import { IFeatureMap } from 'pal/system-info';
-import { Director } from '../../../cocos/core';
 import { EventTarget } from '../../../cocos/core/event';
 import { SplashScreen } from '../../../cocos/core/splash-screen';
 import legacyCC from '../../../predefine';


### PR DESCRIPTION
Build with
* https://github.com/cocos-creator/engine-native/pull/4008 
To support windows platform if window goes to background, and the surface should be destroyed, while the render frame should pause.

Just a temp solution