### PR TITLE
Triggers should be only reset when a motion state arrived

### DIFF
--- a/cocos/core/animation/marionette/graph-eval.ts
+++ b/cocos/core/animation/marionette/graph-eval.ts
@@ -858,10 +858,6 @@ class LayerEval {
     }
 
     private _resetTriggersOnTransition (transition: TransitionEval) {
-        if (transition.to.kind === NodeKind.exit) {
-            // Exit transition(transitions whose target is exit)
-            return;
-        }
         const { triggers } = transition;
         if (triggers) {
             const nTriggers = triggers.length;

--- a/cocos/core/animation/marionette/graph-eval.ts
+++ b/cocos/core/animation/marionette/graph-eval.ts
@@ -728,16 +728,26 @@ class LayerEval {
     private _consumeTransition (transition: TransitionEval) {
         const { to } = transition;
 
-        // Reset triggers
-        this._resetTriggersOnTransition(transition);
-
         if (to.kind === NodeKind.entry) {
             // We're entering a state machine
             this._callEnterMethods(to);
         }
     }
 
+    private _resetTriggersAlongThePath () {
+        const { _currentTransitionPath: currentTransitionPath } = this;
+
+        const nTransitions = currentTransitionPath.length;
+        for (let iTransition = 0; iTransition < nTransitions; ++iTransition) {
+            const transition = currentTransitionPath[iTransition];
+            this._resetTriggersOnTransition(transition);
+        }
+    }
+
     private _doTransitionToMotion (targetNode: MotionStateEval) {
+        // Reset triggers
+        this._resetTriggersAlongThePath();
+
         this._transitionProgress = 0.0;
         this._currentTransitionToNode = targetNode;
         this._toUpdated = false;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
