### PR TITLE
Fix color.fromHex function  can't set alpha  to zero

### DIFF
--- a/cocos/core/math/color.ts
+++ b/cocos/core/math/color.ts
@@ -102,7 +102,8 @@ export class Color extends ValueType {
         out.r = parseInt(hexString.substr(0, 2), 16) || 0;
         out.g = parseInt(hexString.substr(2, 2), 16) || 0;
         out.b = parseInt(hexString.substr(4, 2), 16) || 0;
-        out.a = parseInt(hexString.substr(6, 2), 16) || 255;
+        out.a = parseInt(hexString.substr(6, 2), 16);
+        out.a = !Number.isNaN(out.a) ? out.a : 255;
         out._val = ((out.a << 24) >>> 0) + (out.b << 16) + (out.g << 8) + out.r;
         return out;
     }
@@ -435,7 +436,8 @@ export class Color extends ValueType {
         const r = parseInt(hexString.substr(0, 2), 16) || 0;
         const g = parseInt(hexString.substr(2, 2), 16) || 0;
         const b = parseInt(hexString.substr(4, 2), 16) || 0;
-        const a = parseInt(hexString.substr(6, 2), 16) || 255;
+        let a = parseInt(hexString.substr(6, 2), 16);
+        a = !Number.isNaN(a) ? a : 255;
         this._val = ((a << 24) >>> 0) + (b << 16) + (g << 8) + (r | 0);
         return this;
     }
@@ -451,8 +453,8 @@ export class Color extends ValueType {
      * ```
      * const color = new Color(255, 14, 0, 255);
      * color.toHEX("#rgb");      // "f00";
-     * color.toHEX("#rrggbbaa"); // "ff0e00"
-     * color.toHEX("#rrggbb");   // "ff0e00ff"
+     * color.toHEX("#rrggbbaa"); // "ff0e00ff"
+     * color.toHEX("#rrggbb");   // "ff0e00"
      * ```
      */
     public toHEX (fmt: '#rgb' | '#rrggbb' | '#rrggbbaa' = '#rrggbb') {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Fix color.fromHex function  can't set alpha  to zero
 * 修复 color.fromHex 函数不能设置透明度为 0
 * 修复 color.toHex 函数注释错误

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
