### PR TITLE
Fix initialize function override mip levels(groundalbedo.w)

### DIFF
--- a/cocos/core/renderer/scene/ambient.ts
+++ b/cocos/core/renderer/scene/ambient.ts
@@ -153,11 +153,15 @@ export class Ambient {
     public initialize (ambientInfo: AmbientInfo) {
         // Init HDR/LDR from serialized data on load
         this._skyColorHDR = ambientInfo.skyColorHDR;
-        this._groundAlbedoHDR = ambientInfo.groundAlbedoHDR;
+        this._groundAlbedoHDR.x = ambientInfo.groundAlbedoHDR.x;
+        this._groundAlbedoHDR.y = ambientInfo.groundAlbedoHDR.y;
+        this._groundAlbedoHDR.z = ambientInfo.groundAlbedoHDR.z;
         this._skyIllumHDR = ambientInfo.skyIllumHDR;
 
         this._skyColorLDR = ambientInfo.skyColorLDR;
-        this._groundAlbedoLDR = ambientInfo.groundAlbedoLDR;
+        this._groundAlbedoLDR.x = ambientInfo.groundAlbedoLDR.x;
+        this._groundAlbedoLDR.y = ambientInfo.groundAlbedoLDR.y;
+        this._groundAlbedoLDR.z = ambientInfo.groundAlbedoLDR.z;
         this._skyIllumLDR = ambientInfo.skyIllumLDR;
 
         if (JSB) {

--- a/cocos/core/scene-graph/scene-globals.ts
+++ b/cocos/core/scene-graph/scene-globals.ts
@@ -39,6 +39,8 @@ import { Root } from '../root';
 
 const _up = new Vec3(0, 1, 0);
 const _v3 = new Vec3();
+const _v4 = new Vec4();
+const _col = new Color();
 const _qt = new Quat();
 
 // Normalize HDR color
@@ -114,31 +116,28 @@ export class AmbientInfo {
     })
     @editable
     set skyLightingColor (val: Color) {
-        let result;
-        const color = new Vec4(val.x, val.y, val.z, val.w);
+        _v4.set(val.x, val.y, val.z, val.w);
         if ((legacyCC.director.root as Root).pipeline.pipelineSceneData.isHDR) {
-            this._skyColorHDR = color;
-            (result as Vec4) = this._skyColorHDR;
+            this._skyColorHDR.set(_v4);
         } else {
-            this._skyColorLDR = color;
-            (result as Vec4) = this._skyColorLDR;
+            this._skyColorLDR.set(_v4);
         }
-        if (this._resource) { this._resource.skyColor = color; }
+        if (this._resource) { this._resource.skyColor.set(_v4); }
     }
     get skyLightingColor () {
         const isHDR = (legacyCC.director.root as Root).pipeline.pipelineSceneData.isHDR;
-        const color = isHDR ? this._skyColorHDR.clone() : this._skyColorLDR.clone();
-        normalizeHDRColor(color);
-        return new Color(color.x * 255, color.y * 255, color.z * 255, 255);
+        _v4.set(isHDR ? this._skyColorHDR : this._skyColorLDR);
+        normalizeHDRColor(_v4);
+        return _col.set(_v4.x * 255, _v4.y * 255, _v4.z * 255, 255);
     }
 
     set skyColor (val: Vec4) {
         if ((legacyCC.director.root as Root).pipeline.pipelineSceneData.isHDR) {
-            this._skyColorHDR = val;
+            this._skyColorHDR.set(val);
         } else {
-            this._skyColorLDR = val;
+            this._skyColorLDR.set(val);
         }
-        if (this._resource) { this._resource.skyColor = val; }
+        if (this._resource) { this._resource.skyColor.set(val); }
     }
 
     /**
@@ -179,31 +178,28 @@ export class AmbientInfo {
     })
     @editable
     set groundLightingColor (val: Color) {
-        let result;
-        const color = new Vec4(val.x, val.y, val.z, val.w);
+        _v4.set(val.x, val.y, val.z, val.w);
         if ((legacyCC.director.root as Root).pipeline.pipelineSceneData.isHDR) {
-            this._groundAlbedoHDR = color;
-            (result as Vec4) = this._groundAlbedoHDR;
+            this._groundAlbedoHDR.set(_v4);
         } else {
-            this._groundAlbedoLDR = color;
-            (result as Vec4) = this._groundAlbedoLDR;
+            this._groundAlbedoLDR.set(_v4);
         }
-        if (this._resource) { this._resource.groundAlbedo = color; }
+        if (this._resource) { this._resource.groundAlbedo.set(_v4); }
     }
     get groundLightingColor () {
         const isHDR = (legacyCC.director.root as Root).pipeline.pipelineSceneData.isHDR;
-        const color = isHDR ? this._groundAlbedoHDR : this._groundAlbedoLDR;
-        normalizeHDRColor(color);
-        return new Color(color.x * 255, color.y * 255, color.z * 255, 255);
+        _v4.set(isHDR ? this._groundAlbedoHDR : this._groundAlbedoLDR);
+        normalizeHDRColor(_v4);
+        return _col.set(_v4.x * 255, _v4.y * 255, _v4.z * 255, 255);
     }
 
     set groundAlbedo (val: Vec4) {
         if ((legacyCC.director.root as Root).pipeline.pipelineSceneData.isHDR) {
-            this._groundAlbedoHDR = val;
+            this._groundAlbedoHDR.set(val);
         } else {
-            this._groundAlbedoLDR = val;
+            this._groundAlbedoLDR.set(val);
         }
-        if (this._resource) { this._resource.groundAlbedo = val; }
+        if (this._resource) { this._resource.groundAlbedo.set(val); }
     }
 
     public activate (resource: Ambient) {

--- a/cocos/core/scene-graph/scene-globals.ts
+++ b/cocos/core/scene-graph/scene-globals.ts
@@ -123,7 +123,7 @@ export class AmbientInfo {
             this._skyColorLDR = color;
             (result as Vec4) = this._skyColorLDR;
         }
-        if (this._resource) { this._resource.skyColor = _v3.set(color.x, color.y, color.z); }
+        if (this._resource) { this._resource.skyColor = color; }
     }
     get skyLightingColor () {
         const isHDR = (legacyCC.director.root as Root).pipeline.pipelineSceneData.isHDR;
@@ -188,7 +188,7 @@ export class AmbientInfo {
             this._groundAlbedoLDR = color;
             (result as Vec4) = this._groundAlbedoLDR;
         }
-        if (this._resource) { this._resource.groundAlbedo = _v3.set(color.x, color.y, color.z); }
+        if (this._resource) { this._resource.groundAlbedo = color; }
     }
     get groundLightingColor () {
         const isHDR = (legacyCC.director.root as Root).pipeline.pipelineSceneData.isHDR;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 覆盖了w分量导致mip层数被改掉, 粗糙度变得无效
 * 修复了AmbientInfo中设置Ambient groundAlbedo和skyColor的vector维数不匹配问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
