### PR TITLE
Fix fog macro->function arguments type error

### DIFF
--- a/cocos/core/assets/material.ts
+++ b/cocos/core/assets/material.ts
@@ -40,6 +40,7 @@ import { MacroRecord, MaterialProperty } from '../renderer/core/pass-utils';
 import { Color } from '../math/color';
 import { warnID } from '../platform/debug';
 import { Vec4 } from '../math';
+import { SRGBToLinear } from '../pipeline/pipeline-funcs';
 
 const v4_1 = new Vec4();
 
@@ -428,9 +429,7 @@ export class Material extends Asset {
             } else if (val !== null) {
                 if (pass.properties[name]?.linear) {
                     const v4 = val as Vec4;
-                    v4_1.x = v4.x * v4.x;
-                    v4_1.y = v4.y * v4.y;
-                    v4_1.z = v4.z * v4.z;
+                    SRGBToLinear(v4_1, v4);
                     v4_1.w = v4.w;
                     val = v4_1;
                 }

--- a/cocos/core/pipeline/pipeline-ubo.ts
+++ b/cocos/core/pipeline/pipeline-ubo.ts
@@ -132,7 +132,11 @@ export class PipelineUBO {
         Mat4.toArray(cv, camera.matViewProjInv, UBOCamera.MAT_VIEW_PROJ_INV_OFFSET);
         cv[UBOCamera.CAMERA_POS_OFFSET + 3] = this.getCombineSignY();
 
-        cv.set(fog.colorArray, UBOCamera.GLOBAL_FOG_COLOR_OFFSET);
+        const colorTempRGB = fog.colorArray;
+        cv[UBOCamera.GLOBAL_FOG_COLOR_OFFSET] = colorTempRGB.x;
+        cv[UBOCamera.GLOBAL_FOG_COLOR_OFFSET + 1] = colorTempRGB.y;
+        cv[UBOCamera.GLOBAL_FOG_COLOR_OFFSET + 2] = colorTempRGB.z;
+        cv[UBOCamera.GLOBAL_FOG_COLOR_OFFSET + 3] = colorTempRGB.z;
 
         cv[UBOCamera.GLOBAL_FOG_BASE_OFFSET] = fog.fogStart;
         cv[UBOCamera.GLOBAL_FOG_BASE_OFFSET + 1] = fog.fogEnd;

--- a/cocos/core/renderer/scene/fog.ts
+++ b/cocos/core/renderer/scene/fog.ts
@@ -85,8 +85,12 @@ export class Fog {
      */
     set enabled (val: boolean) {
         this._setEnable(val);
-        if (!val) this._type = FOG_TYPE_NONE;
-        val ? this.activate() : this._updatePipeline();
+        if (!val) {
+            this._type = FOG_TYPE_NONE;
+            this._updatePipeline();
+        } else {
+            this.activate();
+        }
     }
 
     get enabled (): boolean {

--- a/cocos/core/renderer/scene/fog.ts
+++ b/cocos/core/renderer/scene/fog.ts
@@ -25,10 +25,13 @@
 
 import { JSB } from 'internal:constants';
 import { Enum } from '../../value-types';
-import { Color } from '../../math';
+import { Color, Vec4 } from '../../math';
 import { legacyCC } from '../../global-exports';
 import { FogInfo } from '../../scene-graph/scene-globals';
 import { NativeFog } from './native-scene';
+import { SRGBToLinear } from '../../pipeline/pipeline-funcs';
+
+const _v4 = new Vec4();
 
 /**
  * @zh
@@ -109,7 +112,8 @@ export class Fog {
      */
     set fogColor (val: Color) {
         this._fogColor.set(val);
-        Color.toArray(this._colorArray, this._fogColor);
+        _v4.set(val.x, val.y, val.z, val.w);
+        SRGBToLinear(this._colorArray, _v4);
         if (JSB) {
             this._nativeObj!.color = this._fogColor;
         }
@@ -226,11 +230,11 @@ export class Fog {
             this._nativeObj!.range = val;
         }
     }
-    get colorArray (): Float32Array {
+    get colorArray (): Readonly<Vec4> {
         return this._colorArray;
     }
     protected _fogColor = new Color('#C8C8C8');
-    protected _colorArray: Float32Array = new Float32Array([0.2, 0.2, 0.2, 1.0]);
+    protected _colorArray: Vec4 = new Vec4(0.2, 0.2, 0.2, 1.0);
     protected _enabled = false;
     protected _accurate = false;
     protected _type = 0;

--- a/editor/assets/chunks/cc-fog-fs.chunk
+++ b/editor/assets/chunks/cc-fog-fs.chunk
@@ -10,14 +10,13 @@ in float v_fog_factor;
 
 // Just to be compatible with old projects only
 // Do not support accurate fog
-vec4 CC_APPLY_FOG(vec4 color) {
+void CC_APPLY_FOG(inout vec4 color) {
 #if !CC_USE_ACCURATE_FOG
     CC_APPLY_FOG_BASE(color, CC_FOG_FACTOR);
 #endif
-    return color;
 }
 
-vec4 CC_APPLY_FOG(vec4 color, vec3 worldPos) {
+void CC_APPLY_FOG(inout vec4 color, vec3 worldPos) {
 #if CC_USE_ACCURATE_FOG
     float factor;
     CC_TRANSFER_FOG_BASE(vec4(worldPos, 1.0), factor);
@@ -25,5 +24,4 @@ vec4 CC_APPLY_FOG(vec4 color, vec3 worldPos) {
     float factor = CC_FOG_FACTOR;
 #endif
     CC_APPLY_FOG_BASE(color, factor);
-    return color;
 }

--- a/editor/assets/chunks/cc-global.chunk
+++ b/editor/assets/chunks/cc-global.chunk
@@ -24,7 +24,7 @@ layout(set = 0, binding = 1) uniform CCCamera {
   mediump vec4 cc_mainLitColor; // xyz: main direcitonal light color, w: intensity
   mediump vec4 cc_ambientSky; //xyz: sky illumination color, w: intensity
   mediump vec4 cc_ambientGround; // xyz: ground albedo color, w: envmap LOD
-  mediump vec4 cc_fogColor; // xyzw: global fog color
+  mediump vec4 cc_fogColor; // xyz: global fog color
   mediump vec4 cc_fogBase; // xyz: fogStart, fogEnd, fogDensity
   mediump vec4 cc_fogAdd; // xyz: fogTop, fogRange, fogAtten
   mediump vec4 cc_nearFar; // xy: frustum near, frustum far


### PR DESCRIPTION
Fix fog color linear conversion

Re: cocos-creator/3d-tasks#

Changelog:
 * fog相关宏改函数的时候,函数参数类型未加inout导致雾化失效的问题
 * fogcolor线性化处理, 需要配合数据迁移的pr一起合并 https://github.com/cocos-creator/engine-extensions/pull/15
 * 材质颜色线性化处理改用统一的函数计算, 方便GammaCorrection选项控制

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
