### PR TITLE
rich-text vertical alignment

### DIFF
--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -199,6 +199,29 @@ export class RichText extends UIComponent {
 
     /**
      * @en
+     * Vertical Alignment of each line in RichText.
+     *
+     * @zh
+     * 文本内容的竖直对齐方式。
+     */
+    @type(VerticalTextAlignment)
+    @tooltip('i18n:richtext.vertical_align')
+    get verticalAlign () {
+        return this._verticalAlign;
+    }
+
+    set verticalAlign (value) {
+        if (this._verticalAlign === value) {
+            return;
+        }
+
+        this._verticalAlign = value;
+        this._layoutDirty = true;
+        this._updateRichTextStatus();
+    }
+
+    /**
+     * @en
      * Font size of RichText.
      *
      * @zh
@@ -421,6 +444,8 @@ export class RichText extends UIComponent {
     // protected _updateRichTextStatus =
     @serializable
     protected _horizontalAlign = HorizontalTextAlignment.LEFT;
+    @serializable
+    protected _verticalAlign = VerticalTextAlignment.TOP;
     @serializable
     protected _fontSize = 40;
     @serializable
@@ -781,13 +806,13 @@ export class RichText extends UIComponent {
             const sprite = segment.comp;
             switch (style.imageAlign) {
             case 'top':
-                    segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 1);
+                segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 1);
                 break;
             case 'center':
-                    segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 0.5);
+                segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 0.5);
                 break;
             default:
-                    segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 0);
+                segment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 0);
                 break;
             }
 

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -680,11 +680,9 @@ export class RichText extends UIComponent {
             }
         }
 
-        // set alignments
+        // set vertical alignments
+        // because horizontal alignment is applied with line offsets in method "_updateRichTextPosition"
         if (labelSegment.comp instanceof Label) {
-            if (labelSegment.comp.horizontalAlign !== this._horizontalAlign) {
-                labelSegment.comp.horizontalAlign = this._horizontalAlign;
-            }
             if (labelSegment.comp.verticalAlign !== this._verticalAlign) {
                 labelSegment.comp.verticalAlign = this._verticalAlign;
             }

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -680,6 +680,16 @@ export class RichText extends UIComponent {
             }
         }
 
+        // set alignments
+        if (labelSegment.comp instanceof Label) {
+            if (labelSegment.comp.horizontalAlign !== this._horizontalAlign) {
+                labelSegment.comp.horizontalAlign = this._horizontalAlign;
+            }
+            if (labelSegment.comp.verticalAlign !== this._verticalAlign) {
+                labelSegment.comp.verticalAlign = this._verticalAlign;
+            }
+        }
+
         labelSegment.styleIndex = styleIndex;
         labelSegment.lineCount = this._lineCount;
         labelSegment.node._uiProps.uiTransformComp!.setAnchorPoint(0, 0);

--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -489,6 +489,7 @@ module.exports = {
     richtext: {
         string: 'Text of the RichText, you could use BBcode in the string',
         horizontal_align: 'Horizontal alignment',
+        vertical_align: 'Vertical alignment',
         font_size: 'Font size, in points',
         font: 'Custom TTF font of RichText',
         font_family:'Custom System font of RichText',

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -479,6 +479,7 @@ module.exports = {
     richtext: {
         string: '富文本的内容字符串, 你可以在里面使用 BBCode 来指定特定文本的样式',
         horizontal_align: '水平对齐方式',
+        vertical_align: '竖直对齐方式',
         font_size: '字体大小, 单位是 point',
         font: '富文本定制字体',
         font_family: '富文本定制系统字体',


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#9984

Changelog:
 * 添加了序列化属性 verticalAlignment 以及它的 tooltips 。
 * 实现了 rich-text 的竖直对齐

### 竖直对齐
![image](https://user-images.githubusercontent.com/32831993/140844819-a1d864ba-3886-4de6-bf93-5c76bc4c71aa.png)
可以看到竖直对齐是将 rich-text 的竖直对齐方式传递给label组件labelseg，使labelseg自己计算竖直对齐

### 水平对齐
![image](https://user-images.githubusercontent.com/32831993/140844985-c04658a8-6509-4b54-bcf2-d3c8adafabab.png)
而水平对齐较为复杂，通过计算labelseg的偏移位置，将其node设置为对应的位置来实现

### 为何有这种区别
![rich-text-alignment](https://user-images.githubusercontent.com/32831993/140846124-6f096c14-8b27-4814-ae13-1ddec9d42aa2.png)
- richtext 里的 labelsegment 是 richtext 的**子物体**（有多少行就有多少个labelsegment），其 uitransform 的宽和当前一行字宽度一致，而高度则和 richtext 设置的 lineheight 一致
- 因为 labelsegment 的宽**恰好装满**当前行，所以无法再使用label的horizontalalign进行对齐，只能控制 label 的 **node的位置** 来做适配
- 而 labelsegment 的高是等于 richtext 的 lineheight 的，即可以在每一行使用 label 的 verticalalignment 进行竖直对齐

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
