### PR TITLE
compability for PROPORTIONAL_TO_FRAME container strategy

### DIFF
--- a/@types/pal/screen-adapter.d.ts
+++ b/@types/pal/screen-adapter.d.ts
@@ -34,6 +34,12 @@ declare module 'pal/screen-adapter' {
          */
         public isFrameRotated: boolean;
         /**
+         * On web platform, we support to set container strategy.
+         * This field record whether we apply ProportionalToFrame strategy on container, which is false by default.
+         */
+        public get isProportionalToFrame (): boolean;
+        public set isProportionalToFrame (v: boolean);
+        /**
          * In some case we don't want to handle the resize event.
          * For example, when the soft keyboard shows up, we don't want to resize the canvas.
          * This is true by default.

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -3055,7 +3055,7 @@ cc.view.enableAntiAlias is deprecated, please use cc.Texture2D.setFilters instea
 
 ### 9201
 
-Cannot access game frame.
+Cannot access game frame or container.
 
 ### 9202
 

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -286,11 +286,15 @@ export class Game extends EventTarget {
     /**
      * @en The outer frame of the game canvas; parent of game container.
      * @zh 游戏画布的外框，container 的父容器。
+     *
+     * @deprecated since 3.4.0, frame is a concept on web standard, please manager screens via the `screen` module.
      */
     public frame: HTMLDivElement | null = null;
     /**
      * @en The container of game canvas.
      * @zh 游戏画布的容器。
+     *
+     * @deprecated since 3.4.0, container is a concept on web standard, please manager screens via the `screen` module.
      */
     public container: HTMLDivElement | null = null;
     /**

--- a/cocos/core/platform/deprecated.ts
+++ b/cocos/core/platform/deprecated.ts
@@ -71,7 +71,7 @@ markAsWarning(View.prototype, 'View.prototype', [
     },
     {
         name: 'getDevicePixelRatio',
-        suggest: 'devicePixelRatio is a concept on web standard, please use screen.resolutionScale instead',
+        suggest: 'devicePixelRatio is a concept on web standard',
     },
     {
         name: 'convertToLocationInView',

--- a/cocos/core/platform/screen.ts
+++ b/cocos/core/platform/screen.ts
@@ -70,9 +70,9 @@ class Screen {
 
     /**
      * @en Get the current resolution of game.
-     * This is a readonly property, you can change the value by setting screen.resolutionScale.
+     * This is a readonly property.
      * @zh 获取当前游戏的分辨率。
-     * 这是一个只读属性，你可以通过设置 screen.resolutionScale 来改变这个值。
+     * 这是一个只读属性。
      *
      * @readonly
      */
@@ -80,18 +80,18 @@ class Screen {
         return screenAdapter.resolution;
     }
 
-    /**
-     * @en Get and set the resolution scale of screen, which will affect the quality of the rendering.
-     * Note: if this value is set too high, the rendering performance of GPU will be reduced, this value is 1 by default.
-     * @zh 获取和设置屏幕的分辨率缩放比，这将会影响最终渲染的质量。
-     * 注意：如果这个值设置的太高，会降低 GPU 的渲染性能，该值默认为 1。
-     */
-    public get resolutionScale () {
-        return screenAdapter.resolutionScale;
-    }
-    public set resolutionScale (v: number) {
-        screenAdapter.resolutionScale = v;
-    }
+    // /**
+    //  * @en Get and set the resolution scale of screen, which will affect the quality of the rendering.
+    //  * Note: if this value is set too high, the rendering performance of GPU will be reduced, this value is 1 by default.
+    //  * @zh 获取和设置屏幕的分辨率缩放比，这将会影响最终渲染的质量。
+    //  * 注意：如果这个值设置的太高，会降低 GPU 的渲染性能，该值默认为 1。
+    //  */
+    // public get resolutionScale () {
+    //     return screenAdapter.resolutionScale;
+    // }
+    // public set resolutionScale (v: number) {
+    //     screenAdapter.resolutionScale = v;
+    // }
 
     /**
      * @en Whether it supports full screen？

--- a/cocos/core/platform/screen.ts
+++ b/cocos/core/platform/screen.ts
@@ -52,9 +52,14 @@ class Screen {
 
     /**
      * @en Get and set the size of current window in physical pixels.
-     * NOTE: Setting window size is only supported on Web platform for now.
+     * NOTE:
+     * - Setting window size is only supported on Web platform for now.
+     * - On Web platform, if the ContainerStrategy is PROPORTIONAL_TO_FRAME, we set windowSize on game frame,
+     *    and get windowSize from the game container after adaptation.
      * @zh 获取和设置当前窗口的物理像素尺寸。
-     * 注意：设置窗口尺寸目前只在 Web 平台上支持。
+     * 注意
+     * - 设置窗口尺寸目前只在 Web 平台上支持。
+     * - Web 平台上，如果 ContainerStrategy 为 PROPORTIONAL_TO_FRAME, 则设置 windowSize 作用于 game frame, 而从适配之后 game container 尺寸获取 windowSize.
      */
     public get windowSize (): Size {
         return screenAdapter.windowSize;

--- a/cocos/core/platform/view.ts
+++ b/cocos/core/platform/view.ts
@@ -642,7 +642,7 @@ class ContainerStrategy {
 
     }
 
-    protected _setupContainer (_view, w, h) {
+    protected _setupCanvas () {
         const locCanvas = game.canvas;
         if (locCanvas) {
             const windowSize = screen.windowSize;
@@ -737,8 +737,8 @@ class ContentStrategy {
     class EqualToFrame extends ContainerStrategy {
         public name = 'EqualToFrame';
         public apply (_view) {
-            const windowSize = screen.windowSize;
-            this._setupContainer(_view, windowSize.width, windowSize.height);
+            screenAdapter.isProportionalToFrame = false;
+            this._setupCanvas();
         }
     }
 
@@ -749,10 +749,10 @@ class ContentStrategy {
     class ProportionalToFrame extends ContainerStrategy {
         public name = 'ProportionalToFrame';
         public apply (_view, designedResolution) {
-            const windowSize = screen.windowSize;
-            const frameW = windowSize.width;
-            const frameH = windowSize.height;
-            const containerStyle = legacyCC.game.container.style;
+            screenAdapter.isProportionalToFrame = true;
+            const frame = game.frame!;
+            const frameW = frame.clientWidth;
+            const frameH = frame.clientHeight;
             const designW = designedResolution.width;
             const designH = designedResolution.height;
             const scaleX = frameW / designW;
@@ -767,6 +767,8 @@ class ContentStrategy {
                 containerW = designW * scaleY;
                 containerH = frameH;
             }
+            screenAdapter.windowSize = new Size(containerW, containerH);
+            this._setupCanvas();
 
             // Adjust container size with integer value
             const offx = Math.round((frameW - containerW) / 2);
@@ -774,8 +776,8 @@ class ContentStrategy {
             containerW = frameW - 2 * offx;
             containerH = frameH - 2 * offy;
 
-            this._setupContainer(_view, containerW, containerH);
             if (!EDITOR) {
+                const containerStyle = legacyCC.game.container.style;
                 // Setup container's margin and padding
                 if (screenAdapter.isFrameRotated) {
                     containerStyle.margin = `0 0 0 ${frameH}px`;

--- a/cocos/core/platform/view.ts
+++ b/cocos/core/platform/view.ts
@@ -384,12 +384,7 @@ export class View extends EventTarget {
         return this._resolutionPolicy;
     }
 
-    /**
-     * @en Sets the current resolution policy
-     * @zh 设置当前分辨率模式
-     * @see {{ResolutionPolicy}}
-     */
-    public setResolutionPolicy (resolutionPolicy: ResolutionPolicy|number) {
+    private _updateResolutionPolicy (resolutionPolicy: ResolutionPolicy|number) {
         if (resolutionPolicy instanceof ResolutionPolicy) {
             this._resolutionPolicy = resolutionPolicy;
         } else {
@@ -411,6 +406,16 @@ export class View extends EventTarget {
                 this._resolutionPolicy = this._rpFixedWidth;
             }
         }
+    }
+    /**
+     * @en Sets the current resolution policy
+     * @zh 设置当前分辨率模式
+     * @see {{ResolutionPolicy}}
+     */
+    public setResolutionPolicy (resolutionPolicy: ResolutionPolicy|number) {
+        this._updateResolutionPolicy(resolutionPolicy);
+        const designedResolution = view.getDesignResolutionSize();
+        view.setDesignResolutionSize(designedResolution.width, designedResolution.height, resolutionPolicy);
     }
 
     /**
@@ -434,7 +439,7 @@ export class View extends EventTarget {
             return;
         }
 
-        this.setResolutionPolicy(resolutionPolicy);
+        this._updateResolutionPolicy(resolutionPolicy);
         const policy = this._resolutionPolicy;
         if (policy) {
             policy.preApply(this);

--- a/cocos/core/platform/view.ts
+++ b/cocos/core/platform/view.ts
@@ -282,7 +282,7 @@ export class View extends EventTarget {
      */
     public setCanvasSize (width: number, height: number) {
         // set resolution scale to 1;
-        screen.resolutionScale = 1;
+        screenAdapter.resolutionScale = 1;
 
         // set window size
         const dpr = screenAdapter.devicePixelRatio;
@@ -546,7 +546,7 @@ export class View extends EventTarget {
      * @en Returns device pixel ratio for retina display.
      * @zh 返回设备或浏览器像素比例。
      *
-     * @deprecated since v3.4.0, devicePixelRatio is a concept on web standard, please use screen.resolutionScale instead.
+     * @deprecated since v3.4.0, devicePixelRatio is a concept on web standard.
      */
     public getDevicePixelRatio (): number {
         return screenAdapter.devicePixelRatio;

--- a/cocos/core/platform/view.ts
+++ b/cocos/core/platform/view.ts
@@ -741,7 +741,7 @@ class ContentStrategy {
      */
     class EqualToFrame extends ContainerStrategy {
         public name = 'EqualToFrame';
-        public apply (_view) {
+        public apply (_view, designedResolution) {
             screenAdapter.isProportionalToFrame = false;
             this._setupCanvas();
         }
@@ -755,45 +755,7 @@ class ContentStrategy {
         public name = 'ProportionalToFrame';
         public apply (_view, designedResolution) {
             screenAdapter.isProportionalToFrame = true;
-            const frame = game.frame!;
-            const frameW = frame.clientWidth;
-            const frameH = frame.clientHeight;
-            const designW = designedResolution.width;
-            const designH = designedResolution.height;
-            const scaleX = frameW / designW;
-            const scaleY = frameH / designH;
-            let containerW;
-            let containerH;
-
-            if (scaleX < scaleY) {
-                containerW = frameW;
-                containerH = designH * scaleX;
-            } else {
-                containerW = designW * scaleY;
-                containerH = frameH;
-            }
-            screenAdapter.windowSize = new Size(containerW, containerH);
             this._setupCanvas();
-
-            // Adjust container size with integer value
-            const offx = Math.round((frameW - containerW) / 2);
-            const offy = Math.round((frameH - containerH) / 2);
-            containerW = frameW - 2 * offx;
-            containerH = frameH - 2 * offy;
-
-            if (!EDITOR) {
-                const containerStyle = legacyCC.game.container.style;
-                // Setup container's margin and padding
-                if (screenAdapter.isFrameRotated) {
-                    containerStyle.margin = `0 0 0 ${frameH}px`;
-                } else {
-                    containerStyle.margin = '0px';
-                }
-                containerStyle.paddingLeft = `${offx}px`;
-                containerStyle.paddingRight = `${offx}px`;
-                containerStyle.paddingTop = `${offy}px`;
-                containerStyle.paddingBottom = `${offy}px`;
-            }
         }
     }
 

--- a/cocos/ui/safe-area.ts
+++ b/cocos/ui/safe-area.ts
@@ -65,12 +65,12 @@ export class SafeArea extends Component {
     public onEnable () {
         this.updateArea();
         // IDEA: need to delay the callback on Native platform ?
-        screenAdapter.on('resolution-change', this.updateArea, this);
+        screenAdapter.on('window-resize', this.updateArea, this);
         screenAdapter.on('orientation-change', this.updateArea, this);
     }
 
     public onDisable () {
-        screenAdapter.off('resolution-change', this.updateArea, this);
+        screenAdapter.off('window-resize', this.updateArea, this);
         screenAdapter.off('orientation-change', this.updateArea, this);
     }
 

--- a/pal/screen-adapter/enum-type/screen-event.ts
+++ b/pal/screen-adapter/enum-type/screen-event.ts
@@ -1,1 +1,1 @@
-export type PalScreenEvent = 'window-resize' | 'resolution-change' | 'orientation-change' | 'fullscreen-change';
+export type PalScreenEvent = 'window-resize' | 'orientation-change' | 'fullscreen-change';

--- a/pal/screen-adapter/minigame/screen-adapter.ts
+++ b/pal/screen-adapter/minigame/screen-adapter.ts
@@ -67,7 +67,9 @@ class ScreenAdapter extends EventTarget {
     }
 
     public get resolution () {
-        return this._resolution;
+        const windowSize = this.windowSize;
+        const resolutionScale = this.resolutionScale;
+        return new Size(windowSize.width * resolutionScale, windowSize.height * resolutionScale);
     }
     public get resolutionScale () {
         return this._resolutionScale;
@@ -77,7 +79,7 @@ class ScreenAdapter extends EventTarget {
             return;
         }
         this._resolutionScale = value;
-        this._updateResolution();
+        this._cbToUpdateFrameBuffer?.();
     }
 
     public get orientation (): Orientation {
@@ -122,7 +124,6 @@ class ScreenAdapter extends EventTarget {
     public set isProportionalToFrame (v: boolean) { }
 
     private _cbToUpdateFrameBuffer?: () => void;
-    private _resolution: Size = new Size(0, 0);
     private _resolutionScale = 1;
     private _isProportionalToFrame = false;
 
@@ -133,7 +134,7 @@ class ScreenAdapter extends EventTarget {
 
     public init (options: IScreenOptions, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
-        this._updateResolution();
+        this._cbToUpdateFrameBuffer();
     }
 
     public requestFullScreen (): Promise<void> {
@@ -141,15 +142,6 @@ class ScreenAdapter extends EventTarget {
     }
     public exitFullScreen (): Promise<void> {
         return Promise.reject(new Error('exit fullscreen is not supported on this platform.'));
-    }
-
-    private _updateResolution () {
-        const windowSize = this.windowSize;
-        // update resolution
-        this._resolution.width = windowSize.width * this.resolutionScale;
-        this._resolution.height = windowSize.height * this.resolutionScale;
-        this._cbToUpdateFrameBuffer?.();
-        this.emit('resolution-change');
     }
 }
 

--- a/pal/screen-adapter/minigame/screen-adapter.ts
+++ b/pal/screen-adapter/minigame/screen-adapter.ts
@@ -116,9 +116,15 @@ class ScreenAdapter extends EventTarget {
         };
     }
 
+    public get isProportionalToFrame (): boolean {
+        return this._isProportionalToFrame;
+    }
+    public set isProportionalToFrame (v: boolean) { }
+
     private _cbToUpdateFrameBuffer?: () => void;
     private _resolution: Size = new Size(0, 0);
     private _resolutionScale = 1;
+    private _isProportionalToFrame = false;
 
     constructor () {
         super();

--- a/pal/screen-adapter/native/screen-adapter.ts
+++ b/pal/screen-adapter/native/screen-adapter.ts
@@ -37,7 +37,7 @@ class ScreenAdapter extends EventTarget {
         console.warn('Setting window size is not supported yet.');
     }
 
-    public get resolution() {
+    public get resolution () {
         const windowSize = this.windowSize;
         const resolutionScale = this.resolutionScale;
         return new Size(windowSize.width * resolutionScale, windowSize.height * resolutionScale);

--- a/pal/screen-adapter/native/screen-adapter.ts
+++ b/pal/screen-adapter/native/screen-adapter.ts
@@ -37,8 +37,10 @@ class ScreenAdapter extends EventTarget {
         console.warn('Setting window size is not supported yet.');
     }
 
-    public get resolution () {
-        return this._resolution;
+    public get resolution() {
+        const windowSize = this.windowSize;
+        const resolutionScale = this.resolutionScale;
+        return new Size(windowSize.width * resolutionScale, windowSize.height * resolutionScale);
     }
     public get resolutionScale () {
         return this._resolutionScale;
@@ -48,7 +50,7 @@ class ScreenAdapter extends EventTarget {
             return;
         }
         this._resolutionScale = v;
-        this._updateResolution();
+        this._cbToUpdateFrameBuffer?.();
     }
 
     public get orientation (): Orientation {
@@ -91,7 +93,6 @@ class ScreenAdapter extends EventTarget {
     public set isProportionalToFrame (v: boolean) { }
 
     private _cbToUpdateFrameBuffer?: () => void;
-    private _resolution: Size = new Size(1, 1);  // NOTE: crash when init device if resolution is Size.ZERO on native platform.
     private _resolutionScale = 1;
     private _isProportionalToFrame = false;
 
@@ -102,7 +103,7 @@ class ScreenAdapter extends EventTarget {
 
     public init (options: IScreenOptions, cbToRebuildFrameBuffer: () => void) {
         this._cbToUpdateFrameBuffer = cbToRebuildFrameBuffer;
-        this._updateResolution();
+        this._cbToUpdateFrameBuffer();
     }
 
     public requestFullScreen (): Promise<void> {
@@ -125,14 +126,6 @@ class ScreenAdapter extends EventTarget {
         jsb.onOrientationChanged = (event) => {
             this.emit('orientation-change');
         };
-    }
-    private _updateResolution () {
-        const windowSize = this.windowSize;
-        // update resolution
-        this._resolution.width = windowSize.width * this.resolutionScale;
-        this._resolution.height = windowSize.height * this.resolutionScale;
-        this._cbToUpdateFrameBuffer?.();
-        this.emit('resolution-change');
     }
 }
 

--- a/pal/screen-adapter/native/screen-adapter.ts
+++ b/pal/screen-adapter/native/screen-adapter.ts
@@ -85,10 +85,15 @@ class ScreenAdapter extends EventTarget {
             right: rightEdge,
         };
     }
+    public get isProportionalToFrame (): boolean {
+        return this._isProportionalToFrame;
+    }
+    public set isProportionalToFrame (v: boolean) { }
 
     private _cbToUpdateFrameBuffer?: () => void;
     private _resolution: Size = new Size(1, 1);  // NOTE: crash when init device if resolution is Size.ZERO on native platform.
     private _resolutionScale = 1;
+    private _isProportionalToFrame = false;
 
     constructor () {
         super();

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -7,6 +7,11 @@ import { Size } from '../../../cocos/core/math';
 import { Orientation } from '../enum-type';
 import legacyCC from '../../../predefine';
 
+interface ICachedStyle {
+    width: string;
+    height: string;
+}
+
 const EVENT_TIMEOUT = EDITOR ? 5 : 200;
 const orientationMap: Record<ConfigOrientation, Orientation> = {
     auto: Orientation.AUTO,
@@ -134,6 +139,8 @@ class ScreenAdapter extends EventTarget {
     private _gameContainer?: HTMLDivElement;
     private _gameCanvas?: HTMLCanvasElement;
     private _isProportionalToFrame = false;
+    private _cachedFrameStyle: ICachedStyle = { width: '0px', height: '0px' };
+    private _cachedContainerStyle: ICachedStyle = { width: '0px', height: '0px' };
     private _cbToUpdateFrameBuffer?: () => void;
     private _supportFullScreen = false;
     private _touchEventName: string;
@@ -501,7 +508,21 @@ class ScreenAdapter extends EventTarget {
             containerStyle.width = '100%';
             containerStyle.height = '100%';
         }
-        this.emit('window-resize');
+
+        // Cache Test
+        if (this._gameFrame
+            && (this._cachedFrameStyle.width !== this._gameFrame.style.width
+            || this._cachedFrameStyle.height !== this._gameFrame.style.height
+            || this._cachedContainerStyle.width !== this._gameContainer.style.width
+            || this._cachedContainerStyle.height !== this._gameContainer.style.height)) {
+            this.emit('window-resize');
+
+            // Update Cache
+            this._cachedFrameStyle.width = this._gameFrame.style.width;
+            this._cachedFrameStyle.height = this._gameFrame.style.height;
+            this._cachedContainerStyle.width = this._gameContainer.style.width;
+            this._cachedContainerStyle.height = this._gameContainer.style.height;
+        }
     }
 }
 

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -88,11 +88,12 @@ class ScreenAdapter extends EventTarget {
             return;
         }
         this._resizeFrame(this._convertToSizeInCssPixels(size));
-        this._updateResolution();
     }
 
     public get resolution () {
-        return this._resolution;
+        const windowSize = this.windowSize;
+        const resolutionScale = this.resolutionScale;
+        return new Size(windowSize.width * resolutionScale, windowSize.height * resolutionScale);
     }
     public get resolutionScale () {
         return this._resolutionScale;
@@ -102,7 +103,7 @@ class ScreenAdapter extends EventTarget {
             return;
         }
         this._resolutionScale = v;
-        this._updateResolution();
+        this._cbToUpdateFrameBuffer?.();
     }
 
     public get orientation (): Orientation {
@@ -244,7 +245,6 @@ class ScreenAdapter extends EventTarget {
         }
         return WindowType.SubFrame;
     }
-    private _resolution: Size = new Size(0, 0);
     private _resolutionScale = 1;
     private _orientation = Orientation.AUTO;
 
@@ -285,6 +285,7 @@ class ScreenAdapter extends EventTarget {
         this.orientation = orientationMap[options.configOrientation];
         this._exactFitScreen = options.exactFitScreen;
         this._resizeFrame();
+        this._cbToUpdateFrameBuffer();
     }
 
     public requestFullScreen (): Promise<void> {
@@ -416,15 +417,6 @@ class ScreenAdapter extends EventTarget {
         }
 
         this._updateContainer();
-    }
-
-    private _updateResolution () {
-        const windowSize = this.windowSize;
-        // update resolution
-        this._resolution.width = windowSize.width * this.resolutionScale;
-        this._resolution.height = windowSize.height * this.resolutionScale;
-        this._cbToUpdateFrameBuffer?.();
-        this.emit('resolution-change');
     }
 
     private _getFullscreenTarget () {

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -119,10 +119,21 @@ class ScreenAdapter extends EventTarget {
             right: 0,
         };
     }
+    public get isProportionalToFrame (): boolean {
+        return this._isProportionalToFrame;
+    }
+    public set isProportionalToFrame (v: boolean) {
+        if (this._isProportionalToFrame === v) {
+            return;
+        }
+        // TODO
+        this._isProportionalToFrame = v;
+    }
 
     private _gameFrame?: HTMLDivElement;
     private _gameContainer?: HTMLDivElement;
     private _gameCanvas?: HTMLCanvasElement;
+    private _isProportionalToFrame = false;
     private _cbToUpdateFrameBuffer?: () => void;
     private _supportFullScreen = false;
     private _touchEventName: string;

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -140,7 +140,6 @@ class ScreenAdapter extends EventTarget {
     private _onFullscreenChange?: () => void;
     private _onFullscreenError?: () => void;
     // We need to set timeout to handle screen event.
-    private _resizeTimeoutId = -1;
     private _orientationChangeTimeoutId = -1;
     private _cachedFrameSize = new Size(0, 0); // cache before enter fullscreen.
     private _exactFitScreen = false;
@@ -311,19 +310,10 @@ class ScreenAdapter extends EventTarget {
         });
 
         window.addEventListener('resize', () => {
-            if (this._resizeTimeoutId !== -1) {
-                clearTimeout(this._resizeTimeoutId);
+            if (!this.handleResizeEvent) {
+                return;
             }
-            this._resizeTimeoutId = setTimeout(() => {
-                if (!this.handleResizeEvent) {
-                    return;
-                }
-                this._resizeFrame();
-                if (this._windowType !== WindowType.SubFrame) {
-                    this.emit('window-resize');
-                }
-                this._resizeTimeoutId = -1;
-            }, EVENT_TIMEOUT);
+            this._resizeFrame();
         });
         if (typeof window.matchMedia === 'function') {
             const updateDPRChangeListener = () => {

--- a/tests/core/view.test.ts
+++ b/tests/core/view.test.ts
@@ -22,8 +22,8 @@ describe('cc.view', () => {
         // new interface
         // screen.resolutionScale = 2;
         // expect(screen.resolutionScale).toBe(2);
-        expect(screen.windowSize).toEqual(new Size(1024, 768));
-        expect(screen.resolution).toEqual(new Size(2048, 1536));
+        // expect(screen.windowSize).toEqual(new Size(1024, 768));
+        // expect(screen.resolution).toEqual(new Size(2048, 1536));
 
         // screen.resolutionScale = 1;
         // expect(screen.resolutionScale).toBe(1);

--- a/tests/core/view.test.ts
+++ b/tests/core/view.test.ts
@@ -20,13 +20,13 @@ describe('cc.view', () => {
         expect(view.getDevicePixelRatio()).toBe(1);
 
         // new interface
-        screen.resolutionScale = 2;
-        expect(screen.resolutionScale).toBe(2);
+        // screen.resolutionScale = 2;
+        // expect(screen.resolutionScale).toBe(2);
         expect(screen.windowSize).toEqual(new Size(1024, 768));
         expect(screen.resolution).toEqual(new Size(2048, 1536));
 
-        screen.resolutionScale = 1;
-        expect(screen.resolutionScale).toBe(1);
+        // screen.resolutionScale = 1;
+        // expect(screen.resolutionScale).toBe(1);
         expect(screen.windowSize).toEqual(new Size(1024, 768));
         expect(screen.resolution).toEqual(new Size(1024, 768));
     });


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/10026

### Test Case
https://github.com/cocos-creator/test-cases-3d/pull/545

### Changelog
 * compability for ContainerStrategy.PROPORTIONAL_TO_FRAME
 * update UI adaption when setting resolution policy
 * remove TIME_OUT to handle resize event in WEB pal/screen-adapter
 * optimize WEB 'window-resize' event, only emit 'window-resize' event when container and frame resize or DPR changed
 * deprecate game.container and game.frame
 * close screen.resolutionScale interface

### Tested Platform
 - [x] Editor Scene Panel
 - [x] Web Preview (PC & Mobile)
 - [x] Web-Mobile
 - [x] Web-Desktop

### Tested Browser
- [x] Android UC Browser
- [x] Android Chrome
- [x] iOS Safari
- [x] iOS QQ Browser
 
<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
