### PR TITLE
fix `nodeEventProcessor.once()`

### DIFF
--- a/cocos/core/event/callbacks-invoker.ts
+++ b/cocos/core/event/callbacks-invoker.ts
@@ -186,6 +186,7 @@ type EventType = string | number;
  */
 export class CallbacksInvoker<EventTypeClass extends EventType = EventType> {
     public _callbackTable: ICallbackTable = createMap(true);
+    private _offCallback?: () => void;
 
     /**
      * @zh 向一个事件名注册一个新的事件监听器，包含回调函数和调用者
@@ -308,6 +309,7 @@ export class CallbacksInvoker<EventTypeClass extends EventType = EventType> {
                 this.removeAll(key);
             }
         }
+        this._offCallback?.();
     }
 
     /**
@@ -369,6 +371,10 @@ export class CallbacksInvoker<EventTypeClass extends EventType = EventType> {
                 delete this._callbackTable[key];
             }
         }
+    }
+
+    private _registerOffCallback (cb: () => void) {
+        this._offCallback = cb;
     }
 }
 

--- a/cocos/core/scene-graph/node-event-processor.ts
+++ b/cocos/core/scene-graph/node-event-processor.ts
@@ -244,14 +244,40 @@ export class NodeEventProcessor {
         }
     }
 
+    /**
+     * Fix when reigster 'once' event callback, `this.off` method isn't be invoked after event is emitted.
+     * We need to inject some nodeEventProcessor's logic into the `callbacksInvoker.off` method.
+     * @returns {CallbacksInvoker} decorated callbacks invoker
+     */
+    private _newDecoratedCallbacksInvoker () {
+        const callbacksInvoker = new CallbacksInvoker<SystemEventTypeUnion>();
+        // decorate off method
+        const offMethod = callbacksInvoker.off;
+        callbacksInvoker.off = (...args: any) => {
+            offMethod.apply(callbacksInvoker, args);
+
+            // Injected logic
+            if (this.shouldHandleEventTouch && !this._hasTouchListeners()) {
+                this.shouldHandleEventTouch = false;
+            }
+            if (this.shouldHandleEventMouse && !this._hasMouseListeners()) {
+                this.shouldHandleEventMouse = false;
+            }
+            if (!this._hasPointerListeners()) {
+                NodeEventProcessor.callbacksInvoker.emit(DispatcherEventType.REMOVE_POINTER_EVENT_PROCESSOR, this);
+            }
+        };
+        return callbacksInvoker;
+    }
+
     public on (type: NodeEventType, callback: AnyFunction, target?: unknown, useCapture?: boolean) {
         this._tryEmittingAddEvent(type);
         useCapture = !!useCapture;
         let invoker: CallbacksInvoker<SystemEventTypeUnion>;
         if (useCapture) {
-            invoker = this.capturingTarget ??= new CallbacksInvoker<SystemEventTypeUnion>();
+            invoker = this.capturingTarget ??= this._newDecoratedCallbacksInvoker();
         } else {
-            invoker = this.bubblingTarget ??= new CallbacksInvoker<SystemEventTypeUnion>();
+            invoker = this.bubblingTarget ??= this._newDecoratedCallbacksInvoker();
         }
         invoker.on(type, callback, target);
         return callback;
@@ -262,9 +288,9 @@ export class NodeEventProcessor {
         useCapture = !!useCapture;
         let invoker: CallbacksInvoker<SystemEventTypeUnion>;
         if (useCapture) {
-            invoker = this.capturingTarget ??= new CallbacksInvoker<SystemEventTypeUnion>();
+            invoker = this.capturingTarget ??= this._newDecoratedCallbacksInvoker();
         } else {
-            invoker = this.bubblingTarget ??= new CallbacksInvoker<SystemEventTypeUnion>();
+            invoker = this.bubblingTarget ??= this._newDecoratedCallbacksInvoker();
         }
 
         invoker.on(type, callback, target, true);
@@ -280,17 +306,6 @@ export class NodeEventProcessor {
             invoker = this.bubblingTarget;
         }
         invoker?.off(type, callback, target);
-
-        // emit event
-        if (this.shouldHandleEventTouch && !this._hasTouchListeners()) {
-            this.shouldHandleEventTouch = false;
-        }
-        if (this.shouldHandleEventMouse && !this._hasMouseListeners()) {
-            this.shouldHandleEventMouse = false;
-        }
-        if (!this._hasPointerListeners()) {
-            NodeEventProcessor.callbacksInvoker.emit(DispatcherEventType.REMOVE_POINTER_EVENT_PROCESSOR, this);
-        }
     }
 
     public targetOff (target: unknown) {

--- a/cocos/core/scene-graph/node-event-processor.ts
+++ b/cocos/core/scene-graph/node-event-processor.ts
@@ -249,14 +249,10 @@ export class NodeEventProcessor {
      * We need to inject some nodeEventProcessor's logic into the `callbacksInvoker.off` method.
      * @returns {CallbacksInvoker<SystemEventTypeUnion>} decorated callbacks invoker
      */
-    private _newDecoratedCallbacksInvoker (): CallbacksInvoker<SystemEventTypeUnion> {
+    private _newCallbacksInvoker (): CallbacksInvoker<SystemEventTypeUnion> {
         const callbacksInvoker = new CallbacksInvoker<SystemEventTypeUnion>();
-        // decorate off method
-        const offMethod = callbacksInvoker.off;
-        callbacksInvoker.off = (...args: any) => {
-            offMethod.apply(callbacksInvoker, args);
-
-            // Injected logic
+        // @ts-expect-error Property '_registerOffCallback' is private
+        callbacksInvoker._registerOffCallback(() => {
             if (this.shouldHandleEventTouch && !this._hasTouchListeners()) {
                 this.shouldHandleEventTouch = false;
             }
@@ -266,7 +262,7 @@ export class NodeEventProcessor {
             if (!this._hasPointerListeners()) {
                 NodeEventProcessor.callbacksInvoker.emit(DispatcherEventType.REMOVE_POINTER_EVENT_PROCESSOR, this);
             }
-        };
+        });
         return callbacksInvoker;
     }
 
@@ -275,9 +271,9 @@ export class NodeEventProcessor {
         useCapture = !!useCapture;
         let invoker: CallbacksInvoker<SystemEventTypeUnion>;
         if (useCapture) {
-            invoker = this.capturingTarget ??= this._newDecoratedCallbacksInvoker();
+            invoker = this.capturingTarget ??= this._newCallbacksInvoker();
         } else {
-            invoker = this.bubblingTarget ??= this._newDecoratedCallbacksInvoker();
+            invoker = this.bubblingTarget ??= this._newCallbacksInvoker();
         }
         invoker.on(type, callback, target);
         return callback;
@@ -288,9 +284,9 @@ export class NodeEventProcessor {
         useCapture = !!useCapture;
         let invoker: CallbacksInvoker<SystemEventTypeUnion>;
         if (useCapture) {
-            invoker = this.capturingTarget ??= this._newDecoratedCallbacksInvoker();
+            invoker = this.capturingTarget ??= this._newCallbacksInvoker();
         } else {
-            invoker = this.bubblingTarget ??= this._newDecoratedCallbacksInvoker();
+            invoker = this.bubblingTarget ??= this._newCallbacksInvoker();
         }
 
         invoker.on(type, callback, target, true);

--- a/cocos/core/scene-graph/node-event-processor.ts
+++ b/cocos/core/scene-graph/node-event-processor.ts
@@ -247,9 +247,9 @@ export class NodeEventProcessor {
     /**
      * Fix when reigster 'once' event callback, `this.off` method isn't be invoked after event is emitted.
      * We need to inject some nodeEventProcessor's logic into the `callbacksInvoker.off` method.
-     * @returns {CallbacksInvoker} decorated callbacks invoker
+     * @returns {CallbacksInvoker<SystemEventTypeUnion>} decorated callbacks invoker
      */
-    private _newDecoratedCallbacksInvoker () {
+    private _newDecoratedCallbacksInvoker (): CallbacksInvoker<SystemEventTypeUnion> {
         const callbacksInvoker = new CallbacksInvoker<SystemEventTypeUnion>();
         // decorate off method
         const offMethod = callbacksInvoker.off;


### PR DESCRIPTION
Feadback from @dumganhar 

### Changelog
 * 修复 node.once() 注册的事件回调，在事件触发后，不能从 PointerEventDispatcher 的管理列表里移除的问题

### Note
这个是事件重构后出现的问题，在重构之前 once 的处理逻辑是这样的
```ts
public once (type: NodeEventType, callback: AnyFunction, target?: unknown, useCapture?: boolean) {
        invokers.on(type, callback, target, true);
        invokers.on(type, () => {
            this.off(type, callback, target);
        }, undefined, true);
}
```

不过这样会引发的问题是，once 注册之后，没办法反注册匿名函数，只能等下一次事件触发后自动清除

目前的处理逻辑是在 callbacksInvoker 的 off 方法里，注入 nodeEventProcessor 的 off 逻辑
