### PR TITLE
start audioSourceBufferNode before running audio context

### DIFF
--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -236,10 +236,21 @@ export class AudioSource extends Component {
      * Play the clip.<br>
      * Restart if already playing.<br>
      * Resume if paused.
+     *
+     * NOTE: On Web platforms, the Auto Play Policy bans auto playing audios at the first time, because the user gesture is required.
+     * there are 2 ways to play audios at the first time:
+     * - play audios in the callback of TOUCH_END or MOUSE_UP event
+     * - play audios straightly, the engine will auto play audios at the next user gesture.
+     *
      * @zh
      * 开始播放。<br>
      * 如果音频处于正在播放状态，将会重新开始播放音频。<br>
      * 如果音频处于暂停状态，则会继续播放音频。
+     *
+     * 注意:在 Web 平台，Auto Play Policy 禁止首次自动播放音频，因为需要发生用户交互之后才能播放音频。
+     * 有两种方式实现音频首次自动播放：
+     * - 在 TOUCH_END 或者 MOUSE_UP 的事件回调里播放音频。
+     * - 直接播放音频，引擎会在下一次发生用户交互时自动播放。
      */
     public play () {
         if (!this._isLoaded) {

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -11,7 +11,7 @@ import { audioBufferManager } from '../audio-buffer-manager';
 const AudioContextClass = (window.AudioContext || window.webkitAudioContext || window.mozAudioContext);
 export class AudioContextAgent {
     public static support = !!AudioContextClass;
-    public _context: AudioContext;
+    private _context: AudioContext;
     constructor () {
         this._context = new (window.AudioContext || window.webkitAudioContext || window.mozAudioContext)();
     }
@@ -36,22 +36,23 @@ export class AudioContextAgent {
         return new Promise((resolve) => {
             const context = this._context;
             if (!context.resume) {
-                return resolve();
+                resolve();
+                return;
             }
             if (context.state === 'running') {
-                return resolve();
+                resolve();
+                return;
             }
-            context.resume().catch((e) => {});
-            // promise rejection cannot be caught, need to check running state again
-            if (<string>context.state !== 'running') {
-                const canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
-                const onGesture = () => {
-                    context.resume().then(resolve).catch((e) => {});
-                };
-                canvas?.addEventListener('touchend', onGesture, { once: true });
-                canvas?.addEventListener('mousedown', onGesture, { once: true });
-            }
-            return null;
+            // Force running audio context if state is not 'running', may be 'suspended' or 'interrupted'.
+            const canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
+            const onGesture = () => {
+                context.resume().then(() => {
+                    console.log('test');
+                    resolve();
+                }).catch((e) => {});
+            };
+            canvas?.addEventListener('touchend', onGesture, { once: true, capture: true });
+            canvas?.addEventListener('mouseup', onGesture, { once: true, capture: true });
         });
     }
 
@@ -133,9 +134,9 @@ export class OneShotAudioWeb {
         if (EDITOR) {
             return;
         }
+        this._bufferSourceNode.start();
         // audioContextAgent does exist
         audioContextAgent!.runContext().then(() => {
-            this._bufferSourceNode.start();
             this.onPlay?.();
             this._currentTimer = window.setTimeout(() => {
                 audioBufferManager.tryReleasingCache(this._url);
@@ -308,12 +309,12 @@ export class AudioPlayerWeb implements OperationQueueable {
     // so we define this method to ensure that the audio seeking works.
     private _doPlay (): Promise<void> {
         return new Promise((resolve) => {
+            // one AudioBufferSourceNode can't start twice
+            this._stopSourceNode();
+            this._sourceNode = audioContextAgent!.createBufferSource(this._audioBuffer, this.loop);
+            this._sourceNode.connect(this._gainNode);
+            this._sourceNode.start(0, this._audioTimer.currentTime);
             audioContextAgent!.runContext().then(() => {
-                // one AudioBufferSourceNode can't start twice
-                this._stopSourceNode();
-                this._sourceNode = audioContextAgent!.createBufferSource(this._audioBuffer, this.loop);
-                this._sourceNode.connect(this._gainNode);
-                this._sourceNode.start(0, this._audioTimer.currentTime);
                 this._state = AudioState.PLAYING;
                 this._audioTimer.start();
 

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -46,10 +46,7 @@ export class AudioContextAgent {
             // Force running audio context if state is not 'running', may be 'suspended' or 'interrupted'.
             const canvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
             const onGesture = () => {
-                context.resume().then(() => {
-                    console.log('test');
-                    resolve();
-                }).catch((e) => {});
+                context.resume().then(resolve).catch((e) => {});
             };
             canvas?.addEventListener('touchend', onGesture, { once: true, capture: true });
             canvas?.addEventListener('mouseup', onGesture, { once: true, capture: true });


### PR DESCRIPTION
resolve https://github.com/cocos-creator/3d-tasks/issues/8282

### related pr
https://github.com/cocos-creator/engine/pull/9652

### Changelog
- fix can't play audio on the button clicked callback

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
