### PR TITLE
Fix log() takes not effect if debug mode <= verbose

### DIFF
--- a/cocos/core/platform/debug.ts
+++ b/cocos/core/platform/debug.ts
@@ -231,7 +231,7 @@ export function _resetDebugSetting (mode: DebugMode) {
 
     if (EDITOR) {
         ccLog = console.log.bind(console);
-    } else if (mode === DebugMode.INFO) {
+    } else if (mode <= DebugMode.INFO) {
         if (JSB) {
             // @ts-expect-error We have no typing for this
             if (scriptEngineType === 'JavaScriptCore') {

--- a/tests/core/logging.test.ts
+++ b/tests/core/logging.test.ts
@@ -1,21 +1,31 @@
 
-import { debug, DebugMode, _resetDebugSetting } from '../../cocos/core/platform/debug';
+import { debug, DebugMode, log, _resetDebugSetting } from '../../cocos/core/platform/debug';
 
 describe('Logging', () => {
-    test('Verbose level', () => {
-        const spy = jest.spyOn(globalThis.console, 'debug');
+    test('Debug mode', () => {
+        const debugSpy = jest.spyOn(globalThis.console, 'debug');
+        const logSpy = jest.spyOn(globalThis.console, 'log');
 
         _resetDebugSetting(DebugMode.VERBOSE);
         debug('Hiya');
-        expect(spy).toBeCalledTimes(1);
-        expect(spy).toBeCalledWith('Hiya');
-        spy.mockClear();
+        log('Hiya');
+        expect(debugSpy).toBeCalledTimes(1);
+        expect(debugSpy).toBeCalledWith('Hiya');
+        expect(logSpy).toBeCalledTimes(1);
+        expect(logSpy).toBeCalledWith('Hiya');
+        debugSpy.mockClear();
+        logSpy.mockClear();
 
         _resetDebugSetting(DebugMode.INFO);
         debug('Hiya');
-        expect(spy).toBeCalledTimes(0);
-        spy.mockClear();
+        log('Hiya');
+        expect(debugSpy).toBeCalledTimes(0);
+        expect(logSpy).toBeCalledTimes(1);
+        expect(logSpy).toBeCalledWith('Hiya');
+        debugSpy.mockClear();
+        logSpy.mockClear();
 
-        spy.mockRestore();
+        debugSpy.mockRestore();
+        logSpy.mockRestore();
     });
 });


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
