### PR TITLE
fix default property missing when property index is set

### DIFF
--- a/cocos/core/assets/material.ts
+++ b/cocos/core/assets/material.ts
@@ -379,10 +379,9 @@ export class Material extends Asset {
             const passInfo = tech.passes[k] as IPassInfoFull;
             const propIdx = passInfo.passIndex = k;
             const defines = passInfo.defines = this._defines[propIdx] || (this._defines[propIdx] = {});
-            const states = passInfo.stateOverrides = this._states[propIdx] || (this._states[propIdx] = {});
+            passInfo.stateOverrides = this._states[propIdx] || (this._states[propIdx] = {});
             if (passInfo.propertyIndex !== undefined) {
                 Object.assign(defines, this._defines[passInfo.propertyIndex]);
-                Object.assign(states, this._states[passInfo.propertyIndex]);
             }
             if (passInfo.embeddedMacros !== undefined) {
                 Object.assign(defines, passInfo.embeddedMacros);

--- a/cocos/core/renderer/core/program-lib.ts
+++ b/cocos/core/renderer/core/program-lib.ts
@@ -198,6 +198,16 @@ class ProgramLib {
             const tmpl = this.define(effect.shaders[i]);
             tmpl.effectName = effect.name;
         }
+        for (let i = 0; i < effect.techniques.length; i++) {
+            const tech = effect.techniques[i];
+            for (let j = 0; j < tech.passes.length; j++) {
+                const pass = tech.passes[j];
+                // grab default property declaration if there is none
+                if (pass.propertyIndex !== undefined && pass.properties === undefined) {
+                    pass.properties = tech.passes[pass.propertyIndex].properties;
+                }
+            }
+        }
     }
 
     /**

--- a/cocos/core/splash-screen.ts
+++ b/cocos/core/splash-screen.ts
@@ -28,8 +28,6 @@
  * @hidden
  */
 
-/* eslint-disable no-restricted-globals */
-import { JSB } from 'internal:constants';
 import * as easing from './animation/easing';
 import { Material } from './assets/material';
 import { clamp01 } from './math/utils';

--- a/editor/assets/effects/builtin-standard.effect
+++ b/editor/assets/effects/builtin-standard.effect
@@ -41,7 +41,6 @@ CCEffect %{
           blendDst: one
           blendSrcAlpha: zero
           blendDstAlpha: one
-      properties: *props
     - &shadow-caster
       vert: shadow-caster-vs:vert
       frag: shadow-caster-fs:frag


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * now the `properties: *props` line can be safely removed
 * `propertyIndex` shouldn't affect pipeline states


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->