### PR TITLE
Smooth Motion Streak movement

### DIFF
--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -61,6 +61,7 @@ var MotionStreak = cc.Class({
 
     ctor () {
         this._points = [];
+        this._lastWPos = new cc.Vec2();
     },
 
     properties: {
@@ -247,6 +248,8 @@ var MotionStreak = cc.Class({
     reset () {
         this._points.length = 0;
         this._assembler && this._assembler._renderData.clear();
+        this._lastWPos.x = 0;
+        this._lastWPos.y = 0;
         if (CC_EDITOR) {
             cc.engine.repaintInEditMode();
         }


### PR DESCRIPTION
Changelog:
 * 在不影响整个组件定位的前提下尽可能优化 Motion Streak 的视觉效果，减少破面、穿帮，突变。
 
优化的点：
- 起始面片的平滑出现
- 修复原先慢慢移动的话，第一个拖尾始终出不来的问题（特别是  minSeg 设大之后）
- 最后一个面片的平滑消失
- 移动过程中，拖尾随着时间变短，而不是一节一节消失（旧版也有，但是实现有问题，经常出不来效果）
- 方向改变时，减少破面的出现概率。原理是在 minSeg 阈值到达前，始终允许前一个定点的方向进行重新变更，减少了方向的改变频率，就减少了频繁微小移动带来的破面（参考视频 old/new 20）

警告：
- 只测试了 web 平台，模拟器由于硬盘空间不足删掉了跑不了也没测试。请协助测试！

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
