### PR TITLE
fix get prefab clip spriteFrame missing for cc.GifAsset

### DIFF
--- a/cocos2d/core/assets/CCGifAssset.js
+++ b/cocos2d/core/assets/CCGifAssset.js
@@ -60,7 +60,6 @@ const GifAsset = cc.Class({
          */
         _spriteFrames: {
             default: {},
-            type: cc.SpriteFrame,
         },
         /**
          * !#en Gif AnimationClip

--- a/cocos2d/core/assets/CCGifAssset.js
+++ b/cocos2d/core/assets/CCGifAssset.js
@@ -38,13 +38,18 @@ const GifAsset = cc.Class({
          * @type {Prefab}
          * @default null
          */
+        _prefab: {
+            default: null,
+            type: cc.Prefab
+        },
         prefab: {
             get: function () {
                 return this._prefab;
             },
             set: function (value) {
                 this._prefab = value;
-            }
+            },
+            type: cc.Prefab,
         },
         /**
          * !#en Gif sequence SpriteFrame
@@ -53,13 +58,9 @@ const GifAsset = cc.Class({
          * @type {Object}
          * @default {}
          */
-        spriteFrames: {
-            get: function () {
-                return this._spriteFrames;
-            },
-            set: function (value) {
-                this._spriteFrames = value;
-            }
+        _spriteFrames: {
+            default: {},
+            type: cc.SpriteFrame,
         },
         /**
          * !#en Gif AnimationClip
@@ -68,22 +69,56 @@ const GifAsset = cc.Class({
          * @type {AnimationClip}
          * @default null
          */
+        _animationClip: {
+            default: null,
+            type: cc.AnimationClip,
+        },
         animationClip: {
             get: function () {
                 return this._animationClip;
             },
             set: function (value) {
                 this._animationClip = value;
-            }
+            },
+            type: cc.AnimationClip,
         }
     },
 
-    ctor: function () {
-        this._prefab = null;
-        this._animationClip = null;
-        this._spriteFrames = {};
+
+    /**
+     * !#en Get a single SpriteFrame by name
+     * !#zh 通过名字获取单个 SpriteFrame
+     * @method getSpriteFrame
+     * @param {String} name
+     * @returns {SpriteFrame}
+     */
+    getSpriteFrame: function (name) {
+        let sf = this._spriteFrames[name];
+        if (!sf) {
+            return null;
+        }
+        if (!sf.name) {
+            sf.name = name;
+        }
+        return sf;
     },
 
+    /**
+     * !#en Gif sequence SpriteFrame
+     * !#zh gif 序列 SpriteFrame
+     * @method getSpriteFrames
+     * @returns {[SpriteFrame]}
+     */
+    getSpriteFrames: function () {
+        const frames = [];
+        const spriteFrames = this._spriteFrames;
+
+        for (const key in spriteFrames) {
+            frames.push(this.getSpriteFrame(key));
+        }
+
+        return frames;
+    }
 });
 cc.GifAsset = GifAsset;
 module.exports = GifAsset;


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 修复通过 cc.GifAsset 获取不到 prefab、clip、sprite frames 的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
