### PR TITLE
Always expose component missing error in runtime

### DIFF
--- a/cocos/core/scene-graph/node-activator.ts
+++ b/cocos/core/scene-graph/node-activator.ts
@@ -136,7 +136,7 @@ function _componentCorrupted (node, comp, index) {
 
 function _onLoadInEditor (comp) {
     if (comp.onLoad && !legacyCC.GAME_VIEW) {
-        // @ts-expect-error
+        // @ts-expect-error Editor API usage
         const focused = Editor.Selection.getLastSelected('node') === comp.node.uuid;
         if (focused) {
             if (comp.onFocusInEditor && callOnFocusInTryCatch) {
@@ -147,7 +147,7 @@ function _onLoadInEditor (comp) {
         }
     }
     if (!TEST) {
-        // @ts-expect-error
+        // @ts-expect-error Editor API usage
         _Scene.AssetsWatcher.start(comp);
     }
 }

--- a/cocos/core/scene-graph/node-activator.ts
+++ b/cocos/core/scene-graph/node-activator.ts
@@ -125,10 +125,8 @@ activateTasksPool.get = function getActivateTask () {
 };
 
 function _componentCorrupted (node, comp, index) {
-    if (DEV) {
-        errorID(3817, node.name, index);
-        console.log('Corrupted component value:', comp);
-    }
+    errorID(3817, node.name, index);
+    console.log('Corrupted component value:', comp);
     if (comp) {
         node._removeComponent(comp);
     } else {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Always expose component missing error in runtime

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
