### PR TITLE
Fix onPaused naming error in video player code

### DIFF
--- a/cocos/video/deprecated.ts
+++ b/cocos/video/deprecated.ts
@@ -24,10 +24,15 @@
  */
 
 /**
+ * @packageDocumentation
  * @hidden
  */
+import { replaceProperty } from '../core/utils/x-deprecated';
+import { VideoPlayer } from "./video-player";
 
-export { VideoClip } from '../cocos/video/assets/video-clip';
-import '../cocos/video/video-downloader';
-
-export * from '../cocos/video';
+replaceProperty(VideoPlayer.prototype, 'VideoPlayer.prototype', [
+    {
+        name: 'onPasued',
+        newName: 'onPaused',
+    }
+]);

--- a/cocos/video/deprecated.ts
+++ b/cocos/video/deprecated.ts
@@ -28,11 +28,11 @@
  * @hidden
  */
 import { replaceProperty } from '../core/utils/x-deprecated';
-import { VideoPlayer } from "./video-player";
+import { VideoPlayer } from './video-player';
 
 replaceProperty(VideoPlayer.prototype, 'VideoPlayer.prototype', [
     {
         name: 'onPasued',
         newName: 'onPaused',
-    }
+    },
 ]);

--- a/cocos/video/index.ts
+++ b/cocos/video/index.ts
@@ -28,7 +28,7 @@ THE SOFTWARE.
  * @hidden
  */
 
-import '../video-downloader';
+import './video-downloader';
 
 import { VideoClip } from './assets/video-clip';
 import { VideoPlayer } from './video-player';

--- a/cocos/video/index.ts
+++ b/cocos/video/index.ts
@@ -28,7 +28,11 @@ THE SOFTWARE.
  * @hidden
  */
 
+import '../video-downloader';
+
+import { VideoClip } from './assets/video-clip';
 import { VideoPlayer } from './video-player';
 import './deprecated';
 
+export { VideoClip };
 export { VideoPlayer };

--- a/cocos/video/index.ts
+++ b/cocos/video/index.ts
@@ -1,0 +1,3 @@
+
+export { VideoPlayer } from './video-player';
+import './deprecated';

--- a/cocos/video/index.ts
+++ b/cocos/video/index.ts
@@ -1,3 +1,34 @@
+/*
+Copyright (c) 2020 Xiamen Yaji Software Co., Ltd.
 
-export { VideoPlayer } from './video-player';
+https://www.cocos.com/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated engine source code (the "Software"), a limited,
+ worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+to use Cocos Creator solely to develop games on your target platforms. You shall
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
+
+The software or tools in this License Agreement are licensed, not sold.
+Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * @packageDocumentation
+ * @hidden
+ */
+
+import { VideoPlayer } from './video-player';
 import './deprecated';
+
+export { VideoPlayer };

--- a/cocos/video/video-player.ts
+++ b/cocos/video/video-player.ts
@@ -389,7 +389,7 @@ export class VideoPlayer extends Component {
         this._impl.componentEventList.set(EventType.META_LOADED, this.onMetaLoaded.bind(this));
         this._impl.componentEventList.set(EventType.READY_TO_PLAY, this.onReadyToPlay.bind(this));
         this._impl.componentEventList.set(EventType.PLAYING, this.onPlaying.bind(this));
-        this._impl.componentEventList.set(EventType.PAUSED, this.onPasued.bind(this));
+        this._impl.componentEventList.set(EventType.PAUSED, this.onPaused.bind(this));
         this._impl.componentEventList.set(EventType.STOPPED, this.onStopped.bind(this));
         this._impl.componentEventList.set(EventType.COMPLETED, this.onCompleted.bind(this));
         this._impl.componentEventList.set(EventType.ERROR, this.onError.bind(this));
@@ -439,7 +439,7 @@ export class VideoPlayer extends Component {
         this.node.emit(EventType.PLAYING, this);
     }
 
-    public onPasued () {
+    public onPaused () {
         ComponentEventHandler.emitEvents(this.videoPlayerEvent, this, EventType.PAUSED);
         this.node.emit(EventType.PAUSED, this);
     }

--- a/exports/video.ts
+++ b/exports/video.ts
@@ -26,9 +26,4 @@
 /**
  * @hidden
  */
-
-import '../cocos/video/video-downloader';
-
-export { VideoClip } from '../cocos/video/assets/video-clip';
-
 export * from '../cocos/video';

--- a/exports/video.ts
+++ b/exports/video.ts
@@ -27,7 +27,8 @@
  * @hidden
  */
 
-export { VideoClip } from '../cocos/video/assets/video-clip';
 import '../cocos/video/video-downloader';
+
+export { VideoClip } from '../cocos/video/assets/video-clip';
 
 export * from '../cocos/video';

--- a/extensions/videoplayer/CCVideoPlayer.js
+++ b/extensions/videoplayer/CCVideoPlayer.js
@@ -312,7 +312,7 @@ let VideoPlayer = cc.Class({
 
             if (!CC_EDITOR) {
                 impl.setEventListener(EventType.PLAYING, this.onPlaying.bind(this));
-                impl.setEventListener(EventType.PAUSED, this.onPasued.bind(this));
+                impl.setEventListener(EventType.PAUSED, this.onPaused.bind(this));
                 impl.setEventListener(EventType.STOPPED, this.onStopped.bind(this));
                 impl.setEventListener(EventType.COMPLETED, this.onCompleted.bind(this));
                 impl.setEventListener(EventType.META_LOADED, this.onMetaLoaded.bind(this));
@@ -373,7 +373,7 @@ let VideoPlayer = cc.Class({
         this.node.emit('playing', this);
     },
 
-    onPasued () {
+    onPaused () {
         cc.Component.EventHandler.emitEvents(this.videoPlayerEvent, this, EventType.PAUSED);
         this.node.emit('paused', this);
     },


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * synced 2.x wrong function names, 2.x fixed, now 3.x fixed
 * add deprecated in video

Renderings:
![image](https://user-images.githubusercontent.com/7564028/143534846-cf57181a-bda8-4ab1-9a9c-9f44299581cc.png)


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
