### PR TITLE
fix RenderData bug when node not add to scene

### DIFF
--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -161,7 +161,10 @@ export class RenderData extends BaseRenderData {
         if (this.nodeDirty) {
             this.renderScene = comp.node.scene ? comp._getRenderScene() : null;
             this.layer = comp.node.layer;
-            this.nodeDirty = false;
+            // Hack for updateRenderData when node not add to scene
+            if (this.renderScene !== null) {
+                this.nodeDirty = false;
+            }
             this.hashDirty = true;
         }
         if (this.textureDirty) {


### PR DESCRIPTION
Re: https://forum.cocos.org/t/topic/124094/237

由于char模式提前更新了 renderData，而此时 node 尚未添加到场景中，且 dirty 已经被重置了导致。
此修改为 Hack，应该由 node 通知组件进行 dirty change 操作。