### PR TITLE
when the pointer is locked, don't move it.

### DIFF
--- a/pal/input/web/mouse-input.ts
+++ b/pal/input/web/mouse-input.ts
@@ -37,8 +37,8 @@ export class MouseInputSource {
     private _getLocation (mouseEvent: MouseEvent): Vec2 {
         const canvasRect = this._getCanvasRect();
         const dpr = screenAdapter.devicePixelRatio;
-        let x = this._pointLocked ? (this._preMousePos.x / dpr + mouseEvent.movementX) : (mouseEvent.clientX - canvasRect.x);
-        let y = this._pointLocked ? (this._preMousePos.y / dpr - mouseEvent.movementY) : (canvasRect.y + canvasRect.height - mouseEvent.clientY);
+        let x = this._pointLocked ? (this._preMousePos.x / dpr) : (mouseEvent.clientX - canvasRect.x);
+        let y = this._pointLocked ? (this._preMousePos.y / dpr) : (canvasRect.y + canvasRect.height - mouseEvent.clientY);
         x *= dpr;
         y *= dpr;
         return new Vec2(x, y);


### PR DESCRIPTION
Bug fix with locked pointer. Issue [https://github.com/cocos-creator/engine/issues/9749](url)

Changelog:
 * Remove the adjustment to the pointer when the cursor is locked.

