### PR TITLE
remove render data when particle has been destroy

### DIFF
--- a/cocos/particle-2d/particle-system-2d-assembler.ts
+++ b/cocos/particle-2d/particle-system-2d-assembler.ts
@@ -41,6 +41,9 @@ export const ParticleAssembler: IAssembler = {
     createData (comp: ParticleSystem2D) {
         return MeshRenderData.add();
     },
+    removeData (data) {
+        MeshRenderData.remove(data);
+    },
     updateRenderData () {
     },
     fillBuffers (comp: ParticleSystem2D, renderer: IBatcher) {

--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -765,6 +765,10 @@ export class ParticleSystem2D extends Renderable2D {
 
         // reset uv data so next time simulator will refill buffer uv info when exit edit mode from prefab.
         this._simulator.uvFilled = 0;
+
+        if (this._simulator.renderData && this._assembler) {
+            this._assembler.removeData(this._simulator.renderData);
+        }
     }
 
     private initProperties () {


### PR DESCRIPTION
Thanks for contribution by **david**

Changelog:
 * recycle render data when particle has been destroy

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
