### PR TITLE
Refactor communication between skinned mesh renderer and skeletal animation

### DIFF
--- a/cocos/3d/skeletal-animation/skeletal-animation.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation.ts
@@ -276,6 +276,14 @@ export class SkeletalAnimation extends Animation {
         this._users.delete(user);
     }
 
+    /**
+     * Get all users.
+     * @internal This method only friends to the skeleton animation state.
+     */
+    public getUsers () {
+        return this._users;
+    }
+
     protected _createState (clip: AnimationClip, name?: string) {
         return new SkeletalAnimationState(clip, name);
     }

--- a/cocos/3d/skeletal-animation/skeletal-animation.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation.ts
@@ -43,6 +43,7 @@ import { getWorldTransformUntilRoot } from '../../core/animation/transform-utils
 import { legacyCC } from '../../core/global-exports';
 import { AnimationManager } from '../../core/animation/animation-manager';
 import { js } from '../../core/utils/js';
+import type { AnimationState } from '../../core/animation/animation-state';
 
 @ccclass('cc.SkeletalAnimation.Socket')
 export class Socket {
@@ -141,17 +142,22 @@ export class SkeletalAnimation extends Animation {
 
     set useBakedAnimation (val) {
         this._useBakedAnimation = val;
+        this._removeAllUsers();
+
+        // Actively search for potential users and notify them that an animation is usable.
         const comps = this.node.getComponentsInChildren(SkinnedMeshRenderer);
         for (let i = 0; i < comps.length; ++i) {
             const comp = comps[i];
             if (comp.skinningRoot === this.node) {
-                comp.setUseBakedAnimation(this._useBakedAnimation, true);
+                comp.notifyAnimationUsable(this);
             }
         }
+
         if (this._useBakedAnimation) {
             (legacyCC.director.getAnimationManager() as AnimationManager).removeSockets(this.node, this._sockets);
         } else {
             (legacyCC.director.getAnimationManager() as AnimationManager).addSockets(this.node, this._sockets);
+            this._currentBakedState = null;
         }
     }
 
@@ -171,6 +177,31 @@ export class SkeletalAnimation extends Animation {
         this.sockets = this._sockets;
         this.useBakedAnimation = this._useBakedAnimation;
         super.start();
+    }
+
+    public pause () {
+        if (!this._useBakedAnimation) {
+            super.pause();
+        } else {
+            this._currentBakedState?.pause();
+        }
+    }
+
+    public resume () {
+        if (!this._useBakedAnimation) {
+            super.resume();
+        } else {
+            this._currentBakedState?.resume();
+        }
+    }
+
+    public stop () {
+        if (!this._useBakedAnimation) {
+            super.stop();
+        } else if (this._currentBakedState) {
+            this._currentBakedState.stop();
+            this._currentBakedState = null;
+        }
     }
 
     public querySockets () {
@@ -218,6 +249,33 @@ export class SkeletalAnimation extends Animation {
         return target;
     }
 
+    /**
+     * Adds an user which uses this animation.
+     * @internal This method only friends to skinned mesh renderer.
+     */
+    public addUser (user: SkinnedMeshRenderer) {
+        this._users.add(user);
+        const { _useBakedAnimation: useBakedAnimation } = this;
+        user.setUseBakedAnimation(useBakedAnimation, true);
+        if (useBakedAnimation) {
+            const { _currentBakedState: playingState } = this;
+            if (playingState) {
+                user.uploadAnimation(playingState.clip);
+            }
+        }
+    }
+
+    /**
+     * Remove specific user of this animation.
+     * The user should receive an "animation useless" notification.
+     * @internal This method only friends to skinned mesh renderer.
+     */
+    public removeUser (user: SkinnedMeshRenderer) {
+        user.setUseBakedAnimation(false);
+        user.notifyAnimationUnusable();
+        this._users.delete(user);
+    }
+
     protected _createState (clip: AnimationClip, name?: string) {
         return new SkeletalAnimationState(clip, name);
     }
@@ -226,5 +284,21 @@ export class SkeletalAnimation extends Animation {
         const state = super._doCreateState(clip, name) as SkeletalAnimationState;
         state.rebuildSocketCurves(this._sockets);
         return state;
+    }
+
+    protected doPlayOrCrossFade (state: AnimationState) {
+        const skeletalAnimationState = state as SkeletalAnimationState;
+        this._currentBakedState = skeletalAnimationState;
+        skeletalAnimationState.play();
+    }
+
+    private _users = new Set<SkinnedMeshRenderer>();
+
+    private _currentBakedState: SkeletalAnimationState | null = null;
+
+    private _removeAllUsers () {
+        Array.from(this._users).forEach((user) => {
+            this.removeUser(user);
+        });
     }
 }

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -220,8 +220,7 @@ export class Animation extends Eventify(Component) {
         this._hasBeenPlayed = true;
         const state = this._nameToState[name];
         if (state) {
-            this._crossFade.play();
-            this._crossFade.crossFade(state, duration);
+            this.doPlayOrCrossFade(state, duration);
         }
     }
 
@@ -451,18 +450,13 @@ export class Animation extends Eventify(Component) {
         return state;
     }
 
-    private _getStateByNameOrDefaultClip (name?: string) {
-        if (!name) {
-            if (!this._defaultClip) {
-                return null;
-            }
-            name = this._defaultClip.name;
-        }
-        const state = this._nameToState[name];
-        if (state) {
-            return state;
-        }
-        return null;
+    /**
+     *
+     * @internal This method only friends to skeletal animation component.
+     */
+    protected doPlayOrCrossFade (state: AnimationState, duration: number) {
+        this._crossFade.play();
+        this._crossFade.crossFade(state, duration);
     }
 
     private _removeStateOfAutomaticClip (clip: AnimationClip) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Refactor communication between skinned mesh renderer and skeletal animation.

This also fixes:

 - If the skinned mesh renderer component is added after the skeleton animation component has been started. https://github.com/cocos-creator/3d-tasks/issues/10395

 - Remove the skeletal animation component, then the skinned mesh renderer component would be mis-rendered.

------------------------------

## Refactor

- Skinned mesh renderer components are users of skeletal animation components. Let's call them mesh and animation, respectively.

- One animation may be used by zero or more meshes.

- How does a mesh become user of animation?

  - Once an animation initialized, it will search for meshes and notify them that an animation is useable, then the mesh call `addUser()` to register itself as a user of the animation.

  - Once an mesh initialized, it will search for an animation, and register itself as a user of that animation.

- How does they terminate the relationship?

  - Once the animation got destroyed, it terminate the relationship and notify all users it's unusable.

  - Once the mesh got destroyed, it call `removeUser()` to unregister itself.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
