### PR TITLE
support internal interface filter

### DIFF
--- a/cocos/2d/assets/sprite-atlas.ts
+++ b/cocos/2d/assets/sprite-atlas.ts
@@ -107,7 +107,7 @@ export class SpriteAtlas extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -130,7 +130,7 @@ export class SpriteAtlas extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _deserialize (serializeData: any, handle: any) {
         const data = serializeData as ISpriteAtlasSerializeData;

--- a/cocos/2d/assets/sprite-atlas.ts
+++ b/cocos/2d/assets/sprite-atlas.ts
@@ -107,7 +107,7 @@ export class SpriteAtlas extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -130,7 +130,7 @@ export class SpriteAtlas extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _deserialize (serializeData: any, handle: any) {
         const data = serializeData as ISpriteAtlasSerializeData;

--- a/cocos/2d/assets/sprite-atlas.ts
+++ b/cocos/2d/assets/sprite-atlas.ts
@@ -106,6 +106,9 @@ export class SpriteAtlas extends Asset {
         return frames;
     }
 
+    /**
+     * @private_cc
+     */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
             const frames: string[] = [];
@@ -126,6 +129,9 @@ export class SpriteAtlas extends Asset {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _deserialize (serializeData: any, handle: any) {
         const data = serializeData as ISpriteAtlasSerializeData;
         this._name = data.name;

--- a/cocos/2d/assets/sprite-frame.ts
+++ b/cocos/2d/assets/sprite-frame.ts
@@ -801,7 +801,7 @@ export class SpriteFrame extends Asset {
 
     /**
      * Calculate UV for sliced
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _calculateSlicedUV () {
         if (UI_GPU_DRIVEN) {
@@ -866,7 +866,7 @@ export class SpriteFrame extends Asset {
 
     /**
      * Calculate UV
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _calculateUV () {
         const rect = this._rect;
@@ -1109,7 +1109,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _setDynamicAtlasFrame (frame) {
         if (!frame) return;
@@ -1127,7 +1127,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _resetDynamicAtlasFrame () {
         if (!this._original) return;
@@ -1139,7 +1139,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _checkPackable () {
         const dynamicAtlas = dynamicAtlasManager;
@@ -1165,7 +1165,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -1211,7 +1211,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _deserialize (serializeData: any, handle: any) {
         const data = serializeData as ISpriteFramesSerializeData;

--- a/cocos/2d/assets/sprite-frame.ts
+++ b/cocos/2d/assets/sprite-frame.ts
@@ -799,7 +799,10 @@ export class SpriteFrame extends Asset {
         return super.destroy();
     }
 
-    // Calculate UV for sliced
+    /**
+     * Calculate UV for sliced
+     * @private_cc
+     */
     public _calculateSlicedUV () {
         if (UI_GPU_DRIVEN) {
             this._calculateSlicedData();
@@ -861,7 +864,10 @@ export class SpriteFrame extends Asset {
         }
     }
 
-    // Calculate UV
+    /**
+     * Calculate UV
+     * @private_cc
+     */
     public _calculateUV () {
         const rect = this._rect;
         const uv = this.uv;
@@ -1102,6 +1108,9 @@ export class SpriteFrame extends Asset {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _setDynamicAtlasFrame (frame) {
         if (!frame) return;
 
@@ -1117,6 +1126,9 @@ export class SpriteFrame extends Asset {
         this._calculateUV();
     }
 
+    /**
+     * @private_cc
+     */
     public _resetDynamicAtlasFrame () {
         if (!this._original) return;
         this._rect.x = this._original._x;
@@ -1126,6 +1138,9 @@ export class SpriteFrame extends Asset {
         this._calculateUV();
     }
 
+    /**
+     * @private_cc
+     */
     public _checkPackable () {
         const dynamicAtlas = dynamicAtlasManager;
         if (!dynamicAtlas) return;
@@ -1149,7 +1164,9 @@ export class SpriteFrame extends Asset {
         }
     }
 
-    // SERIALIZATION
+    /**
+     * @private_cc
+     */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
             const rect = { x: this._rect.x, y: this._rect.y, width: this._rect.width, height: this._rect.height };
@@ -1193,6 +1210,9 @@ export class SpriteFrame extends Asset {
         return null;
     }
 
+    /**
+     * @private_cc
+     */
     public _deserialize (serializeData: any, handle: any) {
         const data = serializeData as ISpriteFramesSerializeData;
         const rect = data.rect;

--- a/cocos/2d/assets/sprite-frame.ts
+++ b/cocos/2d/assets/sprite-frame.ts
@@ -801,7 +801,7 @@ export class SpriteFrame extends Asset {
 
     /**
      * Calculate UV for sliced
-     * @private_cc
+     * @deprecated_to_user
      */
     public _calculateSlicedUV () {
         if (UI_GPU_DRIVEN) {
@@ -866,7 +866,7 @@ export class SpriteFrame extends Asset {
 
     /**
      * Calculate UV
-     * @private_cc
+     * @deprecated_to_user
      */
     public _calculateUV () {
         const rect = this._rect;
@@ -1109,7 +1109,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _setDynamicAtlasFrame (frame) {
         if (!frame) return;
@@ -1127,7 +1127,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _resetDynamicAtlasFrame () {
         if (!this._original) return;
@@ -1139,7 +1139,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _checkPackable () {
         const dynamicAtlas = dynamicAtlasManager;
@@ -1165,7 +1165,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -1211,7 +1211,7 @@ export class SpriteFrame extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _deserialize (serializeData: any, handle: any) {
         const data = serializeData as ISpriteFramesSerializeData;

--- a/cocos/2d/assets/ttf-font.ts
+++ b/cocos/2d/assets/ttf-font.ts
@@ -40,6 +40,9 @@ import { legacyCC } from '../../core/global-exports';
  */
 @ccclass('cc.TTFFont')
 export class TTFFont extends Font {
+    /**
+     * @private_cc
+     */
     @serializable
     public _fontFamily: string | null = null;
 

--- a/cocos/2d/assets/ttf-font.ts
+++ b/cocos/2d/assets/ttf-font.ts
@@ -46,6 +46,9 @@ export class TTFFont extends Font {
     @serializable
     public _fontFamily: string | null = null;
 
+    /**
+     * @private_cc
+     */
     @override
     @string
     get _nativeAsset () {
@@ -55,6 +58,9 @@ export class TTFFont extends Font {
         this._fontFamily = value || 'Arial';
     }
 
+    /**
+     * @private_cc
+     */
     @override
     get _nativeDep () {
         return { uuid: this._uuid, __nativeName__: this._native, ext: extname(this._native), __isNative__: true };

--- a/cocos/2d/assets/ttf-font.ts
+++ b/cocos/2d/assets/ttf-font.ts
@@ -41,13 +41,13 @@ import { legacyCC } from '../../core/global-exports';
 @ccclass('cc.TTFFont')
 export class TTFFont extends Font {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _fontFamily: string | null = null;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @override
     @string
@@ -59,7 +59,7 @@ export class TTFFont extends Font {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @override
     get _nativeDep () {

--- a/cocos/2d/assets/ttf-font.ts
+++ b/cocos/2d/assets/ttf-font.ts
@@ -41,13 +41,13 @@ import { legacyCC } from '../../core/global-exports';
 @ccclass('cc.TTFFont')
 export class TTFFont extends Font {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _fontFamily: string | null = null;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @override
     @string
@@ -59,7 +59,7 @@ export class TTFFont extends Font {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @override
     get _nativeDep () {

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -637,7 +637,7 @@ export class Label extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     get _bmFontOriginalSize () {
         if (this._font instanceof BitmapFont) {

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -637,7 +637,7 @@ export class Label extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _bmFontOriginalSize () {
         if (this._font instanceof BitmapFont) {

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -636,6 +636,9 @@ export class Label extends Renderable2D {
         this._fontAtlas = value;
     }
 
+    /**
+     * @private_cc
+     */
     get _bmFontOriginalSize () {
         if (this._font instanceof BitmapFont) {
             return this._font.fontSize;

--- a/cocos/2d/components/mask.ts
+++ b/cocos/2d/components/mask.ts
@@ -328,11 +328,11 @@ export class Mask extends Renderable2D {
     public static Type = MaskType;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _clearStencilMtl: Material | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _clearModel: Model | null = null;
 

--- a/cocos/2d/components/mask.ts
+++ b/cocos/2d/components/mask.ts
@@ -328,11 +328,11 @@ export class Mask extends Renderable2D {
     public static Type = MaskType;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _clearStencilMtl: Material | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _clearModel: Model | null = null;
 

--- a/cocos/2d/components/mask.ts
+++ b/cocos/2d/components/mask.ts
@@ -327,7 +327,13 @@ export class Mask extends Renderable2D {
 
     public static Type = MaskType;
 
+    /**
+     * @private_cc
+     */
     public _clearStencilMtl: Material | null = null;
+    /**
+     * @private_cc
+     */
     public _clearModel: Model | null = null;
 
     @serializable

--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -753,7 +753,7 @@ export class Sprite extends Renderable2D {
 
     // macro.UI_GPU_DRIVEN
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _calculateSlicedData (out: number[]) {
         const content = this.node._uiProps.uiTransformComp!.contentSize;
@@ -786,7 +786,7 @@ export class Sprite extends Renderable2D {
 
     // macro.UI_GPU_DRIVEN
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateUVWithTrim () {
         this.tillingOffsetWithTrim.length = 0;

--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -753,7 +753,7 @@ export class Sprite extends Renderable2D {
 
     // macro.UI_GPU_DRIVEN
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _calculateSlicedData (out: number[]) {
         const content = this.node._uiProps.uiTransformComp!.contentSize;
@@ -786,7 +786,7 @@ export class Sprite extends Renderable2D {
 
     // macro.UI_GPU_DRIVEN
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateUVWithTrim () {
         this.tillingOffsetWithTrim.length = 0;

--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -752,6 +752,9 @@ export class Sprite extends Renderable2D {
     }
 
     // macro.UI_GPU_DRIVEN
+    /**
+     * @private_cc
+     */
     public _calculateSlicedData (out: number[]) {
         const content = this.node._uiProps.uiTransformComp!.contentSize;
 
@@ -782,6 +785,9 @@ export class Sprite extends Renderable2D {
     }
 
     // macro.UI_GPU_DRIVEN
+    /**
+     * @private_cc
+     */
     public _updateUVWithTrim () {
         this.tillingOffsetWithTrim.length = 0;
         const frame = this.spriteFrame!;

--- a/cocos/2d/components/ui-static-batch.ts
+++ b/cocos/2d/components/ui-static-batch.ts
@@ -159,6 +159,9 @@ export class UIStaticBatch extends Renderable2D {
         this._clearData();
     }
 
+    /**
+     * @private_cc
+     */
     public _requireDrawBatch () {
         const batch = new DrawBatch2D();
         batch.isStatic = true;

--- a/cocos/2d/components/ui-static-batch.ts
+++ b/cocos/2d/components/ui-static-batch.ts
@@ -160,7 +160,7 @@ export class UIStaticBatch extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _requireDrawBatch () {
         const batch = new DrawBatch2D();

--- a/cocos/2d/components/ui-static-batch.ts
+++ b/cocos/2d/components/ui-static-batch.ts
@@ -160,7 +160,7 @@ export class UIStaticBatch extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _requireDrawBatch () {
         const batch = new DrawBatch2D();

--- a/cocos/2d/framework/renderable-2d.ts
+++ b/cocos/2d/framework/renderable-2d.ts
@@ -446,7 +446,7 @@ export class Renderable2D extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateBlendFunc () {
         // todo: Not only Pass[0].target[0]

--- a/cocos/2d/framework/renderable-2d.ts
+++ b/cocos/2d/framework/renderable-2d.ts
@@ -257,6 +257,7 @@ export class Renderable2D extends RenderableComponent {
     protected _renderData: RenderData | null = null;
     protected _renderDataFlag = true;
     protected _renderFlag = true;
+
     // 特殊渲染节点，给一些不在节点树上的组件做依赖渲染（例如 mask 组件内置两个 graphics 来渲染）
     protected _delegateSrc: Node | null = null;
     protected _instanceMaterialType = -1;
@@ -444,6 +445,9 @@ export class Renderable2D extends RenderableComponent {
         this._colorDirty = true;
     }
 
+    /**
+     * @private_cc
+     */
     public _updateBlendFunc () {
         // todo: Not only Pass[0].target[0]
         let target = this._blendState.targets[0];

--- a/cocos/2d/framework/renderable-2d.ts
+++ b/cocos/2d/framework/renderable-2d.ts
@@ -446,7 +446,7 @@ export class Renderable2D extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateBlendFunc () {
         // todo: Not only Pass[0].target[0]

--- a/cocos/2d/framework/ui-transform.ts
+++ b/cocos/2d/framework/ui-transform.ts
@@ -256,15 +256,15 @@ export class UITransform extends Component {
 
     // macro.UI_GPU_DRIVEN
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     declare public _rectDirty: boolean;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     declare public _rectWithScale: Vec3;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     declare public _anchorCache: Vec3;
 

--- a/cocos/2d/framework/ui-transform.ts
+++ b/cocos/2d/framework/ui-transform.ts
@@ -255,8 +255,17 @@ export class UITransform extends Component {
     protected _anchorPoint = new Vec2(0.5, 0.5);
 
     // macro.UI_GPU_DRIVEN
+    /**
+     * @private_cc
+     */
     declare public _rectDirty: boolean;
+    /**
+     * @private_cc
+     */
     declare public _rectWithScale: Vec3;
+    /**
+     * @private_cc
+     */
     declare public _anchorCache: Vec3;
 
     constructor () {

--- a/cocos/2d/framework/ui-transform.ts
+++ b/cocos/2d/framework/ui-transform.ts
@@ -256,15 +256,15 @@ export class UITransform extends Component {
 
     // macro.UI_GPU_DRIVEN
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     declare public _rectDirty: boolean;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     declare public _rectWithScale: Vec3;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     declare public _anchorCache: Vec3;
 

--- a/cocos/2d/renderer/draw-batch.ts
+++ b/cocos/2d/renderer/draw-batch.ts
@@ -43,7 +43,6 @@ import { NativeDrawBatch2D, NativePass } from '../../core/renderer/scene';
 import { IBatcher } from './i-batcher';
 
 const UI_VIS_FLAG = Layers.Enum.NONE | Layers.Enum.UI_3D;
-
 export class DrawBatch2D {
     public get native (): NativeDrawBatch2D {
         return this._nativeObj!;

--- a/cocos/2d/renderer/render-uniform-buffer.ts
+++ b/cocos/2d/renderer/render-uniform-buffer.ts
@@ -178,7 +178,7 @@ interface ILocalBuffers {
 
 export class UILocalUBOManger {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _localBuffers: ILocalBuffers[] = []; // UIPerUBO -> buffer[]
     private _device: Device;

--- a/cocos/2d/renderer/render-uniform-buffer.ts
+++ b/cocos/2d/renderer/render-uniform-buffer.ts
@@ -177,6 +177,9 @@ interface ILocalBuffers {
 }
 
 export class UILocalUBOManger {
+    /**
+     * @private_cc
+     */
     public _localBuffers: ILocalBuffers[] = []; // UIPerUBO -> buffer[]
     private _device: Device;
     private _element: ILocalBuffers | null = null;

--- a/cocos/2d/renderer/render-uniform-buffer.ts
+++ b/cocos/2d/renderer/render-uniform-buffer.ts
@@ -178,7 +178,7 @@ interface ILocalBuffers {
 
 export class UILocalUBOManger {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _localBuffers: ILocalBuffers[] = []; // UIPerUBO -> buffer[]
     private _device: Device;

--- a/cocos/3d/assets/mesh.ts
+++ b/cocos/3d/assets/mesh.ts
@@ -184,7 +184,7 @@ const globalEmptyMeshBuffer = new Uint8Array();
 @ccclass('cc.Mesh')
 export class Mesh extends Asset {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     get _nativeAsset (): ArrayBuffer {
         return this._data.buffer;

--- a/cocos/3d/assets/mesh.ts
+++ b/cocos/3d/assets/mesh.ts
@@ -184,7 +184,7 @@ const globalEmptyMeshBuffer = new Uint8Array();
 @ccclass('cc.Mesh')
 export class Mesh extends Asset {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _nativeAsset (): ArrayBuffer {
         return this._data.buffer;

--- a/cocos/3d/assets/mesh.ts
+++ b/cocos/3d/assets/mesh.ts
@@ -183,10 +183,12 @@ const globalEmptyMeshBuffer = new Uint8Array();
  */
 @ccclass('cc.Mesh')
 export class Mesh extends Asset {
+    /**
+     * @private_cc
+     */
     get _nativeAsset (): ArrayBuffer {
         return this._data.buffer;
     }
-
     set _nativeAsset (value: ArrayBuffer) {
         this._data = new Uint8Array(value);
     }

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -398,6 +398,9 @@ export class MeshRenderer extends RenderableComponent {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _updateLightmap (lightmap: Texture2D|null, uOff: number, vOff: number, uScale: number, vScale: number) {
         this.lightmapSettings.texture = lightmap;
         this.lightmapSettings.uvParam.x = uOff;

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -399,7 +399,7 @@ export class MeshRenderer extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateLightmap (lightmap: Texture2D|null, uOff: number, vOff: number, uScale: number, vScale: number) {
         this.lightmapSettings.texture = lightmap;

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -399,7 +399,7 @@ export class MeshRenderer extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateLightmap (lightmap: Texture2D|null, uOff: number, vOff: number, uScale: number, vScale: number) {
         this.lightmapSettings.texture = lightmap;

--- a/cocos/3d/models/skinning-model.ts
+++ b/cocos/3d/models/skinning-model.ts
@@ -218,7 +218,7 @@ export class SkinningModel extends MorphModel {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateLocalDescriptors (submodelIdx: number, descriptorSet: DescriptorSet) {
         super._updateLocalDescriptors(submodelIdx, descriptorSet);

--- a/cocos/3d/models/skinning-model.ts
+++ b/cocos/3d/models/skinning-model.ts
@@ -218,7 +218,7 @@ export class SkinningModel extends MorphModel {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateLocalDescriptors (submodelIdx: number, descriptorSet: DescriptorSet) {
         super._updateLocalDescriptors(submodelIdx, descriptorSet);

--- a/cocos/3d/models/skinning-model.ts
+++ b/cocos/3d/models/skinning-model.ts
@@ -217,6 +217,9 @@ export class SkinningModel extends MorphModel {
         return myPatches;
     }
 
+    /**
+     * @private_cc
+     */
     public _updateLocalDescriptors (submodelIdx: number, descriptorSet: DescriptorSet) {
         super._updateLocalDescriptors(submodelIdx, descriptorSet);
         if (JSB) {

--- a/cocos/3d/skinned-mesh-renderer/skinned-mesh-batch-renderer.ts
+++ b/cocos/3d/skinned-mesh-renderer/skinned-mesh-batch-renderer.ts
@@ -73,7 +73,7 @@ export class SkinnedMeshUnit {
     public material: Material | null = null;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _localTransform = new Mat4();
@@ -213,7 +213,7 @@ export class SkinnedMeshBatchRenderer extends SkinnedMeshRenderer {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onMaterialModified (idx: number, material: Material | null) {
         this.cookMaterials();

--- a/cocos/3d/skinned-mesh-renderer/skinned-mesh-batch-renderer.ts
+++ b/cocos/3d/skinned-mesh-renderer/skinned-mesh-batch-renderer.ts
@@ -73,7 +73,7 @@ export class SkinnedMeshUnit {
     public material: Material | null = null;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _localTransform = new Mat4();
@@ -213,7 +213,7 @@ export class SkinnedMeshBatchRenderer extends SkinnedMeshRenderer {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onMaterialModified (idx: number, material: Material | null) {
         this.cookMaterials();

--- a/cocos/3d/skinned-mesh-renderer/skinned-mesh-batch-renderer.ts
+++ b/cocos/3d/skinned-mesh-renderer/skinned-mesh-batch-renderer.ts
@@ -72,6 +72,9 @@ export class SkinnedMeshUnit {
     @type(Material)
     public material: Material | null = null;
 
+    /**
+     * @private_cc
+     */
     @serializable
     public _localTransform = new Mat4();
 
@@ -209,6 +212,9 @@ export class SkinnedMeshBatchRenderer extends SkinnedMeshRenderer {
         super.onDestroy();
     }
 
+    /**
+     * @private_cc
+     */
     public _onMaterialModified (idx: number, material: Material | null) {
         this.cookMaterials();
         super._onMaterialModified(idx, this.getMaterialInstance(idx));

--- a/cocos/audio/audio-clip.ts
+++ b/cocos/audio/audio-clip.ts
@@ -73,7 +73,7 @@ export class AudioClip extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     set _nativeAsset (meta: AudioMeta | null) {
         this._meta = meta;
@@ -91,7 +91,7 @@ export class AudioClip extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @override
     get _nativeDep () {

--- a/cocos/audio/audio-clip.ts
+++ b/cocos/audio/audio-clip.ts
@@ -72,6 +72,9 @@ export class AudioClip extends Asset {
         return destroyResult;
     }
 
+    /**
+     * @private_cc
+     */
     set _nativeAsset (meta: AudioMeta | null) {
         this._meta = meta;
         if (meta) {
@@ -83,11 +86,13 @@ export class AudioClip extends Asset {
             this._duration = 0;
         }
     }
-
     get _nativeAsset () {
         return this._meta;
     }
 
+    /**
+     * @private_cc
+     */
     @override
     get _nativeDep () {
         return {

--- a/cocos/audio/audio-clip.ts
+++ b/cocos/audio/audio-clip.ts
@@ -73,7 +73,7 @@ export class AudioClip extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     set _nativeAsset (meta: AudioMeta | null) {
         this._meta = meta;
@@ -91,7 +91,7 @@ export class AudioClip extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @override
     get _nativeDep () {

--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -139,7 +139,7 @@ export class AnimationClip extends Asset {
     /**
      * Sets if node TRS curves in this animation can be blended.
      * Normally this flag is enabled for model animation and disabled for other case.
-     * @private_cc This is an internal slot. Never use it in your code.
+     * @deprecated_to_user This is an internal slot. Never use it in your code.
      */
     @serializable
     public enableTrsBlending = false;
@@ -286,7 +286,7 @@ export class AnimationClip extends Asset {
      * Creates an event evaluator for this animation.
      * @param targetNode Target node used to fire events.
      * @returns
-     * @private_cc Do not use this in your code.
+     * @deprecated_to_user Do not use this in your code.
      */
     public createEventEvaluator (targetNode: Node) {
         return new EventEvaluator(
@@ -301,7 +301,7 @@ export class AnimationClip extends Asset {
      * Creates an evaluator for this animation.
      * @param context The context.
      * @returns The evaluator.
-     * @private_cc Do not use this in your code.
+     * @deprecated_to_user Do not use this in your code.
      */
     public createEvaluator (context: AnimationClipEvalContext) {
         const {
@@ -407,7 +407,7 @@ export class AnimationClip extends Asset {
     /**
      * Convert all untyped tracks into typed ones and delete the original.
      * @param refine How to decide the type on specified path.
-     * @private_cc DO NOT USE THIS IN YOUR CODE.
+     * @deprecated_to_user DO NOT USE THIS IN YOUR CODE.
      */
     public upgradeUntypedTracks (refine: UntypedTrackRefine) {
         const newTracks: Track[] = [];

--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -493,7 +493,6 @@ export class AnimationClip extends Asset {
     }
 
     /**
-     * @private_cc
      * @deprecated Since V3.3. Please reference to the track/channel/curve mechanism introduced in V3.3.
      */
     public getPropertyCurves () {
@@ -514,7 +513,6 @@ export class AnimationClip extends Asset {
      * @en
      * Commit event data update.
      * You should call this function after you changed the `events` data to take effect.
-     * @private_cc
      * @deprecated Since V3.3. Please Assign to `this.events`.
      */
     public updateEventDatas () {
@@ -532,7 +530,7 @@ export class AnimationClip extends Asset {
 
     /**
      * Migrates legacy data into tracks.
-     * @private_cc This method tend to be used as internal purpose or patch.
+     * NOTE: This method tend to be used as internal purpose or patch.
      * DO NOT use it in your code since it might be removed for the future at any time.
      * @deprecated Since V3.3. Please reference to the track/channel/curve mechanism introduced in V3.3.
      */

--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -139,7 +139,7 @@ export class AnimationClip extends Asset {
     /**
      * Sets if node TRS curves in this animation can be blended.
      * Normally this flag is enabled for model animation and disabled for other case.
-     * @internal This is an internal slot. Never use it in your code.
+     * @private_cc This is an internal slot. Never use it in your code.
      */
     @serializable
     public enableTrsBlending = false;
@@ -286,7 +286,7 @@ export class AnimationClip extends Asset {
      * Creates an event evaluator for this animation.
      * @param targetNode Target node used to fire events.
      * @returns
-     * @internal Do not use this in your code.
+     * @private_cc Do not use this in your code.
      */
     public createEventEvaluator (targetNode: Node) {
         return new EventEvaluator(
@@ -301,7 +301,7 @@ export class AnimationClip extends Asset {
      * Creates an evaluator for this animation.
      * @param context The context.
      * @returns The evaluator.
-     * @internal Do not use this in your code.
+     * @private_cc Do not use this in your code.
      */
     public createEvaluator (context: AnimationClipEvalContext) {
         const {
@@ -407,7 +407,7 @@ export class AnimationClip extends Asset {
     /**
      * Convert all untyped tracks into typed ones and delete the original.
      * @param refine How to decide the type on specified path.
-     * @internal DO NOT USE THIS IN YOUR CODE.
+     * @private_cc DO NOT USE THIS IN YOUR CODE.
      */
     public upgradeUntypedTracks (refine: UntypedTrackRefine) {
         const newTracks: Track[] = [];
@@ -493,7 +493,7 @@ export class AnimationClip extends Asset {
     }
 
     /**
-     * @internal
+     * @private_cc
      * @deprecated Since V3.3. Please reference to the track/channel/curve mechanism introduced in V3.3.
      */
     public getPropertyCurves () {
@@ -514,7 +514,7 @@ export class AnimationClip extends Asset {
      * @en
      * Commit event data update.
      * You should call this function after you changed the `events` data to take effect.
-     * @internal
+     * @private_cc
      * @deprecated Since V3.3. Please Assign to `this.events`.
      */
     public updateEventDatas () {
@@ -532,7 +532,7 @@ export class AnimationClip extends Asset {
 
     /**
      * Migrates legacy data into tracks.
-     * @internal This method tend to be used as internal purpose or patch.
+     * @private_cc This method tend to be used as internal purpose or patch.
      * DO NOT use it in your code since it might be removed for the future at any time.
      * @deprecated Since V3.3. Please reference to the track/channel/curve mechanism introduced in V3.3.
      */

--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -818,9 +818,6 @@ interface RootMotionOptions {
 type ExoticAnimationEvaluator = ReturnType<ExoticAnimation['createEvaluator']>;
 
 class AnimationClipEvaluation {
-    /**
-     * @internal
-     */
     constructor (
         trackEvalStatuses: TrackEvalStatus[],
         exoticAnimationEvaluator: ExoticAnimationEvaluator | undefined,

--- a/cocos/core/animation/animation-clip.ts
+++ b/cocos/core/animation/animation-clip.ts
@@ -139,7 +139,7 @@ export class AnimationClip extends Asset {
     /**
      * Sets if node TRS curves in this animation can be blended.
      * Normally this flag is enabled for model animation and disabled for other case.
-     * @deprecated_to_user This is an internal slot. Never use it in your code.
+     * @marked_as_engine_private This is an internal slot. Never use it in your code.
      */
     @serializable
     public enableTrsBlending = false;
@@ -286,7 +286,7 @@ export class AnimationClip extends Asset {
      * Creates an event evaluator for this animation.
      * @param targetNode Target node used to fire events.
      * @returns
-     * @deprecated_to_user Do not use this in your code.
+     * @marked_as_engine_private Do not use this in your code.
      */
     public createEventEvaluator (targetNode: Node) {
         return new EventEvaluator(
@@ -301,7 +301,7 @@ export class AnimationClip extends Asset {
      * Creates an evaluator for this animation.
      * @param context The context.
      * @returns The evaluator.
-     * @deprecated_to_user Do not use this in your code.
+     * @marked_as_engine_private Do not use this in your code.
      */
     public createEvaluator (context: AnimationClipEvalContext) {
         const {
@@ -407,7 +407,7 @@ export class AnimationClip extends Asset {
     /**
      * Convert all untyped tracks into typed ones and delete the original.
      * @param refine How to decide the type on specified path.
-     * @deprecated_to_user DO NOT USE THIS IN YOUR CODE.
+     * @marked_as_engine_private DO NOT USE THIS IN YOUR CODE.
      */
     public upgradeUntypedTracks (refine: UntypedTrackRefine) {
         const newTracks: Track[] = [];

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -441,6 +441,7 @@ export class AnimationState extends Playable {
 
     /**
      * This method is used for internal purpose only.
+     * @private_cc
      */
     public _setEventTarget (target) {
         this._target = target;

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -441,7 +441,7 @@ export class AnimationState extends Playable {
 
     /**
      * This method is used for internal purpose only.
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _setEventTarget (target) {
         this._target = target;

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -441,7 +441,7 @@ export class AnimationState extends Playable {
 
     /**
      * This method is used for internal purpose only.
-     * @private_cc
+     * @deprecated_to_user
      */
     public _setEventTarget (target) {
         this._target = target;

--- a/cocos/core/animation/compression/compressed-data.ts
+++ b/cocos/core/animation/compression/compressed-data.ts
@@ -175,7 +175,7 @@ export class CompressedData {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _addQuatCurve (curve: QuatCurve): CompressedQuatCurvePointer {
         const times = Array.from(curve.times());

--- a/cocos/core/animation/compression/compressed-data.ts
+++ b/cocos/core/animation/compression/compressed-data.ts
@@ -175,7 +175,7 @@ export class CompressedData {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _addQuatCurve (curve: QuatCurve): CompressedQuatCurvePointer {
         const times = Array.from(curve.times());

--- a/cocos/core/animation/compression/compressed-data.ts
+++ b/cocos/core/animation/compression/compressed-data.ts
@@ -174,6 +174,9 @@ export class CompressedData {
         };
     }
 
+    /**
+     * @private_cc
+     */
     public _addQuatCurve (curve: QuatCurve): CompressedQuatCurvePointer {
         const times = Array.from(curve.times());
         let iKeySharedCurves = this._quatCurves.findIndex((shared) => shared.matchCurve(curve));

--- a/cocos/core/animation/exotic-animation/exotic-animation.ts
+++ b/cocos/core/animation/exotic-animation/exotic-animation.ts
@@ -50,7 +50,7 @@ export class ExoticAnimation {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public toHashString () {
         return this._nodeAnimations.map((nodeAnimation) => nodeAnimation.toHashString()).join('\n');
@@ -116,7 +116,7 @@ class ExoticNodeAnimation {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public toHashString (): string {
         return `${this._path}\n${
@@ -183,7 +183,7 @@ class ExoticVectorLikeTrackValues {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public toHashString (): string {
         const { _isQuantized: isQuantized, _values: values } = this;
@@ -305,7 +305,7 @@ class ExoticTrack<TTrackValues extends { toHashString(): string; }> {
     public values!: TTrackValues;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public toHashString (): string {
         const { times, values } = this;
@@ -802,7 +802,7 @@ class QuantizedFloatArray {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public toHashString (): string {
         const { originalPrecision, min, extent, values } = this;

--- a/cocos/core/animation/exotic-animation/exotic-animation.ts
+++ b/cocos/core/animation/exotic-animation/exotic-animation.ts
@@ -50,7 +50,7 @@ export class ExoticAnimation {
     }
 
     /**
-     * @internal
+     * @private_cc
      */
     public toHashString () {
         return this._nodeAnimations.map((nodeAnimation) => nodeAnimation.toHashString()).join('\n');
@@ -116,7 +116,7 @@ class ExoticNodeAnimation {
     }
 
     /**
-     * @internal
+     * @private_cc
      */
     public toHashString (): string {
         return `${this._path}\n${
@@ -183,7 +183,7 @@ class ExoticVectorLikeTrackValues {
     }
 
     /**
-     * @internal
+     * @private_cc
      */
     public toHashString (): string {
         const { _isQuantized: isQuantized, _values: values } = this;
@@ -305,7 +305,7 @@ class ExoticTrack<TTrackValues extends { toHashString(): string; }> {
     public values!: TTrackValues;
 
     /**
-     * @internal
+     * @private_cc
      */
     public toHashString (): string {
         const { times, values } = this;
@@ -802,7 +802,7 @@ class QuantizedFloatArray {
     }
 
     /**
-     * @internal
+     * @private_cc
      */
     public toHashString (): string {
         const { originalPrecision, min, extent, values } = this;

--- a/cocos/core/animation/exotic-animation/exotic-animation.ts
+++ b/cocos/core/animation/exotic-animation/exotic-animation.ts
@@ -50,7 +50,7 @@ export class ExoticAnimation {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public toHashString () {
         return this._nodeAnimations.map((nodeAnimation) => nodeAnimation.toHashString()).join('\n');
@@ -116,7 +116,7 @@ class ExoticNodeAnimation {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public toHashString (): string {
         return `${this._path}\n${
@@ -183,7 +183,7 @@ class ExoticVectorLikeTrackValues {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public toHashString (): string {
         const { _isQuantized: isQuantized, _values: values } = this;
@@ -305,7 +305,7 @@ class ExoticTrack<TTrackValues extends { toHashString(): string; }> {
     public values!: TTrackValues;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public toHashString (): string {
         const { times, values } = this;
@@ -802,7 +802,7 @@ class QuantizedFloatArray {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public toHashString (): string {
         const { originalPrecision, min, extent, values } = this;

--- a/cocos/core/animation/marionette/animation-graph.ts
+++ b/cocos/core/animation/marionette/animation-graph.ts
@@ -45,7 +45,7 @@ class Transition extends EditorExtendable implements OwnedBy<StateMachine>, Tran
     public conditions: Condition[] = [];
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     constructor (from: State, to: State, conditions?: Condition[]) {
         super();
@@ -130,7 +130,7 @@ export class StateMachine extends EditorExtendable {
 
     /**
      * // TODO: HACK
-     * @private_cc
+     * @deprecated_to_user
      */
     public __callOnAfterDeserializeRecursive () {
         this[onAfterDeserializedTag]();
@@ -144,7 +144,7 @@ export class StateMachine extends EditorExtendable {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     constructor () {
         super();
@@ -482,7 +482,7 @@ export class Layer implements OwnedBy<AnimationGraph> {
     public blending: LayerBlending = LayerBlending.additive;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     constructor () {
         this._stateMachine = new StateMachine();

--- a/cocos/core/animation/marionette/animation-graph.ts
+++ b/cocos/core/animation/marionette/animation-graph.ts
@@ -45,7 +45,7 @@ class Transition extends EditorExtendable implements OwnedBy<StateMachine>, Tran
     public conditions: Condition[] = [];
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     constructor (from: State, to: State, conditions?: Condition[]) {
         super();
@@ -130,7 +130,7 @@ export class StateMachine extends EditorExtendable {
 
     /**
      * // TODO: HACK
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public __callOnAfterDeserializeRecursive () {
         this[onAfterDeserializedTag]();
@@ -144,7 +144,7 @@ export class StateMachine extends EditorExtendable {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     constructor () {
         super();
@@ -482,7 +482,7 @@ export class Layer implements OwnedBy<AnimationGraph> {
     public blending: LayerBlending = LayerBlending.additive;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     constructor () {
         this._stateMachine = new StateMachine();

--- a/cocos/core/animation/marionette/animation-graph.ts
+++ b/cocos/core/animation/marionette/animation-graph.ts
@@ -45,7 +45,7 @@ class Transition extends EditorExtendable implements OwnedBy<StateMachine>, Tran
     public conditions: Condition[] = [];
 
     /**
-     * @internal
+     * @private_cc
      */
     constructor (from: State, to: State, conditions?: Condition[]) {
         super();
@@ -130,7 +130,7 @@ export class StateMachine extends EditorExtendable {
 
     /**
      * // TODO: HACK
-     * @internal
+     * @private_cc
      */
     public __callOnAfterDeserializeRecursive () {
         this[onAfterDeserializedTag]();
@@ -144,7 +144,7 @@ export class StateMachine extends EditorExtendable {
     }
 
     /**
-     * @internal
+     * @private_cc
      */
     constructor () {
         super();
@@ -482,7 +482,7 @@ export class Layer implements OwnedBy<AnimationGraph> {
     public blending: LayerBlending = LayerBlending.additive;
 
     /**
-     * @internal
+     * @private_cc
      */
     constructor () {
         this._stateMachine = new StateMachine();

--- a/cocos/core/animation/marionette/clip-motion.ts
+++ b/cocos/core/animation/marionette/clip-motion.ts
@@ -24,6 +24,9 @@ export class ClipMotion extends EditorExtendable implements Motion {
 }
 
 class ClipMotionEval implements MotionEval {
+    /**
+     * @private_cc
+     */
     public declare __DEBUG__ID__?: string;
 
     private declare _state: AnimationState;

--- a/cocos/core/animation/marionette/clip-motion.ts
+++ b/cocos/core/animation/marionette/clip-motion.ts
@@ -25,7 +25,7 @@ export class ClipMotion extends EditorExtendable implements Motion {
 
 class ClipMotionEval implements MotionEval {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public declare __DEBUG__ID__?: string;
 

--- a/cocos/core/animation/marionette/clip-motion.ts
+++ b/cocos/core/animation/marionette/clip-motion.ts
@@ -25,7 +25,7 @@ export class ClipMotion extends EditorExtendable implements Motion {
 
 class ClipMotionEval implements MotionEval {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public declare __DEBUG__ID__?: string;
 

--- a/cocos/core/animation/marionette/graph-eval.ts
+++ b/cocos/core/animation/marionette/graph-eval.ts
@@ -964,6 +964,9 @@ enum NodeKind {
 }
 
 export class StateEval {
+    /**
+     * @private_cc
+     */
     public declare __DEBUG_ID__?: string;
 
     public declare stateMachine: StateMachineInfo;

--- a/cocos/core/animation/marionette/graph-eval.ts
+++ b/cocos/core/animation/marionette/graph-eval.ts
@@ -965,7 +965,7 @@ enum NodeKind {
 
 export class StateEval {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public declare __DEBUG_ID__?: string;
 

--- a/cocos/core/animation/marionette/graph-eval.ts
+++ b/cocos/core/animation/marionette/graph-eval.ts
@@ -965,7 +965,7 @@ enum NodeKind {
 
 export class StateEval {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public declare __DEBUG_ID__?: string;
 

--- a/cocos/core/animation/marionette/state.ts
+++ b/cocos/core/animation/marionette/state.ts
@@ -23,7 +23,7 @@ export class State extends EditorExtendable implements OwnedBy<Layer | StateMach
     public [incomingsSymbol]: TransitionInternal[] = [];
 
     /**
-     * @internal
+     * @private_cc
      */
     constructor () {
         super();

--- a/cocos/core/animation/marionette/state.ts
+++ b/cocos/core/animation/marionette/state.ts
@@ -23,7 +23,7 @@ export class State extends EditorExtendable implements OwnedBy<Layer | StateMach
     public [incomingsSymbol]: TransitionInternal[] = [];
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     constructor () {
         super();

--- a/cocos/core/animation/marionette/state.ts
+++ b/cocos/core/animation/marionette/state.ts
@@ -23,7 +23,7 @@ export class State extends EditorExtendable implements OwnedBy<Layer | StateMach
     public [incomingsSymbol]: TransitionInternal[] = [];
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     constructor () {
         super();

--- a/cocos/core/animation/motion-path-helper.ts
+++ b/cocos/core/animation/motion-path-helper.ts
@@ -95,7 +95,7 @@ export class Bezier {
     public endCtrlPoint = new Vec2();
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public __arcLengthDivisions?: number;
 

--- a/cocos/core/animation/motion-path-helper.ts
+++ b/cocos/core/animation/motion-path-helper.ts
@@ -94,6 +94,9 @@ export class Bezier {
      */
     public endCtrlPoint = new Vec2();
 
+    /**
+     * @private_cc
+     */
     public __arcLengthDivisions?: number;
 
     private cacheArcLengths?: number[];

--- a/cocos/core/animation/motion-path-helper.ts
+++ b/cocos/core/animation/motion-path-helper.ts
@@ -95,7 +95,7 @@ export class Bezier {
     public endCtrlPoint = new Vec2();
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public __arcLengthDivisions?: number;
 

--- a/cocos/core/animation/tracks/track.ts
+++ b/cocos/core/animation/tracks/track.ts
@@ -55,7 +55,7 @@ class TrackPath {
     }
 
     /**
-     * @private_cc Reserved for backward compatibility. DO NOT USE IT IN YOUR CODE.
+     * @deprecated_to_user Reserved for backward compatibility. DO NOT USE IT IN YOUR CODE.
      */
     public toCustomized (resolver: CustomizedTrackPathResolver) {
         this._paths.push(resolver);

--- a/cocos/core/animation/tracks/track.ts
+++ b/cocos/core/animation/tracks/track.ts
@@ -55,7 +55,7 @@ class TrackPath {
     }
 
     /**
-     * @internal Reserved for backward compatibility. DO NOT USE IT IN YOUR CODE.
+     * @private_cc Reserved for backward compatibility. DO NOT USE IT IN YOUR CODE.
      */
     public toCustomized (resolver: CustomizedTrackPathResolver) {
         this._paths.push(resolver);

--- a/cocos/core/animation/tracks/track.ts
+++ b/cocos/core/animation/tracks/track.ts
@@ -55,7 +55,7 @@ class TrackPath {
     }
 
     /**
-     * @deprecated_to_user Reserved for backward compatibility. DO NOT USE IT IN YOUR CODE.
+     * @marked_as_engine_private Reserved for backward compatibility. DO NOT USE IT IN YOUR CODE.
      */
     public toCustomized (resolver: CustomizedTrackPathResolver) {
         this._paths.push(resolver);

--- a/cocos/core/asset-manager/bundle.ts
+++ b/cocos/core/asset-manager/bundle.ts
@@ -596,7 +596,7 @@ export default class Bundle {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _destroy () {
         this._config.destroy();

--- a/cocos/core/asset-manager/bundle.ts
+++ b/cocos/core/asset-manager/bundle.ts
@@ -596,7 +596,7 @@ export default class Bundle {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _destroy () {
         this._config.destroy();

--- a/cocos/core/asset-manager/bundle.ts
+++ b/cocos/core/asset-manager/bundle.ts
@@ -595,6 +595,9 @@ export default class Bundle {
         });
     }
 
+    /**
+     * @private_cc
+     */
     public _destroy () {
         this._config.destroy();
     }

--- a/cocos/core/asset-manager/depend-util.ts
+++ b/cocos/core/asset-manager/depend-util.ts
@@ -54,7 +54,7 @@ export interface IDependencies {
  */
 export class DependUtil {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _depends: Cache<IDependencies> = new Cache<IDependencies>();
 

--- a/cocos/core/asset-manager/depend-util.ts
+++ b/cocos/core/asset-manager/depend-util.ts
@@ -53,6 +53,9 @@ export interface IDependencies {
  *
  */
 export class DependUtil {
+    /**
+     * @private_cc
+     */
     public _depends: Cache<IDependencies> = new Cache<IDependencies>();
 
     public init (): void {

--- a/cocos/core/asset-manager/depend-util.ts
+++ b/cocos/core/asset-manager/depend-util.ts
@@ -54,7 +54,7 @@ export interface IDependencies {
  */
 export class DependUtil {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _depends: Cache<IDependencies> = new Cache<IDependencies>();
 

--- a/cocos/core/asset-manager/deprecated.ts
+++ b/cocos/core/asset-manager/deprecated.ts
@@ -107,13 +107,13 @@ export class CCLoader {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _autoReleaseSetting: Record<string, boolean> = Object.create(null);
     private _parseLoadResArgs = parseLoadResArgs;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public get _cache (): Record<string, Asset> {
         if (assets instanceof Cache) {

--- a/cocos/core/asset-manager/deprecated.ts
+++ b/cocos/core/asset-manager/deprecated.ts
@@ -107,13 +107,13 @@ export class CCLoader {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _autoReleaseSetting: Record<string, boolean> = Object.create(null);
     private _parseLoadResArgs = parseLoadResArgs;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public get _cache (): Record<string, Asset> {
         if (assets instanceof Cache) {

--- a/cocos/core/asset-manager/deprecated.ts
+++ b/cocos/core/asset-manager/deprecated.ts
@@ -112,6 +112,9 @@ export class CCLoader {
     public _autoReleaseSetting: Record<string, boolean> = Object.create(null);
     private _parseLoadResArgs = parseLoadResArgs;
 
+    /**
+     * @private_cc
+     */
     public get _cache (): Record<string, Asset> {
         if (assets instanceof Cache) {
             // @ts-expect-error return private property

--- a/cocos/core/asset-manager/deprecated.ts
+++ b/cocos/core/asset-manager/deprecated.ts
@@ -106,6 +106,9 @@ export class CCLoader {
         setDefaultProgressCallback(val);
     }
 
+    /**
+     * @private_cc
+     */
     public _autoReleaseSetting: Record<string, boolean> = Object.create(null);
     private _parseLoadResArgs = parseLoadResArgs;
 

--- a/cocos/core/asset-manager/release-manager.ts
+++ b/cocos/core/asset-manager/release-manager.ts
@@ -129,7 +129,7 @@ class ReleaseManager {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _addPersistNodeRef (node: Node) {
         const deps = [];
@@ -144,7 +144,7 @@ class ReleaseManager {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _removePersistNodeRef (node: Node) {
         if (!this._persistNodeDeps.has(node.uuid)) { return; }
@@ -161,7 +161,7 @@ class ReleaseManager {
 
     // do auto release
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _autoRelease (oldScene: Scene, newScene: Scene, persistNodes: Record<string, Node>) {
         if (oldScene) {

--- a/cocos/core/asset-manager/release-manager.ts
+++ b/cocos/core/asset-manager/release-manager.ts
@@ -128,6 +128,9 @@ class ReleaseManager {
         this._toDelete.clear();
     }
 
+    /**
+     * @private_cc
+     */
     public _addPersistNodeRef (node: Node) {
         const deps = [];
         visitNode(node, deps);
@@ -140,6 +143,9 @@ class ReleaseManager {
         this._persistNodeDeps.add(node.uuid, deps);
     }
 
+    /**
+     * @private_cc
+     */
     public _removePersistNodeRef (node: Node) {
         if (!this._persistNodeDeps.has(node.uuid)) { return; }
 
@@ -154,6 +160,9 @@ class ReleaseManager {
     }
 
     // do auto release
+    /**
+     * @private_cc
+     */
     public _autoRelease (oldScene: Scene, newScene: Scene, persistNodes: Record<string, Node>) {
         if (oldScene) {
             const childs = dependUtil.getDeps(oldScene.uuid);

--- a/cocos/core/asset-manager/release-manager.ts
+++ b/cocos/core/asset-manager/release-manager.ts
@@ -129,7 +129,7 @@ class ReleaseManager {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _addPersistNodeRef (node: Node) {
         const deps = [];
@@ -144,7 +144,7 @@ class ReleaseManager {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _removePersistNodeRef (node: Node) {
         if (!this._persistNodeDeps.has(node.uuid)) { return; }
@@ -161,7 +161,7 @@ class ReleaseManager {
 
     // do auto release
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _autoRelease (oldScene: Scene, newScene: Scene, persistNodes: Record<string, Node>) {
         if (oldScene) {

--- a/cocos/core/assets/asset.ts
+++ b/cocos/core/assets/asset.ts
@@ -85,7 +85,7 @@ export class Asset extends Eventify(GCObject) {
     public loaded = true;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public declare _uuid: string;
 
@@ -98,12 +98,12 @@ export class Asset extends Eventify(GCObject) {
      * 用于本机资产的可序列化URL。供内部使用。
      * @default ""
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _native = '';
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _nativeUrl = '';
 
@@ -146,7 +146,7 @@ export class Asset extends Eventify(GCObject) {
      * 此资源的基础资源（如果有）。 此属性可用于访问与资源相关的其他详细信息或功能。<br>
      * 如果`_native`可用，则此属性将由加载器初始化。
      * @default null
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @property
     get _nativeAsset () {
@@ -219,7 +219,7 @@ export class Asset extends Eventify(GCObject) {
      *
      * @param filename
      * @param inLibrary
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _setRawAsset (filename: string, inLibrary = true) {
         if (inLibrary !== false) {
@@ -240,7 +240,7 @@ export class Asset extends Eventify(GCObject) {
     public createNode? (callback: CreateNodeCallback): void;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public get _nativeDep () {
         if (this._native) {

--- a/cocos/core/assets/asset.ts
+++ b/cocos/core/assets/asset.ts
@@ -85,7 +85,7 @@ export class Asset extends Eventify(GCObject) {
     public loaded = true;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public declare _uuid: string;
 
@@ -98,12 +98,12 @@ export class Asset extends Eventify(GCObject) {
      * 用于本机资产的可序列化URL。供内部使用。
      * @default ""
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _native = '';
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _nativeUrl = '';
 
@@ -146,7 +146,7 @@ export class Asset extends Eventify(GCObject) {
      * 此资源的基础资源（如果有）。 此属性可用于访问与资源相关的其他详细信息或功能。<br>
      * 如果`_native`可用，则此属性将由加载器初始化。
      * @default null
-     * @private_cc
+     * @deprecated_to_user
      */
     @property
     get _nativeAsset () {
@@ -219,7 +219,7 @@ export class Asset extends Eventify(GCObject) {
      *
      * @param filename
      * @param inLibrary
-     * @private_cc
+     * @deprecated_to_user
      */
     public _setRawAsset (filename: string, inLibrary = true) {
         if (inLibrary !== false) {
@@ -240,7 +240,7 @@ export class Asset extends Eventify(GCObject) {
     public createNode? (callback: CreateNodeCallback): void;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public get _nativeDep () {
         if (this._native) {

--- a/cocos/core/assets/asset.ts
+++ b/cocos/core/assets/asset.ts
@@ -84,6 +84,9 @@ export class Asset extends Eventify(GCObject) {
      */
     public loaded = true;
 
+    /**
+     * @private_cc
+     */
     public declare _uuid: string;
 
     public declare isDefault: boolean;

--- a/cocos/core/assets/asset.ts
+++ b/cocos/core/assets/asset.ts
@@ -219,7 +219,7 @@ export class Asset extends Eventify(GCObject) {
      *
      * @param filename
      * @param inLibrary
-     * @private
+     * @private_cc
      */
     public _setRawAsset (filename: string, inLibrary = true) {
         if (inLibrary !== false) {

--- a/cocos/core/assets/asset.ts
+++ b/cocos/core/assets/asset.ts
@@ -143,7 +143,7 @@ export class Asset extends Eventify(GCObject) {
      * 此资源的基础资源（如果有）。 此属性可用于访问与资源相关的其他详细信息或功能。<br>
      * 如果`_native`可用，则此属性将由加载器初始化。
      * @default null
-     * @private
+     * @private_cc
      */
     @property
     get _nativeAsset () {
@@ -236,6 +236,9 @@ export class Asset extends Eventify(GCObject) {
      */
     public createNode? (callback: CreateNodeCallback): void;
 
+    /**
+     * @private_cc
+     */
     public get _nativeDep () {
         if (this._native) {
             return { __isNative__: true, uuid: this._uuid, ext: this._native };

--- a/cocos/core/assets/asset.ts
+++ b/cocos/core/assets/asset.ts
@@ -94,9 +94,14 @@ export class Asset extends Eventify(GCObject) {
      * @zh
      * 用于本机资产的可序列化URL。供内部使用。
      * @default ""
+     *
+     * @private_cc
      */
     @serializable
     public _native = '';
+    /**
+     * @private_cc
+     */
     public _nativeUrl = '';
 
     private _file: any = null;

--- a/cocos/core/assets/buffer-asset.ts
+++ b/cocos/core/assets/buffer-asset.ts
@@ -37,7 +37,7 @@ export class BufferAsset extends Asset {
     private _buffer: ArrayBuffer | null = null;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @override
     get _nativeAsset () {

--- a/cocos/core/assets/buffer-asset.ts
+++ b/cocos/core/assets/buffer-asset.ts
@@ -37,7 +37,7 @@ export class BufferAsset extends Asset {
     private _buffer: ArrayBuffer | null = null;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @override
     get _nativeAsset () {

--- a/cocos/core/assets/buffer-asset.ts
+++ b/cocos/core/assets/buffer-asset.ts
@@ -36,11 +36,13 @@ import { Asset } from './asset';
 export class BufferAsset extends Asset {
     private _buffer: ArrayBuffer | null = null;
 
+    /**
+     * @private_cc
+     */
     @override
     get _nativeAsset () {
         return this._buffer as ArrayBuffer;
     }
-
     set _nativeAsset (bin: ArrayBufferView | ArrayBuffer) {
         if (bin instanceof ArrayBuffer) {
             this._buffer = bin;

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -215,6 +215,9 @@ export class ImageAsset extends Asset {
 
     // SERIALIZATION
 
+    /**
+     * @private_cc
+     */
     // eslint-disable-next-line consistent-return
     public _serialize () {
         if (EDITOR || TEST) {
@@ -241,6 +244,9 @@ export class ImageAsset extends Asset {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _deserialize (data: any) {
         let fmtStr = '';
         if (typeof data === 'string') {

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -83,7 +83,7 @@ function isNativeImage (imageSource: ImageSource): imageSource is (HTMLImageElem
 @ccclass('cc.ImageAsset')
 export class ImageAsset extends Asset {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @override
     get _nativeAsset () {
@@ -218,7 +218,7 @@ export class ImageAsset extends Asset {
     // SERIALIZATION
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     // eslint-disable-next-line consistent-return
     public _serialize () {
@@ -247,7 +247,7 @@ export class ImageAsset extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _deserialize (data: any) {
         let fmtStr = '';

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -82,12 +82,14 @@ function isNativeImage (imageSource: ImageSource): imageSource is (HTMLImageElem
  */
 @ccclass('cc.ImageAsset')
 export class ImageAsset extends Asset {
+    /**
+     * @private_cc
+     */
     @override
     get _nativeAsset () {
         // Maybe returned to pool in webgl.
         return this._nativeData;
     }
-
     set _nativeAsset (value: ImageSource) {
         if (!(value instanceof HTMLElement) && !isImageBitmap(value)) {
             // @ts-expect-error internal API usage

--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -83,7 +83,7 @@ function isNativeImage (imageSource: ImageSource): imageSource is (HTMLImageElem
 @ccclass('cc.ImageAsset')
 export class ImageAsset extends Asset {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @override
     get _nativeAsset () {
@@ -218,7 +218,7 @@ export class ImageAsset extends Asset {
     // SERIALIZATION
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     // eslint-disable-next-line consistent-return
     public _serialize () {
@@ -247,7 +247,7 @@ export class ImageAsset extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _deserialize (data: any) {
         let fmtStr = '';

--- a/cocos/core/assets/render-texture.ts
+++ b/cocos/core/assets/render-texture.ts
@@ -114,7 +114,7 @@ export class RenderTexture extends TextureBase {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -124,7 +124,7 @@ export class RenderTexture extends TextureBase {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData;

--- a/cocos/core/assets/render-texture.ts
+++ b/cocos/core/assets/render-texture.ts
@@ -114,7 +114,7 @@ export class RenderTexture extends TextureBase {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -124,7 +124,7 @@ export class RenderTexture extends TextureBase {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData;

--- a/cocos/core/assets/render-texture.ts
+++ b/cocos/core/assets/render-texture.ts
@@ -113,6 +113,9 @@ export class RenderTexture extends TextureBase {
         this.emit('resize', this._window);
     }
 
+    /**
+     * @private_cc
+     */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
             return { base: super._serialize(ctxForExporting), w: this._width, h: this._height, n: this._name };
@@ -120,6 +123,9 @@ export class RenderTexture extends TextureBase {
         return {};
     }
 
+    /**
+     * @private_cc
+     */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData;
         this._width = data.w;

--- a/cocos/core/assets/texture-2d.ts
+++ b/cocos/core/assets/texture-2d.ts
@@ -125,7 +125,7 @@ export class Texture2D extends SimpleTexture {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @type([ImageAsset])
     public _mipmaps: ImageAsset[] = [];
@@ -232,7 +232,7 @@ export class Texture2D extends SimpleTexture {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _serialize (ctxForExporting: any) {
         if (EDITOR || TEST) {
@@ -254,7 +254,7 @@ export class Texture2D extends SimpleTexture {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData as ITexture2DSerializeData;

--- a/cocos/core/assets/texture-2d.ts
+++ b/cocos/core/assets/texture-2d.ts
@@ -124,6 +124,9 @@ export class Texture2D extends SimpleTexture {
         this.mipmaps = value ? [value] : [];
     }
 
+    /**
+     * @private_cc
+     */
     @type([ImageAsset])
     public _mipmaps: ImageAsset[] = [];
 
@@ -228,6 +231,9 @@ export class Texture2D extends SimpleTexture {
         this.destroy();
     }
 
+    /**
+     * @private_cc
+     */
     public _serialize (ctxForExporting: any) {
         if (EDITOR || TEST) {
             return {
@@ -247,6 +253,9 @@ export class Texture2D extends SimpleTexture {
         return null;
     }
 
+    /**
+     * @private_cc
+     */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData as ITexture2DSerializeData;
         super._deserialize(data.base, handle);

--- a/cocos/core/assets/texture-2d.ts
+++ b/cocos/core/assets/texture-2d.ts
@@ -125,7 +125,7 @@ export class Texture2D extends SimpleTexture {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @type([ImageAsset])
     public _mipmaps: ImageAsset[] = [];
@@ -232,7 +232,7 @@ export class Texture2D extends SimpleTexture {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _serialize (ctxForExporting: any) {
         if (EDITOR || TEST) {
@@ -254,7 +254,7 @@ export class Texture2D extends SimpleTexture {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData as ITexture2DSerializeData;

--- a/cocos/core/assets/texture-base.ts
+++ b/cocos/core/assets/texture-base.ts
@@ -287,7 +287,7 @@ export class TextureBase extends Asset {
     // SERIALIZATION
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -299,7 +299,7 @@ export class TextureBase extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData as string;

--- a/cocos/core/assets/texture-base.ts
+++ b/cocos/core/assets/texture-base.ts
@@ -287,7 +287,7 @@ export class TextureBase extends Asset {
     // SERIALIZATION
 
     /**
-     * @return
+     * @private_cc
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -299,8 +299,7 @@ export class TextureBase extends Asset {
     }
 
     /**
-     *
-     * @param data
+     * @private_cc
      */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData as string;

--- a/cocos/core/assets/texture-base.ts
+++ b/cocos/core/assets/texture-base.ts
@@ -287,7 +287,7 @@ export class TextureBase extends Asset {
     // SERIALIZATION
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _serialize (ctxForExporting: any): any {
         if (EDITOR || TEST) {
@@ -299,7 +299,7 @@ export class TextureBase extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _deserialize (serializedData: any, handle: any) {
         const data = serializedData as string;

--- a/cocos/core/assets/texture-cube.ts
+++ b/cocos/core/assets/texture-cube.ts
@@ -169,7 +169,7 @@ export class TextureCube extends SimpleTexture {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _mipmaps: ITextureCubeMipmap[] = [];
@@ -229,7 +229,7 @@ export class TextureCube extends SimpleTexture {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _serialize (ctxForExporting: any): Record<string, unknown> | null {
         if (EDITOR || TEST) {
@@ -257,7 +257,7 @@ export class TextureCube extends SimpleTexture {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _deserialize (serializedData: ITextureCubeSerializeData, handle: any) {
         const data = serializedData;

--- a/cocos/core/assets/texture-cube.ts
+++ b/cocos/core/assets/texture-cube.ts
@@ -168,6 +168,9 @@ export class TextureCube extends SimpleTexture {
         return out;
     }
 
+    /**
+     * @private_cc
+     */
     @serializable
     public _mipmaps: ITextureCubeMipmap[] = [];
 
@@ -225,6 +228,9 @@ export class TextureCube extends SimpleTexture {
         this.mipmaps = [];
     }
 
+    /**
+     * @private_cc
+     */
     public _serialize (ctxForExporting: any): Record<string, unknown> | null {
         if (EDITOR || TEST) {
             return {
@@ -250,6 +256,9 @@ export class TextureCube extends SimpleTexture {
         return null;
     }
 
+    /**
+     * @private_cc
+     */
     public _deserialize (serializedData: ITextureCubeSerializeData, handle: any) {
         const data = serializedData;
         super._deserialize(data.base, handle);

--- a/cocos/core/assets/texture-cube.ts
+++ b/cocos/core/assets/texture-cube.ts
@@ -169,7 +169,7 @@ export class TextureCube extends SimpleTexture {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _mipmaps: ITextureCubeMipmap[] = [];
@@ -229,7 +229,7 @@ export class TextureCube extends SimpleTexture {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _serialize (ctxForExporting: any): Record<string, unknown> | null {
         if (EDITOR || TEST) {
@@ -257,7 +257,7 @@ export class TextureCube extends SimpleTexture {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _deserialize (serializedData: ITextureCubeSerializeData, handle: any) {
         const data = serializedData;

--- a/cocos/core/components/camera-component.ts
+++ b/cocos/core/components/camera-component.ts
@@ -532,7 +532,7 @@ export class Camera extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _createCamera () {
         if (!this._camera) {

--- a/cocos/core/components/camera-component.ts
+++ b/cocos/core/components/camera-component.ts
@@ -532,7 +532,7 @@ export class Camera extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _createCamera () {
         if (!this._camera) {

--- a/cocos/core/components/camera-component.ts
+++ b/cocos/core/components/camera-component.ts
@@ -531,6 +531,9 @@ export class Camera extends Component {
         return out;
     }
 
+    /**
+     * @private_cc
+     */
     public _createCamera () {
         if (!this._camera) {
             this._camera = (legacyCC.director.root as Root).createCamera();

--- a/cocos/core/components/component-event-handler.ts
+++ b/cocos/core/components/component-event-handler.ts
@@ -64,7 +64,7 @@ import { legacyCC } from '../global-exports';
 @ccclass('cc.ClickEvent')
 export class EventHandler {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _componentName () {
         this._genCompIdIfNeeded();
@@ -118,7 +118,7 @@ export class EventHandler {
     public component = '';
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _componentId = '';

--- a/cocos/core/components/component-event-handler.ts
+++ b/cocos/core/components/component-event-handler.ts
@@ -64,7 +64,7 @@ import { legacyCC } from '../global-exports';
 @ccclass('cc.ClickEvent')
 export class EventHandler {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     get _componentName () {
         this._genCompIdIfNeeded();
@@ -118,7 +118,7 @@ export class EventHandler {
     public component = '';
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _componentId = '';

--- a/cocos/core/components/component-event-handler.ts
+++ b/cocos/core/components/component-event-handler.ts
@@ -63,6 +63,9 @@ import { legacyCC } from '../global-exports';
  */
 @ccclass('cc.ClickEvent')
 export class EventHandler {
+    /**
+     * @private_cc
+     */
     get _componentName () {
         this._genCompIdIfNeeded();
 

--- a/cocos/core/components/component-event-handler.ts
+++ b/cocos/core/components/component-event-handler.ts
@@ -114,6 +114,9 @@ export class EventHandler {
     @tooltip('i18n:button.click_event.component')
     public component = '';
 
+    /**
+     * @private_cc
+     */
     @serializable
     public _componentId = '';
 

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -96,7 +96,7 @@ class Component extends CCObject {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @displayName('Script')
     @type(Script)
@@ -156,7 +156,7 @@ class Component extends CCObject {
      * log(this._isOnLoadCalled > 0);
      * ```
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _isOnLoadCalled () {
         return this._objFlags & IsOnLoadCalled;
@@ -176,32 +176,32 @@ class Component extends CCObject {
     public node: Node = NullNode;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _enabled = true;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public __prefab: CompPrefabInfo | null = null;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _sceneGetter: null | (() => RenderScene) = null;
 
     /**
      * For internal usage.
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _id: string = idGenerator.getNewId();
 
     // private __scriptUuid = '';
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _getRenderScene (): RenderScene {
         if (this._sceneGetter) {
@@ -379,7 +379,7 @@ class Component extends CCObject {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onPreDestroy () {
         // Schedules
@@ -399,7 +399,7 @@ class Component extends CCObject {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _instantiate (cloned?: Component) {
         if (!cloned) {

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -171,32 +171,32 @@ class Component extends CCObject {
     public node: Node = NullNode;
 
     /**
-     * @private
+     * @private_cc
      */
     @serializable
     public _enabled = true;
 
     /**
-     * @private
+     * @private_cc
      */
     @serializable
     public __prefab: CompPrefabInfo | null = null;
 
     /**
-     * @private
+     * @private_cc
      */
     public _sceneGetter: null | (() => RenderScene) = null;
 
     /**
      * For internal usage.
-     * @private
+     * @private_cc
      */
     public _id: string = idGenerator.getNewId();
 
     // private __scriptUuid = '';
 
     /**
-     * @private
+     * @private_cc
      */
     public _getRenderScene (): RenderScene {
         if (this._sceneGetter) {
@@ -373,6 +373,9 @@ class Component extends CCObject {
         return false;
     }
 
+    /**
+     * @private_cc
+     */
     public _onPreDestroy () {
         // Schedules
         this.unscheduleAllCallbacks();
@@ -390,6 +393,9 @@ class Component extends CCObject {
         this.node._removeComponent(this);
     }
 
+    /**
+     * @private_cc
+     */
     public _instantiate (cloned?: Component) {
         if (!cloned) {
             cloned = legacyCC.instantiate._clone(this, this);

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -96,7 +96,7 @@ class Component extends CCObject {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @displayName('Script')
     @type(Script)
@@ -156,7 +156,7 @@ class Component extends CCObject {
      * log(this._isOnLoadCalled > 0);
      * ```
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     get _isOnLoadCalled () {
         return this._objFlags & IsOnLoadCalled;
@@ -176,32 +176,32 @@ class Component extends CCObject {
     public node: Node = NullNode;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _enabled = true;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public __prefab: CompPrefabInfo | null = null;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _sceneGetter: null | (() => RenderScene) = null;
 
     /**
      * For internal usage.
-     * @private_cc
+     * @deprecated_to_user
      */
     public _id: string = idGenerator.getNewId();
 
     // private __scriptUuid = '';
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _getRenderScene (): RenderScene {
         if (this._sceneGetter) {
@@ -379,7 +379,7 @@ class Component extends CCObject {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onPreDestroy () {
         // Schedules
@@ -399,7 +399,7 @@ class Component extends CCObject {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _instantiate (cloned?: Component) {
         if (!cloned) {

--- a/cocos/core/components/component.ts
+++ b/cocos/core/components/component.ts
@@ -95,6 +95,9 @@ class Component extends CCObject {
         return this._id;
     }
 
+    /**
+     * @private_cc
+     */
     @displayName('Script')
     @type(Script)
     @tooltip('i18n:INSPECTOR.component.script')
@@ -152,6 +155,8 @@ class Component extends CCObject {
      * import { log } from 'cc';
      * log(this._isOnLoadCalled > 0);
      * ```
+     *
+     * @private_cc
      */
     get _isOnLoadCalled () {
         return this._objFlags & IsOnLoadCalled;

--- a/cocos/core/components/missing-script.ts
+++ b/cocos/core/components/missing-script.ts
@@ -71,6 +71,9 @@ export default class MissingScript extends Component {
     }
 
     // the serialized data for original script object
+    /**
+     * @private_cc
+     */
     @serializable
     @editorOnly
     public _$erialized = null;

--- a/cocos/core/components/missing-script.ts
+++ b/cocos/core/components/missing-script.ts
@@ -72,7 +72,7 @@ export default class MissingScript extends Component {
 
     // the serialized data for original script object
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     @editorOnly

--- a/cocos/core/components/missing-script.ts
+++ b/cocos/core/components/missing-script.ts
@@ -72,7 +72,7 @@ export default class MissingScript extends Component {
 
     // the serialized data for original script object
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     @editorOnly

--- a/cocos/core/components/renderable-component.ts
+++ b/cocos/core/components/renderable-component.ts
@@ -225,7 +225,7 @@ export class RenderableComponent extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _collectModels (): scene.Model[] {
         return this._models;

--- a/cocos/core/components/renderable-component.ts
+++ b/cocos/core/components/renderable-component.ts
@@ -224,6 +224,9 @@ export class RenderableComponent extends Component {
         return this._materialInstances[index] || this._materials[index];
     }
 
+    /**
+     * @private_cc
+     */
     public _collectModels (): scene.Model[] {
         return this._models;
     }

--- a/cocos/core/components/renderable-component.ts
+++ b/cocos/core/components/renderable-component.ts
@@ -225,7 +225,7 @@ export class RenderableComponent extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _collectModels (): scene.Model[] {
         return this._models;

--- a/cocos/core/data/custom-serializable.ts
+++ b/cocos/core/data/custom-serializable.ts
@@ -2,13 +2,13 @@ import { assertIsNonNullable, assertIsTrue } from './utils/asserts';
 
 /**
  * Tag to define the custom serialization method.
- * @deprecated_to_user
+ * @marked_as_engine_private
  */
 export const serializeTag = Symbol('[[Serialize]]');
 
 /**
  * Tag to define the custom deserialization method.
- * @deprecated_to_user
+ * @marked_as_engine_private
  */
 export const deserializeTag = Symbol('[[Deserialize]]');
 
@@ -82,7 +82,7 @@ export interface CustomSerializable {
 
 /**
  * Enables the custom serialize/deserialize method only if the (de)serialize procedure is targeting CCON.
- * @deprecated_to_user
+ * @marked_as_engine_private
  */
 export const enableIfCCON: MethodDecorator = <T>(
     // eslint-disable-next-line @typescript-eslint/ban-types

--- a/cocos/core/data/custom-serializable.ts
+++ b/cocos/core/data/custom-serializable.ts
@@ -2,13 +2,13 @@ import { assertIsNonNullable, assertIsTrue } from './utils/asserts';
 
 /**
  * Tag to define the custom serialization method.
- * @internal
+ * @private_cc
  */
 export const serializeTag = Symbol('[[Serialize]]');
 
 /**
  * Tag to define the custom deserialization method.
- * @internal
+ * @private_cc
  */
 export const deserializeTag = Symbol('[[Deserialize]]');
 
@@ -82,7 +82,7 @@ export interface CustomSerializable {
 
 /**
  * Enables the custom serialize/deserialize method only if the (de)serialize procedure is targeting CCON.
- * @internal
+ * @private_cc
  */
 export const enableIfCCON: MethodDecorator = <T>(
     // eslint-disable-next-line @typescript-eslint/ban-types

--- a/cocos/core/data/custom-serializable.ts
+++ b/cocos/core/data/custom-serializable.ts
@@ -2,13 +2,13 @@ import { assertIsNonNullable, assertIsTrue } from './utils/asserts';
 
 /**
  * Tag to define the custom serialization method.
- * @private_cc
+ * @deprecated_to_user
  */
 export const serializeTag = Symbol('[[Serialize]]');
 
 /**
  * Tag to define the custom deserialization method.
- * @private_cc
+ * @deprecated_to_user
  */
 export const deserializeTag = Symbol('[[Deserialize]]');
 
@@ -82,7 +82,7 @@ export interface CustomSerializable {
 
 /**
  * Enables the custom serialize/deserialize method only if the (de)serialize procedure is targeting CCON.
- * @private_cc
+ * @deprecated_to_user
  */
 export const enableIfCCON: MethodDecorator = <T>(
     // eslint-disable-next-line @typescript-eslint/ban-types

--- a/cocos/core/data/gc-object.ts
+++ b/cocos/core/data/gc-object.ts
@@ -26,7 +26,7 @@ import { CCObject } from './object';
 @ccclass('cc.GCObject')
 export class GCObject extends CCObject {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public declare _finalizationToken: any;
 

--- a/cocos/core/data/gc-object.ts
+++ b/cocos/core/data/gc-object.ts
@@ -25,6 +25,9 @@ import { CCObject } from './object';
 
 @ccclass('cc.GCObject')
 export class GCObject extends CCObject {
+    /**
+     * @private_cc
+     */
     public declare _finalizationToken: any;
 
     constructor (...arg: ConstructorParameters<typeof CCObject>) {

--- a/cocos/core/data/gc-object.ts
+++ b/cocos/core/data/gc-object.ts
@@ -26,7 +26,7 @@ import { CCObject } from './object';
 @ccclass('cc.GCObject')
 export class GCObject extends CCObject {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public declare _finalizationToken: any;
 

--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -194,6 +194,9 @@ class CCObject implements EditorExtendableObject {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public declare [editorExtrasTag]: unknown;
 
     /**

--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -195,12 +195,12 @@ class CCObject implements EditorExtendableObject {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public declare [editorExtrasTag]: unknown;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _objFlags: number;
     protected _name: string;
@@ -345,7 +345,7 @@ class CCObject implements EditorExtendableObject {
      *           }
      *       }
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     public _destruct () {
         const ctor: any = this.constructor;
@@ -358,7 +358,7 @@ class CCObject implements EditorExtendableObject {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _destroyImmediate () {
         if (this._objFlags & Destroyed) {

--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -195,12 +195,12 @@ class CCObject implements EditorExtendableObject {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public declare [editorExtrasTag]: unknown;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _objFlags: number;
     protected _name: string;
@@ -345,7 +345,7 @@ class CCObject implements EditorExtendableObject {
      *           }
      *       }
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _destruct () {
         const ctor: any = this.constructor;
@@ -358,7 +358,7 @@ class CCObject implements EditorExtendableObject {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _destroyImmediate () {
         if (this._objFlags & Destroyed) {

--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -196,6 +196,9 @@ class CCObject implements EditorExtendableObject {
 
     public declare [editorExtrasTag]: unknown;
 
+    /**
+     * @private_cc
+     */
     public _objFlags: number;
     protected _name: string;
 
@@ -339,6 +342,7 @@ class CCObject implements EditorExtendableObject {
      *           }
      *       }
      *
+     * @private_cc
      */
     public _destruct () {
         const ctor: any = this.constructor;
@@ -350,6 +354,9 @@ class CCObject implements EditorExtendableObject {
         destruct(this);
     }
 
+    /**
+     * @private_cc
+     */
     public _destroyImmediate () {
         if (this._objFlags & Destroyed) {
             errorID(5000);

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -202,11 +202,11 @@ export class Director extends EventTarget {
     public static instance: Director;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _compScheduler: ComponentScheduler;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _nodeActivator: NodeActivator;
     private _invalid: boolean;

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -202,11 +202,11 @@ export class Director extends EventTarget {
     public static instance: Director;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _compScheduler: ComponentScheduler;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _nodeActivator: NodeActivator;
     private _invalid: boolean;

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -201,7 +201,13 @@ export class Director extends EventTarget {
 
     public static instance: Director;
 
+    /**
+     * @private_cc
+     */
     public _compScheduler: ComponentScheduler;
+    /**
+     * @private_cc
+     */
     public _nodeActivator: NodeActivator;
     private _invalid: boolean;
     private _paused: boolean;

--- a/cocos/core/event/callbacks-invoker.ts
+++ b/cocos/core/event/callbacks-invoker.ts
@@ -186,7 +186,7 @@ type EventType = string | number;
  */
 export class CallbacksInvoker<EventTypeClass extends EventType = EventType> {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _callbackTable: ICallbackTable = createMap(true);
     private _offCallback?: () => void;

--- a/cocos/core/event/callbacks-invoker.ts
+++ b/cocos/core/event/callbacks-invoker.ts
@@ -186,7 +186,7 @@ type EventType = string | number;
  */
 export class CallbacksInvoker<EventTypeClass extends EventType = EventType> {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _callbackTable: ICallbackTable = createMap(true);
     private _offCallback?: () => void;

--- a/cocos/core/event/callbacks-invoker.ts
+++ b/cocos/core/event/callbacks-invoker.ts
@@ -185,6 +185,9 @@ type EventType = string | number;
  * each key is mapped to a CallbackList.
  */
 export class CallbacksInvoker<EventTypeClass extends EventType = EventType> {
+    /**
+     * @private_cc
+     */
     public _callbackTable: ICallbackTable = createMap(true);
     private _offCallback?: () => void;
 

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -390,25 +390,25 @@ export class Game extends EventTarget {
     public groupList: any[] = [];
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _persistRootNodes = {};
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _gfxDevice: Device | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _swapchain: Swapchain | null = null;
     // states
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _configLoaded = false; // whether config loaded
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _isCloning = false;    // deserializing or instantiating
     private _inited = false;

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -390,25 +390,25 @@ export class Game extends EventTarget {
     public groupList: any[] = [];
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _persistRootNodes = {};
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _gfxDevice: Device | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _swapchain: Swapchain | null = null;
     // states
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _configLoaded = false; // whether config loaded
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _isCloning = false;    // deserializing or instantiating
     private _inited = false;

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -389,12 +389,27 @@ export class Game extends EventTarget {
     public collisionMatrix = [];
     public groupList: any[] = [];
 
+    /**
+     * @private_cc
+     */
     public _persistRootNodes = {};
 
+    /**
+     * @private_cc
+     */
     public _gfxDevice: Device | null = null;
+    /**
+     * @private_cc
+     */
     public _swapchain: Swapchain | null = null;
     // states
+    /**
+     * @private_cc
+     */
     public _configLoaded = false; // whether config loaded
+    /**
+     * @private_cc
+     */
     public _isCloning = false;    // deserializing or instantiating
     private _inited = false;
     private _engineInited = false; // whether the engine has inited

--- a/cocos/core/geometry/curve.ts
+++ b/cocos/core/geometry/curve.ts
@@ -122,7 +122,7 @@ export class AnimationCurve {
 
     /**
      * For internal usage only.
-     * @private_cc
+     * @deprecated_to_user
      */
     get _internalCurve () {
         return this._curve;

--- a/cocos/core/geometry/curve.ts
+++ b/cocos/core/geometry/curve.ts
@@ -122,7 +122,7 @@ export class AnimationCurve {
 
     /**
      * For internal usage only.
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _internalCurve () {
         return this._curve;

--- a/cocos/core/geometry/curve.ts
+++ b/cocos/core/geometry/curve.ts
@@ -122,7 +122,7 @@ export class AnimationCurve {
 
     /**
      * For internal usage only.
-     * @internal
+     * @private_cc
      */
     get _internalCurve () {
         return this._curve;

--- a/cocos/core/math/color.ts
+++ b/cocos/core/math/color.ts
@@ -300,6 +300,9 @@ export class Color extends ValueType {
     get w () { return this.a * toFloat; }
     set w (value) { this.a = value * 255; }
 
+    /**
+     * @private_cc
+     */
     public _val = 0;
 
     /**
@@ -648,21 +651,33 @@ export class Color extends ValueType {
         return this;
     }
 
+    /**
+     * @private_cc
+     */
     public _set_r_unsafe (red) {
         this._val = ((this._val & 0xffffff00) | red) >>> 0;
         return this;
     }
 
+    /**
+     * @private_cc
+     */
     public _set_g_unsafe (green) {
         this._val = ((this._val & 0xffff00ff) | (green << 8)) >>> 0;
         return this;
     }
 
+    /**
+     * @private_cc
+     */
     public _set_b_unsafe (blue) {
         this._val = ((this._val & 0xff00ffff) | (blue << 16)) >>> 0;
         return this;
     }
 
+    /**
+     * @private_cc
+     */
     public _set_a_unsafe (alpha) {
         this._val = ((this._val & 0x00ffffff) | (alpha << 24)) >>> 0;
         return this;

--- a/cocos/core/math/color.ts
+++ b/cocos/core/math/color.ts
@@ -301,7 +301,7 @@ export class Color extends ValueType {
     set w (value) { this.a = value * 255; }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _val = 0;
 
@@ -652,7 +652,7 @@ export class Color extends ValueType {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _set_r_unsafe (red) {
         this._val = ((this._val & 0xffffff00) | red) >>> 0;
@@ -660,7 +660,7 @@ export class Color extends ValueType {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _set_g_unsafe (green) {
         this._val = ((this._val & 0xffff00ff) | (green << 8)) >>> 0;
@@ -668,7 +668,7 @@ export class Color extends ValueType {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _set_b_unsafe (blue) {
         this._val = ((this._val & 0xff00ffff) | (blue << 16)) >>> 0;
@@ -676,7 +676,7 @@ export class Color extends ValueType {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _set_a_unsafe (alpha) {
         this._val = ((this._val & 0x00ffffff) | (alpha << 24)) >>> 0;

--- a/cocos/core/math/color.ts
+++ b/cocos/core/math/color.ts
@@ -301,7 +301,7 @@ export class Color extends ValueType {
     set w (value) { this.a = value * 255; }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _val = 0;
 
@@ -652,7 +652,7 @@ export class Color extends ValueType {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _set_r_unsafe (red) {
         this._val = ((this._val & 0xffffff00) | red) >>> 0;
@@ -660,7 +660,7 @@ export class Color extends ValueType {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _set_g_unsafe (green) {
         this._val = ((this._val & 0xffff00ff) | (green << 8)) >>> 0;
@@ -668,7 +668,7 @@ export class Color extends ValueType {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _set_b_unsafe (blue) {
         this._val = ((this._val & 0xff00ffff) | (blue << 16)) >>> 0;
@@ -676,7 +676,7 @@ export class Color extends ValueType {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _set_a_unsafe (alpha) {
         this._val = ((this._val & 0x00ffffff) | (alpha << 24)) >>> 0;

--- a/cocos/core/memop/scalable-container.ts
+++ b/cocos/core/memop/scalable-container.ts
@@ -26,7 +26,7 @@ import { containerManager } from './container-manager';
 
 export abstract class ScalableContainer {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _poolHandle = -1;
     constructor () {

--- a/cocos/core/memop/scalable-container.ts
+++ b/cocos/core/memop/scalable-container.ts
@@ -25,6 +25,9 @@
 import { containerManager } from './container-manager';
 
 export abstract class ScalableContainer {
+    /**
+     * @private_cc
+     */
     public _poolHandle = -1;
     constructor () {
         containerManager.addContainer(this);

--- a/cocos/core/memop/scalable-container.ts
+++ b/cocos/core/memop/scalable-container.ts
@@ -26,7 +26,7 @@ import { containerManager } from './container-manager';
 
 export abstract class ScalableContainer {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _poolHandle = -1;
     constructor () {

--- a/cocos/core/pipeline/geometry-renderer.ts
+++ b/cocos/core/pipeline/geometry-renderer.ts
@@ -73,27 +73,27 @@ enum GeometryType {
 
 class GeometryVertexBuffer {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _maxVertices = 0;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _vertexCount = 0;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _stride = 0;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _vertices!: Float32Array;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _buffer!: Buffer;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _inputAssembler!: InputAssembler;
 

--- a/cocos/core/pipeline/geometry-renderer.ts
+++ b/cocos/core/pipeline/geometry-renderer.ts
@@ -72,11 +72,29 @@ enum GeometryType {
 }
 
 class GeometryVertexBuffer {
+    /**
+     * @private_cc
+     */
     public _maxVertices = 0;
+    /**
+     * @private_cc
+     */
     public _vertexCount = 0;
+    /**
+     * @private_cc
+     */
     public _stride = 0;
+    /**
+     * @private_cc
+     */
     public _vertices!: Float32Array;
+    /**
+     * @private_cc
+     */
     public _buffer!: Buffer;
+    /**
+     * @private_cc
+     */
     public _inputAssembler!: InputAssembler;
 
     public init (device: Device, maxVertices: number, stride: number, attributes: Attribute[]) {

--- a/cocos/core/pipeline/geometry-renderer.ts
+++ b/cocos/core/pipeline/geometry-renderer.ts
@@ -73,27 +73,27 @@ enum GeometryType {
 
 class GeometryVertexBuffer {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _maxVertices = 0;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _vertexCount = 0;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _stride = 0;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _vertices!: Float32Array;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _buffer!: Buffer;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _inputAssembler!: InputAssembler;
 

--- a/cocos/core/pipeline/shadow/shadow-flow.ts
+++ b/cocos/core/pipeline/shadow/shadow-flow.ts
@@ -163,6 +163,9 @@ export class ShadowFlow extends RenderFlow {
         if (this._shadowRenderPass) { this._shadowRenderPass.destroy(); }
     }
 
+    /**
+     * @private_cc
+     */
     public _initShadowFrameBuffer  (pipeline: RenderPipeline, light: Light, swapchain: Swapchain) {
         const { device } = pipeline;
         const shadows = pipeline.pipelineSceneData.shadows;

--- a/cocos/core/pipeline/shadow/shadow-flow.ts
+++ b/cocos/core/pipeline/shadow/shadow-flow.ts
@@ -164,7 +164,7 @@ export class ShadowFlow extends RenderFlow {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _initShadowFrameBuffer  (pipeline: RenderPipeline, light: Light, swapchain: Swapchain) {
         const { device } = pipeline;

--- a/cocos/core/pipeline/shadow/shadow-flow.ts
+++ b/cocos/core/pipeline/shadow/shadow-flow.ts
@@ -164,7 +164,7 @@ export class ShadowFlow extends RenderFlow {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _initShadowFrameBuffer  (pipeline: RenderPipeline, light: Light, swapchain: Swapchain) {
         const { device } = pipeline;

--- a/cocos/core/platform/view.ts
+++ b/cocos/core/platform/view.ts
@@ -71,6 +71,9 @@ const orientationMap = {
 
 export class View extends EventTarget {
     public static instance: View;
+    /**
+     * @private_cc
+     */
     public _designResolutionSize: Size;
 
     private _scaleX: number;
@@ -714,6 +717,9 @@ class ContentStrategy {
     public postApply (_view: View) {
     }
 
+    /**
+     * @private_cc
+     */
     public _buildResult (containerW, containerH, contentW, contentH, scaleX, scaleY): AdaptResult {
         // Makes content fit better the canvas
         if (Math.abs(containerW - contentW) < 2) {

--- a/cocos/core/platform/view.ts
+++ b/cocos/core/platform/view.ts
@@ -72,7 +72,7 @@ const orientationMap = {
 export class View extends EventTarget {
     public static instance: View;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _designResolutionSize: Size;
 
@@ -718,7 +718,7 @@ class ContentStrategy {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _buildResult (containerW, containerH, contentW, contentH, scaleX, scaleY): AdaptResult {
         // Makes content fit better the canvas

--- a/cocos/core/platform/view.ts
+++ b/cocos/core/platform/view.ts
@@ -72,7 +72,7 @@ const orientationMap = {
 export class View extends EventTarget {
     public static instance: View;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _designResolutionSize: Size;
 
@@ -718,7 +718,7 @@ class ContentStrategy {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _buildResult (containerW, containerH, contentW, contentH, scaleX, scaleY): AdaptResult {
         // Makes content fit better the canvas

--- a/cocos/core/root.ts
+++ b/cocos/core/root.ts
@@ -221,7 +221,13 @@ export class Root {
         return this._useDeferredPipeline;
     }
 
+    /**
+     * @private_cc
+     */
     public _createSceneFun: (root: Root) => RenderScene = null!;
+    /**
+     * @private_cc
+     */
     public _createWindowFun: (root: Root) => RenderWindow = null!;
 
     private _device: Device;

--- a/cocos/core/root.ts
+++ b/cocos/core/root.ts
@@ -222,11 +222,11 @@ export class Root {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _createSceneFun: (root: Root) => RenderScene = null!;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _createWindowFun: (root: Root) => RenderWindow = null!;
 

--- a/cocos/core/root.ts
+++ b/cocos/core/root.ts
@@ -222,11 +222,11 @@ export class Root {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _createSceneFun: (root: Root) => RenderScene = null!;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _createWindowFun: (root: Root) => RenderWindow = null!;
 

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -95,7 +95,7 @@ export class BaseNode extends CCObject implements ISchedulable {
      * @zh 如果为true，则该节点是一个常驻节点，不会在场景转换期间被销毁。
      * 如果为false，节点将在加载新场景时自动销毁。默认为 false。
      * @default false
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @property
     get _persistNode (): boolean {
@@ -333,7 +333,7 @@ export class BaseNode extends CCObject implements ISchedulable {
 
     /**
      * record scene's id when set this node as persist node
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _originalSceneId = '';
 
@@ -1225,7 +1225,7 @@ export class BaseNode extends CCObject implements ISchedulable {
 
     /**
      * Do remove component, only used internally.
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _removeComponent (component: Component) {
         if (!component) {
@@ -1247,7 +1247,7 @@ export class BaseNode extends CCObject implements ISchedulable {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateSiblingIndex () {
         for (let i = 0; i < this._children.length; ++i) {

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -95,7 +95,7 @@ export class BaseNode extends CCObject implements ISchedulable {
      * @zh 如果为true，则该节点是一个常驻节点，不会在场景转换期间被销毁。
      * 如果为false，节点将在加载新场景时自动销毁。默认为 false。
      * @default false
-     * @private_cc
+     * @deprecated_to_user
      */
     @property
     get _persistNode (): boolean {
@@ -333,7 +333,7 @@ export class BaseNode extends CCObject implements ISchedulable {
 
     /**
      * record scene's id when set this node as persist node
-     * @private_cc
+     * @deprecated_to_user
      */
     public _originalSceneId = '';
 
@@ -1225,7 +1225,7 @@ export class BaseNode extends CCObject implements ISchedulable {
 
     /**
      * Do remove component, only used internally.
-     * @private_cc
+     * @deprecated_to_user
      */
     public _removeComponent (component: Component) {
         if (!component) {
@@ -1247,7 +1247,7 @@ export class BaseNode extends CCObject implements ISchedulable {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateSiblingIndex () {
         for (let i = 0; i < this._children.length; ++i) {

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -331,7 +331,10 @@ export class BaseNode extends CCObject implements ISchedulable {
 
     protected _siblingIndex = 0;
 
-    // record scene's id when set this node as persist node
+    /**
+     * record scene's id when set this node as persist node
+     * @private_cc
+     */
     public _originalSceneId = '';
 
     /**
@@ -1220,7 +1223,10 @@ export class BaseNode extends CCObject implements ISchedulable {
         }
     }
 
-    // Do remove component, only used internally.
+    /**
+     * Do remove component, only used internally.
+     * @private_cc
+     */
     public _removeComponent (component: Component) {
         if (!component) {
             errorID(3814);
@@ -1240,6 +1246,9 @@ export class BaseNode extends CCObject implements ISchedulable {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _updateSiblingIndex () {
         for (let i = 0; i < this._children.length; ++i) {
             this._children[i]._siblingIndex = i;

--- a/cocos/core/scene-graph/base-node.ts
+++ b/cocos/core/scene-graph/base-node.ts
@@ -95,7 +95,7 @@ export class BaseNode extends CCObject implements ISchedulable {
      * @zh 如果为true，则该节点是一个常驻节点，不会在场景转换期间被销毁。
      * 如果为false，节点将在加载新场景时自动销毁。默认为 false。
      * @default false
-     * @protected
+     * @private_cc
      */
     @property
     get _persistNode (): boolean {

--- a/cocos/core/scene-graph/component-scheduler.ts
+++ b/cocos/core/scene-graph/component-scheduler.ts
@@ -368,6 +368,9 @@ export class ComponentScheduler {
         this._updating = false;
     }
 
+    /**
+     * @private_cc
+     */
     public _onEnabled (comp) {
         legacyCC.director.getScheduler().resumeTarget(comp);
         comp._objFlags |= IsOnEnableCalled;
@@ -380,6 +383,9 @@ export class ComponentScheduler {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _onDisabled (comp) {
         legacyCC.director.getScheduler().pauseTarget(comp);
         comp._objFlags &= ~IsOnEnableCalled;

--- a/cocos/core/scene-graph/component-scheduler.ts
+++ b/cocos/core/scene-graph/component-scheduler.ts
@@ -369,7 +369,7 @@ export class ComponentScheduler {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onEnabled (comp) {
         legacyCC.director.getScheduler().resumeTarget(comp);
@@ -384,7 +384,7 @@ export class ComponentScheduler {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onDisabled (comp) {
         legacyCC.director.getScheduler().pauseTarget(comp);

--- a/cocos/core/scene-graph/component-scheduler.ts
+++ b/cocos/core/scene-graph/component-scheduler.ts
@@ -369,7 +369,7 @@ export class ComponentScheduler {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onEnabled (comp) {
         legacyCC.director.getScheduler().resumeTarget(comp);
@@ -384,7 +384,7 @@ export class ComponentScheduler {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onDisabled (comp) {
         legacyCC.director.getScheduler().pauseTarget(comp);

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -158,7 +158,7 @@ export class Node extends BaseNode implements CustomSerializable {
     public static TransformBit = TransformBit;
 
     /**
-     * @internal
+     * @private_cc
      */
     public static reserveContentsForAllSyncablePrefabTag = reserveContentsForAllSyncablePrefabTag;
 

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -162,9 +162,8 @@ export class Node extends BaseNode implements CustomSerializable {
      */
     public static reserveContentsForAllSyncablePrefabTag = reserveContentsForAllSyncablePrefabTag;
 
-    // UI 部分的脏数据
     /**
-     * @private
+     * @private_cc
      */
     public _uiProps = new NodeUIProperties(this);
 
@@ -175,6 +174,9 @@ export class Node extends BaseNode implements CustomSerializable {
     private static ClearFrame = 0;
     private static ClearRound = 1000;
 
+    /**
+     * @private_cc
+     */
     public _static = false;
 
     // world transform, don't access this directly
@@ -549,6 +551,9 @@ export class Node extends BaseNode implements CustomSerializable {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _onSetParent (oldParent: this | null, keepWorldTransform: boolean) {
         super._onSetParent(oldParent, keepWorldTransform);
         if (keepWorldTransform) {
@@ -573,6 +578,9 @@ export class Node extends BaseNode implements CustomSerializable {
         super._onHierarchyChangedBase(oldParent);
     }
 
+    /**
+     * @private_cc
+     */
     public _onBatchCreated (dontSyncChildPrefab: boolean) {
         if (JSB) {
             this._nativeLayer[0] = this._layer;
@@ -587,11 +595,17 @@ export class Node extends BaseNode implements CustomSerializable {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _onBeforeSerialize () {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         this.eulerAngles; // make sure we save the correct eulerAngles
     }
 
+    /**
+     * @private_cc
+     */
     public _onPostActivated (active: boolean) {
         if (active) { // activated
             this._eventProcessor.setEnabled(true);

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -158,12 +158,12 @@ export class Node extends BaseNode implements CustomSerializable {
     public static TransformBit = TransformBit;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public static reserveContentsForAllSyncablePrefabTag = reserveContentsForAllSyncablePrefabTag;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _uiProps = new NodeUIProperties(this);
 
@@ -175,7 +175,7 @@ export class Node extends BaseNode implements CustomSerializable {
     private static ClearRound = 1000;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _static = false;
 
@@ -552,7 +552,7 @@ export class Node extends BaseNode implements CustomSerializable {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onSetParent (oldParent: this | null, keepWorldTransform: boolean) {
         super._onSetParent(oldParent, keepWorldTransform);
@@ -579,7 +579,7 @@ export class Node extends BaseNode implements CustomSerializable {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onBatchCreated (dontSyncChildPrefab: boolean) {
         if (JSB) {
@@ -596,7 +596,7 @@ export class Node extends BaseNode implements CustomSerializable {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onBeforeSerialize () {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -604,7 +604,7 @@ export class Node extends BaseNode implements CustomSerializable {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onPostActivated (active: boolean) {
         if (active) { // activated

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -158,12 +158,12 @@ export class Node extends BaseNode implements CustomSerializable {
     public static TransformBit = TransformBit;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public static reserveContentsForAllSyncablePrefabTag = reserveContentsForAllSyncablePrefabTag;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _uiProps = new NodeUIProperties(this);
 
@@ -175,7 +175,7 @@ export class Node extends BaseNode implements CustomSerializable {
     private static ClearRound = 1000;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _static = false;
 
@@ -552,7 +552,7 @@ export class Node extends BaseNode implements CustomSerializable {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onSetParent (oldParent: this | null, keepWorldTransform: boolean) {
         super._onSetParent(oldParent, keepWorldTransform);
@@ -579,7 +579,7 @@ export class Node extends BaseNode implements CustomSerializable {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onBatchCreated (dontSyncChildPrefab: boolean) {
         if (JSB) {
@@ -596,7 +596,7 @@ export class Node extends BaseNode implements CustomSerializable {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onBeforeSerialize () {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -604,7 +604,7 @@ export class Node extends BaseNode implements CustomSerializable {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onPostActivated (active: boolean) {
         if (active) { // activated

--- a/cocos/core/scene-graph/scene-globals.ts
+++ b/cocos/core/scene-graph/scene-globals.ts
@@ -1088,7 +1088,7 @@ export class SceneGlobals {
     @editable
     public shadows = new ShadowsInfo();
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _skybox = new SkyboxInfo();

--- a/cocos/core/scene-graph/scene-globals.ts
+++ b/cocos/core/scene-graph/scene-globals.ts
@@ -1087,6 +1087,9 @@ export class SceneGlobals {
     @serializable
     @editable
     public shadows = new ShadowsInfo();
+    /**
+     * @private_cc
+     */
     @serializable
     public _skybox = new SkyboxInfo();
     @editable

--- a/cocos/core/scene-graph/scene-globals.ts
+++ b/cocos/core/scene-graph/scene-globals.ts
@@ -1088,7 +1088,7 @@ export class SceneGlobals {
     @editable
     public shadows = new ShadowsInfo();
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _skybox = new SkyboxInfo();

--- a/cocos/core/scene-graph/scene.ts
+++ b/cocos/core/scene-graph/scene.ts
@@ -76,7 +76,7 @@ export class Scene extends BaseNode {
      * @en Per-scene level rendering info
      * @zh 场景级别的渲染信息
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _globals = new SceneGlobals();
@@ -165,12 +165,12 @@ export class Scene extends BaseNode {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onHierarchyChanged () { }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onBatchCreated (dontSyncChildPrefab: boolean) {
         super._onBatchCreated(dontSyncChildPrefab);

--- a/cocos/core/scene-graph/scene.ts
+++ b/cocos/core/scene-graph/scene.ts
@@ -76,7 +76,7 @@ export class Scene extends BaseNode {
      * @en Per-scene level rendering info
      * @zh 场景级别的渲染信息
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _globals = new SceneGlobals();
@@ -165,12 +165,12 @@ export class Scene extends BaseNode {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onHierarchyChanged () { }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onBatchCreated (dontSyncChildPrefab: boolean) {
         super._onBatchCreated(dontSyncChildPrefab);

--- a/cocos/core/scene-graph/scene.ts
+++ b/cocos/core/scene-graph/scene.ts
@@ -75,6 +75,8 @@ export class Scene extends BaseNode {
     /**
      * @en Per-scene level rendering info
      * @zh 场景级别的渲染信息
+     *
+     * @private_cc
      */
     @serializable
     public _globals = new SceneGlobals();
@@ -162,8 +164,14 @@ export class Scene extends BaseNode {
         throw new Error(getError(3822));
     }
 
+    /**
+     * @private_cc
+     */
     public _onHierarchyChanged () { }
 
+    /**
+     * @private_cc
+     */
     public _onBatchCreated (dontSyncChildPrefab: boolean) {
         super._onBatchCreated(dontSyncChildPrefab);
         const len = this._children.length;

--- a/cocos/core/utils/js-typed.ts
+++ b/cocos/core/utils/js-typed.ts
@@ -470,7 +470,13 @@ function isTempClassId (id) {
 }
 
 // id registration
+/**
+ * @private_cc
+ */
 export const _idToClass: Record<string, Constructor> = createMap(true);
+/**
+ * @private_cc
+ */
 export const _nameToClass: Record<string, Constructor> = createMap(true);
 
 function setup (tag: string, table: object) {
@@ -506,7 +512,7 @@ js.unregisterClass to remove the id of unused class';
  * @method _setClassId
  * @param classId
  * @param constructor
- * @private
+ * @private_cc
  */
 export const _setClassId = setup('__cid__', _idToClass);
 
@@ -600,7 +606,7 @@ export function unregisterClass (...constructors: Function[]) {
  * Get the registered class by id
  * @param classId
  * @return constructor
- * @private
+ * @private_cc
  */
 export function _getClassById (classId) {
     return _idToClass[classId];
@@ -620,7 +626,7 @@ export function getClassByName (classname) {
  * @param obj - instance or constructor
  * @param [allowTempId = true]   - can return temp id in editor
  * @return
- * @private
+ * @private_cc
  */
 export function _getClassId (obj, allowTempId?: boolean) {
     allowTempId = (typeof allowTempId !== 'undefined' ? allowTempId : true);

--- a/cocos/core/utils/js-typed.ts
+++ b/cocos/core/utils/js-typed.ts
@@ -471,11 +471,11 @@ function isTempClassId (id) {
 
 // id registration
 /**
- * @deprecated_to_user
+ * @marked_as_engine_private
  */
 export const _idToClass: Record<string, Constructor> = createMap(true);
 /**
- * @deprecated_to_user
+ * @marked_as_engine_private
  */
 export const _nameToClass: Record<string, Constructor> = createMap(true);
 
@@ -512,7 +512,7 @@ js.unregisterClass to remove the id of unused class';
  * @method _setClassId
  * @param classId
  * @param constructor
- * @deprecated_to_user
+ * @marked_as_engine_private
  */
 export const _setClassId = setup('__cid__', _idToClass);
 
@@ -606,7 +606,7 @@ export function unregisterClass (...constructors: Function[]) {
  * Get the registered class by id
  * @param classId
  * @return constructor
- * @deprecated_to_user
+ * @marked_as_engine_private
  */
 export function _getClassById (classId) {
     return _idToClass[classId];
@@ -626,7 +626,7 @@ export function getClassByName (classname) {
  * @param obj - instance or constructor
  * @param [allowTempId = true]   - can return temp id in editor
  * @return
- * @deprecated_to_user
+ * @marked_as_engine_private
  */
 export function _getClassId (obj, allowTempId?: boolean) {
     allowTempId = (typeof allowTempId !== 'undefined' ? allowTempId : true);

--- a/cocos/core/utils/js-typed.ts
+++ b/cocos/core/utils/js-typed.ts
@@ -471,11 +471,11 @@ function isTempClassId (id) {
 
 // id registration
 /**
- * @private_cc
+ * @deprecated_to_user
  */
 export const _idToClass: Record<string, Constructor> = createMap(true);
 /**
- * @private_cc
+ * @deprecated_to_user
  */
 export const _nameToClass: Record<string, Constructor> = createMap(true);
 
@@ -512,7 +512,7 @@ js.unregisterClass to remove the id of unused class';
  * @method _setClassId
  * @param classId
  * @param constructor
- * @private_cc
+ * @deprecated_to_user
  */
 export const _setClassId = setup('__cid__', _idToClass);
 
@@ -606,7 +606,7 @@ export function unregisterClass (...constructors: Function[]) {
  * Get the registered class by id
  * @param classId
  * @return constructor
- * @private_cc
+ * @deprecated_to_user
  */
 export function _getClassById (classId) {
     return _idToClass[classId];
@@ -626,7 +626,7 @@ export function getClassByName (classname) {
  * @param obj - instance or constructor
  * @param [allowTempId = true]   - can return temp id in editor
  * @return
- * @private_cc
+ * @deprecated_to_user
  */
 export function _getClassId (obj, allowTempId?: boolean) {
     allowTempId = (typeof allowTempId !== 'undefined' ? allowTempId : true);

--- a/cocos/core/utils/js.ts
+++ b/cocos/core/utils/js.ts
@@ -93,7 +93,7 @@ export const js = {
     /**
      * @en All classes registered in the engine, indexed by name.
      * @zh 引擎中已注册的所有类型，通过名称进行索引。
-     * @private_cc
+     * @deprecated_to_user
      * @example
      * ```
      * import { js } from 'cc';
@@ -107,7 +107,7 @@ export const js = {
      * js._registeredClassNames = builtinClassNames;
      * ```
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     get _registeredClassNames (): typeof _nameToClass {
         return { ..._nameToClass };
@@ -132,7 +132,7 @@ export const js = {
      * js._registeredClassNames = builtinClassNames;
      * ```
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     get _registeredClassIds (): typeof _idToClass {
         return { ..._idToClass };
@@ -142,15 +142,15 @@ export const js = {
         Object.assign(_idToClass, value);
     },
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     _getClassId,
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     _setClassId,
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     _getClassById,
     obsolete,

--- a/cocos/core/utils/js.ts
+++ b/cocos/core/utils/js.ts
@@ -106,6 +106,8 @@ export const js = {
      * js._registeredClassIds = builtinClassIds;
      * js._registeredClassNames = builtinClassNames;
      * ```
+     *
+     * @private_cc
      */
     get _registeredClassNames (): typeof _nameToClass {
         return { ..._nameToClass };
@@ -130,6 +132,8 @@ export const js = {
      * js._registeredClassIds = builtinClassIds;
      * js._registeredClassNames = builtinClassNames;
      * ```
+     *
+     * @private_cc
      */
     get _registeredClassIds (): typeof _idToClass {
         return { ..._idToClass };

--- a/cocos/core/utils/js.ts
+++ b/cocos/core/utils/js.ts
@@ -93,7 +93,7 @@ export const js = {
     /**
      * @en All classes registered in the engine, indexed by name.
      * @zh 引擎中已注册的所有类型，通过名称进行索引。
-     * @deprecated_to_user
+     * @marked_as_engine_private
      * @example
      * ```
      * import { js } from 'cc';
@@ -107,7 +107,7 @@ export const js = {
      * js._registeredClassNames = builtinClassNames;
      * ```
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _registeredClassNames (): typeof _nameToClass {
         return { ..._nameToClass };
@@ -132,7 +132,7 @@ export const js = {
      * js._registeredClassNames = builtinClassNames;
      * ```
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _registeredClassIds (): typeof _idToClass {
         return { ..._idToClass };
@@ -142,15 +142,15 @@ export const js = {
         Object.assign(_idToClass, value);
     },
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     _getClassId,
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     _setClassId,
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     _getClassById,
     obsolete,

--- a/cocos/core/utils/js.ts
+++ b/cocos/core/utils/js.ts
@@ -93,7 +93,7 @@ export const js = {
     /**
      * @en All classes registered in the engine, indexed by name.
      * @zh 引擎中已注册的所有类型，通过名称进行索引。
-     * @private
+     * @private_cc
      * @example
      * ```
      * import { js } from 'cc';
@@ -119,7 +119,6 @@ export const js = {
     /**
      * @en All classes registered in the engine, indexed by ID.
      * @zh 引擎中已注册的所有类型，通过 ID 进行索引。
-     * @private
      * @example
      * ```
      * import { js } from 'cc';
@@ -142,8 +141,17 @@ export const js = {
         clear(_idToClass);
         Object.assign(_idToClass, value);
     },
+    /**
+     * @private_cc
+     */
     _getClassId,
+    /**
+     * @private_cc
+     */
     _setClassId,
+    /**
+     * @private_cc
+     */
     _getClassById,
     obsolete,
     obsoletes,

--- a/cocos/core/utils/pool.ts
+++ b/cocos/core/utils/pool.ts
@@ -139,7 +139,7 @@ export default class Pool<T> {
      * @zh
      * 获取对象池中的对象，如果对象池没有可用对象，则返回空。
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     public _get () {
         if (this.count > 0) {

--- a/cocos/core/utils/pool.ts
+++ b/cocos/core/utils/pool.ts
@@ -138,6 +138,8 @@ export default class Pool<T> {
      * Get an object from pool, if no available object in the pool, null will be returned.
      * @zh
      * 获取对象池中的对象，如果对象池没有可用对象，则返回空。
+     *
+     * @private_cc
      */
     public _get () {
         if (this.count > 0) {

--- a/cocos/core/utils/pool.ts
+++ b/cocos/core/utils/pool.ts
@@ -139,7 +139,7 @@ export default class Pool<T> {
      * @zh
      * 获取对象池中的对象，如果对象池没有可用对象，则返回空。
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _get () {
         if (this.count > 0) {

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -437,7 +437,7 @@ export class ArmatureDisplay extends Renderable2D {
     /* protected */ _debugDraw: Graphics | null = null;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _enableBatch = false;
@@ -561,7 +561,7 @@ export class ArmatureDisplay extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -436,6 +436,9 @@ export class ArmatureDisplay extends Renderable2D {
     protected _debugBones = false;
     /* protected */ _debugDraw: Graphics | null = null;
 
+    /**
+     * @private_cc
+     */
     @serializable
     public _enableBatch = false;
 
@@ -557,6 +560,9 @@ export class ArmatureDisplay extends Renderable2D {
         return inst;
     }
 
+    /**
+     * @private_cc
+     */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {
         if (this._meshRenderDataArray) {

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -223,9 +223,6 @@ export class ArmatureDisplay extends Renderable2D {
         this._animationName = value;
     }
 
-    /**
-     * @deprecated_to_user
-     */
     @displayName('Armature')
     @editable
     @type(DefaultArmaturesEnum)
@@ -258,9 +255,6 @@ export class ArmatureDisplay extends Renderable2D {
         this.markForUpdateRenderData();
     }
 
-    /**
-     * @deprecated_to_user
-     */
     @editable
     @type(DefaultAnimsEnum)
     @displayName('Animation')
@@ -294,9 +288,6 @@ export class ArmatureDisplay extends Renderable2D {
         }
     }
 
-    /**
-     * @deprecated_to_user
-     */
     @editable
     @displayName('Animation Cache Mode')
     @tooltip('i18n:COMPONENT.dragon_bones.animation_cache_mode')

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -224,7 +224,7 @@ export class ArmatureDisplay extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @displayName('Armature')
     @editable
@@ -259,7 +259,7 @@ export class ArmatureDisplay extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @editable
     @type(DefaultAnimsEnum)
@@ -295,7 +295,7 @@ export class ArmatureDisplay extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @editable
     @displayName('Animation Cache Mode')
@@ -446,7 +446,7 @@ export class ArmatureDisplay extends Renderable2D {
     /* protected */ _debugDraw: Graphics | null = null;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _enableBatch = false;
@@ -570,7 +570,7 @@ export class ArmatureDisplay extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -223,6 +223,9 @@ export class ArmatureDisplay extends Renderable2D {
         this._animationName = value;
     }
 
+    /**
+     * @private_cc
+     */
     @displayName('Armature')
     @editable
     @type(DefaultArmaturesEnum)
@@ -255,6 +258,9 @@ export class ArmatureDisplay extends Renderable2D {
         this.markForUpdateRenderData();
     }
 
+    /**
+     * @private_cc
+     */
     @editable
     @type(DefaultAnimsEnum)
     @displayName('Animation')
@@ -288,6 +294,9 @@ export class ArmatureDisplay extends Renderable2D {
         }
     }
 
+    /**
+     * @private_cc
+     */
     @editable
     @displayName('Animation Cache Mode')
     @tooltip('i18n:COMPONENT.dragon_bones.animation_cache_mode')

--- a/cocos/dragon-bones/CCSlot.ts
+++ b/cocos/dragon-bones/CCSlot.ts
@@ -17,28 +17,28 @@ export class CCSlot extends Slot {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     _localVertices: number[];
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     _indices: number[];
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     _matrix: Mat4;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _worldMatrix: Mat4;
     protected _worldMatrixDirty: boolean;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     _color: Color;
 

--- a/cocos/dragon-bones/CCSlot.ts
+++ b/cocos/dragon-bones/CCSlot.ts
@@ -17,28 +17,28 @@ export class CCSlot extends Slot {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     _localVertices: number[];
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     _indices: number[];
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     _matrix: Mat4;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _worldMatrix: Mat4;
     protected _worldMatrixDirty: boolean;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     _color: Color;
 

--- a/cocos/dragon-bones/CCSlot.ts
+++ b/cocos/dragon-bones/CCSlot.ts
@@ -16,12 +16,31 @@ export class CCSlot extends Slot {
         return '[class dragonBones.CCSlot]';
     }
 
-    /* protected */ _localVertices: number[];
-    /* protected */ _indices: number[];
-    /* protected */ _matrix: Mat4;
+    /**
+     * @private_cc
+     */
+    _localVertices: number[];
+
+    /**
+     * @private_cc
+     */
+    _indices: number[];
+
+    /**
+     * @private_cc
+     */
+    _matrix: Mat4;
+
+    /**
+     * @private_cc
+     */
     public _worldMatrix: Mat4;
     protected _worldMatrixDirty: boolean;
-    /* protected */ _color: Color;
+
+    /**
+     * @private_cc
+     */
+    _color: Color;
 
     constructor () {
         super();

--- a/cocos/particle-2d/motion-streak-2d.ts
+++ b/cocos/particle-2d/motion-streak-2d.ts
@@ -229,6 +229,9 @@ export class MotionStreak extends Renderable2D {
         if (this._assembler) this._assembler.update(this, dt);
     }
 
+    /**
+     * @private_cc
+     */
     public _render (render: IBatcher) {
         render.commitComp(this, this._texture, this._assembler, null);
     }

--- a/cocos/particle-2d/motion-streak-2d.ts
+++ b/cocos/particle-2d/motion-streak-2d.ts
@@ -230,7 +230,7 @@ export class MotionStreak extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _render (render: IBatcher) {
         render.commitComp(this, this._texture, this._assembler, null);

--- a/cocos/particle-2d/motion-streak-2d.ts
+++ b/cocos/particle-2d/motion-streak-2d.ts
@@ -230,7 +230,7 @@ export class MotionStreak extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _render (render: IBatcher) {
         render.commitComp(this, this._texture, this._assembler, null);

--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -695,11 +695,11 @@ export class ParticleSystem2D extends Renderable2D {
     public aspectRatio = 1;
     /**
      * The temporary SpriteFrame object used for the renderer. Because there is no corresponding asset, it can't be serialized.
-     * @private_cc
+     * @deprecated_to_user
      */
     public declare _renderSpriteFrame: SpriteFrame | null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public declare _simulator: Simulator;
 
@@ -904,7 +904,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _applyFile () {
         const file = this._file;
@@ -936,7 +936,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _initTextureWithDictionary (dict: any) {
         if (dict.spriteFrameUuid) {
@@ -1020,7 +1020,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _initWithDictionary (dict: any) {
         this.totalParticles = parseInt(dict.maxParticles || 0);
@@ -1135,7 +1135,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _syncAspect () {
         if (this._renderSpriteFrame) {
@@ -1145,7 +1145,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _applySpriteFrame () {
         this._renderSpriteFrame = this._renderSpriteFrame || this._spriteFrame;
@@ -1163,14 +1163,14 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _getTexture () {
         return (this._renderSpriteFrame && this._renderSpriteFrame.texture);
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateMaterial () {
         const mat = this.getMaterialInstance(0);
@@ -1178,7 +1178,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _finishedSimulation () {
         if (EDITOR) {

--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -693,8 +693,14 @@ export class ParticleSystem2D extends Renderable2D {
         return this._assembler;
     }
     public aspectRatio = 1;
-    // The temporary SpriteFrame object used for the renderer. Because there is no corresponding asset, it can't be serialized.
+    /**
+     * The temporary SpriteFrame object used for the renderer. Because there is no corresponding asset, it can't be serialized.
+     * @private_cc
+     */
     public declare _renderSpriteFrame: SpriteFrame | null;
+    /**
+     * @private_cc
+     */
     public declare _simulator: Simulator;
 
     /**

--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -695,11 +695,11 @@ export class ParticleSystem2D extends Renderable2D {
     public aspectRatio = 1;
     /**
      * The temporary SpriteFrame object used for the renderer. Because there is no corresponding asset, it can't be serialized.
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public declare _renderSpriteFrame: SpriteFrame | null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public declare _simulator: Simulator;
 
@@ -904,7 +904,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _applyFile () {
         const file = this._file;
@@ -936,7 +936,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _initTextureWithDictionary (dict: any) {
         if (dict.spriteFrameUuid) {
@@ -1020,7 +1020,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _initWithDictionary (dict: any) {
         this.totalParticles = parseInt(dict.maxParticles || 0);
@@ -1135,7 +1135,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _syncAspect () {
         if (this._renderSpriteFrame) {
@@ -1145,7 +1145,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _applySpriteFrame () {
         this._renderSpriteFrame = this._renderSpriteFrame || this._spriteFrame;
@@ -1163,14 +1163,14 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _getTexture () {
         return (this._renderSpriteFrame && this._renderSpriteFrame.texture);
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateMaterial () {
         const mat = this.getMaterialInstance(0);
@@ -1178,7 +1178,7 @@ export class ParticleSystem2D extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _finishedSimulation () {
         if (EDITOR) {

--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -897,7 +897,9 @@ export class ParticleSystem2D extends Renderable2D {
         return (this.particleCount >= this.totalParticles);
     }
 
-    // PRIVATE METHODS
+    /**
+     * @private_cc
+     */
     public _applyFile () {
         const file = this._file;
         if (file) {
@@ -927,6 +929,9 @@ export class ParticleSystem2D extends Renderable2D {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _initTextureWithDictionary (dict: any) {
         if (dict.spriteFrameUuid) {
             const spriteFrameUuid = dict.spriteFrameUuid;
@@ -1008,7 +1013,9 @@ export class ParticleSystem2D extends Renderable2D {
         return true;
     }
 
-    // parsing process
+    /**
+     * @private_cc
+     */
     public _initWithDictionary (dict: any) {
         this.totalParticles = parseInt(dict.maxParticles || 0);
 
@@ -1121,6 +1128,9 @@ export class ParticleSystem2D extends Renderable2D {
         return true;
     }
 
+    /**
+     * @private_cc
+     */
     public _syncAspect () {
         if (this._renderSpriteFrame) {
             const frameRect = this._renderSpriteFrame.rect;
@@ -1128,6 +1138,9 @@ export class ParticleSystem2D extends Renderable2D {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _applySpriteFrame () {
         this._renderSpriteFrame = this._renderSpriteFrame || this._spriteFrame;
         if (this._renderSpriteFrame) {
@@ -1143,15 +1156,24 @@ export class ParticleSystem2D extends Renderable2D {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _getTexture () {
         return (this._renderSpriteFrame && this._renderSpriteFrame.texture);
     }
 
+    /**
+     * @private_cc
+     */
     public _updateMaterial () {
         const mat = this.getMaterialInstance(0);
         if (mat) mat.recompileShaders({ USE_LOCAL: this._positionType !== PositionType.FREE });
     }
 
+    /**
+     * @private_cc
+     */
     public _finishedSimulation () {
         if (EDITOR) {
             if (this._preview && this._focused && !this.active /* && !cc.engine.isPlaying */) {

--- a/cocos/particle/animator/curve-range.ts
+++ b/cocos/particle/animator/curve-range.ts
@@ -178,7 +178,7 @@ export default class CurveRange  {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onBeforeSerialize (props) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/cocos/particle/animator/curve-range.ts
+++ b/cocos/particle/animator/curve-range.ts
@@ -178,7 +178,7 @@ export default class CurveRange  {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onBeforeSerialize (props) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/cocos/particle/animator/curve-range.ts
+++ b/cocos/particle/animator/curve-range.ts
@@ -177,6 +177,9 @@ export default class CurveRange  {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _onBeforeSerialize (props) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return SerializableTable[this.mode];

--- a/cocos/particle/animator/gradient-range.ts
+++ b/cocos/particle/animator/gradient-range.ts
@@ -142,7 +142,7 @@ export default class GradientRange {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onBeforeSerialize (props: any): any {
         return SerializableTable[this._mode];

--- a/cocos/particle/animator/gradient-range.ts
+++ b/cocos/particle/animator/gradient-range.ts
@@ -141,6 +141,9 @@ export default class GradientRange {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _onBeforeSerialize (props: any): any {
         return SerializableTable[this._mode];
     }

--- a/cocos/particle/animator/gradient-range.ts
+++ b/cocos/particle/animator/gradient-range.ts
@@ -142,7 +142,7 @@ export default class GradientRange {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onBeforeSerialize (props: any): any {
         return SerializableTable[this._mode];

--- a/cocos/particle/emitter/shape-module.ts
+++ b/cocos/particle/emitter/shape-module.ts
@@ -126,7 +126,7 @@ export default class ShapeModule {
     /**
      * @zh 粒子发射器类型 [[ShapeType]]。
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @type(ShapeType)
     @formerlySerializedAs('shapeType')

--- a/cocos/particle/emitter/shape-module.ts
+++ b/cocos/particle/emitter/shape-module.ts
@@ -126,7 +126,7 @@ export default class ShapeModule {
     /**
      * @zh 粒子发射器类型 [[ShapeType]]。
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     @type(ShapeType)
     @formerlySerializedAs('shapeType')

--- a/cocos/particle/emitter/shape-module.ts
+++ b/cocos/particle/emitter/shape-module.ts
@@ -125,6 +125,8 @@ export default class ShapeModule {
 
     /**
      * @zh 粒子发射器类型 [[ShapeType]]。
+     *
+     * @private_cc
      */
     @type(ShapeType)
     @formerlySerializedAs('shapeType')

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -776,7 +776,7 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onMaterialModified (index: number, material: Material) {
         if (this.processor !== null) {
@@ -785,14 +785,14 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onRebuildPSO (index: number, material: Material) {
         this.processor.onRebuildPSO(index, material);
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _collectModels (): scene.Model[] {
         this._models.length = 0;
@@ -1345,7 +1345,7 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onBeforeSerialize (props) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -776,7 +776,7 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onMaterialModified (index: number, material: Material) {
         if (this.processor !== null) {
@@ -785,14 +785,14 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onRebuildPSO (index: number, material: Material) {
         this.processor.onRebuildPSO(index, material);
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _collectModels (): scene.Model[] {
         this._models.length = 0;
@@ -1345,7 +1345,7 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onBeforeSerialize (props) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -775,16 +775,25 @@ export class ParticleSystem extends RenderableComponent {
         // this._system.add(this);
     }
 
+    /**
+     * @private_cc
+     */
     public _onMaterialModified (index: number, material: Material) {
         if (this.processor !== null) {
             this.processor.onMaterialModified(index, material);
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _onRebuildPSO (index: number, material: Material) {
         this.processor.onRebuildPSO(index, material);
     }
 
+    /**
+     * @private_cc
+     */
     public _collectModels (): scene.Model[] {
         this._models.length = 0;
         this._models.push((this.processor as any)._model);
@@ -1335,6 +1344,9 @@ export class ParticleSystem extends RenderableComponent {
         return this._time;
     }
 
+    /**
+     * @private_cc
+     */
     public _onBeforeSerialize (props) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this.dataCulling ? props.filter((p) => !PARTICLE_MODULE_PROPERTY.includes(p) || (this[p] && this[p].enable)) : props;

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -199,6 +199,9 @@ export default class TrailModule {
         else this.onDisable();
     }
 
+    /**
+     * @private_cc
+     */
     @serializable
     public _enable = false;
 
@@ -221,6 +224,9 @@ export default class TrailModule {
     @tooltip('i18n:trailSegment.lifeTime')
     public lifeTime = new CurveRange();
 
+    /**
+     * @private_cc
+     */
     @serializable
     public _minParticleDistance = 0.1;
 
@@ -373,6 +379,9 @@ export default class TrailModule {
         this._detachFromScene();
     }
 
+    /**
+     * @private_cc
+     */
     public _attachToScene () {
         if (this._trailModel) {
             if (this._trailModel.scene) {
@@ -382,6 +391,9 @@ export default class TrailModule {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _detachFromScene () {
         if (this._trailModel && this._trailModel.scene) {
             this._trailModel.scene.removeModel(this._trailModel);

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -200,7 +200,7 @@ export default class TrailModule {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _enable = false;
@@ -225,7 +225,7 @@ export default class TrailModule {
     public lifeTime = new CurveRange();
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _minParticleDistance = 0.1;
@@ -380,7 +380,7 @@ export default class TrailModule {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _attachToScene () {
         if (this._trailModel) {
@@ -392,7 +392,7 @@ export default class TrailModule {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _detachFromScene () {
         if (this._trailModel && this._trailModel.scene) {

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -200,7 +200,7 @@ export default class TrailModule {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _enable = false;
@@ -225,7 +225,7 @@ export default class TrailModule {
     public lifeTime = new CurveRange();
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _minParticleDistance = 0.1;
@@ -380,7 +380,7 @@ export default class TrailModule {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _attachToScene () {
         if (this._trailModel) {
@@ -392,7 +392,7 @@ export default class TrailModule {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _detachFromScene () {
         if (this._trailModel && this._trailModel.scene) {

--- a/cocos/physics/framework/physics-ray-result.ts
+++ b/cocos/physics/framework/physics-ray-result.ts
@@ -90,7 +90,7 @@ export class PhysicsRayResult {
      * @zh
      * 设置射线，此方法由引擎内部使用，请勿在外部脚本调用。
      *
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _assign (hitPoint: IVec3Like, distance: number, collider: Collider, hitNormal: IVec3Like) {
         Vec3.copy(this._hitPoint, hitPoint);

--- a/cocos/physics/framework/physics-ray-result.ts
+++ b/cocos/physics/framework/physics-ray-result.ts
@@ -90,7 +90,7 @@ export class PhysicsRayResult {
      * @zh
      * 设置射线，此方法由引擎内部使用，请勿在外部脚本调用。
      *
-     * @private_cc
+     * @deprecated_to_user
      */
     public _assign (hitPoint: IVec3Like, distance: number, collider: Collider, hitNormal: IVec3Like) {
         Vec3.copy(this._hitPoint, hitPoint);

--- a/cocos/physics/framework/physics-ray-result.ts
+++ b/cocos/physics/framework/physics-ray-result.ts
@@ -89,6 +89,8 @@ export class PhysicsRayResult {
      * internal methods.
      * @zh
      * 设置射线，此方法由引擎内部使用，请勿在外部脚本调用。
+     *
+     * @private_cc
      */
     public _assign (hitPoint: IVec3Like, distance: number, collider: Collider, hitNormal: IVec3Like) {
         Vec3.copy(this._hitPoint, hitPoint);

--- a/cocos/profiler/profiler.ts
+++ b/cocos/profiler/profiler.ts
@@ -93,7 +93,7 @@ const _constants = {
 
 export class Profiler {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _stats: IProfilerState | null = null;
     public id = '__Profiler__';

--- a/cocos/profiler/profiler.ts
+++ b/cocos/profiler/profiler.ts
@@ -93,7 +93,7 @@ const _constants = {
 
 export class Profiler {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _stats: IProfilerState | null = null;
     public id = '__Profiler__';

--- a/cocos/profiler/profiler.ts
+++ b/cocos/profiler/profiler.ts
@@ -92,6 +92,9 @@ const _constants = {
 };
 
 export class Profiler {
+    /**
+     * @private_cc
+     */
     public _stats: IProfilerState | null = null;
     public id = '__Profiler__';
 

--- a/cocos/spine/skeleton-cache.ts
+++ b/cocos/spine/skeleton-cache.ts
@@ -98,7 +98,7 @@ export class AnimationCache {
     public isCompleted = false;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _privateMode = false;
     protected _inited = false;

--- a/cocos/spine/skeleton-cache.ts
+++ b/cocos/spine/skeleton-cache.ts
@@ -97,6 +97,9 @@ export class AnimationCache {
     public totalTime = 0;
     public isCompleted = false;
 
+    /**
+     * @private_cc
+     */
     public _privateMode = false;
     protected _inited = false;
     protected _invalid = true;

--- a/cocos/spine/skeleton-cache.ts
+++ b/cocos/spine/skeleton-cache.ts
@@ -98,7 +98,7 @@ export class AnimationCache {
     public isCompleted = false;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _privateMode = false;
     protected _inited = false;

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -21,7 +21,7 @@ import { legacyCC } from '../core/global-exports';
 @ccclass('sp.SkeletonData')
 export class SkeletonData extends Asset {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @serializable
     public _skeletonJson: spine.SkeletonJson | null = null;
@@ -98,7 +98,7 @@ export class SkeletonData extends Asset {
     public scale = 1;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     get _nativeAsset (): ArrayBuffer {
         return this._buffer!;

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -20,6 +20,9 @@ import { legacyCC } from '../core/global-exports';
  */
 @ccclass('sp.SkeletonData')
 export class SkeletonData extends Asset {
+    /**
+     * @private_cc
+     */
     @serializable
     public _skeletonJson: spine.SkeletonJson | null = null;
 

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -97,6 +97,9 @@ export class SkeletonData extends Asset {
     @serializable
     public scale = 1;
 
+    /**
+     * @private_cc
+     */
     get _nativeAsset (): ArrayBuffer {
         return this._buffer!;
     }

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -21,7 +21,7 @@ import { legacyCC } from '../core/global-exports';
 @ccclass('sp.SkeletonData')
 export class SkeletonData extends Asset {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     @serializable
     public _skeletonJson: spine.SkeletonJson | null = null;
@@ -98,7 +98,7 @@ export class SkeletonData extends Asset {
     public scale = 1;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _nativeAsset (): ArrayBuffer {
         return this._buffer!;

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -466,19 +466,47 @@ export class Skeleton extends Renderable2D {
     // private _enableBatch: boolean = true;
 
     public enableBatch = false;
-    // Frame cache
+    /**
+     * @private_cc
+     */
     public _frameCache: AnimationCache | null = null;
-    // Cur frame
+    /**
+     * @private_cc
+     */
     public _curFrame: AnimationFrame | null = null;
 
     // protected _materialCache = {};
+    /**
+     * @private_cc
+     */
     public _effectDelegate: VertexEffectDelegate | null | undefined = null;
+    /**
+     * @private_cc
+     */
     public _skeleton: spine.Skeleton | null;
+    /**
+     * @private_cc
+     */
     public _clipper?: spine.SkeletonClipping;
+    /**
+     * @private_cc
+     */
     public _debugRenderer: Graphics | null;
+    /**
+     * @private_cc
+     */
     public _startSlotIndex;
+    /**
+     * @private_cc
+     */
     public _endSlotIndex;
+    /**
+     * @private_cc
+     */
     public _startEntry;
+    /**
+     * @private_cc
+     */
     public _endEntry;
     public attachUtil: AttachUtil;
 
@@ -1360,6 +1388,9 @@ export class Skeleton extends Renderable2D {
         return [];
     }
 
+    /**
+     * @private_cc
+     */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {
         if (this._meshRenderDataArray) {

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -217,7 +217,7 @@ export class Skeleton extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @displayName('Default Skin')
     @type(DefaultSkinsEnum)
@@ -268,7 +268,7 @@ export class Skeleton extends Renderable2D {
     // value of 0 represents no animation
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     @displayName('Animation')
     @type(DefaultAnimsEnum)
@@ -473,45 +473,45 @@ export class Skeleton extends Renderable2D {
 
     public enableBatch = false;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _frameCache: AnimationCache | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _curFrame: AnimationFrame | null = null;
 
     // protected _materialCache = {};
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _effectDelegate: VertexEffectDelegate | null | undefined = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _skeleton: spine.Skeleton | null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _clipper?: spine.SkeletonClipping;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _debugRenderer: Graphics | null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _startSlotIndex;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _endSlotIndex;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _startEntry;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _endEntry;
     public attachUtil: AttachUtil;
@@ -1395,7 +1395,7 @@ export class Skeleton extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -467,45 +467,45 @@ export class Skeleton extends Renderable2D {
 
     public enableBatch = false;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _frameCache: AnimationCache | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _curFrame: AnimationFrame | null = null;
 
     // protected _materialCache = {};
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _effectDelegate: VertexEffectDelegate | null | undefined = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _skeleton: spine.Skeleton | null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _clipper?: spine.SkeletonClipping;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _debugRenderer: Graphics | null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _startSlotIndex;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _endSlotIndex;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _startEntry;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _endEntry;
     public attachUtil: AttachUtil;
@@ -1389,7 +1389,7 @@ export class Skeleton extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -216,6 +216,9 @@ export class Skeleton extends Renderable2D {
         }
     }
 
+    /**
+     * @private_cc
+     */
     @displayName('Default Skin')
     @type(DefaultSkinsEnum)
     @tooltip('i18n:COMPONENT.skeleton.default_skin')
@@ -264,6 +267,9 @@ export class Skeleton extends Renderable2D {
 
     // value of 0 represents no animation
 
+    /**
+     * @private_cc
+     */
     @displayName('Animation')
     @type(DefaultAnimsEnum)
     @tooltip('i18n:COMPONENT.skeleton.animation')

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -216,9 +216,6 @@ export class Skeleton extends Renderable2D {
         }
     }
 
-    /**
-     * @deprecated_to_user
-     */
     @displayName('Default Skin')
     @type(DefaultSkinsEnum)
     @tooltip('i18n:COMPONENT.skeleton.default_skin')
@@ -267,9 +264,6 @@ export class Skeleton extends Renderable2D {
 
     // value of 0 represents no animation
 
-    /**
-     * @deprecated_to_user
-     */
     @displayName('Animation')
     @type(DefaultAnimsEnum)
     @tooltip('i18n:COMPONENT.skeleton.animation')

--- a/cocos/terrain/terrain-asset.ts
+++ b/cocos/terrain/terrain-asset.ts
@@ -250,10 +250,12 @@ export class TerrainAsset extends Asset {
         super();
     }
 
+    /**
+     * @private_cc
+     */
     get _nativeAsset (): ArrayBuffer {
         return this._data!.buffer;
     }
-
     set _nativeAsset (value: ArrayBuffer) {
         if (this._data && this._data.byteLength === value.byteLength) {
             this._data.set(new Uint8Array(value));

--- a/cocos/terrain/terrain-asset.ts
+++ b/cocos/terrain/terrain-asset.ts
@@ -251,7 +251,7 @@ export class TerrainAsset extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _nativeAsset (): ArrayBuffer {
         return this._data!.buffer;
@@ -408,14 +408,14 @@ export class TerrainAsset extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _setNativeData (_nativeData: Uint8Array) {
         this._data = _nativeData;
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _loadNativeData (_nativeData: Uint8Array) {
         if (!_nativeData || _nativeData.length === 0) {
@@ -489,7 +489,7 @@ export class TerrainAsset extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _exportNativeData (): Uint8Array {
         const stream = new TerrainBuffer();
@@ -551,7 +551,7 @@ export class TerrainAsset extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _exportDefaultNativeData (): Uint8Array {
         const stream = new TerrainBuffer();

--- a/cocos/terrain/terrain-asset.ts
+++ b/cocos/terrain/terrain-asset.ts
@@ -251,7 +251,7 @@ export class TerrainAsset extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     get _nativeAsset (): ArrayBuffer {
         return this._data!.buffer;
@@ -408,14 +408,14 @@ export class TerrainAsset extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _setNativeData (_nativeData: Uint8Array) {
         this._data = _nativeData;
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _loadNativeData (_nativeData: Uint8Array) {
         if (!_nativeData || _nativeData.length === 0) {
@@ -489,7 +489,7 @@ export class TerrainAsset extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _exportNativeData (): Uint8Array {
         const stream = new TerrainBuffer();
@@ -551,7 +551,7 @@ export class TerrainAsset extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _exportDefaultNativeData (): Uint8Array {
         const stream = new TerrainBuffer();

--- a/cocos/terrain/terrain-asset.ts
+++ b/cocos/terrain/terrain-asset.ts
@@ -405,10 +405,16 @@ export class TerrainAsset extends Asset {
         return this._blockCount[1] * TERRAIN_BLOCK_TILE_COMPLEXITY + 1;
     }
 
+    /**
+     * @private_cc
+     */
     public _setNativeData (_nativeData: Uint8Array) {
         this._data = _nativeData;
     }
 
+    /**
+     * @private_cc
+     */
     public _loadNativeData (_nativeData: Uint8Array) {
         if (!_nativeData || _nativeData.length === 0) {
             return false;
@@ -480,6 +486,9 @@ export class TerrainAsset extends Asset {
         return true;
     }
 
+    /**
+     * @private_cc
+     */
     public _exportNativeData (): Uint8Array {
         const stream = new TerrainBuffer();
 
@@ -539,6 +548,9 @@ export class TerrainAsset extends Asset {
         return stream.buffer;
     }
 
+    /**
+     * @private_cc
+     */
     public _exportDefaultNativeData (): Uint8Array {
         const stream = new TerrainBuffer();
         stream.writeInt32(TERRAIN_DATA_VERSION_DEFAULT);

--- a/cocos/terrain/terrain-lod.ts
+++ b/cocos/terrain/terrain-lod.ts
@@ -63,19 +63,19 @@ export class TerrainLod {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _bodyIndexPool: TerrainIndexPool[];
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _connecterIndexPool: TerrainIndexPool[];
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _indexMap: TerrainIndexData[] = [];
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _indexBuffer: Uint16Array = new Uint16Array();
 

--- a/cocos/terrain/terrain-lod.ts
+++ b/cocos/terrain/terrain-lod.ts
@@ -62,9 +62,21 @@ export class TerrainLod {
         return i * (TERRAIN_LOD_LEVELS * TERRAIN_LOD_LEVELS) + j * TERRAIN_LOD_LEVELS + k;
     }
 
+    /**
+     * @private_cc
+     */
     public _bodyIndexPool: TerrainIndexPool[];
+    /**
+     * @private_cc
+     */
     public _connecterIndexPool: TerrainIndexPool[];
+    /**
+     * @private_cc
+     */
     public _indexMap: TerrainIndexData[] = [];
+    /**
+     * @private_cc
+     */
     public _indexBuffer: Uint16Array = new Uint16Array();
 
     constructor () {

--- a/cocos/terrain/terrain-lod.ts
+++ b/cocos/terrain/terrain-lod.ts
@@ -63,19 +63,19 @@ export class TerrainLod {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _bodyIndexPool: TerrainIndexPool[];
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _connecterIndexPool: TerrainIndexPool[];
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _indexMap: TerrainIndexData[] = [];
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _indexBuffer: Uint16Array = new Uint16Array();
 

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -179,12 +179,29 @@ export class TerrainLayer {
  * @zh 地形渲染组件
  */
 class TerrainRenderable extends RenderableComponent {
+    /**
+     * @private_cc
+     */
     public _model: scene.Model | null = null;
+    /**
+     * @private_cc
+     */
     public _meshData: RenderingSubMesh | null = null;
-
+    /**
+     * @private_cc
+     */
     public _brushPass: Pass | null = null;
+    /**
+     * @private_cc
+     */
     public _brushMaterial: Material | null = null;
+    /**
+     * @private_cc
+     */
     public _currentMaterial: Material | null = null;
+    /**
+     * @private_cc
+     */
     public _currentMaterialLayers = 0;
 
     public destroy () {
@@ -197,6 +214,9 @@ class TerrainRenderable extends RenderableComponent {
         return super.destroy();
     }
 
+    /**
+     * @private_cc
+     */
     public _destroyModel () {
         // this._invalidMaterial();
         if (this._model != null) {
@@ -205,6 +225,9 @@ class TerrainRenderable extends RenderableComponent {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _invalidMaterial () {
         if (this._currentMaterial == null) {
             return;
@@ -219,6 +242,9 @@ class TerrainRenderable extends RenderableComponent {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _updateMaterial (block: TerrainBlock, init: boolean) {
         if (this._meshData == null || this._model == null) {
             return;
@@ -259,6 +285,9 @@ class TerrainRenderable extends RenderableComponent {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _onMaterialModified (idx: number, mtl: Material|null) {
         if (this._model == null) {
             return;
@@ -875,11 +904,17 @@ export class TerrainBlock {
         this._weightMap.uploadData(weightData);
     }
 
+    /**
+     * @private_cc
+     */
     public _updateLightmap (info: TerrainBlockLightmapInfo) {
         this._lightmapInfo = info;
         this._invalidMaterial();
     }
 
+    /**
+     * @private_cc
+     */
     public _updateLod () {
         const key = new TerrainLodKey();
         key.level = this._lodLevel;
@@ -928,6 +963,9 @@ export class TerrainBlock {
         this._updateIndexBuffer();
     }
 
+    /**
+     * @private_cc
+     */
     public _resetLod () {
         const key = new TerrainLodKey();
         key.level = 0;
@@ -944,6 +982,9 @@ export class TerrainBlock {
         this._updateIndexBuffer();
     }
 
+    /**
+     * @private_cc
+     */
     public _updateIndexBuffer () {
         if (this._renderable._meshData === null) {
             return;
@@ -1734,6 +1775,9 @@ export class Terrain extends Component {
         return h;
     }
 
+    /**
+     * @private_cc
+     */
     public _setNormal (i: number, j: number, n: Vec3) {
         const index = j * this.vertexCount[0] + i;
 
@@ -2044,6 +2088,9 @@ export class Terrain extends Component {
         return position;
     }
 
+    /**
+     * @private_cc
+     */
     public _getSharedIndexBuffer () {
         if (this._sharedIndexBuffer == null) {
             // initialize shared index buffer
@@ -2060,10 +2107,16 @@ export class Terrain extends Component {
         return this._sharedIndexBuffer;
     }
 
+    /**
+     * @private_cc
+     */
     public _getIndexData (key: TerrainLodKey) {
         return this._lod.getIndexData(key);
     }
 
+    /**
+     * @private_cc
+     */
     public _resetLightmap (enble: boolean) {
         this._lightmapInfos.length = 0;
         if (enble) {
@@ -2073,6 +2126,9 @@ export class Terrain extends Component {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _updateLightmap (blockId: number, tex: Texture2D|null, uOff: number, vOff: number, uScale: number, vScale: number) {
         this._lightmapInfos[blockId].texture = tex;
         this._lightmapInfos[blockId].UOff = uOff;
@@ -2082,11 +2138,17 @@ export class Terrain extends Component {
         this._blocks[blockId]._updateLightmap(this._lightmapInfos[blockId]);
     }
 
+    /**
+     * @private_cc
+     */
     public _getLightmapInfo (i: number, j: number) {
         const index = j * this._blockCount[0] + i;
         return index < this._lightmapInfos.length ? this._lightmapInfos[index] : null;
     }
 
+    /**
+     * @private_cc
+     */
     public _calcNormal (x: number, z: number) {
         let flip = 1;
         const here = this.getPosition(x, z);
@@ -2119,6 +2181,9 @@ export class Terrain extends Component {
         return normal;
     }
 
+    /**
+     * @private_cc
+     */
     public _buildNormals () {
         let index = 0;
         for (let y = 0; y < this.vertexCount[1]; ++y) {

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -180,27 +180,27 @@ export class TerrainLayer {
  */
 class TerrainRenderable extends RenderableComponent {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _model: scene.Model | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _meshData: RenderingSubMesh | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _brushPass: Pass | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _brushMaterial: Material | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _currentMaterial: Material | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _currentMaterialLayers = 0;
 
@@ -215,7 +215,7 @@ class TerrainRenderable extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _destroyModel () {
         // this._invalidMaterial();
@@ -226,7 +226,7 @@ class TerrainRenderable extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _invalidMaterial () {
         if (this._currentMaterial == null) {
@@ -243,7 +243,7 @@ class TerrainRenderable extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateMaterial (block: TerrainBlock, init: boolean) {
         if (this._meshData == null || this._model == null) {
@@ -286,7 +286,7 @@ class TerrainRenderable extends RenderableComponent {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _onMaterialModified (idx: number, mtl: Material|null) {
         if (this._model == null) {
@@ -905,7 +905,7 @@ export class TerrainBlock {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateLightmap (info: TerrainBlockLightmapInfo) {
         this._lightmapInfo = info;
@@ -913,7 +913,7 @@ export class TerrainBlock {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateLod () {
         const key = new TerrainLodKey();
@@ -964,7 +964,7 @@ export class TerrainBlock {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _resetLod () {
         const key = new TerrainLodKey();
@@ -983,7 +983,7 @@ export class TerrainBlock {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateIndexBuffer () {
         if (this._renderable._meshData === null) {
@@ -1230,7 +1230,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public get _asset () {
         return this.__asset;
@@ -1779,7 +1779,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _setNormal (i: number, j: number, n: Vec3) {
         const index = j * this.vertexCount[0] + i;
@@ -2092,7 +2092,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _getSharedIndexBuffer () {
         if (this._sharedIndexBuffer == null) {
@@ -2111,14 +2111,14 @@ export class Terrain extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _getIndexData (key: TerrainLodKey) {
         return this._lod.getIndexData(key);
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _resetLightmap (enble: boolean) {
         this._lightmapInfos.length = 0;
@@ -2130,7 +2130,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateLightmap (blockId: number, tex: Texture2D|null, uOff: number, vOff: number, uScale: number, vScale: number) {
         this._lightmapInfos[blockId].texture = tex;
@@ -2142,7 +2142,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _getLightmapInfo (i: number, j: number) {
         const index = j * this._blockCount[0] + i;
@@ -2150,7 +2150,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _calcNormal (x: number, z: number) {
         let flip = 1;
@@ -2185,7 +2185,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _buildNormals () {
         let index = 0;

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -180,27 +180,27 @@ export class TerrainLayer {
  */
 class TerrainRenderable extends RenderableComponent {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _model: scene.Model | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _meshData: RenderingSubMesh | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _brushPass: Pass | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _brushMaterial: Material | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _currentMaterial: Material | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _currentMaterialLayers = 0;
 
@@ -215,7 +215,7 @@ class TerrainRenderable extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _destroyModel () {
         // this._invalidMaterial();
@@ -226,7 +226,7 @@ class TerrainRenderable extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _invalidMaterial () {
         if (this._currentMaterial == null) {
@@ -243,7 +243,7 @@ class TerrainRenderable extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateMaterial (block: TerrainBlock, init: boolean) {
         if (this._meshData == null || this._model == null) {
@@ -286,7 +286,7 @@ class TerrainRenderable extends RenderableComponent {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _onMaterialModified (idx: number, mtl: Material|null) {
         if (this._model == null) {
@@ -905,7 +905,7 @@ export class TerrainBlock {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateLightmap (info: TerrainBlockLightmapInfo) {
         this._lightmapInfo = info;
@@ -913,7 +913,7 @@ export class TerrainBlock {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateLod () {
         const key = new TerrainLodKey();
@@ -964,7 +964,7 @@ export class TerrainBlock {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _resetLod () {
         const key = new TerrainLodKey();
@@ -983,7 +983,7 @@ export class TerrainBlock {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateIndexBuffer () {
         if (this._renderable._meshData === null) {
@@ -1230,7 +1230,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public get _asset () {
         return this.__asset;
@@ -1779,7 +1779,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _setNormal (i: number, j: number, n: Vec3) {
         const index = j * this.vertexCount[0] + i;
@@ -2092,7 +2092,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _getSharedIndexBuffer () {
         if (this._sharedIndexBuffer == null) {
@@ -2111,14 +2111,14 @@ export class Terrain extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _getIndexData (key: TerrainLodKey) {
         return this._lod.getIndexData(key);
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _resetLightmap (enble: boolean) {
         this._lightmapInfos.length = 0;
@@ -2130,7 +2130,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateLightmap (blockId: number, tex: Texture2D|null, uOff: number, vOff: number, uScale: number, vScale: number) {
         this._lightmapInfos[blockId].texture = tex;
@@ -2142,7 +2142,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _getLightmapInfo (i: number, j: number) {
         const index = j * this._blockCount[0] + i;
@@ -2150,7 +2150,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _calcNormal (x: number, z: number) {
         let flip = 1;
@@ -2185,7 +2185,7 @@ export class Terrain extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _buildNormals () {
         let index = 0;

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -1229,6 +1229,9 @@ export class Terrain extends Component {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public get _asset () {
         return this.__asset;
     }

--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -1434,7 +1434,7 @@ export class TiledLayer extends Renderable2D {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {

--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -1434,7 +1434,7 @@ export class TiledLayer extends Renderable2D {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {

--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -1433,7 +1433,9 @@ export class TiledLayer extends Renderable2D {
         }
     }
 
-    // 当前的 _meshRenderDataArray 的索引, 以便 fillBuffers 选取 RenderData
+    /**
+     * @private_cc
+     */
     public _meshRenderDataArrayIdx = 0;
     protected _render (ui: IBatcher) {
         if (this._meshRenderDataArray) {

--- a/cocos/tiledmap/tiled-object-group.ts
+++ b/cocos/tiledmap/tiled-object-group.ts
@@ -161,7 +161,7 @@ export class TiledObjectGroup extends Component {
     protected _objects: TMXObject[] = [];
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _init (groupInfo: TMXObjectGroupInfo, mapInfo: TMXMapInfo, texGrids: TiledTextureGrids) {
         const FLIPPED_MASK = TileFlag.FLIPPED_MASK;

--- a/cocos/tiledmap/tiled-object-group.ts
+++ b/cocos/tiledmap/tiled-object-group.ts
@@ -160,6 +160,9 @@ export class TiledObjectGroup extends Component {
     }[];
     protected _objects: TMXObject[] = [];
 
+    /**
+     * @private_cc
+     */
     public _init (groupInfo: TMXObjectGroupInfo, mapInfo: TMXMapInfo, texGrids: TiledTextureGrids) {
         const FLIPPED_MASK = TileFlag.FLIPPED_MASK;
         const FLAG_HORIZONTAL = TileFlag.HORIZONTAL;

--- a/cocos/tiledmap/tiled-object-group.ts
+++ b/cocos/tiledmap/tiled-object-group.ts
@@ -161,7 +161,7 @@ export class TiledObjectGroup extends Component {
     protected _objects: TMXObject[] = [];
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _init (groupInfo: TMXObjectGroupInfo, mapInfo: TMXMapInfo, texGrids: TiledTextureGrids) {
         const FLIPPED_MASK = TileFlag.FLIPPED_MASK;

--- a/cocos/ui/editbox/edit-box-impl-base.ts
+++ b/cocos/ui/editbox/edit-box-impl-base.ts
@@ -35,11 +35,11 @@ import { EditBox } from './edit-box';
 
 export class EditBoxImplBase {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _editing = false;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _delegate: EditBox | null = null;
 

--- a/cocos/ui/editbox/edit-box-impl-base.ts
+++ b/cocos/ui/editbox/edit-box-impl-base.ts
@@ -35,11 +35,11 @@ import { EditBox } from './edit-box';
 
 export class EditBoxImplBase {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _editing = false;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _delegate: EditBox | null = null;
 

--- a/cocos/ui/editbox/edit-box-impl-base.ts
+++ b/cocos/ui/editbox/edit-box-impl-base.ts
@@ -34,7 +34,13 @@
 import { EditBox } from './edit-box';
 
 export class EditBoxImplBase {
+    /**
+     * @private_cc
+     */
     public _editing = false;
+    /**
+     * @private_cc
+     */
     public _delegate: EditBox | null = null;
 
     public init (delegate: EditBox) {}

--- a/cocos/ui/editbox/edit-box-impl.ts
+++ b/cocos/ui/editbox/edit-box-impl.ts
@@ -64,13 +64,37 @@ let _currentEditBoxImpl: EditBoxImpl | null = null;
 let _domCount = 0;
 
 export class EditBoxImpl extends EditBoxImplBase {
+    /**
+     * @private_cc
+     */
     public _delegate: EditBox | null = null;
+    /**
+     * @private_cc
+     */
     public _inputMode: InputMode = -1;
+    /**
+     * @private_cc
+     */
     public _inputFlag: InputFlag = -1;
+    /**
+     * @private_cc
+     */
     public _returnType: KeyboardReturnType = -1;
+    /**
+     * @private_cc
+     */
     public __eventListeners: any = {};
+    /**
+     * @private_cc
+     */
     public __autoResize = false;
+    /**
+     * @private_cc
+     */
     public __orientationChanged: any;
+    /**
+     * @private_cc
+     */
     public _edTxt: HTMLInputElement | HTMLTextAreaElement | null = null;
     private _isTextArea = false;
 

--- a/cocos/ui/editbox/edit-box-impl.ts
+++ b/cocos/ui/editbox/edit-box-impl.ts
@@ -65,35 +65,35 @@ let _domCount = 0;
 
 export class EditBoxImpl extends EditBoxImplBase {
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _delegate: EditBox | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _inputMode: InputMode = -1;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _inputFlag: InputFlag = -1;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _returnType: KeyboardReturnType = -1;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public __eventListeners: any = {};
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public __autoResize = false;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public __orientationChanged: any;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _edTxt: HTMLInputElement | HTMLTextAreaElement | null = null;
     private _isTextArea = false;
@@ -398,7 +398,7 @@ export class EditBoxImpl extends EditBoxImplBase {
         } else if (inputMode === InputMode.PHONE_NUMBER) {
             type = 'number';
             elem.pattern = '[0-9]*';
-            elem.addEventListener("wheel", () => false);
+            elem.addEventListener('wheel', () => false);
         } else if (inputMode === InputMode.URL) {
             type = 'url';
         } else {

--- a/cocos/ui/editbox/edit-box-impl.ts
+++ b/cocos/ui/editbox/edit-box-impl.ts
@@ -65,35 +65,35 @@ let _domCount = 0;
 
 export class EditBoxImpl extends EditBoxImplBase {
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _delegate: EditBox | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _inputMode: InputMode = -1;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _inputFlag: InputFlag = -1;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _returnType: KeyboardReturnType = -1;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public __eventListeners: any = {};
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public __autoResize = false;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public __orientationChanged: any;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _edTxt: HTMLInputElement | HTMLTextAreaElement | null = null;
     private _isTextArea = false;

--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -356,11 +356,11 @@ export class EditBox extends Component {
     public editingReturn: ComponentEventHandler[] = [];
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _impl: EditBoxImplBase | null = null;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _background: Sprite | null = null;
 
@@ -464,7 +464,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _editBoxEditingDidBegan () {
         ComponentEventHandler.emitEvents(this.editingDidBegan, this);
@@ -472,7 +472,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _editBoxEditingDidEnded () {
         ComponentEventHandler.emitEvents(this.editingDidEnded, this);
@@ -480,7 +480,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _editBoxTextChanged (text: string) {
         text = this._updateLabelStringStyle(text, true);
@@ -490,7 +490,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _editBoxEditingReturn () {
         ComponentEventHandler.emitEvents(this.editingReturn, this);
@@ -498,7 +498,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _showLabels () {
         this._isLabelVisible = true;
@@ -506,7 +506,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _hideLabels () {
         this._isLabelVisible = false;

--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -355,7 +355,13 @@ export class EditBox extends Component {
     @tooltip('i18n:editbox.editing_return')
     public editingReturn: ComponentEventHandler[] = [];
 
+    /**
+     * @private_cc
+     */
     public _impl: EditBoxImplBase | null = null;
+    /**
+     * @private_cc
+     */
     public _background: Sprite | null = null;
 
     @serializable
@@ -457,16 +463,25 @@ export class EditBox extends Component {
         return false;
     }
 
+    /**
+     * @private_cc
+     */
     public _editBoxEditingDidBegan () {
         ComponentEventHandler.emitEvents(this.editingDidBegan, this);
         this.node.emit(EventType.EDITING_DID_BEGAN, this);
     }
 
+    /**
+     * @private_cc
+     */
     public _editBoxEditingDidEnded () {
         ComponentEventHandler.emitEvents(this.editingDidEnded, this);
         this.node.emit(EventType.EDITING_DID_ENDED, this);
     }
 
+    /**
+     * @private_cc
+     */
     public _editBoxTextChanged (text: string) {
         text = this._updateLabelStringStyle(text, true);
         this.string = text;
@@ -474,16 +489,25 @@ export class EditBox extends Component {
         this.node.emit(EventType.TEXT_CHANGED, this);
     }
 
+    /**
+     * @private_cc
+     */
     public _editBoxEditingReturn () {
         ComponentEventHandler.emitEvents(this.editingReturn, this);
         this.node.emit(EventType.EDITING_RETURN, this);
     }
 
+    /**
+     * @private_cc
+     */
     public _showLabels () {
         this._isLabelVisible = true;
         this._updateLabels();
     }
 
+    /**
+     * @private_cc
+     */
     public _hideLabels () {
         this._isLabelVisible = false;
         if (this._textLabel) {

--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -356,11 +356,11 @@ export class EditBox extends Component {
     public editingReturn: ComponentEventHandler[] = [];
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _impl: EditBoxImplBase | null = null;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _background: Sprite | null = null;
 
@@ -464,7 +464,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _editBoxEditingDidBegan () {
         ComponentEventHandler.emitEvents(this.editingDidBegan, this);
@@ -472,7 +472,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _editBoxEditingDidEnded () {
         ComponentEventHandler.emitEvents(this.editingDidEnded, this);
@@ -480,7 +480,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _editBoxTextChanged (text: string) {
         text = this._updateLabelStringStyle(text, true);
@@ -490,7 +490,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _editBoxEditingReturn () {
         ComponentEventHandler.emitEvents(this.editingReturn, this);
@@ -498,7 +498,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _showLabels () {
         this._isLabelVisible = true;
@@ -506,7 +506,7 @@ export class EditBox extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _hideLabels () {
         this._isLabelVisible = false;

--- a/cocos/ui/page-view-indicator.ts
+++ b/cocos/ui/page-view-indicator.ts
@@ -182,7 +182,7 @@ export class PageViewIndicator extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _updateLayout () {
         this._layout = this.getComponent(Layout);
@@ -202,7 +202,7 @@ export class PageViewIndicator extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _createIndicator () {
         const node = new Node();
@@ -216,7 +216,7 @@ export class PageViewIndicator extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _changedState () {
         const indicators = this._indicators;
@@ -244,7 +244,7 @@ export class PageViewIndicator extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _refresh () {
         if (!this._pageView) { return; }

--- a/cocos/ui/page-view-indicator.ts
+++ b/cocos/ui/page-view-indicator.ts
@@ -182,7 +182,7 @@ export class PageViewIndicator extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _updateLayout () {
         this._layout = this.getComponent(Layout);
@@ -202,7 +202,7 @@ export class PageViewIndicator extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _createIndicator () {
         const node = new Node();
@@ -216,7 +216,7 @@ export class PageViewIndicator extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _changedState () {
         const indicators = this._indicators;
@@ -244,7 +244,7 @@ export class PageViewIndicator extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _refresh () {
         if (!this._pageView) { return; }

--- a/cocos/ui/page-view-indicator.ts
+++ b/cocos/ui/page-view-indicator.ts
@@ -181,6 +181,9 @@ export class PageViewIndicator extends Component {
         this._refresh();
     }
 
+    /**
+     * @private_cc
+     */
     public _updateLayout () {
         this._layout = this.getComponent(Layout);
         if (!this._layout) {
@@ -198,6 +201,9 @@ export class PageViewIndicator extends Component {
         layout.resizeMode = Layout.ResizeMode.CONTAINER;
     }
 
+    /**
+     * @private_cc
+     */
     public _createIndicator () {
         const node = new Node();
         node.layer = this.node.layer;
@@ -209,6 +215,9 @@ export class PageViewIndicator extends Component {
         return node;
     }
 
+    /**
+     * @private_cc
+     */
     public _changedState () {
         const indicators = this._indicators;
         if (indicators.length === 0 || !this._pageView) { return; }
@@ -234,6 +243,9 @@ export class PageViewIndicator extends Component {
         }
     }
 
+    /**
+     * @private_cc
+     */
     public _refresh () {
         if (!this._pageView) { return; }
         const indicators = this._indicators;

--- a/cocos/ui/toggle.ts
+++ b/cocos/ui/toggle.ts
@@ -103,6 +103,9 @@ export class Toggle extends Button {
         }
     }
 
+    /**
+     * @private_cc
+     */
     get _toggleContainer () {
         const parent = this.node.parent!;
         if (legacyCC.Node.isNode(parent)) {

--- a/cocos/ui/toggle.ts
+++ b/cocos/ui/toggle.ts
@@ -104,7 +104,7 @@ export class Toggle extends Button {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     get _toggleContainer () {
         const parent = this.node.parent!;

--- a/cocos/ui/toggle.ts
+++ b/cocos/ui/toggle.ts
@@ -104,7 +104,7 @@ export class Toggle extends Button {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     get _toggleContainer () {
         const parent = this.node.parent!;

--- a/cocos/ui/widget.ts
+++ b/cocos/ui/widget.ts
@@ -727,19 +727,19 @@ export class Widget extends Component {
     public static AlignMode = AlignMode;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _lastPos = new Vec3();
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _lastSize = new Size();
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _dirty = true;
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _hadAlignOnce = false;
 
@@ -805,7 +805,7 @@ export class Widget extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _validateTargetInDEV () {
         if (!DEV) {
@@ -846,23 +846,23 @@ export class Widget extends Component {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _adjustWidgetToAllowMovingInEditor (eventType: TransformBit) {}
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _adjustWidgetToAllowResizingInEditor () {}
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _adjustWidgetToAnchorChanged () {
         this.setDirty();
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _adjustTargetToParentChanged (oldParent: Node) {
         if (oldParent) {

--- a/cocos/ui/widget.ts
+++ b/cocos/ui/widget.ts
@@ -726,9 +726,21 @@ export class Widget extends Component {
 
     public static AlignMode = AlignMode;
 
+    /**
+     * @private_cc
+     */
     public _lastPos = new Vec3();
+    /**
+     * @private_cc
+     */
     public _lastSize = new Size();
+    /**
+     * @private_cc
+     */
     public _dirty = true;
+    /**
+     * @private_cc
+     */
     public _hadAlignOnce = false;
 
     @serializable
@@ -792,6 +804,9 @@ export class Widget extends Component {
         legacyCC._widgetManager.updateAlignment(this.node);
     }
 
+    /**
+     * @private_cc
+     */
     public _validateTargetInDEV () {
         if (!DEV) {
             return;
@@ -830,13 +845,25 @@ export class Widget extends Component {
         this._removeParentEvent();
     }
 
+    /**
+     * @private_cc
+     */
     public _adjustWidgetToAllowMovingInEditor (eventType: TransformBit) {}
+    /**
+     * @private_cc
+     */
     public _adjustWidgetToAllowResizingInEditor () {}
 
+    /**
+     * @private_cc
+     */
     public _adjustWidgetToAnchorChanged () {
         this.setDirty();
     }
 
+    /**
+     * @private_cc
+     */
     public _adjustTargetToParentChanged (oldParent: Node) {
         if (oldParent) {
             this._unregisterOldParentEvents(oldParent);

--- a/cocos/ui/widget.ts
+++ b/cocos/ui/widget.ts
@@ -727,19 +727,19 @@ export class Widget extends Component {
     public static AlignMode = AlignMode;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _lastPos = new Vec3();
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _lastSize = new Size();
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _dirty = true;
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _hadAlignOnce = false;
 
@@ -805,7 +805,7 @@ export class Widget extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _validateTargetInDEV () {
         if (!DEV) {
@@ -846,23 +846,23 @@ export class Widget extends Component {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _adjustWidgetToAllowMovingInEditor (eventType: TransformBit) {}
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _adjustWidgetToAllowResizingInEditor () {}
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _adjustWidgetToAnchorChanged () {
         this.setDirty();
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _adjustTargetToParentChanged (oldParent: Node) {
         if (oldParent) {

--- a/cocos/video/assets/video-clip.ts
+++ b/cocos/video/assets/video-clip.ts
@@ -47,6 +47,9 @@ export class VideoClip extends Asset {
         super();
     }
 
+    /**
+     * @private_cc
+     */
     set _nativeAsset (clip: HTMLVideoElement | null) {
         this._video = clip;
         if (clip) {
@@ -55,7 +58,6 @@ export class VideoClip extends Asset {
             this._duration = 0;
         }
     }
-
     get _nativeAsset (): HTMLVideoElement | null {
         return this._video;
     }

--- a/cocos/video/assets/video-clip.ts
+++ b/cocos/video/assets/video-clip.ts
@@ -48,7 +48,7 @@ export class VideoClip extends Asset {
     }
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     set _nativeAsset (clip: HTMLVideoElement | null) {
         this._video = clip;

--- a/cocos/video/assets/video-clip.ts
+++ b/cocos/video/assets/video-clip.ts
@@ -48,7 +48,7 @@ export class VideoClip extends Asset {
     }
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     set _nativeAsset (clip: HTMLVideoElement | null) {
         this._video = clip;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1746,9 +1746,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.2.21-beta.1",
-      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.21-beta.1.tgz",
-      "integrity": "sha512-7qH4LUAkRGVR102TB2pB3zJjZCSDX+855jYv/m9vTeypL2PNK/OLxQYNUyKadenaLIboe8wUUNp8gTjN8OFFgA==",
+      "version": "4.2.21-beta.2",
+      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.21-beta.2.tgz",
+      "integrity": "sha512-BjcKbqaPcoxcDjZiGf/AAMVSuz21Wj79LuN7kQzEPv13qF7UzQXLVLaFpAUUZ6ZExk6twa6mvlABwQhOPBxN0w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.13.10",
@@ -3344,9 +3344,9 @@
       "dev": true
     },
     "@rollup/pluginutils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
-      "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+      "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
       "dev": true,
       "requires": {
         "estree-walker": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1746,9 +1746,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.2.21-beta.2",
-      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.21-beta.2.tgz",
-      "integrity": "sha512-BjcKbqaPcoxcDjZiGf/AAMVSuz21Wj79LuN7kQzEPv13qF7UzQXLVLaFpAUUZ6ZExk6twa6mvlABwQhOPBxN0w==",
+      "version": "4.2.21-beta.3",
+      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.21-beta.3.tgz",
+      "integrity": "sha512-TQBh1UUSpIfYPgoszD7ElozFMJ9uRTm3SzV0SGXVxNLIbEG7tETvBJ7uEgf0zH2R0+5DvGEOK2BMwfkK7MxSPA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.13.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1746,9 +1746,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.2.21-beta.3",
-      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.21-beta.3.tgz",
-      "integrity": "sha512-TQBh1UUSpIfYPgoszD7ElozFMJ9uRTm3SzV0SGXVxNLIbEG7tETvBJ7uEgf0zH2R0+5DvGEOK2BMwfkK7MxSPA==",
+      "version": "4.2.21-beta.5",
+      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.21-beta.5.tgz",
+      "integrity": "sha512-IEbTRyooUQ7DwMyaM9W2kQaDiFXxib94IQWH71n1wzaKL9aDhCIsbzfVf7cUzhgnVl1P00aJ665Y4paLWojUmA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.13.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1045,7 +1045,7 @@
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-async-generators/download/@babel/plugin-syntax-async-generators-7.8.4.tgz",
+      "resolved": "https://registry.nlark.com/@babel/plugin-syntax-async-generators/download/@babel/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
       "dev": true,
       "requires": {
@@ -1063,7 +1063,7 @@
     },
     "@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-class-properties/download/@babel/plugin-syntax-class-properties-7.12.13.tgz?cache=0&sync_timestamp=1612314770269&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fplugin-syntax-class-properties%2Fdownload%2F%40babel%2Fplugin-syntax-class-properties-7.12.13.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-class-properties/download/@babel/plugin-syntax-class-properties-7.12.13.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fplugin-syntax-class-properties%2Fdownload%2F%40babel%2Fplugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
       "dev": true,
       "requires": {
@@ -1097,7 +1097,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-dynamic-import/download/@babel/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "resolved": "https://registry.nlark.com/@babel/plugin-syntax-dynamic-import/download/@babel/plugin-syntax-dynamic-import-7.8.3.tgz?cache=0&sync_timestamp=1618847125283&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40babel%2Fplugin-syntax-dynamic-import%2Fdownload%2F%40babel%2Fplugin-syntax-dynamic-import-7.8.3.tgz",
       "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
       "dev": true,
       "requires": {
@@ -1106,7 +1106,7 @@
     },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-import-meta/download/@babel/plugin-syntax-import-meta-7.10.4.tgz",
+      "resolved": "https://registry.nlark.com/@babel/plugin-syntax-import-meta/download/@babel/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
       "dev": true,
       "requires": {
@@ -1123,7 +1123,7 @@
     },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-json-strings/download/@babel/plugin-syntax-json-strings-7.8.3.tgz",
+      "resolved": "https://registry.nlark.com/@babel/plugin-syntax-json-strings/download/@babel/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
       "dev": true,
       "requires": {
@@ -1132,7 +1132,7 @@
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-logical-assignment-operators/download/@babel/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "resolved": "https://registry.nlark.com/@babel/plugin-syntax-logical-assignment-operators/download/@babel/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
       "dev": true,
       "requires": {
@@ -1158,7 +1158,7 @@
     },
     "@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-numeric-separator/download/@babel/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-numeric-separator/download/@babel/plugin-syntax-numeric-separator-7.10.4.tgz?cache=0&sync_timestamp=1593522054358&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fplugin-syntax-numeric-separator%2Fdownload%2F%40babel%2Fplugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
       "dev": true,
       "requires": {
@@ -1175,7 +1175,7 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-object-rest-spread/download/@babel/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "resolved": "https://registry.nlark.com/@babel/plugin-syntax-object-rest-spread/download/@babel/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
       "dev": true,
       "requires": {
@@ -1193,7 +1193,7 @@
     },
     "@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-optional-chaining/download/@babel/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "resolved": "https://registry.nlark.com/@babel/plugin-syntax-optional-chaining/download/@babel/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
       "dev": true,
       "requires": {
@@ -1553,7 +1553,7 @@
     },
     "@babel/preset-env": {
       "version": "7.8.7",
-      "resolved": "https://registry.npm.taobao.org/@babel/preset-env/download/@babel/preset-env-7.8.7.tgz?cache=0&sync_timestamp=1593522855920&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fpreset-env%2Fdownload%2F%40babel%2Fpreset-env-7.8.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/preset-env/download/@babel/preset-env-7.8.7.tgz?cache=0&sync_timestamp=1637103615805&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40babel%2Fpreset-env%2Fdownload%2F%40babel%2Fpreset-env-7.8.7.tgz",
       "integrity": "sha1-H8fYnH910tcMK2do3mwuBJs8uds=",
       "dev": true,
       "requires": {
@@ -1698,13 +1698,13 @@
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "resolved": "https://registry.npm.taobao.org/@bcoe/v8-coverage/download/@bcoe/v8-coverage-0.2.3.tgz",
+      "resolved": "https://registry.nlark.com/@bcoe/v8-coverage/download/@bcoe/v8-coverage-0.2.3.tgz",
       "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk=",
       "dev": true
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/@cnakazawa/watch/download/@cnakazawa/watch-1.0.4.tgz",
+      "resolved": "https://registry.nlark.com/@cnakazawa/watch/download/@cnakazawa/watch-1.0.4.tgz",
       "integrity": "sha1-+GSuhQBND8q29QvpFBxNo2jRZWo=",
       "dev": true,
       "requires": {
@@ -1714,8 +1714,8 @@
     },
     "@cocos/babel-plugin-dynamic-import-vars": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/@cocos/babel-plugin-dynamic-import-vars/download/@cocos/babel-plugin-dynamic-import-vars-1.0.2.tgz?cache=0&sync_timestamp=1604048375532&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40cocos%2Fbabel-plugin-dynamic-import-vars%2Fdownload%2F%40cocos%2Fbabel-plugin-dynamic-import-vars-1.0.2.tgz",
-      "integrity": "sha1-chaboK/r3jjHTS02cU95rWZBT5g=",
+      "resolved": "https://registry.npmjs.org/@cocos/babel-plugin-dynamic-import-vars/-/babel-plugin-dynamic-import-vars-1.0.2.tgz",
+      "integrity": "sha512-Jd1rUZWp1YKF+3nSaCmVqG/lAgQCmdiziqgptiY6EONo9jHpXcB7iShs6pfDpQcmkiJNPEOqcKxXINPLhs9FsQ==",
       "dev": true,
       "requires": {
         "globby": "^11.0.1"
@@ -1739,16 +1739,16 @@
     },
     "@cocos/box2d": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/@cocos/box2d/download/@cocos/box2d-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@cocos/box2d/download/@cocos/box2d-1.0.1.tgz",
       "integrity": "sha1-Fc2lzPxRCCt91tNoo+S55IXS5To=",
       "requires": {
         "@types/systemjs": "^0.20.6"
       }
     },
     "@cocos/build-engine": {
-      "version": "4.2.19",
-      "resolved": "https://registry.npmmirror.com/@cocos/build-engine/download/@cocos/build-engine-4.2.19.tgz",
-      "integrity": "sha512-gH20zlmoalTEEKrE9xCU/Cr4gxdPh1J8/pznC6nGL5aliQeTXwWAufRKd/WUIfVoICwNC7L6mPrtveD38Yssaw==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.20.tgz",
+      "integrity": "sha512-89iFN1eAeXcIHKA0b2UjkDxt/Yg7WFi6AQu23tfe2RSvrOQFm3XM/nI780hdxfhICPBDZEEPBSPcYXLNB18Y8A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.13.10",
@@ -1779,14 +1779,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1",
-          "resolved": "https://registry.nlark.com/ansi-regex/download/ansi-regex-5.0.1.tgz?cache=0&sync_timestamp=1631634988487&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fansi-regex%2Fdownload%2Fansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
-          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -1794,8 +1794,8 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-6.0.0.tgz",
-          "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
@@ -1805,8 +1805,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
-          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -1814,14 +1814,14 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.4.tgz",
-          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-4.1.0.tgz",
-          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
@@ -1830,8 +1830,8 @@
         },
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.nlark.com/fs-extra/download/fs-extra-8.1.0.tgz",
-          "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -1841,20 +1841,20 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": "https://registry.npm.taobao.org/get-caller-file/download/get-caller-file-2.0.5.tgz",
-          "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz?cache=0&sync_timestamp=1618552489864&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-fullwidth-code-point%2Fdownload%2Fis-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "json5": {
           "version": "2.2.0",
-          "resolved": "https://registry.npm.taobao.org/json5/download/json5-2.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-2.2.0.tgz",
-          "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -1862,8 +1862,8 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-5.0.0.tgz",
-          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
@@ -1871,8 +1871,8 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-4.1.0.tgz",
-          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
@@ -1880,20 +1880,20 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-4.0.0.tgz",
-          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/require-main-filename/download/require-main-filename-2.0.0.tgz",
-          "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "resolve": {
           "version": "1.20.0",
-          "resolved": "https://registry.npm.taobao.org/resolve/download/resolve-1.20.0.tgz",
-          "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
@@ -1902,8 +1902,8 @@
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-7.3.5.tgz?cache=0&sync_timestamp=1616463603361&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-7.3.5.tgz",
-          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -1911,8 +1911,8 @@
         },
         "string-width": {
           "version": "4.2.3",
-          "resolved": "https://registry.npmmirror.com/string-width/download/string-width-4.2.3.tgz?cache=0&sync_timestamp=1632421309919&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fstring-width%2Fdownload%2Fstring-width-4.2.3.tgz",
-          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -1922,8 +1922,8 @@
         },
         "strip-ansi": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmmirror.com/strip-ansi/download/strip-ansi-6.0.1.tgz",
-          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
@@ -1931,14 +1931,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -1948,14 +1948,14 @@
         },
         "y18n": {
           "version": "4.0.3",
-          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.3.tgz",
-          "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.nlark.com/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1620086465147&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
-          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "dev": true,
           "requires": {
             "cliui": "^6.0.0",
@@ -1975,7 +1975,7 @@
     },
     "@cocos/bullet": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@cocos/bullet/-/bullet-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@cocos/bullet/download/@cocos/bullet-1.0.2.tgz",
       "integrity": "sha512-jd/oMO/zL/C0IsYQJrhClU4H5nyd2WOvk+9z2nsQNyh+5QVqk9D+WtOg49ObZud1W7PNksLxmVdczLaaAAUL8Q=="
     },
     "@cocos/cannon": {
@@ -1995,13 +1995,13 @@
     },
     "@cocos/typedoc-plugin-internal-external": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/@cocos/typedoc-plugin-internal-external/download/@cocos/typedoc-plugin-internal-external-1.0.1.tgz",
+      "resolved": "https://registry.nlark.com/@cocos/typedoc-plugin-internal-external/download/@cocos/typedoc-plugin-internal-external-1.0.1.tgz",
       "integrity": "sha1-p3mtZYlcZV8JWKPQel1cexxJM8g=",
       "dev": true
     },
     "@cocos/typedoc-plugin-localization": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/@cocos/typedoc-plugin-localization/download/@cocos/typedoc-plugin-localization-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/@cocos/typedoc-plugin-localization/download/@cocos/typedoc-plugin-localization-1.0.0.tgz",
       "integrity": "sha1-tgm8/YW1fcRE/BasUWCjP9uix0g=",
       "dev": true,
       "requires": {
@@ -2021,7 +2021,7 @@
         },
         "typedoc": {
           "version": "0.16.11",
-          "resolved": "https://registry.npm.taobao.org/typedoc/download/typedoc-0.16.11.tgz",
+          "resolved": "https://registry.npmmirror.com/typedoc/download/typedoc-0.16.11.tgz",
           "integrity": "sha1-lfhixuunhTPtya9wltIpW3GO3cE=",
           "dev": true,
           "requires": {
@@ -2040,7 +2040,7 @@
           "dependencies": {
             "fs-extra": {
               "version": "8.1.0",
-              "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-8.1.0.tgz?cache=0&sync_timestamp=1591229972229&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-8.1.0.tgz",
+              "resolved": "https://registry.nlark.com/fs-extra/download/fs-extra-8.1.0.tgz",
               "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
               "dev": true,
               "requires": {
@@ -2118,7 +2118,7 @@
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/@istanbuljs/load-nyc-config/download/@istanbuljs/load-nyc-config-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/@istanbuljs/load-nyc-config/download/@istanbuljs/load-nyc-config-1.1.0.tgz",
       "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
       "dev": true,
       "requires": {
@@ -2131,7 +2131,7 @@
       "dependencies": {
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/find-up/download/find-up-4.1.0.tgz?cache=0&sync_timestamp=1633620747957&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Ffind-up%2Fdownload%2Ffind-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
@@ -2141,7 +2141,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.nlark.com/locate-path/download/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
@@ -2150,7 +2150,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.nlark.com/p-locate/download/p-locate-4.1.0.tgz?cache=0&sync_timestamp=1629892721671&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fp-locate%2Fdownload%2Fp-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
@@ -2159,13 +2159,13 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/path-exists/download/path-exists-4.0.0.tgz",
           "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-5.0.0.tgz",
+          "resolved": "https://registry.nlark.com/resolve-from/download/resolve-from-5.0.0.tgz?cache=0&sync_timestamp=1622605305717&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fresolve-from%2Fdownload%2Fresolve-from-5.0.0.tgz",
           "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
           "dev": true
         }
@@ -2173,13 +2173,13 @@
     },
     "@istanbuljs/schema": {
       "version": "0.1.3",
-      "resolved": "https://registry.npm.taobao.org/@istanbuljs/schema/download/@istanbuljs/schema-0.1.3.tgz?cache=0&sync_timestamp=1613227144228&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40istanbuljs%2Fschema%2Fdownload%2F%40istanbuljs%2Fschema-0.1.3.tgz",
+      "resolved": "https://registry.nlark.com/@istanbuljs/schema/download/@istanbuljs/schema-0.1.3.tgz",
       "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg=",
       "dev": true
     },
     "@jest/console": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/@jest/console/download/@jest/console-26.6.2.tgz?cache=0&sync_timestamp=1616701585589&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40jest%2Fconsole%2Fdownload%2F%40jest%2Fconsole-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/console/download/@jest/console-26.6.2.tgz",
       "integrity": "sha1-TgS8RkAUNYsDq0k3gF7jagrrmPI=",
       "dev": true,
       "requires": {
@@ -2193,7 +2193,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -2224,7 +2224,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -2243,7 +2243,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2258,13 +2258,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -2275,7 +2275,7 @@
     },
     "@jest/core": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/@jest/core/download/@jest/core-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/core/download/@jest/core-26.6.3.tgz",
       "integrity": "sha1-djn8s4M9dIpGVq2lS94ZMFHkX60=",
       "dev": true,
       "requires": {
@@ -2311,7 +2311,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -2348,7 +2348,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -2376,7 +2376,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2406,7 +2406,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -2437,7 +2437,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -2457,7 +2457,7 @@
     },
     "@jest/environment": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/@jest/environment/download/@jest/environment-26.6.2.tgz?cache=0&sync_timestamp=1616701586653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40jest%2Fenvironment%2Fdownload%2F%40jest%2Fenvironment-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/environment/download/@jest/environment-26.6.2.tgz",
       "integrity": "sha1-ujZMxy4iHnnMjwqZVVv111d8+Sw=",
       "dev": true,
       "requires": {
@@ -2469,7 +2469,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -2500,7 +2500,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -2519,7 +2519,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2534,13 +2534,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -2551,7 +2551,7 @@
     },
     "@jest/fake-timers": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/@jest/fake-timers/download/@jest/fake-timers-26.6.2.tgz?cache=0&sync_timestamp=1616701585743&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40jest%2Ffake-timers%2Fdownload%2F%40jest%2Ffake-timers-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/fake-timers/download/@jest/fake-timers-26.6.2.tgz",
       "integrity": "sha1-RZwym89wzuSvTX4/PmeEgSNTWq0=",
       "dev": true,
       "requires": {
@@ -2565,7 +2565,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -2596,7 +2596,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -2615,7 +2615,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2630,13 +2630,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -2647,7 +2647,7 @@
     },
     "@jest/globals": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/@jest/globals/download/@jest/globals-26.6.2.tgz?cache=0&sync_timestamp=1616701587468&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40jest%2Fglobals%2Fdownload%2F%40jest%2Fglobals-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/globals/download/@jest/globals-26.6.2.tgz",
       "integrity": "sha1-W2E7eKGqJlWukI66Y4zJaiDfcgo=",
       "dev": true,
       "requires": {
@@ -2658,7 +2658,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -2689,7 +2689,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -2708,7 +2708,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2723,13 +2723,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -2740,7 +2740,7 @@
     },
     "@jest/reporters": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/@jest/reporters/download/@jest/reporters-26.6.2.tgz?cache=0&sync_timestamp=1616701586851&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40jest%2Freporters%2Fdownload%2F%40jest%2Freporters-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/reporters/download/@jest/reporters-26.6.2.tgz",
       "integrity": "sha1-H1GLmWN6Xxgwe9Ps+SdfaIKmZ/Y=",
       "dev": true,
       "requires": {
@@ -2773,7 +2773,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -2804,7 +2804,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -2823,7 +2823,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2844,7 +2844,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -2856,7 +2856,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -2867,7 +2867,7 @@
     },
     "@jest/source-map": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/@jest/source-map/download/@jest/source-map-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/source-map/download/@jest/source-map-26.6.2.tgz",
       "integrity": "sha1-Ka9eHi4yTK/MyTbyGDCfVKtp1TU=",
       "dev": true,
       "requires": {
@@ -2892,7 +2892,7 @@
     },
     "@jest/test-result": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/@jest/test-result/download/@jest/test-result-26.6.2.tgz?cache=0&sync_timestamp=1616701586169&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40jest%2Ftest-result%2Fdownload%2F%40jest%2Ftest-result-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/test-result/download/@jest/test-result-26.6.2.tgz",
       "integrity": "sha1-VdpYti3xNFdsyVR276X3lJ4/Xxg=",
       "dev": true,
       "requires": {
@@ -2904,7 +2904,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -2935,7 +2935,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -2954,7 +2954,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2969,13 +2969,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -2986,7 +2986,7 @@
     },
     "@jest/test-sequencer": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/@jest/test-sequencer/download/@jest/test-sequencer-26.6.3.tgz?cache=0&sync_timestamp=1616701589657&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40jest%2Ftest-sequencer%2Fdownload%2F%40jest%2Ftest-sequencer-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/test-sequencer/download/@jest/test-sequencer-26.6.3.tgz",
       "integrity": "sha1-mOikUQCGOIbQdCBej/3Fp+tYKxc=",
       "dev": true,
       "requires": {
@@ -3007,7 +3007,7 @@
     },
     "@jest/transform": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/@jest/transform/download/@jest/transform-26.6.2.tgz?cache=0&sync_timestamp=1616701584954&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40jest%2Ftransform%2Fdownload%2F%40jest%2Ftransform-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/transform/download/@jest/transform-26.6.2.tgz",
       "integrity": "sha1-WsV8X6GtF7Kq6D5z5FgTiU3PLks=",
       "dev": true,
       "requires": {
@@ -3030,7 +3030,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -3061,7 +3061,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -3089,7 +3089,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -3119,7 +3119,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -3147,7 +3147,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -3167,7 +3167,7 @@
     },
     "@jest/types": {
       "version": "24.9.0",
-      "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-24.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-24.9.0.tgz",
       "integrity": "sha1-Y8smy3UA0Gnlo4lEGnxqtekJ/Fk=",
       "dev": true,
       "requires": {
@@ -3215,8 +3215,8 @@
     },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-babel/download/@rollup/plugin-babel-5.3.0.tgz",
-      "integrity": "sha1-nLHFFG3daklorZbyCcUMYvkvmHk=",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
+      "integrity": "sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -3225,8 +3225,8 @@
       "dependencies": {
         "@babel/helper-module-imports": {
           "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/helper-module-imports/download/@babel/helper-module-imports-7.16.0.tgz",
-          "integrity": "sha1-kFOOYLZy7PG0SPX09UM9N+eaPsM=",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+          "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.16.0"
@@ -3234,14 +3234,14 @@
         },
         "@babel/helper-validator-identifier": {
           "version": "7.15.7",
-          "resolved": "https://registry.nlark.com/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.15.7.tgz?cache=0&sync_timestamp=1631920000984&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40babel%2Fhelper-validator-identifier%2Fdownload%2F%40babel%2Fhelper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k=",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
           "dev": true
         },
         "@babel/types": {
           "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/types/download/@babel/types-7.16.0.tgz",
-          "integrity": "sha1-2zsxOAT5aq3Qt3bEgj4SetZyibo=",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.15.7",
@@ -3250,8 +3250,8 @@
         },
         "@rollup/pluginutils": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/@rollup/pluginutils/download/@rollup/pluginutils-3.1.0.tgz?cache=0&sync_timestamp=1603767889260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-3.1.0.tgz",
-          "integrity": "sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
           "dev": true,
           "requires": {
             "@types/estree": "0.0.39",
@@ -3263,8 +3263,8 @@
     },
     "@rollup/plugin-commonjs": {
       "version": "11.1.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-11.1.0.tgz",
-      "integrity": "sha1-YGNsenIvVLQeQZ4XCd8FxyNFV+8=",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz",
+      "integrity": "sha512-Ycr12N3ZPN96Fw2STurD21jMqzKwL9QuFhms3SD7KKRK7oaXUsBU9Zt0jL/rOPHiPYisI21/rXGO3jr9BnLHUA==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.8",
@@ -3278,8 +3278,8 @@
       "dependencies": {
         "@rollup/pluginutils": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/@rollup/pluginutils/download/@rollup/pluginutils-3.1.0.tgz?cache=0&sync_timestamp=1603767889260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-3.1.0.tgz",
-          "integrity": "sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
           "dev": true,
           "requires": {
             "@types/estree": "0.0.39",
@@ -3291,8 +3291,8 @@
     },
     "@rollup/plugin-json": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-json/download/@rollup/plugin-json-4.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fplugin-json%2Fdownload%2F%40rollup%2Fplugin-json-4.1.0.tgz",
-      "integrity": "sha1-VOCYZ65pY8WThE2L16nHGClElvM=",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.8"
@@ -3300,8 +3300,8 @@
       "dependencies": {
         "@rollup/pluginutils": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/@rollup/pluginutils/download/@rollup/pluginutils-3.1.0.tgz?cache=0&sync_timestamp=1603767889260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-3.1.0.tgz",
-          "integrity": "sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
           "dev": true,
           "requires": {
             "@types/estree": "0.0.39",
@@ -3313,8 +3313,8 @@
     },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-node-resolve/download/@rollup/plugin-node-resolve-7.1.3.tgz?cache=0&sync_timestamp=1603765888985&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fplugin-node-resolve%2Fdownload%2F%40rollup%2Fplugin-node-resolve-7.1.3.tgz",
-      "integrity": "sha1-gN44Tt+9e/yRARZJEPhgeBUaPso=",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
+      "integrity": "sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.8",
@@ -3326,8 +3326,8 @@
       "dependencies": {
         "@rollup/pluginutils": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/@rollup/pluginutils/download/@rollup/pluginutils-3.1.0.tgz?cache=0&sync_timestamp=1603767889260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-3.1.0.tgz",
-          "integrity": "sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
           "dev": true,
           "requires": {
             "@types/estree": "0.0.39",
@@ -3339,14 +3339,14 @@
     },
     "@rollup/plugin-virtual": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/@rollup/plugin-virtual/download/@rollup/plugin-virtual-2.0.3.tgz",
-      "integrity": "sha1-CvyI11weE3irKQuOmJjU7bW+DXQ=",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-2.0.3.tgz",
+      "integrity": "sha512-pw6ziJcyjZtntQ//bkad9qXaBx665SgEL8C8KI5wO8G5iU5MPxvdWrQyVaAvjojGm9tJoS8M9Z/EEepbqieYmw==",
       "dev": true
     },
     "@rollup/pluginutils": {
       "version": "4.1.1",
-      "resolved": "https://registry.nlark.com/@rollup/pluginutils/download/@rollup/pluginutils-4.1.1.tgz?cache=0&sync_timestamp=1626393703548&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40rollup%2Fpluginutils%2Fdownload%2F%40rollup%2Fpluginutils-4.1.1.tgz",
-      "integrity": "sha1-HU2obdTt7RVlalfZM/2iuaCNR+w=",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+      "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
       "dev": true,
       "requires": {
         "estree-walker": "^2.0.1",
@@ -3355,8 +3355,8 @@
       "dependencies": {
         "estree-walker": {
           "version": "2.0.2",
-          "resolved": "https://registry.npm.taobao.org/estree-walker/download/estree-walker-2.0.2.tgz?cache=0&sync_timestamp=1611956983677&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Festree-walker%2Fdownload%2Festree-walker-2.0.2.tgz",
-          "integrity": "sha1-UvAQF4wqTBF6d1fP6UKtt9LaTKw=",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
           "dev": true
         }
       }
@@ -3372,7 +3372,7 @@
     },
     "@sinonjs/fake-timers": {
       "version": "6.0.1",
-      "resolved": "https://registry.npm.taobao.org/@sinonjs/fake-timers/download/@sinonjs/fake-timers-6.0.1.tgz?cache=0&sync_timestamp=1610984495885&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40sinonjs%2Ffake-timers%2Fdownload%2F%40sinonjs%2Ffake-timers-6.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@sinonjs/fake-timers/download/@sinonjs/fake-timers-6.0.1.tgz?cache=0&sync_timestamp=1635949916472&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40sinonjs%2Ffake-timers%2Fdownload%2F%40sinonjs%2Ffake-timers-6.0.1.tgz",
       "integrity": "sha1-KTZ0/MsyYqx4LHqt/eyoaxDHXEA=",
       "dev": true,
       "requires": {
@@ -3422,13 +3422,13 @@
     },
     "@types/estree": {
       "version": "0.0.39",
-      "resolved": "https://registry.npm.taobao.org/@types/estree/download/@types/estree-0.0.39.tgz",
-      "integrity": "sha1-4Xfmme4bjCLSMXTKqnQiZEOJUJ8=",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/fs-extra": {
       "version": "5.1.0",
-      "resolved": "https://registry.npm.taobao.org/@types/fs-extra/download/@types/fs-extra-5.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/fs-extra/download/@types/fs-extra-5.1.0.tgz",
       "integrity": "sha1-KjJe+XkBUEo4KHGMOQ00uEJqEKE=",
       "dev": true,
       "requires": {
@@ -3437,7 +3437,7 @@
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
-      "resolved": "https://registry.npm.taobao.org/@types/graceful-fs/download/@types/graceful-fs-4.1.5.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/graceful-fs/download/@types/graceful-fs-4.1.5.tgz",
       "integrity": "sha1-If+6DZjaQ1DbZIkfkqnl2zzbThU=",
       "dev": true,
       "requires": {
@@ -3461,7 +3461,7 @@
     },
     "@types/istanbul-reports": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/@types/istanbul-reports/download/@types/istanbul-reports-1.1.2.tgz?cache=0&sync_timestamp=1613379043554&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fistanbul-reports%2Fdownload%2F%40types%2Fistanbul-reports-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/istanbul-reports/download/@types/istanbul-reports-1.1.2.tgz?cache=0&sync_timestamp=1637266160892&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fistanbul-reports%2Fdownload%2F%40types%2Fistanbul-reports-1.1.2.tgz",
       "integrity": "sha1-6HXMaJ5HvOVJ7IHz315vbxHPrrI=",
       "dev": true,
       "requires": {
@@ -3471,7 +3471,7 @@
     },
     "@types/jest": {
       "version": "24.9.1",
-      "resolved": "https://registry.npm.taobao.org/@types/jest/download/@types/jest-24.9.1.tgz?cache=0&sync_timestamp=1616695463771&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fjest%2Fdownload%2F%40types%2Fjest-24.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/jest/download/@types/jest-24.9.1.tgz",
       "integrity": "sha1-Arr5Vzx48bmXSl82d4s2aqd71TQ=",
       "dev": true,
       "requires": {
@@ -3486,7 +3486,7 @@
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "https://registry.npm.taobao.org/@types/minimatch/download/@types/minimatch-3.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/minimatch/download/@types/minimatch-3.0.3.tgz?cache=0&sync_timestamp=1637267363432&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fminimatch%2Fdownload%2F%40types%2Fminimatch-3.0.3.tgz",
       "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
       "dev": true
     },
@@ -3510,8 +3510,8 @@
     },
     "@types/resolve": {
       "version": "0.0.8",
-      "resolved": "https://registry.npm.taobao.org/@types/resolve/download/@types/resolve-0.0.8.tgz?cache=0&sync_timestamp=1596840738717&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fresolve%2Fdownload%2F%40types%2Fresolve-0.0.8.tgz",
-      "integrity": "sha1-8mB00jjgJlnjI84aE9BB7uKA4ZQ=",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3701,7 +3701,7 @@
     },
     "acorn-globals": {
       "version": "6.0.0",
-      "resolved": "https://registry.npm.taobao.org/acorn-globals/download/acorn-globals-6.0.0.tgz",
+      "resolved": "https://registry.nlark.com/acorn-globals/download/acorn-globals-6.0.0.tgz",
       "integrity": "sha1-Rs3Tnw+P8IqHZhm1X1rIptx3C0U=",
       "dev": true,
       "requires": {
@@ -3717,7 +3717,7 @@
     },
     "acorn-walk": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/acorn-walk/download/acorn-walk-7.2.0.tgz",
+      "resolved": "https://registry.nlark.com/acorn-walk/download/acorn-walk-7.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Facorn-walk%2Fdownload%2Facorn-walk-7.2.0.tgz",
       "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
       "dev": true
     },
@@ -3754,7 +3754,7 @@
     },
     "ansi-escapes": {
       "version": "4.3.2",
-      "resolved": "https://registry.npm.taobao.org/ansi-escapes/download/ansi-escapes-4.3.2.tgz?cache=0&sync_timestamp=1616593406066&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-escapes%2Fdownload%2Fansi-escapes-4.3.2.tgz",
+      "resolved": "https://registry.nlark.com/ansi-escapes/download/ansi-escapes-4.3.2.tgz?cache=0&sync_timestamp=1618847144938&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fansi-escapes%2Fdownload%2Fansi-escapes-4.3.2.tgz",
       "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
       "dev": true,
       "requires": {
@@ -3763,7 +3763,7 @@
       "dependencies": {
         "type-fest": {
           "version": "0.21.3",
-          "resolved": "https://registry.npm.taobao.org/type-fest/download/type-fest-0.21.3.tgz?cache=0&sync_timestamp=1616514381586&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftype-fest%2Fdownload%2Ftype-fest-0.21.3.tgz",
+          "resolved": "https://registry.npmmirror.com/type-fest/download/type-fest-0.21.3.tgz",
           "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
           "dev": true
         }
@@ -3771,7 +3771,7 @@
     },
     "ansi-gray": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/ansi-gray/download/ansi-gray-0.1.1.tgz",
       "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
       "dev": true,
       "requires": {
@@ -3786,7 +3786,7 @@
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
@@ -3795,13 +3795,13 @@
     },
     "ansi-wrap": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "resolved": "https://registry.nlark.com/ansi-wrap/download/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz",
+      "resolved": "https://registry.nlark.com/anymatch/download/anymatch-2.0.0.tgz",
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "dev": true,
       "requires": {
@@ -3820,7 +3820,7 @@
     },
     "archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/archy/download/archy-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/archy/download/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
@@ -3835,7 +3835,7 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.nlark.com/arr-diff/download/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
@@ -3850,13 +3850,13 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/arr-flatten/download/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/arr-flatten/download/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-map": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/arr-map/download/arr-map-2.0.2.tgz",
+      "resolved": "https://registry.nlark.com/arr-map/download/arr-map-2.0.2.tgz",
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "dev": true,
       "requires": {
@@ -3865,7 +3865,7 @@
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.nlark.com/arr-union/download/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
@@ -3973,13 +3973,13 @@
     },
     "array-union": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/array-union/download/array-union-2.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/array-union/download/array-union-2.1.0.tgz?cache=0&sync_timestamp=1614624262896&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Farray-union%2Fdownload%2Farray-union-2.1.0.tgz",
       "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://registry.npm.taobao.org/array-unique/download/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.nlark.com/array-unique/download/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
@@ -4011,7 +4011,7 @@
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/assign-symbols/download/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
@@ -4023,7 +4023,7 @@
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "https://registry.npm.taobao.org/async/download/async-2.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/async/download/async-2.6.3.tgz",
       "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
       "dev": true,
       "requires": {
@@ -4044,13 +4044,13 @@
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/async-each/download/async-each-1.0.3.tgz",
+      "resolved": "https://registry.nlark.com/async-each/download/async-each-1.0.3.tgz",
       "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true
     },
     "async-settle": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/async-settle/download/async-settle-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/async-settle/download/async-settle-1.0.0.tgz",
       "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
       "dev": true,
       "requires": {
@@ -4059,13 +4059,13 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.nlark.com/asynckit/download/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/atob/download/atob-2.1.2.tgz",
+      "resolved": "https://registry.nlark.com/atob/download/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
@@ -4083,7 +4083,7 @@
     },
     "babel-jest": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/babel-jest/download/babel-jest-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/babel-jest/download/babel-jest-26.6.3.tgz",
       "integrity": "sha1-2H0lywA3V3oMifguV1XF0pPAEFY=",
       "dev": true,
       "requires": {
@@ -4099,7 +4099,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -4130,7 +4130,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -4149,7 +4149,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -4170,13 +4170,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -4219,7 +4219,7 @@
     },
     "babel-plugin-jest-hoist": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/babel-plugin-jest-hoist/download/babel-plugin-jest-hoist-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/babel-plugin-jest-hoist/download/babel-plugin-jest-hoist-26.6.2.tgz",
       "integrity": "sha1-gYW9AwNI0lTG192XQ1Xmoosh5i0=",
       "dev": true,
       "requires": {
@@ -4231,7 +4231,7 @@
     },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/babel-preset-current-node-syntax/download/babel-preset-current-node-syntax-1.0.1.tgz",
+      "resolved": "https://registry.nlark.com/babel-preset-current-node-syntax/download/babel-preset-current-node-syntax-1.0.1.tgz",
       "integrity": "sha1-tDmSObibKgEfndvj5PQB/EDP9zs=",
       "dev": true,
       "requires": {
@@ -4251,7 +4251,7 @@
     },
     "babel-preset-jest": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/babel-preset-jest/download/babel-preset-jest-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/babel-preset-jest/download/babel-preset-jest-26.6.2.tgz",
       "integrity": "sha1-dHhysRcd8DIlJCZYaIHWLTF5j+4=",
       "dev": true,
       "requires": {
@@ -4261,7 +4261,7 @@
     },
     "bach": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/bach/download/bach-1.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/bach/download/bach-1.2.0.tgz",
       "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
       "dev": true,
       "requires": {
@@ -4317,7 +4317,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -4326,7 +4326,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -4348,7 +4348,7 @@
     },
     "basic-auth": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/basic-auth/download/basic-auth-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/basic-auth/download/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
       "dev": true
     },
@@ -4363,13 +4363,13 @@
     },
     "binary-extensions": {
       "version": "1.13.1",
-      "resolved": "https://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.13.1.tgz",
+      "resolved": "https://registry.nlark.com/binary-extensions/download/binary-extensions-1.13.1.tgz",
       "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.nlark.com/brace-expansion/download/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
@@ -4408,7 +4408,7 @@
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/browser-process-hrtime/download/browser-process-hrtime-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/browser-process-hrtime/download/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=",
       "dev": true
     },
@@ -4447,7 +4447,7 @@
     },
     "bs-logger": {
       "version": "0.2.6",
-      "resolved": "https://registry.npm.taobao.org/bs-logger/download/bs-logger-0.2.6.tgz",
+      "resolved": "https://registry.nlark.com/bs-logger/download/bs-logger-0.2.6.tgz",
       "integrity": "sha1-6302UwenLPl0zGzadraDVK0za9g=",
       "dev": true,
       "requires": {
@@ -4456,7 +4456,7 @@
     },
     "bser": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/bser/download/bser-2.1.1.tgz",
+      "resolved": "https://registry.nlark.com/bser/download/bser-2.1.1.tgz",
       "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
       "dev": true,
       "requires": {
@@ -4477,13 +4477,13 @@
     },
     "builtin-modules": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/builtin-modules/download/builtin-modules-3.2.0.tgz?cache=0&sync_timestamp=1608615096289&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbuiltin-modules%2Fdownload%2Fbuiltin-modules-3.2.0.tgz",
-      "integrity": "sha1-RdXbmefuXmvE82LgCL+RerUEmIc=",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
       "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/cache-base/download/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/cache-base/download/cache-base-1.0.1.tgz?cache=0&sync_timestamp=1636237266442&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fcache-base%2Fdownload%2Fcache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
@@ -4510,13 +4510,13 @@
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/callsites/download/callsites-3.1.0.tgz",
+      "resolved": "https://registry.nlark.com/callsites/download/callsites-3.1.0.tgz",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npm.taobao.org/camelcase/download/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/camelcase/download/camelcase-5.3.1.tgz?cache=0&sync_timestamp=1636945130104&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fcamelcase%2Fdownload%2Fcamelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true
     },
@@ -4537,7 +4537,7 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz?cache=0&sync_timestamp=1573282918610&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-2.4.2.tgz",
+      "resolved": "https://registry.npmmirror.com/chalk/download/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
@@ -4548,19 +4548,19 @@
     },
     "char-regex": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/char-regex/download/char-regex-1.0.2.tgz",
+      "resolved": "https://registry.nlark.com/char-regex/download/char-regex-1.0.2.tgz",
       "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=",
       "dev": true
     },
     "child_process": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/child_process/download/child_process-1.0.2.tgz",
       "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o=",
       "dev": true
     },
     "chokidar": {
       "version": "2.1.8",
-      "resolved": "https://registry.npm.taobao.org/chokidar/download/chokidar-2.1.8.tgz",
+      "resolved": "https://registry.npmmirror.com/chokidar/download/chokidar-2.1.8.tgz",
       "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
       "dev": true,
       "requires": {
@@ -4580,7 +4580,7 @@
       "dependencies": {
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/glob-parent/download/glob-parent-3.1.0.tgz?cache=0&sync_timestamp=1569108917227&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglob-parent%2Fdownload%2Fglob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/glob-parent/download/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -4590,7 +4590,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://registry.npm.taobao.org/is-glob/download/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmmirror.com/is-glob/download/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
@@ -4618,19 +4618,19 @@
     },
     "ci-info": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/ci-info/download/ci-info-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ci-info/download/ci-info-2.0.0.tgz",
       "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
       "dev": true
     },
     "cjs-module-lexer": {
       "version": "0.6.0",
-      "resolved": "https://registry.npm.taobao.org/cjs-module-lexer/download/cjs-module-lexer-0.6.0.tgz?cache=0&sync_timestamp=1615466444581&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcjs-module-lexer%2Fdownload%2Fcjs-module-lexer-0.6.0.tgz",
+      "resolved": "https://registry.nlark.com/cjs-module-lexer/download/cjs-module-lexer-0.6.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fcjs-module-lexer%2Fdownload%2Fcjs-module-lexer-0.6.0.tgz",
       "integrity": "sha1-QYb8yg6uF1lwruhwuf4tbPjVZV8=",
       "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://registry.npm.taobao.org/class-utils/download/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.nlark.com/class-utils/download/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
@@ -4670,7 +4670,7 @@
     },
     "clone": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/clone/download/clone-2.1.2.tgz",
+      "resolved": "https://registry.nlark.com/clone/download/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
@@ -4699,13 +4699,13 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/co/download/co-4.6.0.tgz",
+      "resolved": "https://registry.nlark.com/co/download/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/code-point-at/download/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/code-point-at/download/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
@@ -4717,7 +4717,7 @@
     },
     "collection-map": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/collection-map/download/collection-map-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/collection-map/download/collection-map-1.0.0.tgz",
       "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
       "dev": true,
       "requires": {
@@ -4738,7 +4738,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-1.9.3.tgz",
+      "resolved": "https://registry.nlark.com/color-convert/download/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
@@ -4780,19 +4780,19 @@
     },
     "commander": {
       "version": "2.20.3",
-      "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.20.3.tgz",
+      "resolved": "https://registry.npmmirror.com/commander/download/commander-2.20.3.tgz?cache=0&sync_timestamp=1634886357672&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fcommander%2Fdownload%2Fcommander-2.20.3.tgz",
       "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/commondir/download/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/component-emitter/download/component-emitter-1.3.0.tgz",
+      "resolved": "https://registry.nlark.com/component-emitter/download/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
@@ -4804,7 +4804,7 @@
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npm.taobao.org/concat-stream/download/concat-stream-1.6.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fconcat-stream%2Fdownload%2Fconcat-stream-1.6.2.tgz",
+      "resolved": "https://registry.nlark.com/concat-stream/download/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
@@ -4831,7 +4831,7 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/copy-descriptor/download/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.nlark.com/copy-descriptor/download/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
@@ -4857,7 +4857,7 @@
       "dependencies": {
         "semver": {
           "version": "7.0.0",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-7.0.0.tgz?cache=0&sync_timestamp=1581458063470&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-7.0.0.tgz",
+          "resolved": "https://registry.nlark.com/semver/download/semver-7.0.0.tgz?cache=0&sync_timestamp=1618846864940&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fsemver%2Fdownload%2Fsemver-7.0.0.tgz",
           "integrity": "sha1-XzyjV2HkfgWyBsba/yz4FPAxa44=",
           "dev": true
         }
@@ -4871,7 +4871,7 @@
     },
     "corser": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/corser/download/corser-2.0.1.tgz",
+      "resolved": "https://registry.nlark.com/corser/download/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
       "dev": true
     },
@@ -4890,7 +4890,7 @@
     },
     "cssom": {
       "version": "0.4.4",
-      "resolved": "https://registry.npm.taobao.org/cssom/download/cssom-0.4.4.tgz",
+      "resolved": "https://registry.nlark.com/cssom/download/cssom-0.4.4.tgz?cache=0&sync_timestamp=1624218957158&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fcssom%2Fdownload%2Fcssom-0.4.4.tgz",
       "integrity": "sha1-WmbPk9LQtmHYC/akT7ZfXC5OChA=",
       "dev": true
     },
@@ -4905,7 +4905,7 @@
       "dependencies": {
         "cssom": {
           "version": "0.3.8",
-          "resolved": "https://registry.npm.taobao.org/cssom/download/cssom-0.3.8.tgz",
+          "resolved": "https://registry.nlark.com/cssom/download/cssom-0.3.8.tgz?cache=0&sync_timestamp=1624218957158&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fcssom%2Fdownload%2Fcssom-0.3.8.tgz",
           "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
           "dev": true
         }
@@ -4938,7 +4938,7 @@
     },
     "data-urls": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/data-urls/download/data-urls-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/data-urls/download/data-urls-2.0.0.tgz",
       "integrity": "sha1-FWSFpyljqXD11YIar2Qr7yvy25s=",
       "dev": true,
       "requires": {
@@ -4958,7 +4958,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/decamelize/download/decamelize-1.2.0.tgz?cache=0&sync_timestamp=1633055760479&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fdecamelize%2Fdownload%2Fdecamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -4970,13 +4970,13 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/decode-uri-component/download/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.nlark.com/decode-uri-component/download/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "dedent": {
       "version": "0.7.0",
-      "resolved": "https://registry.npm.taobao.org/dedent/download/dedent-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
@@ -5017,7 +5017,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/define-properties/download/define-properties-1.1.3.tgz",
+      "resolved": "https://registry.nlark.com/define-properties/download/define-properties-1.1.3.tgz?cache=0&sync_timestamp=1618847174317&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fdefine-properties%2Fdownload%2Fdefine-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
@@ -5036,7 +5036,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -5045,7 +5045,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -5091,7 +5091,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -5103,13 +5103,13 @@
     },
     "detect-newline": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/detect-newline/download/detect-newline-3.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/detect-newline/download/detect-newline-3.1.0.tgz",
       "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=",
       "dev": true
     },
     "diff-sequences": {
       "version": "24.9.0",
-      "resolved": "https://registry.npm.taobao.org/diff-sequences/download/diff-sequences-24.9.0.tgz?cache=0&sync_timestamp=1579655107286&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdiff-sequences%2Fdownload%2Fdiff-sequences-24.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/diff-sequences/download/diff-sequences-24.9.0.tgz",
       "integrity": "sha1-VxXWJE4qpl9Iu6C8ly2wsLEelbU=",
       "dev": true
     },
@@ -5141,7 +5141,7 @@
     },
     "domexception": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/domexception/download/domexception-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/domexception/download/domexception-2.0.1.tgz",
       "integrity": "sha1-+0Su+6eT4VdLCvau0oAdBXUp8wQ=",
       "dev": true,
       "requires": {
@@ -5150,7 +5150,7 @@
       "dependencies": {
         "webidl-conversions": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/webidl-conversions/download/webidl-conversions-5.0.0.tgz",
+          "resolved": "https://registry.nlark.com/webidl-conversions/download/webidl-conversions-5.0.0.tgz?cache=0&sync_timestamp=1631408600646&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fwebidl-conversions%2Fdownload%2Fwebidl-conversions-5.0.0.tgz",
           "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8=",
           "dev": true
         }
@@ -5190,7 +5190,7 @@
     },
     "ecstatic": {
       "version": "3.3.2",
-      "resolved": "https://registry.npm.taobao.org/ecstatic/download/ecstatic-3.3.2.tgz",
+      "resolved": "https://registry.npmmirror.com/ecstatic/download/ecstatic-3.3.2.tgz",
       "integrity": "sha1-bR3UmBTQBZRoLGUq22YHamnUbEg=",
       "dev": true,
       "requires": {
@@ -5202,14 +5202,14 @@
     },
     "emittery": {
       "version": "0.7.2",
-      "resolved": "https://registry.npm.taobao.org/emittery/download/emittery-0.7.2.tgz",
+      "resolved": "https://registry.nlark.com/emittery/download/emittery-0.7.2.tgz",
       "integrity": "sha1-JVlZCOE68PVnSrQZOW4vs5TN+oI=",
       "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmmirror.com/emoji-regex/download/emoji-regex-8.0.0.tgz?cache=0&sync_timestamp=1632751333727&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Femoji-regex%2Fdownload%2Femoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "end-of-stream": {
@@ -5240,7 +5240,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npm.taobao.org/error-ex/download/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.nlark.com/error-ex/download/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
@@ -5343,7 +5343,7 @@
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/es6-iterator/download/es6-iterator-2.0.3.tgz",
+      "resolved": "https://registry.nlark.com/es6-iterator/download/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
@@ -5376,19 +5376,19 @@
     },
     "escalade": {
       "version": "3.1.1",
-      "resolved": "https://registry.npm.taobao.org/escalade/download/escalade-3.1.1.tgz?cache=0&sync_timestamp=1602567343144&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fescalade%2Fdownload%2Fescalade-3.1.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/escalade/download/escalade-3.1.1.tgz",
       "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.nlark.com/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escodegen": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/escodegen/download/escodegen-2.0.0.tgz",
+      "resolved": "https://registry.nlark.com/escodegen/download/escodegen-2.0.0.tgz",
       "integrity": "sha1-XjKxKDPoqo+jXhvwvvqJOASEx90=",
       "dev": true,
       "requires": {
@@ -5794,7 +5794,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/find-up/download/find-up-2.1.0.tgz?cache=0&sync_timestamp=1633620747957&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Ffind-up%2Fdownload%2Ffind-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -5803,7 +5803,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.nlark.com/locate-path/download/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -5822,7 +5822,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.nlark.com/p-locate/download/p-locate-2.0.0.tgz?cache=0&sync_timestamp=1629892721671&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fp-locate%2Fdownload%2Fp-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -5831,7 +5831,7 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/p-try/download/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
@@ -5920,7 +5920,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
@@ -6104,8 +6104,8 @@
     },
     "estree-walker": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/estree-walker/download/estree-walker-1.0.1.tgz",
-      "integrity": "sha1-MbxdYSyWtwQQa0d+bdXYqhOMtwA=",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "esutils": {
@@ -6122,13 +6122,13 @@
     },
     "exec-sh": {
       "version": "0.3.6",
-      "resolved": "https://registry.npm.taobao.org/exec-sh/download/exec-sh-0.3.6.tgz?cache=0&sync_timestamp=1616788551774&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexec-sh%2Fdownload%2Fexec-sh-0.3.6.tgz",
+      "resolved": "https://registry.nlark.com/exec-sh/download/exec-sh-0.3.6.tgz",
       "integrity": "sha1-/yZPnjJVGaYMteJzaSlDSDzKY7w=",
       "dev": true
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/execa/download/execa-1.0.0.tgz?cache=0&sync_timestamp=1576749091315&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/execa/download/execa-1.0.0.tgz?cache=0&sync_timestamp=1637147207309&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fexeca%2Fdownload%2Fexeca-1.0.0.tgz",
       "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "dev": true,
       "requires": {
@@ -6143,7 +6143,7 @@
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/exit/download/exit-0.1.2.tgz",
+      "resolved": "https://registry.nlark.com/exit/download/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
@@ -6164,7 +6164,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -6182,7 +6182,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -6191,7 +6191,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -6199,7 +6199,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/expand-tilde/download/expand-tilde-2.0.2.tgz",
+      "resolved": "https://registry.nlark.com/expand-tilde/download/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
@@ -6208,7 +6208,7 @@
     },
     "expect": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/expect/download/expect-26.6.2.tgz?cache=0&sync_timestamp=1616701586390&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexpect%2Fdownload%2Fexpect-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/expect/download/expect-26.6.2.tgz",
       "integrity": "sha1-xrmWvya/P+GLZ7LQ9R/JgbqTRBc=",
       "dev": true,
       "requires": {
@@ -6222,7 +6222,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -6253,7 +6253,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -6272,7 +6272,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -6287,19 +6287,19 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "jest-get-type": {
           "version": "26.3.0",
-          "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-26.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-26.3.0.tgz",
           "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -6333,7 +6333,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.nlark.com/extend-shallow/download/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -6343,7 +6343,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.nlark.com/is-extendable/download/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -6354,7 +6354,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/extglob/download/extglob-2.0.4.tgz",
+      "resolved": "https://registry.nlark.com/extglob/download/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
@@ -6379,7 +6379,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -6388,7 +6388,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -6397,7 +6397,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -6425,7 +6425,7 @@
     },
     "fancy-log": {
       "version": "1.3.3",
-      "resolved": "https://registry.npm.taobao.org/fancy-log/download/fancy-log-1.3.3.tgz",
+      "resolved": "https://registry.nlark.com/fancy-log/download/fancy-log-1.3.3.tgz",
       "integrity": "sha1-28GRVPVYaQFQojlToK29A1vkX8c=",
       "dev": true,
       "requires": {
@@ -6508,7 +6508,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npm.taobao.org/fast-levenshtein/download/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.nlark.com/fast-levenshtein/download/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -6564,8 +6564,8 @@
     },
     "find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-3.0.0.tgz?cache=0&sync_timestamp=1597169872380&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffind-up%2Fdownload%2Ffind-up-3.0.0.tgz",
-      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
@@ -6653,7 +6653,7 @@
     },
     "for-own": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/for-own/download/for-own-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/for-own/download/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
@@ -6679,7 +6679,7 @@
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/fragment-cache/download/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.nlark.com/fragment-cache/download/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -6688,13 +6688,13 @@
     },
     "fs": {
       "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "resolved": "https://registry.npm.taobao.org/fs/download/fs-0.0.1-security.tgz",
       "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ=",
       "dev": true
     },
     "fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-7.0.1.tgz",
+      "resolved": "https://registry.nlark.com/fs-extra/download/fs-extra-7.0.1.tgz",
       "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "dev": true,
       "requires": {
@@ -6705,7 +6705,7 @@
     },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/fs-mkdirp-stream/download/fs-mkdirp-stream-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/fs-mkdirp-stream/download/fs-mkdirp-stream-1.0.0.tgz",
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "dev": true,
       "requires": {
@@ -6715,7 +6715,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/fs.realpath/download/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -7335,19 +7335,19 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/function-bind/download/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.nlark.com/function-bind/download/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/functional-red-black-tree/download/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.nlark.com/functional-red-black-tree/download/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npm.taobao.org/gensync/download/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://registry.nlark.com/gensync/download/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true
     },
@@ -7370,13 +7370,13 @@
     },
     "get-package-type": {
       "version": "0.1.0",
-      "resolved": "https://registry.npm.taobao.org/get-package-type/download/get-package-type-0.1.0.tgz",
+      "resolved": "https://registry.nlark.com/get-package-type/download/get-package-type-0.1.0.tgz",
       "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
       "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/get-stream/download/get-stream-4.1.0.tgz",
+      "resolved": "https://registry.nlark.com/get-stream/download/get-stream-4.1.0.tgz",
       "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "dev": true,
       "requires": {
@@ -7385,7 +7385,7 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://registry.npm.taobao.org/get-value/download/get-value-2.0.6.tgz",
+      "resolved": "https://registry.nlark.com/get-value/download/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
@@ -7434,7 +7434,7 @@
     },
     "glob-stream": {
       "version": "6.1.0",
-      "resolved": "https://registry.npm.taobao.org/glob-stream/download/glob-stream-6.1.0.tgz",
+      "resolved": "https://registry.nlark.com/glob-stream/download/glob-stream-6.1.0.tgz",
       "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
       "dev": true,
       "requires": {
@@ -7452,7 +7452,7 @@
       "dependencies": {
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/glob-parent/download/glob-parent-3.1.0.tgz?cache=0&sync_timestamp=1569108917227&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglob-parent%2Fdownload%2Fglob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/glob-parent/download/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -7462,7 +7462,7 @@
         },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/is-glob/download/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/is-glob/download/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -7487,7 +7487,7 @@
     },
     "global-modules": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/global-modules/download/global-modules-1.0.0.tgz?cache=0&sync_timestamp=1571657602039&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobal-modules%2Fdownload%2Fglobal-modules-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/global-modules/download/global-modules-1.0.0.tgz",
       "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
       "dev": true,
       "requires": {
@@ -7511,7 +7511,7 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npm.taobao.org/globals/download/globals-11.12.0.tgz",
+      "resolved": "https://registry.npmmirror.com/globals/download/globals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true
     },
@@ -7539,7 +7539,7 @@
     },
     "glogg": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/glogg/download/glogg-1.0.2.tgz",
+      "resolved": "https://registry.nlark.com/glogg/download/glogg-1.0.2.tgz",
       "integrity": "sha1-LX3XAr7aIus7/634gGltpthGMT8=",
       "dev": true,
       "requires": {
@@ -7554,7 +7554,7 @@
     },
     "growly": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/growly/download/growly-1.3.0.tgz",
+      "resolved": "https://registry.nlark.com/growly/download/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
@@ -7573,7 +7573,7 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/camelcase/download/camelcase-3.0.0.tgz?cache=0&sync_timestamp=1636945130104&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fcamelcase%2Fdownload%2Fcamelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
@@ -7605,7 +7605,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -7614,7 +7614,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstring-width%2Fdownload%2Fstring-width-1.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/string-width/download/string-width-1.0.2.tgz?cache=0&sync_timestamp=1632421309919&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fstring-width%2Fdownload%2Fstring-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -7663,7 +7663,7 @@
     },
     "gulplog": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/gulplog/download/gulplog-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/gulplog/download/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
@@ -7729,7 +7729,7 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/has/download/has-1.0.3.tgz",
+      "resolved": "https://registry.nlark.com/has/download/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
@@ -7744,7 +7744,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.nlark.com/has-flag/download/has-flag-3.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
@@ -7773,7 +7773,7 @@
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-value/download/has-value-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/has-value/download/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -7784,7 +7784,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-values/download/has-values-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/has-values/download/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -7832,7 +7832,7 @@
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/html-encoding-sniffer/download/html-encoding-sniffer-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/html-encoding-sniffer/download/html-encoding-sniffer-2.0.1.tgz",
       "integrity": "sha1-QqbcT9M/ACgRduiyN1nKTk+hhfM=",
       "dev": true,
       "requires": {
@@ -7841,13 +7841,13 @@
     },
     "html-escaper": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/html-escaper/download/html-escaper-2.0.2.tgz?cache=0&sync_timestamp=1613643585723&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtml-escaper%2Fdownload%2Fhtml-escaper-2.0.2.tgz",
+      "resolved": "https://registry.nlark.com/html-escaper/download/html-escaper-2.0.2.tgz",
       "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
       "dev": true
     },
     "http-proxy": {
       "version": "1.18.1",
-      "resolved": "https://registry.npm.taobao.org/http-proxy/download/http-proxy-1.18.1.tgz",
+      "resolved": "https://registry.nlark.com/http-proxy/download/http-proxy-1.18.1.tgz?cache=0&sync_timestamp=1618847045732&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhttp-proxy%2Fdownload%2Fhttp-proxy-1.18.1.tgz",
       "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
       "dev": true,
       "requires": {
@@ -7858,7 +7858,7 @@
     },
     "http-server": {
       "version": "0.12.3",
-      "resolved": "https://registry.npm.taobao.org/http-server/download/http-server-0.12.3.tgz",
+      "resolved": "https://registry.npmmirror.com/http-server/download/http-server-0.12.3.tgz?cache=0&sync_timestamp=1634685922991&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fhttp-server%2Fdownload%2Fhttp-server-0.12.3.tgz",
       "integrity": "sha1-ugRx0OzEJYhmFss1xPryeRQKDTc=",
       "dev": true,
       "requires": {
@@ -7887,13 +7887,13 @@
     },
     "human-signals": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/human-signals/download/human-signals-1.1.1.tgz",
+      "resolved": "https://registry.nlark.com/human-signals/download/human-signals-1.1.1.tgz?cache=0&sync_timestamp=1624364695595&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhuman-signals%2Fdownload%2Fhuman-signals-1.1.1.tgz",
       "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M=",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npm.taobao.org/iconv-lite/download/iconv-lite-0.4.24.tgz?cache=0&sync_timestamp=1579333981154&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ficonv-lite%2Fdownload%2Ficonv-lite-0.4.24.tgz",
+      "resolved": "https://registry.nlark.com/iconv-lite/download/iconv-lite-0.4.24.tgz?cache=0&sync_timestamp=1621826342262&other_urls=https%3A%2F%2Fregistry.nlark.com%2Ficonv-lite%2Fdownload%2Ficonv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dev": true,
       "requires": {
@@ -7928,7 +7928,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/imurmurhash/download/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.nlark.com/imurmurhash/download/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -7950,7 +7950,7 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz",
+      "resolved": "https://registry.nlark.com/inherits/download/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
@@ -7992,7 +7992,7 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://registry.npm.taobao.org/invariant/download/invariant-2.2.4.tgz",
+      "resolved": "https://registry.npm.taobao.org/invariant/download/invariant-2.2.4.tgz?cache=0&sync_timestamp=1615984365242&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finvariant%2Fdownload%2Finvariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "dev": true,
       "requires": {
@@ -8001,7 +8001,7 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/invert-kv/download/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/invert-kv/download/invert-kv-1.0.0.tgz?cache=0&sync_timestamp=1630996809231&other_urls=https%3A%2F%2Fregistry.nlark.com%2Finvert-kv%2Fdownload%2Finvert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
@@ -8017,7 +8017,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.nlark.com/is-accessor-descriptor/download/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -8052,7 +8052,7 @@
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/is-binary-path/download/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.nlark.com/is-binary-path/download/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -8094,7 +8094,7 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz?cache=0&sync_timestamp=1604432327227&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-buffer%2Fdownload%2Fis-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
@@ -8106,7 +8106,7 @@
     },
     "is-ci": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-ci/download/is-ci-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-ci/download/is-ci-2.0.0.tgz?cache=0&sync_timestamp=1635261061017&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fis-ci%2Fdownload%2Fis-ci-2.0.0.tgz",
       "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
       "dev": true,
       "requires": {
@@ -8124,7 +8124,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.nlark.com/is-data-descriptor/download/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -8179,7 +8179,7 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/is-extendable/download/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.nlark.com/is-extendable/download/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
@@ -8197,7 +8197,7 @@
     },
     "is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-generator-fn/download/is-generator-fn-2.1.0.tgz",
+      "resolved": "https://registry.nlark.com/is-generator-fn/download/is-generator-fn-2.1.0.tgz",
       "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true
     },
@@ -8212,13 +8212,13 @@
     },
     "is-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-module/download/is-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
     },
     "is-negated-glob": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-negated-glob/download/is-negated-glob-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/is-negated-glob/download/is-negated-glob-1.0.0.tgz",
       "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
       "dev": true
     },
@@ -8286,8 +8286,8 @@
     },
     "is-reference": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/is-reference/download/is-reference-1.2.1.tgz",
-      "integrity": "sha1-iy2sCzcfS8mU/eq6nrVC0DAC0Lc=",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
       "dev": true,
       "requires": {
         "@types/estree": "*"
@@ -8337,7 +8337,7 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/is-stream/download/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
@@ -8369,7 +8369,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/is-typedarray/download/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
@@ -8396,13 +8396,13 @@
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/is-windows/download/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.nlark.com/is-windows/download/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "is-wsl": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/is-wsl/download/is-wsl-2.2.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/is-wsl/download/is-wsl-2.2.0.tgz?cache=0&sync_timestamp=1592843177178&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-wsl%2Fdownload%2Fis-wsl-2.2.0.tgz",
       "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
       "dev": true,
       "optional": true,
@@ -8412,19 +8412,19 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.nlark.com/isexe/download/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/isobject/download/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
@@ -8442,7 +8442,7 @@
     },
     "istanbul-lib-instrument": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/istanbul-lib-instrument/download/istanbul-lib-instrument-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/istanbul-lib-instrument/download/istanbul-lib-instrument-4.0.3.tgz",
       "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
       "dev": true,
       "requires": {
@@ -8462,7 +8462,7 @@
     },
     "istanbul-lib-report": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/istanbul-lib-report/download/istanbul-lib-report-3.0.0.tgz",
+      "resolved": "https://registry.nlark.com/istanbul-lib-report/download/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha1-dRj+UupE3jcvRgp2tezan/tz2KY=",
       "dev": true,
       "requires": {
@@ -8473,13 +8473,13 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -8519,7 +8519,7 @@
     },
     "jest": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/jest/download/jest-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/jest/download/jest-26.6.3.tgz",
       "integrity": "sha1-QOj9vkjwDfofDOgSHKdLiKyRSO8=",
       "dev": true,
       "requires": {
@@ -8530,7 +8530,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -8567,7 +8567,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -8586,7 +8586,7 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-6.0.0.tgz",
+          "resolved": "https://registry.nlark.com/cliui/download/cliui-6.0.0.tgz",
           "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
           "dev": true,
           "requires": {
@@ -8597,7 +8597,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -8618,7 +8618,7 @@
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/find-up/download/find-up-4.1.0.tgz?cache=0&sync_timestamp=1633620747957&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Ffind-up%2Fdownload%2Ffind-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
@@ -8640,7 +8640,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -8652,7 +8652,7 @@
         },
         "jest-cli": {
           "version": "26.6.3",
-          "resolved": "https://registry.npm.taobao.org/jest-cli/download/jest-cli-26.6.3.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-cli/download/jest-cli-26.6.3.tgz",
           "integrity": "sha1-QxF8/vJLxM1pGhdKh5alMuE16So=",
           "dev": true,
           "requires": {
@@ -8673,7 +8673,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.nlark.com/locate-path/download/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
@@ -8682,7 +8682,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.nlark.com/p-locate/download/p-locate-4.1.0.tgz?cache=0&sync_timestamp=1629892721671&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fp-locate%2Fdownload%2Fp-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
@@ -8691,7 +8691,7 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/path-exists/download/path-exists-4.0.0.tgz",
           "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         },
@@ -8723,7 +8723,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -8738,7 +8738,7 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-6.2.0.tgz",
+          "resolved": "https://registry.nlark.com/wrap-ansi/download/wrap-ansi-6.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fwrap-ansi%2Fdownload%2Fwrap-ansi-6.2.0.tgz",
           "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
           "dev": true,
           "requires": {
@@ -8755,7 +8755,7 @@
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1616790495164&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
+          "resolved": "https://registry.npmmirror.com/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1632605487521&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
           "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
           "dev": true,
           "requires": {
@@ -8776,7 +8776,7 @@
     },
     "jest-changed-files": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-changed-files/download/jest-changed-files-26.6.2.tgz?cache=0&sync_timestamp=1615211268885&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-changed-files%2Fdownload%2Fjest-changed-files-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-changed-files/download/jest-changed-files-26.6.2.tgz",
       "integrity": "sha1-9hmEeeHMZvIvmuHiKsqgtCnAQtA=",
       "dev": true,
       "requires": {
@@ -8787,7 +8787,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -8818,7 +8818,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -8837,7 +8837,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -8863,7 +8863,7 @@
         },
         "execa": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/execa/download/execa-4.1.0.tgz?cache=0&sync_timestamp=1606970975645&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/execa/download/execa-4.1.0.tgz?cache=0&sync_timestamp=1637147207309&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fexeca%2Fdownload%2Fexeca-4.1.0.tgz",
           "integrity": "sha1-TlSRrRVy8vF6d9OIxshXE1sihHo=",
           "dev": true,
           "requires": {
@@ -8880,7 +8880,7 @@
         },
         "get-stream": {
           "version": "5.2.0",
-          "resolved": "https://registry.npm.taobao.org/get-stream/download/get-stream-5.2.0.tgz",
+          "resolved": "https://registry.nlark.com/get-stream/download/get-stream-5.2.0.tgz",
           "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
           "dev": true,
           "requires": {
@@ -8889,7 +8889,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -8901,7 +8901,7 @@
         },
         "npm-run-path": {
           "version": "4.0.1",
-          "resolved": "https://registry.npm.taobao.org/npm-run-path/download/npm-run-path-4.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/npm-run-path/download/npm-run-path-4.0.1.tgz?cache=0&sync_timestamp=1633420566316&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fnpm-run-path%2Fdownload%2Fnpm-run-path-4.0.1.tgz",
           "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
           "dev": true,
           "requires": {
@@ -8931,7 +8931,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -8951,7 +8951,7 @@
     },
     "jest-config": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/jest-config/download/jest-config-26.6.3.tgz?cache=0&sync_timestamp=1616701589957&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-config%2Fdownload%2Fjest-config-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-config/download/jest-config-26.6.3.tgz",
       "integrity": "sha1-ZPQURO756wPcUdXFO3XIxx9kU0k=",
       "dev": true,
       "requires": {
@@ -8977,7 +8977,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -9014,7 +9014,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -9042,7 +9042,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -9072,7 +9072,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -9084,7 +9084,7 @@
         },
         "jest-get-type": {
           "version": "26.3.0",
-          "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-26.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-26.3.0.tgz",
           "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=",
           "dev": true
         },
@@ -9100,7 +9100,7 @@
         },
         "pretty-format": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-26.6.2.tgz?cache=0&sync_timestamp=1616701219088&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-format%2Fdownload%2Fpretty-format-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-26.6.2.tgz",
           "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
           "dev": true,
           "requires": {
@@ -9112,13 +9112,13 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -9138,7 +9138,7 @@
     },
     "jest-diff": {
       "version": "24.9.0",
-      "resolved": "https://registry.npm.taobao.org/jest-diff/download/jest-diff-24.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-diff/download/jest-diff-24.9.0.tgz",
       "integrity": "sha1-kxt9DVd4obr3RSy4FuMl43JAVdo=",
       "dev": true,
       "requires": {
@@ -9150,7 +9150,7 @@
     },
     "jest-docblock": {
       "version": "26.0.0",
-      "resolved": "https://registry.npm.taobao.org/jest-docblock/download/jest-docblock-26.0.0.tgz?cache=0&sync_timestamp=1607352761462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-docblock%2Fdownload%2Fjest-docblock-26.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-docblock/download/jest-docblock-26.0.0.tgz",
       "integrity": "sha1-Pi+iCJn8koyxO9D/aL03EaNoibU=",
       "dev": true,
       "requires": {
@@ -9159,7 +9159,7 @@
     },
     "jest-each": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-each/download/jest-each-26.6.2.tgz?cache=0&sync_timestamp=1616701584361&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-each%2Fdownload%2Fjest-each-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-each/download/jest-each-26.6.2.tgz",
       "integrity": "sha1-AlJkOKd6Z0AcimOC3+WZmVLBZ8s=",
       "dev": true,
       "requires": {
@@ -9172,7 +9172,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -9209,7 +9209,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -9228,7 +9228,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -9243,19 +9243,19 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "jest-get-type": {
           "version": "26.3.0",
-          "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-26.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-26.3.0.tgz",
           "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=",
           "dev": true
         },
         "pretty-format": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-26.6.2.tgz?cache=0&sync_timestamp=1616701219088&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-format%2Fdownload%2Fpretty-format-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-26.6.2.tgz",
           "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
           "dev": true,
           "requires": {
@@ -9267,13 +9267,13 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -9284,7 +9284,7 @@
     },
     "jest-environment-jsdom": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-environment-jsdom/download/jest-environment-jsdom-26.6.2.tgz?cache=0&sync_timestamp=1616701587256&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-environment-jsdom%2Fdownload%2Fjest-environment-jsdom-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-environment-jsdom/download/jest-environment-jsdom-26.6.2.tgz",
       "integrity": "sha1-eNCf6c8BmjVwCbm34fEB0jvR2j4=",
       "dev": true,
       "requires": {
@@ -9299,7 +9299,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -9330,7 +9330,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -9349,7 +9349,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -9364,13 +9364,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -9381,7 +9381,7 @@
     },
     "jest-environment-node": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-environment-node/download/jest-environment-node-26.6.2.tgz?cache=0&sync_timestamp=1616701587707&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-environment-node%2Fdownload%2Fjest-environment-node-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-environment-node/download/jest-environment-node-26.6.2.tgz",
       "integrity": "sha1-gk5Mf7SURkY1bxGsdbIpsANfKww=",
       "dev": true,
       "requires": {
@@ -9395,7 +9395,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -9426,7 +9426,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -9445,7 +9445,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -9460,13 +9460,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -9502,7 +9502,7 @@
         },
         "@types/istanbul-reports": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmmirror.com/@types/istanbul-reports/download/@types/istanbul-reports-3.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/@types/istanbul-reports/download/@types/istanbul-reports-3.0.1.tgz?cache=0&sync_timestamp=1637266160892&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fistanbul-reports%2Fdownload%2F%40types%2Fistanbul-reports-3.0.1.tgz",
           "integrity": "sha1-kVP+mLuivVZaY63ZQ21vDX+EaP8=",
           "dev": true,
           "requires": {
@@ -9511,7 +9511,7 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
-          "resolved": "https://registry.npmmirror.com/@types/yargs/download/@types/yargs-16.0.4.tgz",
+          "resolved": "https://registry.npmmirror.com/@types/yargs/download/@types/yargs-16.0.4.tgz?cache=0&sync_timestamp=1637271118840&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fyargs%2Fdownload%2F%40types%2Fyargs-16.0.4.tgz",
           "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
           "dev": true,
           "requires": {
@@ -9526,7 +9526,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1618995588464&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -9535,7 +9535,7 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.nlark.com/chalk/download/chalk-4.1.2.tgz?cache=0&sync_timestamp=1627646655305&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fchalk%2Fdownload%2Fchalk-4.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/chalk/download/chalk-4.1.2.tgz",
           "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
           "dev": true,
           "requires": {
@@ -9614,7 +9614,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "5.2.0",
-              "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-5.2.0.tgz?cache=0&sync_timestamp=1618995588464&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fansi-styles%2Fdownload%2Fansi-styles-5.2.0.tgz",
+              "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-5.2.0.tgz",
               "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
               "dev": true
             }
@@ -9622,7 +9622,7 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz?cache=0&sync_timestamp=1637338596901&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Freact-is%2Fdownload%2Freact-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
@@ -9639,13 +9639,13 @@
     },
     "jest-get-type": {
       "version": "24.9.0",
-      "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-24.9.0.tgz?cache=0&sync_timestamp=1579655144842&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-get-type%2Fdownload%2Fjest-get-type-24.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-24.9.0.tgz",
       "integrity": "sha1-FoSgyKUPLkkBtmRK6GH1ee7S7w4=",
       "dev": true
     },
     "jest-haste-map": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-haste-map/download/jest-haste-map-26.6.2.tgz?cache=0&sync_timestamp=1616701583207&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-haste-map%2Fdownload%2Fjest-haste-map-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-haste-map/download/jest-haste-map-26.6.2.tgz",
       "integrity": "sha1-3X5g/n3A6fkRoj15xf9/tcLK/qo=",
       "dev": true,
       "requires": {
@@ -9667,7 +9667,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -9698,7 +9698,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -9736,7 +9736,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -9773,7 +9773,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -9801,7 +9801,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -9821,7 +9821,7 @@
     },
     "jest-jasmine2": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/jest-jasmine2/download/jest-jasmine2-26.6.3.tgz?cache=0&sync_timestamp=1616701588911&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-jasmine2%2Fdownload%2Fjest-jasmine2-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-jasmine2/download/jest-jasmine2-26.6.3.tgz",
       "integrity": "sha1-rcPPkV3qy1ISyTufNUfNEpWPLt0=",
       "dev": true,
       "requires": {
@@ -9847,7 +9847,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -9884,7 +9884,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -9903,7 +9903,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -9918,13 +9918,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "pretty-format": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-26.6.2.tgz?cache=0&sync_timestamp=1616701219088&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-format%2Fdownload%2Fpretty-format-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-26.6.2.tgz",
           "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
           "dev": true,
           "requires": {
@@ -9936,13 +9936,13 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -9953,7 +9953,7 @@
     },
     "jest-leak-detector": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-leak-detector/download/jest-leak-detector-26.6.2.tgz?cache=0&sync_timestamp=1616701584570&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-leak-detector%2Fdownload%2Fjest-leak-detector-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-leak-detector/download/jest-leak-detector-26.6.2.tgz",
       "integrity": "sha1-dxfPEYuSI48uumUFTIoMnGU6ka8=",
       "dev": true,
       "requires": {
@@ -9963,7 +9963,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -10000,7 +10000,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -10019,7 +10019,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -10034,19 +10034,19 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "jest-get-type": {
           "version": "26.3.0",
-          "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-26.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-26.3.0.tgz",
           "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=",
           "dev": true
         },
         "pretty-format": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-26.6.2.tgz?cache=0&sync_timestamp=1616701219088&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-format%2Fdownload%2Fpretty-format-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-26.6.2.tgz",
           "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
           "dev": true,
           "requires": {
@@ -10058,13 +10058,13 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -10075,7 +10075,7 @@
     },
     "jest-matcher-deep-close-to": {
       "version": "2.0.1",
-      "resolved": "https://registry.nlark.com/jest-matcher-deep-close-to/download/jest-matcher-deep-close-to-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-matcher-deep-close-to/download/jest-matcher-deep-close-to-2.0.1.tgz",
       "integrity": "sha1-L50NpE94oWo5BNGJguOV6Y43XFo=",
       "dev": true,
       "requires": {
@@ -10084,7 +10084,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "25.5.0",
-          "resolved": "https://registry.nlark.com/@jest/types/download/@jest/types-25.5.0.tgz?cache=0&sync_timestamp=1624900057884&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40jest%2Ftypes%2Fdownload%2F%40jest%2Ftypes-25.5.0.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-25.5.0.tgz",
           "integrity": "sha1-TWpHk/e5WZ/DaAh3uFapfbzPKp0=",
           "dev": true,
           "requires": {
@@ -10096,7 +10096,7 @@
         },
         "@types/yargs": {
           "version": "15.0.14",
-          "resolved": "https://registry.nlark.com/@types/yargs/download/@types/yargs-15.0.14.tgz",
+          "resolved": "https://registry.npmmirror.com/@types/yargs/download/@types/yargs-15.0.14.tgz?cache=0&sync_timestamp=1637271118840&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fyargs%2Fdownload%2F%40types%2Fyargs-15.0.14.tgz",
           "integrity": "sha1-Jtgh3biecEkhYLZtEKDrbfj2+wY=",
           "dev": true,
           "requires": {
@@ -10120,7 +10120,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "https://registry.nlark.com/chalk/download/chalk-3.0.0.tgz?cache=0&sync_timestamp=1618995367379&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fchalk%2Fdownload%2Fchalk-3.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/chalk/download/chalk-3.0.0.tgz",
           "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "dev": true,
           "requires": {
@@ -10130,7 +10130,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -10145,7 +10145,7 @@
         },
         "diff-sequences": {
           "version": "25.2.6",
-          "resolved": "https://registry.nlark.com/diff-sequences/download/diff-sequences-25.2.6.tgz?cache=0&sync_timestamp=1624900057366&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fdiff-sequences%2Fdownload%2Fdiff-sequences-25.2.6.tgz",
+          "resolved": "https://registry.npmmirror.com/diff-sequences/download/diff-sequences-25.2.6.tgz",
           "integrity": "sha1-X0Z8AO3TU1K3vKRteSfWDmh6dt0=",
           "dev": true
         },
@@ -10157,7 +10157,7 @@
         },
         "jest-diff": {
           "version": "25.5.0",
-          "resolved": "https://registry.nlark.com/jest-diff/download/jest-diff-25.5.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-diff/download/jest-diff-25.5.0.tgz",
           "integrity": "sha1-HdJu1k+WZnwGjO8Ca2d9+gGvz6k=",
           "dev": true,
           "requires": {
@@ -10169,13 +10169,13 @@
         },
         "jest-get-type": {
           "version": "25.2.6",
-          "resolved": "https://registry.nlark.com/jest-get-type/download/jest-get-type-25.2.6.tgz?cache=0&sync_timestamp=1624900056951&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fjest-get-type%2Fdownload%2Fjest-get-type-25.2.6.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-25.2.6.tgz",
           "integrity": "sha1-Cwoy+riQi0TVCL6BaBSH26u42Hc=",
           "dev": true
         },
         "jest-matcher-utils": {
           "version": "25.4.0",
-          "resolved": "https://registry.nlark.com/jest-matcher-utils/download/jest-matcher-utils-25.4.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-matcher-utils/download/jest-matcher-utils-25.4.0.tgz",
           "integrity": "sha1-3D567EAqHlZ+2AtXK5rShYeIleY=",
           "dev": true,
           "requires": {
@@ -10187,7 +10187,7 @@
         },
         "pretty-format": {
           "version": "25.5.0",
-          "resolved": "https://registry.nlark.com/pretty-format/download/pretty-format-25.5.0.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-25.5.0.tgz",
           "integrity": "sha1-eHPB13T2gsNLjUi2dDor8qxVeRo=",
           "dev": true,
           "requires": {
@@ -10199,7 +10199,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.nlark.com/supports-color/download/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -10210,7 +10210,7 @@
     },
     "jest-matcher-utils": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-matcher-utils/download/jest-matcher-utils-26.6.2.tgz?cache=0&sync_timestamp=1616701585427&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-matcher-utils%2Fdownload%2Fjest-matcher-utils-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-matcher-utils/download/jest-matcher-utils-26.6.2.tgz",
       "integrity": "sha1-jm/W6GPIstMaxkcu6yN7xZXlPno=",
       "dev": true,
       "requires": {
@@ -10222,7 +10222,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -10259,7 +10259,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -10278,7 +10278,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -10293,19 +10293,19 @@
         },
         "diff-sequences": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/diff-sequences/download/diff-sequences-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/diff-sequences/download/diff-sequences-26.6.2.tgz",
           "integrity": "sha1-SLqZFX3hkjQS7tQdtrbUqpynwLE=",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "jest-diff": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/jest-diff/download/jest-diff-26.6.2.tgz?cache=0&sync_timestamp=1616701585219&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-diff%2Fdownload%2Fjest-diff-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-diff/download/jest-diff-26.6.2.tgz",
           "integrity": "sha1-GqdGi1LDpo19XF/c381eSb0WQ5Q=",
           "dev": true,
           "requires": {
@@ -10317,13 +10317,13 @@
         },
         "jest-get-type": {
           "version": "26.3.0",
-          "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-26.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-26.3.0.tgz",
           "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=",
           "dev": true
         },
         "pretty-format": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-26.6.2.tgz?cache=0&sync_timestamp=1616701219088&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-format%2Fdownload%2Fpretty-format-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-26.6.2.tgz",
           "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
           "dev": true,
           "requires": {
@@ -10335,13 +10335,13 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -10352,7 +10352,7 @@
     },
     "jest-message-util": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-message-util/download/jest-message-util-26.6.2.tgz?cache=0&sync_timestamp=1616701584149&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-message-util%2Fdownload%2Fjest-message-util-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-message-util/download/jest-message-util-26.6.2.tgz",
       "integrity": "sha1-WBc3RK1vwFBrXSEVC5vlbvABygc=",
       "dev": true,
       "requires": {
@@ -10369,7 +10369,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -10406,7 +10406,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -10434,7 +10434,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -10464,7 +10464,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -10486,7 +10486,7 @@
         },
         "pretty-format": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-26.6.2.tgz?cache=0&sync_timestamp=1616701219088&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-format%2Fdownload%2Fpretty-format-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-26.6.2.tgz",
           "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
           "dev": true,
           "requires": {
@@ -10498,13 +10498,13 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -10524,7 +10524,7 @@
     },
     "jest-mock": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-mock/download/jest-mock-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-mock/download/jest-mock-26.6.2.tgz",
       "integrity": "sha1-1stxKwQe1H/g2bb8NHS8ZUP+swI=",
       "dev": true,
       "requires": {
@@ -10534,7 +10534,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -10565,7 +10565,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -10584,7 +10584,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -10599,13 +10599,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -10616,19 +10616,19 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
-      "resolved": "https://registry.npm.taobao.org/jest-pnp-resolver/download/jest-pnp-resolver-1.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-pnp-resolver/download/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha1-twSsCuAoqJEIpNBAs/kZ393I4zw=",
       "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
-      "resolved": "https://registry.npm.taobao.org/jest-regex-util/download/jest-regex-util-26.0.0.tgz?cache=0&sync_timestamp=1607352728942&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-regex-util%2Fdownload%2Fjest-regex-util-26.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-regex-util/download/jest-regex-util-26.0.0.tgz",
       "integrity": "sha1-0l5xhLNuOf1GbDvEG+CXHoIf7ig=",
       "dev": true
     },
     "jest-resolve": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-resolve/download/jest-resolve-26.6.2.tgz?cache=0&sync_timestamp=1616701583467&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-resolve%2Fdownload%2Fjest-resolve-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-resolve/download/jest-resolve-26.6.2.tgz",
       "integrity": "sha1-o6sVFyF/RptQTxtWYDxbtUH7tQc=",
       "dev": true,
       "requires": {
@@ -10644,7 +10644,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -10675,7 +10675,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -10694,7 +10694,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -10709,7 +10709,7 @@
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/find-up/download/find-up-4.1.0.tgz?cache=0&sync_timestamp=1633620747957&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Ffind-up%2Fdownload%2Ffind-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
@@ -10725,7 +10725,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -10740,7 +10740,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.nlark.com/locate-path/download/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
@@ -10749,7 +10749,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.nlark.com/p-locate/download/p-locate-4.1.0.tgz?cache=0&sync_timestamp=1629892721671&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fp-locate%2Fdownload%2Fp-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
@@ -10758,7 +10758,7 @@
         },
         "parse-json": {
           "version": "5.2.0",
-          "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-5.2.0.tgz?cache=0&sync_timestamp=1610966646988&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse-json%2Fdownload%2Fparse-json-5.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/parse-json/download/parse-json-5.2.0.tgz?cache=0&sync_timestamp=1637475717072&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fparse-json%2Fdownload%2Fparse-json-5.2.0.tgz",
           "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
           "dev": true,
           "requires": {
@@ -10770,13 +10770,13 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/path-exists/download/path-exists-4.0.0.tgz",
           "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         },
         "read-pkg": {
           "version": "5.2.0",
-          "resolved": "https://registry.npm.taobao.org/read-pkg/download/read-pkg-5.2.0.tgz",
+          "resolved": "https://registry.nlark.com/read-pkg/download/read-pkg-5.2.0.tgz",
           "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
           "dev": true,
           "requires": {
@@ -10788,7 +10788,7 @@
           "dependencies": {
             "type-fest": {
               "version": "0.6.0",
-              "resolved": "https://registry.npm.taobao.org/type-fest/download/type-fest-0.6.0.tgz?cache=0&sync_timestamp=1616514381586&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftype-fest%2Fdownload%2Ftype-fest-0.6.0.tgz",
+              "resolved": "https://registry.npmmirror.com/type-fest/download/type-fest-0.6.0.tgz",
               "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
               "dev": true
             }
@@ -10796,7 +10796,7 @@
         },
         "read-pkg-up": {
           "version": "7.0.1",
-          "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-7.0.1.tgz?cache=0&sync_timestamp=1609905367026&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fread-pkg-up%2Fdownload%2Fread-pkg-up-7.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/read-pkg-up/download/read-pkg-up-7.0.1.tgz",
           "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
           "dev": true,
           "requires": {
@@ -10817,7 +10817,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -10828,7 +10828,7 @@
     },
     "jest-resolve-dependencies": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/jest-resolve-dependencies/download/jest-resolve-dependencies-26.6.3.tgz?cache=0&sync_timestamp=1616701588284&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-resolve-dependencies%2Fdownload%2Fjest-resolve-dependencies-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-resolve-dependencies/download/jest-resolve-dependencies-26.6.3.tgz",
       "integrity": "sha1-ZoCFnuXSLuXc2WH+SHH1n0x4T7Y=",
       "dev": true,
       "requires": {
@@ -10839,7 +10839,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -10870,7 +10870,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -10889,7 +10889,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -10904,13 +10904,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -10921,7 +10921,7 @@
     },
     "jest-runner": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/jest-runner/download/jest-runner-26.6.3.tgz?cache=0&sync_timestamp=1616701589442&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-runner%2Fdownload%2Fjest-runner-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-runner/download/jest-runner-26.6.3.tgz",
       "integrity": "sha1-LR/tPUbhDyM/0dvTv6o/6JJL4Vk=",
       "dev": true,
       "requires": {
@@ -10949,7 +10949,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -10980,7 +10980,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -10999,7 +10999,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -11020,13 +11020,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -11037,7 +11037,7 @@
     },
     "jest-runtime": {
       "version": "26.6.3",
-      "resolved": "https://registry.npm.taobao.org/jest-runtime/download/jest-runtime-26.6.3.tgz?cache=0&sync_timestamp=1616701588589&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-runtime%2Fdownload%2Fjest-runtime-26.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-runtime/download/jest-runtime-26.6.3.tgz",
       "integrity": "sha1-T2TvvPrDmDMbdLSzyC0n1AG4+is=",
       "dev": true,
       "requires": {
@@ -11072,7 +11072,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -11109,7 +11109,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -11128,7 +11128,7 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-6.0.0.tgz",
+          "resolved": "https://registry.nlark.com/cliui/download/cliui-6.0.0.tgz",
           "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
           "dev": true,
           "requires": {
@@ -11139,7 +11139,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -11160,7 +11160,7 @@
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/find-up/download/find-up-4.1.0.tgz?cache=0&sync_timestamp=1633620747957&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Ffind-up%2Fdownload%2Ffind-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
@@ -11182,7 +11182,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -11194,7 +11194,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.nlark.com/locate-path/download/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
@@ -11203,7 +11203,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.nlark.com/p-locate/download/p-locate-4.1.0.tgz?cache=0&sync_timestamp=1629892721671&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fp-locate%2Fdownload%2Fp-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
@@ -11212,7 +11212,7 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/path-exists/download/path-exists-4.0.0.tgz",
           "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         },
@@ -11244,13 +11244,13 @@
         },
         "strip-bom": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-bom/download/strip-bom-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/strip-bom/download/strip-bom-4.0.0.tgz",
           "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -11265,7 +11265,7 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-6.2.0.tgz",
+          "resolved": "https://registry.nlark.com/wrap-ansi/download/wrap-ansi-6.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fwrap-ansi%2Fdownload%2Fwrap-ansi-6.2.0.tgz",
           "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
           "dev": true,
           "requires": {
@@ -11282,7 +11282,7 @@
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1616790495164&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
+          "resolved": "https://registry.npmmirror.com/yargs/download/yargs-15.4.1.tgz?cache=0&sync_timestamp=1632605487521&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fyargs%2Fdownload%2Fyargs-15.4.1.tgz",
           "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
           "dev": true,
           "requires": {
@@ -11303,7 +11303,7 @@
     },
     "jest-serializer": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-serializer/download/jest-serializer-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-serializer/download/jest-serializer-26.6.2.tgz",
       "integrity": "sha1-0Tmq/UaVfTpEjzps2r4pGboHQtE=",
       "dev": true,
       "requires": {
@@ -11321,7 +11321,7 @@
     },
     "jest-snapshot": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-snapshot/download/jest-snapshot-26.6.2.tgz?cache=0&sync_timestamp=1616701588021&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-snapshot%2Fdownload%2Fjest-snapshot-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-snapshot/download/jest-snapshot-26.6.2.tgz",
       "integrity": "sha1-87CvGssiMxaFC9FOG+6pg3+znIQ=",
       "dev": true,
       "requires": {
@@ -11345,7 +11345,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -11382,7 +11382,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -11401,7 +11401,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -11416,7 +11416,7 @@
         },
         "diff-sequences": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/diff-sequences/download/diff-sequences-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/diff-sequences/download/diff-sequences-26.6.2.tgz",
           "integrity": "sha1-SLqZFX3hkjQS7tQdtrbUqpynwLE=",
           "dev": true
         },
@@ -11428,13 +11428,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "jest-diff": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/jest-diff/download/jest-diff-26.6.2.tgz?cache=0&sync_timestamp=1616701585219&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-diff%2Fdownload%2Fjest-diff-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-diff/download/jest-diff-26.6.2.tgz",
           "integrity": "sha1-GqdGi1LDpo19XF/c381eSb0WQ5Q=",
           "dev": true,
           "requires": {
@@ -11446,13 +11446,13 @@
         },
         "jest-get-type": {
           "version": "26.3.0",
-          "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-26.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-26.3.0.tgz",
           "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=",
           "dev": true
         },
         "pretty-format": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-26.6.2.tgz?cache=0&sync_timestamp=1616701219088&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-format%2Fdownload%2Fpretty-format-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-26.6.2.tgz",
           "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
           "dev": true,
           "requires": {
@@ -11464,13 +11464,13 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-7.3.5.tgz?cache=0&sync_timestamp=1616463603361&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-7.3.5.tgz",
+          "resolved": "https://registry.nlark.com/semver/download/semver-7.3.5.tgz?cache=0&sync_timestamp=1618846864940&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fsemver%2Fdownload%2Fsemver-7.3.5.tgz",
           "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
@@ -11479,7 +11479,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -11490,7 +11490,7 @@
     },
     "jest-util": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-util/download/jest-util-26.6.2.tgz?cache=0&sync_timestamp=1616701582882&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-util%2Fdownload%2Fjest-util-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-util/download/jest-util-26.6.2.tgz",
       "integrity": "sha1-kHU12+TVpstMR6ybkm9q8pV2y8E=",
       "dev": true,
       "requires": {
@@ -11504,7 +11504,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -11535,7 +11535,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -11563,7 +11563,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -11593,7 +11593,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -11615,7 +11615,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -11635,7 +11635,7 @@
     },
     "jest-validate": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-validate/download/jest-validate-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-validate/download/jest-validate-26.6.2.tgz",
       "integrity": "sha1-I9OAlxWHFQRnNCkRw9e0rFerIOw=",
       "dev": true,
       "requires": {
@@ -11649,7 +11649,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -11686,7 +11686,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -11711,7 +11711,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -11726,19 +11726,19 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "jest-get-type": {
           "version": "26.3.0",
-          "resolved": "https://registry.npm.taobao.org/jest-get-type/download/jest-get-type-26.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/jest-get-type/download/jest-get-type-26.3.0.tgz",
           "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=",
           "dev": true
         },
         "pretty-format": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-26.6.2.tgz?cache=0&sync_timestamp=1616701219088&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-format%2Fdownload%2Fpretty-format-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-26.6.2.tgz",
           "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
           "dev": true,
           "requires": {
@@ -11750,13 +11750,13 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-17.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
           "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -11767,7 +11767,7 @@
     },
     "jest-watcher": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-watcher/download/jest-watcher-26.6.2.tgz?cache=0&sync_timestamp=1616701587020&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-watcher%2Fdownload%2Fjest-watcher-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-watcher/download/jest-watcher-26.6.2.tgz",
       "integrity": "sha1-pbaDuPnWjbyx19rjIXLSzKBZKXU=",
       "dev": true,
       "requires": {
@@ -11782,7 +11782,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "26.6.2",
-          "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-26.6.2.tgz",
+          "resolved": "https://registry.npmmirror.com/@jest/types/download/@jest/types-26.6.2.tgz",
           "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
           "dev": true,
           "requires": {
@@ -11813,7 +11813,7 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz?cache=0&sync_timestamp=1611327117754&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -11832,7 +11832,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -11847,13 +11847,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -11864,7 +11864,7 @@
     },
     "jest-worker": {
       "version": "26.6.2",
-      "resolved": "https://registry.npm.taobao.org/jest-worker/download/jest-worker-26.6.2.tgz?cache=0&sync_timestamp=1616701360211&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjest-worker%2Fdownload%2Fjest-worker-26.6.2.tgz",
+      "resolved": "https://registry.npmmirror.com/jest-worker/download/jest-worker-26.6.2.tgz",
       "integrity": "sha1-f3LLxNZDw2Xie5/XdfnQ6qnHqO0=",
       "dev": true,
       "requires": {
@@ -11875,13 +11875,13 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -11898,7 +11898,7 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/js-tokens/download/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.nlark.com/js-tokens/download/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
@@ -11962,7 +11962,7 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://registry.npm.taobao.org/jsesc/download/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.nlark.com/jsesc/download/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
@@ -11974,7 +11974,7 @@
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npm.taobao.org/json-parse-even-better-errors/download/json-parse-even-better-errors-2.3.1.tgz",
+      "resolved": "https://registry.nlark.com/json-parse-even-better-errors/download/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
       "dev": true
     },
@@ -11986,13 +11986,13 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.nlark.com/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/json-stable-stringify-without-jsonify/download/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.nlark.com/json-stable-stringify-without-jsonify/download/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
@@ -12013,7 +12013,7 @@
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/jsonfile/download/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.nlark.com/jsonfile/download/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
@@ -12046,13 +12046,13 @@
     },
     "kleur": {
       "version": "3.0.3",
-      "resolved": "https://registry.npm.taobao.org/kleur/download/kleur-3.0.3.tgz",
+      "resolved": "https://registry.nlark.com/kleur/download/kleur-3.0.3.tgz",
       "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true
     },
     "last-run": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/last-run/download/last-run-1.1.1.tgz",
+      "resolved": "https://registry.nlark.com/last-run/download/last-run-1.1.1.tgz",
       "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
       "dev": true,
       "requires": {
@@ -12071,7 +12071,7 @@
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/lcid/download/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lcid/download/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -12089,7 +12089,7 @@
     },
     "leven": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/leven/download/leven-3.1.0.tgz",
+      "resolved": "https://registry.nlark.com/leven/download/leven-3.1.0.tgz?cache=0&sync_timestamp=1628597922950&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fleven%2Fdownload%2Fleven-3.1.0.tgz",
       "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true
     },
@@ -12136,7 +12136,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/load-json-file/download/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/load-json-file/download/load-json-file-1.1.0.tgz?cache=0&sync_timestamp=1631508607226&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fload-json-file%2Fdownload%2Fload-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -12149,8 +12149,8 @@
     },
     "locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-3.0.0.tgz",
-      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
@@ -12177,13 +12177,13 @@
     },
     "lodash.truncate": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/lodash.truncate/download/lodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/loose-envify/download/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.nlark.com/loose-envify/download/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "requires": {
@@ -12192,7 +12192,7 @@
     },
     "lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-6.0.0.tgz",
+      "resolved": "https://registry.nlark.com/lru-cache/download/lru-cache-6.0.0.tgz",
       "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
       "dev": true,
       "requires": {
@@ -12207,8 +12207,8 @@
     },
     "magic-string": {
       "version": "0.25.7",
-      "resolved": "https://registry.npm.taobao.org/magic-string/download/magic-string-0.25.7.tgz?cache=0&sync_timestamp=1583500518436&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmagic-string%2Fdownload%2Fmagic-string-0.25.7.tgz",
-      "integrity": "sha1-P0l9b9NMZpxnmNy4IfLvMfVEUFE=",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
       "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
@@ -12233,7 +12233,7 @@
     },
     "make-error": {
       "version": "1.3.6",
-      "resolved": "https://registry.npm.taobao.org/make-error/download/make-error-1.3.6.tgz?cache=0&sync_timestamp=1582105630664&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmake-error%2Fdownload%2Fmake-error-1.3.6.tgz",
+      "resolved": "https://registry.nlark.com/make-error/download/make-error-1.3.6.tgz",
       "integrity": "sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=",
       "dev": true
     },
@@ -12257,7 +12257,7 @@
     },
     "map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "https://registry.npm.taobao.org/map-age-cleaner/download/map-age-cleaner-0.1.3.tgz",
+      "resolved": "https://registry.nlark.com/map-age-cleaner/download/map-age-cleaner-0.1.3.tgz?cache=0&sync_timestamp=1629750856019&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fmap-age-cleaner%2Fdownload%2Fmap-age-cleaner-0.1.3.tgz",
       "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "dev": true,
       "requires": {
@@ -12266,13 +12266,13 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/map-cache/download/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.nlark.com/map-cache/download/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/map-visit/download/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/map-visit/download/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -12281,7 +12281,7 @@
     },
     "marked": {
       "version": "0.8.2",
-      "resolved": "https://registry.npm.taobao.org/marked/download/marked-0.8.2.tgz",
+      "resolved": "https://registry.npmmirror.com/marked/download/marked-0.8.2.tgz",
       "integrity": "sha1-T6rSjSbt41Gnoaql/sZ5Fchp41U=",
       "dev": true
     },
@@ -12299,7 +12299,7 @@
       "dependencies": {
         "findup-sync": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/findup-sync/download/findup-sync-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/findup-sync/download/findup-sync-2.0.0.tgz?cache=0&sync_timestamp=1635766114067&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Ffindup-sync%2Fdownload%2Ffindup-sync-2.0.0.tgz",
           "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
           "dev": true,
           "requires": {
@@ -12311,7 +12311,7 @@
         },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/is-glob/download/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/is-glob/download/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -12322,7 +12322,7 @@
     },
     "mem": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/mem/download/mem-4.3.0.tgz",
+      "resolved": "https://registry.nlark.com/mem/download/mem-4.3.0.tgz?cache=0&sync_timestamp=1626534487701&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fmem%2Fdownload%2Fmem-4.3.0.tgz",
       "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
       "dev": true,
       "requires": {
@@ -12341,7 +12341,7 @@
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/merge-stream/download/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.nlark.com/merge-stream/download/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
@@ -12374,7 +12374,7 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz?cache=0&sync_timestamp=1560034758817&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-1.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mime/download/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "dev": true
     },
@@ -12410,13 +12410,13 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npm.taobao.org/minimist/download/minimist-1.2.5.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fminimist%2Fdownload%2Fminimist-1.2.5.tgz",
+      "resolved": "https://registry.npm.taobao.org/minimist/download/minimist-1.2.5.tgz",
       "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://registry.npm.taobao.org/mixin-deep/download/mixin-deep-1.3.2.tgz",
+      "resolved": "https://registry.nlark.com/mixin-deep/download/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
@@ -12426,7 +12426,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.nlark.com/is-extendable/download/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -12437,7 +12437,7 @@
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/download/ms-2.1.2.tgz",
       "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
@@ -12456,14 +12456,14 @@
     },
     "nanoid": {
       "version": "3.1.30",
-      "resolved": "https://registry.npmmirror.com/nanoid/download/nanoid-3.1.30.tgz?cache=0&sync_timestamp=1634166192601&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fnanoid%2Fdownload%2Fnanoid-3.1.30.tgz",
-      "integrity": "sha1-Y/k8xUjSoRPcXfvGO/oJ4rm2Q2I=",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
       "dev": true,
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://registry.npm.taobao.org/nanomatch/download/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.nlark.com/nanomatch/download/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
@@ -12482,7 +12482,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/natural-compare/download/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.nlark.com/natural-compare/download/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
@@ -12494,19 +12494,19 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/next-tick/download/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/next-tick/download/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/nice-try/download/nice-try-1.0.5.tgz",
+      "resolved": "https://registry.nlark.com/nice-try/download/nice-try-1.0.5.tgz",
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/node-int64/download/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.nlark.com/node-int64/download/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
@@ -12518,7 +12518,7 @@
     },
     "node-notifier": {
       "version": "8.0.2",
-      "resolved": "https://registry.npm.taobao.org/node-notifier/download/node-notifier-8.0.2.tgz",
+      "resolved": "https://registry.nlark.com/node-notifier/download/node-notifier-8.0.2.tgz?cache=0&sync_timestamp=1621962189467&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fnode-notifier%2Fdownload%2Fnode-notifier-8.0.2.tgz",
       "integrity": "sha1-8xZ6OO8NLIqGaoPjGMG6Dv63AsU=",
       "dev": true,
       "optional": true,
@@ -12533,7 +12533,7 @@
       "dependencies": {
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-7.3.5.tgz?cache=0&sync_timestamp=1616463603361&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-7.3.5.tgz",
+          "resolved": "https://registry.nlark.com/semver/download/semver-7.3.5.tgz?cache=0&sync_timestamp=1618846864940&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fsemver%2Fdownload%2Fsemver-7.3.5.tgz",
           "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "optional": true,
@@ -12555,7 +12555,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npm.taobao.org/normalize-package-data/download/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.nlark.com/normalize-package-data/download/normalize-package-data-2.5.0.tgz?cache=0&sync_timestamp=1629301872905&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fnormalize-package-data%2Fdownload%2Fnormalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
@@ -12585,7 +12585,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/npm-run-path/download/npm-run-path-2.0.2.tgz?cache=0&sync_timestamp=1577053500910&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnpm-run-path%2Fdownload%2Fnpm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/npm-run-path/download/npm-run-path-2.0.2.tgz?cache=0&sync_timestamp=1633420566316&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fnpm-run-path%2Fdownload%2Fnpm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -12594,13 +12594,13 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/number-is-nan/download/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/number-is-nan/download/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/nwsapi/download/nwsapi-2.2.0.tgz",
+      "resolved": "https://registry.nlark.com/nwsapi/download/nwsapi-2.2.0.tgz",
       "integrity": "sha1-IEh5qePQaP8qVROcLHcngGgaOLc=",
       "dev": true
     },
@@ -12649,13 +12649,13 @@
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/object-keys/download/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.nlark.com/object-keys/download/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/object-visit/download/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.nlark.com/object-visit/download/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -12785,7 +12785,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/once/download/once-1.4.0.tgz",
+      "resolved": "https://registry.nlark.com/once/download/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -12803,8 +12803,8 @@
     },
     "open": {
       "version": "7.4.2",
-      "resolved": "https://registry.nlark.com/open/download/open-7.4.2.tgz?cache=0&sync_timestamp=1621868447130&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fopen%2Fdownload%2Fopen-7.4.2.tgz",
-      "integrity": "sha1-uBR+Jtzz5CYxbHMAif1x7dKcIyE=",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -12814,7 +12814,7 @@
     },
     "opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npm.taobao.org/opener/download/opener-1.5.2.tgz",
+      "resolved": "https://registry.nlark.com/opener/download/opener-1.5.2.tgz?cache=0&sync_timestamp=1618847055043&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fopener%2Fdownload%2Fopener-1.5.2.tgz",
       "integrity": "sha1-XTfh81B3udysQwE3InGv3rKhNZg=",
       "dev": true
     },
@@ -12843,7 +12843,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/os-locale/download/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/os-locale/download/os-locale-1.4.0.tgz?cache=0&sync_timestamp=1633618260196&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fos-locale%2Fdownload%2Fos-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -12858,13 +12858,13 @@
     },
     "p-each-series": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/p-each-series/download/p-each-series-2.2.0.tgz",
+      "resolved": "https://registry.nlark.com/p-each-series/download/p-each-series-2.2.0.tgz",
       "integrity": "sha1-EFqwNXznKyAqiouUkzZyZXteKpo=",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/p-finally/download/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/p-finally/download/p-finally-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fp-finally%2Fdownload%2Fp-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
@@ -12885,8 +12885,8 @@
     },
     "p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-3.0.0.tgz",
-      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
@@ -12903,7 +12903,7 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/p-try/download/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/p-try/download/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
@@ -12929,7 +12929,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/parse-json/download/parse-json-2.2.0.tgz?cache=0&sync_timestamp=1637475717072&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fparse-json%2Fdownload%2Fparse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -12938,7 +12938,7 @@
     },
     "parse-node-version": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/parse-node-version/download/parse-node-version-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/parse-node-version/download/parse-node-version-1.0.1.tgz",
       "integrity": "sha1-4rXb7eAOf6m8NjYH9TMn6LBzGJs=",
       "dev": true
     },
@@ -12950,19 +12950,19 @@
     },
     "parse5": {
       "version": "6.0.1",
-      "resolved": "https://registry.npm.taobao.org/parse5/download/parse5-6.0.1.tgz",
+      "resolved": "https://registry.nlark.com/parse5/download/parse5-6.0.1.tgz",
       "integrity": "sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/pascalcase/download/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.nlark.com/pascalcase/download/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path": {
       "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "resolved": "https://registry.npm.taobao.org/path/download/path-0.12.7.tgz?cache=0&sync_timestamp=1615984699708&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpath%2Fdownload%2Fpath-0.12.7.tgz",
       "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
       "dev": true,
       "requires": {
@@ -12972,13 +12972,13 @@
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/path-dirname/download/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.nlark.com/path-dirname/download/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.nlark.com/path-exists/download/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
@@ -13002,7 +13002,7 @@
     },
     "path-root": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/path-root/download/path-root-0.1.1.tgz",
+      "resolved": "https://registry.nlark.com/path-root/download/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
@@ -13011,7 +13011,7 @@
     },
     "path-root-regex": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/path-root-regex/download/path-root-regex-0.1.2.tgz",
+      "resolved": "https://registry.nlark.com/path-root-regex/download/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
@@ -13040,19 +13040,19 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz?cache=0&sync_timestamp=1581697613983&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpify%2Fdownload%2Fpify-2.3.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.nlark.com/pinkie/download/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.nlark.com/pinkie-promise/download/pinkie-promise-2.0.1.tgz?cache=0&sync_timestamp=1618847023792&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fpinkie-promise%2Fdownload%2Fpinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -13061,7 +13061,7 @@
     },
     "pirates": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/pirates/download/pirates-4.0.1.tgz",
+      "resolved": "https://registry.nlark.com/pirates/download/pirates-4.0.1.tgz",
       "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
       "dev": true,
       "requires": {
@@ -13175,7 +13175,7 @@
     },
     "portfinder": {
       "version": "1.0.28",
-      "resolved": "https://registry.npm.taobao.org/portfinder/download/portfinder-1.0.28.tgz",
+      "resolved": "https://registry.nlark.com/portfinder/download/portfinder-1.0.28.tgz",
       "integrity": "sha1-Z8RiKFK9U3TdHdkA93n1NGL6x3g=",
       "dev": true,
       "requires": {
@@ -13186,7 +13186,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566580543&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-3.2.7.tgz",
           "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
           "dev": true,
           "requires": {
@@ -13206,7 +13206,7 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/posix-character-classes/download/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.nlark.com/posix-character-classes/download/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
@@ -13218,7 +13218,7 @@
     },
     "pretty-format": {
       "version": "24.9.0",
-      "resolved": "https://registry.npm.taobao.org/pretty-format/download/pretty-format-24.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/pretty-format/download/pretty-format-24.9.0.tgz",
       "integrity": "sha1-EvrDGzcBmk7qPBGqmpWet2KKp8k=",
       "dev": true,
       "requires": {
@@ -13230,7 +13230,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-regex/download/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         }
@@ -13250,7 +13250,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.nlark.com/process/download/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
@@ -13328,13 +13328,13 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/punycode/download/punycode-2.1.1.tgz",
+      "resolved": "https://registry.nlark.com/punycode/download/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
     "qs": {
       "version": "6.10.1",
-      "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.10.1.tgz?cache=0&sync_timestamp=1616385328325&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.10.1.tgz",
+      "resolved": "https://registry.nlark.com/qs/download/qs-6.10.1.tgz",
       "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
       "dev": true,
       "requires": {
@@ -13343,8 +13343,8 @@
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/randombytes/download/randombytes-2.1.0.tgz",
-      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -13352,13 +13352,13 @@
     },
     "react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-16.13.1.tgz",
+      "resolved": "https://registry.npmmirror.com/react-is/download/react-is-16.13.1.tgz",
       "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
       "dev": true
     },
     "read-pkg": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/read-pkg/download/read-pkg-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/read-pkg/download/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
@@ -13369,7 +13369,7 @@
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
@@ -13379,7 +13379,7 @@
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/find-up/download/find-up-1.1.2.tgz?cache=0&sync_timestamp=1633620747957&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Ffind-up%2Fdownload%2Ffind-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
@@ -13389,7 +13389,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "https://registry.nlark.com/path-exists/download/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
@@ -13426,7 +13426,7 @@
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1575629866543&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
+      "resolved": "https://registry.nlark.com/readdirp/download/readdirp-2.2.1.tgz",
       "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "dev": true,
       "requires": {
@@ -13437,7 +13437,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://registry.npm.taobao.org/rechoir/download/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.nlark.com/rechoir/download/rechoir-0.6.2.tgz?cache=0&sync_timestamp=1627101677944&other_urls=https%3A%2F%2Fregistry.nlark.com%2Frechoir%2Fdownload%2Frechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -13477,7 +13477,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/regex-not/download/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.nlark.com/regex-not/download/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
@@ -13522,7 +13522,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npm.taobao.org/jsesc/download/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.nlark.com/jsesc/download/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -13551,7 +13551,7 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/remove-trailing-separator/download/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/remove-trailing-separator/download/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
@@ -13678,7 +13678,7 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/require-directory/download/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.nlark.com/require-directory/download/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
@@ -13696,7 +13696,7 @@
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/requires-port/download/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/requires-port/download/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
@@ -13711,7 +13711,7 @@
     },
     "resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/resolve-cwd/download/resolve-cwd-3.0.0.tgz",
+      "resolved": "https://registry.nlark.com/resolve-cwd/download/resolve-cwd-3.0.0.tgz",
       "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
       "dev": true,
       "requires": {
@@ -13720,7 +13720,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-5.0.0.tgz",
+          "resolved": "https://registry.nlark.com/resolve-from/download/resolve-from-5.0.0.tgz?cache=0&sync_timestamp=1622605305717&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fresolve-from%2Fdownload%2Fresolve-from-5.0.0.tgz",
           "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
           "dev": true
         }
@@ -13753,13 +13753,13 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/resolve-url/download/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/resolve-url/download/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://registry.npm.taobao.org/ret/download/ret-0.1.15.tgz",
+      "resolved": "https://registry.nlark.com/ret/download/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
@@ -13780,8 +13780,8 @@
     },
     "rollup": {
       "version": "2.26.6",
-      "resolved": "https://registry.npm.taobao.org/rollup/download/rollup-2.26.6.tgz",
-      "integrity": "sha1-C0YMHaIkxq8SoelIooxROqEfK5M=",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.6.tgz",
+      "integrity": "sha512-iSB7eE3k/VNQHnI7ckS++4yIqTamoUCB1xo7MswhJ/fg22oFYR5+xCrUZVviBj97jvc5A31MPbVMw1Wc3jWxmw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
@@ -13789,8 +13789,8 @@
       "dependencies": {
         "fsevents": {
           "version": "2.1.3",
-          "resolved": "https://registry.npm.taobao.org/fsevents/download/fsevents-2.1.3.tgz?cache=0&sync_timestamp=1612537044236&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffsevents%2Fdownload%2Ffsevents-2.1.3.tgz",
-          "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
           "dev": true,
           "optional": true
         }
@@ -13798,8 +13798,8 @@
     },
     "rollup-plugin-progress": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/rollup-plugin-progress/download/rollup-plugin-progress-1.1.2.tgz",
-      "integrity": "sha1-XB3+fFD2VJBrw00WfVUS7hpLctU=",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-progress/-/rollup-plugin-progress-1.1.2.tgz",
+      "integrity": "sha512-6ehSZOMTZdAlRpe45kf56BnIOsDYC2GKWhGlK/Dh/Ae/AMUneMDyKdiv9ZlRrW/HVc986frTZcc2Zka+oF6W7Q==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2"
@@ -13807,8 +13807,8 @@
     },
     "rollup-plugin-terser": {
       "version": "7.0.2",
-      "resolved": "https://registry.npm.taobao.org/rollup-plugin-terser/download/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha1-6Pu6SGmYGy3DWufopQLVxsBNMk0=",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -13819,8 +13819,8 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/code-frame/download/@babel/code-frame-7.16.0.tgz",
-          "integrity": "sha1-DfyAMJvuyEEeZecGRhxAiwu5tDE=",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
             "@babel/highlight": "^7.16.0"
@@ -13828,14 +13828,14 @@
         },
         "@babel/helper-validator-identifier": {
           "version": "7.15.7",
-          "resolved": "https://registry.nlark.com/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.15.7.tgz?cache=0&sync_timestamp=1631920000984&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40babel%2Fhelper-validator-identifier%2Fdownload%2F%40babel%2Fhelper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k=",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
           "dev": true
         },
         "@babel/highlight": {
           "version": "7.16.0",
-          "resolved": "https://registry.npmmirror.com/@babel/highlight/download/@babel/highlight-7.16.0.tgz",
-          "integrity": "sha1-bOsysspLj182H7f9gh4/3fShclo=",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.15.7",
@@ -13847,8 +13847,8 @@
     },
     "rollup-plugin-visualizer": {
       "version": "4.2.2",
-      "resolved": "https://registry.nlark.com/rollup-plugin-visualizer/download/rollup-plugin-visualizer-4.2.2.tgz",
-      "integrity": "sha1-7euLP8b0mzyV9sxmj066V8YRIJk=",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-4.2.2.tgz",
+      "integrity": "sha512-10/TsugsaQL5rdynl0lrklBngTtkRBESZdxUJy+3fN+xKqNdg5cr7JQU1OoPx4p5mhQ+nspa6EvX3qc8SsBvnA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -13860,15 +13860,15 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1",
-          "resolved": "https://registry.nlark.com/ansi-regex/download/ansi-regex-5.0.1.tgz?cache=0&sync_timestamp=1631634988487&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fansi-regex%2Fdownload%2Fansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true,
           "optional": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.nlark.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
-          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13877,8 +13877,8 @@
         },
         "cliui": {
           "version": "7.0.4",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-7.0.4.tgz",
-          "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13889,8 +13889,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
-          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13899,36 +13899,36 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.4.tgz",
-          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true,
           "optional": true
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": "https://registry.npm.taobao.org/get-caller-file/download/get-caller-file-2.0.5.tgz",
-          "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz?cache=0&sync_timestamp=1618552489864&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-fullwidth-code-point%2Fdownload%2Fis-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true,
           "optional": true
         },
         "source-map": {
           "version": "0.7.3",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.7.3.tgz",
-          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "4.2.3",
-          "resolved": "https://registry.npmmirror.com/string-width/download/string-width-4.2.3.tgz?cache=0&sync_timestamp=1632421309919&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fstring-width%2Fdownload%2Fstring-width-4.2.3.tgz",
-          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13939,8 +13939,8 @@
         },
         "strip-ansi": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmmirror.com/strip-ansi/download/strip-ansi-6.0.1.tgz",
-          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13949,8 +13949,8 @@
         },
         "wrap-ansi": {
           "version": "7.0.0",
-          "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13961,8 +13961,8 @@
         },
         "yargs": {
           "version": "16.2.0",
-          "resolved": "https://registry.nlark.com/yargs/download/yargs-16.2.0.tgz?cache=0&sync_timestamp=1620086465147&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fyargs%2Fdownload%2Fyargs-16.2.0.tgz",
-          "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13977,8 +13977,8 @@
         },
         "yargs-parser": {
           "version": "20.2.9",
-          "resolved": "https://registry.nlark.com/yargs-parser/download/yargs-parser-20.2.9.tgz",
-          "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true,
           "optional": true
         }
@@ -13986,7 +13986,7 @@
     },
     "rsvp": {
       "version": "4.8.5",
-      "resolved": "https://registry.npm.taobao.org/rsvp/download/rsvp-4.8.5.tgz",
+      "resolved": "https://registry.nlark.com/rsvp/download/rsvp-4.8.5.tgz",
       "integrity": "sha1-yPFVMR0Wf2jyHhaN9x7FsIMRNzQ=",
       "dev": true
     },
@@ -13998,7 +13998,7 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.nlark.com/safe-buffer/download/safe-buffer-5.1.2.tgz?cache=0&sync_timestamp=1618847044058&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fsafe-buffer%2Fdownload%2Fsafe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
@@ -14013,13 +14013,13 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/safer-buffer/download/safer-buffer-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsafer-buffer%2Fdownload%2Fsafer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.nlark.com/safer-buffer/download/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "sane": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/sane/download/sane-4.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/sane/download/sane-4.1.0.tgz",
       "integrity": "sha1-7Ygf2SJzOmxGG8GJ3CtsAG8//e0=",
       "dev": true,
       "requires": {
@@ -14036,7 +14036,7 @@
     },
     "saxes": {
       "version": "5.0.1",
-      "resolved": "https://registry.npm.taobao.org/saxes/download/saxes-5.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/saxes/download/saxes-5.0.1.tgz?cache=0&sync_timestamp=1636312078741&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fsaxes%2Fdownload%2Fsaxes-5.0.1.tgz",
       "integrity": "sha1-7rq5U/o7dgjb6U5drbFciI+maW0=",
       "dev": true,
       "requires": {
@@ -14057,7 +14057,7 @@
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/semver-greatest-satisfied-range/download/semver-greatest-satisfied-range-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/semver-greatest-satisfied-range/download/semver-greatest-satisfied-range-1.1.0.tgz",
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
       "dev": true,
       "requires": {
@@ -14066,8 +14066,8 @@
     },
     "serialize-javascript": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/serialize-javascript/download/serialize-javascript-4.0.0.tgz?cache=0&sync_timestamp=1599740689479&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fserialize-javascript%2Fdownload%2Fserialize-javascript-4.0.0.tgz",
-      "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -14075,13 +14075,13 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/set-blocking/download/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.nlark.com/set-blocking/download/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/set-value/download/set-value-2.0.1.tgz",
+      "resolved": "https://registry.nlark.com/set-value/download/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
@@ -14093,7 +14093,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -14119,7 +14119,7 @@
     },
     "shelljs": {
       "version": "0.8.4",
-      "resolved": "https://registry.npm.taobao.org/shelljs/download/shelljs-0.8.4.tgz?cache=0&sync_timestamp=1587787210621&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fshelljs%2Fdownload%2Fshelljs-0.8.4.tgz",
+      "resolved": "https://registry.npm.taobao.org/shelljs/download/shelljs-0.8.4.tgz",
       "integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
       "dev": true,
       "requires": {
@@ -14130,14 +14130,14 @@
     },
     "shellwords": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/shellwords/download/shellwords-0.1.1.tgz",
+      "resolved": "https://registry.nlark.com/shellwords/download/shellwords-0.1.1.tgz",
       "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
       "dev": true,
       "optional": true
     },
     "side-channel": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/side-channel/download/side-channel-1.0.4.tgz",
+      "resolved": "https://registry.nlark.com/side-channel/download/side-channel-1.0.4.tgz",
       "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
       "dev": true,
       "requires": {
@@ -14167,13 +14167,13 @@
     },
     "sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/sisteransi/download/sisteransi-1.0.5.tgz",
+      "resolved": "https://registry.nlark.com/sisteransi/download/sisteransi-1.0.5.tgz",
       "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
       "dev": true
     },
     "slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/slash/download/slash-3.0.0.tgz",
+      "resolved": "https://registry.nlark.com/slash/download/slash-3.0.0.tgz",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true
     },
@@ -14222,7 +14222,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://registry.npm.taobao.org/snapdragon/download/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/snapdragon/download/snapdragon-0.8.2.tgz?cache=0&sync_timestamp=1617971785350&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsnapdragon%2Fdownload%2Fsnapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
@@ -14238,7 +14238,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -14256,7 +14256,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.nlark.com/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -14265,7 +14265,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -14293,7 +14293,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -14302,7 +14302,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.nlark.com/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -14324,7 +14324,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/snapdragon-util/download/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.nlark.com/snapdragon-util/download/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
@@ -14373,7 +14373,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz?cache=0&sync_timestamp=1571657176668&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsource-map%2Fdownload%2Fsource-map-0.6.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -14387,13 +14387,13 @@
     },
     "sourcemap-codec": {
       "version": "1.4.8",
-      "resolved": "https://registry.npm.taobao.org/sourcemap-codec/download/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "sparkles": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/sparkles/download/sparkles-1.0.1.tgz",
+      "resolved": "https://registry.nlark.com/sparkles/download/sparkles-1.0.1.tgz",
       "integrity": "sha1-AI22XtzmxQ7sDF4ijhlFBh3QQ3w=",
       "dev": true
     },
@@ -14437,7 +14437,7 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/split-string/download/split-string-3.1.0.tgz",
+      "resolved": "https://registry.nlark.com/split-string/download/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
@@ -14446,7 +14446,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/sprintf-js/download/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.nlark.com/sprintf-js/download/sprintf-js-1.0.3.tgz?cache=0&sync_timestamp=1618847174560&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fsprintf-js%2Fdownload%2Fsprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -14469,7 +14469,7 @@
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved": "https://registry.npm.taobao.org/stack-trace/download/stack-trace-0.0.10.tgz",
+      "resolved": "https://registry.nlark.com/stack-trace/download/stack-trace-0.0.10.tgz?cache=0&sync_timestamp=1620387179562&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fstack-trace%2Fdownload%2Fstack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
@@ -14484,7 +14484,7 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-2.0.0.tgz",
+          "resolved": "https://registry.nlark.com/escape-string-regexp/download/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
           "dev": true
         }
@@ -14537,7 +14537,7 @@
     },
     "string-length": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/string-length/download/string-length-4.0.2.tgz?cache=0&sync_timestamp=1615963663372&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstring-length%2Fdownload%2Fstring-length-4.0.2.tgz",
+      "resolved": "https://registry.nlark.com/string-length/download/string-length-4.0.2.tgz?cache=0&sync_timestamp=1631558154323&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fstring-length%2Fdownload%2Fstring-length-4.0.2.tgz",
       "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
       "dev": true,
       "requires": {
@@ -14670,13 +14670,13 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/strip-eof/download/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-eof/download/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/strip-final-newline/download/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://registry.nlark.com/strip-final-newline/download/strip-final-newline-2.0.0.tgz?cache=0&sync_timestamp=1620046435959&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fstrip-final-newline%2Fdownload%2Fstrip-final-newline-2.0.0.tgz",
       "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "dev": true
     },
@@ -14688,7 +14688,7 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
@@ -14707,13 +14707,13 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.nlark.com/has-flag/download/has-flag-4.0.0.tgz?cache=0&sync_timestamp=1626715907927&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhas-flag%2Fdownload%2Fhas-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz?cache=0&sync_timestamp=1611394043517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -14812,7 +14812,7 @@
     },
     "terminal-link": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/terminal-link/download/terminal-link-2.1.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/terminal-link/download/terminal-link-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fterminal-link%2Fdownload%2Fterminal-link-2.1.1.tgz",
       "integrity": "sha1-FKZKJ6s8Dfkz6lRvulXy0HjtyZQ=",
       "dev": true,
       "requires": {
@@ -14822,7 +14822,7 @@
     },
     "terser": {
       "version": "5.10.0",
-      "resolved": "https://registry.npmmirror.com/terser/download/terser-5.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
       "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
       "dev": true,
       "requires": {
@@ -14833,13 +14833,13 @@
       "dependencies": {
         "source-map": {
           "version": "0.7.3",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.7.3.tgz",
-          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         },
         "source-map-support": {
           "version": "0.5.21",
-          "resolved": "https://registry.npmmirror.com/source-map-support/download/source-map-support-0.5.21.tgz",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
           "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
           "dev": true,
           "requires": {
@@ -14849,8 +14849,8 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": "https://registry.nlark.com/source-map/download/source-map-0.6.1.tgz",
-              "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
           }
@@ -14859,7 +14859,7 @@
     },
     "test-exclude": {
       "version": "6.0.0",
-      "resolved": "https://registry.npm.taobao.org/test-exclude/download/test-exclude-6.0.0.tgz",
+      "resolved": "https://registry.nlark.com/test-exclude/download/test-exclude-6.0.0.tgz",
       "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
       "dev": true,
       "requires": {
@@ -14870,14 +14870,14 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/text-table/download/text-table-0.2.0.tgz",
+      "resolved": "https://registry.nlark.com/text-table/download/text-table-0.2.0.tgz?cache=0&sync_timestamp=1618847142316&other_urls=https%3A%2F%2Fregistry.nlark.com%2Ftext-table%2Fdownload%2Ftext-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "tfig": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmmirror.com/tfig/download/tfig-3.2.2.tgz?cache=0&sync_timestamp=1636105695153&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Ftfig%2Fdownload%2Ftfig-3.2.2.tgz",
-      "integrity": "sha1-sqgkI7L3FXQLph8jyJv1Q6HvpDY=",
+      "resolved": "https://registry.npmjs.org/tfig/-/tfig-3.2.2.tgz",
+      "integrity": "sha512-CUW4hwk9azbJNhbONf1mdTn//tWt83Dj/75xkjOpZdtpRxRMx+gFXGSsDhcXlFEkIP3lI0gnBrBL/uXubNwlbQ==",
       "dev": true,
       "requires": {
         "fs-extra": "^7.0.1",
@@ -14887,14 +14887,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.nlark.com/ansi-regex/download/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "cliui": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-5.0.0.tgz",
-          "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
             "string-width": "^3.1.0",
@@ -14904,26 +14904,26 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmmirror.com/emoji-regex/download/emoji-regex-7.0.3.tgz?cache=0&sync_timestamp=1632751333727&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Femoji-regex%2Fdownload%2Femoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": "https://registry.npm.taobao.org/get-caller-file/download/get-caller-file-2.0.5.tgz",
-          "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/require-main-filename/download/require-main-filename-2.0.0.tgz",
-          "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://registry.nlark.com/string-width/download/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -14933,8 +14933,8 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz?cache=0&sync_timestamp=1618553320591&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -14942,14 +14942,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
@@ -14959,14 +14959,14 @@
         },
         "y18n": {
           "version": "4.0.3",
-          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.3.tgz",
-          "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {
           "version": "13.3.2",
-          "resolved": "https://registry.nlark.com/yargs/download/yargs-13.3.2.tgz?cache=0&sync_timestamp=1620086465147&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fyargs%2Fdownload%2Fyargs-13.3.2.tgz",
-          "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
             "cliui": "^5.0.0",
@@ -14983,8 +14983,8 @@
         },
         "yargs-parser": {
           "version": "13.1.2",
-          "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-13.1.2.tgz",
-          "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -14995,7 +14995,7 @@
     },
     "throat": {
       "version": "5.0.0",
-      "resolved": "https://registry.npm.taobao.org/throat/download/throat-5.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/throat/download/throat-5.0.0.tgz",
       "integrity": "sha1-xRmSNYA6rRh1SmZ9ZZtecs4Wdks=",
       "dev": true
     },
@@ -15021,7 +15021,7 @@
     },
     "time-stamp": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "resolved": "https://registry.nlark.com/time-stamp/download/time-stamp-1.1.0.tgz",
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
@@ -15033,7 +15033,7 @@
     },
     "to-absolute-glob": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/to-absolute-glob/download/to-absolute-glob-2.0.2.tgz",
+      "resolved": "https://registry.nlark.com/to-absolute-glob/download/to-absolute-glob-2.0.2.tgz",
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "requires": {
@@ -15043,13 +15043,13 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/to-fast-properties/download/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.nlark.com/to-fast-properties/download/to-fast-properties-2.0.0.tgz?cache=0&sync_timestamp=1628418893613&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fto-fast-properties%2Fdownload%2Fto-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/to-object-path/download/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.nlark.com/to-object-path/download/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -15069,7 +15069,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://registry.npm.taobao.org/to-regex/download/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.nlark.com/to-regex/download/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
@@ -15138,13 +15138,13 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "https://registry.npm.taobao.org/mkdirp/download/mkdirp-1.0.4.tgz?cache=0&sync_timestamp=1587535418745&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmkdirp%2Fdownload%2Fmkdirp-1.0.4.tgz",
+          "resolved": "https://registry.npmmirror.com/mkdirp/download/mkdirp-1.0.4.tgz",
           "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
           "dev": true
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-7.3.5.tgz?cache=0&sync_timestamp=1616463603361&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-7.3.5.tgz",
+          "resolved": "https://registry.nlark.com/semver/download/semver-7.3.5.tgz?cache=0&sync_timestamp=1618846864940&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fsemver%2Fdownload%2Fsemver-7.3.5.tgz",
           "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
@@ -15234,7 +15234,7 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npm.taobao.org/type-detect/download/type-detect-4.0.8.tgz",
+      "resolved": "https://registry.nlark.com/type-detect/download/type-detect-4.0.8.tgz",
       "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
@@ -15246,13 +15246,13 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npm.taobao.org/typedarray/download/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://registry.npm.taobao.org/typedarray-to-buffer/download/typedarray-to-buffer-3.1.5.tgz?cache=0&sync_timestamp=1606167099511&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftypedarray-to-buffer%2Fdownload%2Ftypedarray-to-buffer-3.1.5.tgz",
+      "resolved": "https://registry.nlark.com/typedarray-to-buffer/download/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
       "dev": true,
       "requires": {
@@ -15261,7 +15261,7 @@
     },
     "typedoc": {
       "version": "0.17.8",
-      "resolved": "https://registry.npm.taobao.org/typedoc/download/typedoc-0.17.8.tgz",
+      "resolved": "https://registry.npmmirror.com/typedoc/download/typedoc-0.17.8.tgz",
       "integrity": "sha1-lrZ+lFSqeFO/xNyaVciget/VR44=",
       "dev": true,
       "requires": {
@@ -15279,7 +15279,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-8.1.0.tgz?cache=0&sync_timestamp=1591229972229&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-8.1.0.tgz",
+          "resolved": "https://registry.nlark.com/fs-extra/download/fs-extra-8.1.0.tgz",
           "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
           "dev": true,
           "requires": {
@@ -15296,7 +15296,7 @@
         },
         "marked": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/marked/download/marked-1.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/marked/download/marked-1.0.0.tgz",
           "integrity": "sha1-01eEJFoEhx5ZiKSR4ohnNi6UFpM=",
           "dev": true
         },
@@ -15399,7 +15399,7 @@
     },
     "unc-path-regex": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/unc-path-regex/download/unc-path-regex-0.1.2.tgz",
+      "resolved": "https://registry.nlark.com/unc-path-regex/download/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
@@ -15462,7 +15462,7 @@
     },
     "union": {
       "version": "0.5.0",
-      "resolved": "https://registry.npm.taobao.org/union/download/union-0.5.0.tgz",
+      "resolved": "https://registry.nlark.com/union/download/union-0.5.0.tgz",
       "integrity": "sha1-ssEb6E9gU4U3uEbtuboma6AJAHU=",
       "dev": true,
       "requires": {
@@ -15471,7 +15471,7 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/union-value/download/union-value-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/union-value/download/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
@@ -15493,13 +15493,13 @@
     },
     "universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/universalify/download/universalify-0.1.2.tgz",
+      "resolved": "https://registry.nlark.com/universalify/download/universalify-0.1.2.tgz",
       "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/unset-value/download/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/unset-value/download/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -15509,7 +15509,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://registry.npm.taobao.org/has-value/download/has-value-0.3.1.tgz",
+          "resolved": "https://registry.nlark.com/has-value/download/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -15531,7 +15531,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://registry.npm.taobao.org/has-values/download/has-values-0.1.4.tgz",
+          "resolved": "https://registry.nlark.com/has-values/download/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         },
@@ -15545,7 +15545,7 @@
     },
     "upath": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/upath/download/upath-1.2.0.tgz?cache=0&sync_timestamp=1567457281208&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fupath%2Fdownload%2Fupath-1.2.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/upath/download/upath-1.2.0.tgz",
       "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
       "dev": true
     },
@@ -15568,19 +15568,19 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://registry.npm.taobao.org/urix/download/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/urix/download/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url-join": {
       "version": "2.0.5",
-      "resolved": "https://registry.npm.taobao.org/url-join/download/url-join-2.0.5.tgz",
+      "resolved": "https://registry.nlark.com/url-join/download/url-join-2.0.5.tgz",
       "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
       "dev": true
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://registry.npm.taobao.org/use/download/use-3.1.1.tgz",
+      "resolved": "https://registry.nlark.com/use/download/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
@@ -15595,7 +15595,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.nlark.com/inherits/download/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -15603,13 +15603,13 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.nlark.com/util-deprecate/download/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npm.taobao.org/uuid/download/uuid-8.3.2.tgz?cache=0&sync_timestamp=1607460052228&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fuuid%2Fdownload%2Fuuid-8.3.2.tgz",
+      "resolved": "https://registry.npmmirror.com/uuid/download/uuid-8.3.2.tgz",
       "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
       "dev": true,
       "optional": true
@@ -15650,7 +15650,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npm.taobao.org/validate-npm-package-license/download/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.nlark.com/validate-npm-package-license/download/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
@@ -15660,7 +15660,7 @@
     },
     "value-or-function": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/value-or-function/download/value-or-function-3.0.0.tgz",
+      "resolved": "https://registry.nlark.com/value-or-function/download/value-or-function-3.0.0.tgz",
       "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
       "dev": true
     },
@@ -15755,7 +15755,7 @@
     },
     "w3c-hr-time": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/w3c-hr-time/download/w3c-hr-time-1.0.2.tgz",
+      "resolved": "https://registry.nlark.com/w3c-hr-time/download/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=",
       "dev": true,
       "requires": {
@@ -15764,7 +15764,7 @@
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/w3c-xmlserializer/download/w3c-xmlserializer-2.0.0.tgz",
+      "resolved": "https://registry.nlark.com/w3c-xmlserializer/download/w3c-xmlserializer-2.0.0.tgz",
       "integrity": "sha1-PnEEoFt1FGzGD1ZDgLf2g6zxAgo=",
       "dev": true,
       "requires": {
@@ -15782,13 +15782,13 @@
     },
     "webidl-conversions": {
       "version": "6.1.0",
-      "resolved": "https://registry.npm.taobao.org/webidl-conversions/download/webidl-conversions-6.1.0.tgz",
+      "resolved": "https://registry.nlark.com/webidl-conversions/download/webidl-conversions-6.1.0.tgz?cache=0&sync_timestamp=1631408600646&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fwebidl-conversions%2Fdownload%2Fwebidl-conversions-6.1.0.tgz",
       "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ=",
       "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/whatwg-encoding/download/whatwg-encoding-1.0.5.tgz",
+      "resolved": "https://registry.nlark.com/whatwg-encoding/download/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
       "dev": true,
       "requires": {
@@ -15797,7 +15797,7 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/whatwg-mimetype/download/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "https://registry.nlark.com/whatwg-mimetype/download/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
       "dev": true
     },
@@ -15848,7 +15848,7 @@
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/wordwrap/download/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.nlark.com/wordwrap/download/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
@@ -15864,7 +15864,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/wrappy/download/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.nlark.com/wrappy/download/wrappy-1.0.2.tgz?cache=0&sync_timestamp=1619133505879&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fwrappy%2Fdownload%2Fwrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -15888,13 +15888,13 @@
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/xml-name-validator/download/xml-name-validator-3.0.0.tgz",
+      "resolved": "https://registry.nlark.com/xml-name-validator/download/xml-name-validator-3.0.0.tgz?cache=0&sync_timestamp=1632002514407&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fxml-name-validator%2Fdownload%2Fxml-name-validator-3.0.0.tgz",
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/xmlchars/download/xmlchars-2.2.0.tgz",
+      "resolved": "https://registry.nlark.com/xmlchars/download/xmlchars-2.2.0.tgz",
       "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
       "dev": true
     },
@@ -15906,20 +15906,20 @@
     },
     "y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-5.0.8.tgz",
-      "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "optional": true
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-4.0.0.tgz",
+      "resolved": "https://registry.nlark.com/yallist/download/yallist-4.0.0.tgz?cache=0&sync_timestamp=1622604530774&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fyallist%2Fdownload%2Fyallist-4.0.0.tgz",
       "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "dev": true
     },
     "yargs": {
       "version": "12.0.5",
-      "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-12.0.5.tgz?cache=0&sync_timestamp=1583129847322&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-12.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/yargs/download/yargs-12.0.5.tgz?cache=0&sync_timestamp=1632605487521&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fyargs%2Fdownload%2Fyargs-12.0.5.tgz",
       "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
       "dev": true,
       "requires": {
@@ -15939,13 +15939,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz?cache=0&sync_timestamp=1570188663907&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.nlark.com/ansi-regex/download/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-4.1.0.tgz?cache=0&sync_timestamp=1573943292170&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcliui%2Fdownload%2Fcliui-4.1.0.tgz",
+          "resolved": "https://registry.nlark.com/cliui/download/cliui-4.1.0.tgz",
           "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
           "dev": true,
           "requires": {
@@ -15965,13 +15965,13 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/invert-kv/download/invert-kv-2.0.0.tgz",
+          "resolved": "https://registry.nlark.com/invert-kv/download/invert-kv-2.0.0.tgz?cache=0&sync_timestamp=1630996809231&other_urls=https%3A%2F%2Fregistry.nlark.com%2Finvert-kv%2Fdownload%2Finvert-kv-2.0.0.tgz",
           "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
           "dev": true
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/lcid/download/lcid-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/lcid/download/lcid-2.0.0.tgz",
           "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
           "dev": true,
           "requires": {
@@ -15990,7 +15990,7 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/os-locale/download/os-locale-3.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/os-locale/download/os-locale-3.1.0.tgz?cache=0&sync_timestamp=1633618260196&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fos-locale%2Fdownload%2Fos-locale-3.1.0.tgz",
           "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
           "dev": true,
           "requires": {
@@ -16016,7 +16016,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstring-width%2Fdownload%2Fstring-width-2.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/string-width/download/string-width-2.1.1.tgz?cache=0&sync_timestamp=1632421309919&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fstring-width%2Fdownload%2Fstring-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -16026,7 +16026,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz?cache=0&sync_timestamp=1573280518303&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/strip-ansi/download/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -16047,7 +16047,7 @@
         },
         "yargs-parser": {
           "version": "11.1.1",
-          "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-11.1.1.tgz?cache=0&sync_timestamp=1583130314354&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-11.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/yargs-parser/download/yargs-parser-11.1.1.tgz?cache=0&sync_timestamp=1637031045984&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fyargs-parser%2Fdownload%2Fyargs-parser-11.1.1.tgz",
           "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1746,9 +1746,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.2.20",
-      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.20.tgz",
-      "integrity": "sha512-89iFN1eAeXcIHKA0b2UjkDxt/Yg7WFi6AQu23tfe2RSvrOQFm3XM/nI780hdxfhICPBDZEEPBSPcYXLNB18Y8A==",
+      "version": "4.2.21-beta.1",
+      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.2.21-beta.1.tgz",
+      "integrity": "sha512-7qH4LUAkRGVR102TB2pB3zJjZCSDX+855jYv/m9vTeypL2PNK/OLxQYNUyKadenaLIboe8wUUNp8gTjN8OFFgA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.13.10",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.2.20-beta.2",
+    "@cocos/build-engine": "4.2.20",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.2.19",
+    "@cocos/build-engine": "4.2.20-beta.2",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.2.21-beta.3",
+    "@cocos/build-engine": "4.2.21-beta.5",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.2.21-beta.1",
+    "@cocos/build-engine": "4.2.21-beta.2",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.2.21-beta.2",
+    "@cocos/build-engine": "4.2.21-beta.3",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.2.20",
+    "@cocos/build-engine": "4.2.21-beta.1",
     "@cocos/typedoc-plugin-internal-external": "^1.0.1",
     "@cocos/typedoc-plugin-localization": "^1.0.0",
     "@types/fs-extra": "^5.0.4",

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -56,11 +56,11 @@ export class AudioPlayerMinigame implements OperationQueueable {
     private _readyToHandleOnShow = false;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -56,11 +56,11 @@ export class AudioPlayerMinigame implements OperationQueueable {
     private _readyToHandleOnShow = false;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -55,8 +55,13 @@ export class AudioPlayerMinigame implements OperationQueueable {
     private _audioTimer: AudioTimer;
     private _readyToHandleOnShow = false;
 
-    // NOTE: the implemented interface properties need to be public access
+    /**
+     * @private_cc
+     */
     public _eventTarget: EventTarget = new EventTarget();
+    /**
+     * @private_cc
+     */
     public _operationQueue: OperationInfo[] = [];
 
     constructor (innerAudioContext: InnerAudioContext) {

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -70,8 +70,13 @@ export class AudioPlayerWeb implements OperationQueueable {
     private _audioTimer: AudioTimer;
     private _readyToHandleOnShow = false;
 
-    // NOTE: the implemented interface properties need to be public access
+    /**
+     * @private_cc
+     */
     public _eventTarget: EventTarget = new EventTarget();
+    /**
+     * @private_cc
+     */
     public _operationQueue: OperationInfo[] = [];
 
     constructor (audioBuffer: AudioBuffer, url: string) {

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -71,11 +71,11 @@ export class AudioPlayerWeb implements OperationQueueable {
     private _readyToHandleOnShow = false;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -71,11 +71,11 @@ export class AudioPlayerWeb implements OperationQueueable {
     private _readyToHandleOnShow = false;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/native/player.ts
+++ b/pal/audio/native/player.ts
@@ -55,11 +55,11 @@ export class AudioPlayer implements OperationQueueable {
     private _state: AudioState = AudioState.INIT;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/native/player.ts
+++ b/pal/audio/native/player.ts
@@ -55,11 +55,11 @@ export class AudioPlayer implements OperationQueueable {
     private _state: AudioState = AudioState.INIT;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/native/player.ts
+++ b/pal/audio/native/player.ts
@@ -54,8 +54,13 @@ export class AudioPlayer implements OperationQueueable {
     private _id: number = INVALID_AUDIO_ID;
     private _state: AudioState = AudioState.INIT;
 
-    // NOTE: the implemented interface properties need to be public access
+    /**
+     * @private_cc
+     */
     public _eventTarget: EventTarget = new EventTarget();
+    /**
+     * @private_cc
+     */
     public _operationQueue: OperationInfo[] = [];
 
     // NOTE: we need to cache the state in case the audio id is invalid.

--- a/pal/audio/web/player-dom.ts
+++ b/pal/audio/web/player-dom.ts
@@ -68,11 +68,11 @@ export class AudioPlayerDOM implements OperationQueueable {
     private _onEnded: () => void;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/web/player-dom.ts
+++ b/pal/audio/web/player-dom.ts
@@ -68,11 +68,11 @@ export class AudioPlayerDOM implements OperationQueueable {
     private _onEnded: () => void;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/web/player-dom.ts
+++ b/pal/audio/web/player-dom.ts
@@ -67,8 +67,13 @@ export class AudioPlayerDOM implements OperationQueueable {
     private _state: AudioState = AudioState.INIT;
     private _onEnded: () => void;
 
-    // NOTE: the implemented interface properties need to be public access
+    /**
+     * @private_cc
+     */
     public _eventTarget: EventTarget = new EventTarget();
+    /**
+     * @private_cc
+     */
     public _operationQueue: OperationInfo[] = [];
 
     constructor (nativeAudio: HTMLAudioElement) {

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -160,8 +160,13 @@ export class AudioPlayerWeb implements OperationQueueable {
     private _state: AudioState = AudioState.INIT;
     private _audioTimer: AudioTimer;
 
-    // NOTE: the implemented interface properties need to be public access
+    /**
+     * @private_cc
+     */
     public _eventTarget: EventTarget = new EventTarget();
+    /**
+     * @private_cc
+     */
     public _operationQueue: OperationInfo[] = [];
 
     constructor (audioBuffer: AudioBuffer, url: string) {

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -161,11 +161,11 @@ export class AudioPlayerWeb implements OperationQueueable {
     private _audioTimer: AudioTimer;
 
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @private_cc
+     * @deprecated_to_user
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -161,11 +161,11 @@ export class AudioPlayerWeb implements OperationQueueable {
     private _audioTimer: AudioTimer;
 
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _eventTarget: EventTarget = new EventTarget();
     /**
-     * @deprecated_to_user
+     * @marked_as_engine_private
      */
     public _operationQueue: OperationInfo[] = [];
 

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.18",
+  "version": "4.2.21-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.21-beta.3",
+  "version": "4.2.21-beta.5",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.18",
+  "version": "4.2.20-beta.1",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.20-beta.2",
+  "version": "4.2.20",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.21-beta.1",
+  "version": "4.2.21-beta.2",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.20",
+  "version": "4.2.21-beta.1",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.20-beta.1",
+  "version": "4.2.20-beta.2",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.2.21-beta.2",
+  "version": "4.2.21-beta.3",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/src/build-declarations/index.ts
+++ b/scripts/build-engine/src/build-declarations/index.ts
@@ -220,7 +220,7 @@ export async function build (options: {
         interfaceFilter.cullInterface({
             inputDts: indexOutputPath,
             privateTag: 'private_cc',
-            deprecateTag: 'deprecated_to_user',
+            deprecateTag: 'marked_as_engine_private',
             deprecateTip: 'since v3.5.0, this is an engine private interface that will be removed in the future.',
         });
     } catch (error) {

--- a/scripts/build-engine/src/build-declarations/index.ts
+++ b/scripts/build-engine/src/build-declarations/index.ts
@@ -1,8 +1,9 @@
-import ps from 'path';
+import ps, { dirname, join } from 'path';
 import fs from 'fs-extra';
 import ts from 'typescript';
 import * as gift from 'tfig';
 import { StatsQuery } from '../stats-query';
+import { interfaceFilter } from './interface-filter';
 
 const DEBUG = false;
 const REMOVE_TMP = true;
@@ -215,6 +216,11 @@ export async function build (options: {
                 { encoding: 'utf8' },
             );
         }
+
+        interfaceFilter.cullInterface({
+            inputDts: indexOutputPath,
+            outputDts: join(dirname(indexOutputPath), 'output.cc.d.ts'),
+        })
     } catch (error) {
         console.error(error);
         return false;

--- a/scripts/build-engine/src/build-declarations/index.ts
+++ b/scripts/build-engine/src/build-declarations/index.ts
@@ -219,7 +219,9 @@ export async function build (options: {
 
         interfaceFilter.cullInterface({
             inputDts: indexOutputPath,
-            targetTag: 'private_cc',
+            privateTag: 'private_cc',
+            deprecateTag: 'deprecated_to_user',
+            deprecateTip: 'since v3.5.0, this is an engine private interface that will be removed in the future.',
         });
     } catch (error) {
         console.error(error);

--- a/scripts/build-engine/src/build-declarations/index.ts
+++ b/scripts/build-engine/src/build-declarations/index.ts
@@ -219,6 +219,7 @@ export async function build (options: {
 
         interfaceFilter.cullInterface({
             inputDts: indexOutputPath,
+            targetTag: 'private_cc',
         });
     } catch (error) {
         console.error(error);

--- a/scripts/build-engine/src/build-declarations/index.ts
+++ b/scripts/build-engine/src/build-declarations/index.ts
@@ -219,8 +219,7 @@ export async function build (options: {
 
         interfaceFilter.cullInterface({
             inputDts: indexOutputPath,
-            outputDts: join(dirname(indexOutputPath), 'output.cc.d.ts'),
-        })
+        });
     } catch (error) {
         console.error(error);
         return false;

--- a/scripts/build-engine/src/build-declarations/interface-filter.ts
+++ b/scripts/build-engine/src/build-declarations/interface-filter.ts
@@ -12,11 +12,15 @@ export namespace interfaceFilter {
          * It is set to inputDts by default.
          */
         outputDts?: string;
+        /**
+         * Taget jsDoc tag to cull.
+         * this tag is `internal` by default.
+         */
+        targetTag?: string;
     }
     
     /**
      * Culling interface.
-     * Now we only cull the interface with `@internal` JSDoc tag.
      * @param cullingOptions 
      */
     export function cullInterface(cullingOptions: CullingOptions) {
@@ -24,6 +28,7 @@ export namespace interfaceFilter {
         const {
             inputDts,
             outputDts = inputDts,
+            targetTag = 'internal',
         } = cullingOptions;
 
         
@@ -54,7 +59,7 @@ export namespace interfaceFilter {
                         if (tags) {
                             for (let i = 0; i < tags.length; ++i) {
                                 let tag = tags[i];
-                                if (tag.name === 'internal') {
+                                if (tag.name === targetTag) {
                                     // delete interface
                                     return undefined;
                                 }
@@ -68,7 +73,7 @@ export namespace interfaceFilter {
                                 const tags = jsDoc.tags;
                                 if (tags) {
                                     for (let tag of tags) {
-                                        if (tag.tagName.escapedText === 'internal') {
+                                        if (tag.tagName.escapedText === targetTag) {
                                             return undefined;
                                         }
                                     }

--- a/scripts/build-engine/src/build-declarations/interface-filter.ts
+++ b/scripts/build-engine/src/build-declarations/interface-filter.ts
@@ -52,6 +52,7 @@ export namespace interfaceFilter {
                         kind === SyntaxKind.PropertySignature ||
                         kind === SyntaxKind.MethodSignature ||
 
+                        kind === SyntaxKind.FunctionDeclaration ||
                         kind === SyntaxKind.EnumDeclaration) {
                         // @ts-ignore
                         const symbol = checker.getSymbolAtLocation(node.name);

--- a/scripts/build-engine/src/build-declarations/interface-filter.ts
+++ b/scripts/build-engine/src/build-declarations/interface-filter.ts
@@ -1,0 +1,75 @@
+import * as ts from 'typescript';
+import * as fs from 'fs-extra';
+
+export namespace interfaceFilter {
+    export interface CullingOptions {
+        /**
+         * The path of input declaration file.
+         */
+        inputDts: string;
+        /**
+         * The path of output declaration file.
+         * It is set to inputDts by default.
+         */
+        outputDts?: string;
+    }
+    
+    /**
+     * Culling interface.
+     * Now we only cull the interface with `@internal` JSDoc tag.
+     * @param cullingOptions 
+     */
+    export function cullInterface(cullingOptions: CullingOptions) {
+        console.time('Culling interface');
+        const {
+            inputDts,
+            outputDts = inputDts,
+        } = cullingOptions;
+
+        
+        const program = ts.createProgram([inputDts], {});
+        const checker = program.getTypeChecker();
+        
+        const transformerFactory: ts.TransformerFactory<ts.Node> = (
+            context: ts.TransformationContext
+        ) => {
+            return (rootNode) => {
+                function visit(node: ts.Node): ts.Node | undefined {
+                    // @ts-ignore
+                    // console.log(syntaxToKind(node.kind) + ' ' + node.text);
+                    if (node.kind === ts.SyntaxKind.MethodDeclaration || node.kind === ts.SyntaxKind.PropertyDeclaration) {
+                        // @ts-ignore
+                        const symbol = checker.getSymbolAtLocation(node.name);
+                        const tags = symbol?.getJsDocTags();
+                        if (tags) {
+                            for (let i = 0; i < tags.length; ++i) {
+                                let tag = tags[i];
+                                if (tag.name === 'internal') {
+                                    // delete interface
+                                    return undefined;
+                                }
+                            }
+                        }
+                    }
+                    node = ts.visitEachChild(node, visit, context);
+                    return node;
+                }
+                return ts.visitNode(rootNode, visit);
+            };
+        };
+
+        const sourceFiles = program.getSourceFiles();
+        const targetInputDts = inputDts.replace(/\\/g, '/');
+        const sourceFileIndex = sourceFiles.findIndex(file => file.fileName === targetInputDts);
+        const sourceFile = sourceFiles[sourceFileIndex];
+        if (sourceFile) {
+            const result = ts.transform(sourceFile, [transformerFactory]);
+            const printer = ts.createPrinter();
+            const printResult = printer.printNode(ts.EmitHint.Unspecified, result.transformed[0] as ts.Node, sourceFile)
+            fs.outputFileSync(outputDts, printResult, { encoding: 'utf8' });
+        } else {
+            console.error('Cannot find source file.');
+        }
+        console.timeEnd('Culling interface');
+    }
+}

--- a/scripts/build-engine/src/build-declarations/interface-filter.ts
+++ b/scripts/build-engine/src/build-declarations/interface-filter.ts
@@ -35,9 +35,19 @@ export namespace interfaceFilter {
         ) => {
             return (rootNode) => {
                 function visit(node: ts.Node): ts.Node | undefined {
-                    // @ts-ignore
-                    // console.log(syntaxToKind(node.kind) + ' ' + node.text);
-                    if (node.kind === ts.SyntaxKind.MethodDeclaration || node.kind === ts.SyntaxKind.PropertyDeclaration) {
+                    const SyntaxKind = ts.SyntaxKind;
+                    const kind = node.kind;
+                    if (kind === SyntaxKind.ClassDeclaration ||
+                        kind === SyntaxKind.PropertyDeclaration ||
+                        kind === SyntaxKind.GetAccessor ||
+                        kind === SyntaxKind.SetAccessor ||
+                        kind === SyntaxKind.MethodDeclaration ||
+
+                        kind === SyntaxKind.InterfaceDeclaration ||
+                        kind === SyntaxKind.PropertySignature ||
+                        kind === SyntaxKind.MethodSignature ||
+
+                        kind === SyntaxKind.EnumDeclaration) {
                         // @ts-ignore
                         const symbol = checker.getSymbolAtLocation(node.name);
                         const tags = symbol?.getJsDocTags();
@@ -47,6 +57,21 @@ export namespace interfaceFilter {
                                 if (tag.name === 'internal') {
                                     // delete interface
                                     return undefined;
+                                }
+                            }
+                        }
+                    } else if (kind === SyntaxKind.VariableStatement) {
+                        // @ts-ignore VariableStatement can't use TypeChecker
+                        const jsDocs = node.jsDoc;
+                        if (jsDocs) {
+                            for (let jsDoc of jsDocs) {
+                                const tags = jsDoc.tags;
+                                if (tags) {
+                                    for (let tag of tags) {
+                                        if (tag.tagName.escapedText === 'internal') {
+                                            return undefined;
+                                        }
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
resolve: https://github.com/cocos-creator/3d-tasks/issues/10035


## 说明
dragonBone 模块里有 155 条  `@internal`  记录，这些都不是我们的研发手动标记的，是第三方库的标记， 第三方库使用的是 JSDoc 标准
所以需要一个跟 JSDoc 标准错开的标记，这里我用了 `@marked_as_engine_private`

**这个 PR 需要确认被移除的 `@internal` 接口，有没有问题**

我这边接口移除的标准是
- 已经明确标明 `DO NOT USE IT IN YOUR CODE` 的就直接标记上 `@marked_as_engine_private` https://github.com/cocos-creator/engine/commit/dd5c6edddd6ff591b5f641bb1f0c35c0330407b0 https://github.com/cocos-creator/engine/pull/9797/commits/77b770033d2856056b6363ea1f73ee1877ceef3e
- 既标记了 `@deprecated` 又标记了 `@marked_as_engine_private`, 以  `@deprecated` 标签为主 https://github.com/cocos-creator/engine/pull/9797/commits/dd5c6edddd6ff591b5f641bb1f0c35c0330407b0
- 带下划线开头的，也可以标记为 `@marked_as_engine_private` https://github.com/cocos-creator/engine/pull/9797/commits/afc8d2ba9d2f8a7278879be689c8cfd216a93763 https://github.com/cocos-creator/engine/pull/9797/commits/96dabcb370c9e2a73b879fdffabb370a69c8c7f1 https://github.com/cocos-creator/engine/pull/9797/commits/b0f3dc1ac2890b5d501623547636c78ff61881ea https://github.com/cocos-creator/engine/pull/9797/commits/7d5fa562f8901cc9c75dfdac1d87d90501a33aae https://github.com/cocos-creator/engine/pull/9797/commits/6a29cb7dd8da0160002c930a309a73a681bf2cb7 https://github.com/cocos-creator/engine/pull/9797/commits/a5d5105d4bc3cd2c4cc2ee096047a177a1ba5246
- `constructor` 构造函数不应该被标记为  `@marked_as_engine_private` https://github.com/cocos-creator/engine/pull/9797/commits/68b994601e9c48d526b1405a580ee083cc6cb95f

比较有争议的几个接口：
- serializeTag
- deserializeTag
- reserveContentsForAllSyncablePrefabTag
- toHashString

## 已知问题
依赖剔除的问题，另外建立了 issue 跟进 https://github.com/cocos-creator/3d-tasks/issues/10468