### PR TITLE
Fix the error of calculating child scaling when parent scaling is 0

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -3133,7 +3133,10 @@ let NodeDefines = {
     setWorldScale (scale) {
         if (this._parent) {
             this._parent.getWorldScale(_swsVec3);
-            Vec3.div(_swsVec3, scale, _swsVec3);
+            // Element-wise vector division, the divisor cannot be 0.
+            _swsVec3.x = scale.x / (_swsVec3.x || 1);
+            _swsVec3.y = scale.y / (_swsVec3.y || 1);
+            _swsVec3.z = scale.z / (_swsVec3.z || 1);
         }
         else {
             Vec3.copy(_swsVec3, scale);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

复现步骤：

A、B节点  如果先把A节点scale设置成0  再把B节点拖进A节点 
B节点（子节点）scale也会被设置成0 并且position重置为0

Changelog:
 * 修复父节点 scale 为 0 时，导致计算子节点 scale 错误


