### PR TITLE
Negative scale widget in editor

### DIFF
--- a/cocos/ui/widget-manager.ts
+++ b/cocos/ui/widget-manager.ts
@@ -352,7 +352,7 @@ export const widgetManager = legacyCC._widgetManager = {
                 let l = -parentAP.x * matchSize.width;
                 l += zero.x;
                 l *= one.x;
-                temp = pos.x - myAP.x * trans.width * widgetNodeScale.x - l;
+                temp = pos.x - myAP.x * trans.width * Math.abs(widgetNodeScale.x) - l;
                 if (!widget.isAbsoluteLeft) {
                     temp /= matchSize.width;
                 }
@@ -364,7 +364,7 @@ export const widgetManager = legacyCC._widgetManager = {
             if (e & alignFlags.RIGHT) {
                 let r = (1 - parentAP.x) * matchSize.width;
                 r += zero.x;
-                temp = (r *= one.x) - (pos.x + (1 - myAP.x) * trans.width * widgetNodeScale.x);
+                temp = (r *= one.x) - (pos.x + (1 - myAP.x) * trans.width * Math.abs(widgetNodeScale.x));
                 if (!widget.isAbsoluteRight) {
                     temp /= matchSize.width;
                 }
@@ -376,7 +376,7 @@ export const widgetManager = legacyCC._widgetManager = {
             if (e & alignFlags.TOP) {
                 let t = (1 - parentAP.y) * matchSize.height;
                 t += zero.y;
-                temp = (t *= one.y) - (pos.y + (1 - myAP.y) * trans.height * widgetNodeScale.y);
+                temp = (t *= one.y) - (pos.y + (1 - myAP.y) * trans.height * Math.abs(widgetNodeScale.y));
                 if (!widget.isAbsoluteTop) {
                     temp /= matchSize.height;
                 }
@@ -389,7 +389,7 @@ export const widgetManager = legacyCC._widgetManager = {
                 let b = -parentAP.y * matchSize.height;
                 b += zero.y;
                 b *= one.y;
-                temp = pos.y - myAP.y * trans.height * widgetNodeScale.y - b;
+                temp = pos.y - myAP.y * trans.height * Math.abs(widgetNodeScale.y) - b;
                 if (!widget.isAbsoluteBottom) {
                     temp /= matchSize.height;
                 }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#10449

Changelog:
 * editor下，修改align和target的计算align数据逻辑有误，已修改。

## 分析
![image](https://user-images.githubusercontent.com/32831993/145968239-99f75045-bf4c-42d9-a1e8-377d77a12702.png)
![企业微信截图_16394709514403](https://user-images.githubusercontent.com/32831993/145968335-252bae8e-080b-43a7-80a2-27cacf42dbdd.png)
![企业微信截图_16394708606376](https://user-images.githubusercontent.com/32831993/145967960-a55f8a14-bb29-470f-be0c-9ef649d139dc.png)

#### 现象
以上例来讲，编辑器下由none切换对齐模式为left时，因为scalex = -1，导致切换后，计算alignleft = 400，而非之前设置的0，从而导致位置偏移。
#### 原因
![image](https://user-images.githubusercontent.com/32831993/145969101-551819a1-0ec5-4798-98d1-703f1ea766ce.png)
因为是widget缩放可能为负，而非widget父物体（上例中是canvas）的scale为负，即
```pos.x - myAP.x * trans.width * Math.abs(widgetNodeScale.x)```
这一段其实是**在canvas的本地坐标系**中进行计算，并没有被翻转，所以**不能考虑符号**。只是这里计算widget中心到左边的距离时要考虑scale的倍数（绝对值），他影响了中心到左边的距离。
<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
