### PR TITLE
Mask does not work with spine on native Android

### DIFF
--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -880,7 +880,9 @@ const cacheManager = require('./jsb-cache-manager');
             if (middleware.indicesStart != _tempIndicesOffset ||
                 middleware.preRenderBufferIndex != _tempBufferIndex ||
                 middleware.preRenderBufferType != _tempVfmt) {
-                ui.autoMergeBatches(middleware.preRenderComponent);
+                if(middleware.preRenderComponent) {
+                    ui.autoMergeBatches(middleware.preRenderComponent);
+                }
                 middleware.resetIndicesStart = true;
             } else {
                 middleware.resetIndicesStart = false;

--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -880,6 +880,9 @@ const cacheManager = require('./jsb-cache-manager');
             if (middleware.indicesStart != _tempIndicesOffset ||
                 middleware.preRenderBufferIndex != _tempBufferIndex ||
                 middleware.preRenderBufferType != _tempVfmt) {
+                // Firstly, when the first spine in the scene excutes this method, the preRenderComponent(the last rendered spine component) of middleware which is a singleton must be null.
+                // Then, autoMergeBatches(null) leads to that the 'indicesStart' is modified as the value of the 'indicesOffset'.
+                // At Last, there is another autoMergeBatches in commmitComp, but this function will not work under condition that 'indicesStart' equals to 'indicesOffset'.
                 if(middleware.preRenderComponent) {
                     ui.autoMergeBatches(middleware.preRenderComponent);
                 }


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#10103

Changelog:
 * spine触发合批前，判断preRenderComponent是否合法。以此避免autoMergeBatches里错误设置indicesStart（具体分析详见issue10103）。

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
