### PR TITLE
update richtext truncation condition

### DIFF
--- a/cocos/2d/utils/text-utils.ts
+++ b/cocos/2d/utils/text-utils.ts
@@ -258,7 +258,9 @@ export function fragmentText (stringToken: string, allWidth: number, maxWidth: n
         checkWhile = 0;
 
         // Find the truncation point
-        while (width <= maxWidth && checkWhile++ < checkCount) {
+        // if the 'tempText' which is truncated from the next line content equals to '',
+        // we should break this loop because there is no available character in the next line.
+        while (tmpText && width <= maxWidth && checkWhile++ < checkCount) {
             if (tmpText) {
                 const exec = WORD_REG.exec(tmpText);
                 pushNum = exec ? exec[0].length : 1;

--- a/cocos/2d/utils/text-utils.ts
+++ b/cocos/2d/utils/text-utils.ts
@@ -261,11 +261,9 @@ export function fragmentText (stringToken: string, allWidth: number, maxWidth: n
         // if the 'tempText' which is truncated from the next line content equals to '',
         // we should break this loop because there is no available character in the next line.
         while (tmpText && width <= maxWidth && checkWhile++ < checkCount) {
-            if (tmpText) {
-                const exec = WORD_REG.exec(tmpText);
-                pushNum = exec ? exec[0].length : 1;
-                sLine = tmpText;
-            }
+            const exec = WORD_REG.exec(tmpText);
+            pushNum = exec ? exec[0].length : 1;
+            sLine = tmpText;
 
             fuzzyLen += pushNum;
             tmpText = _safeSubstring(text, fuzzyLen);


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#10454

Changelog:
 * 修改了富文本按行切割文本的条件

### 分析
![image](https://user-images.githubusercontent.com/32831993/146338043-0c49c6f7-91c9-473d-a903-f505f8c22745.png)
#### 条件
图中说的某种情况其实这里如outline
issue中outline的宽度是4，所有allWidth = 84，maxWidth = 80，
#### 执行
1. 在line263循环时，fuzzylen可以到达4，因为4个字符恰好装满80的宽度，此时tmpText === ""（定义上是空串，但是带有富文本的宽度），所以width在循环里始终是80不会超过maxWidth。
2. 所以当前循环只会终结在checkWhile>=checkCount情况，而这种情况下，fuzzyLen已经被**错误地增加了**很多次了，后面会根据fuzzyLen进行**最终的切割**，故产生错误。
#### 解决
所以，这里是在尝试把第二段的部分串往第一段塞的时候，加上第二段剩余串**是否为空串**的判断（如果在尝试塞时，第二段已经为空了，就说明参数text本就可以直接填入当前行而不用切割，这又与上面的循环相悖，所以这里一定有例如outline这样的特殊的宽度产生影响）

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
