### PR TITLE
compability for undefined game frame

### DIFF
--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -255,11 +255,19 @@ class ScreenAdapter extends EventTarget {
         this._gameContainer = document.getElementById('Cocos3dGameContainer') as HTMLDivElement;
         this._gameCanvas = document.getElementById('GameCanvas') as HTMLCanvasElement;
         // Compability with old preview or build template in Editor.
-        if (!TEST && !EDITOR && !this._gameContainer) {
-            this._gameContainer = document.createElement<'div'>('div');
-            this._gameContainer.setAttribute('id', 'Cocos3dGameContainer');
-            this._gameCanvas?.parentNode?.insertBefore(this._gameContainer, this._gameCanvas);
-            this._gameContainer.appendChild(this._gameCanvas);
+        if (!TEST && !EDITOR) {
+            if (!this._gameFrame) {
+                this._gameFrame = document.createElement<'div'>('div');
+                this._gameFrame.setAttribute('id', 'GameDiv');
+                this._gameCanvas?.parentNode?.insertBefore(this._gameFrame, this._gameCanvas);
+                this._gameFrame.appendChild(this._gameCanvas);
+            }
+            if (!this._gameContainer) {
+                this._gameContainer = document.createElement<'div'>('div');
+                this._gameContainer.setAttribute('id', 'Cocos3dGameContainer');
+                this._gameCanvas?.parentNode?.insertBefore(this._gameContainer, this._gameCanvas);
+                this._gameContainer.appendChild(this._gameCanvas);
+            }
         }
 
         let fnList: Array<string>;


### PR DESCRIPTION
代码层级上做好运行时 dom 模板的兼容

如果用户定制了 GameDiv 的内部结构，我们仍然建议用户手动将模板改成这个固定结构
```html
<div id="GameDiv"
    <div id="Cocos3dGameContainer">
        <canvas id="GameCanvas"></canvas>
    </div>
</div>
```