### PR TITLE
fix the bugs found in PR9854.

### DIFF
--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -1583,14 +1583,17 @@ export function WebGLCmdFuncCreateInputAssember (device: WebGLDevice, gpuInputAs
 export function WebGLCmdFuncDestroyInputAssembler (device: WebGLDevice, gpuInputAssembler: IWebGLGPUInputAssembler) {
     const it = gpuInputAssembler.glVAOs.values();
     let res = it.next();
+    const OES_vertex_array_object = device.extensions.OES_vertex_array_object!;
+    let glVAO = device.stateCache.glVAO;
     while (!res.done) {
-        device.extensions.OES_vertex_array_object!.deleteVertexArrayOES(res.value);
-        if (device.stateCache.glVAO === res.value) {
-            device.extensions.OES_vertex_array_object!.bindVertexArrayOES(null);
-            device.stateCache.glVAO = null;
+        OES_vertex_array_object.deleteVertexArrayOES(res.value);
+        if (glVAO === res.value) {
+            OES_vertex_array_object.bindVertexArrayOES(null);
+            glVAO = null;
         }
         res = it.next();
     }
+    device.stateCache.glVAO = glVAO;
     gpuInputAssembler.glVAOs.clear();
 }
 

--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -953,7 +953,7 @@ export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWe
     const { gl } = device;
     if (gpuTexture.glTexture) {
         const glTexUnits = device.stateCache.glTexUnits;
-        let texUnit = 0;
+        let texUnit = device.stateCache.texUnit;
         gl.deleteTexture(gpuTexture.glTexture);
         for (let i = 0; i < glTexUnits.length; i++) {
             if (glTexUnits[i].glTexture === gpuTexture.glTexture) {

--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -951,6 +951,7 @@ export function WebGLCmdFuncCreateTexture (device: WebGLDevice, gpuTexture: IWeb
 
 export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWebGLGPUTexture) {
     if (gpuTexture.glTexture) {
+        device.gl.deleteTexture(gpuTexture.glTexture);
         for (let i = 0; i < device.stateCache.glTexUnits.length; i++) {
             if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
                 device.gl.activeTexture(device.gl.TEXTURE0 + i);
@@ -958,16 +959,15 @@ export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWe
                 device.stateCache.glTexUnits[i].glTexture = null;
             }
         }
-        device.gl.deleteTexture(gpuTexture.glTexture);
         gpuTexture.glTexture = null;
     }
 
     if (gpuTexture.glRenderbuffer) {
+        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
         if (device.stateCache.glRenderbuffer === gpuTexture.glRenderbuffer) {
             device.gl.bindRenderbuffer(device.gl.RENDERBUFFER, null);
             device.stateCache.glRenderbuffer = null;
         }
-        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
         gpuTexture.glRenderbuffer = null;
     }
 }
@@ -1174,11 +1174,11 @@ export function WebGLCmdFuncCreateFramebuffer (device: WebGLDevice, gpuFramebuff
 
 export function WebGLCmdFuncDestroyFramebuffer (device: WebGLDevice, gpuFramebuffer: IWebGLGPUFramebuffer) {
     if (gpuFramebuffer.glFramebuffer) {
+        device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
         if (device.stateCache.glFramebuffer === gpuFramebuffer.glFramebuffer) {
             device.gl.bindFramebuffer(device.gl.FRAMEBUFFER, null);
             device.stateCache.glFramebuffer = null;
         }
-        device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
         gpuFramebuffer.glFramebuffer = null;
     }
 }
@@ -1531,11 +1531,11 @@ export function WebGLCmdFuncDestroyShader (device: WebGLDevice, gpuShader: IWebG
                 }
             }
         }
+        gl.deleteProgram(gpuShader.glProgram);
         if (device.stateCache.glProgram === gpuShader.glProgram) {
             device.gl.useProgram(null);
             device.stateCache.glProgram = null;
         }
-        gl.deleteProgram(gpuShader.glProgram);
         gpuShader.glProgram = null;
     }
 }
@@ -1578,11 +1578,11 @@ export function WebGLCmdFuncDestroyInputAssembler (device: WebGLDevice, gpuInput
     const it = gpuInputAssembler.glVAOs.values();
     let res = it.next();
     while (!res.done) {
+        device.extensions.OES_vertex_array_object!.deleteVertexArrayOES(res.value);
         if (device.stateCache.glVAO === res.value) {
             device.extensions.OES_vertex_array_object!.bindVertexArrayOES(null);
             device.stateCache.glVAO = null;
         }
-        device.extensions.OES_vertex_array_object!.deleteVertexArrayOES(res.value);
         res = it.next();
     }
     gpuInputAssembler.glVAOs.clear();

--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -952,11 +952,22 @@ export function WebGLCmdFuncCreateTexture (device: WebGLDevice, gpuTexture: IWeb
 export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWebGLGPUTexture) {
     if (gpuTexture.glTexture) {
         device.gl.deleteTexture(gpuTexture.glTexture);
+        for (let i = 0; i < device.stateCache.glTexUnits.length; i++) {
+            if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
+                device.gl.activeTexture(device.gl.TEXTURE0 + i);
+                device.gl.bindTexture(gpuTexture.glTarget, null);
+                device.stateCache.glTexUnits[i].glTexture = null!;
+            }
+        }
         gpuTexture.glTexture = null;
     }
 
     if (gpuTexture.glRenderbuffer) {
         device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
+        if (device.stateCache.glRenderbuffer === gpuTexture.glRenderbuffer) {
+            device.gl.bindRenderbuffer(device.gl.RENDERBUFFER, null);
+            device.stateCache.glRenderbuffer = null;
+        }
         gpuTexture.glRenderbuffer = null;
     }
 }
@@ -1164,6 +1175,10 @@ export function WebGLCmdFuncCreateFramebuffer (device: WebGLDevice, gpuFramebuff
 export function WebGLCmdFuncDestroyFramebuffer (device: WebGLDevice, gpuFramebuffer: IWebGLGPUFramebuffer) {
     if (gpuFramebuffer.glFramebuffer) {
         device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
+        if (device.stateCache.glFramebuffer === gpuFramebuffer.glFramebuffer) {
+            device.gl.bindFramebuffer(device.gl.FRAMEBUFFER, null);
+            device.stateCache.glFramebuffer = null;
+        }
         gpuFramebuffer.glFramebuffer = null;
     }
 }
@@ -1517,6 +1532,10 @@ export function WebGLCmdFuncDestroyShader (device: WebGLDevice, gpuShader: IWebG
             }
         }
         gl.deleteProgram(gpuShader.glProgram);
+        if (device.stateCache.glProgram === gpuShader.glProgram) {
+            device.gl.useProgram(null);
+            device.stateCache.glProgram = null;
+        }
         gpuShader.glProgram = null;
     }
 }
@@ -1559,6 +1578,10 @@ export function WebGLCmdFuncDestroyInputAssembler (device: WebGLDevice, gpuInput
     const it = gpuInputAssembler.glVAOs.values();
     let res = it.next();
     while (!res.done) {
+        if (device.stateCache.glVAO === res.value) {
+            device.extensions.OES_vertex_array_object!.bindVertexArrayOES(null);
+            device.stateCache.glVAO = null;
+        }
         device.extensions.OES_vertex_array_object!.deleteVertexArrayOES(res.value);
         res = it.next();
     }

--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -950,24 +950,29 @@ export function WebGLCmdFuncCreateTexture (device: WebGLDevice, gpuTexture: IWeb
 }
 
 export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWebGLGPUTexture) {
+    const { gl } = device;
     if (gpuTexture.glTexture) {
-        device.gl.deleteTexture(gpuTexture.glTexture);
-        for (let i = 0; i < device.stateCache.glTexUnits.length; i++) {
-            if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
-                device.gl.activeTexture(device.gl.TEXTURE0 + i);
-                device.stateCache.texUnit = i;
-                device.gl.bindTexture(gpuTexture.glTarget, null);
-                device.stateCache.glTexUnits[i].glTexture = null;
+        const glTexUnits = device.stateCache.glTexUnits;
+        let texUnit = 0;
+        gl.deleteTexture(gpuTexture.glTexture);
+        for (let i = 0; i < glTexUnits.length; i++) {
+            if (glTexUnits[i].glTexture === gpuTexture.glTexture) {
+                gl.activeTexture(gl.TEXTURE0 + i);
+                texUnit = i;
+                gl.bindTexture(gpuTexture.glTarget, null);
+                glTexUnits[i].glTexture = null;
             }
         }
+        device.stateCache.texUnit = texUnit;
         gpuTexture.glTexture = null;
     }
 
     if (gpuTexture.glRenderbuffer) {
-        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
-        if (device.stateCache.glRenderbuffer === gpuTexture.glRenderbuffer) {
-            device.gl.bindRenderbuffer(device.gl.RENDERBUFFER, null);
-            device.stateCache.glRenderbuffer = null;
+        let glRenderbuffer = device.stateCache.glRenderbuffer;
+        gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
+        if (glRenderbuffer === gpuTexture.glRenderbuffer) {
+            gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+            glRenderbuffer = null;
         }
         gpuTexture.glRenderbuffer = null;
     }

--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -955,7 +955,7 @@ export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWe
             if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
                 device.gl.activeTexture(device.gl.TEXTURE0 + i);
                 device.gl.bindTexture(gpuTexture.glTarget, null);
-                device.stateCache.glTexUnits[i].glTexture = null!;
+                device.stateCache.glTexUnits[i].glTexture = null;
             }
         }
         device.gl.deleteTexture(gpuTexture.glTexture);

--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -951,7 +951,6 @@ export function WebGLCmdFuncCreateTexture (device: WebGLDevice, gpuTexture: IWeb
 
 export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWebGLGPUTexture) {
     if (gpuTexture.glTexture) {
-        device.gl.deleteTexture(gpuTexture.glTexture);
         for (let i = 0; i < device.stateCache.glTexUnits.length; i++) {
             if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
                 device.gl.activeTexture(device.gl.TEXTURE0 + i);
@@ -959,15 +958,16 @@ export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWe
                 device.stateCache.glTexUnits[i].glTexture = null!;
             }
         }
+        device.gl.deleteTexture(gpuTexture.glTexture);
         gpuTexture.glTexture = null;
     }
 
     if (gpuTexture.glRenderbuffer) {
-        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
         if (device.stateCache.glRenderbuffer === gpuTexture.glRenderbuffer) {
             device.gl.bindRenderbuffer(device.gl.RENDERBUFFER, null);
             device.stateCache.glRenderbuffer = null;
         }
+        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
         gpuTexture.glRenderbuffer = null;
     }
 }
@@ -1174,11 +1174,11 @@ export function WebGLCmdFuncCreateFramebuffer (device: WebGLDevice, gpuFramebuff
 
 export function WebGLCmdFuncDestroyFramebuffer (device: WebGLDevice, gpuFramebuffer: IWebGLGPUFramebuffer) {
     if (gpuFramebuffer.glFramebuffer) {
-        device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
         if (device.stateCache.glFramebuffer === gpuFramebuffer.glFramebuffer) {
             device.gl.bindFramebuffer(device.gl.FRAMEBUFFER, null);
             device.stateCache.glFramebuffer = null;
         }
+        device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
         gpuFramebuffer.glFramebuffer = null;
     }
 }
@@ -1531,11 +1531,11 @@ export function WebGLCmdFuncDestroyShader (device: WebGLDevice, gpuShader: IWebG
                 }
             }
         }
-        gl.deleteProgram(gpuShader.glProgram);
         if (device.stateCache.glProgram === gpuShader.glProgram) {
             device.gl.useProgram(null);
             device.stateCache.glProgram = null;
         }
+        gl.deleteProgram(gpuShader.glProgram);
         gpuShader.glProgram = null;
     }
 }

--- a/cocos/core/gfx/webgl/webgl-commands.ts
+++ b/cocos/core/gfx/webgl/webgl-commands.ts
@@ -955,6 +955,7 @@ export function WebGLCmdFuncDestroyTexture (device: WebGLDevice, gpuTexture: IWe
         for (let i = 0; i < device.stateCache.glTexUnits.length; i++) {
             if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
                 device.gl.activeTexture(device.gl.TEXTURE0 + i);
+                device.stateCache.texUnit = i;
                 device.gl.bindTexture(gpuTexture.glTarget, null);
                 device.stateCache.glTexUnits[i].glTexture = null;
             }

--- a/cocos/core/gfx/webgl/webgl-device.ts
+++ b/cocos/core/gfx/webgl/webgl-device.ts
@@ -116,6 +116,10 @@ export class WebGLDevice extends Device {
         this._caps.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         this._caps.maxCubeMapTextureSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
 
+        // WebGL doesn't support UBOs at all, so here we return
+        // the guaranteed minimum number of available bindings in WebGL2
+        this._caps.maxUniformBufferBindings = 16;
+
         const extensions = gl.getSupportedExtensions();
         let extStr = '';
         if (extensions) {

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1391,7 +1391,7 @@ export function WebGL2CmdFuncDestroyFramebuffer (device: WebGL2Device, gpuFrameb
     if (gpuFramebuffer.glFramebuffer) {
         if (device.stateCache.glFramebuffer === gpuFramebuffer.glFramebuffer) {
             device.gl.bindFramebuffer(device.gl.FRAMEBUFFER, null);
-            device.stateCache.glFramebuffer = null!;
+            device.stateCache.glFramebuffer = null;
         }
         device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
         gpuFramebuffer.glFramebuffer = null;

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1132,11 +1132,11 @@ export function WebGL2CmdFuncDestroyTexture (device: WebGL2Device, gpuTexture: I
     }
 
     if (gpuTexture.glRenderbuffer) {
-        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
         if (device.stateCache.glRenderbuffer === gpuTexture.glRenderbuffer) {
             device.gl.bindRenderbuffer(device.gl.RENDERBUFFER, null);
             device.stateCache.glRenderbuffer = null;
         }
+        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
         gpuTexture.glRenderbuffer = null;
     }
 }
@@ -1677,11 +1677,11 @@ export function WebGL2CmdFuncCreateShader (device: WebGL2Device, gpuShader: IWeb
 
 export function WebGL2CmdFuncDestroyShader (device: WebGL2Device, gpuShader: IWebGL2GPUShader) {
     if (gpuShader.glProgram) {
-        device.gl.deleteProgram(gpuShader.glProgram);
         if (device.stateCache.glProgram === gpuShader.glProgram) {
             device.gl.useProgram(null);
             device.stateCache.glProgram = null;
         }
+        device.gl.deleteProgram(gpuShader.glProgram);
         gpuShader.glProgram = null;
     }
 }

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1119,24 +1119,29 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
 }
 
 export function WebGL2CmdFuncDestroyTexture (device: WebGL2Device, gpuTexture: IWebGL2GPUTexture) {
+    const { gl } = device;
     if (gpuTexture.glTexture) {
-        device.gl.deleteTexture(gpuTexture.glTexture);
-        for (let i = 0; i < device.stateCache.glTexUnits.length; ++i) {
-            if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
-                device.gl.activeTexture(device.gl.TEXTURE0 + i);
-                device.stateCache.texUnit = i;
-                device.gl.bindTexture(gpuTexture.glTarget, null);
-                device.stateCache.glTexUnits[i].glTexture = null;
+        const glTexUnits = device.stateCache.glTexUnits;
+        let texUnit = 0;
+        gl.deleteTexture(gpuTexture.glTexture);
+        for (let i = 0; i < glTexUnits.length; ++i) {
+            if (glTexUnits[i].glTexture === gpuTexture.glTexture) {
+                gl.activeTexture(gl.TEXTURE0 + i);
+                texUnit = i;
+                gl.bindTexture(gpuTexture.glTarget, null);
+                glTexUnits[i].glTexture = null;
             }
         }
+        device.stateCache.texUnit = texUnit;
         gpuTexture.glTexture = null;
     }
 
     if (gpuTexture.glRenderbuffer) {
-        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
-        if (device.stateCache.glRenderbuffer === gpuTexture.glRenderbuffer) {
-            device.gl.bindRenderbuffer(device.gl.RENDERBUFFER, null);
-            device.stateCache.glRenderbuffer = null;
+        let glRenderbuffer = device.stateCache.glRenderbuffer;
+        gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
+        if (glRenderbuffer === gpuTexture.glRenderbuffer) {
+            gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+            glRenderbuffer = null;
         }
         gpuTexture.glRenderbuffer = null;
     }
@@ -1276,12 +1281,14 @@ export function WebGL2CmdFuncCreateSampler (device: WebGL2Device, gpuSampler: IW
 }
 
 export function WebGL2CmdFuncDestroySampler (device: WebGL2Device, gpuSampler: IWebGL2GPUSampler) {
+    const { gl } = device;
     if (gpuSampler.glSampler) {
-        device.gl.deleteSampler(gpuSampler.glSampler);
-        for (let i = 0; i < device.stateCache.glSamplerUnits.length; ++i) {
-            if (device.stateCache.glSamplerUnits[i] === gpuSampler.glSampler) {
-                device.gl.bindSampler(i, null);
-                device.stateCache.glSamplerUnits[i] = null;
+        gl.deleteSampler(gpuSampler.glSampler);
+        const glSamplerUnits = device.stateCache.glSamplerUnits;
+        for (let i = 0; i < glSamplerUnits.length; ++i) {
+            if (glSamplerUnits[i] === gpuSampler.glSampler) {
+                gl.bindSampler(i, null);
+                glSamplerUnits[i] = null;
             }
         }
         gpuSampler.glSampler = null;

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1120,12 +1120,23 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
 
 export function WebGL2CmdFuncDestroyTexture (device: WebGL2Device, gpuTexture: IWebGL2GPUTexture) {
     if (gpuTexture.glTexture) {
+        for (let i = 0; i < device.stateCache.glTexUnits.length; ++i) {
+            if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
+                device.gl.activeTexture(device.gl.TEXTURE0 + i);
+                device.gl.bindTexture(gpuTexture.glTarget, null);
+                device.stateCache.glTexUnits[i].glTexture = null;
+            }
+        }
         device.gl.deleteTexture(gpuTexture.glTexture);
         gpuTexture.glTexture = null;
     }
 
     if (gpuTexture.glRenderbuffer) {
         device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
+        if (device.stateCache.glRenderbuffer === gpuTexture.glRenderbuffer) {
+            device.gl.bindRenderbuffer(device.gl.RENDERBUFFER, null);
+            device.stateCache.glRenderbuffer = null;
+        }
         gpuTexture.glRenderbuffer = null;
     }
 }
@@ -1265,6 +1276,12 @@ export function WebGL2CmdFuncCreateSampler (device: WebGL2Device, gpuSampler: IW
 
 export function WebGL2CmdFuncDestroySampler (device: WebGL2Device, gpuSampler: IWebGL2GPUSampler) {
     if (gpuSampler.glSampler) {
+        for (let i = 0; i < device.stateCache.glSamplerUnits.length; ++i) {
+            if (device.stateCache.glSamplerUnits[i] === gpuSampler.glSampler) {
+                device.gl.bindSampler(i, null);
+                device.stateCache.glSamplerUnits[i] = null;
+            }
+        }
         device.gl.deleteSampler(gpuSampler.glSampler);
         gpuSampler.glSampler = null;
     }
@@ -1372,6 +1389,10 @@ export function WebGL2CmdFuncCreateFramebuffer (device: WebGL2Device, gpuFramebu
 
 export function WebGL2CmdFuncDestroyFramebuffer (device: WebGL2Device, gpuFramebuffer: IWebGL2GPUFramebuffer) {
     if (gpuFramebuffer.glFramebuffer) {
+        if (device.stateCache.glFramebuffer === gpuFramebuffer.glFramebuffer) {
+            device.gl.bindFramebuffer(device.gl.FRAMEBUFFER, null);
+            device.stateCache.glFramebuffer = null!;
+        }
         device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
         gpuFramebuffer.glFramebuffer = null;
     }
@@ -1657,6 +1678,10 @@ export function WebGL2CmdFuncCreateShader (device: WebGL2Device, gpuShader: IWeb
 export function WebGL2CmdFuncDestroyShader (device: WebGL2Device, gpuShader: IWebGL2GPUShader) {
     if (gpuShader.glProgram) {
         device.gl.deleteProgram(gpuShader.glProgram);
+        if (device.stateCache.glProgram === gpuShader.glProgram) {
+            device.gl.useProgram(null);
+            device.stateCache.glProgram = null;
+        }
         gpuShader.glProgram = null;
     }
 }
@@ -1700,6 +1725,10 @@ export function WebGL2CmdFuncDestroyInputAssembler (device: WebGL2Device, gpuInp
     const it = gpuInputAssembler.glVAOs.values();
     let res = it.next();
     while (!res.done) {
+        if (device.stateCache.glVAO === res.value) {
+            device.gl.bindVertexArray(null);
+            device.stateCache.glVAO = null;
+        }
         device.gl.deleteVertexArray(res.value);
         res = it.next();
     }

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1124,6 +1124,7 @@ export function WebGL2CmdFuncDestroyTexture (device: WebGL2Device, gpuTexture: I
         for (let i = 0; i < device.stateCache.glTexUnits.length; ++i) {
             if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
                 device.gl.activeTexture(device.gl.TEXTURE0 + i);
+                device.stateCache.texUnit = i;
                 device.gl.bindTexture(gpuTexture.glTarget, null);
                 device.stateCache.glTexUnits[i].glTexture = null;
             }

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1122,7 +1122,7 @@ export function WebGL2CmdFuncDestroyTexture (device: WebGL2Device, gpuTexture: I
     const { gl } = device;
     if (gpuTexture.glTexture) {
         const glTexUnits = device.stateCache.glTexUnits;
-        let texUnit = 0;
+        let texUnit = device.stateCache.texUnit;
         gl.deleteTexture(gpuTexture.glTexture);
         for (let i = 0; i < glTexUnits.length; ++i) {
             if (glTexUnits[i].glTexture === gpuTexture.glTexture) {

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1120,6 +1120,7 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
 
 export function WebGL2CmdFuncDestroyTexture (device: WebGL2Device, gpuTexture: IWebGL2GPUTexture) {
     if (gpuTexture.glTexture) {
+        device.gl.deleteTexture(gpuTexture.glTexture);
         for (let i = 0; i < device.stateCache.glTexUnits.length; ++i) {
             if (device.stateCache.glTexUnits[i].glTexture === gpuTexture.glTexture) {
                 device.gl.activeTexture(device.gl.TEXTURE0 + i);
@@ -1127,16 +1128,15 @@ export function WebGL2CmdFuncDestroyTexture (device: WebGL2Device, gpuTexture: I
                 device.stateCache.glTexUnits[i].glTexture = null;
             }
         }
-        device.gl.deleteTexture(gpuTexture.glTexture);
         gpuTexture.glTexture = null;
     }
 
     if (gpuTexture.glRenderbuffer) {
+        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
         if (device.stateCache.glRenderbuffer === gpuTexture.glRenderbuffer) {
             device.gl.bindRenderbuffer(device.gl.RENDERBUFFER, null);
             device.stateCache.glRenderbuffer = null;
         }
-        device.gl.deleteRenderbuffer(gpuTexture.glRenderbuffer);
         gpuTexture.glRenderbuffer = null;
     }
 }
@@ -1276,13 +1276,13 @@ export function WebGL2CmdFuncCreateSampler (device: WebGL2Device, gpuSampler: IW
 
 export function WebGL2CmdFuncDestroySampler (device: WebGL2Device, gpuSampler: IWebGL2GPUSampler) {
     if (gpuSampler.glSampler) {
+        device.gl.deleteSampler(gpuSampler.glSampler);
         for (let i = 0; i < device.stateCache.glSamplerUnits.length; ++i) {
             if (device.stateCache.glSamplerUnits[i] === gpuSampler.glSampler) {
                 device.gl.bindSampler(i, null);
                 device.stateCache.glSamplerUnits[i] = null;
             }
         }
-        device.gl.deleteSampler(gpuSampler.glSampler);
         gpuSampler.glSampler = null;
     }
 }
@@ -1389,11 +1389,11 @@ export function WebGL2CmdFuncCreateFramebuffer (device: WebGL2Device, gpuFramebu
 
 export function WebGL2CmdFuncDestroyFramebuffer (device: WebGL2Device, gpuFramebuffer: IWebGL2GPUFramebuffer) {
     if (gpuFramebuffer.glFramebuffer) {
+        device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
         if (device.stateCache.glFramebuffer === gpuFramebuffer.glFramebuffer) {
             device.gl.bindFramebuffer(device.gl.FRAMEBUFFER, null);
             device.stateCache.glFramebuffer = null;
         }
-        device.gl.deleteFramebuffer(gpuFramebuffer.glFramebuffer);
         gpuFramebuffer.glFramebuffer = null;
     }
 }
@@ -1677,11 +1677,11 @@ export function WebGL2CmdFuncCreateShader (device: WebGL2Device, gpuShader: IWeb
 
 export function WebGL2CmdFuncDestroyShader (device: WebGL2Device, gpuShader: IWebGL2GPUShader) {
     if (gpuShader.glProgram) {
+        device.gl.deleteProgram(gpuShader.glProgram);
         if (device.stateCache.glProgram === gpuShader.glProgram) {
             device.gl.useProgram(null);
             device.stateCache.glProgram = null;
         }
-        device.gl.deleteProgram(gpuShader.glProgram);
         gpuShader.glProgram = null;
     }
 }
@@ -1725,11 +1725,11 @@ export function WebGL2CmdFuncDestroyInputAssembler (device: WebGL2Device, gpuInp
     const it = gpuInputAssembler.glVAOs.values();
     let res = it.next();
     while (!res.done) {
+        device.gl.deleteVertexArray(res.value);
         if (device.stateCache.glVAO === res.value) {
             device.gl.bindVertexArray(null);
             device.stateCache.glVAO = null;
         }
-        device.gl.deleteVertexArray(res.value);
         res = it.next();
     }
     gpuInputAssembler.glVAOs.clear();

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1732,14 +1732,17 @@ export function WebGL2CmdFuncCreateInputAssember (device: WebGL2Device, gpuInput
 export function WebGL2CmdFuncDestroyInputAssembler (device: WebGL2Device, gpuInputAssembler: IWebGL2GPUInputAssembler) {
     const it = gpuInputAssembler.glVAOs.values();
     let res = it.next();
+    const { gl } = device;
+    let glVAO = device.stateCache.glVAO;
     while (!res.done) {
-        device.gl.deleteVertexArray(res.value);
-        if (device.stateCache.glVAO === res.value) {
-            device.gl.bindVertexArray(null);
-            device.stateCache.glVAO = null;
+        gl.deleteVertexArray(res.value);
+        if (glVAO === res.value) {
+            gl.bindVertexArray(null);
+            glVAO = null;
         }
         res = it.next();
     }
+    device.stateCache.glVAO = glVAO;
     gpuInputAssembler.glVAOs.clear();
 }
 


### PR DESCRIPTION
Fix the bugs found in PR9854.

https://github.com/cocos-creator/engine/pull/9873#issue-1088323238

Bug: when destroying a texture object, the active texture unit changed, but the stateCache.texUnit kept unchanged.