### PR TITLE
fix bug: remove all actions by tag

### DIFF
--- a/cocos/tween/actions/action-manager.ts
+++ b/cocos/tween/actions/action-manager.ts
@@ -205,6 +205,9 @@ export class ActionManager {
         }
     }
 
+    /**
+     * @internal
+     */
     _removeActionByTag (tag: number, element: any, target?: Node) {
         for (let i = 0, l = element.actions.length; i < l; ++i) {
             const action = element.actions[i];
@@ -218,6 +221,9 @@ export class ActionManager {
         }
     }
 
+    /**
+     * @internal
+     */
     _removeAllActionsByTag (tag: number, element: any, target?: Node) {
         const validActions:any[] = [];
         for (let i = 0, l = element.actions.length; i < l; ++i) {

--- a/cocos/tween/actions/action-manager.ts
+++ b/cocos/tween/actions/action-manager.ts
@@ -218,6 +218,25 @@ export class ActionManager {
         }
     }
 
+    _removeAllActionsByTag (tag: number, element: any, target?: Node) {
+        const validActions:any[] = [];
+        for (let i = 0, l = element.actions.length; i < l; ++i) {
+            const action = element.actions[i];
+            if (action && action.getTag() === tag) {
+                if (target && action.getOriginalTarget() !== target) {
+                    validActions.push(action);
+                    continue;
+                }
+            } else {
+                validActions.push(action);
+            }
+        }
+        element.actions = validActions;
+        if (element.actions.length === 0) {
+            this._deleteHashElement(element);
+        }
+    }
+
     /**
      * @en Removes an action given its tag and the target.
      * @zh 删除指定对象下特定标签的一个动作，将删除首个匹配到的动作。
@@ -237,6 +256,29 @@ export class ActionManager {
         } else {
             hashTargets.forEach((element) => {
                 this._removeActionByTag(tag, element);
+            });
+        }
+    }
+
+    /**
+     * @en Removes all actions given the tag and the target.
+     * @zh 删除指定对象下特定标签的所有动作。
+     * @method removeAllActionsByTag
+     * @param {Number} tag
+     * @param {Node} target
+     */
+    removeAllActionsByTag (tag: number, target?: Node) {
+        if (tag === Action.TAG_INVALID) logID(1002);
+
+        const hashTargets = this._hashTargets;
+        if (target) {
+            const element = hashTargets.get(target);
+            if (element) {
+                this._removeAllActionsByTag(tag, element, target);
+            }
+        } else {
+            hashTargets.forEach((element) => {
+                this._removeAllActionsByTag(tag, element);
             });
         }
     }

--- a/cocos/tween/actions/action-manager.ts
+++ b/cocos/tween/actions/action-manager.ts
@@ -225,21 +225,14 @@ export class ActionManager {
      * @internal
      */
     _removeAllActionsByTag (tag: number, element: any, target?: Node) {
-        const validActions:any[] = [];
-        for (let i = 0, l = element.actions.length; i < l; ++i) {
+        for (let i = element.actions.length - 1; i >= 0; --i) {
             const action = element.actions[i];
             if (action && action.getTag() === tag) {
                 if (target && action.getOriginalTarget() !== target) {
-                    validActions.push(action);
                     continue;
                 }
-            } else {
-                validActions.push(action);
+                this._removeActionAtIndex(i, element);
             }
-        }
-        element.actions = validActions;
-        if (element.actions.length === 0) {
-            this._deleteHashElement(element);
         }
     }
 

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -282,7 +282,7 @@ export class Tween<T> {
      */
     repeat (repeatTimes: number, embedTween?: Tween<T>): Tween<T> {
         /** adapter */
-        if (repeatTimes == Infinity) {
+        if (repeatTimes === Infinity) {
             return this.repeatForever(embedTween);
         }
 

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -397,7 +397,7 @@ export class Tween<T> {
      * 停止所有指定标签的缓动
      */
     static stopAllByTag (tag: number, target?: object) {
-        TweenSystem.instance.ActionManager.removeActionByTag(tag, target as any);
+        TweenSystem.instance.ActionManager.removeAllActionsByTag(tag, target as any);
     }
     /**
      * @en

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -43,6 +43,7 @@ type FlagExcludedType<Base, Type> = { [Key in keyof Base]: Base[Key] extends Typ
 type AllowedNames<Base, Type> = FlagExcludedType<Base, Type>[keyof Base];
 type KeyPartial<T, K extends keyof T> = { [P in K]?: T[P] };
 type OmitType<Base, Type> = KeyPartial<Base, AllowedNames<Base, Type>>;
+// eslint-disable-next-line @typescript-eslint/ban-types
 type ConstructorType<T> = OmitType<T, Function>;
 
 /**
@@ -241,6 +242,7 @@ export class Tween<T> {
      * @param {Function} callback
      * @return {Tween}
      */
+    // eslint-disable-next-line @typescript-eslint/ban-types
     call (callback: Function): Tween<T> {
         const action = callFunc(callback);
         this._actions.push(action);
@@ -396,6 +398,7 @@ export class Tween<T> {
      * @zh
      * 停止所有指定标签的缓动
      */
+    // eslint-disable-next-line @typescript-eslint/ban-types
     static stopAllByTag (tag: number, target?: object) {
         TweenSystem.instance.ActionManager.removeAllActionsByTag(tag, target as any);
     }
@@ -405,6 +408,7 @@ export class Tween<T> {
      * @zh
      * 停止所有指定对象的缓动
      */
+    // eslint-disable-next-line @typescript-eslint/ban-types
     static stopAllByTarget (target?: object) {
         TweenSystem.instance.ActionManager.removeAllActionsFromTarget(target as any);
     }

--- a/tests/tween/tween.test.ts
+++ b/tests/tween/tween.test.ts
@@ -1,0 +1,21 @@
+import { director, Node, Scene, Vec3, System } from "../../cocos/core";
+import { tween, Tween, TweenSystem } from "../../cocos/tween";
+
+test('remove actions by tag', function () {
+    const scene = new Scene('test-tags');
+    const node = new Node();
+    scene.addChild(node);
+
+    const sys = new TweenSystem();
+    (TweenSystem.instance as any) = sys;
+    director.registerSystem(TweenSystem.ID, sys, System.Priority.MEDIUM);
+
+    director.runSceneImmediate(scene);
+
+    tween(node).tag(1).repeat(10, tween<Node>().by(3, { scale : new Vec3(1, 1, 1) })).start();;
+    tween(node).tag(1).repeat(10, tween<Node>().by(3, { position: new Vec3(10,10,0) })).start();
+
+    Tween.stopAllByTag(1);
+
+    expect(TweenSystem.instance.ActionManager.getActionByTag(1, node)).toBeNull();
+});


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#](https://github.com/cocos-creator/3d-tasks/issues/10612)

Changelog:
- ActionManager新增removeAllActionsByTag函数，用于删除同一个tag的所有actions。
- Tween的stopAllByTag改为调用ActionManager.removeAllActionsByTag。
