### PR TITLE
Fix skybox RGBE macro get invalid in startup and mipmap count is overrided

### DIFF
--- a/cocos/core/pipeline/pipeline-ubo.ts
+++ b/cocos/core/pipeline/pipeline-ubo.ts
@@ -122,7 +122,7 @@ export class PipelineUBO {
         cv[UBOCamera.AMBIENT_GROUND_OFFSET + 0] = ambient.groundAlbedo.x;
         cv[UBOCamera.AMBIENT_GROUND_OFFSET + 1] = ambient.groundAlbedo.y;
         cv[UBOCamera.AMBIENT_GROUND_OFFSET + 2] = ambient.groundAlbedo.z;
-        cv[UBOCamera.AMBIENT_GROUND_OFFSET + 3] = ambient.groundAlbedo.w;
+        cv[UBOCamera.AMBIENT_GROUND_OFFSET + 3] = ambient.mipmapCount;
 
         Mat4.toArray(cv, camera.matView, UBOCamera.MAT_VIEW_OFFSET);
         Mat4.toArray(cv, camera.node.worldMatrix, UBOCamera.MAT_VIEW_INV_OFFSET);

--- a/cocos/core/renderer/scene/ambient.ts
+++ b/cocos/core/renderer/scene/ambient.ts
@@ -62,13 +62,9 @@ export class Ambient {
     set skyColor (color: Vec4) {
         const isHDR = (legacyCC.director.root).pipeline.pipelineSceneData.isHDR;
         if (isHDR) {
-            this._skyColorHDR.x = color.x;
-            this._skyColorHDR.y = color.y;
-            this._skyColorHDR.z = color.z;
+            this._skyColorHDR.set(color);
         } else {
-            this._skyColorLDR.x = color.x;
-            this._skyColorLDR.y = color.y;
-            this._skyColorLDR.z = color.z;
+            this._skyColorLDR.set(color);
         }
         if (JSB) {
             this._nativeObj!.skyColor = isHDR ? this._skyColorHDR : this._skyColorLDR;
@@ -115,18 +111,22 @@ export class Ambient {
     set groundAlbedo (color: Vec4) {
         const isHDR = (legacyCC.director.root).pipeline.pipelineSceneData.isHDR;
         if (isHDR) {
-            this._groundAlbedoHDR.x = color.x;
-            this._groundAlbedoHDR.y = color.y;
-            this._groundAlbedoHDR.z = color.z;
+            this._groundAlbedoHDR.set(color);
         } else {
-            this._groundAlbedoLDR.x = color.x;
-            this._groundAlbedoLDR.y = color.y;
-            this._groundAlbedoLDR.z = color.z;
+            this._groundAlbedoLDR.set(color);
         }
 
         if (JSB) {
             this._nativeObj!.groundAlbedo = isHDR ? this._groundAlbedoHDR : this._groundAlbedoLDR;
         }
+    }
+
+    get mipmapCount (): number {
+        return this._mipmapCount;
+    }
+
+    set mipmapCount (count : number) {
+        this._mipmapCount = count;
     }
 
     protected _groundAlbedoHDR = new Vec4(0.2, 0.2, 0.2, 1.0);
@@ -136,6 +136,8 @@ export class Ambient {
     protected _groundAlbedoLDR = new Vec4(0.2, 0.2, 0.2, 1.0);
     protected _skyColorLDR = new Vec4(0.2, 0.5, 0.8, 1.0);
     protected _skyIllumLDR = 0;
+
+    protected _mipmapCount = 1;
 
     protected _enabled = false;
     protected declare _nativeObj: NativeAmbient | null;
@@ -153,15 +155,11 @@ export class Ambient {
     public initialize (ambientInfo: AmbientInfo) {
         // Init HDR/LDR from serialized data on load
         this._skyColorHDR = ambientInfo.skyColorHDR;
-        this._groundAlbedoHDR.x = ambientInfo.groundAlbedoHDR.x;
-        this._groundAlbedoHDR.y = ambientInfo.groundAlbedoHDR.y;
-        this._groundAlbedoHDR.z = ambientInfo.groundAlbedoHDR.z;
+        this._groundAlbedoHDR.set(ambientInfo.groundAlbedoHDR);
         this._skyIllumHDR = ambientInfo.skyIllumHDR;
 
         this._skyColorLDR = ambientInfo.skyColorLDR;
-        this._groundAlbedoLDR.x = ambientInfo.groundAlbedoLDR.x;
-        this._groundAlbedoLDR.y = ambientInfo.groundAlbedoLDR.y;
-        this._groundAlbedoLDR.z = ambientInfo.groundAlbedoLDR.z;
+        this._groundAlbedoLDR.set(ambientInfo.groundAlbedoLDR);
         this._skyIllumLDR = ambientInfo.skyIllumLDR;
 
         if (JSB) {

--- a/cocos/core/renderer/scene/skybox.ts
+++ b/cocos/core/renderer/scene/skybox.ts
@@ -219,10 +219,10 @@ export class Skybox {
         const isHDR = root.pipeline.pipelineSceneData.isHDR;
         if (isHDR) {
             if (envmapHDR) {
-                root.pipeline.pipelineSceneData.ambient.groundAlbedo.w = envmapHDR.mipmapLevel;
+                root.pipeline.pipelineSceneData.ambient.mipmapCount = envmapHDR.mipmapLevel;
             }
         } else if (envmapLDR) {
-            root.pipeline.pipelineSceneData.ambient.groundAlbedo.w = envmapLDR.mipmapLevel;
+            root.pipeline.pipelineSceneData.ambient.mipmapCount = envmapLDR.mipmapLevel;
         }
 
         this._updateGlobalBinding();
@@ -293,16 +293,15 @@ export class Skybox {
         const useDiffuseMapValue = (this.useIBL && this.useDiffuseMap && this.diffuseMap) ? (this.isRGBE ? 2 : 1) : 0;
         const useHDRValue = this.useHDR;
 
-        if (pipeline.macros.CC_USE_IBL === useIBLValue
-            && pipeline.macros.CC_USE_DIFFUSEMAP === useDiffuseMapValue
-            && pipeline.macros.CC_USE_HDR === useHDRValue) {
-            return;
-        }
-        pipeline.macros.CC_USE_IBL = useIBLValue;
-        pipeline.macros.CC_USE_DIFFUSEMAP = useDiffuseMapValue;
-        pipeline.macros.CC_USE_HDR = useHDRValue;
+        if (pipeline.macros.CC_USE_IBL !== useIBLValue
+            || pipeline.macros.CC_USE_DIFFUSEMAP !== useDiffuseMapValue
+            || pipeline.macros.CC_USE_HDR !== useHDRValue) {
+            pipeline.macros.CC_USE_IBL = useIBLValue;
+            pipeline.macros.CC_USE_DIFFUSEMAP = useDiffuseMapValue;
+            pipeline.macros.CC_USE_HDR = useHDRValue;
 
-        root.onGlobalPipelineStateChanged();
+            root.onGlobalPipelineStateChanged();
+        }
 
         if (this.enabled && skybox_material) {
             skybox_material.recompileShaders({ USE_RGBE_CUBEMAP: this.isRGBE });

--- a/cocos/core/renderer/scene/skybox.ts
+++ b/cocos/core/renderer/scene/skybox.ts
@@ -94,8 +94,7 @@ export class Skybox {
 
     set useDiffuseMap (val: boolean) {
         this._useDiffuseMap = val;
-        this._updateGlobalBinding();
-        this._updatePipeline();
+        this.setDiffuseMaps(null, null);
     }
 
     /**


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
