### PR TITLE
fix particle capacity <= 0

### DIFF
--- a/cocos/particle/models/particle-batch-model.ts
+++ b/cocos/particle/models/particle-batch-model.ts
@@ -123,7 +123,7 @@ export default class ParticleBatchModel extends scene.Model {
             this._vertSize,
         ));
         const vBuffer: ArrayBuffer = new ArrayBuffer(this._vertSize * this._capacity * this._vertCount);
-        if (this._mesh) {
+        if (this._mesh && this._capacity > 0) {
             let vOffset = (this._vertAttrs![this._vertAttrs!.findIndex((val) => val.name === AttributeName.ATTR_TEX_COORD)] as any).offset;
             this._mesh.copyAttribute(0, AttributeName.ATTR_TEX_COORD, vBuffer, this._vertSize, vOffset);  // copy mesh uv to ATTR_TEX_COORD
             let vIdx = this._vertAttrs!.findIndex((val) => val.name === AttributeName.ATTR_TEX_COORD3);
@@ -146,7 +146,7 @@ export default class ParticleBatchModel extends scene.Model {
         vertexBuffer.update(vBuffer);
 
         const indices: Uint16Array = new Uint16Array(this._capacity * this._indexCount);
-        if (this._mesh) {
+        if (this._mesh && this._capacity > 0) {
             this._mesh.copyIndices(0, indices);
             for (let i = 1; i < this._capacity; i++) {
                 for (let j = 0; j < this._indexCount; j++) {

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -61,6 +61,7 @@ import { TransformBit } from '../core/scene-graph/node-enum';
 import { AABB, intersect } from '../core/geometry';
 import { Camera } from '../core/renderer/scene';
 import { ParticleCuller } from './particle-culler';
+import { clampf } from '../core/utils/misc';
 
 const _world_mat = new Mat4();
 const _world_rol = new Quat();
@@ -76,6 +77,7 @@ export class ParticleSystem extends RenderableComponent {
     /**
      * @zh 粒子系统能生成的最大粒子数量。
      */
+    @range([0, Number.POSITIVE_INFINITY])
     @displayOrder(1)
     @tooltip('i18n:particle_system.capacity')
     public get capacity () {
@@ -83,16 +85,7 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     public set capacity (val) {
-        const lastCapacity = this._capacity;
-
-        this._capacity = Math.floor(val);
-        if (this._capacity <= 0) {
-            this._detachFromScene();
-            return;
-        } else if (this._capacity > 0 && lastCapacity <= 0) {
-            this._attachToScene();
-        }
-
+        this._capacity = Math.floor(clampf(val, 0, Number.POSITIVE_INFINITY));
         // @ts-expect-error private property access
         if (this.processor && this.processor._model) {
             // @ts-expect-error private property access

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -61,7 +61,6 @@ import { TransformBit } from '../core/scene-graph/node-enum';
 import { AABB, intersect } from '../core/geometry';
 import { Camera } from '../core/renderer/scene';
 import { ParticleCuller } from './particle-culler';
-import { clampf } from '../core/utils/misc';
 
 const _world_mat = new Mat4();
 const _world_rol = new Quat();

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -85,7 +85,7 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     public set capacity (val) {
-        this._capacity = Math.floor(clampf(val, 0, Number.POSITIVE_INFINITY));
+        this._capacity = Math.floor(val > 0 ? val : 0);
         // @ts-expect-error private property access
         if (this.processor && this.processor._model) {
             // @ts-expect-error private property access

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -83,7 +83,16 @@ export class ParticleSystem extends RenderableComponent {
     }
 
     public set capacity (val) {
+        const lastCapacity = this._capacity;
+
         this._capacity = Math.floor(val);
+        if (this._capacity <= 0) {
+            this._detachFromScene();
+            return;
+        } else if (this._capacity > 0 && lastCapacity <= 0) {
+            this._attachToScene();
+        }
+
         // @ts-expect-error private property access
         if (this.processor && this.processor._model) {
             // @ts-expect-error private property access

--- a/tests/particle/capacity.test.ts
+++ b/tests/particle/capacity.test.ts
@@ -2,24 +2,20 @@ import { director, Node, Scene } from "../../cocos/core";
 import { legacyCC } from "../../cocos/core/global-exports";
 import { ParticleSystem } from "../../exports/particle";
 
-test('particle system capacity test', () => {
-});
+test('particle system capacity test', function () {
+    const scene = new Scene('test');
+    director.runSceneImmediate(scene);
 
-// Will be updated later with the fix on particle capacity
-// test('particle system capacity test', function () {
-//     const scene = new Scene('test');
-//     director.runSceneImmediate(scene);
+    const temp0 = new Node();
+    scene.addChild(temp0);
 
-//     const temp0 = new Node();
-//     scene.addChild(temp0);
+    const particle = temp0.addComponent(ParticleSystem) as ParticleSystem;
 
-//     const particle = temp0.addComponent(ParticleSystem) as ParticleSystem;
+    particle.capacity = 0;
+    particle.renderer.useGPU = false;
 
-//     particle.capacity = 0;
-//     particle.renderer.useGPU = false;
-
-//     legacyCC.game.step();
+    legacyCC.game.step();
     
-//     // @ts-expect-error
-//     expect(!!particle.processor.getModel()._vBuffer).toBe(true);
-// });
+    // @ts-expect-error
+    expect(!!particle.processor.getModel()._vBuffer).toBe(true);
+});


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#](https://github.com/cocos-creator/3d-tasks/issues/10417)

Changelog:

- 修复粒子系统capacity小于等于0时引起的崩溃。

- 添加粒子系统capacity的单元测试。

原因分析：
![2021-12-31_140429](https://user-images.githubusercontent.com/95199410/147806539-d75aecb5-103c-47e5-949f-714fa8fe4cb8.png)
　　如图所示，当粒子系统capacity小于等于0时，由capacity参与构建出来的两个buffer都为空，在更新submesh的时候，往buffer中拷贝会引发异常。
　　现改为在设置capacity的时候，判断capacity如果小于等于0，则将粒子系统从scene中detach；当前capacity小于等于0，新的capacity大于0，则将粒子系统attach到scene中。