### PR TITLE
scrollview calculation exception with layout

### DIFF
--- a/cocos2d/core/CCNode.js
+++ b/cocos2d/core/CCNode.js
@@ -26,6 +26,7 @@
 'use strict';
 
 import { Mat4, Vec2, Vec3, Quat, Trs } from './value-types';
+import { approx } from './value-types/utils'
 
 const BaseNode = require('./utils/base-node');
 const PrefabHelper = require('./utils/prefab-helper');
@@ -2881,7 +2882,7 @@ let NodeDefines = {
         var locContentSize = this._contentSize;
         var clone;
         if (height === undefined) {
-            if ((size.width === locContentSize.width) && (size.height === locContentSize.height))
+            if (approx(size.width, locContentSize.width) && approx(size.height, locContentSize.height))
                 return;
             if (CC_EDITOR) {
                 clone = cc.size(locContentSize.width, locContentSize.height);
@@ -2889,7 +2890,7 @@ let NodeDefines = {
             locContentSize.width = size.width;
             locContentSize.height = size.height;
         } else {
-            if ((size === locContentSize.width) && (height === locContentSize.height))
+            if (approx(size, locContentSize.width) && approx(height, locContentSize.height))
                 return;
             if (CC_EDITOR) {
                 clone = cc.size(locContentSize.width, locContentSize.height);

--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -549,7 +549,8 @@ var Layout = cc.Class({
             var child = children[i];
             let childScaleX = this._getUsedScaleValue(child.scaleX);
             let childScaleY = this._getUsedScaleValue(child.scaleY);
-            if (!child.activeInHierarchy) {
+            // Ensure that containerResizeBoundary is calculated at least once.
+            if (!child.activeInHierarchy && children.length > 1) {
                 continue;
             }
             //for resizing children
@@ -695,7 +696,8 @@ var Layout = cc.Class({
             var child = children[i];
             let childScaleX = this._getUsedScaleValue(child.scaleX);
             let childScaleY = this._getUsedScaleValue(child.scaleY);
-            if (!child.activeInHierarchy) {
+            // Ensure that containerResizeBoundary is calculated at least once.
+            if (!child.activeInHierarchy && children.length > 1) {
                 continue;
             }
 

--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -545,7 +545,6 @@ var Layout = cc.Class({
             newChildWidth = (baseWidth - (this.paddingLeft + this.paddingRight) - (activeChildCount - 1) * this.spacingX) / activeChildCount;
         }
 
-        var hasCalculatedcontainerResizeBoundaryOnce = false;
         for (var i = 0; i < children.length; ++i) {
             var child = children[i];
             let childScaleX = this._getUsedScaleValue(child.scaleX);
@@ -632,7 +631,6 @@ var Layout = cc.Class({
                     containerResizeBoundary = tempFinalPositionY;
                 }
             }
-            hasCalculatedcontainerResizeBoundaryOnce = true;
 
             nextX += rightBoundaryOfChild;
         }

--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -990,14 +990,8 @@ var Layout = cc.Class({
      */
     updateLayout: function () {
         if (this._layoutDirty && this.node.children.length > 0) {
-            var needToLayout = false;
-            for(let i = 0; i < this.node.children.length; i++) {
-                if(this.node.children[i].activeInHierarchy) {
-                    needToLayout = true;
-                    break;
-                }
-            }
-            if(needToLayout) {
+            var activeChild = this.node.children.find((node) => node.activeInHierarchy);
+            if(activeChild) {
                 this._doLayout();
                 this._layoutDirty = false;
             }

--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -550,8 +550,7 @@ var Layout = cc.Class({
             var child = children[i];
             let childScaleX = this._getUsedScaleValue(child.scaleX);
             let childScaleY = this._getUsedScaleValue(child.scaleY);
-            // Ensure that containerResizeBoundary is calculated at least once.
-            if (!child.activeInHierarchy && (hasCalculatedcontainerResizeBoundaryOnce || i !== children.length-1)) {
+            if (!child.activeInHierarchy) {
                 continue;
             }
 
@@ -699,7 +698,6 @@ var Layout = cc.Class({
             var child = children[i];
             let childScaleX = this._getUsedScaleValue(child.scaleX);
             let childScaleY = this._getUsedScaleValue(child.scaleY);
-            // Ensure that containerResizeBoundary is calculated at least once.
             if (!child.activeInHierarchy) {
                 continue;
             }

--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -545,14 +545,16 @@ var Layout = cc.Class({
             newChildWidth = (baseWidth - (this.paddingLeft + this.paddingRight) - (activeChildCount - 1) * this.spacingX) / activeChildCount;
         }
 
+        var hasCalculatedcontainerResizeBoundaryOnce = false;
         for (var i = 0; i < children.length; ++i) {
             var child = children[i];
             let childScaleX = this._getUsedScaleValue(child.scaleX);
             let childScaleY = this._getUsedScaleValue(child.scaleY);
             // Ensure that containerResizeBoundary is calculated at least once.
-            if (!child.activeInHierarchy && children.length > 1) {
+            if (!child.activeInHierarchy && (hasCalculatedcontainerResizeBoundaryOnce || i !== children.length-1)) {
                 continue;
             }
+
             //for resizing children
             if (this._resize === ResizeMode.CHILDREN) {
                 child.width = newChildWidth / childScaleX;
@@ -631,6 +633,7 @@ var Layout = cc.Class({
                     containerResizeBoundary = tempFinalPositionY;
                 }
             }
+            hasCalculatedcontainerResizeBoundaryOnce = true;
 
             nextX += rightBoundaryOfChild;
         }
@@ -692,12 +695,13 @@ var Layout = cc.Class({
             newChildHeight = (baseHeight - (this.paddingTop + this.paddingBottom) - (activeChildCount - 1) * this.spacingY) / activeChildCount;
         }
 
+        var hasCalculatedcontainerResizeBoundaryOnce = false;
         for (var i = 0; i < children.length; ++i) {
             var child = children[i];
             let childScaleX = this._getUsedScaleValue(child.scaleX);
             let childScaleY = this._getUsedScaleValue(child.scaleY);
             // Ensure that containerResizeBoundary is calculated at least once.
-            if (!child.activeInHierarchy && children.length > 1) {
+            if (!child.activeInHierarchy && (hasCalculatedcontainerResizeBoundaryOnce || i !== children.length-1)) {
                 continue;
             }
 
@@ -778,8 +782,8 @@ var Layout = cc.Class({
                 if (tempFinalPositionX > containerResizeBoundary) {
                     containerResizeBoundary = tempFinalPositionX;
                 }
-
             }
+            hasCalculatedcontainerResizeBoundaryOnce = true;
 
             nextY += topBoundaryOfChild;
         }

--- a/cocos2d/core/components/CCLayout.js
+++ b/cocos2d/core/components/CCLayout.js
@@ -695,13 +695,12 @@ var Layout = cc.Class({
             newChildHeight = (baseHeight - (this.paddingTop + this.paddingBottom) - (activeChildCount - 1) * this.spacingY) / activeChildCount;
         }
 
-        var hasCalculatedcontainerResizeBoundaryOnce = false;
         for (var i = 0; i < children.length; ++i) {
             var child = children[i];
             let childScaleX = this._getUsedScaleValue(child.scaleX);
             let childScaleY = this._getUsedScaleValue(child.scaleY);
             // Ensure that containerResizeBoundary is calculated at least once.
-            if (!child.activeInHierarchy && (hasCalculatedcontainerResizeBoundaryOnce || i !== children.length-1)) {
+            if (!child.activeInHierarchy) {
                 continue;
             }
 
@@ -783,7 +782,6 @@ var Layout = cc.Class({
                     containerResizeBoundary = tempFinalPositionX;
                 }
             }
-            hasCalculatedcontainerResizeBoundaryOnce = true;
 
             nextY += topBoundaryOfChild;
         }
@@ -945,7 +943,6 @@ var Layout = cc.Class({
     },
 
     _doLayout: function () {
-
         if (this.type === Type.HORIZONTAL) {
             var newWidth = this._getHorizontalBaseWidth(this.node.children);
 
@@ -997,8 +994,17 @@ var Layout = cc.Class({
      */
     updateLayout: function () {
         if (this._layoutDirty && this.node.children.length > 0) {
-            this._doLayout();
-            this._layoutDirty = false;
+            var needToLayout = false;
+            for(let i = 0; i < this.node.children.length; i++) {
+                if(this.node.children[i].activeInHierarchy) {
+                    needToLayout = true;
+                    break;
+                }
+            }
+            if(needToLayout) {
+                this._doLayout();
+                this._layoutDirty = false;
+            }
         }
     }
 });


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#3462

Changelog:
 * scrollview下的匿名方法会造成浮点误差，暂时无法避免。故在node的setcontentsize里使用约等于判断来取代"==="
![image](https://user-images.githubusercontent.com/32831993/148028358-da4b6a11-9033-4f29-b3cb-ff44aca898dd.png)
* 因为子物体处于隐藏状态会跳过当前循环，所以加了条件保证了_doLayoutVertically和_doLayoutHorizontally里的返回值至少被计算一次。continue的条件是：item为不活跃状态 且(计算过一次返回值 或 非最后一个item)
![image](https://user-images.githubusercontent.com/32831993/148033117-95a3f001-eb33-479e-943c-7af1b3dab376.png)


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
