### PR TITLE
fix event MOUSE_WHEEL can't be swallowed by node

### DIFF
--- a/cocos/2d/event/pointer-event-dispatcher.ts
+++ b/cocos/2d/event/pointer-event-dispatcher.ts
@@ -24,7 +24,8 @@
 */
 
 import { Node } from '../../core/scene-graph/node';
-import { Input, input, pointerEvent2SystemEvent } from '../../input';
+import { Input, input } from '../../input';
+import { pointerEvent2SystemEvent } from '../../input/system-event';
 import { EventMouse, EventTouch } from '../../input/types';
 import { DispatcherEventType, NodeEventProcessor } from '../../core/scene-graph/node-event-processor';
 import { js } from '../../core/utils/js';

--- a/cocos/input/index.ts
+++ b/cocos/input/index.ts
@@ -1,4 +1,4 @@
 import './deprecated';
 
 export { input, Input } from './input';
-export * from './system-event';
+export { systemEvent, SystemEvent } from './system-event';

--- a/cocos/input/system-event.ts
+++ b/cocos/input/system-event.ts
@@ -43,6 +43,7 @@ export const pointerEvent2SystemEvent = {
     [InputEventType.MOUSE_DOWN]: `system-event-${InputEventType.MOUSE_DOWN}`,
     [InputEventType.MOUSE_MOVE]: `system-event-${InputEventType.MOUSE_MOVE}`,
     [InputEventType.MOUSE_UP]: `system-event-${InputEventType.MOUSE_UP}`,
+    [InputEventType.MOUSE_WHEEL]: `system-event-${InputEventType.MOUSE_WHEEL}`,
 };
 
 export declare namespace SystemEvent {


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#](https://github.com/cocos-creator/3d-tasks/issues/10728)

Changelog:
 * 修复 node 能够透传 MOUSE_WHEEL 事件到 systemEvent 的问题
