### PR TITLE
compability for string SystemEventTypeUnion

### DIFF
--- a/cocos/input/types/event-enum.ts
+++ b/cocos/input/types/event-enum.ts
@@ -379,6 +379,6 @@ export enum InputEventType {
     DEVICEMOTION = 'devicemotion',
 }
 
-export type SystemEventTypeUnion = SystemEventType | NodeEventType | InputEventType;
+export type SystemEventTypeUnion = SystemEventType | NodeEventType | InputEventType | string;
 
 legacyCC.SystemEventType = SystemEventType;

--- a/cocos/input/types/event/event.ts
+++ b/cocos/input/types/event/event.ts
@@ -221,7 +221,6 @@ export class Event {
      * 重置事件对象以便在对象池中存储。
      */
     public unuse () {
-        // @ts-expect-error type is not SystemEventUnion
         this.type = Event.NO_TYPE;
         this.target = null;
         this.currentTarget = null;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/10601

Changelog:
 * SystemEventTypeUntion 类型兼容 string 类型

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
