### PR TITLE
fix keyboard event listening on mobile

### DIFF
--- a/cocos/core/platform/macro.ts
+++ b/cocos/core/platform/macro.ts
@@ -47,7 +47,7 @@ const KEY = {
      * @en The back key on mobile phone
      * @zh 移动端返回键
      * @readonly
-     * @deprecated since v3.3
+     * @deprecated since v3.3, please use KeyCode.MOBILE_BACK instead.
      */
     back: 6,
     /**

--- a/cocos/input/types/key-code.ts
+++ b/cocos/input/types/key-code.ts
@@ -10,6 +10,12 @@ export enum KeyCode {
     NONE = 0,
 
     /**
+     * @en The back key on mobile phone
+     * @zh 移动端返回键
+     */
+    MOBILE_BACK = 6,
+
+    /**
     * @en The backspace key
     * @zh 退格键
     */

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -83,7 +83,7 @@ class SystemInfo extends EventTarget {
             [Feature.SAFE_AREA]: this.isMobile,
 
             [Feature.INPUT_TOUCH]: this.isMobile,
-            [Feature.EVENT_KEYBOARD]: !this.isMobile,
+            [Feature.EVENT_KEYBOARD]: true,
             [Feature.EVENT_MOUSE]: !this.isMobile,
             [Feature.EVENT_TOUCH]: true,
             [Feature.EVENT_ACCELEROMETER]: this.isMobile,


### PR DESCRIPTION
Re: 
https://github.com/cocos-creator/engine/issues/9408
https://github.com/cocos-creator/3d-tasks/issues/9443

Changelog:
 * 修复原生移动端返回键监听问题，对应的枚举请使用 `KeyCode.MOBILE_BACK`

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
