### PR TITLE
fix culling deprecated module

### DIFF
--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -796,3 +796,5 @@ if (typeof window === 'object' && typeof document === 'object' && !MINIGAME && !
  * ```
  * @return {Boolean} whether it is the first time the destroy being called
  */
+
+legacyCC.internal.EditBox = EditBox;

--- a/platforms/minigame/common/engine/Editbox.js
+++ b/platforms/minigame/common/engine/Editbox.js
@@ -1,9 +1,9 @@
 (function () {
-    if (!(cc && cc.EditBoxComponent)) {
+    if (!(cc && cc.internal && cc.internal.EditBox)) {
         return;
     }
 
-    const EditBoxComp = cc.EditBoxComponent;
+    const EditBoxComp = cc.internal.EditBox;
     const js = cc.js;
     const KeyboardReturnType = EditBoxComp.KeyboardReturnType;
     const MAX_VALUE = 65535;

--- a/platforms/native/engine/jsb-editbox.js
+++ b/platforms/native/engine/jsb-editbox.js
@@ -24,11 +24,11 @@
  ****************************************************************************/
 
 (function () {
-    if (!(cc && cc.EditBoxComponent)) {
+    if (!(cc && cc.internal && cc.internal.EditBox)) {
         return;
     }
 
-    const EditBox = cc.EditBoxComponent;
+    const EditBox = cc.internal.EditBox;
     const KeyboardReturnType = EditBox.KeyboardReturnType;
     const InputMode = EditBox.InputMode;
     const InputFlag = EditBox.InputFlag;

--- a/platforms/runtime/common/engine/EditBox.js
+++ b/platforms/runtime/common/engine/EditBox.js
@@ -1,9 +1,9 @@
 (function () {
-    if (!(cc && cc.EditBoxComponent)) {
+    if (!(cc && cc.internal && cc.internal.EditBox)) {
         return;
     }
 
-    const EditBoxComp = cc.EditBoxComponent;
+    const EditBoxComp = cc.internal.EditBox;
     const js = cc.js;
     const KeyboardReturnType = EditBoxComp.KeyboardReturnType;
     const MAX_VALUE = 65535;


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#](https://github.com/cocos-creator/3d-tasks/issues/10550)

Changelog:
 * 修复勾选剔除废弃引擎接口，导致 EditBox 无法正常工作的问题

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
