### PR TITLE
reset swallow state after event handling

### DIFF
--- a/cocos/2d/event/pointer-event-dispatcher.ts
+++ b/cocos/2d/event/pointer-event-dispatcher.ts
@@ -135,6 +135,8 @@ class PointerEventDispatcher {
                     }
                 }
             }
+            // reset swallow state
+            eventTouch.preventSwallow = false;
         }
         const type = pointerEvent2SystemEvent[eventTouch.type];
         if (shouldDispatchToSystemEvent && type) {

--- a/cocos/2d/event/pointer-event-dispatcher.ts
+++ b/cocos/2d/event/pointer-event-dispatcher.ts
@@ -88,10 +88,11 @@ class PointerEventDispatcher {
                 shouldDispatchToSystemEvent = false;
                 if (!eventMouse.preventSwallow) {
                     break;
+                } else {
+                    // reset swallow state
+                    eventMouse.preventSwallow = false;
                 }
             }
-            // reset swallow state
-            eventMouse.preventSwallow = false;
         }
         const type = pointerEvent2SystemEvent[eventMouse.type];
         if (shouldDispatchToSystemEvent && type) {
@@ -120,6 +121,9 @@ class PointerEventDispatcher {
                         shouldDispatchToSystemEvent = false;
                         if (!eventTouch.preventSwallow) {
                             break;
+                        } else {
+                            // reset swallow state
+                            eventTouch.preventSwallow = false;
                         }
                     }
                 } else if (pointerEventProcessor.claimedTouchIdList.length > 0) {
@@ -133,12 +137,13 @@ class PointerEventDispatcher {
                         shouldDispatchToSystemEvent = false;
                         if (!eventTouch.preventSwallow) {
                             break;
+                        } else {
+                            // reset swallow state
+                            eventTouch.preventSwallow = false;
                         }
                     }
                 }
             }
-            // reset swallow state
-            eventTouch.preventSwallow = false;
         }
         const type = pointerEvent2SystemEvent[eventTouch.type];
         if (shouldDispatchToSystemEvent && type) {

--- a/cocos/2d/event/pointer-event-dispatcher.ts
+++ b/cocos/2d/event/pointer-event-dispatcher.ts
@@ -90,6 +90,8 @@ class PointerEventDispatcher {
                     break;
                 }
             }
+            // reset swallow state
+            eventMouse.preventSwallow = false;
         }
         const type = pointerEvent2SystemEvent[eventMouse.type];
         if (shouldDispatchToSystemEvent && type) {

--- a/cocos/2d/event/pointer-event-dispatcher.ts
+++ b/cocos/2d/event/pointer-event-dispatcher.ts
@@ -89,8 +89,7 @@ class PointerEventDispatcher {
                 if (!eventMouse.preventSwallow) {
                     break;
                 } else {
-                    // reset swallow state
-                    eventMouse.preventSwallow = false;
+                    eventMouse.preventSwallow = false;  // reset swallow state
                 }
             }
         }
@@ -122,8 +121,7 @@ class PointerEventDispatcher {
                         if (!eventTouch.preventSwallow) {
                             break;
                         } else {
-                            // reset swallow state
-                            eventTouch.preventSwallow = false;
+                            eventTouch.preventSwallow = false;  // reset swallow state
                         }
                     }
                 } else if (pointerEventProcessor.claimedTouchIdList.length > 0) {
@@ -138,8 +136,7 @@ class PointerEventDispatcher {
                         if (!eventTouch.preventSwallow) {
                             break;
                         } else {
-                            // reset swallow state
-                            eventTouch.preventSwallow = false;
+                            eventTouch.preventSwallow = false;  // reset swallow state
                         }
                     }
                 }


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#10632](https://github.com/cocos-creator/3d-tasks/issues/10632)
https://forum.cocos.org/t/topic/127457/102

Changelog:
 * 事件穿透派发，只穿透一次

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
