### PR TITLE
Fix skeletal animation sample() does not work as intended

### DIFF
--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -164,7 +164,7 @@ export class SkeletalAnimationState extends AnimationState {
         const info = this._animInfo!;
 
         // Ensure I'm the one on which the anim info is sampling.
-        if (!this._animInfoMgr.isCurrentlySampling(info, this.clip)) {
+        if (!this._animInfoMgr.isSampling(info, this.clip)) {
             // If not, switch to me.
             this._animInfoMgr.switchClip(this._animInfo!, this.clip);
 

--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -179,11 +179,8 @@ export class SkeletalAnimationState extends AnimationState {
         }
 
         const curFrame = (ratio * this._frames + 0.5) | 0;
-        if (info.hasSampled && curFrame === info.data[0]) {
-            return;
-        }
+        if (curFrame === info.data[0]) { return; }
 
-        info.hasSampled = true;
         info.data[0] = curFrame;
         this._setAnimInfoDirty(info, true);
         for (let i = 0; i < this._sockets.length; ++i) {

--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -162,15 +162,16 @@ export class SkeletalAnimationState extends AnimationState {
     private _sampleCurvesBaked (time: number) {
         const ratio = time / this.duration;
         const info = this._animInfo!;
+        const clip = this.clip;
 
         // Ensure I'm the one on which the anim info is sampling.
-        if (!this._animInfoMgr.isSampling(info, this.clip)) {
+        if (info.currentClip !== clip) {
             // If not, switch to me.
-            this._animInfoMgr.switchClip(this._animInfo!, this.clip);
+            this._animInfoMgr.switchClip(this._animInfo!, clip);
 
             const users = this._parent!.getUsers();
             users.forEach((user) => {
-                user.uploadAnimation(this.clip);
+                user.uploadAnimation(clip);
             });
         }
 

--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -83,7 +83,7 @@ export class SkeletalAnimationState extends AnimationState {
         this._frames = frames - 1;
         this._animInfo = this._animInfoMgr.getData(root.uuid);
         this._bakedDuration = this._frames / samples; // last key
-        this.setUseBaked(this._parent.useBakedAnimation);
+        this.setUseBaked(baked);
     }
 
     public setUseBaked (useBaked: boolean) {

--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -180,7 +180,6 @@ export class SkeletalAnimationState extends AnimationState {
 
         const curFrame = (ratio * this._frames + 0.5) | 0;
         if (curFrame === info.data[0]) { return; }
-
         info.data[0] = curFrame;
         this._setAnimInfoDirty(info, true);
         for (let i = 0; i < this._sockets.length; ++i) {

--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -86,6 +86,9 @@ export class SkeletalAnimationState extends AnimationState {
         this.setUseBaked(baked);
     }
 
+    /**
+     * @internal This method only friends to `SkeletalAnimation`.
+     */
     public setUseBaked (useBaked: boolean) {
         if (useBaked) {
             this._sampleCurves = this._sampleCurvesBaked;

--- a/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
@@ -511,10 +511,6 @@ export class JointAnimationInfo {
         }
     }
 
-    public isSampling (info: IAnimInfo, clip: AnimationClip) {
-        return info.currentClip === clip;
-    }
-
     public switchClip (info: IAnimInfo, clip: AnimationClip | null) {
         info.hasSampled = false;
         info.currentClip = clip;

--- a/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
@@ -511,7 +511,7 @@ export class JointAnimationInfo {
         }
     }
 
-    public isCurrentlySampling (info: IAnimInfo, clip: AnimationClip) {
+    public isSampling (info: IAnimInfo, clip: AnimationClip) {
         return info.currentClip === clip;
     }
 

--- a/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
@@ -458,10 +458,6 @@ export interface IAnimInfo {
     data: Float32Array;
     dirty: boolean;
     currentClip: AnimationClip | null;
-    /**
-     * Has sampled at least once since last switching.
-     */
-    hasSampled: boolean;
 }
 
 export class JointAnimationInfo {
@@ -512,9 +508,8 @@ export class JointAnimationInfo {
     }
 
     public switchClip (info: IAnimInfo, clip: AnimationClip | null) {
-        info.hasSampled = false;
         info.currentClip = clip;
-        info.data[0] = 0;
+        info.data[0] = -1;
         info.buffer.update(info.data);
         this._setAnimInfoDirty(info, false);
         return info;

--- a/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
@@ -480,7 +480,7 @@ export class JointAnimationInfo {
         ));
         const data = new Float32Array([0, 0, 0, 0]);
         buffer.update(data);
-        const info: IAnimInfo = { buffer, data, dirty: false, currentClip: null, hasSampled: false };
+        const info: IAnimInfo = { buffer, data, dirty: false, currentClip: null };
         this._setAnimInfoDirty(info, false);
         this._pool.set(nodeID, info);
         return info;

--- a/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
@@ -457,7 +457,7 @@ export interface IAnimInfo {
     buffer: Buffer;
     data: Float32Array;
     dirty: boolean;
-    currentClipRef: WeakSet<AnimationClip>;
+    currentClip: AnimationClip | null;
     /**
      * Has sampled at least once since last switching.
      */
@@ -484,7 +484,7 @@ export class JointAnimationInfo {
         ));
         const data = new Float32Array([0, 0, 0, 0]);
         buffer.update(data);
-        const info: IAnimInfo = { buffer, data, dirty: false, currentClipRef: new WeakSet(), hasSampled: false };
+        const info: IAnimInfo = { buffer, data, dirty: false, currentClip: null, hasSampled: false };
         this._setAnimInfoDirty(info, false);
         this._pool.set(nodeID, info);
         return info;
@@ -512,15 +512,12 @@ export class JointAnimationInfo {
     }
 
     public isCurrentlySampling (info: IAnimInfo, clip: AnimationClip) {
-        return info.currentClipRef.has(clip);
+        return info.currentClip === clip;
     }
 
     public switchClip (info: IAnimInfo, clip: AnimationClip | null) {
         info.hasSampled = false;
-        info.currentClipRef = new WeakSet();
-        if (clip) {
-            info.currentClipRef.add(clip);
-        }
+        info.currentClip = clip;
         info.data[0] = 0;
         info.buffer.update(info.data);
         this._setAnimInfoDirty(info, false);

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -295,7 +295,7 @@ export class AnimationState extends Playable {
     private _playbackDuration = 0.0;
     private _invDuration = 1.0;
     private _poseOutput: PoseOutput | null = null;
-    private _weight = 0.0;
+    private _weight = 1.0;
     private _clipEval: ReturnType<AnimationClip['createEvaluator']> | undefined;
     private _clipEventEval: ReturnType<AnimationClip['createEventEvaluator']> | undefined;
     /**

--- a/tests/animation/skeletal-animation.test.ts
+++ b/tests/animation/skeletal-animation.test.ts
@@ -1,0 +1,173 @@
+
+import { SkeletalAnimationState } from '../../cocos/3d/skeletal-animation/skeletal-animation-state';
+import { SkeletalAnimation } from '../../cocos/3d/skeletal-animation/skeletal-animation';
+import { CCObject, director, game, Node, Scene } from '../../cocos/core';
+import { AnimationClip } from '../../cocos/core/animation/animation-clip';
+import { VectorTrack } from '../../cocos/core/animation/animation';
+import { JointAnimationInfo } from '../../cocos/3d/skeletal-animation/skeletal-animation-utils';
+import { SkinnedMeshRenderer } from '../../cocos/3d/skinned-mesh-renderer';
+
+describe('Skeletal animation state', () => {
+    function createSimpleClip(name: string, duration: number, from: number, to: number, path = '') {
+        const animationClip = new AnimationClip();
+        animationClip.name = name;
+        animationClip.duration = duration;
+        const vectorTrack = new VectorTrack();
+        if (path) {
+            vectorTrack.path.toHierarchy(path);
+        }
+        vectorTrack.path.toProperty('position');
+        vectorTrack.componentsCount = 3;
+        vectorTrack.channels()[0].curve.assignSorted([
+            [0.0, from],
+            [duration, to],
+        ]);
+        animationClip.addTrack(vectorTrack);
+        return animationClip;
+    }
+
+    test('Baked - Sample()', () => {
+        const switchClipMock = JointAnimationInfo.prototype.switchClip = jest.fn(JointAnimationInfo.prototype.switchClip);
+
+        const clips = [
+            createSimpleClip('Clip1', 2.0, 1.2, 1.8, 'Observed'),
+            createSimpleClip('Clip2', 5.0, -0.7, 0.98, 'Observed'),
+        ];
+
+        const rootNode = new Node();
+
+        const observedNode = new Node('Observed');
+        rootNode.addChild(observedNode);
+
+        const skeletonAnimation = rootNode.addComponent(SkeletalAnimation) as SkeletalAnimation;
+        skeletonAnimation.useBakedAnimation = true;
+        skeletonAnimation.clips = clips;
+
+        const socketNode = skeletonAnimation.createSocket('Observed');
+
+        const state1 = skeletonAnimation.getState('Clip1') as SkeletalAnimationState;
+        expect(state1).toBeInstanceOf(SkeletalAnimationState);
+        const state2 = skeletonAnimation.getState('Clip2') as SkeletalAnimationState;
+        expect(state2).toBeInstanceOf(SkeletalAnimationState);
+
+        expect(switchClipMock).toBeCalledTimes(0);
+        
+        state1.sample();
+        expect(switchClipMock).toBeCalledTimes(1);
+        expect(socketNode.position.x).toBe(1.2);
+        game.step();
+
+        state1.setTime(0.3);
+        state1.sample();
+        expect(switchClipMock).toBeCalledTimes(1);
+        switchClipMock.mockClear();
+        game.step();
+
+        state2.setTime(0.9);
+        state2.sample();
+        expect(switchClipMock).toBeCalledTimes(1);
+        state1.sample();
+        expect(switchClipMock).toBeCalledTimes(2);
+        game.step();
+    });
+
+    test('Communication with SkinnedMeshRenderer', () => {
+        const scene = new Scene('Scene');
+        director.runSceneImmediate(scene);
+
+        const parentNode = new Node('0');
+        scene.addChild(parentNode);
+
+        const n_0_0 = new Node('0-0');
+        parentNode.addChild(n_0_0);
+
+        const siblingNode = new Node('0-1');
+        parentNode.addChild(siblingNode);
+
+        const anotherChildNode = new Node('0-0-1');
+        n_0_0.addChild(anotherChildNode);
+
+        const animation_0_0 = n_0_0.addComponent(SkeletalAnimation) as SkeletalAnimation;
+        const animationAddUserMock = animation_0_0.notifySkinnedMeshAdded =
+            jest.fn(SkeletalAnimation.prototype.notifySkinnedMeshAdded);
+        const animationRemoveUserMock = animation_0_0.notifySkinnedMeshRemoved =
+            jest.fn(SkeletalAnimation.prototype.notifySkinnedMeshRemoved);
+
+        const mockSkinSetUseBakedAnimation = (skinnedMeshRenderer: SkinnedMeshRenderer) => {
+            return skinnedMeshRenderer.setUseBakedAnimation =
+                jest.fn(SkinnedMeshRenderer.prototype.setUseBakedAnimation);
+        };
+
+        const childNode = new Node('Child');
+        const childSkin = childNode.addComponent(SkinnedMeshRenderer) as SkinnedMeshRenderer;
+        childSkin.skinningRoot = n_0_0;
+        n_0_0.addChild(childNode);
+        const childSkinSetUseBakedAnimationMock = mockSkinSetUseBakedAnimation(childSkin);
+        expect(animationAddUserMock).toBeCalledTimes(1);
+        expect(animationAddUserMock.mock.calls[0][0]).toBe(childSkin);
+        animationAddUserMock.mockClear();
+
+        // Another child's skin
+        const anotherChildSkin = anotherChildNode.addComponent(SkinnedMeshRenderer) as SkinnedMeshRenderer;
+        anotherChildSkin.skinningRoot = n_0_0;
+        const anotherChildSkinSetUseBakedAnimationMock = mockSkinSetUseBakedAnimation(anotherChildSkin);
+        expect(animationAddUserMock).toBeCalledTimes(1);
+        expect(animationAddUserMock.mock.calls[0][0]).toBe(anotherChildSkin);
+        animationAddUserMock.mockClear();
+
+        // Sibling's skin
+        const siblingSkin = siblingNode.addComponent(SkinnedMeshRenderer) as SkinnedMeshRenderer;
+        const siblingSkinSetUseBakedAnimationMock = mockSkinSetUseBakedAnimation(siblingSkin);
+        siblingSkin.skinningRoot = n_0_0;
+        expect(animationAddUserMock).toBeCalledTimes(0);
+
+        // Parent's skin
+        const parentSkin = siblingNode.addComponent(SkinnedMeshRenderer) as SkinnedMeshRenderer;
+        const parentSkinSetUseBakedAnimationMock = mockSkinSetUseBakedAnimation(parentSkin);
+        parentSkin.skinningRoot = n_0_0;
+        expect(animationAddUserMock).toBeCalledTimes(0);
+
+        // Assigning to the skinning root cause `setUseBakedAnimation` to be called.
+        childSkin.skinningRoot = n_0_0;
+        expect(childSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
+        expect(childSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(true);
+        childSkinSetUseBakedAnimationMock.mockClear();
+
+        // Change to the animation's bake option. Skins are notified.
+        animation_0_0.useBakedAnimation = true;
+        expect(childSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
+        expect(childSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(true);
+        childSkinSetUseBakedAnimationMock.mockClear();
+        expect(anotherChildSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
+        expect(anotherChildSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(true);
+        anotherChildSkinSetUseBakedAnimationMock.mockClear();
+
+        expect(siblingSkinSetUseBakedAnimationMock).toBeCalledTimes(0);
+        expect(parentSkinSetUseBakedAnimationMock).toBeCalledTimes(0);
+
+        anotherChildSkin.destroy();
+        CCObject._deferredDestroy();
+        expect(animationRemoveUserMock).toBeCalledTimes(1);
+        expect(animationRemoveUserMock.mock.calls[0][0]).toBe(anotherChildSkin);
+        animationRemoveUserMock.mockClear();
+        expect(anotherChildSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
+        expect(anotherChildSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(false);
+        anotherChildSkinSetUseBakedAnimationMock.mockClear();
+
+        // Once the animation is destroyed, the skinned are reset to non-bake mode.
+        animation_0_0.destroy();
+        CCObject._deferredDestroy();
+        expect(childSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
+        expect(childSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(false);
+        childSkinSetUseBakedAnimationMock.mockClear();
+
+        {
+            const animation_0_0_new = n_0_0.addComponent(SkeletalAnimation) as SkeletalAnimation;
+            expect(childSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
+            expect(childSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(true);
+            childSkinSetUseBakedAnimationMock.mockClear();
+        };
+
+        scene.destroy();
+    });
+});

--- a/tests/init.ts
+++ b/tests/init.ts
@@ -63,10 +63,12 @@ import { DebugMode } from "../cocos/core/platform/debug";
 import { game, IGameConfig } from '../exports/base';
 import './asset-manager/init';
 import '../cocos/core/gfx/empty/empty-device';
+import '../cocos/3d/skeletal-animation/data-pool-manager';
 
 const canvas = document.createElement('canvas');
 const div = document.createElement('div');
 const config: IGameConfig = {
+    customJointTextureLayouts: [],
     debugMode: DebugMode.INFO,
     renderMode: 3, // Headless Mode
     adapter: {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * This PR fixes:
   - The first frame of skeletal animation is not played.

   - If `SkeletalAnimationState.play()` is not called, the `SkeletalAnimationState.sample()` takes no effect. (https://forum.cocos.org/t/topic/127457/198?u=shrinktofit)

 * Also optimized:
 
  - The mesh renderer should be child of skeletal animation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
