### PR TITLE
use byteLength instead of byteCount in tiled-layer

### DIFF
--- a/cocos/2d/renderer/deprecated.ts
+++ b/cocos/2d/renderer/deprecated.ts
@@ -72,14 +72,15 @@ removeProperty(MeshRenderData.prototype, 'MeshRenderData', [
     {
         name: 'byteStart',
     },
-    {
-        name: 'byteCount',
-    },
 ]);
 
 replaceProperty(MeshRenderData.prototype, 'MeshRenderData', [
     {
         name: 'indicesStart',
         newName: 'indexStart',
+    },
+    {
+        name: 'byteCount',
+        newName: 'byteLength',
     },
 ]);

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -295,6 +295,8 @@ export class MeshRenderData extends BaseRenderData {
      */
     get vDataOffset () { return this._byteLength >>> 2; }
 
+    get byteLength () { return this._byteLength; }
+
     public isMeshBuffer = true;
     public vData: Float32Array;
     public iData: Uint16Array;

--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -1397,7 +1397,7 @@ export class TiledLayer extends Renderable2D {
             this._meshRenderDataArray = [];
         }
         const arr = this._meshRenderDataArray as any[];
-        while (arr.length > 0 && arr[arr.length - 1].renderData && arr[arr.length - 1].renderData.byteCount === 0) {
+        while (arr.length > 0 && arr[arr.length - 1].renderData && arr[arr.length - 1].renderData.byteLength === 0) {
             arr.pop();
         }
         if (arr.length > 0) {


### PR DESCRIPTION
byteCount 重命名为_byteLength 且从public 变为private
