### PR TITLE
Add Methods `getTouchById` & `isValidTouch`

### DIFF
--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -612,6 +612,15 @@ let inputManager = {
     _registerAccelerometerEvent () {},
 
     /**
+     * @method getTouchById
+     * @param {Number} touchID
+     * @return {Touch} Touch Object
+     */
+    getTouchById (touchID) {
+        return this._touchesCache[touchID];
+    },
+
+    /**
      * @method isValidTouch
      * @param {Number} touchID
      * @returns {Boolean} whether the touch object with touchID is valid.

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -612,6 +612,16 @@ let inputManager = {
     _registerAccelerometerEvent () {},
 
     /**
+     * @method isValidTouch
+     * @param {Number} touchID
+     * @returns {Boolean} whether the touch object with touchID is valid.
+     */
+    isValidTouch (touchID) {
+        const locTouchesIntDict = this._touchesIntegerDict
+        return locTouchesIntDict[touchID] !== undefined
+    },
+
+    /**
      * @method update
      * @param {Number} dt
      */

--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -617,8 +617,8 @@ let inputManager = {
      * @returns {Boolean} whether the touch object with touchID is valid.
      */
     isValidTouch (touchID) {
-        const locTouchesIntDict = this._touchesIntegerDict
-        return locTouchesIntDict[touchID] !== undefined
+        const locTouchesIntDict = this._touchesIntegerDict;
+        return locTouchesIntDict[touchID] !== undefined;
     },
 
     /**


### PR DESCRIPTION
* Get touch object By touchId
* For checking that whether the touch object with touchID is valid.

ccTouch 对象在 超时后 ( (now - ccTouch._lastModified > timeout ) 会被移除.
如果 游戏逻辑层 还持有 该 对象的 id,  会产生问题.
所以 游戏逻辑层有时候需要去检测 自己这边持有 的 touchId 是否还有效.

另外  有时候开发者需要直接获得 touch 对象, 进行一些修改,  
比如 游戏中有一个按钮是 长按蓄力, 需要让这个touch长时间不要timeout (其他touch的还是正常的timeout), 那么可以获得这个 touch对象, 修改它的_lastModified. 

该 pr 在 ts/js/web 端没问题, 不知道 jsb/runtime 是否需要做类似修改.

cc @PPpro @pandamicro

Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
