### PR TITLE
Fix TypeError: Cannot read property ‘_onMaterialModified’ of null

### DIFF
--- a/cocos2d/core/3d/particle/particle-system-3d.ts
+++ b/cocos2d/core/3d/particle/particle-system-3d.ts
@@ -159,8 +159,10 @@ export default class ParticleSystem3D extends RenderComponent {
     set simulationSpace (val) {
         if (val !== this._simulationSpace) {
             this._simulationSpace = val;
-            this._assembler._updateMaterialParams();
-            this._assembler._updateTrailMaterial();
+            if (this._assembler) {
+                this._assembler._updateMaterialParams();
+                this._assembler._updateTrailMaterial();
+            }
         }
     }
 
@@ -494,9 +496,11 @@ export default class ParticleSystem3D extends RenderComponent {
             return;
         }
         this._renderMode = val;
-        this._assembler._setVertexAttrib();
-        this._assembler._updateModel();
-        this._assembler._updateMaterialParams();
+        if (this._assembler) {
+            this._assembler._setVertexAttrib();
+            this._assembler._updateModel();
+            this._assembler._updateMaterialParams();
+        }
     }
 
     @property
@@ -516,7 +520,7 @@ export default class ParticleSystem3D extends RenderComponent {
 
     set velocityScale (val) {
         this._velocityScale = val;
-        this._assembler._updateMaterialParams();
+        this._assembler && this._assembler._updateMaterialParams();
     }
 
     @property
@@ -535,7 +539,7 @@ export default class ParticleSystem3D extends RenderComponent {
 
     set lengthScale (val) {
         this._lengthScale = val;
-        this._assembler._updateMaterialParams();
+        this._assembler && this._assembler._updateMaterialParams();
     }
 
     @property
@@ -556,7 +560,7 @@ export default class ParticleSystem3D extends RenderComponent {
 
     set mesh (val) {
         this._mesh = val;
-        this._assembler._updateModel();
+        this._assembler && this._assembler._updateModel();
     }
 
     /**
@@ -646,11 +650,11 @@ export default class ParticleSystem3D extends RenderComponent {
     }
 
     _onMaterialModified (index, material) {
-        this._assembler._onMaterialModified(index, material);
+        this._assembler && this._assembler._onMaterialModified(index, material);
     }
 
     _onRebuildPSO (index, material) {
-        this._assembler._onRebuildPSO(index, material);
+        this._assembler && this._assembler._onRebuildPSO(index, material);
     }
 
     // TODO: fastforward current particle system by simulating particles over given period of time, then pause it.
@@ -730,13 +734,13 @@ export default class ParticleSystem3D extends RenderComponent {
      */
     clear () {
         if (this.enabledInHierarchy) {
-            this._assembler.clear();
+            this._assembler && this._assembler.clear();
             this.trailModule.clear();
         }
     }
 
     getParticleCount () {
-        return this._assembler.getParticleCount();
+        return this._assembler ? this._assembler.getParticleCount() : 0;
     }
 
     setCustomData1 (x, y) {
@@ -792,6 +796,9 @@ export default class ParticleSystem3D extends RenderComponent {
     }
 
     emit (count, dt) {
+        if (!this._assembler) {
+            return;
+        }
 
         if (this._simulationSpace === Space.World) {
             this.node.getWorldMatrix(_world_mat);
@@ -864,7 +871,7 @@ export default class ParticleSystem3D extends RenderComponent {
         for (let i = 0; i < cnt; ++i) {
             this._time += dt;
             this._emit(dt);
-            this._assembler._updateParticles(dt);
+            this._assembler && this._assembler._updateParticles(dt);
         }
     }
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/3620

Changelog:
 * Fix `_onMaterialModified` property error of ParticleSystem3D（修复 ParticleSystem3D 无法访问 `_onMaterialModified` 的报错）

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
