### PR TITLE
fix binding mappings

### DIFF
--- a/cocos/core/pipeline/define.ts
+++ b/cocos/core/pipeline/define.ts
@@ -145,12 +145,14 @@ export enum ModelLocalBindings {
     SAMPLER_LIGHTMAP,
     SAMPLER_SPRITE,
     SAMPLER_REFLECTION,
+
     STORAGE_REFLECTION,
 
     COUNT,
 }
 const LOCAL_UBO_COUNT = ModelLocalBindings.SAMPLER_JOINTS;
-const LOCAL_SAMPLER_COUNT = ModelLocalBindings.COUNT - LOCAL_UBO_COUNT;
+const LOCAL_SAMPLER_COUNT = ModelLocalBindings.STORAGE_REFLECTION - LOCAL_UBO_COUNT;
+const LOCAL_STORAGE_IMAGE_COUNT = ModelLocalBindings.COUNT - LOCAL_UBO_COUNT - LOCAL_SAMPLER_COUNT;
 
 export enum SetIndex {
     GLOBAL,
@@ -164,7 +166,7 @@ export const bindingMappingInfo = new BindingMappingInfo(
     [0, 0, 0],                                      // Sampler Counts
     [0, 0, 0],                                      // Texture Counts
     [0, 0, 0],                                      // Storage Buffer Counts
-    [0, 0, 0],                                      // Storage Image Counts
+    [0, 0, LOCAL_STORAGE_IMAGE_COUNT],              // Storage Image Counts
     [0, 0, 0],                                      // Subpass Input Counts
     [0, 2, 1],                                      // Set Order Indices
 );


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * binding mappings are not specified correctly for local set's storage image count

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->