### PR TITLE
fix tiledmap show wrong

### DIFF
--- a/cocos/tiledmap/assembler/simple.ts
+++ b/cocos/tiledmap/assembler/simple.ts
@@ -383,7 +383,6 @@ function traverseGrids (leftDown: { col: number, row: number }, rightTop: { col:
             cols = checkColRange && leftDown.col < rowData.minCol ? rowData.minCol : leftDown.col;
         }
 
-        const renderData = _renderData!.renderData;
         // traverse col
         for (; (cols - col) * colMoveDir >= 0; col += colMoveDir) {
             colData = rowData && rowData[col];
@@ -424,6 +423,7 @@ function traverseGrids (leftDown: { col: number, row: number }, rightTop: { col:
             // begin to fill vertex buffer
             tiledNode = tiledTiles[colData.index];
 
+            const renderData = _renderData!.renderData;
             renderData.reserve(4, 0);
             _vfOffset = renderData.vertexCount * 9;
             vertexBuf = renderData.vData;


### PR DESCRIPTION
* https://github.com/cocos-creator/3d-tasks/issues/11054

_renderData 在下面回被重新赋值。renderData 不能使用同一个.
