### PR TITLE
fix releaseMapInfo error.

### DIFF
--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -407,10 +407,8 @@ export class TiledLayer extends Renderable2D {
 
     onDisable () {
         super.onDisable();
-        if (this.node.parent !== null) {
-            this.node.parent.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
-            this.node.parent.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
-        }
+        this.node.parent?.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
+        this.node.parent?.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
         this.node.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
         this.node.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
         this.node.off(NodeEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);

--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -407,8 +407,10 @@ export class TiledLayer extends Renderable2D {
 
     onDisable () {
         super.onDisable();
-        this.node.parent!.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
-        this.node.parent!.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
+        if (this.node.parent !== null) {
+            this.node.parent.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
+            this.node.parent.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
+        }
         this.node.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
         this.node.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
         this.node.off(NodeEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);

--- a/cocos/tiledmap/tiled-map.ts
+++ b/cocos/tiledmap/tiled-map.ts
@@ -381,6 +381,8 @@ export class TiledMap extends Component {
         // remove the layers & object groups added before
         const layers = this._layers;
         for (let i = 0, l = layers.length; i < l; i++) {
+            layers[i].node.parent?.off(NodeEventType.SIZE_CHANGED, layers[i].updateCulling, layers[i]);
+            layers[i].node.parent?.off(NodeEventType.TRANSFORM_CHANGED, layers[i].updateCulling, layers[i]);
             layers[i].node.removeFromParent();
             layers[i].node.destroy();
         }


### PR DESCRIPTION
_releaseMapInfo函数中会调用layers[i].node.removeFromParent();
将node的parent关系移除,此时parent 为空