### PR TITLE
reset input assembler when particle is reset

### DIFF
--- a/cocos2d/particle/particle-simulator.js
+++ b/cocos2d/particle/particle-simulator.js
@@ -112,6 +112,9 @@ Simulator.prototype.reset = function () {
     for (let id = 0; id < particles.length; ++id)
         pool.put(particles[id]);
     particles.length = 0;
+    let assembler = this.sys._assembler;
+    if (assembler && assembler._ia)
+        assembler._ia._count = 0;
 }
 
 Simulator.prototype.emitParticle = function (pos) {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#

### Bug Description
I would like to re-use a pool of `cc.ParticleSystem` for performance reason.
But when I reuse a particle system, its previous state is rendered to screen in the 1st frame after I call `resetSystem()`.

This bug is similar to https://github.com/cocos-creator/engine/pull/7060

### How to Reproduce
1. If particle system is no longer used, stop it and also call **`active = false`** on its node.
2. To reuse a particle system, call **`active = true`** and `resetSystem()` **in tween callback**

### How to Fix
Reset input assembler when particle is reset.

### Screen
![粒子残留_v248](https://user-images.githubusercontent.com/4058573/153755335-a2ba4e28-ba04-4674-a076-5acd06b2da73.gif)

### Demo
[testParticleReuseBug248.zip](https://github.com/cocos-creator/engine/files/8055603/testParticleReuseBug248.zip)
