### PR TITLE
V3.4.2  user custom component which extends ccClass to show group style

### DIFF
--- a/editor/inspector/utils/prop.js
+++ b/editor/inspector/utils/prop.js
@@ -219,11 +219,13 @@ exports.updatePropByDump = function(panel, dump) {
             } else {
                 $prop = panel.$props[key] = panel.$[key] = document.createElement('ui-prop');
                 $prop.setAttribute('type', 'dump');
-                $prop.render(info);
             }
 
+            $prop.displayOrder = info.displayOrder === undefined ? 0 : Number(info.displayOrder);
+            $prop.displayOrder += 100;
+
             if (element && element.displayOrder !== undefined) {
-                info.displayOrder = element.displayOrder;
+                $prop.displayOrder = element.displayOrder;
             }
 
             if (!element || !element.isAppendToParent || element.isAppendToParent.call(panel)) {
@@ -247,14 +249,14 @@ exports.updatePropByDump = function(panel, dump) {
                         }
                     }
 
-                    exports.appendChildByDisplayOrder(panel.$groups[id].tabs[name], $prop, info.displayOrder);
+                    exports.appendChildByDisplayOrder(panel.$groups[id].tabs[name], $prop, $prop.displayOrder);
                 } else {
-                    exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop, info.displayOrder);
+                    exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop, $prop.displayOrder);
                 }
             }
         } else if (!$prop.isConnected || !$prop.parentElement) {
             if (!element || !element.isAppendToParent || element.isAppendToParent.call(panel)) {
-                exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop, info.displayOrder);
+                exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop, $prop.displayOrder);
             }
         }
         $prop.render(info);
@@ -436,7 +438,7 @@ exports.appendChildByDisplayOrder = function(parent, newChild, displayOrder = 0)
     const children = Array.from(parent.children);
 
     const child = children.find((child) => {
-        if (child.dump && child.dump.displayOrder > displayOrder) {
+        if (child.dump && child.displayOrder > displayOrder) {
             return child;
         }
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#11206

Changelog:
 * editor inspector support user custom component which extends ccClass to show group style
 
![image](https://user-images.githubusercontent.com/13517177/154273455-ac2c587a-e943-435f-a39e-90f595109375.png)
![QQ截图20220216211908](https://user-images.githubusercontent.com/13517177/154273515-9e6dd5d5-092a-4bb8-84f1-af15e15765ee.png)


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
