### PR TITLE
fix custom class missing when the instantiate error (#10054)

### DIFF
--- a/cocos2d/core/platform/instantiate-jit.js
+++ b/cocos2d/core/platform/instantiate-jit.js
@@ -531,7 +531,7 @@ proto.instantiateObj = function (obj) {
                     }
                 }
                 else if (obj instanceof cc.Component) {
-                    if (!obj.node.isChildOf(this.parent)) {
+                    if (!obj.node?.isChildOf(this.parent)) {
                         // should not clone other component if not descendant
                         return this.getObjRef(obj);
                     }

--- a/cocos2d/core/platform/instantiate.js
+++ b/cocos2d/core/platform/instantiate.js
@@ -276,7 +276,7 @@ function instantiateObj (obj, parent) {
                     }
                 }
                 else if (obj instanceof cc.Component) {
-                    if (!obj.node.isChildOf(parent)) {
+                    if (!obj.node?.isChildOf(parent)) {
                         // should not clone other component if not descendant
                         return obj;
                     }


### PR DESCRIPTION
(cherry picked from commit cc5ac37d6878c2e414ba8030446081a1c69465f8)

Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
