### PR TITLE
fix dragonbones dispose with args's size error warning

### DIFF
--- a/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -58,7 +58,7 @@ CCArmatureDisplay::CCArmatureDisplay() {
 }
 
 CCArmatureDisplay::~CCArmatureDisplay() {
-    dispose(true);
+    dispose();
 
     if (_debugBuffer) {
         delete _debugBuffer;
@@ -76,7 +76,7 @@ CCArmatureDisplay::~CCArmatureDisplay() {
     }
 }
 
-void CCArmatureDisplay::dispose(bool /*disposeProxy*/) {
+void CCArmatureDisplay::dispose() {
     if (_armature != nullptr) {
         _armature->dispose();
         _armature = nullptr;

--- a/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.h
+++ b/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.h
@@ -82,7 +82,7 @@ public:
     /**
      * @inheritDoc
      */
-    void dispose(bool disposeProxy) override;
+    void dispose() override;
     /**
      * @inheritDoc
      */

--- a/native/cocos/editor-support/dragonbones/armature/IArmatureProxy.h
+++ b/native/cocos/editor-support/dragonbones/armature/IArmatureProxy.h
@@ -83,7 +83,7 @@ public:
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    virtual void dispose(bool disposeProxy) = 0;
+    virtual void dispose() = 0;
     /**
      * - The armature.
      * @version DragonBones 4.5


### PR DESCRIPTION
参数未被使用, 但默认值被删除，导致dispose函数需传参，否则参数size 不匹配报错。
