### PR TITLE
update editBox size when node resize

### DIFF
--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -734,6 +734,8 @@ export class EditBox extends Component {
         if (backgroundNode) {
             backgroundNode._uiProps.uiTransformComp!.setContentSize(trans.contentSize);
         }
+
+        this._syncSize();
     }
 }
 


### PR DESCRIPTION
Re: https://forum.cocos.org/t/topic/130605/8?u=panda

Changelog:
 * 修复 editBox 节点 resize 后，EditBox 输入框尺寸不对的问题

resize 可能来自于 widget 组件