### PR TITLE
fix: node panel just need asset.section config

### DIFF
--- a/editor/inspector/assets/material-header.js
+++ b/editor/inspector/assets/material-header.js
@@ -83,9 +83,10 @@ exports.methods = {
             panel.refreshPreview();
         });
     },
-    updatePreviewDataDirty() {
+    async updatePreviewDataDirty(assetUuid, material) {
         const panel = this;
 
+        await Editor.Message.request('scene', 'preview-material', assetUuid, material);
         panel.isPreviewDataDirty = true;
     },
 };

--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -71,8 +71,8 @@ exports.methods = {
         this.cacheData = {};
     },
     /**
-     * 
-     * @param {string} inspector 
+     *
+     * @param {string} inspector
      */
     async updateCustomInspector(inspector) {
         this.$.customPanel.hidden = false;
@@ -295,9 +295,8 @@ exports.methods = {
         this.$.materialDump.style = hide ? 'display:none' : '';
     },
 
-    async updatePreview() {
-        await Editor.Message.request('scene', 'preview-material', this.asset.uuid, this.material);
-        Editor.Message.broadcast('material-inspector:change-dump');
+    updatePreview() {
+        Editor.Message.broadcast('material-inspector:change-dump', this.asset.uuid, this.material);
     },
 
     storeCache() {

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -1030,7 +1030,8 @@ const Elements = {
                     materialPanel.setAttribute('uuid', materialUuid);
                     materialPanel.panelObject.$.container.removeAttribute('whole');
                     materialPanel.panelObject.$.container.setAttribute('cache-expand', materialUuid);
-                    materialPanel.update([materialUuid], panel.renderManager[materialPanelType]);
+                    const { section = {} } = panel.renderManager[materialPanelType];
+                    materialPanel.update([materialUuid], { section });
 
                     // 按数组顺序放置
                     if (materialPrevPanel) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#10814

Changelog:
 * move preview-material from material.js to material-header
 * node panel just need asset.section config

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
