### PR TITLE
Fix promise exception output

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
@@ -320,7 +320,7 @@ void ScriptEngine::onMessageCallback(v8::Local<v8::Message> message, v8::Local<v
 * But if no reject handler is added, then "unhandledRejectedPromise" exception will be called again, but the stacktrace this time become empty
 * LastStackTrace is used to store it.
 */
-std::string LastStackTrace;
+std::string lastStackTrace;
 void ScriptEngine::pushPromiseExeception(const v8::Local<v8::Promise> &promise, const char* event, const char *stackTrace) {
     using element_type = decltype(_promiseArray)::value_type;
     element_type *current;
@@ -340,8 +340,8 @@ void ScriptEngine::pushPromiseExeception(const v8::Local<v8::Promise> &promise, 
     auto &exceptions = std::get<1>(*current);
     if (std::strcmp(event,"handlerAddedAfterPromiseRejected") == 0) {
         for (int i = 0; i < exceptions.size(); i++) {
-            if (std::strcmp(exceptions[i].event.c_str(), "unhandledRejectedPromise") == 0) {
-                LastStackTrace = exceptions[i].stackTrace;
+            if (std::strcmp(exceptions[i].event.c_str(),"unhandledRejectedPromise") == 0) {
+                lastStackTrace = exceptions[i].stackTrace;
                 exceptions.erase(exceptions.begin() + i);
                 return;
             }
@@ -434,7 +434,7 @@ void ScriptEngine::onPromiseRejectCallback(v8::PromiseRejectMessage msg) {
     auto stackStr = getInstance()->getCurrentStackTrace();
     ss << "stacktrace: " << std::endl;
     if (stackStr.empty()) {
-        ss << LastStackTrace << std::endl;
+        ss << lastStackTrace << std::endl;
     } else {
         ss << stackStr << std::endl;
     }

--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
@@ -320,9 +320,6 @@ void ScriptEngine::onMessageCallback(v8::Local<v8::Message> message, v8::Local<v
 * But if no reject handler is added, then "unhandledRejectedPromise" exception will be called again, but the stacktrace this time become empty
 * LastStackTrace is used to store it.
 */
-namespace{
-    std::string lastStackTrace;
-}
 void ScriptEngine::pushPromiseExeception(const v8::Local<v8::Promise> &promise, const char* event, const char *stackTrace) {
     using element_type = decltype(_promiseArray)::value_type;
     element_type *current;
@@ -343,7 +340,7 @@ void ScriptEngine::pushPromiseExeception(const v8::Local<v8::Promise> &promise, 
     if (std::strcmp(event,"handlerAddedAfterPromiseRejected") == 0) {
         for (int i = 0; i < exceptions.size(); i++) {
             if (exceptions[i].event == "unhandledRejectedPromise") {
-                lastStackTrace = exceptions[i].stackTrace;
+                _lastStackTrace = exceptions[i].stackTrace;
                 exceptions.erase(exceptions.begin() + i);
                 return;
             }
@@ -364,7 +361,7 @@ void ScriptEngine::handlePromiseExceptions() {
         std::get<0>(exceptionsPair).get()->Reset();
     }
     _promiseArray.clear();
-    lastStackTrace.clear();
+    _lastStackTrace.clear();
 }
 
 void ScriptEngine::onPromiseRejectCallback(v8::PromiseRejectMessage msg) {
@@ -437,7 +434,7 @@ void ScriptEngine::onPromiseRejectCallback(v8::PromiseRejectMessage msg) {
     auto stackStr = getInstance()->getCurrentStackTrace();
     ss << "stacktrace: " << std::endl;
     if (stackStr.empty()) {
-        ss << lastStackTrace << std::endl;
+        ss << getInstance()->_lastStackTrace << std::endl;
     } else {
         ss << stackStr << std::endl;
     }

--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
@@ -342,7 +342,7 @@ void ScriptEngine::pushPromiseExeception(const v8::Local<v8::Promise> &promise, 
     auto &exceptions = std::get<1>(*current);
     if (std::strcmp(event,"handlerAddedAfterPromiseRejected") == 0) {
         for (int i = 0; i < exceptions.size(); i++) {
-            if (std::strcmp(exceptions[i].event.c_str(),"unhandledRejectedPromise") == 0) {
+            if (exceptions[i].event == "unhandledRejectedPromise") {
                 lastStackTrace = exceptions[i].stackTrace;
                 exceptions.erase(exceptions.begin() + i);
                 return;
@@ -364,6 +364,7 @@ void ScriptEngine::handlePromiseExceptions() {
         std::get<0>(exceptionsPair).get()->Reset();
     }
     _promiseArray.clear();
+    lastStackTrace.clear();
 }
 
 void ScriptEngine::onPromiseRejectCallback(v8::PromiseRejectMessage msg) {

--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
@@ -320,7 +320,9 @@ void ScriptEngine::onMessageCallback(v8::Local<v8::Message> message, v8::Local<v
 * But if no reject handler is added, then "unhandledRejectedPromise" exception will be called again, but the stacktrace this time become empty
 * LastStackTrace is used to store it.
 */
-std::string lastStackTrace;
+namespace{
+    std::string lastStackTrace;
+}
 void ScriptEngine::pushPromiseExeception(const v8::Local<v8::Promise> &promise, const char* event, const char *stackTrace) {
     using element_type = decltype(_promiseArray)::value_type;
     element_type *current;

--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.h
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.h
@@ -401,7 +401,7 @@ private:
     VMStringPool _stringPool;
 
     std::thread::id _engineThreadId;
-
+    std::string _lastStackTrace;
     std::string _debuggerServerAddr;
     uint32_t    _debuggerServerPort;
     bool        _isWaitForConnect;

--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.h
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.h
@@ -366,8 +366,8 @@ private:
     bool postInit();
     // Struct to save exception info
     struct PromiseExceptionMsg {
-        const char* event;
-        const char* stackTrace;
+        std::string event;
+        std::string stackTrace;
     };
     // Push promise and exception msg to _promiseArray
     void pushPromiseExeception(const v8::Local<v8::Promise> &promise, const char* event, const char *stackTrace);


### PR DESCRIPTION
## Changes
* use std::string to store event and stack trace
* record stack trace for second time unhandledRejectedPromise exception

## Extra info
Bug in v8 stacktrace:
"handlerAddedAfterPromiseRejected" event is triggered if a resolve handler is added.
But if no reject handler is added, then "unhandledRejectedPromise" exception will be called again, but the stacktrace this time become empty
LastStackTrace is used to store it.

For example:
```js
let p = new Promise<SpriteFrame>((resolve,reject)=>{
 reject();
});
p.then((img)=>{
 console.log("resolve!!!");
});
```
3 exceptions would be throwed:
```
18:11:04 [DEBUG]: ---------- promise exception unhandledRejectedPromise stack trace ----------

18:11:04 [DEBUG]:  - [0]anonymous@assets/main/index.js:65
 - [1]getImg@assets/main/index.js:63
 - [2]NoHandlerClick@assets/main/index.js:70
 - [3]emit@src/cocos-js/instantiated-81c861ca.js:8295
 - [4]emitEvents@src/cocos-js/instantiated-81c861ca.js:8263
 - [5]_onTouchEnded@src/cocos-js/cc.js:36966
 - [6]emit@src/cocos-js/instantiated-81c861ca.js:3609
 - [7]dispatchEvent@src/cocos-js/cc.js:26767
 - [8]anonymous@src/cocos-js/instantiated-81c861ca.js:17536
 - [9]_handleTouchEnd@src/cocos-js/cc.js:27022
 - [10]_handleEventTouch@src/cocos-js/cc.js:26964
 - [11]dispatchEventTouch@src/cocos-js/cc.js:35035
 - [12]dispatchEvent@src/cocos-js/cc.js:34945
 - [13]_emitEvent@src/cocos-js/instantiated-81c861ca.js:29907
 - [14]_frameDispatchEvents@src/cocos-js/instantiated-81c861ca.js:30042
 - [15]tick@src/cocos-js/instantiated-81c861ca.js:36205
 - [16]callback@src/cocos-js/instantiated-81c861ca.js:32748
 - [17]tick@jsb-adapter/jsb-builtin.js:607
18:11:04 [DEBUG]: --------------------

18:11:04 [DEBUG]: ---------- promise exception handlerAddedAfterPromiseRejected stack trace ----------

18:11:04 [DEBUG]:  - [0]NoHandlerClick@assets/main/index.js:71
 - [1]emit@src/cocos-js/instantiated-81c861ca.js:8295
 - [2]emitEvents@src/cocos-js/instantiated-81c861ca.js:8263
 - [3]_onTouchEnded@src/cocos-js/cc.js:36966
 - [4]emit@src/cocos-js/instantiated-81c861ca.js:3609
 - [5]dispatchEvent@src/cocos-js/cc.js:26767
 - [6]anonymous@src/cocos-js/instantiated-81c861ca.js:17536
 - [7]_handleTouchEnd@src/cocos-js/cc.js:27022
 - [8]_handleEventTouch@src/cocos-js/cc.js:26964
 - [9]dispatchEventTouch@src/cocos-js/cc.js:35035
 - [10]dispatchEvent@src/cocos-js/cc.js:34945
 - [11]_emitEvent@src/cocos-js/instantiated-81c861ca.js:29907
 - [12]_frameDispatchEvents@src/cocos-js/instantiated-81c861ca.js:30042
 - [13]tick@src/cocos-js/instantiated-81c861ca.js:36205
 - [14]callback@src/cocos-js/instantiated-81c861ca.js:32748
 - [15]tick@jsb-adapter/jsb-builtin.js:607
18:11:04 [DEBUG]: --------------------

18:11:04 [DEBUG]: ---------- promise exception unhandledRejectedPromise stack trace ----------

18:11:04 [DEBUG]: 
18:11:04 [DEBUG]: --------------------
```

So the third exception has no stacktrace output. So just use the last stacktrace because it's actually the same promise.

PS: Complex scenario was not tested.
