### PR TITLE
[v3.6.0 pipeline] shadingScale moved from PipelineSceneData to Pipeline

### DIFF
--- a/cocos/core/pipeline/custom/pipeline.ts
+++ b/cocos/core/pipeline/custom/pipeline.ts
@@ -53,6 +53,8 @@ export abstract class PipelineRuntime {
     public abstract get constantMacros(): string;
     public abstract get profiler(): Model | null;
     public abstract set profiler(profiler: Model | null);
+    public abstract get shadingScale(): number;
+    public abstract set shadingScale(scale: number);
     public abstract onGlobalPipelineStateChanged(): void;
 }
 

--- a/cocos/core/pipeline/pipeline-scene-data.ts
+++ b/cocos/core/pipeline/pipeline-scene-data.ts
@@ -29,7 +29,6 @@ import { Device, Framebuffer, InputAssembler, InputAssemblerInfo, Buffer, Buffer
     BufferUsageBit, MemoryUsageBit, Attribute, Format, Shader } from '../gfx';
 import { RenderPipeline } from './render-pipeline';
 import { Light } from '../renderer/scene/light';
-import { PipelineEventType } from './pipeline-event';
 import { Material } from '../assets';
 import { Pass } from '../renderer/core/pass';
 
@@ -53,10 +52,7 @@ export class PipelineSceneData {
     }
 
     public set shadingScale (val: number) {
-        if (this._shadingScale !== val) {
-            this._shadingScale = val;
-            this._pipeline.emit(PipelineEventType.ATTACHMENT_SCALE_CAHNGED, val);
-        }
+        this._shadingScale = val;
     }
 
     public fog: Fog = new Fog();
@@ -93,7 +89,7 @@ export class PipelineSceneData {
     protected _shadingScale = 1.0;
 
     constructor () {
-        this.shadingScale = 1.0;
+        this._shadingScale = 1.0;
     }
 
     public activate (device: Device, pipeline: RenderPipeline) {

--- a/cocos/core/pipeline/render-pipeline.ts
+++ b/cocos/core/pipeline/render-pipeline.ts
@@ -376,6 +376,17 @@ export abstract class RenderPipeline extends Asset implements IPipelineEvent, Pi
         return out;
     }
 
+    public get shadingScale () {
+        return this._pipelineSceneData.shadingScale;
+    }
+
+    public set shadingScale (val: number) {
+        if (this._pipelineSceneData.shadingScale !== val) {
+            this._pipelineSceneData.shadingScale = val;
+            this.emit(PipelineEventType.ATTACHMENT_SCALE_CAHNGED, val);
+        }
+    }
+
     /**
      * @en Activate the render pipeline after loaded, it mainly activate the flows
      * @zh 当渲染管线资源加载完成后，启用管线，主要是启用管线内的 flow

--- a/cocos/core/platform/screen.ts
+++ b/cocos/core/platform/screen.ts
@@ -46,7 +46,7 @@ class Screen {
                 warnID(1220);
                 return;
             }
-            director.root.pipeline.pipelineSceneData.shadingScale = screenAdapter.resolutionScale;
+            director.root.pipeline.shadingScale = screenAdapter.resolutionScale;
         });
     }
 

--- a/native/cocos/bindings/auto/jsb_pipeline_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_pipeline_auto.cpp
@@ -895,6 +895,25 @@ static bool js_pipeline_RenderPipeline_getScissor(se::State& s) // NOLINT(readab
 }
 SE_BIND_FUNC(js_pipeline_RenderPipeline_getScissor)
 
+static bool js_pipeline_RenderPipeline_getShadingScale(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::pipeline::RenderPipeline>(s);
+    SE_PRECONDITION2(cobj, false, "js_pipeline_RenderPipeline_getShadingScale : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        float result = cobj->getShadingScale();
+        ok &= nativevalue_to_se(result, s.rval(), nullptr /*ctx*/);
+        SE_PRECONDITION2(ok, false, "js_pipeline_RenderPipeline_getShadingScale : Error processing arguments");
+        SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_GET(js_pipeline_RenderPipeline_getShadingScale)
+
 static bool js_pipeline_RenderPipeline_getViewport(se::State& s) // NOLINT(readability-identifier-naming)
 {
     auto* cobj = SE_THIS_OBJECT<cc::pipeline::RenderPipeline>(s);
@@ -1187,6 +1206,25 @@ static bool js_pipeline_RenderPipeline_setProfiler(se::State& s) // NOLINT(reada
 }
 SE_BIND_FUNC_AS_PROP_SET(js_pipeline_RenderPipeline_setProfiler)
 
+static bool js_pipeline_RenderPipeline_setShadingScale(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::pipeline::RenderPipeline>(s);
+    SE_PRECONDITION2(cobj, false, "js_pipeline_RenderPipeline_setShadingScale : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<float, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_pipeline_RenderPipeline_setShadingScale : Error processing arguments");
+        cobj->setShadingScale(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_SET(js_pipeline_RenderPipeline_setShadingScale)
+
 static bool js_pipeline_RenderPipeline_setValue(se::State& s) // NOLINT(readability-identifier-naming)
 {
     CC_UNUSED bool ok = true;
@@ -1310,6 +1348,7 @@ bool js_register_pipeline_RenderPipeline(se::Object* obj) // NOLINT(readability-
     cls->defineProperty("bloomEnabled", nullptr, _SE(js_pipeline_RenderPipeline_setBloomEnabled_asSetter));
     cls->defineProperty("pipelineSceneData", _SE(js_pipeline_RenderPipeline_getPipelineSceneData_asGetter), nullptr);
     cls->defineProperty("profiler", _SE(js_pipeline_RenderPipeline_getProfiler_asGetter), _SE(js_pipeline_RenderPipeline_setProfiler_asSetter));
+    cls->defineProperty("shadingScale", _SE(js_pipeline_RenderPipeline_getShadingScale_asGetter), _SE(js_pipeline_RenderPipeline_setShadingScale_asSetter));
     cls->defineFunction("activate", _SE(js_pipeline_RenderPipeline_activate));
     cls->defineFunction("createQuadInputAssembler", _SE(js_pipeline_RenderPipeline_createQuadInputAssembler));
     cls->defineFunction("ensureEnoughSize", _SE(js_pipeline_RenderPipeline_ensureEnoughSize));

--- a/native/cocos/bindings/auto/jsb_render_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_render_auto.cpp
@@ -174,6 +174,25 @@ static bool js_render_PipelineRuntime_getProfiler(se::State& s) // NOLINT(readab
 }
 SE_BIND_FUNC_AS_PROP_GET(js_render_PipelineRuntime_getProfiler)
 
+static bool js_render_PipelineRuntime_getShadingScale(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::render::PipelineRuntime>(s);
+    SE_PRECONDITION2(cobj, false, "js_render_PipelineRuntime_getShadingScale : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        float result = cobj->getShadingScale();
+        ok &= nativevalue_to_se(result, s.rval(), nullptr /*ctx*/);
+        SE_PRECONDITION2(ok, false, "js_render_PipelineRuntime_getShadingScale : Error processing arguments");
+        SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_GET(js_render_PipelineRuntime_getShadingScale)
+
 static bool js_render_PipelineRuntime_onGlobalPipelineStateChanged(se::State& s) // NOLINT(readability-identifier-naming)
 {
     auto* cobj = SE_THIS_OBJECT<cc::render::PipelineRuntime>(s);
@@ -227,6 +246,25 @@ static bool js_render_PipelineRuntime_setProfiler(se::State& s) // NOLINT(readab
 }
 SE_BIND_FUNC_AS_PROP_SET(js_render_PipelineRuntime_setProfiler)
 
+static bool js_render_PipelineRuntime_setShadingScale(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::render::PipelineRuntime>(s);
+    SE_PRECONDITION2(cobj, false, "js_render_PipelineRuntime_setShadingScale : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<float, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_render_PipelineRuntime_setShadingScale : Error processing arguments");
+        cobj->setShadingScale(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_SET(js_render_PipelineRuntime_setShadingScale)
+
 bool js_register_render_PipelineRuntime(se::Object* obj) // NOLINT(readability-identifier-naming)
 {
     auto* cls = se::Class::create("PipelineRuntime", obj, nullptr, nullptr);
@@ -237,6 +275,7 @@ bool js_register_render_PipelineRuntime(se::Object* obj) // NOLINT(readability-i
     cls->defineProperty("pipelineSceneData", _SE(js_render_PipelineRuntime_getPipelineSceneData_asGetter), nullptr);
     cls->defineProperty("constantMacros", _SE(js_render_PipelineRuntime_getConstantMacros_asGetter), nullptr);
     cls->defineProperty("profiler", _SE(js_render_PipelineRuntime_getProfiler_asGetter), _SE(js_render_PipelineRuntime_setProfiler_asSetter));
+    cls->defineProperty("shadingScale", _SE(js_render_PipelineRuntime_getShadingScale_asGetter), _SE(js_render_PipelineRuntime_setShadingScale_asSetter));
     cls->defineFunction("activate", _SE(js_render_PipelineRuntime_activate));
     cls->defineFunction("destroy", _SE(js_render_PipelineRuntime_destroy));
     cls->defineFunction("onGlobalPipelineStateChanged", _SE(js_render_PipelineRuntime_onGlobalPipelineStateChanged));

--- a/native/cocos/renderer/pipeline/RenderPipeline.cpp
+++ b/native/cocos/renderer/pipeline/RenderPipeline.cpp
@@ -258,6 +258,14 @@ gfx::Rect RenderPipeline::getRenderArea(scene::Camera *camera) {
     };
 }
 
+float RenderPipeline::getShadingScale() const {
+    return _pipelineSceneData->getShadingScale();
+}
+
+void RenderPipeline::setShadingScale(float scale) {
+    _pipelineSceneData->setShadingScale(scale);
+}
+
 void RenderPipeline::genQuadVertexData(const Vec4 &viewport, float *vbData) {
     auto minX = static_cast<float>(viewport.x);
     auto maxX = static_cast<float>(viewport.x + viewport.z);

--- a/native/cocos/renderer/pipeline/RenderPipeline.h
+++ b/native/cocos/renderer/pipeline/RenderPipeline.h
@@ -110,6 +110,9 @@ public:
     void                    ensureEnoughSize(const vector<scene::Camera *> &cameras);
     bool                    createQuadInputAssembler(gfx::Buffer *quadIB, gfx::Buffer **quadVB, gfx::InputAssembler **quadIA);
 
+    float getShadingScale() const;
+    void  setShadingScale(float scale);
+
     inline scene::Model *getProfiler() const { return _profiler; }
     inline void          setProfiler(scene::Model *value) { _profiler = value; }
 

--- a/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
@@ -89,7 +89,11 @@ public:
     virtual const std::string           &getConstantMacros() const = 0;
     virtual scene::Model                *getProfiler() const = 0;
     virtual void                         setProfiler(scene::Model *profiler) const = 0;
-    virtual void                         onGlobalPipelineStateChanged() = 0;
+
+    virtual float getShadingScale() const = 0;
+    virtual void  setShadingScale(float scale) = 0;
+
+    virtual void onGlobalPipelineStateChanged() = 0;
 };
 
 inline PipelineRuntime::~PipelineRuntime() noexcept = default;

--- a/native/tools/tojs/pipeline.ini
+++ b/native/tools/tojs/pipeline.ini
@@ -61,7 +61,7 @@ skip = ForwardPipeline::[getOrCreateRenderPass getLightsUBO getValidLights getLi
 
 rename_functions =
 
-getter_setter= RenderPipeline::[globalDSManager descriptorSet descriptorSetLayout constantMacros  clusterEnabled bloomEnabled pipelineSceneData profiler],
+getter_setter= RenderPipeline::[globalDSManager descriptorSet descriptorSetLayout constantMacros  clusterEnabled bloomEnabled pipelineSceneData profiler shadingScale],
                PipelineSceneData::[isHDR/isHDR/setHDR shadingScale fog ambient skybox shadows/getShadows],
                BloomStage::[threshold intensity iterations]
 

--- a/native/tools/tojs/render.ini
+++ b/native/tools/tojs/render.ini
@@ -52,7 +52,7 @@ skip = SceneVisitor::[updateBuffer]
 
 skip_public_fields =
 
-getter_setter = PipelineRuntime::[macros globalDSManager descriptorSetLayout pipelineSceneData constantMacros profiler],
+getter_setter = PipelineRuntime::[macros globalDSManager descriptorSetLayout pipelineSceneData constantMacros profiler shadingScale],
                 SceneTask::[taskType]
 
 rename_functions =


### PR DESCRIPTION
move features from PipelineSceneData to Pipeline.
Pipeline is  now in charge of event dispatch instead of PipelineSceneData.

might cause shadingScale bugs.

Changelog:
 * add shadingScale to Pipeline interface

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
