### PR TITLE
[v3.6.0 pipeline] pipelineEvent removed from native pipeline

### DIFF
--- a/cocos/core/pipeline/index.jsb.ts
+++ b/cocos/core/pipeline/index.jsb.ts
@@ -49,7 +49,7 @@ export const LightingStage = nr.LightingStage;
 export const PostProcessStage = nr.PostProcessStage;
 export const GbufferStage = nr.GbufferStage;
 export const BloomStage = nr.BloomStage;
-export { PipelineEventProcessor, PipelineEventType } from './pipeline-event';
+export { PipelineEventType } from './pipeline-event';
 
 let getOrCreatePipelineState = nr.PipelineStateManager.getOrCreatePipelineState;
 nr.PipelineStateManager.getOrCreatePipelineState = function(device, pass, shader, renderPass, ia) {
@@ -73,14 +73,6 @@ forwardPipelineProto.init = function () {
       const info = new nr.RenderPipelineInfo(this._tag, this._flows);
       this.initialize(info);
 };
-
-forwardPipelineProto.on = function(type: PipelineEventType, callback: any, target?: any, once?: boolean){}
-forwardPipelineProto.once = function(type: PipelineEventType, callback: any, target?: any) {}
-forwardPipelineProto.off = function(type: PipelineEventType, callback?: any, target?: any) {}
-forwardPipelineProto.emit = function(type: PipelineEventType, arg0?: any, arg1?: any, arg2?: any, arg3?: any, arg4?: any) {}
-forwardPipelineProto.targetOff = function(typeOrTarget: any): void {}
-forwardPipelineProto.removeAll = function(typeOrTarget: any): void {}
-forwardPipelineProto.hasEventListener = function(type: PipelineEventType, callback?: any, target?: any): boolean { return false; }
 
 const oldForwardOnLoaded = forwardPipelineProto.onLoaded;
 // hook to invoke init after deserialization
@@ -176,13 +168,6 @@ deferredPipelineProto._ctor = function() {
     // noinspection JSConstantReassignment
     this.geometryRenderer = new GeometryRenderer();
 }
-deferredPipelineProto.on = function(type: PipelineEventType, callback: any, target?: any, once?: boolean){}
-deferredPipelineProto.once = function(type: PipelineEventType, callback: any, target?: any) {}
-deferredPipelineProto.off = function(type: PipelineEventType, callback?: any, target?: any) {}
-deferredPipelineProto.emit = function(type: PipelineEventType, arg0?: any, arg1?: any, arg2?: any, arg3?: any, arg4?: any) {}
-deferredPipelineProto.targetOff = function(typeOrTarget: any): void {}
-deferredPipelineProto.removeAll = function(typeOrTarget: any): void {}
-deferredPipelineProto.hasEventListener = function(type: PipelineEventType, callback?: any, target?: any): boolean { return false; }
 
 const oldDeferredOnLoaded = deferredPipelineProto.onLoaded;
 // hook to invoke init after deserialization

--- a/cocos/core/root.jsb.ts
+++ b/cocos/core/root.jsb.ts
@@ -56,9 +56,19 @@ Object.defineProperty(rootProto, 'pipelineEvent', {
     configurable: true,
     enumerable: true,
     get () {
-        return this._pipeline;
+        return this._pipelineEvent;
     }
 });
+
+class DymmyPipelineEvent {
+    on (type: any, callback: any, target?: any, once?: boolean) {}
+    once (type: any, callback: any, target?: any) {}
+    off (type: any, callback?: any, target?: any) {}
+    emit (type: any, arg0?: any, arg1?: any, arg2?: any, arg3?: any, arg4?: any) {}
+    targetOff (typeOrTarget: any) {}
+    removeAll (typeOrTarget: any) {}
+    hasEventListener (type: any, callback?: any, target?: any): boolean { return false; }
+}
 
 rootProto._ctor = function (device: Device) {
     this._device = device;
@@ -67,6 +77,7 @@ rootProto._ctor = function (device: Device) {
     this._lightPools = new Map();
     this._batcher = null;
     this._pipeline = null;
+    this._pipelineEvent = new DymmyPipelineEvent();
     this._registerListeners();
 };
 

--- a/cocos/core/root.jsb.ts
+++ b/cocos/core/root.jsb.ts
@@ -60,7 +60,7 @@ Object.defineProperty(rootProto, 'pipelineEvent', {
     }
 });
 
-class DymmyPipelineEvent {
+class DummyPipelineEvent {
     on (type: any, callback: any, target?: any, once?: boolean) {}
     once (type: any, callback: any, target?: any) {}
     off (type: any, callback?: any, target?: any) {}
@@ -77,7 +77,7 @@ rootProto._ctor = function (device: Device) {
     this._lightPools = new Map();
     this._batcher = null;
     this._pipeline = null;
-    this._pipelineEvent = new DymmyPipelineEvent();
+    this._pipelineEvent = new DummyPipelineEvent();
     this._registerListeners();
 };
 

--- a/cocos/core/root.ts
+++ b/cocos/core/root.ts
@@ -128,7 +128,7 @@ export class Root {
      * 渲染管线事件
      */
     public get pipelineEvent (): IPipelineEvent {
-        return this._pipeline!;
+        return this._pipelineEvent!;
     }
 
     /**
@@ -220,6 +220,7 @@ export class Root {
     private _curWindow: RenderWindow | null = null;
     private _tempWindow: RenderWindow | null = null;
     private _pipeline: RenderPipeline | null = null;
+    private _pipelineEvent: IPipelineEvent | null = null;
     private _customPipeline: Pipeline | null = null;
     private _batcher: Batcher2D | null = null;
     private _dataPoolMgr: DataPoolManager;
@@ -282,6 +283,7 @@ export class Root {
         if (this._pipeline) {
             this._pipeline.destroy();
             this._pipeline = null;
+            this._pipelineEvent = null;
         }
 
         if (this._batcher) {
@@ -319,6 +321,7 @@ export class Root {
             isCreateDefaultPipeline = true;
         }
         this._pipeline = rppl;
+        this._pipelineEvent = rppl;
         // now cluster just enabled in deferred pipeline
         if (!this._useDeferredPipeline || !this.device.hasFeature(Feature.COMPUTE_SHADER)) {
             // disable cluster
@@ -331,6 +334,7 @@ export class Root {
                 this._pipeline.destroy();
             }
             this._pipeline = null;
+            this._pipelineEvent = null;
 
             return false;
         }


### PR DESCRIPTION
pipelineEvent removed from native pipeline interface. pipelineEvent is not used in native pipeline.

Changelog:
 * pipelineEvent removed from native RenderPipeline and DeferredRenderPipeline
 * DummyPipelineEvent added in root.jsb.ts
 * member _pipelineEvent is added to root.ts and root.jsb.ts
 * pipelineEvent interface implementation changed

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
