### PR TITLE
avoid spine and dragon crash.

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -475,8 +475,10 @@ void Object::clearPrivateData(bool clearMapping) {
         if (clearMapping) {
             NativePtrToObjectMap::erase(_privateData);
         }
-        internal::clearPrivate(__isolate, _obj);
-        setProperty("__native_ptr__", se::Value(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(nullptr))));
+        if (!_obj.persistent().IsEmpty()) {
+            internal::clearPrivate(__isolate, _obj);
+            setProperty("__native_ptr__", se::Value(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(nullptr))));
+        }
         _privateData = nullptr;
     }
 }

--- a/native/cocos/bindings/manual/jsb_dragonbones_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_dragonbones_manual.cpp
@@ -434,14 +434,11 @@ bool register_all_dragonbones_manual(se::Object *obj) {
     __jsb_dragonBones_BaseFactory_proto->defineFunction("parseTextureAtlasData", _SE(js_cocos2dx_dragonbones_BaseFactory_parseTextureAtlasData));
 
     dragonBones::BaseObject::setObjectRecycleOrDestroyCallback([](dragonBones::BaseObject *obj, int type) {
-        //std::string typeName = typeid(*obj).name();
-
-        //se::Object* seObj = nullptr;
-
+        se::Object* seObj = nullptr;
         auto iter = se::NativePtrToObjectMap::find(obj);
         if (iter != se::NativePtrToObjectMap::end()) {
             // Save se::Object pointer for being used in cleanup method.
-            //seObj = iter->second;
+            seObj = iter->second;
             // Unmap native and js object since native object was destroyed.
             // Otherwise, it may trigger 'assertion' in se::Object::setPrivateData later
             // since native obj is already released and the new native object may be assigned with
@@ -453,32 +450,31 @@ bool register_all_dragonbones_manual(se::Object *obj) {
             return;
         }
 
-        //std::string typeNameStr = typeName;
-        //auto cleanup = [seObj, typeNameStr](){
+        auto cleanup = [seObj](){
 
-        //    auto se = se::ScriptEngine::getInstance();
-        //    if (!se->isValid() || se->isInCleanup())
-        //        return;
+            auto se = se::ScriptEngine::getInstance();
+            if (!se->isValid() || se->isInCleanup())
+                return;
 
-        //    se::AutoHandleScope hs;
-        //    se->clearException();
+            se::AutoHandleScope hs;
+            se->clearException();
 
-        //    // The mapping of native object & se::Object was cleared in above code.
-        //    // The private data (native object) may be a different object associated with other se::Object.
-        //    // Therefore, don't clear the mapping again.
-        //    seObj->clearPrivateData(false);
-        //    seObj->unroot();
-        //    seObj->decRef();
-        //};
+            // The mapping of native object & se::Object was cleared in above code.
+            // The private data (native object) may be a different object associated with other se::Object.
+            // Therefore, don't clear the mapping again.
+            seObj->clearPrivateData(false);
+            seObj->unroot();
+            seObj->decRef();
+        };
 
-        //if (!se::ScriptEngine::getInstance()->isGarbageCollecting())
-        //{
-        //    cleanup();
-        //}
-        //else
-        //{
-        //    CleanupTask::pushTaskToAutoReleasePool(cleanup);
-        //}
+        if (!se::ScriptEngine::getInstance()->isGarbageCollecting())
+        {
+            cleanup();
+        }
+        else
+        {
+            CleanupTask::pushTaskToAutoReleasePool(cleanup);
+        }
     });
 
     se::ScriptEngine::getInstance()->addAfterCleanupHook([]() {


### PR DESCRIPTION
without call Object::clearPrivateData, the c++ object maybe bind to two JS object, when one was release, other one will case crash.

Some existent crash stacks.
![image](https://user-images.githubusercontent.com/8321365/157820040-1dd7db31-9b2e-48b2-84a1-2171af669d87.png)
![image](https://user-images.githubusercontent.com/8321365/157820054-f8326dc2-d8c5-4910-b005-67d4c20c8892.png)
![image](https://user-images.githubusercontent.com/8321365/157820070-75494af6-d7b5-4a43-9e49-8d921d048f09.png)
