### PR TITLE
fix opacity of spine’s vertices with wrong value

### DIFF
--- a/cocos/2d/framework/renderable-2d.ts
+++ b/cocos/2d/framework/renderable-2d.ts
@@ -46,6 +46,7 @@ import { Stage } from '../renderer/stencil-manager';
 import { warnID } from '../../core/platform/debug';
 import { legacyCC } from '../../core/global-exports';
 import { NodeEventType } from '../../core/scene-graph/node-event';
+import { updateOpacity } from '../assembler/utils';
 
 // hack
 ccenum(BlendFactor);
@@ -489,6 +490,16 @@ export class Renderable2D extends RenderableComponent {
         if (this.renderData) {
             this.renderData.textureDirty = true;
         }
+    }
+
+    /**
+     * @en Update component's opacity
+     * Don't call it unless you know what you are doing.
+     * @zh 更新组件的透明度。
+     * 注意：不要手动调用该函数，除非你理解整个流程。
+     */
+    public updateOpacity(opacity:number) {
+        updateOpacity(this._renderData!, opacity);
     }
 }
 

--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -48,7 +48,6 @@ import { IBatcher } from './i-batcher';
 import { StaticVBAccessor } from './static-vb-accessor';
 import { assertIsTrue } from '../../core/data/utils/asserts';
 import { getAttributeStride, vfmtPosUvColor } from './vertex-format';
-import { updateOpacity } from '../assembler/utils';
 import { BaseRenderData, MeshRenderData } from './render-data';
 import { UIMeshRenderer } from '../components/ui-mesh-renderer';
 
@@ -664,7 +663,8 @@ export class Batcher2D implements IBatcher {
         // Update cascaded opacity to vertex buffer
         if (this._opacityDirty && render && render.renderData && render.renderData.vertexCount > 0) {
             // HARD COUPLING
-            updateOpacity(render.renderData, opacity);
+            render.updateOpacity(opacity);
+            //updateOpacity(render.renderData, opacity);
             const buffer = render.renderData.getMeshBuffer();
             if (buffer) {
                 buffer.setDirty();

--- a/cocos/spine/assembler/simple.ts
+++ b/cocos/spine/assembler/simple.ts
@@ -238,16 +238,21 @@ export const simple: IAssembler = {
     fillBuffers (comp: Skeleton, renderer: Batcher2D) {
         // Fill indices
     },
+
+    updateOpacity (comp: Skeleton, opacity: number) {
+        const batcher = director.root!.batcher2D;
+        updateComponentRenderData(comp, batcher, opacity);
+    }
 };
 
-function updateComponentRenderData (comp: Skeleton, batcher: Batcher2D) {
+function updateComponentRenderData (comp: Skeleton, batcher: Batcher2D, opacity = 1.0) {
     if (!comp._skeleton) return;
 
     const nodeColor = comp.color;
     _nodeR = nodeColor.r / 255;
     _nodeG = nodeColor.g / 255;
     _nodeB = nodeColor.b / 255;
-    _nodeA = nodeColor.a / 255;
+    _nodeA = opacity;
 
     _useTint = comp.useTint || comp.isAnimationCached();
     // x y u v color1 color2 or x y u v color

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -21,7 +21,6 @@ import { BlendFactor, BlendOp } from '../core/gfx';
 import { legacyCC } from '../core/global-exports';
 import { SkeletonSystem } from './skeleton-system';
 import { Batcher2D } from '../2d/renderer/batcher-2d';
-import { RenderData } from '../2d';
 
 export const timeScale = 1.0;
 
@@ -1402,6 +1401,16 @@ export class Skeleton extends Renderable2D {
         draw.indexOffset = indexOffset;
         draw.indexCount = indexCount;
         return draw;
+    }
+
+    /**
+     * @en Update component's opacity
+     * Don't call it unless you know what you are doing.
+     * @zh 更新组件的透明度。
+     * 注意：不要手动调用该函数，除非你理解整个流程。
+     */
+    public updateOpacity(opacity:number) {
+        this._assembler!.updateOpacity(this, opacity);
     }
 
     protected _render (batcher: Batcher2D) {


### PR DESCRIPTION
一些反馈spine组件出现黑块.
经过调查发现其本应是全透明的区域，透明度为1。
目前的透明度更新机制不适用于像spine这种顶点自身带透明度信息的组件，
其node的透明度应乘入顶点透明度，而不是直接设置为其透明度数值.
