### PR TITLE
fix spine rendering confusion after skin change

### DIFF
--- a/extensions/spine/skeleton-cache.js
+++ b/extensions/spine/skeleton-cache.js
@@ -393,6 +393,10 @@ let AnimationCache = cc.Class({
         for (let slotIdx = 0, slotCount = skeleton.drawOrder.length; slotIdx < slotCount; slotIdx++) {
             slot = skeleton.drawOrder[slotIdx];
     
+            if(!slot.bone.active) {
+                continue;
+            }
+
             _vfCount = 0;
             _indexCount = 0;
 

--- a/extensions/spine/spine-assembler.js
+++ b/extensions/spine/spine-assembler.js
@@ -323,7 +323,7 @@ export default class SpineAssembler extends Assembler {
         for (let slotIdx = 0, slotCount = locSkeleton.drawOrder.length; slotIdx < slotCount; slotIdx++) {
             slot = locSkeleton.drawOrder[slotIdx];
 
-            if(slot == undefined) {
+            if(slot == undefined || !slot.bone.active) {
                 continue;
             }
 


### PR DESCRIPTION
Re: cocos/2d-tasks#3621

Changelog:
 *  Skips rendering slots without active bones (only for WebGL side).

