### PR TITLE
[v3.6.0 pipeline] pipeline interface now uses gfx::Color only

### DIFF
--- a/cocos/core/pipeline/custom/pipeline.ts
+++ b/cocos/core/pipeline/custom/pipeline.ts
@@ -31,9 +31,9 @@
 /* eslint-disable max-len */
 import { EffectAsset } from '../../assets';
 import { Camera } from '../../renderer/scene/camera';
-import { Buffer, DescriptorSet, DescriptorSetLayout, DrawInfo, Format, InputAssembler, PipelineState, Rect, Sampler, Swapchain, Texture, Viewport } from '../../gfx';
+import { Buffer, Color, DescriptorSet, DescriptorSetLayout, DrawInfo, Format, InputAssembler, PipelineState, Rect, Sampler, Swapchain, Texture, Viewport } from '../../gfx';
 import { GlobalDSManager } from '../global-descriptor-set-manager';
-import { Color, Mat4, Quat, Vec2, Vec4 } from '../../math';
+import { Mat4, Quat, Vec2, Vec4 } from '../../math';
 import { MacroRecord } from '../../renderer/core/pass-utils';
 import { PipelineSceneData } from '../pipeline-scene-data';
 import { QueueHint, ResourceResidency, TaskType } from './types';

--- a/cocos/core/pipeline/custom/web-pipeline.ts
+++ b/cocos/core/pipeline/custom/web-pipeline.ts
@@ -25,8 +25,8 @@
 
 /* eslint-disable max-len */
 import { systemInfo } from 'pal/system-info';
-import { Buffer, DescriptorSetLayout, Device, Feature, Format, FormatFeatureBit, Sampler, Swapchain, Texture } from '../../gfx/index';
-import { Color, Mat4, Quat, Vec2, Vec4 } from '../../math';
+import { Color, Buffer, DescriptorSetLayout, Device, Feature, Format, FormatFeatureBit, Sampler, Swapchain, Texture } from '../../gfx/index';
+import { Mat4, Quat, Vec2, Vec4 } from '../../math';
 import { QueueHint, ResourceDimension, ResourceFlags, ResourceResidency, TaskType } from './types';
 import { Blit, ComputePass, ComputeView, CopyPair, CopyPass, Dispatch, ManagedResource, MovePair, MovePass, PresentPass, RasterPass, RasterView, RenderData, RenderGraph, RenderGraphValue, RenderQueue, RenderSwapchain, ResourceDesc, ResourceGraph, ResourceGraphValue, ResourceStates, ResourceTraits, SceneData } from './render-graph';
 import { ComputePassBuilder, ComputeQueueBuilder, CopyPassBuilder, MovePassBuilder, Pipeline, RasterPassBuilder, RasterQueueBuilder, SceneTask, SceneTransversal, SceneVisitor, Setter } from './pipeline';

--- a/native/cocos/bindings/auto/jsb_render_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_render_auto.cpp
@@ -340,7 +340,7 @@ static bool js_render_Setter_setColor(se::State& s) // NOLINT(readability-identi
     CC_UNUSED bool ok = true;
     if (argc == 2) {
         HolderType<std::string, true> arg0 = {};
-        HolderType<cc::Color, true> arg1 = {};
+        HolderType<cc::gfx::Color, true> arg1 = {};
         ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
         ok &= sevalue_to_native(args[1], &arg1, s.thisObject());
         SE_PRECONDITION2(ok, false, "js_render_Setter_setColor : Error processing arguments");

--- a/native/cocos/bindings/auto/jsb_render_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_render_auto.cpp
@@ -197,7 +197,7 @@ static bool js_render_PipelineRuntime_render(se::State& s) // NOLINT(readability
     size_t argc = args.size();
     CC_UNUSED bool ok = true;
     if (argc == 1) {
-        HolderType<std::vector<const cc::scene::Camera *>, true> arg0 = {};
+        HolderType<std::vector<cc::scene::Camera *>, true> arg0 = {};
         ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
         SE_PRECONDITION2(ok, false, "js_render_PipelineRuntime_render : Error processing arguments");
         cobj->render(arg0.value());

--- a/native/cocos/renderer/pipeline/custom/NativePipelineImpl.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineImpl.cpp
@@ -24,11 +24,12 @@
 ****************************************************************************/
 
 #include "NativePipelineTypes.h"
-#include "pipeline/custom/GslUtils.h"
-#include "pipeline/custom/RenderCommonTypes.h"
-#include "pipeline/custom/RenderInterfaceFwd.h"
-#include "scene/RenderScene.h"
-#include "scene/RenderWindow.h"
+#include "cocos/renderer/gfx-base/GFXDescriptorSetLayout.h"
+#include "cocos/renderer/pipeline/custom/GslUtils.h"
+#include "cocos/renderer/pipeline/custom/RenderCommonTypes.h"
+#include "cocos/renderer/pipeline/custom/RenderInterfaceFwd.h"
+#include "cocos/scene/RenderScene.h"
+#include "cocos/scene/RenderWindow.h"
 
 namespace cc {
 
@@ -111,7 +112,7 @@ bool NativePipeline::destroy() noexcept {
 }
 
 // NOLINTNEXTLINE
-void NativePipeline::render(const std::vector<const scene::Camera*>& cameras) {
+void NativePipeline::render(const std::vector<scene::Camera*>& cameras) {
 }
 
 const MacroRecord &NativePipeline::getMacros() const {
@@ -119,7 +120,7 @@ const MacroRecord &NativePipeline::getMacros() const {
 }
 
 pipeline::GlobalDSManager *NativePipeline::getGlobalDSManager() const {
-    return globalDSManager;
+    return globalDSManager.get();
 }
 
 gfx::DescriptorSetLayout *NativePipeline::getDescriptorSetLayout() const {

--- a/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
@@ -61,7 +61,7 @@ public:
 
     bool activate(gfx::Swapchain * swapchain) override;
     bool destroy() noexcept override;
-    void render(const std::vector<const scene::Camera*>& cameras) override;
+    void render(const std::vector<scene::Camera*>& cameras) override;
 
     const MacroRecord           &getMacros() const override;
     pipeline::GlobalDSManager   *getGlobalDSManager() const override;
@@ -76,12 +76,12 @@ public:
 
     void onGlobalPipelineStateChanged() override;
 
-    gfx::Device*                              device{nullptr};
-    MacroRecord                               macros;
-    std::string                               constantMacros;
-    pipeline::GlobalDSManager*                globalDSManager{nullptr};
-    scene::Model*                             profiler{nullptr};
-    IntrusivePtr<pipeline::PipelineSceneData> pipelineSceneData;
+    gfx::Device*                               device{nullptr};
+    MacroRecord                                macros;
+    std::string                                constantMacros;
+    std::unique_ptr<pipeline::GlobalDSManager> globalDSManager;
+    scene::Model*                              profiler{nullptr};
+    IntrusivePtr<pipeline::PipelineSceneData>  pipelineSceneData;
 };
 
 } // namespace render

--- a/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
@@ -80,7 +80,7 @@ public:
 
     virtual bool activate(gfx::Swapchain * swapchain) = 0;
     virtual bool destroy() noexcept = 0;
-    virtual void render(const std::vector<const scene::Camera*>& cameras) = 0;
+    virtual void render(const std::vector<scene::Camera*>& cameras) = 0;
 
     virtual const MacroRecord           &getMacros() const = 0;
     virtual pipeline::GlobalDSManager   *getGlobalDSManager() const = 0;

--- a/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
@@ -40,7 +40,6 @@ namespace cc {
 class Mat4;
 class Mat4;
 class Quaternion;
-class Color;
 class Vec4;
 class Vec3;
 class Vec2;
@@ -125,7 +124,7 @@ public:
 
     virtual void setMat4(const std::string& name, const cc::Mat4& mat) = 0;
     virtual void setQuaternion(const std::string& name, const cc::Quaternion& quat) = 0;
-    virtual void setColor(const std::string& name, const cc::Color& color) = 0;
+    virtual void setColor(const std::string& name, const gfx::Color& color) = 0;
     virtual void setVec4(const std::string& name, const cc::Vec4& vec) = 0;
     virtual void setVec2(const std::string& name, const cc::Vec2& vec) = 0;
     virtual void setFloat(const std::string& name, float v) = 0;


### PR DESCRIPTION
pipeline now uses gfx::Color instead of cc::Color.
relaxed pipeline interface

Changelog:
 * relaxed render(const std::vector<const Camera*>& cameras) to render(const std::vector<Camera*>& cameras)
 * pipeline only uses gfx::Color

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
