### PR TITLE
[v3.6.0 pipeline] refactor native root.h

### DIFF
--- a/native/cocos/bindings/auto/jsb_scene_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_scene_auto.cpp
@@ -31,6 +31,7 @@
 #include "core/Root.h"
 #include "renderer/core/ProgramLib.h"
 #include "scene/Octree.h"
+#include "cocos/bindings/auto/jsb_render_auto.h"
 #include "cocos/bindings/auto/jsb_pipeline_auto.h"
 #include "cocos/bindings/auto/jsb_cocos_auto.h"
 
@@ -9859,7 +9860,7 @@ static bool js_scene_Root_getPipeline(se::State& s) // NOLINT(readability-identi
     size_t argc = args.size();
     CC_UNUSED bool ok = true;
     if (argc == 0) {
-        cc::pipeline::RenderPipeline* result = cobj->getPipeline();
+        cc::render::PipelineRuntime* result = cobj->getPipeline();
         ok &= nativevalue_to_se(result, s.rval(), nullptr /*ctx*/);
         SE_PRECONDITION2(ok, false, "js_scene_Root_getPipeline : Error processing arguments");
         SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
@@ -17789,7 +17790,7 @@ static bool js_scene_ProgramLib_getGFXShader(se::State& s) // NOLINT(readability
         HolderType<cc::gfx::Device*, false> arg0 = {};
         HolderType<std::string, true> arg1 = {};
         HolderType<std::unordered_map<std::string, boost::variant2::variant<int, bool, std::string>>, true> arg2 = {};
-        HolderType<cc::pipeline::RenderPipeline*, false> arg3 = {};
+        HolderType<cc::render::PipelineRuntime*, false> arg3 = {};
         ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
         ok &= sevalue_to_native(args[1], &arg1, s.thisObject());
         ok &= sevalue_to_native(args[2], &arg2, s.thisObject());
@@ -17805,7 +17806,7 @@ static bool js_scene_ProgramLib_getGFXShader(se::State& s) // NOLINT(readability
         HolderType<cc::gfx::Device*, false> arg0 = {};
         HolderType<std::string, true> arg1 = {};
         HolderType<std::unordered_map<std::string, boost::variant2::variant<int, bool, std::string>>, true> arg2 = {};
-        HolderType<cc::pipeline::RenderPipeline*, false> arg3 = {};
+        HolderType<cc::render::PipelineRuntime*, false> arg3 = {};
         HolderType<std::string*, false> arg4 = {};
         ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
         ok &= sevalue_to_native(args[1], &arg1, s.thisObject());

--- a/native/cocos/core/Root.cpp
+++ b/native/cocos/core/Root.cpp
@@ -33,6 +33,8 @@
 #include "renderer/pipeline/PipelineSceneData.h"
 #include "renderer/pipeline/deferred/DeferredPipeline.h"
 #include "renderer/pipeline/forward/ForwardPipeline.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
+#include "renderer/pipeline/custom/NativePipelineTypes.h"
 #include "scene/Camera.h"
 #include "scene/DirectionalLight.h"
 #include "scene/DrawBatch2D.h"
@@ -98,6 +100,11 @@ void Root::initialize(gfx::Swapchain *swapchain) {
 void Root::destroy() {
     destroyScenes();
 
+    if (_usesCustomPipeline) {
+        _pipelineRuntime->destroy();
+    }
+    _pipelineRuntime.reset();
+
     CC_SAFE_DESTROY_NULL(_pipeline);
     // TODO(minggo):
     //    CC_SAFE_DESTROY(_batcher2D);
@@ -114,34 +121,101 @@ void Root::resize(uint32_t width, uint32_t height) {
     }
 }
 
+namespace {
+
+class RenderPipelineBridge final : public render::PipelineRuntime {
+public:
+    RenderPipelineBridge(pipeline::RenderPipeline *pipelineIn)
+    : pipeline(pipelineIn) {}
+
+    bool activate(gfx::Swapchain *swapchain) override {
+        return pipeline->activate(swapchain);
+    }
+    bool destroy() noexcept override {
+        return pipeline->destroy();
+    }
+    void render(const std::vector<scene::Camera *> &cameras) override {
+        pipeline->render(cameras);
+    }
+    const MacroRecord &getMacros() const override {
+        return pipeline->getMacros();
+    }
+    pipeline::GlobalDSManager *getGlobalDSManager() const override {
+        return pipeline->getGlobalDSManager();
+    }
+    gfx::DescriptorSetLayout *getDescriptorSetLayout() const override {
+        return pipeline->getDescriptorSetLayout();
+    }
+    pipeline::PipelineSceneData *getPipelineSceneData() const override {
+        return pipeline->getPipelineSceneData();
+    }
+    const std::string &getConstantMacros() const override {
+        return pipeline->getConstantMacros();
+    }
+    scene::Model *getProfiler() const override {
+        return pipeline->getProfiler();
+    }
+    void setProfiler(scene::Model *profiler) override {
+        pipeline->setProfiler(profiler);
+    }
+    float getShadingScale() const override {
+        return pipeline->getShadingScale();
+    }
+    void setShadingScale(float scale) override {
+        pipeline->setShadingScale(scale);
+    }
+    void onGlobalPipelineStateChanged() override {
+        pipeline->onGlobalPipelineStateChanged();
+    }
+    void setValue(const std::string &name, int32_t value) override {
+        pipeline->setValue(name, value);
+    }
+    void setValue(const std::string &name, bool value) override {
+        pipeline->setValue(name, value);
+    }
+    pipeline::RenderPipeline *pipeline = nullptr;
+};
+
+} // namespace
+
 bool Root::setRenderPipeline(pipeline::RenderPipeline *rppl /* = nullptr*/) {
-    if (rppl != nullptr && dynamic_cast<pipeline::DeferredPipeline *>(rppl) != nullptr) {
-        _useDeferredPipeline = true;
-    }
-
-    bool isCreateDefaultPipeline{false};
-    if (!rppl) {
-        rppl = new pipeline::ForwardPipeline();
-        rppl->initialize({});
-        isCreateDefaultPipeline = true;
-    }
-
-    _pipeline = rppl;
-
-    // now cluster just enabled in deferred pipeline
-    if (!_useDeferredPipeline || !_device->hasFeature(gfx::Feature::COMPUTE_SHADER)) {
-        // disable cluster
-        _pipeline->setClusterEnabled(false);
-    }
-    _pipeline->setBloomEnabled(false);
-
-    if (!_pipeline->activate(_mainWindow->getSwapchain())) {
-        if (isCreateDefaultPipeline) {
-            CC_SAFE_DESTROY_AND_DELETE(_pipeline);
+    if (!_usesCustomPipeline) {
+        if (rppl != nullptr && dynamic_cast<pipeline::DeferredPipeline *>(rppl) != nullptr) {
+            _useDeferredPipeline = true;
         }
 
-        _pipeline = nullptr;
-        return false;
+        bool isCreateDefaultPipeline{false};
+        if (!rppl) {
+            rppl = new pipeline::ForwardPipeline();
+            rppl->initialize({});
+            isCreateDefaultPipeline = true;
+        }
+
+        _pipeline = rppl;
+        _pipelineRuntime.reset(new RenderPipelineBridge(rppl));
+
+        // now cluster just enabled in deferred pipeline
+        if (!_useDeferredPipeline || !_device->hasFeature(gfx::Feature::COMPUTE_SHADER)) {
+            // disable cluster
+            _pipeline->setClusterEnabled(false);
+        }
+        _pipeline->setBloomEnabled(false);
+
+        if (!_pipeline->activate(_mainWindow->getSwapchain())) {
+            if (isCreateDefaultPipeline) {
+                CC_SAFE_DESTROY_AND_DELETE(_pipeline);
+            }
+
+            _pipeline = nullptr;
+            return false;
+        }
+    } else {
+        _pipelineRuntime.reset(new render::NativePipeline());
+        if (!_pipelineRuntime->activate(_mainWindow->getSwapchain())) {
+            _pipelineRuntime->destroy();
+            _pipelineRuntime.reset();
+            return false;
+        }
     }
 
     // TODO(minggo):
@@ -170,7 +244,7 @@ void Root::onGlobalPipelineStateChanged() {
         scene->onGlobalPipelineStateChanged();
     }
 
-    _pipeline->onGlobalPipelineStateChanged();
+    _pipelineRuntime->onGlobalPipelineStateChanged();
 }
 
 void Root::activeWindow(scene::RenderWindow *window) {
@@ -210,7 +284,7 @@ void Root::frameMove(float deltaTime, int32_t totalFrames) {
         window->extractRenderCameras(_cameraList);
     }
 
-    if (_pipeline != nullptr && !_cameraList.empty()) {
+    if (_pipelineRuntime != nullptr && !_cameraList.empty()) {
         _swapchains.clear();
         _swapchains.emplace_back(_swapchain);
         _device->acquire(_swapchains);
@@ -231,7 +305,7 @@ void Root::frameMove(float deltaTime, int32_t totalFrames) {
         std::stable_sort(_cameraList.begin(), _cameraList.end(), [](const auto *a, const auto *b) {
             return a->getPriority() < b->getPriority();
         });
-        _pipeline->render(_cameraList);
+        _pipelineRuntime->render(_cameraList);
         _device->present();
     }
 

--- a/native/cocos/core/Root.cpp
+++ b/native/cocos/core/Root.cpp
@@ -125,7 +125,7 @@ namespace {
 
 class RenderPipelineBridge final : public render::PipelineRuntime {
 public:
-    RenderPipelineBridge(pipeline::RenderPipeline *pipelineIn)
+    explicit RenderPipelineBridge(pipeline::RenderPipeline *pipelineIn)
     : pipeline(pipelineIn) {}
 
     bool activate(gfx::Swapchain *swapchain) override {
@@ -192,7 +192,7 @@ bool Root::setRenderPipeline(pipeline::RenderPipeline *rppl /* = nullptr*/) {
         }
 
         _pipeline = rppl;
-        _pipelineRuntime.reset(new RenderPipelineBridge(rppl));
+        _pipelineRuntime = std::make_unique<RenderPipelineBridge>(rppl);
 
         // now cluster just enabled in deferred pipeline
         if (!_useDeferredPipeline || !_device->hasFeature(gfx::Feature::COMPUTE_SHADER)) {
@@ -210,7 +210,7 @@ bool Root::setRenderPipeline(pipeline::RenderPipeline *rppl /* = nullptr*/) {
             return false;
         }
     } else {
-        _pipelineRuntime.reset(new render::NativePipeline());
+        _pipelineRuntime = std::make_unique<render::NativePipeline>();
         if (!_pipelineRuntime->activate(_mainWindow->getSwapchain())) {
             _pipelineRuntime->destroy();
             _pipelineRuntime.reset();

--- a/native/cocos/core/Root.h
+++ b/native/cocos/core/Root.h
@@ -44,6 +44,9 @@ namespace gfx {
 class SwapChain;
 class Device;
 } // namespace gfx
+namespace render {
+class PipelineRuntime;
+} // namespace render
 class CallbacksInvoker;
 
 class Root final {
@@ -187,7 +190,7 @@ public:
      * @zh
      * 渲染管线
      */
-    inline pipeline::RenderPipeline *getPipeline() const { return _pipeline.get(); }
+    inline render::PipelineRuntime *getPipeline() const { return _pipelineRuntime.get(); }
 
     /**
      * @zh
@@ -248,6 +251,7 @@ private:
     IntrusivePtr<scene::RenderWindow>              _tempWindow;
     std::vector<IntrusivePtr<scene::RenderWindow>> _windows;
     IntrusivePtr<pipeline::RenderPipeline>         _pipeline{nullptr};
+    std::unique_ptr<render::PipelineRuntime>       _pipelineRuntime;
     scene::DrawBatch2D *                           _batcher2D{nullptr};
     //    IntrusivePtr<DataPoolManager>                  _dataPoolMgr;
     std::vector<IntrusivePtr<scene::RenderScene>> _scenes;
@@ -259,6 +263,7 @@ private:
     uint32_t                                      _fps{0};
     uint32_t                                      _fixedFPS{0};
     bool                                          _useDeferredPipeline{false};
+    bool                                          _usesCustomPipeline{false};
     CallbacksInvoker *                            _eventProcessor{nullptr};
 
     // Cache std::vector to avoid allocate every frame in frameMove

--- a/native/cocos/core/scene-graph/SceneGlobals.cpp
+++ b/native/cocos/core/scene-graph/SceneGlobals.cpp
@@ -26,6 +26,7 @@
 #include "core/scene-graph/SceneGlobals.h"
 #include "core/Root.h"
 #include "renderer/pipeline/PipelineSceneData.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 #include "scene/Ambient.h"
 #include "scene/Fog.h"
 #include "scene/Octree.h"

--- a/native/cocos/renderer/core/ProgramLib.cpp
+++ b/native/cocos/renderer/core/ProgramLib.cpp
@@ -33,6 +33,7 @@
 #include "renderer/gfx-base/GFXDevice.h"
 #include "renderer/pipeline/Define.h"
 #include "renderer/pipeline/RenderPipeline.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 
 namespace cc {
 
@@ -649,7 +650,7 @@ void ProgramLib::destroyShaderByDefines(const MacroRecord &defines) {
 }
 
 gfx::Shader *ProgramLib::getGFXShader(gfx::Device *device, const std::string &name, MacroRecord &defines,
-                                      pipeline::RenderPipeline *pipeline, std::string *keyOut) {
+                                      render::PipelineRuntime *pipeline, std::string *keyOut) {
     for (const auto &it : pipeline->getMacros()) {
         defines[it.first] = it.second;
     }

--- a/native/cocos/renderer/core/ProgramLib.h
+++ b/native/cocos/renderer/core/ProgramLib.h
@@ -42,6 +42,10 @@
 namespace cc {
 class EffectAsset;
 
+namespace render {
+class PipelineRuntime;
+} // namespace render
+
 struct IDefineRecord : public IDefineInfo {
     std::function<int32_t(const MacroValue &)> map{nullptr};
     int32_t                                    offset{0};
@@ -150,7 +154,7 @@ public:
      * @param key The shader cache key, if already known
      */
     gfx::Shader *getGFXShader(gfx::Device *device, const std::string &name, MacroRecord &defines,
-                              pipeline::RenderPipeline *pipeline, std::string *key = nullptr);
+                              render::PipelineRuntime *pipeline, std::string *key = nullptr);
 
 private:
     CC_DISALLOW_COPY_MOVE_ASSIGN(ProgramLib);

--- a/native/cocos/renderer/pipeline/custom/NativePipelineImpl.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineImpl.cpp
@@ -154,6 +154,14 @@ void NativePipeline::setShadingScale(float scale) {
 void NativePipeline::onGlobalPipelineStateChanged() {
 }
 
+void NativePipeline::setValue(const std::string &name, int32_t value) {
+    macros[name] = value;
+}
+
+void NativePipeline::setValue(const std::string &name, bool value) {
+    macros[name] = value;
+}
+
 } // namespace render
 
 } // namespace cc

--- a/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
@@ -76,6 +76,9 @@ public:
 
     void onGlobalPipelineStateChanged() override;
 
+    void setValue(const std::string& name, int32_t value) override;
+    void setValue(const std::string& name, bool value) override;
+
     gfx::Device*                               device{nullptr};
     MacroRecord                                macros;
     std::string                                constantMacros;

--- a/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
@@ -93,6 +93,9 @@ public:
     virtual void  setShadingScale(float scale) = 0;
 
     virtual void onGlobalPipelineStateChanged() = 0;
+
+    virtual void setValue(const std::string& name, int32_t value) = 0;
+    virtual void setValue(const std::string& name, bool value) = 0;
 };
 
 inline PipelineRuntime::~PipelineRuntime() noexcept = default;

--- a/native/cocos/scene/Ambient.cpp
+++ b/native/cocos/scene/Ambient.cpp
@@ -27,6 +27,7 @@
 #include "core/Root.h"
 #include "renderer/pipeline/RenderPipeline.h"
 #include "renderer/pipeline/PipelineSceneData.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 
 namespace {
 cc::Color col;

--- a/native/cocos/scene/DirectionalLight.cpp
+++ b/native/cocos/scene/DirectionalLight.cpp
@@ -26,6 +26,7 @@
 #include "scene/DirectionalLight.h"
 #include "core/Root.h"
 #include "core/scene-graph/Node.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 #include "renderer/pipeline/PipelineSceneData.h"
 #include "renderer/pipeline/RenderPipeline.h"
 

--- a/native/cocos/scene/Fog.cpp
+++ b/native/cocos/scene/Fog.cpp
@@ -26,6 +26,7 @@
 #include "scene/Fog.h"
 #include "core/Root.h"
 #include "renderer/pipeline/helper/Utils.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 
 namespace cc {
 namespace scene {

--- a/native/cocos/scene/Skybox.cpp
+++ b/native/cocos/scene/Skybox.cpp
@@ -36,6 +36,7 @@
 #include "renderer/core/MaterialInstance.h"
 #include "renderer/core/PassUtils.h"
 #include "renderer/gfx-base/GFXDevice.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 #include "renderer/pipeline/PipelineSceneData.h"
 #include "scene/Ambient.h"
 #include "scene/Model.h"
@@ -288,8 +289,8 @@ void Skybox::updatePipeline() const {
         _model->setSubModelMaterial(0, skyboxMaterial);
     }
 
-    Root *                    root     = Root::getInstance();
-    pipeline::RenderPipeline *pipeline = root->getPipeline();
+    Root * root     = Root::getInstance();
+    auto * pipeline = root->getPipeline();
 
     const bool    useRGBE            = isRGBE();
     const int32_t useIBLValue        = isUseIBL() ? (useRGBE ? 2 : 1) : 0;

--- a/native/cocos/scene/SphereLight.cpp
+++ b/native/cocos/scene/SphereLight.cpp
@@ -26,6 +26,7 @@
 #include "scene/SphereLight.h"
 #include "core/Root.h"
 #include "core/scene-graph/Node.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 #include "renderer/pipeline/PipelineSceneData.h"
 namespace cc {
 namespace scene {

--- a/native/cocos/scene/SpotLight.cpp
+++ b/native/cocos/scene/SpotLight.cpp
@@ -30,6 +30,7 @@
 #include "math/Math.h"
 #include "renderer/pipeline/PipelineSceneData.h"
 #include "renderer/pipeline/RenderPipeline.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 
 namespace cc {
 namespace scene {

--- a/native/cocos/scene/SubModel.cpp
+++ b/native/cocos/scene/SubModel.cpp
@@ -29,6 +29,7 @@
 #include "pipeline/Define.h"
 #include "renderer/pipeline/PipelineSceneData.h"
 #include "renderer/pipeline/forward/ForwardPipeline.h"
+#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 #include "scene/Model.h"
 #include "scene/Pass.h"
 #include "scene/Shadow.h"
@@ -154,7 +155,7 @@ void SubModel::initialize(RenderingSubMesh *subMesh, const std::shared_ptr<std::
 // This is a temporary solution
 // It should not be written in a fixed way, or modified by the user
 void SubModel::initPlanarShadowShader() {
-    const auto *pipeline   = static_cast<pipeline::ForwardPipeline *>(Root::getInstance()->getPipeline());
+    const auto *pipeline   = Root::getInstance()->getPipeline();
     Shadows *   shadowInfo = pipeline->getPipelineSceneData()->getShadows();
     if (shadowInfo != nullptr) {
         _planarShader = shadowInfo->getPlanarShader(_patches);
@@ -167,7 +168,7 @@ void SubModel::initPlanarShadowShader() {
 // This is a temporary solution
 // It should not be written in a fixed way, or modified by the user
 void SubModel::initPlanarShadowInstanceShader() {
-    const auto *pipeline   = static_cast<pipeline::ForwardPipeline *>(Root::getInstance()->getPipeline());
+    const auto *pipeline   = Root::getInstance()->getPipeline();
     Shadows *   shadowInfo = pipeline->getPipelineSceneData()->getShadows();
     if (shadowInfo != nullptr) {
         _planarInstanceShader = shadowInfo->getPlanarInstanceShader(_patches);

--- a/native/tools/tojs/render.ini
+++ b/native/tools/tojs/render.ini
@@ -48,7 +48,7 @@ classes_need_extend =
 # will apply to all class names. This is a convenience wildcard to be able to skip similar named
 # functions from all classes.
 
-skip = PipelineRuntime::[getMacros],
+skip = PipelineRuntime::[getMacros setValue],
        SceneVisitor::[bindDescriptorSet updateBuffer]
 
 skip_public_fields =

--- a/native/tools/tojs/scene.ini
+++ b/native/tools/tojs/scene.ini
@@ -57,7 +57,7 @@ headers = %(cocosdir)s/cocos/core/data/Object.h
 
 hpp_headers = cocos/bindings/auto/jsb_gfx_auto.h cocos/bindings/auto/jsb_geometry_auto.h cocos/bindings/auto/jsb_assets_auto.h
 
-cpp_headers = cocos/bindings/auto/jsb_pipeline_auto.h cocos/bindings/auto/jsb_cocos_auto.h
+cpp_headers = cocos/bindings/auto/jsb_render_auto.h cocos/bindings/auto/jsb_pipeline_auto.h cocos/bindings/auto/jsb_cocos_auto.h
 
 # what classes to produce code for. You can use regular expressions here. When testing the regular
 # expression, it will be enclosed in "^$", like this: "^Menu*$".


### PR DESCRIPTION
Root::pipeline() now returns render::PipelineRuntime instead of pipeline::RenderPipeline.

Changelog:
 * jsb_scene_auto.cpp now depends on jsb_render_auto.h
 * Root.cpp now depends on custom pipeline
 * Root::pipeline() returns render::PipelineRuntime
 * introduced RenderPipelineBridge to erase pipeline::RenderPipeline type, use render::PipelineRuntime instead
 * fixed static_cast bug in SubModel.cpp
 * changed dependencies of the following files: SceneGlobals.cpp ProgramLib.cpp Ambient.cpp DirectionalLight.cpp Fog.cpp Skybox.cpp SphereLight.cpp SpotLight.cpp SubModel.cpp

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
