### PR TITLE
use approx instead of ===

### DIFF
--- a/cocos/2d/framework/ui-transform.ts
+++ b/cocos/2d/framework/ui-transform.ts
@@ -334,7 +334,7 @@ export class UITransform extends Component {
                 clone = new Size(this._contentSize);
             }
 
-            locContentSize.width = size as number;
+            locContentSize.width = size;
             locContentSize.height = height;
         }
 

--- a/cocos/2d/framework/ui-transform.ts
+++ b/cocos/2d/framework/ui-transform.ts
@@ -38,6 +38,7 @@ import { Director, director } from '../../core/director';
 import { warnID } from '../../core/platform/debug';
 import { NodeEventType } from '../../core/scene-graph/node-event';
 import visibleRect from '../../core/platform/visible-rect';
+import { approx, EPSILON } from '../../core/math/utils';
 
 const _vec2a = new Vec2();
 const _vec2b = new Vec2();
@@ -313,7 +314,7 @@ export class UITransform extends Component {
         let clone: Size;
         if (height === undefined) {
             size = size as Size;
-            if ((size.width === locContentSize.width) && (size.height === locContentSize.height)) {
+            if (approx(size.width, locContentSize.width, EPSILON) && approx(size.height, locContentSize.height, EPSILON)) {
                 return;
             }
 
@@ -324,7 +325,8 @@ export class UITransform extends Component {
             locContentSize.width = size.width;
             locContentSize.height = size.height;
         } else {
-            if ((size === locContentSize.width) && (height === locContentSize.height)) {
+            size = size as number;
+            if (approx(size, locContentSize.width, EPSILON) && approx(height, locContentSize.height, EPSILON)) {
                 return;
             }
 


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#11624

Changelog:
 * setContentSize里，使用全等判断会有精度问题，这里改为使用approx接口，允许系统误差

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
