### PR TITLE
Add destroy window event and recreate window event on windows platform

### DIFF
--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -331,7 +331,9 @@ void Engine::onPause() {
     AppEvent appEv;
     appEv.type = AppEvent::Type::PAUSE;
     dispatchEventToApp(OSEventType::APP_OSEVENT, appEv);
-
+#if CC_PLATFORM == CC_PLATFORM_WINDOWS
+    cc::EventDispatcher::dispatchDestroyWindowEvent();
+#endif
     cc::EventDispatcher::dispatchEnterBackgroundEvent();
 }
 
@@ -339,7 +341,9 @@ void Engine::onResume() {
     AppEvent appEv;
     appEv.type = AppEvent::Type::RESUME;
     dispatchEventToApp(OSEventType::APP_OSEVENT, appEv);
-
+#if CC_PLATFORM == CC_PLATFORM_WINDOWS
+    cc::EventDispatcher::dispatchRecreateWindowEvent();
+#endif
     cc::EventDispatcher::dispatchEnterForegroundEvent();
 }
 

--- a/native/cocos/platform/win32/modules/SystemWindow.cpp
+++ b/native/cocos/platform/win32/modules/SystemWindow.cpp
@@ -60,7 +60,6 @@ bool SystemWindow::createWindow(const char *title,
 }
 
 uintptr_t SystemWindow::getWindowHandler() const {
-    //return _handle;
     WindowsPlatform *platform = dynamic_cast<WindowsPlatform *>(BasePlatform::getPlatform());
     CCASSERT(platform != nullptr, "Platform pointer can't be null");
     return platform->getWindowHandler();


### PR DESCRIPTION
[issue](https://github.com/cocos/3d-tasks/issues/8798)

It is available on the android platform and also on the windows platform, but there may be some differences. Apple does not send this event. Currently, these events are added according to the implementation of 3.4.