### PR TITLE
force update for spine color setting.

### DIFF
--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -360,6 +360,7 @@ const cacheManager = require('./jsb-cache-manager');
         if (this._nativeSkeleton) {
             const compColor = this.color;
             this._nativeSkeleton.setColor(compColor.r, compColor.g, compColor.b, compColor.a);
+            this.markForUpdateRenderData();
         }
     };
 


### PR DESCRIPTION
Fix problem of color settings not taking effect on native platform.
[TestRScale.zip](https://github.com/cocos/cocos-engine/files/8313347/TestRScale.zip)

code example:

``` typescript
@ccclass('TestScale')
export class TestScale extends Component {
    @property(sp.Skeleton)
    spine1: sp.Skeleton = null!;

    click () {
        let oldColor = this.spine1.color.clone();
        oldColor.set(oldColor.r, oldColor.g, oldColor.b, 0);
        this.spine1.color = oldColor;
    }
}
```