### PR TITLE
[v3.6.0 pipeline] use native root.pipeline

### DIFF
--- a/native/cocos/bindings/auto/jsb_scene_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_scene_auto.cpp
@@ -9901,7 +9901,7 @@ static bool js_scene_Root_getPipeline(se::State& s) // NOLINT(readability-identi
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
     return false;
 }
-SE_BIND_FUNC(js_scene_Root_getPipeline)
+SE_BIND_FUNC_AS_PROP_GET(js_scene_Root_getPipeline)
 
 static bool js_scene_Root_getScenes(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -10227,6 +10227,7 @@ bool js_register_scene_Root(se::Object* obj) // NOLINT(readability-identifier-na
     cls->defineProperty("fps", _SE(js_scene_Root_getFps_asGetter), nullptr);
     cls->defineProperty("fixedFPS", _SE(js_scene_Root_getFixedFPS_asGetter), _SE(js_scene_Root_setFixedFPS_asSetter));
     cls->defineProperty("useDeferredPipeline", _SE(js_scene_Root_isUsingDeferredPipeline_asGetter), nullptr);
+    cls->defineProperty("pipeline", _SE(js_scene_Root_getPipeline_asGetter), nullptr);
     cls->defineFunction("activeWindow", _SE(js_scene_Root_activeWindow));
     cls->defineFunction("createCamera", _SE(js_scene_Root_createCamera));
     cls->defineFunction("createScene", _SE(js_scene_Root_createScene));
@@ -10241,7 +10242,6 @@ bool js_register_scene_Root(se::Object* obj) // NOLINT(readability-identifier-na
     cls->defineFunction("frameMove", _SE(js_scene_Root_frameMove));
     cls->defineFunction("getBatcher2D", _SE(js_scene_Root_getBatcher2D));
     cls->defineFunction("getEventProcessor", _SE(js_scene_Root_getEventProcessor));
-    cls->defineFunction("getPipeline", _SE(js_scene_Root_getPipeline));
     cls->defineFunction("_initialize", _SE(js_scene_Root_initialize));
     cls->defineFunction("onGlobalPipelineStateChanged", _SE(js_scene_Root_onGlobalPipelineStateChanged));
     cls->defineFunction("resetCumulativeTime", _SE(js_scene_Root_resetCumulativeTime));

--- a/native/cocos/bindings/auto/jsb_scene_auto.h
+++ b/native/cocos/bindings/auto/jsb_scene_auto.h
@@ -426,7 +426,6 @@ SE_DECLARE_FUNC(js_scene_Root_destroyWindows);
 SE_DECLARE_FUNC(js_scene_Root_frameMove);
 SE_DECLARE_FUNC(js_scene_Root_getBatcher2D);
 SE_DECLARE_FUNC(js_scene_Root_getEventProcessor);
-SE_DECLARE_FUNC(js_scene_Root_getPipeline);
 SE_DECLARE_FUNC(js_scene_Root_initialize);
 SE_DECLARE_FUNC(js_scene_Root_onGlobalPipelineStateChanged);
 SE_DECLARE_FUNC(js_scene_Root_resetCumulativeTime);

--- a/native/tools/tojs/scene.ini
+++ b/native/tools/tojs/scene.ini
@@ -92,7 +92,7 @@ rename_functions = Root::[initialize=_initialize],
        Scene::[load=_load activate=_activate],
        Pass::[initPassFromTarget=_initPassFromTarget]
 
-getter_setter = Root::[device:_device mainWindow curWindow tempWindow windows scenes cumulativeTime frameTime frameCount fps fixedFPS useDeferredPipeline/isUsingDeferredPipeline],
+getter_setter = Root::[device:_device mainWindow curWindow tempWindow windows scenes cumulativeTime frameTime frameCount fps fixedFPS useDeferredPipeline/isUsingDeferredPipeline pipeline],
        RenderWindow::[width height framebuffer cameras swapchain],
        Pass::[root device shaderInfo localSetLayout program properties defines passIndex propertyIndex dynamics rootBufferDirty/isRootBufferDirty _rootBufferDirty/isRootBufferDirty/_setRootBufferDirty priority primitive stage phase rasterizerState depthStencilState blendState dynamicStates batchingScheme descriptorSet hash/getHashForJS pipelineLayout],
        PassInstance::[parent],


### PR DESCRIPTION
Currently we added a pipeline property to root in root.jsb.ts. This is not very consistent with jsb conventions.
This pr removed pipeline in root.jsb.ts, and use jsb to export pipeline getter from Root.h

Changelog:
 * removed pipeline from root.jsb.ts
 * export getter pipeline from Root.h, modified scene.ini

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
