### PR TITLE
Optimize the way how animation component update its animation content

### DIFF
--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -190,6 +190,7 @@ export class Animation extends Eventify(Component) {
     public onDisable () {
         assertIsTrue(typeof this._animationUpdateTaskHandle !== 'undefined');
         getGlobalAnimationManager().removeUpdateTask(this._animationUpdateTaskHandle);
+        this._animationUpdateTaskHandle = undefined;
     }
 
     public onDestroy () {

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -39,6 +39,10 @@ import { AnimationClip } from './animation-clip';
 import { AnimationState, EventType } from './animation-state';
 import { CrossFade } from './cross-fade';
 import { legacyCC } from '../global-exports';
+import { LegacyBlendStateBuffer } from '../../3d/skeletal-animation/skeletal-animation-blending';
+import { AnimationUpdateTaskHandle } from './animation-manager';
+import { assertIsTrue } from '../data/utils/asserts';
+import { getGlobalAnimationManager } from './global-animation-manager';
 
 /**
  * @en
@@ -154,6 +158,8 @@ export class Animation extends Eventify(Component) {
     @serializable
     protected _defaultClip: AnimationClip | null = null;
 
+    private _animationUpdateTaskHandle: AnimationUpdateTaskHandle | undefined = undefined;
+
     /**
      * Whether if `crossFade()` or `play()` has been called before this component starts.
      */
@@ -163,7 +169,7 @@ export class Animation extends Eventify(Component) {
         this.clips = this._clips;
         for (const stateName in this._nameToState) {
             const state = this._nameToState[stateName];
-            state.initialize(this.node);
+            this._initializeState(state);
         }
     }
 
@@ -174,15 +180,19 @@ export class Animation extends Eventify(Component) {
     }
 
     public onEnable () {
-        this._crossFade.resume();
+        assertIsTrue(!this._animationUpdateTaskHandle);
+        this._animationUpdateTaskHandle = getGlobalAnimationManager().addUpdateTask(
+            this.doAnimationSystemUpdate,
+            this,
+        );
     }
 
     public onDisable () {
-        this._crossFade.pause();
+        assertIsTrue(typeof this._animationUpdateTaskHandle !== 'undefined');
+        getGlobalAnimationManager().removeUpdateTask(this._animationUpdateTaskHandle);
     }
 
     public onDestroy () {
-        this._crossFade.stop();
         for (const name in this._nameToState) {
             const state = this._nameToState[name];
             state.destroy();
@@ -218,6 +228,7 @@ export class Animation extends Eventify(Component) {
      */
     public crossFade (name: string, duration = 0.3) {
         this._hasBeenPlayed = true;
+        this._playing = true;
         const state = this._nameToState[name];
         if (state) {
             this.doPlayOrCrossFade(state, duration);
@@ -231,6 +242,7 @@ export class Animation extends Eventify(Component) {
      * 暂停所有动画状态，并暂停所有切换。
      */
     public pause () {
+        this._playing = false;
         this._crossFade.pause();
     }
 
@@ -241,6 +253,7 @@ export class Animation extends Eventify(Component) {
      * 恢复所有动画状态，并恢复所有切换。
      */
     public resume () {
+        this._playing = true;
         this._crossFade.resume();
     }
 
@@ -251,7 +264,8 @@ export class Animation extends Eventify(Component) {
      * 停止所有动画状态，并停止所有切换。
      */
     public stop () {
-        this._crossFade.stop();
+        this._playing = false;
+        this._crossFade.clear();
     }
 
     /**
@@ -276,7 +290,7 @@ export class Animation extends Eventify(Component) {
     public getState (name: string) {
         const state = this._nameToState[name];
         if (state && !state.curveLoaded) {
-            state.initialize(this.node);
+            this._initializeState(state);
         }
         return state || null;
     }
@@ -444,7 +458,7 @@ export class Animation extends Eventify(Component) {
         state._setEventTarget(this);
         state.allowLastFrameEvent(this.hasEventListener(EventType.LASTFRAME));
         if (this.node) {
-            state.initialize(this.node);
+            this._initializeState(state);
         }
         this._nameToState[state.name] = state;
         return state;
@@ -455,9 +469,34 @@ export class Animation extends Eventify(Component) {
      * @internal This method only friends to skeletal animation component.
      */
     protected doPlayOrCrossFade (state: AnimationState, duration: number) {
-        this._crossFade.play();
         this._crossFade.crossFade(state, duration);
     }
+
+    /**
+     *
+     * @internal This method only friends to skeletal animation component.
+     */
+    protected doAnimationSystemUpdate (deltaTime: number) {
+        if (!this._playing) {
+            return;
+        }
+
+        this._crossFade.update(deltaTime);
+
+        for (const name in this._nameToState) {
+            const state = this._nameToState[name];
+            if (!state.isMotionless) {
+                state.update(deltaTime);
+            }
+            state.update(deltaTime);
+        }
+
+        this._blendStateBuffer.apply();
+    }
+
+    private _playing = false;
+
+    private _blendStateBuffer = new LegacyBlendStateBuffer();
 
     private _removeStateOfAutomaticClip (clip: AnimationClip) {
         for (const name in this._nameToState) {
@@ -483,6 +522,15 @@ export class Animation extends Eventify(Component) {
                 this._nameToState[stateName].allowLastFrameEvent(false);
             }
         }
+    }
+
+    private _initializeState (state: AnimationState) {
+        state.initialize(
+            this.node,
+            this._blendStateBuffer,
+            undefined, // Animation Mask
+            true, // Passive - The updating of animation state is handled by us
+        );
     }
 }
 

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -182,7 +182,7 @@ export class Animation extends Eventify(Component) {
     public onEnable () {
         assertIsTrue(!this._animationUpdateTaskHandle);
         this._animationUpdateTaskHandle = getGlobalAnimationManager().addUpdateTask(
-            this.doAnimationSystemUpdate,
+            this._onAnimationSystemUpdate,
             this,
         );
     }
@@ -474,11 +474,11 @@ export class Animation extends Eventify(Component) {
         this._crossFade.crossFade(state, duration);
     }
 
-    /**
-     *
-     * @internal This method only friends to skeletal animation component.
-     */
-    protected doAnimationSystemUpdate (deltaTime: number) {
+    private _playing = false;
+
+    private _blendStateBuffer = new LegacyBlendStateBuffer();
+
+    private _onAnimationSystemUpdate (deltaTime: number) {
         if (!this._playing) {
             return;
         }
@@ -495,10 +495,6 @@ export class Animation extends Eventify(Component) {
 
         this._blendStateBuffer.apply();
     }
-
-    private _playing = false;
-
-    private _blendStateBuffer = new LegacyBlendStateBuffer();
 
     private _removeStateOfAutomaticClip (clip: AnimationClip) {
         for (const name in this._nameToState) {

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -210,6 +210,7 @@ export class Animation extends Eventify(Component) {
      */
     public play (name?: string) {
         this._hasBeenPlayed = true;
+        this._playing = true;
         if (!name) {
             if (!this._defaultClip) {
                 return;

--- a/cocos/core/animation/animation-manager.ts
+++ b/cocos/core/animation/animation-manager.ts
@@ -37,7 +37,6 @@ import { Scheduler } from '../scheduler';
 import { MutableForwardIterator, remove } from '../utils/array';
 import { LegacyBlendStateBuffer } from '../../3d/skeletal-animation/skeletal-animation-blending';
 import { AnimationState } from './animation-state';
-import type { CrossFade } from './cross-fade';
 import { legacyCC } from '../global-exports';
 import { IJointTransform, deleteTransform, getTransform, getWorldMatrix } from './skeletal-animation-utils';
 import { Socket } from '../../3d/skeletal-animation/skeletal-animation';
@@ -45,6 +44,18 @@ import { Socket } from '../../3d/skeletal-animation/skeletal-animation';
 interface ISocketData {
     target: Node;
     transform: IJointTransform;
+}
+
+/**
+ * Opacity value which is guaranteed to not be null or undefined.
+ */
+export interface AnimationUpdateTaskHandle {
+    readonly __brand: 'AnimationUpdateTaskHandle';
+}
+
+interface AnimationUpdateTask<T> extends AnimationUpdateTaskHandle {
+    callback: (this: T, deltaTime: number) => void;
+    thisArg: T;
 }
 
 @ccclass
@@ -55,7 +66,6 @@ export class AnimationManager extends System {
 
     public static ID = 'animation';
     private _anims = new MutableForwardIterator<AnimationState>([]);
-    private _crossFades = new MutableForwardIterator<CrossFade>([]);
     private _delayEvents: {
         fn: (...args: any[]) => void;
         thisArg: any;
@@ -63,32 +73,25 @@ export class AnimationManager extends System {
     }[] = [];
     private _blendStateBuffer: LegacyBlendStateBuffer = new LegacyBlendStateBuffer();
     private _sockets: ISocketData[] = [];
+    private _updateTasks: AnimationUpdateTask<any>[] = [];
 
-    public addCrossFade (crossFade: CrossFade) {
-        const index = this._crossFades.array.indexOf(crossFade);
-        if (index === -1) {
-            this._crossFades.push(crossFade);
-        }
+    public addUpdateTask<T> (callback: (this: T, deltaTime: number) => void, thisArg: T): AnimationUpdateTaskHandle {
+        const task = { callback, thisArg } as AnimationUpdateTask<any>;
+        this._updateTasks.push(task);
+        return task;
     }
 
-    public removeCrossFade (crossFade: CrossFade) {
-        const index = this._crossFades.array.indexOf(crossFade);
-        if (index >= 0) {
-            this._crossFades.fastRemoveAt(index);
-        } else {
-            errorID(3907);
-        }
+    public removeUpdateTask (handle: AnimationUpdateTaskHandle) {
+        remove(this._updateTasks, handle);
     }
 
     public update (dt: number) {
-        const { _delayEvents, _crossFades: crossFadesIter, _sockets } = this;
+        const { _updateTasks: updateTasks, _delayEvents, _sockets } = this;
 
-        { // Update cross fades
-            const crossFades = crossFadesIter.array;
-            for (crossFadesIter.i = 0; crossFadesIter.i < crossFades.length; ++crossFadesIter.i) {
-                const crossFade = crossFades[crossFadesIter.i];
-                crossFade.update(dt);
-            }
+        const nUpdateTasks = updateTasks.length;
+        for (let iUpdateTask = 0; iUpdateTask < nUpdateTasks; ++iUpdateTask) {
+            const { callback, thisArg } = updateTasks[iUpdateTask];
+            callback.call(thisArg, dt);
         }
 
         const iterator = this._anims;

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -300,6 +300,13 @@ export class AnimationState extends Playable {
     private _clipEval: ReturnType<AnimationClip['createEvaluator']> | undefined;
     private _clipEventEval: ReturnType<AnimationClip['createEventEvaluator']> | undefined;
     /**
+     * Sets if this animation state is passive.
+     * If a state is passive,
+     * the state's `update()` should be called somewhere to drive the effect of `play()`.
+     * Otherwise, the `update()` is called uniformly by main loop.
+     */
+    private _passive = false;
+    /**
      * For internal usage. Really hack...
      */
     protected _doNotCreateEval = false;
@@ -325,7 +332,7 @@ export class AnimationState extends Playable {
         return this._curveLoaded;
     }
 
-    public initialize (root: Node, blendStateBuffer?: BlendStateBuffer, mask?: AnimationMask) {
+    public initialize (root: Node, blendStateBuffer?: BlendStateBuffer, mask?: AnimationMask, passive?: boolean) {
         if (this._curveLoaded) { return; }
         this._curveLoaded = true;
         if (this._poseOutput) {
@@ -369,6 +376,7 @@ export class AnimationState extends Playable {
         if (!(EDITOR && !legacyCC.GAME_VIEW)) {
             this._clipEventEval = clip.createEventEvaluator(this._targetNode);
         }
+        this._passive = passive ?? false;
     }
 
     public destroy () {
@@ -686,11 +694,15 @@ export class AnimationState extends Playable {
     }
 
     private _onReplayOrResume () {
-        getGlobalAnimationManager().addAnimation(this);
+        if (!this._passive) {
+            getGlobalAnimationManager().addAnimation(this);
+        }
     }
 
     private _onPauseOrStop () {
-        getGlobalAnimationManager().removeAnimation(this);
+        if (!this._passive) {
+            getGlobalAnimationManager().removeAnimation(this);
+        }
     }
 }
 

--- a/cocos/core/animation/cross-fade.ts
+++ b/cocos/core/animation/cross-fade.ts
@@ -30,9 +30,8 @@
 
 import { clamp01 } from '../math/utils';
 import { remove } from '../utils/array';
-import { AnimationState } from './animation-state';
+import type { AnimationState } from './animation-state';
 import { Playable } from './playable';
-import { getGlobalAnimationManager } from './global-animation-manager';
 
 interface IManagedState {
     state: AnimationState | null;
@@ -45,25 +44,17 @@ interface IFading {
     easeDuration: number;
 }
 
-interface CrossFadeScheduler {
-    addCrossFade(crossFade: CrossFade): void;
-
-    removeCrossFade(crossFade: CrossFade): void;
-}
-
-export class CrossFade extends Playable {
+/**
+ * Helper class to allocate weights for animation states,
+ * according to the invocation of "cross fading".
+ */
+export class CrossFade {
     private readonly _managedStates: IManagedState[] = [];
     private readonly _fadings: IFading[] = [];
-    private _scheduled = false;
-    private declare _scheduler: CrossFadeScheduler;
-
-    constructor (scheduler?: CrossFadeScheduler) {
-        super();
-        this._scheduler = scheduler ?? getGlobalAnimationManager();
-    }
+    private _finished = true;
 
     public update (deltaTime: number) {
-        if (this.isMotionless) {
+        if (this._finished) {
             return;
         }
 
@@ -80,7 +71,7 @@ export class CrossFade extends Playable {
         }
 
         if (managedStates.length === 1 && fadings.length === 1) { // Definitely not code repetition
-            this._unscheduleThis();
+            this._finished = true;
         }
     }
 
@@ -90,6 +81,8 @@ export class CrossFade extends Playable {
      * @param duration 切换时间。
      */
     public crossFade (state: AnimationState | null, duration: number) {
+        this._finished = false;
+
         if (this._managedStates.length === 0) {
             // If we are cross fade from a "initial" pose,
             // we do not use the duration.
@@ -117,12 +110,11 @@ export class CrossFade extends Playable {
             easeTime: 0,
             target,
         });
-
-        if (!this.isMotionless) {
-            this._scheduleThis();
-        }
     }
 
+    /**
+     * Invoke `stop()` on all managed states then clear fade queue.
+     */
     public clear () {
         for (let iManagedState = 0; iManagedState < this._managedStates.length; ++iManagedState) {
             const state = this._managedStates[iManagedState].state;
@@ -132,47 +124,31 @@ export class CrossFade extends Playable {
         }
         this._managedStates.length = 0;
         this._fadings.length = 0;
-    }
-
-    protected onPlay () {
-        super.onPlay();
-        this._scheduleThis();
+        this._finished = true;
     }
 
     /**
-     * 停止我们淡入淡出的所有动画状态并停止淡入淡出。
+     * Invoke `pause()` on all managed states.
      */
-    protected onPause () {
-        super.onPause();
+    public pause () {
         for (let iManagedState = 0; iManagedState < this._managedStates.length; ++iManagedState) {
             const state = this._managedStates[iManagedState].state;
             if (state) {
                 state.pause();
             }
         }
-        this._unscheduleThis();
     }
 
     /**
-     * 恢复我们淡入淡出的所有动画状态并继续淡入淡出。
+     * Invoke `resume()` on all managed states.
      */
-    protected onResume () {
-        super.onResume();
+    public resume () {
         for (let iManagedState = 0; iManagedState < this._managedStates.length; ++iManagedState) {
             const state = this._managedStates[iManagedState].state;
             if (state) {
                 state.resume();
             }
         }
-        this._scheduleThis();
-    }
-
-    /**
-     * 停止所有淡入淡出的动画状态。
-     */
-    protected onStop () {
-        super.onStop();
-        this.clear();
     }
 
     private _calculateWeights (deltaTime: number) {
@@ -221,20 +197,6 @@ export class CrossFade extends Playable {
                 }
             }
             fadings.splice(deadFadingBegin);
-        }
-    }
-
-    private _scheduleThis () {
-        if (!this._scheduled) {
-            this._scheduler.addCrossFade(this);
-            this._scheduled = true;
-        }
-    }
-
-    private _unscheduleThis () {
-        if (this._scheduled) {
-            this._scheduler.removeCrossFade(this);
-            this._scheduled = false;
         }
     }
 }

--- a/tests/animation/cross-fade.test.ts
+++ b/tests/animation/cross-fade.test.ts
@@ -1,4 +1,4 @@
-import { AnimationClip, AnimationState, Node } from '../../cocos/core';
+import { AnimationState } from '../../cocos/core/animation';
 import { CrossFade } from '../../cocos/core/animation/cross-fade';
 import { Playable } from '../../cocos/core/animation/playable';
 

--- a/tests/animation/cross-fade.test.ts
+++ b/tests/animation/cross-fade.test.ts
@@ -1,28 +1,6 @@
 import { AnimationClip, AnimationState, Node } from '../../cocos/core';
 import { CrossFade } from '../../cocos/core/animation/cross-fade';
 import { Playable } from '../../cocos/core/animation/playable';
-import { assertIsTrue } from '../../cocos/core/data/utils/asserts';
-import { remove } from '../../cocos/core/utils/array';
-
-type CrossFadeScheduler = NonNullable<ConstructorParameters<typeof CrossFade>[0]>;
-
-class Scheduler implements NonNullable<CrossFadeScheduler> {
-    public addCrossFade(crossFade: CrossFade): void {
-        this._crossFades.push(crossFade);
-    }
-
-    public removeCrossFade(crossFade: CrossFade): void {
-        remove(this._crossFades, crossFade);
-    }
-
-    public update (deltaTime = 1.0 / 30.0) {
-        for (const crossFade of this._crossFades) {
-            crossFade.update(deltaTime);
-        }
-    }
-
-    private _crossFades: CrossFade[] = [];
-}
 
 class DummyState extends Playable {
     constructor (public duration = 1.0) { super(); }
@@ -37,11 +15,9 @@ function createDummyState ({ duration = 1.0 } = {}) {
 describe('Cross fade', () => {
     test('Fade from initial state', () => {
         const state = createDummyState();
-        const scheduler = new Scheduler();
-        const crossFade = new CrossFade(scheduler);
-        crossFade.play();
+        const crossFade = new CrossFade();
         crossFade.crossFade(state, 0.3);
-        scheduler.update(0.1);
+        crossFade.update(0.1);
         expect(state.weight).toBeCloseTo(1.0);
     });
 
@@ -49,20 +25,17 @@ describe('Cross fade', () => {
         const state1 = createDummyState();
         const state2 = createDummyState();
         
-        const scheduler = new Scheduler();
-        const crossFade = new CrossFade(scheduler);
+        const crossFade = new CrossFade();
         crossFade.crossFade(state1, 0.0);
         crossFade.crossFade(state2, 0.3);
 
-        scheduler.update(0.1);
-        expect(state1.weight).toBeCloseTo(1.0);
-        expect(state2.weight).toBeCloseTo(1.0);
-
-        crossFade.play();
-
-        scheduler.update(0.1);
+        crossFade.update(0.1);
         expect(state1.weight).toBeCloseTo(0.2 / 0.3);
         expect(state2.weight).toBeCloseTo(0.1 / 0.3);
+
+        crossFade.update(0.1);
+        expect(state1.weight).toBeCloseTo(0.1 / 0.3);
+        expect(state2.weight).toBeCloseTo(0.2 / 0.3);
     });
 
     test('New fading before previous fadings got finished', () => {
@@ -70,16 +43,14 @@ describe('Cross fade', () => {
         const state2 = createDummyState();
         const state3 = createDummyState();
 
-        const scheduler = new Scheduler();
-        const crossFade = new CrossFade(scheduler);
-        crossFade.play();
+        const crossFade = new CrossFade();
 
         crossFade.crossFade(state1, 0.0);
         crossFade.crossFade(state2, 0.7);
-        scheduler.update(0.2);
+        crossFade.update(0.2);
 
         crossFade.crossFade(state3, 0.5);
-        scheduler.update(0.1);
+        crossFade.update(0.1);
 
         expect(state3.weight).toBeCloseTo(0.1 / 0.5);
         expect(state2.weight).toBeCloseTo((1.0 - 0.1 / 0.5) * ((0.1 + 0.2) / 0.7));
@@ -90,16 +61,14 @@ describe('Cross fade', () => {
         const state1 = createDummyState();
         const state2 = createDummyState();
 
-        const scheduler = new Scheduler();
-        const crossFade = new CrossFade(scheduler);
-        crossFade.play();
+        const crossFade = new CrossFade();
         
         crossFade.crossFade(state1, 0.0);
         crossFade.crossFade(state2, 0.7);
-        scheduler.update(0.2);
+        crossFade.update(0.2);
 
         crossFade.crossFade(state1, 0.5);
-        scheduler.update(0.1);
+        crossFade.update(0.1);
 
         expect(state2.weight).toBeCloseTo((1.0 - 0.1 / 0.5) * ((0.1 + 0.2) / 0.7));
         expect(state1.weight).toBeCloseTo(
@@ -111,12 +80,10 @@ describe('Cross fade', () => {
     test('State playback management', () => {
         const state1 = createDummyState();
         const state2 = createDummyState();
-        const scheduler = new Scheduler();
-        const crossFade = new CrossFade(scheduler);
+        const crossFade = new CrossFade();
 
         crossFade.crossFade(state1, 0.0);
         crossFade.crossFade(state2, 0.3);
-        crossFade.play();
         expect(!state1.isPaused && state1.isPlaying).toBe(true);
         expect(!state2.isPaused && state2.isPlaying).toBe(true);
 
@@ -128,60 +95,8 @@ describe('Cross fade', () => {
         expect(!state1.isPaused && state1.isPlaying).toBe(true);
         expect(!state2.isPaused && state2.isPlaying).toBe(true);
 
-        crossFade.stop();
+        crossFade.clear();
         expect(!state1.isPaused && !state1.isPlaying).toBe(true);
         expect(!state2.isPaused && !state2.isPlaying).toBe(true);
-    });
-
-    test('Self-driven(internal test)', () => {
-        const state1 = createDummyState();
-        const state2 = createDummyState();
-        const scheduler = new Scheduler();
-
-        const crossFade = new CrossFade(scheduler);
-        crossFade.play();
-
-        const crossFadeUpdateMock = jest.spyOn(crossFade, 'update');
-
-        const resetAsInitialState = (state: AnimationState) => {
-            crossFade.crossFade(state1, 0.0);
-            scheduler.update(0.0);
-            crossFadeUpdateMock.mockClear();
-        };
-
-        resetAsInitialState(state1);
-        scheduler.update();
-        expect(crossFadeUpdateMock).toHaveBeenCalledTimes(0);
-
-        crossFade.crossFade(state2, 0.3);
-        scheduler.update();
-        expect(crossFadeUpdateMock).toHaveBeenCalledTimes(1);
-        scheduler.update();
-        expect(crossFadeUpdateMock).toHaveBeenCalledTimes(2);
-        scheduler.update(0.3);
-        expect(crossFadeUpdateMock).toHaveBeenCalledTimes(3);
-        // And then, self-unscheduled
-        scheduler.update();
-        expect(crossFadeUpdateMock).toHaveBeenCalledTimes(3);
-        crossFadeUpdateMock.mockReset();
-
-        // A new cross fade call re-schedule itself
-        crossFade.crossFade(state1, 0.1);
-        scheduler.update();
-        expect(crossFadeUpdateMock).toHaveBeenCalledTimes(1);
-        crossFade.clear();
-        crossFadeUpdateMock.mockReset();
-
-        // Paused? Won't do any work
-        crossFade.crossFade(state1, 0.0);
-        crossFade.crossFade(state2, 0.2);
-        crossFade.pause();
-        scheduler.update();
-        expect(crossFadeUpdateMock).toHaveBeenCalledTimes(0);
-
-        // Let's resume it
-        crossFade.resume();
-        scheduler.update();
-        expect(crossFadeUpdateMock).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Re: cocos/cocos-engine#

Changelog:
 * Optimize the way how animation component update its animation content

This address the issue that even an animation is not played, it will still get update when main loop tick.

Before this PR, all animation components share the same "animation blend buffer" and that buffer is updated per tick. This PR however create individual animation blender buffer for every animation component instance, and control the updating of the buffer by itself.

By the way, the cross fade is optimized to be controled by animation component itself -- even it should be by design at the outset.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet change sets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
