### PR TITLE
change ccstd::pmr::string definition to template instantiation

### DIFF
--- a/native/cocos/base/std/container/string.h
+++ b/native/cocos/base/std/container/string.h
@@ -32,7 +32,6 @@ namespace ccstd {
 using std::string;
 
 namespace pmr {
-template <class charT, class traits = std::char_traits<charT>>
-using string = std::basic_string<charT, traits, boost::container::pmr::polymorphic_allocator<charT>>;
+using string = std::basic_string<char, std::char_traits<char>, boost::container::pmr::polymorphic_allocator<char>>;
 }
 } // namespace ccstd


### PR DESCRIPTION
changed ccstd:pmr::string definition.


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
