### PR TITLE
Fix: animation blending zero check

### DIFF
--- a/cocos/3d/skeletal-animation/skeletal-animation-blending.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-blending.ts
@@ -135,6 +135,18 @@ class BlendStateWriterInternal<P extends BlendingPropertyName> implements Runtim
 
 export type BlendStateWriter<P extends BlendingPropertyName> = Omit<BlendStateWriterInternal<P>, 'node' | 'property'>;
 
+enum EnablingFlags {
+    POSITION = 1,
+    ROTATION = 2,
+    SCALE = 4,
+    EULER_ANGLES = 8,
+}
+
+const ENABLING_FLAGS_ALL = EnablingFlags.POSITION
+    | EnablingFlags.ROTATION
+    | EnablingFlags.SCALE
+    | EnablingFlags.EULER_ANGLES;
+
 interface PropertyBlendState<TValue> {
     /**
      * How many writer reference this property.
@@ -238,32 +250,43 @@ abstract class NodeBlendState<TVec3PropertyBlendState extends PropertyBlendState
     }
 
     public apply (node: Node) {
-        const { _properties: { position, scale, rotation, eulerAngles } } = this;
+        const {
+            _enablingFlags: enablingFlags,
+            _properties: { position, scale, rotation, eulerAngles },
+        } = this;
+
+        if (!enablingFlags) {
+            return;
+        }
 
         let t: Vec3 | undefined;
         let s: Vec3 | undefined;
         let r: Quat | Vec3 | undefined;
 
-        if (position) {
+        if (position && (enablingFlags & EnablingFlags.POSITION)) {
             t = position.result;
         }
 
-        if (scale) {
+        if (scale && (enablingFlags & EnablingFlags.SCALE)) {
             s = scale.result;
         }
 
-        if (eulerAngles) {
+        if (eulerAngles && (enablingFlags & EnablingFlags.EULER_ANGLES)) {
             r = eulerAngles.result;
         }
 
-        if (rotation) {
+        if (rotation && (enablingFlags & EnablingFlags.ROTATION)) {
             r = rotation.result;
         }
 
         if (r || t || s) {
             node.setRTS(r, t, s);
         }
+
+        this._enablingFlags = 0;
     }
+
+    protected _enablingFlags = 0;
 
     protected _properties: {
         position?: TVec3PropertyBlendState;
@@ -282,24 +305,28 @@ class LegacyNodeBlendState extends NodeBlendState<LegacyVec3PropertyBlendState, 
         const { _properties: { position, scale, rotation, eulerAngles } } = this;
 
         if (position && position.accumulatedWeight) {
+            this._enablingFlags |= EnablingFlags.POSITION;
             if (position.accumulatedWeight < 1.0) {
                 position.blend(node.position, 1.0 - position.accumulatedWeight);
             }
         }
 
         if (scale && scale.accumulatedWeight) {
+            this._enablingFlags |= EnablingFlags.SCALE;
             if (scale.accumulatedWeight < 1.0) {
                 scale.blend(node.scale, 1.0 - scale.accumulatedWeight);
             }
         }
 
         if (eulerAngles && eulerAngles.accumulatedWeight) {
+            this._enablingFlags |= EnablingFlags.EULER_ANGLES;
             if (eulerAngles.accumulatedWeight < 1.0) {
                 eulerAngles.blend(node.eulerAngles, 1.0 - eulerAngles.accumulatedWeight);
             }
         }
 
         if (rotation && rotation.accumulatedWeight) {
+            this._enablingFlags |= EnablingFlags.ROTATION;
             if (rotation.accumulatedWeight < 1.0) {
                 rotation.blend(node.rotation, 1.0 - rotation.accumulatedWeight);
             }
@@ -439,6 +466,9 @@ class LayeredNodeBlendState extends NodeBlendState<LayeredVec3PropertyBlendState
     }
 
     public apply (node: Node) {
+        // Layered buffer always enable all flags.
+        this._enablingFlags = ENABLING_FLAGS_ALL;
+
         super.apply(node);
 
         const { _properties: { position, scale, rotation, eulerAngles } } = this;

--- a/cocos/core/animation/global-animation-manager.ts
+++ b/cocos/core/animation/global-animation-manager.ts
@@ -1,7 +1,7 @@
-import { legacyCC } from "../global-exports";
-import type { AnimationManager } from "./animation-manager";
+import { legacyCC } from '../global-exports';
+import type { AnimationManager } from './animation-manager';
 
-export function getGlobalAnimationManager() {
+export function getGlobalAnimationManager () {
     const animationManager = legacyCC.director.getAnimationManager() as AnimationManager;
     return animationManager;
 }

--- a/tests/animation/skeletal-animation-blending.test.ts
+++ b/tests/animation/skeletal-animation-blending.test.ts
@@ -138,6 +138,32 @@ describe('Skeletal animation blending', () => {
             revertNodesTransforms();
         });
 
+        test('All zero', () => {
+            blendBuffer.apply();
+
+            for (const {
+                node,
+                originalEulerAngles,
+                originalPosition,
+                originalRotation,
+                originalScale,
+            } of [
+                nodePosition_all,
+                nodeRotation_all,
+                nodeEulerAngles_all,
+                nodeScale_all,
+                nodeScale_1,
+                nodeScale_1_2,
+            ]) {
+                expect(Vec3.equals(node.position, originalPosition)).toBe(true);
+                expect(Vec3.equals(node.scale, originalScale)).toBe(true);
+                expect(Quat.equals(node.rotation, originalRotation)).toBe(true);
+                if (originalEulerAngles) {
+                    expect(Vec3.equals(node.eulerAngles, originalEulerAngles)).toBe(true);
+                }
+            }
+        });
+
         test('Normalized blending ', () => {
             host1.weight = 0.3;
             host2.weight = 0.5;


### PR DESCRIPTION
Re: cocos/cocos-engine#

Changelog:
 * Fix that if a property is not sampled by any animation, it will be set to zero.

A minimalist reproducable example can be:
```ts
new AnimationState(node); // Transform of bones woud be set to zero, if not playing.
```

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet change sets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
