### PR TITLE
avoid rehash on destroyed resource

### DIFF
--- a/native/cocos/renderer/frame-graph/ResourceAllocator.h
+++ b/native/cocos/renderer/frame-graph/ResourceAllocator.h
@@ -55,9 +55,9 @@ private:
     ResourceAllocator() noexcept = default;
     ~ResourceAllocator()         = default;
 
-    std::unordered_map<DescriptorType, DeviceResourcePool, gfx::Hasher<DescriptorType>> _pool{};
-    std::unordered_map<DeviceResourceType *, int64_t>                                   _ages{};
-    uint64_t                                                                            _age{0};
+    std::unordered_map<size_t, DeviceResourcePool>    _pool{};
+    std::unordered_map<DeviceResourceType *, int64_t> _ages{};
+    uint64_t                                          _age{0};
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -71,7 +71,8 @@ ResourceAllocator<DeviceResourceType, DescriptorType, DeviceResourceCreatorType>
 
 template <typename DeviceResourceType, typename DescriptorType, typename DeviceResourceCreatorType>
 DeviceResourceType *ResourceAllocator<DeviceResourceType, DescriptorType, DeviceResourceCreatorType>::alloc(const DescriptorType &desc) noexcept {
-    DeviceResourcePool &pool{_pool[desc]};
+    size_t              hash = gfx::Hasher<DescriptorType>()(desc);
+    DeviceResourcePool &pool{_pool[hash]};
 
     DeviceResourceType *resource{nullptr};
     for (DeviceResourceType *res : pool) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 
上个pr: https://github.com/cocos/cocos-engine/pull/10359
要解决的问题： https://github.com/cocos/3d-tasks/issues/11549

为什么要改desc为size_t作为key:
把hash这一步拎出来，防止unordered_map触发rehash的时候又对包含销毁的资源再hash。

之前的pr就是想避免这种销毁的解引用再operator==里边层层往下，但是没有考虑到rehash的情况，包含销毁资源的framebuffer再一次hash会解引用悬垂指针。现在保证内部对资源的hash只做一次，即只有在传入info的信息查找的时候。

FrameBufferInfo的hash function是需要现在这么做的，[因为组合指针的问题](https://github.com/cocos/3d-tasks/issues/11549#issuecomment-1068654371)。 但最好的办法还是不要在data里边放指针，建了个issue: https://github.com/cocos/3d-tasks/issues/11717

mac上没有发现问题，win上能必现，猜测是平台上unordered_map rehash/reserve policy不同的原因，同时有另外一种解决方案是: 
`_pool.reserve(1800); // 1800 = recycleTime:30 * fps:60`
给资源resourcePool上来就预留这么大空间，就不会触发rehash了。


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
