### PR TITLE
Adjust the default linewidth of cc.graphics

### DIFF
--- a/cocos2d/core/graphics/graphics.js
+++ b/cocos2d/core/graphics/graphics.js
@@ -48,7 +48,7 @@ let Graphics = cc.Class({
     },
 
     properties: {
-        _lineWidth: 2,
+        _lineWidth: 4,
         _strokeColor: cc.Color.BLACK,
         _lineJoin: LineJoin.MITER,
         _lineCap: LineCap.BUTT,


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Graphics to 4, because with a lineWidth of 2, the drawing effect is not observed at some resolutions. If this is not changed, the user may mistakenly think it is a bug.
 
 Before modification:
![图片](https://user-images.githubusercontent.com/35944775/160312697-9b0d8fc1-9868-45d5-bf6c-ff81cd76a7f6.png)
Modified:
![图片](https://user-images.githubusercontent.com/35944775/160312742-867f8d11-70a5-4d62-ad8b-234b9f55c36e.png)

