### PR TITLE
Prevent errors from being reported when comp.node is missing

### DIFF
--- a/cocos2d/core/component-scheduler.js
+++ b/cocos2d/core/component-scheduler.js
@@ -73,7 +73,7 @@ function stableRemoveInactive (iterator, flagToClear) {
     var next = iterator.i + 1;
     while (next < array.length) {
         var comp = array[next];
-        if (comp._enabled && comp.node._activeInHierarchy) {
+        if (comp._enabled && comp.node && comp.node._activeInHierarchy) {
             ++next;
         }
         else {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Prevent errors from being reported when comp.node is missing
 
 A large number of these errors are reported in the background of the game：
<img width="918" alt="图片" src="https://user-images.githubusercontent.com/35944775/160340675-fe55ff7c-3455-490e-b90a-97740dd0fcd3.png">
