### PR TITLE
Unit test on retrieving class id and class name

### DIFF
--- a/tests/core/ccclass.test.ts
+++ b/tests/core/ccclass.test.ts
@@ -1,6 +1,9 @@
 import { ccclass } from 'cc.decorator';
 import { warnID } from '../../cocos/core';
 import { float, property } from '../../cocos/core/data/class-decorator';
+import * as requiringFrame from '../../cocos/core/data/utils/requiring-frame';
+import { getClassName, unregisterClass, _getClassId } from '../../cocos/core/utils/js-typed';
+import { Component } from '../../cocos/core/components/component'
 
 /**
  * Happened when:
@@ -55,5 +58,81 @@ describe('ccclass warnings', () => {
         @ccclass class C { }
         { @ccclass class _ { @property(C) p; } }
         expect(warnID).not.toHaveBeenCalled();
+    });
+});
+
+describe('Class id & class name', () => {
+    type ExpectedNameComeFrom = 'self-name' | 'explicit-name' | 'frame-name';
+    type ExpectedIdComeFrom = 'self-name' | 'explicit-name' | 'frame-uuid' | 'temp-id';
+
+    test.each([
+        [true, true, true, 'explicit-name', 'frame-uuid'], // Usually: in user land, components, with explicit name
+        [true, true, false, 'explicit-name', 'explicit-name'],  // Usually: in user land, non-components, with explicit name
+        [true, false, true, 'explicit-name', 'explicit-name'], // Usually: in engine, components
+        [true, false, false, 'explicit-name', 'explicit-name'], // Usually: in engine, non-components
+
+        [false, true, true, 'frame-name', 'frame-uuid'], // Usually: in user land, components, no explicit name
+        [false, true, false, 'self-name', 'temp-id'],  // Usually: in user land, non-components, no explicit name
+        [false, false, true, 'self-name', 'temp-id'],
+        [false, false, false, 'self-name', 'temp-id'],
+    ] as Array<[
+        withExplicitName: boolean,
+        withinRequiringFrame: boolean,
+        inheritingFromComponent: boolean,
+        expectedNameComeFrom: ExpectedNameComeFrom,
+        expectedIdComeFrom: ExpectedIdComeFrom,
+    ]>)(
+        `WithExplicitName: %j, WithinRequiringFrame: %j, InheritingFromComponent: %j`,
+        (withExplicitName, withinRequiringFrame, inheritingFromComponent, expectedNameComeFrom, expectedIdComeFrom) => {
+        const EXPLICIT_NAME = '__EXPLICIT_NAME__';
+        const FRAME_NAME = '__FRAME_NAME__';
+        const FRAME_UUID = '__FRAME_UUID__';
+        const expectedName = (() => {
+            switch (expectedNameComeFrom) {
+                case 'frame-name': return FRAME_NAME;
+                case 'explicit-name': return EXPLICIT_NAME;
+                default: case 'self-name': return 'Cls';
+            }
+        })();
+        const expectedId = (() => {
+            switch (expectedIdComeFrom) {
+                case 'frame-uuid': return FRAME_UUID;
+                case 'explicit-name': return EXPLICIT_NAME;
+                case 'temp-id': return expect.stringMatching(/^TmpCId\.\.[0-9]+/i);
+                default: case 'self-name': return 'Cls';
+            }
+        })();
+
+        if (withinRequiringFrame) {
+            requiringFrame.push(
+                {}, // module
+                FRAME_UUID, // uuid
+                FRAME_NAME, // script
+            );
+        }
+
+        let Cls_: Function;
+        if (inheritingFromComponent) {
+            Cls_ = (() => {
+                @(withExplicitName ? ccclass(EXPLICIT_NAME) : ccclass) class Cls extends Component {}
+                return Cls;
+            })();
+        } else {
+            Cls_ = (() => {
+                @(withExplicitName ? ccclass(EXPLICIT_NAME) : ccclass) class Cls {}
+                return Cls;
+            })();
+        }
+
+        if (withinRequiringFrame) {
+            requiringFrame.pop();
+        }
+
+        try {
+            expect(getClassName(Cls_)).toBe(expectedName);
+            expect(_getClassId(Cls_)).toStrictEqual(expectedId);
+        } finally {
+            unregisterClass(Cls_);
+        }
     });
 });


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 *

This test ensures the following **facts** hold:

- Any cc class is associated with a _name_ and an _id_ .

- How does Creator decide the class name:
 
  - If a class name is explicitly specified(i.e `@ccclass(name)`), the name of the class is the specified one. 

  - Otherwise, if it's inheriting from `Component`, it's name woud be _base-name-of-the-containing-module-file_.

  - Otherwise, its name would be  the name of the class itself.

- How does Creator decide the class id:

  - If the class is inheriting from `Component`, its id would be something that was hashed from UUID of the containning module file.

  - Otherwise, if a class name is explicitly specified(i.e `@ccclass(name)`), the id of the class is the specified one.

  - Otherwise, a temporary id is allocated at runtime and instances of such a class are rejected by serialization.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
