### PR TITLE
Fix skeletal animation state got update twice

### DIFF
--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -131,7 +131,7 @@ export class SkeletalAnimationState extends AnimationState {
         }
     }
 
-    protected createEvaluator (...args: Parameters<AnimationState['createEvaluator']>): void {
+    protected _createEvaluator (...args: Parameters<AnimationState['_createEvaluator']>): void {
         assertIsNonNullable(this._parent);
         const baked = this._parent.useBakedAnimation;
         if (baked) {
@@ -140,7 +140,7 @@ export class SkeletalAnimationState extends AnimationState {
         } else {
             this._sampleCurves = super._sampleCurves;
             this.duration = this.clip.duration;
-            super.createEvaluator(...args);
+            super._createEvaluator(...args);
         }
     }
 

--- a/cocos/3d/skeletal-animation/skeletal-animation-state.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-state.ts
@@ -37,6 +37,7 @@ import { AnimationState } from '../../core/animation/animation-state';
 import { SkeletalAnimation, Socket } from './skeletal-animation';
 import { SkelAnimDataHub } from './skeletal-animation-data-hub';
 import { legacyCC } from '../../core/global-exports';
+import { assertIsNonNullable } from '../../core/data/utils/asserts';
 
 const m4_1 = new Mat4();
 const m4_2 = new Mat4();
@@ -65,43 +66,19 @@ export class SkeletalAnimationState extends AnimationState {
 
     protected _parent: SkeletalAnimation | null = null;
 
-    protected _curvesInited = false;
-
     constructor (clip: AnimationClip, name = '') {
         super(clip, name);
         this._animInfoMgr = legacyCC.director.root.dataPoolManager.jointAnimationInfo;
     }
 
-    public initialize (root: Node) {
-        if (this._curveLoaded) { return; }
+    public initialize (...args: Parameters<AnimationState['initialize']>) {
+        const [root] = args;
         this._parent = root.getComponent('cc.SkeletalAnimation') as SkeletalAnimation;
-        const baked = this._parent.useBakedAnimation;
-        this._doNotCreateEval = baked;
-        super.initialize(root);
-        this._curvesInited = !baked;
         const { frames, samples } = SkelAnimDataHub.getOrExtract(this.clip);
         this._frames = frames - 1;
         this._animInfo = this._animInfoMgr.getData(root.uuid);
         this._bakedDuration = this._frames / samples; // last key
-        this.setUseBaked(baked);
-    }
-
-    /**
-     * @internal This method only friends to `SkeletalAnimation`.
-     */
-    public setUseBaked (useBaked: boolean) {
-        if (useBaked) {
-            this._sampleCurves = this._sampleCurvesBaked;
-            this.duration = this._bakedDuration;
-        } else {
-            this._sampleCurves = super._sampleCurves;
-            this.duration = this.clip.duration;
-            if (!this._curvesInited) {
-                this._curveLoaded = false;
-                super.initialize(this._targetNode!);
-                this._curvesInited = true;
-            }
-        }
+        super.initialize(...args);
     }
 
     public rebuildSocketCurves (sockets: Socket[]) {
@@ -151,6 +128,19 @@ export class SkeletalAnimationState extends AnimationState {
                 target: socket.target,
                 frames: transforms,
             });
+        }
+    }
+
+    protected createEvaluator (...args: Parameters<AnimationState['createEvaluator']>): void {
+        assertIsNonNullable(this._parent);
+        const baked = this._parent.useBakedAnimation;
+        if (baked) {
+            this._sampleCurves = this._sampleCurvesBaked;
+            this.duration = this._bakedDuration;
+        } else {
+            this._sampleCurves = super._sampleCurves;
+            this.duration = this.clip.duration;
+            super.createEvaluator(...args);
         }
     }
 

--- a/cocos/3d/skeletal-animation/skeletal-animation.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation.ts
@@ -131,7 +131,7 @@ export class SkeletalAnimation extends Animation {
      * @en
      * Whether to bake animations. Default to true,<br>
      * which substantially increases performance while making all animations completely fixed.<br>
-     * Changing this property will recreate all animation states.
+     * Changing this property will stop and recreate all animation states.
      * @zh
      * 是否使用预烘焙动画，默认启用，可以大幅提高运行效时率，但所有动画效果会被彻底固定，不支持任何形式的编辑和混合。<br>
      * 修改此选项会重新创建所有动画状态。

--- a/cocos/3d/skeletal-animation/skeletal-animation.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation.ts
@@ -131,10 +131,10 @@ export class SkeletalAnimation extends Animation {
      * @en
      * Whether to bake animations. Default to true,<br>
      * which substantially increases performance while making all animations completely fixed.<br>
-     * Changing this property will stop and recreate all animation states.
+     * Changing this property effectively will stop and recreate all animation states.
      * @zh
      * 是否使用预烘焙动画，默认启用，可以大幅提高运行效时率，但所有动画效果会被彻底固定，不支持任何形式的编辑和混合。<br>
-     * 修改此选项会重新创建所有动画状态。
+     * 实际修改此选项会重新创建所有动画状态。
      */
     @tooltip('i18n:animation.use_baked_animation')
     get useBakedAnimation () {

--- a/cocos/3d/skeletal-animation/skeletal-animation.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation.ts
@@ -131,10 +131,10 @@ export class SkeletalAnimation extends Animation {
      * @en
      * Whether to bake animations. Default to true,<br>
      * which substantially increases performance while making all animations completely fixed.<br>
-     * Dynamically changing this property will take effect when playing the next animation clip.
+     * Changing this property will recreate all animation states.
      * @zh
      * 是否使用预烘焙动画，默认启用，可以大幅提高运行效时率，但所有动画效果会被彻底固定，不支持任何形式的编辑和混合。<br>
-     * 运行时动态修改此选项会在播放下一条动画片段时生效。
+     * 修改此选项会重新创建所有动画状态。
      */
     @tooltip('i18n:animation.use_baked_animation')
     get useBakedAnimation () {
@@ -142,12 +142,13 @@ export class SkeletalAnimation extends Animation {
     }
 
     set useBakedAnimation (val) {
+        if (this._useBakedAnimation === val) {
+            return;
+        }
+
         this._useBakedAnimation = val;
 
-        for (const stateName in this._nameToState) {
-            const state = this._nameToState[stateName] as SkeletalAnimationState;
-            state.setUseBaked(val);
-        }
+        this._recreateAllStates();
 
         this._users.forEach((user) => {
             user.setUseBakedAnimation(val);

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -491,10 +491,6 @@ export class Animation extends Eventify(Component) {
     private _blendStateBuffer = new LegacyBlendStateBuffer();
 
     private _onAnimationSystemUpdate (deltaTime: number) {
-        if (!this._playing) {
-            return;
-        }
-
         this._crossFade.update(deltaTime);
 
         for (const name in this._nameToState) {

--- a/cocos/core/animation/animation-component.ts
+++ b/cocos/core/animation/animation-component.ts
@@ -451,6 +451,18 @@ export class Animation extends Eventify(Component) {
         }
     }
 
+    /**
+     * @internal Friends only to skeletal animation component.
+     */
+    protected _recreateAllStates () {
+        this.stop();
+        for (const name in this._nameToState) {
+            const oldState = this._nameToState[name];
+            this._doCreateState(oldState.clip, name);
+            oldState.destroy();
+        }
+    }
+
     protected _createState (clip: AnimationClip, name?: string) {
         return new AnimationState(clip, name);
     }

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -331,7 +331,7 @@ export class AnimationState extends Playable {
     public initialize (root: Node, blendStateBuffer?: BlendStateBuffer | null, mask?: AnimationMask, passive?: boolean) {
         if (this._curveLoaded) { return; }
         this._curveLoaded = true;
-        this.destroyEvaluator();
+        this._destroyEvaluator();
         this._targetNode = root;
         const clip = this._clip;
 
@@ -369,7 +369,7 @@ export class AnimationState extends Playable {
                 getGlobalAnimationManager().removeAnimation(this);
             }
         }
-        this.destroyEvaluator();
+        this._destroyEvaluator();
     }
 
     /**
@@ -520,17 +520,6 @@ export class AnimationState extends Playable {
         });
     }
 
-    protected destroyEvaluator () {
-        if (this._poseOutput) {
-            this._poseOutput.destroy();
-            this._poseOutput = null;
-        }
-        if (this._clipEval) {
-            // TODO: destroy?
-            this._clipEval = undefined;
-        }
-    }
-
     protected _sampleCurves (time: number) {
         const { _poseOutput: poseOutput, _clipEval: clipEval } = this;
         if (poseOutput) {
@@ -538,6 +527,17 @@ export class AnimationState extends Playable {
         }
         if (clipEval) {
             clipEval.evaluate(time);
+        }
+    }
+
+    private _destroyEvaluator () {
+        if (this._poseOutput) {
+            this._poseOutput.destroy();
+            this._poseOutput = null;
+        }
+        if (this._clipEval) {
+            // TODO: destroy?
+            this._clipEval = undefined;
         }
     }
 

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -306,10 +306,6 @@ export class AnimationState extends Playable {
      * Otherwise, the `update()` is called uniformly by main loop.
      */
     private _passive = false;
-    /**
-     * For internal usage. Really hack...
-     */
-    protected _doNotCreateEval = false;
 
     constructor (clip: AnimationClip, name = '') {
         super();
@@ -332,17 +328,10 @@ export class AnimationState extends Playable {
         return this._curveLoaded;
     }
 
-    public initialize (root: Node, blendStateBuffer?: BlendStateBuffer, mask?: AnimationMask, passive?: boolean) {
+    public initialize (root: Node, blendStateBuffer?: BlendStateBuffer | null, mask?: AnimationMask, passive?: boolean) {
         if (this._curveLoaded) { return; }
         this._curveLoaded = true;
-        if (this._poseOutput) {
-            this._poseOutput.destroy();
-            this._poseOutput = null;
-        }
-        if (this._clipEval) {
-            // TODO: destroy?
-            this._clipEval = undefined;
-        }
+        this.destroyEvaluator();
         this._targetNode = root;
         const clip = this._clip;
 
@@ -361,17 +350,12 @@ export class AnimationState extends Playable {
             this.repeatCount = 1;
         }
 
-        if (!this._doNotCreateEval) {
-            const pose = blendStateBuffer ?? getGlobalAnimationManager()?.blendState ?? null;
-            if (pose) {
-                this._poseOutput = new PoseOutput(pose);
-            }
-            this._clipEval = clip.createEvaluator({
-                target: root,
-                pose: this._poseOutput ?? undefined,
-                mask,
-            });
-        }
+        const pose = blendStateBuffer === null ? null : blendStateBuffer ?? getGlobalAnimationManager().blendState;
+        this.createEvaluator(
+            root,
+            pose,
+            mask,
+        );
 
         if (!(EDITOR && !legacyCC.GAME_VIEW)) {
             this._clipEventEval = clip.createEventEvaluator(this._targetNode);
@@ -385,12 +369,7 @@ export class AnimationState extends Playable {
                 getGlobalAnimationManager().removeAnimation(this);
             }
         }
-        if (this._poseOutput) {
-            this._poseOutput.destroy();
-            this._poseOutput = null;
-        }
-        // TODO: destroy?
-        this._clipEval = undefined!;
+        this.destroyEvaluator();
     }
 
     /**
@@ -523,6 +502,33 @@ export class AnimationState extends Playable {
     protected onPause () {
         this._onPauseOrStop();
         this.emit(EventType.PAUSE, this);
+    }
+
+    protected createEvaluator (
+        root: Node,
+        blendStateBuffer: BlendStateBuffer | null,
+        mask: AnimationMask | undefined,
+    ) {
+        const { clip } = this;
+        if (blendStateBuffer) {
+            this._poseOutput = new PoseOutput(blendStateBuffer);
+        }
+        this._clipEval = clip.createEvaluator({
+            target: root,
+            pose: this._poseOutput ?? undefined,
+            mask,
+        });
+    }
+
+    protected destroyEvaluator () {
+        if (this._poseOutput) {
+            this._poseOutput.destroy();
+            this._poseOutput = null;
+        }
+        if (this._clipEval) {
+            // TODO: destroy?
+            this._clipEval = undefined;
+        }
     }
 
     protected _sampleCurves (time: number) {

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -351,7 +351,7 @@ export class AnimationState extends Playable {
         }
 
         const pose = blendStateBuffer === null ? null : blendStateBuffer ?? getGlobalAnimationManager().blendState;
-        this.createEvaluator(
+        this._createEvaluator(
             root,
             pose,
             mask,
@@ -507,7 +507,7 @@ export class AnimationState extends Playable {
     /**
      * @internal This method only friends to skeletal animation state.
      */
-    protected createEvaluator (
+    protected _createEvaluator (
         root: Node,
         blendStateBuffer: BlendStateBuffer | null,
         mask: AnimationMask | undefined,

--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -504,6 +504,9 @@ export class AnimationState extends Playable {
         this.emit(EventType.PAUSE, this);
     }
 
+    /**
+     * @internal This method only friends to skeletal animation state.
+     */
     protected createEvaluator (
         root: Node,
         blendStateBuffer: BlendStateBuffer | null,

--- a/tests/animation/skeletal-animation.test.ts
+++ b/tests/animation/skeletal-animation.test.ts
@@ -134,6 +134,15 @@ describe('Skeletal animation state', () => {
         childSkinSetUseBakedAnimationMock.mockClear();
 
         // Change to the animation's bake option. Skins are notified.
+        animation_0_0.useBakedAnimation = false;
+        expect(childSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
+        expect(childSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(false);
+        childSkinSetUseBakedAnimationMock.mockClear();
+        expect(anotherChildSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
+        expect(anotherChildSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(false);
+        anotherChildSkinSetUseBakedAnimationMock.mockClear();
+
+        // Change to the animation's bake option. Skins are notified.(Test again)
         animation_0_0.useBakedAnimation = true;
         expect(childSkinSetUseBakedAnimationMock).toBeCalledTimes(1);
         expect(childSkinSetUseBakedAnimationMock.mock.calls[0][0]).toBe(true);
@@ -169,5 +178,23 @@ describe('Skeletal animation state', () => {
         };
 
         scene.destroy();
+    });
+
+    test('Change to setUseBakedAnimation', () => {
+        const node = new Node();
+        const skeletalAnimation = node.addComponent(SkeletalAnimation) as SkeletalAnimation;
+        skeletalAnimation.clips = [new AnimationClip('Anim')];
+        let state = skeletalAnimation.getState('Anim');
+
+        skeletalAnimation.useBakedAnimation = true;
+        expect(skeletalAnimation.getState('Anim') === state);
+
+        skeletalAnimation.useBakedAnimation = false;
+        expect(skeletalAnimation.getState('Anim') !== state);
+        state = skeletalAnimation.getState('Anim');
+
+        skeletalAnimation.useBakedAnimation = true;
+        expect(skeletalAnimation.getState('Anim') !== state);
+        state = skeletalAnimation.getState('Anim');
     });
 });


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#11761

Changelog:
 * [BREAKING CHANGE] Now effectively change to `SkeletalAnimation.prototype.useBakedAnimation` would stop and recreate all animation states.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
