### PR TITLE
Refresh scene when outline or shadow components are removed from nodes

### DIFF
--- a/cocos/2d/components/label-outline.ts
+++ b/cocos/2d/components/label-outline.ts
@@ -126,6 +126,11 @@ export class LabelOutline extends Component {
         this._updateRenderData();
     }
 
+    public onDestroy () {
+        this._enabled = false;
+        this._updateRenderData();
+    }
+
     protected _updateRenderData () {
         const label = this.node.getComponent(Label);
         if (label) {

--- a/cocos/2d/components/label-shadow.ts
+++ b/cocos/2d/components/label-shadow.ts
@@ -140,6 +140,11 @@ export class LabelShadow extends Component {
         this._updateRenderData();
     }
 
+    public onDestroy () {
+        this._enabled = false;
+        this._updateRenderData();
+    }
+
     protected _updateRenderData () {
         const label = this.node.getComponent(Label);
         if (label) {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#11816

Changelog:
 * do updateRenderData in ondestroy when outline or shadow components are removed from nodes

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
