### PR TITLE
Add specular intensity for DCC effects

### DIFF
--- a/editor/assets/chunks/cc-shadow-map-base.chunk
+++ b/editor/assets/chunks/cc-shadow-map-base.chunk
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-2020 Xiamen Yaji Software Co., Ltd.
 
+#include <common>
 #include <cc-global>
 #include <cc-shadow>
 #include <packing>

--- a/editor/assets/chunks/common.chunk
+++ b/editor/assets/chunks/common.chunk
@@ -3,6 +3,7 @@
 // common module
 
 // constant value
+#define HALF_PI      1.57079632679
 #define PI           3.14159265359
 #define INV_PI       0.31830988618
 #define PI2          6.28318530718

--- a/editor/assets/chunks/common.chunk
+++ b/editor/assets/chunks/common.chunk
@@ -3,17 +3,26 @@
 // common module
 
 // constant value
-#define HALF_PI      1.57079632679
-#define PI           3.14159265359
-#define INV_PI       0.31830988618
-#define PI2          6.28318530718
-#define EPSILON      1e-6
-#define EPSILON_LOWP 1e-4
-#define LOG2         1.442695
-#define FP_MAX       65504.0
-#define FP_SCALE     0.0009765625
-#define FP_SCALE_INV 1024.0
-#define GRAY_VECTOR  vec3(0.299, 0.587, 0.114)
+#define QUATER_PI         0.78539816340
+#define HALF_PI           1.57079632679
+#define PI                3.14159265359
+#define PI2               6.28318530718
+#define PI4               12.5663706144
+     
+#define INV_QUATER_PI     1.27323954474
+#define INV_HALF_PI       0.63661977237
+#define INV_PI            0.31830988618
+#define INV_PI2           0.15915494309
+#define INV_PI4           0.07957747155
+     
+#define EPSILON           1e-6
+#define EPSILON_LOWP      1e-4
+#define LOG2              1.442695
+#define EXP_VALUE         2.71828183f
+#define FP_MAX            65504.0
+#define FP_SCALE          0.0009765625
+#define FP_SCALE_INV      1024.0
+#define GRAY_VECTOR       vec3(0.299, 0.587, 0.114)
 
 // common function
 #pragma define saturate(a) clamp(a, 0.0, 1.0)

--- a/editor/assets/chunks/shading-standard-base.chunk
+++ b/editor/assets/chunks/shading-standard-base.chunk
@@ -81,6 +81,7 @@ struct StandardSurface {
   float roughness;
   float metallic;
   float occlusion;
+  float specularIntensity;
 
   #if CC_RECEIVE_SHADOW
     vec2 shadowBias;
@@ -91,7 +92,7 @@ vec4 CCStandardShadingBase (StandardSurface s, vec4 shadowPos) {
   // Calculate diffuse & specular
   vec3 diffuse = s.albedo.rgb * (1.0 - s.metallic);
  
-  vec3 specular = mix(vec3(0.04), s.albedo.rgb, s.metallic);
+  vec3 specular = mix(vec3(0.08 * s.specularIntensity), s.albedo.rgb, s.metallic);
 
   vec3 position;
   HIGHP_VALUE_FROM_STRUCT_DEFINED(position, s.position);

--- a/editor/assets/effects/builtin-billboard.effect.meta
+++ b/editor/assets/effects/builtin-billboard.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "711ebe11-f673-4cd9-9a83-63c60ba54c5b",

--- a/editor/assets/effects/builtin-camera-texture.effect
+++ b/editor/assets/effects/builtin-camera-texture.effect
@@ -66,6 +66,7 @@ CCProgram camera-texture-vs %{
   precision highp float;
   #include <input>
   #include <cc-global>
+  #include <decode-base>
   #include <cc-local-batch>
   #include <input>
 

--- a/editor/assets/effects/builtin-camera-texture.effect.meta
+++ b/editor/assets/effects/builtin-camera-texture.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "bf4078d6-d2d7-4073-83bb-cd6f1802e880",

--- a/editor/assets/effects/builtin-clear-stencil.effect.meta
+++ b/editor/assets/effects/builtin-clear-stencil.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "810e96e4-e456-4468-9b59-f4e8f39732c0",

--- a/editor/assets/effects/builtin-geometry-renderer.effect.meta
+++ b/editor/assets/effects/builtin-geometry-renderer.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "4bb480dd-8384-4bc9-987f-de67cc53052a",

--- a/editor/assets/effects/builtin-graphics.effect.meta
+++ b/editor/assets/effects/builtin-graphics.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "1c02ae6f-4492-4915-b8f8-7492a3b1e4cd",

--- a/editor/assets/effects/builtin-occlusion-query.effect.meta
+++ b/editor/assets/effects/builtin-occlusion-query.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "d9937e59-61fe-4ec6-92ab-7ac5a19c89b0",

--- a/editor/assets/effects/builtin-particle-gpu.effect.meta
+++ b/editor/assets/effects/builtin-particle-gpu.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "971bdb23-3ff6-43eb-b422-1c30165a3663",

--- a/editor/assets/effects/builtin-particle-trail.effect.meta
+++ b/editor/assets/effects/builtin-particle-trail.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "17debcc3-0a6b-4b8a-b00b-dc58b885581e",

--- a/editor/assets/effects/builtin-particle.effect.meta
+++ b/editor/assets/effects/builtin-particle.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "d1346436-ac96-4271-b863-1f4fdead95b0",

--- a/editor/assets/effects/builtin-reflection-deferred.effect
+++ b/editor/assets/effects/builtin-reflection-deferred.effect
@@ -49,6 +49,7 @@ CCProgram standard-vs %{
   precision highp float;
   #include <input-standard>
   #include <cc-global>
+  #include <decode-base>
   #include <cc-local-batch>
   #include <shared-ubos>
   #include <cc-fog-vs>
@@ -215,6 +216,7 @@ CCProgram standard-fs %{
     #endif
     s.occlusion = pbr.x;
     s.roughness = pbr.y;
+    s.specularIntensity = 0.5;
     s.metallic = pbr.z;
 
     s.emissive = emissive.rgb * emissiveScaleParam.xyz;

--- a/editor/assets/effects/builtin-reflection-deferred.effect.meta
+++ b/editor/assets/effects/builtin-reflection-deferred.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "99498f84-efe6-43a6-a9a7-e6e93eb845c1",

--- a/editor/assets/effects/builtin-spine.effect.meta
+++ b/editor/assets/effects/builtin-spine.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "c27215d8-6835-4b68-bfbb-bdeac6100c04",

--- a/editor/assets/effects/builtin-sprite.effect.meta
+++ b/editor/assets/effects/builtin-sprite.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "60f7195c-ec2a-45eb-ba94-8955f60e81d0",

--- a/editor/assets/effects/builtin-standard.effect
+++ b/editor/assets/effects/builtin-standard.effect
@@ -88,6 +88,7 @@ CCProgram standard-vs %{
   precision highp float;
   #include <input-standard>
   #include <cc-global>
+  #include <decode-base>
   #include <cc-local-batch>
   #include <shared-ubos>
   #include <cc-fog-vs>
@@ -287,6 +288,7 @@ CCProgram standard-fs %{
     #endif
     s.occlusion = pbr.x;
     s.roughness = pbr.y;
+    s.specularIntensity = 0.5;
     s.metallic = pbr.z;
 
     s.emissive = emissive.rgb * emissiveScaleParam.xyz;
@@ -301,6 +303,7 @@ CCProgram standard-fs %{
 CCProgram shadow-caster-vs %{
   precision highp float;
   #include <input-standard>
+  #include <decode-base>
   #include <cc-local-batch>
   #include <shared-ubos>
   #include <cc-shadow>

--- a/editor/assets/effects/builtin-standard.effect.meta
+++ b/editor/assets/effects/builtin-standard.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "1baf0fc9-befa-459c-8bdd-af1a450a0319",

--- a/editor/assets/effects/builtin-terrain.effect
+++ b/editor/assets/effects/builtin-terrain.effect
@@ -246,8 +246,11 @@ CCProgram terrain-fs %{
         s.roughness = 1.0;
       #endif
 
+      s.specularIntensity = 0.5;
+
       s.metallic = 0.0;
       #if LAYERS == 1
+        s.specularIntensity = 0.5;
         s.metallic = metallic.x;
       #elif LAYERS == 2
         s.metallic += metallic.x * w.r;
@@ -262,10 +265,12 @@ CCProgram terrain-fs %{
         s.metallic += metallic.z * w.b;
         s.metallic += metallic.w * w.a;
       #else
+        s.specularIntensity = 0.5;
         s.metallic = 0.0;
       #endif
     #else
       s.roughness = 1.0;
+      s.specularIntensity = 0.5;
       s.metallic = 0.0;
     #endif
     s.emissive = vec3(0.0, 0.0, 0.0);

--- a/editor/assets/effects/builtin-terrain.effect.meta
+++ b/editor/assets/effects/builtin-terrain.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "1d08ef62-a503-4ce2-8b9a-46c90873f7d3",

--- a/editor/assets/effects/builtin-toon.effect
+++ b/editor/assets/effects/builtin-toon.effect
@@ -101,6 +101,7 @@ CCProgram toon-vs %{
   precision highp float;
   #include <input-standard>
   #include <cc-global>
+  #include <decode-base>
   #include <cc-local-batch>
   #include <shared-ubos>
   #include <cc-shadow-map-vs>
@@ -263,6 +264,7 @@ CCProgram toon-fs %{
 CCProgram shadow-caster-vs %{
   precision highp float;
   #include <input-standard>
+  #include <decode-base>
   #include <cc-local-batch>
   #include <shared-ubos>
   #include <cc-shadow>

--- a/editor/assets/effects/builtin-toon.effect.meta
+++ b/editor/assets/effects/builtin-toon.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "a7612b54-35e3-4238-a1a9-4a7b54635839",

--- a/editor/assets/effects/builtin-unlit.effect
+++ b/editor/assets/effects/builtin-unlit.effect
@@ -66,6 +66,7 @@ CCProgram unlit-vs %{
   precision highp float;
   #include <input>
   #include <cc-global>
+  #include <decode-base>
   #include <cc-local-batch>
   #include <input>
   #include <cc-fog-vs>

--- a/editor/assets/effects/builtin-unlit.effect.meta
+++ b/editor/assets/effects/builtin-unlit.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "a3cd009f-0ab0-420d-9278-b9fdab939bbc",

--- a/editor/assets/effects/builtin-wireframe.effect.meta
+++ b/editor/assets/effects/builtin-wireframe.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "81127eb0-7556-453c-b147-670782dd5e53",

--- a/editor/assets/effects/editor/gizmo.effect.meta
+++ b/editor/assets/effects/editor/gizmo.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "9d6c6bde-2fe2-44ee-883b-909608948b04",

--- a/editor/assets/effects/editor/grid-2d.effect.meta
+++ b/editor/assets/effects/editor/grid-2d.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "cb2c332a-fa5e-4235-a129-f011634bb7ad",

--- a/editor/assets/effects/editor/grid-stroke.effect.meta
+++ b/editor/assets/effects/editor/grid-stroke.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "4736e978-c8fa-449f-9cf6-fe0158ded9d7",

--- a/editor/assets/effects/editor/grid.effect.meta
+++ b/editor/assets/effects/editor/grid.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "ba35f02e-a81c-464c-bfc5-c788328da667",

--- a/editor/assets/effects/editor/light.effect.meta
+++ b/editor/assets/effects/editor/light.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "e4e4cb19-8dd2-450d-ad20-1a818263b8d3",

--- a/editor/assets/effects/editor/terrain-circle-brush.effect.meta
+++ b/editor/assets/effects/editor/terrain-circle-brush.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "a3e72674-c38f-4336-a285-1826b1799cd7",

--- a/editor/assets/effects/editor/terrain-image-brush.effect.meta
+++ b/editor/assets/effects/editor/terrain-image-brush.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "7a115de7-2d94-4620-8b89-766d7f8cbff9",

--- a/editor/assets/effects/editor/terrain-select-brush.effect.meta
+++ b/editor/assets/effects/editor/terrain-select-brush.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "9b4d3fa5-89bf-4715-b69a-dbbd1efaf6a5",

--- a/editor/assets/effects/pipeline/bloom.effect.meta
+++ b/editor/assets/effects/pipeline/bloom.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "28d6d6b8-3f66-4a73-9795-17a0852ba2d4",

--- a/editor/assets/effects/pipeline/deferred-lighting.effect
+++ b/editor/assets/effects/pipeline/deferred-lighting.effect
@@ -94,6 +94,7 @@ CCProgram lighting-fs %{
     s.position = position;
     s.roughness = normalMap.z;
     s.normal = oct_to_float32x3(normalMap.xy);
+    s.specularIntensity = 0.5;
     s.metallic = normalMap.w;
     s.emissive = emissiveMap.xyz;
     s.occlusion = emissiveMap.w;

--- a/editor/assets/effects/pipeline/deferred-lighting.effect.meta
+++ b/editor/assets/effects/pipeline/deferred-lighting.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "5d45aa00-e064-4938-b314-4265f0c2258c",

--- a/editor/assets/effects/pipeline/planar-shadow.effect
+++ b/editor/assets/effects/pipeline/planar-shadow.effect
@@ -27,6 +27,7 @@ CCProgram planar-shadow-vs %{
   precision highp float;
   #include <input>
   #include <cc-global>
+  #include <decode-base>
   #include <cc-local-batch>
   #include <cc-shadow>
 

--- a/editor/assets/effects/pipeline/planar-shadow.effect.meta
+++ b/editor/assets/effects/pipeline/planar-shadow.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "9361fd90-ba52-4f84-aa93-6e878fd576ca",

--- a/editor/assets/effects/pipeline/post-process.effect.meta
+++ b/editor/assets/effects/pipeline/post-process.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "ec8106fe-05bf-4e94-943c-e0d3b7bb5e45",

--- a/editor/assets/effects/pipeline/skybox.effect.meta
+++ b/editor/assets/effects/pipeline/skybox.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "511d2633-09a7-4bdd-ac42-f778032124b3",

--- a/editor/assets/effects/pipeline/smaa.effect.meta
+++ b/editor/assets/effects/pipeline/smaa.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "6624c63c-0e3d-4d5f-bd15-a7805b71c521",

--- a/editor/assets/effects/pipeline/tonemap.effect.meta
+++ b/editor/assets/effects/pipeline/tonemap.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "31b152ff-f689-4082-a292-3eb5a0b33014",

--- a/editor/assets/effects/util/batched-unlit.effect
+++ b/editor/assets/effects/util/batched-unlit.effect
@@ -33,6 +33,7 @@ CCProgram unlit-vs %{
   precision highp float;
   #include <input>
   #include <cc-global>
+  #include <decode-base>
   #include <cc-local-batch>
 
   // array lengths need to be determined at resource-import-time

--- a/editor/assets/effects/util/batched-unlit.effect.meta
+++ b/editor/assets/effects/util/batched-unlit.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "f1556893-88b6-4c65-8c16-a5256ef3ad25",

--- a/editor/assets/effects/util/profiler.effect.meta
+++ b/editor/assets/effects/util/profiler.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "871c3b6c-7379-419d-bda3-794b239ab90d",

--- a/editor/assets/effects/util/sequence-anim.effect
+++ b/editor/assets/effects/util/sequence-anim.effect
@@ -72,6 +72,7 @@ CCProgram unlit-vs %{
   precision highp float;
   #include <input>
   #include <cc-global>
+  #include <decode-base>
   #include <cc-local-batch>
 
   #if USE_VERTEX_COLOR

--- a/editor/assets/effects/util/sequence-anim.effect.meta
+++ b/editor/assets/effects/util/sequence-anim.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "27cc5a0b-ec0b-4a67-98cf-b42d4fa971de",

--- a/editor/assets/effects/util/splash-screen.effect.meta
+++ b/editor/assets/effects/util/splash-screen.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.5.2",
+  "ver": "1.5.4",
   "importer": "effect",
   "imported": true,
   "uuid": "970b0598-bcb0-4714-91fb-2e81440dccd8",


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Effect data migrates for include decode-base and specular intensity

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.

-->
