### PR TITLE
set V3.5.0 simulator window position to center

### DIFF
--- a/native/tools/simulator/frameworks/runtime-src/Classes/Game.cpp
+++ b/native/tools/simulator/frameworks/runtime-src/Classes/Game.cpp
@@ -41,6 +41,7 @@
 #include "ide-support/RuntimeJsImpl.h"
 #include "runtime/ConfigParser.h"
 #include "runtime/Runtime.h"
+#include "windows.h"
 
 using namespace std;
 Game::Game() {
@@ -53,7 +54,11 @@ Game::~Game() {
 
 int Game::init() {
     SimulatorApp::getInstance()->run();
-    createWindow("My game", 0, 0, SimulatorApp::getInstance()->getWidth(),
+    int windowWidth     = SimulatorApp::getInstance()->getWidth();
+    int windowHeight    = SimulatorApp::getInstance()->getHegith();
+    int windowPositionX = (GetSystemMetrics(SM_CXSCREEN) - windowWidth) / 2;
+    int windowPositionY = (GetSystemMetrics(SM_CYSCREEN) - windowHeight) / 2;
+    createWindow("My game", windowPositionX, windowPositionY, SimulatorApp::getInstance()->getWidth(),
                  SimulatorApp::getInstance()->getHegith(),
                  cc::ISystemWindow::CC_WINDOW_SHOWN |
                      cc::ISystemWindow::CC_WINDOW_RESIZABLE |

--- a/native/tools/simulator/frameworks/runtime-src/Classes/Game.cpp
+++ b/native/tools/simulator/frameworks/runtime-src/Classes/Game.cpp
@@ -33,15 +33,17 @@
 
 #if (CC_PLATFORM == CC_PLATFORM_WINDOWS)
     #include "SimulatorApp.h"
+    #include "windows.h"
 #elif (CC_PLATFORM == CC_PLATFORM_MAC_OSX)
     #include "../proj.ios_mac/mac/SimulatorApp.h"
+    #include <CoreGraphics/CGDisplayConfiguration.h>
 #endif
 
 #include "ide-support/CodeIDESupport.h"
 #include "ide-support/RuntimeJsImpl.h"
 #include "runtime/ConfigParser.h"
 #include "runtime/Runtime.h"
-#include "windows.h"
+
 
 using namespace std;
 Game::Game() {
@@ -56,8 +58,14 @@ int Game::init() {
     SimulatorApp::getInstance()->run();
     int windowWidth     = SimulatorApp::getInstance()->getWidth();
     int windowHeight    = SimulatorApp::getInstance()->getHegith();
+#if (CC_PLATFORM == CC_PLATFORM_WINDOWS)
     int windowPositionX = (GetSystemMetrics(SM_CXSCREEN) - windowWidth) / 2;
     int windowPositionY = (GetSystemMetrics(SM_CYSCREEN) - windowHeight) / 2;
+#elif (CC_PLATFORM == CC_PLATFORM_MAC_OSX)
+    auto mainDisplayId = CGMainDisplayID();
+    int windowPositionX = (CGDisplayPixelsWide(mainDisplayId) - windowWidth) / 2;
+    int windowPositionY = (CGDisplayPixelsHigh(mainDisplayId) - windowHeight) / 2;
+#endif
     createWindow("My game", windowPositionX, windowPositionY, SimulatorApp::getInstance()->getWidth(),
                  SimulatorApp::getInstance()->getHegith(),
                  cc::ISystemWindow::CC_WINDOW_SHOWN |


### PR DESCRIPTION
* On Windows, simulator's position will be on top-left without control bar, so reset it to center for better behavior. apply change for mac too.