### PR TITLE
[v3.5.0] disable post-process alpha blend

### DIFF
--- a/editor/assets/effects/pipeline/post-process.effect
+++ b/editor/assets/effects/pipeline/post-process.effect
@@ -11,11 +11,11 @@ CCEffect %{
         depthWrite: false
       blendState:
         targets:
-        - blend: true
-          blendSrc: src_alpha
-          blendDst: one_minus_src_alpha
-          blendSrcAlpha: src_alpha
-          blendDstAlpha: one_minus_src_alpha
+        - blend: false
+          blendSrc: one
+          blendDst: zero
+          blendSrcAlpha: one
+          blendDstAlpha: zero
 }%
 
 CCProgram post-process-vs %{


### PR DESCRIPTION
alpha blend is not needed. there is nothing in the background