### PR TITLE
fix:set skeleton data, _cachedSockets should be reset

### DIFF
--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -778,6 +778,7 @@ const cacheManager = require('./jsb-cache-manager');
             this.skeletonData.init();
             this.setSkeletonData(this.skeletonData);
 
+            this._indexBoneSockets();
             this.attachUtil.init(this);
             this._preCacheMode = this._cacheMode;
 


### PR DESCRIPTION
原生端在设置skeleton data 后应重置cached sockets列表