### PR TITLE
exclude arm64 arch and specify x86_64 for iosimulator by default

### DIFF
--- a/native/templates/cmake/apple.cmake
+++ b/native/templates/cmake/apple.cmake
@@ -55,6 +55,13 @@ macro(cc_ios_after_target target_name)
         XCODE_ATTRIBUTE_SKIP_INSTALL NO
         XCODE_ATTRIBUTE_INSTALL_PATH "$(LOCAL_APPS_DIR)"
     )
+    ## exclude arm64 arch and specify x86_64 for iphonesimulator by default, this will apply to both target.
+    set(CMAKE_XCODE_ATTRIBUTE_EXCLUDED_ARCHS[sdk=iphonesimulator*] "arm64")
+    set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphoneos*] "arm64")
+    set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphonesimulator*] "x86_64")
+    set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphoneos*] "arm64")
+    set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphonesimulator*] "x86_64")
+    
     target_link_libraries(${target_name} cocos2d)
 
     target_include_directories(${target_name} PRIVATE


### PR DESCRIPTION
This will ignore the link error for m1 mac when it tries to compile the application for the arm64 simulator

### Added:

It's actually not a solution, but a way to skip the problem that we might meet on M1 Mac, can keep watch with this [issue](https://github.com/cocos/cocos-engine/issues/10663) for more details.

Once we specify the architecture for the project, Xcode can only build apps for the x86_64 iPhone simulator and arm64 iPhone(up to now that's what we should support). 

Normally we should make it work by using xcframework, but since we build the project by CMake, it's hard to make it work.

Also, this modification will apply to cocos2d and app, otherwise link error will be produced.