### PR TITLE
Fix native module override

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -53,7 +53,7 @@
                 "cocos/core/gfx/pipeline-state.ts": "cocos/core/gfx/pipeline-state.jsb.ts",
                 "cocos/spine/index.ts": "cocos/spine/index.jsb.ts",
                 "cocos/dragon-bones/index.ts": "cocos/dragon-bones/index.jsb.ts",
-                "cocos/core/renderer/scene/native-scene.ts": "cocos/core/renderer/scene/native-scene.jsb.ts",
+                "cocos/core/renderer/native-scene.ts": "cocos/core/renderer/native-scene.jsb.ts",
                 "cocos/physics/physx/instantiate.ts": "cocos/physics/physx/instantiate.jsb.ts",
                 "cocos/core/math/vec3.ts": "cocos/core/math/vec3.jsb.ts",
                 "cocos/core/math/quat.ts": "cocos/core/math/quat.jsb.ts",


### PR DESCRIPTION
caused by [#10643](https://github.com/cocos-creator/engine/issues/10643)