### PR TITLE
fix the performance issue caused by texture mipmap

### DIFF
--- a/cocos/core/assets/simple-texture.ts
+++ b/cocos/core/assets/simple-texture.ts
@@ -76,7 +76,7 @@ export class SimpleTexture extends TextureBase {
     private _textureHeight = 0;
 
     protected _baseLevel = 0;
-    protected _maxLevel = 0;
+    protected _maxLevel = 1000;
 
     /**
      * @en The mipmap level of the texture
@@ -205,15 +205,13 @@ export class SimpleTexture extends TextureBase {
     }
 
     protected _setMipRange (baseLevel: number, maxLevel: number) {
-        this._baseLevel = baseLevel < 0 ? 0 : baseLevel;
-        this._baseLevel = this._baseLevel < this._mipmapLevel ? this._baseLevel : this._mipmapLevel - 1;
-
-        this._maxLevel = maxLevel < this._baseLevel ? this._baseLevel : maxLevel;
-        this._maxLevel = this._maxLevel < this._mipmapLevel ? this._maxLevel : this._mipmapLevel - 1;
+        this._baseLevel = baseLevel < 1 ? 0 : baseLevel;
+        this._maxLevel = maxLevel < 1 ? 0 : maxLevel;
     }
 
     /**
-     * Set mipmap level range for this texture.
+     * @en Set mipmap level range for this texture.
+     * @zh 设置当前贴图的 mipmap 范围。
      * @param baseLevel The base mipmap level.
      * @param maxLevel The maximum mipmap level.
      */
@@ -291,11 +289,12 @@ export class SimpleTexture extends TextureBase {
         if (!this._gfxTexture) {
             return;
         }
+        const maxLevel = this._maxLevel < this._mipmapLevel ? this._maxLevel : this._mipmapLevel - 1;
         const textureViewCreateInfo = this._getGfxTextureViewCreateInfo({
             texture: this._gfxTexture,
             format: this._getGFXFormat(),
             baseLevel: this._baseLevel,
-            levelCount: this._maxLevel - this._baseLevel + 1,
+            levelCount: maxLevel - this._baseLevel + 1,
         });
         if (!textureViewCreateInfo) {
             return;

--- a/cocos/core/assets/texture-2d.ts
+++ b/cocos/core/assets/texture-2d.ts
@@ -79,7 +79,7 @@ export interface ITexture2DCreateInfo {
     /**
      * @en The selected maximum mipmap level
      * @zh 选择使用的最大 mipmap 层级。
-     * @default 1
+     * @default 1000
      */
     maxLevel?: number;
 }
@@ -169,8 +169,8 @@ export class Texture2D extends SimpleTexture {
         this._setGFXFormat(info.format);
         const mipLevels = info.mipmapLevel === undefined ? 1 : info.mipmapLevel;
         this._setMipmapLevel(mipLevels);
-        const minLod = info.baseLevel || 0;
-        const maxLod = info.maxLevel === undefined ? (mipLevels - 1) : info.maxLevel;
+        const minLod = info.baseLevel === undefined ? 1 : info.baseLevel;
+        const maxLod = info.maxLevel === undefined ? 1000 : info.maxLevel;
         this._setMipRange(minLod, maxLod);
         this._tryReset();
     }
@@ -188,7 +188,7 @@ export class Texture2D extends SimpleTexture {
      * @param maxLevel Mipmap maximum level
      * @deprecated since v1.0 please use [[reset]] instead
      */
-    public create (width: number, height: number, format = PixelFormat.RGBA8888, mipmapLevel = 1, baseLevel = 0, maxLevel = 0) {
+    public create (width: number, height: number, format = PixelFormat.RGBA8888, mipmapLevel = 1, baseLevel = 0, maxLevel = 1000) {
         this.reset({
             width,
             height,

--- a/cocos/core/assets/texture-2d.ts
+++ b/cocos/core/assets/texture-2d.ts
@@ -169,7 +169,7 @@ export class Texture2D extends SimpleTexture {
         this._setGFXFormat(info.format);
         const mipLevels = info.mipmapLevel === undefined ? 1 : info.mipmapLevel;
         this._setMipmapLevel(mipLevels);
-        const minLod = info.baseLevel === undefined ? 1 : info.baseLevel;
+        const minLod = info.baseLevel === undefined ? 0 : info.baseLevel;
         const maxLod = info.maxLevel === undefined ? 1000 : info.maxLevel;
         this._setMipRange(minLod, maxLod);
         this._tryReset();

--- a/cocos/core/assets/texture-cube.ts
+++ b/cocos/core/assets/texture-cube.ts
@@ -195,8 +195,8 @@ export class TextureCube extends SimpleTexture {
         this._setGFXFormat(info.format);
         const mipLevels = info.mipmapLevel === undefined ? 1 : info.mipmapLevel;
         this._setMipmapLevel(mipLevels);
-        const minLod = info.baseLevel || 0;
-        const maxLod = info.maxLevel === undefined ? (mipLevels - 1) : info.maxLevel;
+        const minLod = info.baseLevel === undefined ? 1 : info.baseLevel;
+        const maxLod = info.maxLevel === undefined ? 1000 : info.maxLevel;
         this._setMipRange(minLod, maxLod);
         this._tryReset();
     }

--- a/cocos/core/assets/texture-cube.ts
+++ b/cocos/core/assets/texture-cube.ts
@@ -195,7 +195,7 @@ export class TextureCube extends SimpleTexture {
         this._setGFXFormat(info.format);
         const mipLevels = info.mipmapLevel === undefined ? 1 : info.mipmapLevel;
         this._setMipmapLevel(mipLevels);
-        const minLod = info.baseLevel === undefined ? 1 : info.baseLevel;
+        const minLod = info.baseLevel === undefined ? 0 : info.baseLevel;
         const maxLod = info.maxLevel === undefined ? 1000 : info.maxLevel;
         this._setMipRange(minLod, maxLod);
         this._tryReset();


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 

The default mipmap level range of `Texture2D` and `TextureCube` was [0, 1), which caused a serious performance issue.
This pr changed it so that all mipmaps will be included by default.
