### PR TITLE
bypass the bug that vulkan destroys resources that are still in use.

### DIFF
--- a/cocos/core/assets/simple-texture.ts
+++ b/cocos/core/assets/simple-texture.ts
@@ -226,8 +226,11 @@ export class SimpleTexture extends TextureBase {
         if (!device) {
             return;
         }
+        // create a new texture view before the destruction of the previous one to bypass the bug that
+        // vulkan destroys textureview in use. This is a temporary solution, should be fixed later.
+        const textureView = this._createTextureView(device);
         this._tryDestroyTextureView();
-        this._createTextureView(device);
+        this._gfxTextureView = textureView;
     }
 
     /**
@@ -259,7 +262,7 @@ export class SimpleTexture extends TextureBase {
             return;
         }
         this._createTexture(device);
-        this._createTextureView(device);
+        this._gfxTextureView = this._createTextureView(device);
     }
 
     protected _createTexture (device: Device) {
@@ -287,9 +290,9 @@ export class SimpleTexture extends TextureBase {
         this._gfxTexture = texture;
     }
 
-    protected _createTextureView (device: Device) {
+    protected _createTextureView (device: Device) : Texture | null {
         if (!this._gfxTexture) {
-            return;
+            return null;
         }
         const textureViewCreateInfo = this._getGfxTextureViewCreateInfo({
             texture: this._gfxTexture,
@@ -298,11 +301,10 @@ export class SimpleTexture extends TextureBase {
             levelCount: this._maxLevel - this._baseLevel + 1,
         });
         if (!textureViewCreateInfo) {
-            return;
+            return null;
         }
 
-        const textureView = device.createTexture(textureViewCreateInfo);
-        this._gfxTextureView = textureView;
+        return device.createTexture(textureViewCreateInfo);
     }
 
     protected _tryDestroyTexture () {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#11829

Changelog:
 * 

This pr bypass the bug that Vulkan destroys resources that are still in use. If the pointer to the texture view equals the pointer to the previous one, the descriptor will not be updated. So creating a new resource before destroying the old one will solve the problem. It is a temporary solution.