### PR TITLE
Fixed: Return type of `set` is `any` in vec3 and some types

### DIFF
--- a/cocos/core/math/mat3.ts
+++ b/cocos/core/math/mat3.ts
@@ -726,7 +726,7 @@ export class Mat3 extends ValueType {
      * @param other Specified matrix
      * @return this
      */
-    public set (other: Mat3);
+    public set (other: Mat3): Mat3;
 
     /**
      * @en Set the matrix with values of all elements
@@ -735,7 +735,7 @@ export class Mat3 extends ValueType {
      */
     public set (m00?: number, m01?: number, m02?: number,
         m03?: number, m04?: number, m05?: number,
-        m06?: number, m07?: number, m08?: number);
+        m06?: number, m07?: number, m08?: number): Mat3;
 
     public set (m00: number | Mat3 = 1, m01 = 0, m02 = 0,
         m03 = 0, m04 = 1, m05 = 0,

--- a/cocos/core/math/mat4.ts
+++ b/cocos/core/math/mat4.ts
@@ -1549,7 +1549,7 @@ export class Mat4 extends ValueType {
      * @param other Specified matrix.
      * @return this
      */
-    public set (other: Mat4);
+    public set (other: Mat4): Mat4;
 
     /**
      * @en Set the matrix with values of all elements
@@ -1560,7 +1560,7 @@ export class Mat4 extends ValueType {
         m00?: number, m01?: number, m02?: number, m03?: number,
         m04?: number, m05?: number, m06?: number, m07?: number,
         m08?: number, m09?: number, m10?: number, m11?: number,
-        m12?: number, m13?: number, m14?: number, m15?: number);
+        m12?: number, m13?: number, m14?: number, m15?: number): Mat4;
 
     public set (m00: Mat4 | number = 1, m01 = 0, m02 = 0, m03 = 0,
         m04 = 0, m05 = 1, m06 = 0, m07 = 0,

--- a/cocos/core/math/vec2.ts
+++ b/cocos/core/math/vec2.ts
@@ -475,7 +475,7 @@ export class Vec2 extends ValueType {
      * @param other Specified vector
      * @return `this`
      */
-    public set (other: Vec2);
+    public set (other: Vec2): Vec2;
 
     /**
      * @en Set the value of each component of the current vector.
@@ -484,7 +484,7 @@ export class Vec2 extends ValueType {
      * @param y y value
      * @return `this`
      */
-    public set (x?: number, y?: number);
+    public set (x?: number, y?: number): Vec2;
 
     public set (x?: number | Vec2, y?: number) {
         if (x && typeof x === 'object') {

--- a/cocos/core/math/vec3.ts
+++ b/cocos/core/math/vec3.ts
@@ -719,7 +719,7 @@ export class Vec3 extends ValueType {
      * @param other Specified vector
      * @returns `this`
      */
-    public set (other: Vec3);
+    public set (other: Vec3): Vec3;
 
     /**
      * @en Set the value of each component of the current vector.
@@ -729,7 +729,7 @@ export class Vec3 extends ValueType {
      * @param z z value
      * @returns `this`
      */
-    public set (x?: number, y?: number, z?: number);
+    public set (x?: number, y?: number, z?: number): Vec3;
 
     public set (x?: number | Vec3, y?: number, z?: number) {
         if (x && typeof x === 'object') {

--- a/cocos/core/math/vec4.ts
+++ b/cocos/core/math/vec4.ts
@@ -538,7 +538,7 @@ export class Vec4 extends ValueType {
      * @param other Specified vector
      * @returns `this`
      */
-    public set (other: Vec4);
+    public set (other: Vec4): Vec4;
 
     /**
      * @en Set the value of each component of the current vector.
@@ -549,7 +549,7 @@ export class Vec4 extends ValueType {
      * @param w w value
      * @returns `this`
      */
-    public set (x?: number, y?: number, z?: number, w?: number);
+    public set (x?: number, y?: number, z?: number, w?: number): Vec4;
 
     public set (x?: number | Vec4, y?: number, z?: number, w?: number) {
         if (x && typeof x === 'object') {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * Fixed: Return type of `set` method is `any` in `Vec2` `Vec3` `Vec4` `Quat` `Mat3` and `Mat4`