### PR TITLE
Combine hash with validator/agent

### DIFF
--- a/native/cocos/renderer/gfx-base/GFXDef.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDef.cpp
@@ -113,12 +113,14 @@ bool operator==(const RenderPassInfo& lhs, const RenderPassInfo& rhs) {
 template <>
 size_t Hasher<FramebufferInfo>::operator()(const FramebufferInfo& info) const {
     // render pass is mostly irrelevant
-    size_t seed = (info.colorTextures.size() + 1) * 2;
+    size_t seed = (info.colorTextures.size() + 1) * 3;
     for (auto* colorTexture : info.colorTextures) {
+        boost::hash_combine(seed, colorTexture);
         boost::hash_combine(seed, colorTexture->getRaw());
         boost::hash_combine(seed, colorTexture->getHash());
     }
 
+    boost::hash_combine(seed, info.depthStencilTexture);
     boost::hash_combine(seed, info.depthStencilTexture->getRaw());
     boost::hash_combine(seed, info.depthStencilTexture->getHash());
     return seed;


### PR DESCRIPTION
While the texture is destroyed, the old validator is destroyed and new validator inited.

But framebuffer validator maintains the old one as hash is the same, so when it start the validation check, the old texture validator jumped out and assertion failed.