### PR TITLE
Add member method declaration of appdelegate

### DIFF
--- a/native/cocos/platform/mac/AppDelegate.h
+++ b/native/cocos/platform/mac/AppDelegate.h
@@ -26,5 +26,10 @@
 #import <Cocoa/Cocoa.h>
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
-
+- (void)applicationDidFinishLaunching:(NSNotification*)aNotification;
+- (void)windowWillMiniaturizeNotification;
+- (void)windowDidDeminiaturizeNotification;
+- (void)windowWillCloseNotification;
+- (void)applicationWillTerminate:(NSNotification*)aNotification;
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)theApplication;
 @end


### PR DESCRIPTION
If appdelegate is to be inherited and overridden some member methods, it needs to be declared in the header file. Otherwise there will be a warning.

This declaration does not affect other functions
Just to allow developers to rewrite the interface after inheriting appdelegate