### PR TITLE
Fix restart game will create several swapchain

### DIFF
--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -252,6 +252,7 @@ int32_t Engine::restartVM() {
     _scheduler->unscheduleAll();
 
     scriptEngine->cleanup();
+    cc::gfx::DeviceManager::destroy();
     cc::EventDispatcher::destroy();
     // remove all listening events
     offAll();


### PR DESCRIPTION
codes aren't sync with 3.4.2 *https://github.com/cocos/engine-native/pull/4008

The reason why we should destroy here is that the swapchain is created by js binding, yet once restart it will create again, after that multiple swapchain will exist at same time. And only happens on Native platform 