### PR TITLE
validate the AABB buffer in texture.bounds

### DIFF
--- a/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-utils.ts
@@ -199,7 +199,18 @@ export class JointTexturePool {
     public getDefaultPoseTexture (skeleton: Skeleton, mesh: Mesh, skinningRoot: Node) {
         const hash = skeleton.hash ^ 0; // may not equal to skeleton.hash
         let texture: IJointTextureHandle | null = this._textureBuffers.get(hash) || null;
-        if (texture && texture.bounds.has(mesh.hash)) { texture.refCount++; return texture; }
+        if (texture && texture.bounds.has(mesh.hash)) {
+            if (JSB) {
+                for (let i = 0; i < texture.bounds.get(mesh.hash)!.length; i++) {
+                    if (!texture.bounds.get(mesh.hash)![i].isNativeObjValid) {
+                        delete texture.bounds.get(mesh.hash)![i];
+                        texture?.bounds.get(mesh.hash)?.splice(i, 1);
+                    }
+                }
+            }
+            texture.refCount++;
+            return texture;
+        }
         const { joints, bindposes } = skeleton;
         let textureBuffer: Float32Array = null!; let buildTexture = false;
         const jointCount = joints.length;
@@ -257,7 +268,18 @@ export class JointTexturePool {
     public getSequencePoseTexture (skeleton: Skeleton, clip: AnimationClip, mesh: Mesh, skinningRoot: Node) {
         const hash = skeleton.hash ^ clip.hash;
         let texture: IJointTextureHandle | null = this._textureBuffers.get(hash) || null;
-        if (texture && texture.bounds.has(mesh.hash)) { texture.refCount++; return texture; }
+        if (texture && texture.bounds.has(mesh.hash)) {
+            if (JSB) {
+                for (let i = 0; i < texture.bounds.get(mesh.hash)!.length; i++) {
+                    if (!texture.bounds.get(mesh.hash)![i].isNativeObjValid) {
+                        delete texture.bounds.get(mesh.hash)![i];
+                        texture?.bounds.get(mesh.hash)?.splice(i, 1);
+                    }
+                }
+            }
+            texture.refCount++;
+            return texture;
+        }
         const { joints, bindposes } = skeleton;
         const clipData = SkelAnimDataHub.getOrExtract(clip);
         const { frames } = clipData;

--- a/cocos/core/geometry/aabb.ts
+++ b/cocos/core/geometry/aabb.ts
@@ -214,10 +214,14 @@ export class AABB {
     get type () {
         return this._type;
     }
-
+    get isNativeObjValid () {
+        return this._isNativeObjValid;
+    }
+    protected _isNativeObjValid = false;
     protected readonly _type: number;
     protected _aabbHandle: AABBHandle = NULL_HANDLE;
     protected declare _nativeObj: NativeAABB;
+
     constructor (px = 0, py = 0, pz = 0, hw = 1, hh = 1, hl = 1) {
         this._type = enums.SHAPE_AABB;
         if (JSB) {
@@ -229,6 +233,7 @@ export class AABB {
             this.halfExtents.set(hw, hh, hl);
             this._nativeObj = new NativeAABB();
             this._nativeObj.initWithData(AABBPool.getBuffer(this._aabbHandle));
+            this._isNativeObjValid = true;
             return;
         }
         this.center = new Vec3(px, py, pz);
@@ -337,6 +342,7 @@ export class AABB {
     public destroy () {
         if (JSB) {
             AABBPool.free(this._aabbHandle);
+            this._isNativeObjValid = false;
         }
     }
 }


### PR DESCRIPTION
As the AABB might be released with the last destroyed model, the buffer here might be invalid, because nativeobj is actually nothing.

Thus add a flag to signify if aabb's native obj is valid or not.