### PR TITLE
assign underline initial value in richtext

### DIFF
--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -114,6 +114,7 @@ function getSegmentByPool (type: string, content: string | SpriteFrame) {
         seg.comp.string = content as string;
         seg.comp.horizontalAlign = HorizontalTextAlignment.LEFT;
         seg.comp.verticalAlign = VerticalTextAlignment.TOP;
+        seg.comp.underlineHeight = 2;
     }
     node.setPosition(0, 0, 0);
     const trans = node._uiProps.uiTransformComp!;


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/10743

Changelog:
 * assign underline initial value when label segments are contructed in richtext

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.
-->