### PR TITLE
Circular references should cause workflow failed

### DIFF
--- a/.github/workflows/build-problem-matcher.json
+++ b/.github/workflows/build-problem-matcher.json
@@ -2,7 +2,7 @@
 {
     "problemMatcher": [
         {
-            "owner": "circular-reference-check",
+            "owner": "<Web> build",
             "pattern": [
                 {
                     "regexp": "^Circular dependency: (.*)$",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,19 +57,28 @@ gulp.task('build-h5-source', gulp.series('build-debug-infos', async () => {
     await fs.ensureDir(outDir);
     await fs.emptyDir(outDir);
     const cli = require.resolve('@cocos/build-engine/dist/cli');
-    return cp.spawn('node', [
-        cli,
-        `--engine=${__dirname}`,
-        '--module=system',
-        '--build-mode=BUILD',
-        '--platform=HTML5',
-        '--physics=cannon',
-        `--out=${outDir}`,
-    ], {
-        shell: true,
-        stdio: 'inherit',
-        cwd: __dirname,
+    const exitCode = await new Promise((resolve, reject) => {
+        cp.spawn('node', [
+            cli,
+            `--engine=${__dirname}`,
+            '--module=system',
+            '--build-mode=BUILD',
+            '--platform=HTML5',
+            '--physics=cannon',
+            `--out=${outDir}`,
+        ], {
+            shell: true,
+            stdio: 'inherit',
+            cwd: __dirname,
+        }).on('exit', (code) => {
+            resolve(code);
+        }).on('error', (err) => {
+            reject(err);
+        });
     });
+    if (exitCode) {
+        throw new Error(`Build process exit with ${exitCode}`);
+    }
 }));
 
 gulp.task('build-h5-minified', gulp.series('build-debug-infos', async () => {


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- To official teams:
  - [ ] Check that your javascript is following our [style guide](https://github.com/cocos-creator/fireball/blob/dev/.github/CONTRIBUTING.md) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any runtime log information in `cc.log` , `cc.error` or `new Error('')` has been moved into `DebugInfos.js` with an ID, and use `cc.logID(id)` or `new Error(cc._getErrorID(id))` instead.
-->