### PR TITLE
fix debug crash problem

### DIFF
--- a/native/cocos/renderer/pipeline/deferred/GbufferStage.cpp
+++ b/native/cocos/renderer/pipeline/deferred/GbufferStage.cpp
@@ -205,9 +205,9 @@ void GbufferStage::render(scene::Camera *camera) {
             static_cast<uint>(pipeline->getWidth() * shadingScale),
             static_cast<uint>(pipeline->getHeight() * shadingScale),
         };
-        if (_device->getGfxAPI() == gfx::API::VULKAN) { // TODO(Zhenglong Zhou): remove platform dependent settings
-            depthTexInfo.usage |= gfx::TextureUsageBit::INPUT_ATTACHMENT;
-        }
+
+        depthTexInfo.usage |= gfx::TextureUsageBit::INPUT_ATTACHMENT;
+
         data.depth = builder.create(DeferredPipeline::fgStrHandleOutDepthTexture, depthTexInfo);
 
         framegraph::RenderTargetAttachment::Descriptor depthInfo;


### PR DESCRIPTION
fix issue: https://github.com/cocos/3d-tasks/issues/12116
fix debug validation problem by enable input attachment for all platforms.

There are mainly 2 problems:
1.  Currently only one shader descriptor layout can be used across various platforms. As a result, it is impossible to implement certain algorithms.

e.g.
vulkan support color and depth texture as input attachment
gles3 arm_fbf support color and depth as input attachment
gles3 ext_fbf  support color as input attachment
metal support color as input attachment
webgl does not support input attachment.

As a result, at least 4 kinds of descriptor layout are needed to correctly implement deferred lighting. 
Currently implementation might cause gfx validation failure.

2. Currently, the type of descriptor is inferred from both material and resource usage. As a result, the side effect of bindTexture is hard to estimate. Users might be surprised when the shader asset is changed by accident.

Changelog:
 * enable input attachment for all platforms.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->