### PR TITLE
Remove the MEMORY_ALIASING feature introduced by accident.

### DIFF
--- a/native/cocos/renderer/gfx-base/GFXDef-common.h
+++ b/native/cocos/renderer/gfx-base/GFXDef-common.h
@@ -153,7 +153,6 @@ enum class Feature : uint32_t {
     INSTANCED_ARRAYS,
     MULTIPLE_RENDER_TARGETS,
     BLEND_MINMAX,
-    MEMORY_ALIASING,
     COMPUTE_SHADER,
     // This flag indicates whether the device can benefit from subpass-style usages.
     // Specifically, this only differs on the GLES backends: the Framebuffer Fetch


### PR DESCRIPTION
Re: #

Changelog:
 * Remove the MEMORY_ALIASING feature introduced by accident.
