### PR TITLE
fix PhysicsPolygonCollider parse error.

### DIFF
--- a/cocos2d/core/physics/CCPolygonSeparator.js
+++ b/cocos2d/core/physics/CCPolygonSeparator.js
@@ -68,14 +68,14 @@ function ConvexPartition(vertices) {
     var list = [];
     var d, lowerDist, upperDist;
     var p;
-    var lowerInt = cc.v2();
-    var upperInt = cc.v2(); // intersection points
+    var lowerInt = null;
+    var upperInt = null; // intersection points
     var lowerIndex = 0, upperIndex = 0;
     var lowerPoly, upperPoly;
     
     for (var i = 0; i < vertices.length; ++i) {
         if (Reflex(i, vertices)) {
-            lowerDist = upperDist = 10e7; // std::numeric_limits<qreal>::max();
+            lowerDist = upperDist = Number.MAX_SAFE_INTEGER || 9999999999999; // std::numeric_limits<qreal>::max();
             for (var j = 0; j < vertices.length; ++j) {
                 // if line intersects with an edge
                 if (Left(At(i - 1, vertices), At(i, vertices), At(j, vertices)) &&


### PR DESCRIPTION
Fix cc.PhysicsPolygonCollider error, The distance restriction causes the lower point value to not be calculated, and the lower 
 point value default is {x: 0, y: 0}, which by default is the exception data, leading to the following lowerInt.add(upperInt).div(2); exception. For more information please see the source code.

``` shell
CCPolygonSeparator.js:337 Uncaught TypeError: Cannot read properties of undefined (reading 'x')
    at Area (CCPolygonSeparator.js:337:14)
    at Right (CCPolygonSeparator.js:219:12)
    at Reflex (CCPolygonSeparator.js:207:12)
    at ConvexPartition (CCPolygonSeparator.js:77:13)
    at ConvexPartition (CCPolygonSeparator.js:154:33)
    at ConvexPartition (CCPolygonSeparator.js:154:33)
    at Object.ConvexPartition (CCPolygonSeparator.js:154:33)
    at cc_PhysicsPolygonCollider._createShape (CCPhysicsPolygonCollider.js:56:38)
    at cc_PhysicsPolygonCollider.__init (CCPhysicsCollider.js:173:65)
    at CCClass.pushDelayEvent (CCPhysicsManager.js:165:26)
```

Test Project:
[box2d-box2.zip](https://github.com/cocos/cocos-engine/files/8562580/box2d-box2.zip)

