### PR TITLE
Add the support of `texture2DArray` and `texture3D`.

### DIFF
--- a/cocos/core/gfx/base/define.ts
+++ b/cocos/core/gfx/base/define.ts
@@ -719,6 +719,8 @@ export class DeviceCaps {
         public maxUniformBlockSize: number = 0,
         public maxTextureSize: number = 0,
         public maxCubeMapTextureSize: number = 0,
+        public maxArrayTextureLayers: number = 0,
+        public max3DTextureSize: number = 0,
         public uboOffsetAlignment: number = 1,
         public maxComputeSharedMemorySize: number = 0,
         public maxComputeWorkGroupInvocations: number = 0,
@@ -744,6 +746,8 @@ export class DeviceCaps {
         this.maxUniformBlockSize = info.maxUniformBlockSize;
         this.maxTextureSize = info.maxTextureSize;
         this.maxCubeMapTextureSize = info.maxCubeMapTextureSize;
+        this.maxArrayTextureLayers = info.maxArrayTextureLayers;
+        this.max3DTextureSize = info.max3DTextureSize;
         this.uboOffsetAlignment = info.uboOffsetAlignment;
         this.maxComputeSharedMemorySize = info.maxComputeSharedMemorySize;
         this.maxComputeWorkGroupInvocations = info.maxComputeWorkGroupInvocations;

--- a/cocos/core/gfx/webgl/webgl-device.ts
+++ b/cocos/core/gfx/webgl/webgl-device.ts
@@ -147,7 +147,8 @@ export class WebGLDevice extends Device {
         this._caps.maxVertexTextureUnits = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
         this._caps.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         this._caps.maxCubeMapTextureSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
-
+        this._caps.maxArrayTextureLayers = 0;
+        this._caps.max3DTextureSize = 0;
         // WebGL doesn't support UBOs at all, so here we return
         // the guaranteed minimum number of available bindings in WebGL2
         this._caps.maxUniformBufferBindings = 16;

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1085,8 +1085,11 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
         gpuTexture.glTarget = gl.TEXTURE_2D_ARRAY;
 
         const maxSize = Math.max(w, h);
-        if (maxSize > device.capabilities.maxTextureSize || l > device.capabilities.maxArrayTextureLayers) {
+        if (maxSize > device.capabilities.maxTextureSize) {
             errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        }
+        if (l > device.capabilities.maxArrayTextureLayers) {
+            errorID(9100, l, device.capabilities.maxArrayTextureLayers);
         }
 
         gpuTexture.glTexture = gl.createTexture();
@@ -1115,9 +1118,9 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
     case TextureType.TEX3D: {
         gpuTexture.glTarget = gl.TEXTURE_3D;
 
-        const maxSize = Math.max(w, h);
-        if (maxSize > device.capabilities.maxTextureSize) {
-            errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        const maxSize = Math.max(Math.max(w, h), d);
+        if (maxSize > device.capabilities.max3DTextureSize) {
+            errorID(9100, maxSize, device.capabilities.max3DTextureSize);
         }
 
         gpuTexture.glTexture = gl.createTexture();
@@ -1268,8 +1271,11 @@ export function WebGL2CmdFuncResizeTexture (device: WebGL2Device, gpuTexture: IW
         gpuTexture.glTarget = gl.TEXTURE_2D_ARRAY;
 
         const maxSize = Math.max(w, h);
-        if (maxSize > device.capabilities.maxCubeMapTextureSize) {
+        if (maxSize > device.capabilities.maxTextureSize) {
             errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        }
+        if (l > device.capabilities.maxArrayTextureLayers) {
+            errorID(9100, l, device.capabilities.maxArrayTextureLayers);
         }
 
         gpuTexture.glTexture = gl.createTexture();
@@ -1298,9 +1304,9 @@ export function WebGL2CmdFuncResizeTexture (device: WebGL2Device, gpuTexture: IW
     case TextureType.TEX3D: {
         gpuTexture.glTarget = gl.TEXTURE_3D;
 
-        const maxSize = Math.max(w, h);
-        if (maxSize > device.capabilities.maxCubeMapTextureSize) {
-            errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        const maxSize = Math.max(Math.max(w, h), d);
+        if (maxSize > device.capabilities.max3DTextureSize) {
+            errorID(9100, maxSize, device.capabilities.max3DTextureSize);
         }
 
         gpuTexture.glTexture = gl.createTexture();

--- a/cocos/core/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/core/gfx/webgl2/webgl2-commands.ts
@@ -1032,6 +1032,8 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
 
     let w = gpuTexture.width;
     let h = gpuTexture.height;
+    const d = gpuTexture.depth;
+    const l = gpuTexture.arrayLayer;
 
     switch (gpuTexture.type) {
     case TextureType.TEX2D: {
@@ -1075,6 +1077,68 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
 
                 gl.renderbufferStorageMultisample(gl.RENDERBUFFER, gpuTexture.samples,
                     gpuTexture.glInternalFmt, gpuTexture.width, gpuTexture.height);
+            }
+        }
+        break;
+    }
+    case TextureType.TEX2D_ARRAY: {
+        gpuTexture.glTarget = gl.TEXTURE_2D_ARRAY;
+
+        const maxSize = Math.max(w, h);
+        if (maxSize > device.capabilities.maxTextureSize || l > device.capabilities.maxArrayTextureLayers) {
+            errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        }
+
+        gpuTexture.glTexture = gl.createTexture();
+        if (gpuTexture.size > 0) {
+            const glTexUnit = device.stateCache.glTexUnits[device.stateCache.texUnit];
+
+            if (glTexUnit.glTexture !== gpuTexture.glTexture) {
+                gl.bindTexture(gl.TEXTURE_2D_ARRAY, gpuTexture.glTexture);
+                glTexUnit.glTexture = gpuTexture.glTexture;
+            }
+
+            if (FormatInfos[gpuTexture.format].isCompressed) {
+                for (let i = 0; i < gpuTexture.mipLevel; ++i) {
+                    const imgSize = FormatSize(gpuTexture.format, w, h, l);
+                    const view: Uint8Array = new Uint8Array(imgSize);
+                    gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, i, gpuTexture.glInternalFmt, w, h, l, 0, view);
+                    w = Math.max(1, w >> 1);
+                    h = Math.max(1, h >> 1);
+                }
+            } else {
+                gl.texStorage3D(gl.TEXTURE_2D_ARRAY, gpuTexture.mipLevel, gpuTexture.glInternalFmt, w, h, l);
+            }
+        }
+        break;
+    }
+    case TextureType.TEX3D: {
+        gpuTexture.glTarget = gl.TEXTURE_3D;
+
+        const maxSize = Math.max(w, h);
+        if (maxSize > device.capabilities.maxTextureSize) {
+            errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        }
+
+        gpuTexture.glTexture = gl.createTexture();
+        if (gpuTexture.size > 0) {
+            const glTexUnit = device.stateCache.glTexUnits[device.stateCache.texUnit];
+
+            if (glTexUnit.glTexture !== gpuTexture.glTexture) {
+                gl.bindTexture(gl.TEXTURE_3D, gpuTexture.glTexture);
+                glTexUnit.glTexture = gpuTexture.glTexture;
+            }
+
+            if (FormatInfos[gpuTexture.format].isCompressed) {
+                for (let i = 0; i < gpuTexture.mipLevel; ++i) {
+                    const imgSize = FormatSize(gpuTexture.format, w, h, d);
+                    const view: Uint8Array = new Uint8Array(imgSize);
+                    gl.compressedTexImage3D(gl.TEXTURE_3D, i, gpuTexture.glInternalFmt, w, h, d, 0, view);
+                    w = Math.max(1, w >> 1);
+                    h = Math.max(1, h >> 1);
+                }
+            } else {
+                gl.texStorage3D(gl.TEXTURE_3D, gpuTexture.mipLevel, gpuTexture.glInternalFmt, w, h, d);
             }
         }
         break;
@@ -1156,6 +1220,8 @@ export function WebGL2CmdFuncResizeTexture (device: WebGL2Device, gpuTexture: IW
 
     let w = gpuTexture.width;
     let h = gpuTexture.height;
+    const d = gpuTexture.depth;
+    const l = gpuTexture.arrayLayer;
 
     switch (gpuTexture.type) {
     case TextureType.TEX2D: {
@@ -1195,6 +1261,68 @@ export function WebGL2CmdFuncResizeTexture (device: WebGL2Device, gpuTexture: IW
 
             gl.renderbufferStorageMultisample(gl.RENDERBUFFER, gpuTexture.samples,
                 gpuTexture.glInternalFmt, gpuTexture.width, gpuTexture.height);
+        }
+        break;
+    }
+    case TextureType.TEX2D_ARRAY: {
+        gpuTexture.glTarget = gl.TEXTURE_2D_ARRAY;
+
+        const maxSize = Math.max(w, h);
+        if (maxSize > device.capabilities.maxCubeMapTextureSize) {
+            errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        }
+
+        gpuTexture.glTexture = gl.createTexture();
+        if (gpuTexture.size > 0) {
+            const glTexUnit = device.stateCache.glTexUnits[device.stateCache.texUnit];
+
+            if (glTexUnit.glTexture !== gpuTexture.glTexture) {
+                gl.bindTexture(gl.TEXTURE_2D_ARRAY, gpuTexture.glTexture);
+                glTexUnit.glTexture = gpuTexture.glTexture;
+            }
+
+            if (FormatInfos[gpuTexture.format].isCompressed) {
+                for (let i = 0; i < gpuTexture.mipLevel; ++i) {
+                    const imgSize = FormatSize(gpuTexture.format, w, h, l);
+                    const view: Uint8Array = new Uint8Array(imgSize);
+                    gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, i, gpuTexture.glInternalFmt, w, h, l, 0, view);
+                    w = Math.max(1, w >> 1);
+                    h = Math.max(1, h >> 1);
+                }
+            } else {
+                gl.texStorage3D(gl.TEXTURE_2D_ARRAY, gpuTexture.mipLevel, gpuTexture.glInternalFmt, w, h, l);
+            }
+        }
+        break;
+    }
+    case TextureType.TEX3D: {
+        gpuTexture.glTarget = gl.TEXTURE_3D;
+
+        const maxSize = Math.max(w, h);
+        if (maxSize > device.capabilities.maxCubeMapTextureSize) {
+            errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        }
+
+        gpuTexture.glTexture = gl.createTexture();
+        if (gpuTexture.size > 0) {
+            const glTexUnit = device.stateCache.glTexUnits[device.stateCache.texUnit];
+
+            if (glTexUnit.glTexture !== gpuTexture.glTexture) {
+                gl.bindTexture(gl.TEXTURE_3D, gpuTexture.glTexture);
+                glTexUnit.glTexture = gpuTexture.glTexture;
+            }
+
+            if (FormatInfos[gpuTexture.format].isCompressed) {
+                for (let i = 0; i < gpuTexture.mipLevel; ++i) {
+                    const imgSize = FormatSize(gpuTexture.format, w, h, d);
+                    const view: Uint8Array = new Uint8Array(imgSize);
+                    gl.compressedTexImage3D(gl.TEXTURE_3D, i, gpuTexture.glInternalFmt, w, h, d, 0, view);
+                    w = Math.max(1, w >> 1);
+                    h = Math.max(1, h >> 1);
+                }
+            } else {
+                gl.texStorage3D(gl.TEXTURE_3D, gpuTexture.mipLevel, gpuTexture.glInternalFmt, w, h, d);
+            }
         }
         break;
     }

--- a/cocos/core/gfx/webgl2/webgl2-device.ts
+++ b/cocos/core/gfx/webgl2/webgl2-device.ts
@@ -149,6 +149,8 @@ export class WebGL2Device extends Device {
         this._caps.maxUniformBlockSize = gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE);
         this._caps.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         this._caps.maxCubeMapTextureSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+        this._caps.maxArrayTextureLayers = gl.getParameter(gl.MAX_ARRAY_TEXTURE_LAYERS);
+        this._caps.max3DTextureSize = gl.getParameter(gl.MAX_3D_TEXTURE_SIZE);
         this._caps.uboOffsetAlignment = gl.getParameter(gl.UNIFORM_BUFFER_OFFSET_ALIGNMENT);
 
         const extensions = gl.getSupportedExtensions();

--- a/native/cocos/renderer/gfx-agent/DeviceAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/DeviceAgent.cpp
@@ -284,7 +284,7 @@ void doBufferTextureCopy(const uint8_t *const *buffers, Texture *texture, const 
     for (uint32_t i = 0U; i < count; i++) {
         const BufferTextureCopy &region = regions[i];
 
-        uint32_t size = formatSize(texture->getFormat(), region.texExtent.width, region.texExtent.height, 1);
+        uint32_t size = formatSize(texture->getFormat(), region.texExtent.width, region.texExtent.height, region.texExtent.depth);
         totalSize += size * region.texSubres.layerCount;
     }
 
@@ -298,7 +298,7 @@ void doBufferTextureCopy(const uint8_t *const *buffers, Texture *texture, const 
     for (uint32_t i = 0U, n = 0U; i < count; i++) {
         const BufferTextureCopy &region = regions[i];
 
-        uint32_t size = formatSize(texture->getFormat(), region.texExtent.width, region.texExtent.height, 1);
+        uint32_t size = formatSize(texture->getFormat(), region.texExtent.width, region.texExtent.height, region.texExtent.depth);
         for (uint32_t l = 0; l < region.texSubres.layerCount; l++) {
             auto *buffer = allocator->allocate<uint8_t>(size);
             memcpy(buffer, buffers[n], size);

--- a/native/cocos/renderer/gfx-base/GFXDef-common.h
+++ b/native/cocos/renderer/gfx-base/GFXDef-common.h
@@ -155,7 +155,6 @@ enum class Feature : uint32_t {
     INSTANCED_ARRAYS,
     MULTIPLE_RENDER_TARGETS,
     BLEND_MINMAX,
-    MEMORY_ALIASING,
     COMPUTE_SHADER,
     // This flag indicates whether the device can benefit from subpass-style usages.
     // Specifically, this only differs on the GLES backends: the Framebuffer Fetch
@@ -803,6 +802,8 @@ struct DeviceCaps {
     uint32_t maxUniformBlockSize{0};
     uint32_t maxTextureSize{0};
     uint32_t maxCubeMapTextureSize{0};
+    uint32_t maxArrayTextureLayers{0};
+    uint32_t max3DTextureSize{0};
     uint32_t uboOffsetAlignment{1};
 
     uint32_t maxComputeSharedMemorySize{0};

--- a/native/cocos/renderer/gfx-gles2/GLES2Commands.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Commands.cpp
@@ -660,6 +660,86 @@ void cmdFuncGLES2CreateTexture(GLES2Device *device, GLES2GPUTexture *gpuTexture)
                 }
                 break;
             }
+            case TextureType::TEX2D_ARRAY: {
+                gpuTexture->glTarget = GL_TEXTURE_3D;
+                CC_ASSERT((std::max(std::max(gpuTexture->width, gpuTexture->height), gpuTexture->arrayLayer) <= device->getCapabilities().max3DTextureSize)
+                    && "cmdFuncGLES2CreateTexture: texture2DArray's dimension is too large");
+                GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    if (!GFX_FORMAT_INFOS[static_cast<int>(gpuTexture->format)].isCompressed) {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->arrayLayer;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            GL_CHECK(glTexImage3DOES(GL_TEXTURE_3D, i,
+                                                     gpuTexture->glInternalFmt,
+                                                     w, h, d, 0,
+                                                     gpuTexture->glFormat, gpuTexture->glType,
+                                                     nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    } else {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->arrayLayer;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            uint32_t imgSize = formatSize(gpuTexture->format, w, h, d);
+                            GL_CHECK(glCompressedTexImage3DOES(GL_TEXTURE_3D, i,
+                                                               gpuTexture->glInternalFmt,
+                                                               w, h, d, 0, imgSize,
+                                                               nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    }
+                }
+                break;
+            }
+            case TextureType::TEX3D: {
+                gpuTexture->glTarget = GL_TEXTURE_3D;
+                GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    if (!GFX_FORMAT_INFOS[static_cast<int>(gpuTexture->format)].isCompressed) {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->depth;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            GL_CHECK(glTexImage3DOES(GL_TEXTURE_3D, i,
+                                                     gpuTexture->glInternalFmt,
+                                                     w, h, d, 0,
+                                                     gpuTexture->glFormat, gpuTexture->glType,
+                                                     nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    } else {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->depth;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            uint32_t imgSize = formatSize(gpuTexture->format, w, h, d);
+                            GL_CHECK(glCompressedTexImage3DOES(GL_TEXTURE_3D, i,
+                                                               gpuTexture->glInternalFmt,
+                                                               w, h, d, 0, imgSize,
+                                                               nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    }
+                }
+                break;
+            }
             case TextureType::CUBE: {
                 gpuTexture->glTarget = GL_TEXTURE_CUBE_MAP;
                 GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
@@ -791,6 +871,82 @@ void cmdFuncGLES2ResizeTexture(GLES2Device *device, GLES2GPUTexture *gpuTexture)
                                 w = std::max(1U, w >> 1);
                                 h = std::max(1U, h >> 1);
                             }
+                        }
+                    }
+                }
+                break;
+            }
+            case TextureType::TEX2D_ARRAY: {
+                gpuTexture->glTarget = GL_TEXTURE_2D_ARRAY;
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    if (!GFX_FORMAT_INFOS[static_cast<int>(gpuTexture->format)].isCompressed) {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->arrayLayer;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            GL_CHECK(glTexImage3DOES(GL_TEXTURE_3D, i,
+                                                     gpuTexture->glInternalFmt,
+                                                     w, h, d, 0,
+                                                     gpuTexture->glFormat, gpuTexture->glType,
+                                                     nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    } else {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->arrayLayer;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            uint32_t imgSize = formatSize(gpuTexture->format, w, h, d);
+                            GL_CHECK(glCompressedTexImage3DOES(GL_TEXTURE_3D, i,
+                                                               gpuTexture->glInternalFmt,
+                                                               w, h, d, 0, imgSize,
+                                                               nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    }
+                }
+                break;
+            }
+            case TextureType::TEX3D: {
+                gpuTexture->glTarget = GL_TEXTURE_3D;
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    if (!GFX_FORMAT_INFOS[static_cast<int>(gpuTexture->format)].isCompressed) {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->depth;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            GL_CHECK(glTexImage3DOES(GL_TEXTURE_3D, i,
+                                                     gpuTexture->glInternalFmt,
+                                                     w, h, d, 0,
+                                                     gpuTexture->glFormat, gpuTexture->glType,
+                                                     nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    } else {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->depth;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            uint32_t imgSize = formatSize(gpuTexture->format, w, h, d);
+                            GL_CHECK(glCompressedTexImage3DOES(GL_TEXTURE_3D, i,
+                                                               gpuTexture->glInternalFmt,
+                                                               w, h, d, 0, imgSize,
+                                                               nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
                         }
                     }
                 }
@@ -2610,7 +2766,7 @@ void cmdFuncGLES2CopyBuffersToTexture(GLES2Device *device, const uint8_t *const 
                                                               region.texSubres.mipLevel,
                                                               region.texOffset.x,
                                                               region.texOffset.y, z,
-                                                              w, h, d,
+                                                              w, h, 1,
                                                               gpuTexture->glFormat,
                                                               memSize,
                                                               (GLvoid *)buff));
@@ -2620,7 +2776,7 @@ void cmdFuncGLES2CopyBuffersToTexture(GLES2Device *device, const uint8_t *const 
                                                     region.texOffset.x,
                                                     region.texOffset.y,
                                                     z,
-                                                    w, h, d,
+                                                    w, h, 1,
                                                     gpuTexture->glFormat,
                                                     gpuTexture->glType,
                                                     (GLvoid *)buff));
@@ -2640,7 +2796,7 @@ void cmdFuncGLES2CopyBuffersToTexture(GLES2Device *device, const uint8_t *const 
                 d                               = region.texExtent.depth;
                 const uint8_t *buff             = buffers[n++];
                 if (isCompressed) {
-                    auto memSize = static_cast<GLsizei>(formatSize(gpuTexture->format, w, h, 1));
+                    auto memSize = static_cast<GLsizei>(formatSize(gpuTexture->format, w, h, d));
                     GL_CHECK(glCompressedTexSubImage3DOES(GL_TEXTURE_3D,
                                                           region.texSubres.mipLevel,
                                                           region.texOffset.x,

--- a/native/cocos/renderer/gfx-gles2/GLES2Commands.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Commands.cpp
@@ -878,6 +878,8 @@ void cmdFuncGLES2ResizeTexture(GLES2Device *device, GLES2GPUTexture *gpuTexture)
             }
             case TextureType::TEX2D_ARRAY: {
                 gpuTexture->glTarget = GL_TEXTURE_2D_ARRAY;
+                CC_ASSERT((std::max(std::max(gpuTexture->width, gpuTexture->height), gpuTexture->arrayLayer) <= device->getCapabilities().max3DTextureSize)
+                    && "cmdFuncGLES2CreateTexture: texture2DArray's dimension is too large");
                 if (gpuTexture->size > 0) {
                     GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
                     if (gpuTexture->glTexture != glTexture) {

--- a/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -188,6 +188,9 @@ bool GLES2Device::doInit(const DeviceInfo & /*info*/) {
     glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, reinterpret_cast<GLint *>(&_caps.maxVertexTextureUnits));
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxTextureSize));
     glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxCubeMapTextureSize));
+    glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE_OES, reinterpret_cast<GLint *>(&_caps.max3DTextureSize));
+    // texture2DArray fallback to texture3DOES
+    _caps.maxArrayTextureLayers = _caps.max3DTextureSize;
 
     QueueInfo queueInfo;
     queueInfo.type = QueueType::GRAPHICS;

--- a/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
@@ -873,6 +873,38 @@ void cmdFuncGLES3CreateTexture(GLES3Device *device, GLES3GPUTexture *gpuTexture)
                 }
                 break;
             }
+            case TextureType::TEX2D_ARRAY: {
+                gpuTexture->glTarget = GL_TEXTURE_2D_ARRAY;
+                GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_2D_ARRAY, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    uint32_t w = gpuTexture->width;
+                    uint32_t h = gpuTexture->height;
+                    uint32_t d = gpuTexture->arrayLayer;
+                    GL_CHECK(glTexStorage3D(GL_TEXTURE_2D_ARRAY, gpuTexture->mipLevel, gpuTexture->glInternalFmt, w, h, d));
+                }
+                break;
+            }
+            case TextureType::TEX3D: {
+                gpuTexture->glTarget = GL_TEXTURE_3D;
+                GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    uint32_t w = gpuTexture->width;
+                    uint32_t h = gpuTexture->height;
+                    uint32_t d = gpuTexture->depth;
+                    GL_CHECK(glTexStorage3D(GL_TEXTURE_3D, gpuTexture->mipLevel, gpuTexture->glInternalFmt, w, h, d));
+                }
+                break;
+            }
             case TextureType::CUBE: {
                 gpuTexture->glTarget = GL_TEXTURE_CUBE_MAP;
                 GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
@@ -2866,7 +2898,7 @@ void cmdFuncGLES3CopyBuffersToTexture(GLES3Device *device, const uint8_t *const 
                                                            region.texOffset.x,
                                                            region.texOffset.y,
                                                            z,
-                                                           w, h, d,
+                                                           w, h, 1,
                                                            gpuTexture->glFormat,
                                                            memSize,
                                                            (GLvoid *)buff));
@@ -2876,7 +2908,7 @@ void cmdFuncGLES3CopyBuffersToTexture(GLES3Device *device, const uint8_t *const 
                                                  region.texOffset.x,
                                                  region.texOffset.y,
                                                  z,
-                                                 w, h, d,
+                                                 w, h, 1,
                                                  gpuTexture->glFormat,
                                                  gpuTexture->glType,
                                                  (GLvoid *)buff));
@@ -2896,7 +2928,7 @@ void cmdFuncGLES3CopyBuffersToTexture(GLES3Device *device, const uint8_t *const 
                 d                               = region.texExtent.depth;
                 const uint8_t *buff             = buffers[n++];
                 if (isCompressed) {
-                    auto memSize = static_cast<GLsizei>(formatSize(gpuTexture->format, w, h, 1));
+                    auto memSize = static_cast<GLsizei>(formatSize(gpuTexture->format, w, h, d));
                     GL_CHECK(glCompressedTexSubImage3D(GL_TEXTURE_3D,
                                                        region.texSubres.mipLevel,
                                                        region.texOffset.x,

--- a/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -182,6 +182,8 @@ bool GLES3Device::doInit(const DeviceInfo & /*info*/) {
     glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, reinterpret_cast<GLint *>(&_caps.maxVertexTextureUnits));
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxTextureSize));
     glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxCubeMapTextureSize));
+    glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS, reinterpret_cast<GLint *>(&_caps.maxArrayTextureLayers));
+    glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.max3DTextureSize));
     glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, reinterpret_cast<GLint *>(&_caps.uboOffsetAlignment));
 
     if (_gpuConstantRegistry->glMinorVersion) {

--- a/native/cocos/renderer/gfx-validator/TextureValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/TextureValidator.cpp
@@ -72,22 +72,30 @@ void TextureValidator::doInit(const TextureInfo &info) {
             if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxTextureSize) {
                 CC_ASSERT(false);
             }
+            break;
         }
         case TextureType::TEX2D_ARRAY: {
             if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxTextureSize
                 || info.layerCount > DeviceValidator::getInstance()->getCapabilities().maxArrayTextureLayers) {
                 CC_ASSERT(false);
             }
+            break;
         }
         case TextureType::CUBE: {
             if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxCubeMapTextureSize || info.layerCount != 6) {
                 CC_ASSERT(false);
             }
+            break;
         }
         case TextureType::TEX3D: {
             if (std::max(std::max(info.width, info.height), info.depth) > DeviceValidator::getInstance()->getCapabilities().maxCubeMapTextureSize) {
                 CC_ASSERT(false);
             }
+            break;
+        }
+        default: {
+            CC_ASSERT(false);
+            break;
         }
     }
 

--- a/native/cocos/renderer/gfx-validator/TextureValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/TextureValidator.cpp
@@ -67,6 +67,30 @@ void TextureValidator::doInit(const TextureInfo &info) {
         CC_ASSERT(hasAllFlags(DeviceValidator::getInstance()->getFormatFeatures(info.format), ff));
     }
 
+    switch (info.type) {
+        case TextureType::TEX2D: {
+            if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxTextureSize) {
+                CC_ASSERT(false);
+            }
+        }
+        case TextureType::TEX2D_ARRAY: {
+            if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxTextureSize
+                || info.layerCount > DeviceValidator::getInstance()->getCapabilities().maxArrayTextureLayers) {
+                CC_ASSERT(false);
+            }
+        }
+        case TextureType::CUBE: {
+            if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxCubeMapTextureSize || info.layerCount != 6) {
+                CC_ASSERT(false);
+            }
+        }
+        case TextureType::TEX3D: {
+            if (std::max(std::max(info.width, info.height), info.depth) > DeviceValidator::getInstance()->getCapabilities().maxCubeMapTextureSize) {
+                CC_ASSERT(false);
+            }
+        }
+    }
+
     if (hasFlag(info.flags, TextureFlagBit::GEN_MIPMAP)) {
         CC_ASSERT(info.levelCount > 1);
 

--- a/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -304,6 +304,8 @@ bool CCVKDevice::doInit(const DeviceInfo & /*info*/) {
     _caps.maxVertexTextureUnits          = limits.maxPerStageDescriptorSampledImages;
     _caps.maxTextureSize                 = limits.maxImageDimension2D;
     _caps.maxCubeMapTextureSize          = limits.maxImageDimensionCube;
+    _caps.maxArrayTextureLayers          = limits.maxImageArrayLayers;
+    _caps.max3DTextureSize               = limits.maxImageDimension3D;
     _caps.uboOffsetAlignment             = utils::toUint(limits.minUniformBufferOffsetAlignment);
     // compute shaders
     _caps.maxComputeSharedMemorySize     = limits.maxComputeSharedMemorySize;

--- a/native/cocos/renderer/gfx-vulkan/VKUtils.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKUtils.cpp
@@ -254,7 +254,6 @@ VkImageCreateFlags mapVkImageCreateFlags(TextureType type) {
     uint32_t res = 0U;
     switch (type) {
         case TextureType::CUBE: res |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT; break;
-        case TextureType::TEX2D_ARRAY: res |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT; break;
         default: break;
     }
     return static_cast<VkImageCreateFlags>(res);


### PR DESCRIPTION
Re: #

Texture2DArray and Texture3D are important features for a modern engine. With `Texture2DArray` we can bind more textures with only one slot. With `Texture3D` we can implement many complex render effects. This PR added support to Texture3D and Texture2DArray.

Changelog:
 * Add support to `texture2DArray`.
 * Add support to `texture3D`.
 * Fix wrong flag.
 * Add new device caps.
 
The modifications were tested using gfx-test-case (now test-gfx) for `Vulkan` and `GLES3`.