### PR TITLE
fix gfx-define-generator.

### DIFF
--- a/native/tools/gfx-define-generator/generate.js
+++ b/native/tools/gfx-define-generator/generate.js
@@ -132,7 +132,7 @@ const getMemberList = (() => {
 })();
 
 const structRE = /(struct\s+(?:\w+\(\w+\)\s+)?(\w+).*?){\s*.+?\s*};/gs;
-const structMemberRE = /^\s*(const\w*\s*)?([\w[\]]+)\s+?(\w+)(?:\s*[={]?\s*(.*?)\s*}*\s*)?;(?:\s*\/\/\s*@ts-(.*?)$)?/gm;
+const structMemberRE = /^\s*(const\w*\s*)?([\w[\:\]]+)\s+?(\w+)(?:\s*[={]?\s*(.*?)\s*}*\s*)?;(?:\s*\/\/\s*@ts-(.*?)$)?/gm;
 const structMap = {};
 const replaceConstants = (() => {
     const strMap = {
@@ -180,6 +180,7 @@ while (structCap) {
             type = type.replace(/(\b)(?:uint\w+?_t|int\w+?_t|float)(\b)/, '$1number$1');
             type = type.replace(/(\b)(?:bool)(\b)/, '$1boolean$2');
             type = type.replace(/(\b)(?:String)(\b)/, '$1string$2');
+            type = type.replace(/(\b)(?:ccstd::string)(\b)/, '$1string$2');
             if (memberCap[1]) { readonly = true; }
             const isArray = type.endsWith('[]');
             const decayedType = isArray ? type.slice(0, -2) : type;


### PR DESCRIPTION
In v3.6.0, the ccstd::string is used in GFXDef-common.h, this PR adds support to ccstd::string so that the gfx-define-generator can work again.

1. add `\:` to the second group of structMemberRE to make sure we can
   get ccstd::string instead of ccstd.
2. add `type.replace(/(\b)(?:ccstd::string)(\b)/, '$1string$2');` to
   make sure that ccstd::string can be replaced by string.