### PR TITLE
fix native include problem on windows

### DIFF
--- a/native/cocos/core/assets/Font.cpp
+++ b/native/cocos/core/assets/Font.cpp
@@ -34,6 +34,7 @@
 #include "math/Math.h"
 #include "platform/FileUtils.h"
 #include "profiler/Profiler.h"
+#include <cctype>
 
 namespace cc {
 

--- a/native/cocos/core/assets/Font.cpp
+++ b/native/cocos/core/assets/Font.cpp
@@ -26,6 +26,7 @@
 #include "Font.h"
 #include <algorithm>
 #include <boost/functional/hash.hpp>
+#include <cctype>
 #include "base/Data.h"
 #include "base/Log.h"
 #include "base/Macros.h"
@@ -34,7 +35,6 @@
 #include "math/Math.h"
 #include "platform/FileUtils.h"
 #include "profiler/Profiler.h"
-#include <cctype>
 
 namespace cc {
 

--- a/native/cocos/profiler/GameStats.h
+++ b/native/cocos/profiler/GameStats.h
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <sstream>
 #include <utility>
+#include <algorithm>
 #include "base/StringUtil.h"
 #include "base/std/container/string.h"
 #include "base/std/container/unordered_map.h"


### PR DESCRIPTION
 Fix native include problem on windows with VS 2017