### PR TITLE
Utilities to capture logs during unit test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
     ],
     setupFilesAfterEnv: [
         "./tests/setup-after-env.ts",
+        "./tests/utils/log-capture-setup-after-env.ts"
     ],
     setupFiles: [
         './tests/init.ts',

--- a/tests/init.ts
+++ b/tests/init.ts
@@ -38,10 +38,21 @@ jest.mock(
 jest.mock('../cocos/core/platform/debug', () => {
     const result = {
         __esModule: true, // Use it when dealing with esModules
-        ...jest.requireActual('../cocos/core/platform/debug'),
+        ...jest.requireActual('../cocos/core/platform/debug')
     };
-    if (result.warnID) {
-        result.warnID = jest.fn();
+    const { feed } = require('./utils/log-capture');
+    for (const logMethodName of ['warn', 'error', 'warnID', 'errorID']) {
+        if (result[logMethodName]) {
+            const log = result[logMethodName];
+            result[logMethodName] = jest.fn((...args: unknown[]) => {
+                if (feed(logMethodName, ...args)) {
+                    // TODO: this is an old behaviour to shut some warns
+                    if (logMethodName !== 'warnID') {
+                        log.call(result, ...args);
+                    }
+                }
+            });
+        }
     }
     return result;
 });

--- a/tests/utils/log-capture-setup-after-env.ts
+++ b/tests/utils/log-capture-setup-after-env.ts
@@ -1,0 +1,9 @@
+import { hookAfterEach, hookBeforeEach } from "./log-capture";
+
+beforeEach(() => {
+    hookBeforeEach();
+});
+
+afterEach(() => {
+    hookAfterEach();
+});

--- a/tests/utils/log-capture.test.ts
+++ b/tests/utils/log-capture.test.ts
@@ -1,0 +1,62 @@
+import { error, errorID, warn, warnID } from "../../cocos/core";
+import { captureErrorIDs, captureErrors, captureWarnIDs, captureWarns } from "./log-capture";
+
+describe('Log capture', () => {
+    test.each([
+        ['Capture warns', captureWarns, warn],
+        ['Capture errors', captureErrors, error],
+    ])('%s', (_title, captureX, logX) => {
+        logX(`This is a test-purpose log. Ignore it no matter its log level.`);
+
+        const watcher = captureX();
+        // Previous logs are not captured.
+        expect(watcher.captured).toHaveLength(0);
+
+        logX(`This log should not be presented!!`);
+        expect(watcher.captured).toHaveLength(1);
+        expect(watcher.captured[0][0]).toStrictEqual(`This log should not be presented!!`);
+
+        watcher.clear();
+        expect(watcher.captured).toHaveLength(0);
+
+        logX(`This log should not be presented!!`);
+        expect(watcher.captured).toHaveLength(1);
+        expect(watcher.captured[0][0]).toStrictEqual(`This log should not be presented!!`);
+        watcher.stop();
+        // .stop() clear the captures
+        expect(watcher.captured).toHaveLength(0);
+
+        logX(`This is a test-purpose log. Ignore it.`);
+        expect(watcher.captured).toHaveLength(0);
+    });
+
+    test.each([
+        ['Capture warn IDs', captureWarnIDs, warnID],
+        ['Capture error IDs', captureErrorIDs, errorID],
+    ])('%s', (_title, captureX, logX) => {
+        const ID = 3;
+
+        logX(ID);
+
+        const watcher = captureX();
+        // Previous logs are not captured.
+        expect(watcher.captured).toHaveLength(0);
+
+        logX(ID);
+        expect(watcher.captured).toHaveLength(1);
+        expect(watcher.captured[0][0]).toStrictEqual(ID);
+
+        watcher.clear();
+        expect(watcher.captured).toHaveLength(0);
+
+        logX(ID);
+        expect(watcher.captured).toHaveLength(1);
+        expect(watcher.captured[0][0]).toStrictEqual(ID);
+        watcher.stop();
+        // .stop() clear the captures
+        expect(watcher.captured).toHaveLength(0);
+
+        logX(ID);
+        expect(watcher.captured).toHaveLength(0);
+    });
+});

--- a/tests/utils/log-capture.ts
+++ b/tests/utils/log-capture.ts
@@ -1,0 +1,140 @@
+import type { error, errorID, warn, warnID } from "../../cocos/core";
+
+abstract class LogWatcher<TArgs> {
+    constructor(private _stop: () => void) {
+
+    }
+
+    get captured() {
+        return this._logs;
+    }
+
+    public clear() {
+        this._logs.length = 0;
+    }
+
+    public stop() {
+        this.clear();
+        this._stop();
+    }
+
+    /**
+     * Do not call it from your code.
+     */
+    public feed(log: TArgs) {
+        this._logs.push(log);
+    }
+
+    private _logs: TArgs[] = [];
+}
+
+class LogWatcherProvider<TArgs> {
+    get current() {
+        return this._current;
+    }
+
+    public create(): LogWatcher<TArgs> {
+        if (this._current) {
+            throw new Error(`There can be only one watcher of same log-level in the same time.`);
+        }
+        this._current = new LogWatcher(() => this._current = null);
+        return this._current;
+    }
+
+    public beforeEach() {
+        this._current?.clear();
+        this._current = null;
+    }
+
+    public afterEach() {
+        if (this._current) {
+            if (this._current.captured.length !== 0) {
+                throw new Error(
+                    `There are still some logs emitted after your test has ended. ` +
+                    `You should capture them or, ` +
+                    `if they're not concerned by you, call 'watcher.stop()' before your test ends. ` +
+                    `This restriction exists to prevent you from accidentally missing something.`
+                );
+            } else {
+                this._current.clear();
+                this._current = null;
+            }
+        }
+    }
+
+    private _current: LogWatcher<TArgs> | null = null;
+}
+
+const providers = {
+    warn: new LogWatcherProvider<Parameters<typeof warn>>(),
+    error: new LogWatcherProvider<Parameters<typeof error>>(),
+    warnID: new LogWatcherProvider<Parameters<typeof warnID>>(),
+    errorID: new LogWatcherProvider<Parameters<typeof errorID>>(),
+};
+
+type SupportedProviders = typeof providers;
+
+type LogArgsOf<TProvider> = TProvider extends LogWatcherProvider<infer U> ? [U] : never;
+
+//#region Our interactions with external world..
+
+export function hookBeforeEach() {
+    for (const [_, provider] of Object.entries(providers)) {
+        provider.beforeEach();
+    }
+}
+
+export function hookAfterEach() {
+    for (const [_, provider] of Object.entries(providers)) {
+        provider.afterEach();
+    }
+}
+
+export function feed<T extends keyof SupportedProviders>(level: T, ...args: LogArgsOf<T>): boolean {
+    const current = providers[level].current;
+    if (current) {
+        // @ts-expect-error TODO
+        current.feed(args);
+        return false;
+    } else {
+        return true; // Apply original warn
+    }
+}
+
+/**
+ * @zh 开始捕捉后续的警告信息，直到当前的测试结束。
+ * @en Start capturing the following warning logs(produced by `warn()`), until current test ends.
+ * @returns The log watcher.
+ */
+export function captureWarns() {
+    return providers.warn.create();
+}
+
+/**
+ * @zh 开始捕捉后续的错误信息，直到当前的测试结束。
+ * @en Start capturing the following error logs(produced by `error()`), until current test ends.
+ * @returns The log watcher.
+ */
+export function captureErrors() {
+    return providers.error.create();
+}
+
+/**
+ * @zh 开始捕捉后续的警告信息，直到当前的测试结束。
+ * @en Start capturing the following warning logs(produced by `warnID()`), until current test ends.
+ * @returns The log watcher.
+ */
+ export function captureWarnIDs() {
+    return providers.warnID.create();
+}
+
+/**
+ * @zh 开始捕捉后续的错误信息，直到当前的测试结束。
+ * @en Start capturing the following error logs(produced by `errorID()`), until current test ends.
+ * @returns The log watcher.
+ */
+export function captureErrorIDs() {
+    return providers.errorID.create();
+}
+
+//#endregion


### PR DESCRIPTION
Re: #

Here I'm going to provide some useful interfaces to capture invocations to `error()`, `warnID` eg.

Usage:

```ts
test('Some test', () => {
  // Here start to capture all warns, until current test ends
  const watcher = captureWarns();

  // Log something
  warn("meow~");
  
  // We should have captured one warn log.
  expected(watcher.captured).toHaveLength(1);
  // The first argument to the first log should be strictly `"meow~"`
  expected(watcher.captured[0][0]).toStrictEqual("meow~");

  // Current by-design restriction: you should clear or stop the watcher when test ends
  watcher.stop(); // or watcher.clear()
});
```


<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->