### PR TITLE
No longer use animation state to implement clip motion

### DIFF
--- a/cocos/core/animation/animation-state.ts
+++ b/cocos/core/animation/animation-state.ts
@@ -23,8 +23,6 @@
  THE SOFTWARE.
 */
 
-
-
 import { EDITOR } from 'internal:constants';
 import { Node } from '../scene-graph/node';
 import { AnimationClip } from './animation-clip';
@@ -600,7 +598,7 @@ export class AnimationState extends Playable {
             playbackDuration,
             this._wrapMode,
             this._repeatCount,
-            this._speed < 0,
+            this.speed < 0,
             info,
         );
         info.time += playbackStart;

--- a/cocos/core/animation/marionette/clip-motion.ts
+++ b/cocos/core/animation/marionette/clip-motion.ts
@@ -2,7 +2,9 @@ import { editorExtrasTag } from '../../data';
 import { ccclass, type } from '../../data/class-decorator';
 import { EditorExtendable } from '../../data/editor-extendable';
 import { AnimationClip } from '../animation-clip';
-import { AnimationState } from '../animation-state';
+import { PoseOutput } from '../pose-output';
+import { WrapModeMask, WrappedInfo } from '../types';
+import { wrap } from '../wrap';
 import { createEval } from './create-eval';
 import { getMotionRuntimeID, graphDebug, GRAPH_DEBUG_ENABLED, pushWeight, RUNTIME_ID_ENABLED } from './graph-debug';
 import { ClipStatus } from './graph-eval';
@@ -39,14 +41,19 @@ class ClipMotionEval implements MotionEval {
 
     public declare runtimeId?: number;
 
-    private declare _state: AnimationState;
-
     public declare readonly duration: number;
 
     constructor (context: MotionEvalContext, clip: AnimationClip) {
         this.duration = clip.duration / clip.speed;
-        this._state = new AnimationState(clip);
-        this._state.initialize(context.node, context.blendBuffer, context.mask);
+        this._clip = clip;
+        const poseOutput = new PoseOutput(context.blendBuffer);
+        this._poseOutput = poseOutput;
+        this._clipEval = clip.createEvaluator({
+            target: context.node,
+            pose: poseOutput,
+            mask: context.mask,
+        });
+        this._clipEventEval = clip.createEventEvaluator(context.node);
     }
 
     public getClipStatuses (baseWeight: number): Iterator<ClipStatus, any, undefined> {
@@ -64,7 +71,7 @@ class ClipMotionEval implements MotionEval {
                         done: false,
                         value: {
                             __DEBUG_ID__: this.__DEBUG__ID__,
-                            clip: this._state.clip,
+                            clip: this._clip,
                             weight: baseWeight,
                         },
                     };
@@ -74,18 +81,46 @@ class ClipMotionEval implements MotionEval {
     }
 
     get progress () {
-        return this._state.time / this.duration;
+        return this._elapsedTime / this.duration;
     }
 
     public sample (progress: number, weight: number) {
         if (weight === 0.0) {
             return;
         }
-        pushWeight(this._state.name, weight);
-        const time = this._state.duration * progress;
-        this._state.time = time;
-        this._state.weight = weight;
-        this._state.sample();
-        this._state.weight = 0.0;
+        pushWeight(this._clip.name, weight);
+        const { duration } = this;
+        const elapsedTime = this.duration * progress;
+        const { wrapMode } = this._clip;
+        const repeatCount = (wrapMode & WrapModeMask.Loop) === WrapModeMask.Loop
+            ? Infinity : 1;
+        const wrapInfo = wrap(
+            elapsedTime,
+            duration,
+            wrapMode,
+            repeatCount,
+            false,
+            this._wrapInfo,
+        );
+        this._poseOutput.weight = weight;
+        this._clipEval.evaluate(wrapInfo.time);
+        this._poseOutput.weight = 0.0;
+        this._clipEventEval.sample(
+            wrapInfo.ratio,
+            wrapInfo.direction,
+            wrapInfo.iterations,
+        );
     }
+
+    private _clip: AnimationClip;
+
+    private _poseOutput: PoseOutput;
+
+    private _clipEval: ReturnType<AnimationClip['createEvaluator']>;
+
+    private _clipEventEval: ReturnType<AnimationClip['createEventEvaluator']>;
+
+    private _elapsedTime = 0.0;
+
+    private _wrapInfo = new WrappedInfo();
 }

--- a/cocos/core/animation/wrap.ts
+++ b/cocos/core/animation/wrap.ts
@@ -1,0 +1,74 @@
+import { WrapMode, WrapModeMask, WrappedInfo } from './types';
+
+export function wrap (
+    elapsedTime: number,
+    duration: number,
+    wrapMode: WrapMode,
+    repeatCount: number,
+    negativeSpeed: boolean,
+    info: WrappedInfo,
+): WrappedInfo {
+    let stopped = false;
+
+    let currentIterations = elapsedTime > 0 ? (elapsedTime / duration) : -(elapsedTime / duration);
+    if (currentIterations >= repeatCount) {
+        currentIterations = repeatCount;
+
+        stopped = true;
+        let tempRatio = repeatCount - (repeatCount | 0);
+        if (tempRatio === 0) {
+            tempRatio = 1;  // 如果播放过，动画不复位
+        }
+        elapsedTime = tempRatio * duration * (elapsedTime > 0 ? 1 : -1);
+    }
+
+    if (elapsedTime > duration) {
+        const tempTime = elapsedTime % duration;
+        elapsedTime = tempTime === 0 ? duration : tempTime;
+    } else if (elapsedTime < 0) {
+        elapsedTime %= duration;
+        if (elapsedTime !== 0) { elapsedTime += duration; }
+    }
+
+    let needReverse = false;
+    const shouldWrap = wrapMode & WrapModeMask.ShouldWrap;
+    if (shouldWrap) {
+        needReverse = isReverseIteration(wrapMode, currentIterations);
+    }
+
+    let direction = needReverse ? -1 : 1;
+    if (negativeSpeed) {
+        direction *= -1;
+    }
+
+    // calculate wrapped time
+    if (shouldWrap && needReverse) {
+        elapsedTime = duration - elapsedTime;
+    }
+
+    info.time = elapsedTime;
+    info.ratio = info.time / duration;
+    info.direction = direction;
+    info.stopped = stopped;
+    info.iterations = currentIterations;
+
+    return info;
+}
+
+function isReverseIteration (wrapMode: WrapMode, currentIterations: number) {
+    let needReverse = false;
+    if ((wrapMode & WrapModeMask.PingPong) === WrapModeMask.PingPong) {
+        const isEnd = currentIterations - (currentIterations | 0) === 0;
+        if (isEnd && (currentIterations > 0)) {
+            currentIterations -= 1;
+        }
+        const isOddIteration = currentIterations & 1;
+        if (isOddIteration) {
+            needReverse = !needReverse;
+        }
+    }
+    if ((wrapMode & WrapModeMask.Reverse) === WrapModeMask.Reverse) {
+        needReverse = !needReverse;
+    }
+    return needReverse;
+}

--- a/tests/animation/newgenanim.test.ts
+++ b/tests/animation/newgenanim.test.ts
@@ -25,8 +25,9 @@ import 'jest-extended';
 import { assertIsTrue } from '../../cocos/core/data/utils/asserts';
 import { AnimationClip } from '../../cocos/core/animation/animation-clip';
 import { TriggerResetMode } from '../../cocos/core/animation/marionette/variable';
+import { getGlobalAnimationManager } from '../../cocos/core/animation/global-animation-manager';
 
-describe('NewGen Anim', () => {
+describe('Marionette', () => {
     test('Defaults', () => {
         const graph = new AnimationGraph();
         expect(graph.layers).toHaveLength(0);
@@ -2266,6 +2267,74 @@ describe('NewGen Anim', () => {
             ['t0', VariableType.TRIGGER, false],
             ['t1', VariableType.TRIGGER, true],
         ]);
+    });
+
+    class FrameEventHelper {
+        constructor() {
+            const mock = jest.spyOn(getGlobalAnimationManager(), 'pushDelayEvent');
+            mock.mockImplementationOnce((...args: [fn: (...args: any[]) => void, thisArg: any, args: any[]]) => {
+                this._delayEvents.push(args);
+            });
+            this._mock = mock;
+        }
+
+        public unload() {
+            this._mock.mockRestore();
+        }
+
+        public apply() {
+            const { _delayEvents: delayEvents } = this;
+            for (const [fn, thisArg, args] of delayEvents) {
+                fn.call(thisArg, ...args);
+            }
+            delayEvents.length = 0;
+        }
+
+        private _mock: jest.SpyInstance;
+        private _delayEvents: Array<[fn: (...args: any[]) => void, thisArg: any, args: any[]]> = [];
+    }
+
+    test('Animation clip frame events', () => {
+        class TestComponent extends Component {
+            public handleEvent = jest.fn();
+        }
+
+        const node = new Node();
+        const component = node.addComponent(TestComponent) as TestComponent;
+
+        const animationGraph = new AnimationGraph();
+        const mainLayer = animationGraph.addLayer();
+        const motionState = mainLayer.stateMachine.addMotion();
+        const clipMotion = motionState.motion = new ClipMotion();
+        const animationClip = clipMotion.clip = new AnimationClip();
+        animationClip.duration = 1.8;
+        animationClip.events = [{
+            frame: 0.3,
+            func: 'handleEvent',
+            params: ['2'],
+        }];
+        mainLayer.stateMachine.connect(mainLayer.stateMachine.entryState, motionState);
+
+        const { graphEval } = createAnimationGraphEval2(animationGraph, node);
+        const graphUpdater = new GraphUpdater(graphEval);
+
+        const frameEventHelper = new FrameEventHelper();
+
+        graphUpdater.goto(0.1);
+        frameEventHelper.apply();
+        expect(component.handleEvent).not.toBeCalled();
+
+        graphUpdater.goto(0.32);
+        frameEventHelper.apply();
+        expect(component.handleEvent).toBeCalledTimes(1);
+        expect(component.handleEvent.mock.calls[0][0]).toBe('2');
+        component.handleEvent.mockClear();
+
+        graphUpdater.goto(0.37);
+        frameEventHelper.apply();
+        expect(component.handleEvent).not.toBeCalled();
+
+        frameEventHelper.unload();
     });
 });
 


### PR DESCRIPTION
Re: #

Formerly we internally use `AnimationState` to implement clip motion in animation graphs for fast prototyping. Now I decide to drop such implementation instead take up the "raw" animation evaluation way to support animation event and comming soon event-like feature.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->