### PR TITLE
Skip a pair of quotations for avoiding spaces in image name are detected

### DIFF
--- a/cocos/2d/utils/html-text-parser.ts
+++ b/cocos/2d/utils/html-text-parser.ts
@@ -172,7 +172,6 @@ export class HtmlTextParser {
 
         header = /^(img(\s)*src(\s)*=[^>]+\/)/.exec(attribute);
         let remainingArgument = '';
-        let leftQuot = -1;
         let rightQuot = -1;
         if (header && header[0].length > 0) {
             tagName = header[0].trim();
@@ -188,13 +187,14 @@ export class HtmlTextParser {
                     remainingArgument = attribute.substring(tagName.length).trim();
 
                     // Skip a pair of quotations for avoiding spaces in image name are detected.
-                    leftQuot = remainingArgument.indexOf('\'');
-                    if (leftQuot > -1) {
-                        rightQuot = remainingArgument.indexOf('\'', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
-                    } else {
-                        leftQuot = remainingArgument.indexOf('"');
-                        rightQuot = remainingArgument.indexOf('"', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
-                    }
+                    // leftQuot = remainingArgument.indexOf('\'');
+                    // if (leftQuot > -1) {
+                    //     rightQuot = remainingArgument.indexOf('\'', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
+                    // } else {
+                    //     leftQuot = remainingArgument.indexOf('"');
+                    //     rightQuot = remainingArgument.indexOf('"', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
+                    // }
+                    rightQuot = this.getRightQuotationIndex(remainingArgument);
 
                     nextSpace = remainingArgument.indexOf(' ', rightQuot + 1 >= remainingArgument.length ? -1 : rightQuot + 1);
 
@@ -318,6 +318,24 @@ export class HtmlTextParser {
         }
 
         return obj;
+    }
+
+    /**
+    * @engineInternal
+    */
+    public getRightQuotationIndex (remainingArgument: string) {
+        let leftQuot = -1;
+        let rightQuot = -1;
+        // Skip a pair of quotations for avoiding spaces in image name are detected.
+        leftQuot = remainingArgument.indexOf('\'');
+        if (leftQuot > -1) {
+            rightQuot = remainingArgument.indexOf('\'', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
+        } else {
+            leftQuot = remainingArgument.indexOf('"');
+            rightQuot = remainingArgument.indexOf('"', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
+        }
+
+        return rightQuot;
     }
 
     private _processEventHandler (eventString: string) {

--- a/cocos/2d/utils/html-text-parser.ts
+++ b/cocos/2d/utils/html-text-parser.ts
@@ -312,10 +312,7 @@ export class HtmlTextParser {
         return obj;
     }
 
-    /**
-    * @engineInternal
-    */
-    public getRightQuotationIndex (remainingArgument: string) {
+    private getRightQuotationIndex (remainingArgument: string) {
         let leftQuot = -1;
         let rightQuot = -1;
         // Skip a pair of quotations for avoiding spaces in image name are detected.

--- a/cocos/2d/utils/html-text-parser.ts
+++ b/cocos/2d/utils/html-text-parser.ts
@@ -186,14 +186,6 @@ export class HtmlTextParser {
                     // remove space and = character
                     remainingArgument = attribute.substring(tagName.length).trim();
 
-                    // Skip a pair of quotations for avoiding spaces in image name are detected.
-                    // leftQuot = remainingArgument.indexOf('\'');
-                    // if (leftQuot > -1) {
-                    //     rightQuot = remainingArgument.indexOf('\'', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
-                    // } else {
-                    //     leftQuot = remainingArgument.indexOf('"');
-                    //     rightQuot = remainingArgument.indexOf('"', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
-                    // }
                     rightQuot = this.getRightQuotationIndex(remainingArgument);
 
                     nextSpace = remainingArgument.indexOf(' ', rightQuot + 1 >= remainingArgument.length ? -1 : rightQuot + 1);

--- a/cocos/2d/utils/html-text-parser.ts
+++ b/cocos/2d/utils/html-text-parser.ts
@@ -172,6 +172,8 @@ export class HtmlTextParser {
 
         header = /^(img(\s)*src(\s)*=[^>]+\/)/.exec(attribute);
         let remainingArgument = '';
+        let leftQuot = -1;
+        let rightQuot = -1;
         if (header && header[0].length > 0) {
             tagName = header[0].trim();
             if (tagName.startsWith('img') && tagName[tagName.length - 1] === '/') {
@@ -184,7 +186,17 @@ export class HtmlTextParser {
                     tagName = attribute.substr(0, header[0].length);
                     // remove space and = character
                     remainingArgument = attribute.substring(tagName.length).trim();
-                    nextSpace = remainingArgument.indexOf(' ');
+
+                    // Skip a pair of quotations for avoiding spaces in image name are detected.
+                    leftQuot = remainingArgument.indexOf('\'');
+                    if (leftQuot > -1) {
+                        rightQuot = remainingArgument.indexOf('\'', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
+                    } else {
+                        leftQuot = remainingArgument.indexOf('"');
+                        rightQuot = remainingArgument.indexOf('"', leftQuot + 1 >= remainingArgument.length ? -1 : leftQuot + 1);
+                    }
+
+                    nextSpace = remainingArgument.indexOf(' ', rightQuot + 1 >= remainingArgument.length ? -1 : rightQuot + 1);
 
                     tagValue = (nextSpace > -1) ? remainingArgument.substr(0, nextSpace) : remainingArgument;
                     tagName = tagName.replace(/[^a-zA-Z]/g, '').trim();

--- a/tests/ui/richtext.test.ts
+++ b/tests/ui/richtext.test.ts
@@ -3,18 +3,78 @@ import { CacheMode, HorizontalTextAlignment, RichText, Sprite } from "../../coco
 import { Node } from "../../cocos/core/scene-graph/node";
 
 test('get-right-quotation-index', () => {
+    const imageAttrReg = /(\s)*src(\s)*=|(\s)*height(\s)*=|(\s)*width(\s)*=|(\s)*align(\s)*=|(\s)*offset(\s)*=|(\s)*click(\s)*=|(\s)*param(\s)*=/;
+    
     const htmlTextParser = new HtmlTextParser();
     let node =new Node();
     node.addComponent(RichText);
     let richtext = node.getComponent(RichText) as RichText;
-
-    richtext.string = "<img src='123' width=80 height=89 align=top offset=30,5 />";
-    let rightQuot = htmlTextParser.getRightQuotationIndex(richtext.string);
-    expect(rightQuot).toStrictEqual(13);
     
-    richtext.string = "<img src=\"1 23\" width=80 height=89 align=top offset=30,5 />";
-    rightQuot = htmlTextParser.getRightQuotationIndex(richtext.string);
-    expect(rightQuot).toStrictEqual(14);
+    let tagName = '';
+    let attribute = "img src='1 23' width=80 height=89 align=top /";
+    richtext.string = attribute;
+
+    let header = /^(img(\s)*src(\s)*=[^>]+\/)/.exec(attribute);
+    let remainingArgument = '';
+    let rightQuot = -1;
+    let nextSpace = 0;
+    if (header && header[0].length > 0) {
+        tagName = header[0].trim();
+        if (tagName.startsWith('img') && tagName[tagName.length - 1] === '/') {
+            header = imageAttrReg.exec(attribute);
+            let tagValue;
+            let isValidImageTag = false;
+            while (header) {
+                // skip the invalid tags at first
+                attribute = attribute.substring(attribute.indexOf(header[0]));
+                tagName = attribute.substr(0, header[0].length);
+                // remove space and = character
+                remainingArgument = attribute.substring(tagName.length).trim();
+
+                rightQuot = htmlTextParser.getRightQuotationIndex(remainingArgument);
+
+                nextSpace = remainingArgument.indexOf(' ', rightQuot + 1 >= remainingArgument.length ? -1 : rightQuot + 1);
+
+                tagValue = (nextSpace > -1) ? remainingArgument.substr(0, nextSpace) : remainingArgument;
+                tagName = tagName.replace(/[^a-zA-Z]/g, '').trim();
+                tagName = tagName.toLowerCase();
+
+                attribute = remainingArgument.substring(nextSpace).trim();
+                if (tagValue.endsWith('/')) tagValue = tagValue.slice(0, -1);
+                if (tagName === 'src') {
+                    switch (tagValue.charCodeAt(0)) {
+                        case 34: // "
+                        case 39: // '
+                            isValidImageTag = true;
+                            tagValue = tagValue.slice(1, -1);
+                            expect(tagValue).toStrictEqual('1 23');
+                            break;
+                        default:
+                            break;
+                    }
+                } else if (tagName === 'height') {
+                    expect(tagValue).toStrictEqual('89');
+                } else if (tagName === 'width') {
+                    expect(tagValue).toStrictEqual('80');
+                } else if (tagName === 'align') {
+                    switch (tagValue.charCodeAt(0)) {
+                        case 34: // "
+                        case 39: // '
+                            tagValue = tagValue.slice(1, -1);
+                            break;
+                        default:
+                            break;
+      
+                }
+                const alignStr = tagValue.toLowerCase();
+                expect(alignStr).toStrictEqual('top');
+                } else if (tagName === 'offset') {
+    
+                }
+                header = imageAttrReg.exec(attribute);
+            }
+        }
+    }
 });
 
 test('label.string.setter', () => {

--- a/tests/ui/richtext.test.ts
+++ b/tests/ui/richtext.test.ts
@@ -35,6 +35,26 @@ test('parse-richtext', () => {
     expect(htmlAttrArray[0].style.imageHeight).toStrictEqual(89);
     expect(htmlAttrArray[0].style.imageAlign).toStrictEqual('top');
     expect(htmlAttrArray[1].text).toStrictEqual('   前面有三个空格，这是一段文本');
+
+    attribute = "<img src='1 23'/>";
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(1);
+    expect(htmlAttrArray[0].style.src).toStrictEqual('1 23');
+
+    // following tests are exceptional writing
+
+    attribute = "<img ='1 23'/>"; // 'src' missing 
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(0);
+
+    attribute = "<img src='123'>"; // '/' missing 
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(0);
+
+    attribute = "<img src='1 23\" />"; // quotations don't match
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(1);
+    expect(htmlAttrArray[0].style.src).toStrictEqual('');
 });
 
 test('label.string.setter', () => {

--- a/tests/ui/richtext.test.ts
+++ b/tests/ui/richtext.test.ts
@@ -3,8 +3,6 @@ import { CacheMode, HorizontalTextAlignment, RichText, Sprite } from "../../coco
 import { Node } from "../../cocos/core/scene-graph/node";
 
 test('parse-richtext', () => {
-    const imageAttrReg = /(\s)*src(\s)*=|(\s)*height(\s)*=|(\s)*width(\s)*=|(\s)*align(\s)*=|(\s)*offset(\s)*=|(\s)*click(\s)*=|(\s)*param(\s)*=/;
-    
     const htmlTextParser = new HtmlTextParser();
     let node =new Node();
     node.addComponent(RichText);
@@ -12,14 +10,31 @@ test('parse-richtext', () => {
 
     let attribute = "<img src='1 23' width=80 height=89 align=top />这是一段文本";
     richtext.string = attribute;
-
-    const htmlAttrArray = htmlTextParser.parse(attribute);
+    let htmlAttrArray = htmlTextParser.parse(attribute);
     expect(htmlAttrArray.length).toStrictEqual(2);
     expect(htmlAttrArray[0].style.src).toStrictEqual('1 23');
     expect(htmlAttrArray[0].style.imageWidth).toStrictEqual(80);
     expect(htmlAttrArray[0].style.imageHeight).toStrictEqual(89);
     expect(htmlAttrArray[0].style.imageAlign).toStrictEqual('top');
     expect(htmlAttrArray[1].text).toStrictEqual('这是一段文本');
+
+    attribute = "<img src='123'   width=80  height=89    align=top />这是一段文本";
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(2);
+    expect(htmlAttrArray[0].style.src).toStrictEqual('123');
+    expect(htmlAttrArray[0].style.imageWidth).toStrictEqual(80);
+    expect(htmlAttrArray[0].style.imageHeight).toStrictEqual(89);
+    expect(htmlAttrArray[0].style.imageAlign).toStrictEqual('top');
+    expect(htmlAttrArray[1].text).toStrictEqual('这是一段文本');
+
+    attribute = "<img src=\"12 3\" width  =  80 height= 89 align  =top />   前面有三个空格，这是一段文本";
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(2);
+    expect(htmlAttrArray[0].style.src).toStrictEqual('12 3');
+    expect(htmlAttrArray[0].style.imageWidth).toStrictEqual(80);
+    expect(htmlAttrArray[0].style.imageHeight).toStrictEqual(89);
+    expect(htmlAttrArray[0].style.imageAlign).toStrictEqual('top');
+    expect(htmlAttrArray[1].text).toStrictEqual('   前面有三个空格，这是一段文本');
 });
 
 test('label.string.setter', () => {

--- a/tests/ui/richtext.test.ts
+++ b/tests/ui/richtext.test.ts
@@ -1,5 +1,21 @@
+import { HtmlTextParser } from "../../cocos/2d";
 import { CacheMode, HorizontalTextAlignment, RichText, Sprite } from "../../cocos/2d/components";
 import { Node } from "../../cocos/core/scene-graph/node";
+
+test('get-right-quotation-index', () => {
+    const htmlTextParser = new HtmlTextParser();
+    let node =new Node();
+    node.addComponent(RichText);
+    let richtext = node.getComponent(RichText) as RichText;
+
+    richtext.string = "<img src='123' width=80 height=89 align=top offset=30,5 />";
+    let rightQuot = htmlTextParser.getRightQuotationIndex(richtext.string);
+    expect(rightQuot).toStrictEqual(13);
+    
+    richtext.string = "<img src=\"1 23\" width=80 height=89 align=top offset=30,5 />";
+    rightQuot = htmlTextParser.getRightQuotationIndex(richtext.string);
+    expect(rightQuot).toStrictEqual(14);
+});
 
 test('label.string.setter', () => {
     let node = new Node();


### PR DESCRIPTION
Re: #10931 

Changelog:
 * In the parsing process of richtext, skip a pair of quotations for avoiding spaces in image name are detected.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->