### PR TITLE
Fix MotionStreak initializing and avoid trail delay by one frame

### DIFF
--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -62,6 +62,7 @@ var MotionStreak = cc.Class({
     ctor () {
         this._points = [];
         this._lastWPos = new cc.Vec2();
+        this._lastWPosUpdated = false;
     },
 
     properties: {
@@ -248,10 +249,7 @@ var MotionStreak = cc.Class({
     reset () {
         this._points.length = 0;
         this._assembler && this._assembler._renderData.clear();
-        this.node._updateWorldMatrix();
-        let matrix = this.node._worldMatrix.m;
-        this._lastWPos.x = matrix[12];
-        this._lastWPos.y = matrix[13];
+        this._lastWPosUpdated = false;
         if (CC_EDITOR) {
             cc.engine.repaintInEditMode();
         }

--- a/cocos2d/core/components/CCMotionStreak.js
+++ b/cocos2d/core/components/CCMotionStreak.js
@@ -248,8 +248,10 @@ var MotionStreak = cc.Class({
     reset () {
         this._points.length = 0;
         this._assembler && this._assembler._renderData.clear();
-        this._lastWPos.x = 0;
-        this._lastWPos.y = 0;
+        this.node._updateWorldMatrix();
+        let matrix = this.node._worldMatrix.m;
+        this._lastWPos.x = matrix[12];
+        this._lastWPos.y = matrix[13];
         if (CC_EDITOR) {
             cc.engine.repaintInEditMode();
         }

--- a/cocos2d/core/renderer/webgl/assemblers/motion-streak.js
+++ b/cocos2d/core/renderer/webgl/assemblers/motion-streak.js
@@ -24,6 +24,7 @@
  ****************************************************************************/
 
 import Assembler2D from '../../assembler-2d';
+import Mat4 from '../../../value-types/mat4';
 
 const MotionStreak = require('../../../components/CCMotionStreak');
 const RenderFlow = require('../../render-flow');
@@ -49,6 +50,7 @@ let _tangent = cc.v2();
 let _miter = cc.v2();
 let _normal = cc.v2();
 let _vec2 = cc.v2();
+let _worldMat = new Mat4();
 
 function normal (out, dir) {
     //get perpendicular
@@ -92,9 +94,8 @@ export default class MotionStreakAssembler extends Assembler2D {
         let stroke = comp._stroke / 2;
 
         let node = comp.node;
-        node._updateWorldMatrix();
-        let matrix = node._worldMatrix.m;
-        let tx = matrix[12], ty = matrix[13];
+        node.getWorldMatrix(_worldMat);
+        let tx = _worldMat.m[12], ty = _worldMat.m[13];
 
         let points = comp._points;
         let lastPos = comp._lastWPos;

--- a/cocos2d/core/renderer/webgl/assemblers/motion-streak.js
+++ b/cocos2d/core/renderer/webgl/assemblers/motion-streak.js
@@ -92,6 +92,7 @@ export default class MotionStreakAssembler extends Assembler2D {
         let stroke = comp._stroke / 2;
 
         let node = comp.node;
+        node._updateWorldMatrix();
         let matrix = node._worldMatrix.m;
         let tx = matrix[12], ty = matrix[13];
 

--- a/cocos2d/core/renderer/webgl/assemblers/motion-streak.js
+++ b/cocos2d/core/renderer/webgl/assemblers/motion-streak.js
@@ -100,7 +100,7 @@ export default class MotionStreakAssembler extends Assembler2D {
         let lastPos = comp._lastWPos;
         let fadeTime = comp._fadeTime;
 
-        let moved = lastPos.x !== tx || lastPos.y !== ty;
+        let moved = comp._lastWPosUpdated && (lastPos.x !== tx || lastPos.y !== ty);
         if (moved) {
             let cur;
             let newHead = false;
@@ -145,6 +145,7 @@ export default class MotionStreakAssembler extends Assembler2D {
 
         lastPos.x = tx;
         lastPos.y = ty;
+        comp._lastWPosUpdated = true;
 
         if (points.length < 2) {
             return;


### PR DESCRIPTION
Re: #9693 https://github.com/cocos-creator-packages/jsb-adapter/pull/368

Changelog:
 * MotionStreak effect optimization: Fix the trail to the origin when initializing and avoid trail delay by one frame.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->