### PR TITLE
[Fix bug] Play and pause audio in the same frame, the pause operation won't work on native

### DIFF
--- a/native/cocos/audio/AudioEngine.cpp
+++ b/native/cocos/audio/AudioEngine.cpp
@@ -245,6 +245,7 @@ int AudioEngine::play2d(const std::string &filePath, bool loop, float volume, co
             audioRef.volume   = volume;
             audioRef.loop     = loop;
             audioRef.filePath = &it->first;
+            audioRef.state    = AudioState::PLAYING;
 
             if (profileHelper) {
                 profileHelper->lastPlayTime = std::chrono::high_resolution_clock::now();

--- a/native/cocos/audio/apple/AudioEngine-inl.mm
+++ b/native/cocos/audio/apple/AudioEngine-inl.mm
@@ -392,7 +392,8 @@ void AudioEngineImpl::play2dImpl(AudioCache *cache, int audioID) {
         auto playerIt = _audioPlayers.find(audioID);
         if (playerIt != _audioPlayers.end()) {
             // Trust it, or assert it out.
-            assert(playerIt->second->play2d());
+            bool res = playerIt->second->play2d();
+            CCASSERT(res, "AudioPlay failed");
         }
         _threadMutex.unlock();
     } else {

--- a/native/cocos/audio/apple/AudioEngine-inl.mm
+++ b/native/cocos/audio/apple/AudioEngine-inl.mm
@@ -390,14 +390,9 @@ void AudioEngineImpl::play2dImpl(AudioCache *cache, int audioID) {
     if (!*cache->_isDestroyed && cache->_state == AudioCache::State::READY) {
         _threadMutex.lock();
         auto playerIt = _audioPlayers.find(audioID);
-        if (playerIt != _audioPlayers.end() && playerIt->second->play2d()) {
-            if (auto sche = _scheduler.lock()) {
-                sche->performFunctionInCocosThread([audioID]() {
-                    if (AudioEngine::sAudioIDInfoMap.find(audioID) != AudioEngine::sAudioIDInfoMap.end()) {
-                        AudioEngine::sAudioIDInfoMap[audioID].state = AudioEngine::AudioState::PLAYING;
-                    }
-                });
-            }
+        if (playerIt != _audioPlayers.end()) {
+            // Trust it, or assert it out.
+            assert(playerIt->second->play2d());
         }
         _threadMutex.unlock();
     } else {

--- a/native/cocos/audio/apple/AudioPlayer.mm
+++ b/native/cocos/audio/apple/AudioPlayer.mm
@@ -204,9 +204,6 @@ bool AudioPlayer::play2d() {
             ALOGE("%s:alSourcePlay error code:%x", __PRETTY_FUNCTION__, alError);
             break;
         }
-
-        ALint state;
-        alGetSourcei(_alSource, AL_SOURCE_STATE, &state);
         /** Due to the bug of OpenAL, when the second time OpenAL trying to mix audio into bus, the mRampState become kRampingComplete, and for those oalSource whose mRampState == kRampingComplete, nothing happens.
          * OALSource::Play{
          *      switch(mState){

--- a/native/cocos/audio/apple/AudioPlayer.mm
+++ b/native/cocos/audio/apple/AudioPlayer.mm
@@ -207,7 +207,19 @@ bool AudioPlayer::play2d() {
 
         ALint state;
         alGetSourcei(_alSource, AL_SOURCE_STATE, &state);
-        assert(state == AL_PLAYING);
+        /** Due to the bug of OpenAL, when the second time OpenAL trying to mix audio into bus, the mRampState become kRampingComplete, and for those oalSource whose mRampState == kRampingComplete, nothing happens.
+         * OALSource::Play{
+         *      switch(mState){
+         *       case kTransitionToStop:
+         *       case kTransitionToStop:
+         *         if(mRampState != kRampingComplete){..}
+         *         break;
+         *      }
+         * }
+         * So the assert here will trigger this bug as aolSource is reused.
+         * Replace OpenAL with AVAudioEngine on V3.6 mightbe helpful
+        */
+        //assert(state == AL_PLAYING);
         _ready = true;
         ret = true;
     } while (false);


### PR DESCRIPTION
Re: 
 * https://github.com/cocos/3d-tasks/issues/10825
 * https://github.com/cocos/3d-tasks/issues/12036

Changelog:
 * Now once the AudioEngine runs play2d, it will directly set AudioInfo.state correspond to AudioState::PLAYING, which was changed by a scheduler. 
 * Since the AudioEngine has to actually "trust" the AudioEngine-impl, then all errors should be asserted by AudioEngine-impl rather than working with delay schedule.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->