### PR TITLE
3.6 [Optimize] Image displays texture information while in SpriteFrame mode

### DIFF
--- a/editor/inspector/assets/image.js
+++ b/editor/inspector/assets/image.js
@@ -57,7 +57,7 @@ exports.$ = {
     isRGBEProp: '.isRGBE-prop',
     isRGBECheckbox: '.isRGBE-checkbox',
 
-    //bakeOfflineMipmapsCheckbox: '.bakeOfflineMipmaps-checkbox',
+    // bakeOfflineMipmapsCheckbox: '.bakeOfflineMipmaps-checkbox',
 };
 
 /**
@@ -313,7 +313,11 @@ exports.methods = {
         }
 
         const asset = assetList[0];
-        this.$.panelName.setAttribute('value', this.meta.userData.type);
+        let type = this.meta.userData.type;
+        if (type === 'sprite-frame') {
+            type = 'texture';
+        }
+        this.$.panelName.setAttribute('value', type);
         this.$.panel.setAttribute('src', path.join(__dirname, `./${asset.importer}.js`));
         this.$.panel.update(assetList, metaList);
     },


### PR DESCRIPTION
Re: #cocos/3d-tasks#11393

Changelog:
 * Image displays texture information while in SpriteFrame mode

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->