### PR TITLE
Add buffer offset to gfx::BufferTextureCopy.

### DIFF
--- a/cocos/core/gfx/base/define.ts
+++ b/cocos/core/gfx/base/define.ts
@@ -894,6 +894,7 @@ export class BufferTextureCopy {
     declare private _token: never; // to make sure all usages must be an instance of this exact class, not assembled from plain object
 
     constructor (
+        public buffOffset: number = 0,
         public buffStride: number = 0,
         public buffTexHeight: number = 0,
         public texOffset: Offset = new Offset(),
@@ -902,6 +903,7 @@ export class BufferTextureCopy {
     ) {}
 
     public copy (info: Readonly<BufferTextureCopy>) {
+        this.buffOffset = info.buffOffset;
         this.buffStride = info.buffStride;
         this.buffTexHeight = info.buffTexHeight;
         this.texOffset.copy(info.texOffset);

--- a/native/cocos/bindings/auto/jsb_gfx_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_gfx_auto.cpp
@@ -2846,6 +2846,33 @@ static bool js_gfx_BufferTextureCopy_copy(se::State& s) // NOLINT(readability-id
 }
 SE_BIND_FUNC(js_gfx_BufferTextureCopy_copy)
 
+static bool js_gfx_BufferTextureCopy_get_buffOffset(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::gfx::BufferTextureCopy>(s);
+    SE_PRECONDITION2(cobj, false, "js_gfx_BufferTextureCopy_get_buffOffset : Invalid Native Object");
+
+    CC_UNUSED bool ok = true;
+    se::Value jsret;
+    ok &= nativevalue_to_se(cobj->buffOffset, jsret, s.thisObject() /*ctx*/);
+    s.rval() = jsret;
+    SE_HOLD_RETURN_VALUE(cobj->buffOffset, s.thisObject(), s.rval());
+    return true;
+}
+SE_BIND_PROP_GET(js_gfx_BufferTextureCopy_get_buffOffset)
+
+static bool js_gfx_BufferTextureCopy_set_buffOffset(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    const auto& args = s.args();
+    auto* cobj = SE_THIS_OBJECT<cc::gfx::BufferTextureCopy>(s);
+    SE_PRECONDITION2(cobj, false, "js_gfx_BufferTextureCopy_set_buffOffset : Invalid Native Object");
+
+    CC_UNUSED bool ok = true;
+    ok &= sevalue_to_native(args[0], &cobj->buffOffset, s.thisObject());
+    SE_PRECONDITION2(ok, false, "js_gfx_BufferTextureCopy_set_buffOffset : Error processing new value");
+    return true;
+}
+SE_BIND_PROP_SET(js_gfx_BufferTextureCopy_set_buffOffset)
+
 static bool js_gfx_BufferTextureCopy_get_buffStride(se::State& s) // NOLINT(readability-identifier-naming)
 {
     auto* cobj = SE_THIS_OBJECT<cc::gfx::BufferTextureCopy>(s);
@@ -2994,6 +3021,10 @@ bool sevalue_to_native(const se::Value &from, cc::gfx::BufferTextureCopy * to, s
     }
     se::Value field;
     bool ok = true;
+    json->getProperty("buffOffset", &field, true);
+    if(!field.isNullOrUndefined()) {
+        ok &= sevalue_to_native(field, &(to->buffOffset), ctx);
+    }
     json->getProperty("buffStride", &field, true);
     if(!field.isNullOrUndefined()) {
         ok &= sevalue_to_native(field, &(to->buffStride), ctx);
@@ -3050,19 +3081,22 @@ static bool js_gfx_BufferTextureCopy_constructor(se::State& s) // NOLINT(readabi
     auto *ptr = JSB_MAKE_PRIVATE_OBJECT(cc::gfx::BufferTextureCopy);
     auto cobj = ptr->get<cc::gfx::BufferTextureCopy>();
     if (argc > 0 && !args[0].isUndefined()) {
-        ok &= sevalue_to_native(args[0], &(cobj->buffStride), nullptr);
+        ok &= sevalue_to_native(args[0], &(cobj->buffOffset), nullptr);
     }
     if (argc > 1 && !args[1].isUndefined()) {
-        ok &= sevalue_to_native(args[1], &(cobj->buffTexHeight), nullptr);
+        ok &= sevalue_to_native(args[1], &(cobj->buffStride), nullptr);
     }
     if (argc > 2 && !args[2].isUndefined()) {
-        ok &= sevalue_to_native(args[2], &(cobj->texOffset), nullptr);
+        ok &= sevalue_to_native(args[2], &(cobj->buffTexHeight), nullptr);
     }
     if (argc > 3 && !args[3].isUndefined()) {
-        ok &= sevalue_to_native(args[3], &(cobj->texExtent), nullptr);
+        ok &= sevalue_to_native(args[3], &(cobj->texOffset), nullptr);
     }
     if (argc > 4 && !args[4].isUndefined()) {
-        ok &= sevalue_to_native(args[4], &(cobj->texSubres), nullptr);
+        ok &= sevalue_to_native(args[4], &(cobj->texExtent), nullptr);
+    }
+    if (argc > 5 && !args[5].isUndefined()) {
+        ok &= sevalue_to_native(args[5], &(cobj->texSubres), nullptr);
     }
 
     if(!ok) {
@@ -3085,6 +3119,7 @@ bool js_register_gfx_BufferTextureCopy(se::Object* obj) // NOLINT(readability-id
 {
     auto* cls = se::Class::create("BufferTextureCopy", obj, nullptr, _SE(js_gfx_BufferTextureCopy_constructor));
 
+    cls->defineProperty("buffOffset", _SE(js_gfx_BufferTextureCopy_get_buffOffset), _SE(js_gfx_BufferTextureCopy_set_buffOffset));
     cls->defineProperty("buffStride", _SE(js_gfx_BufferTextureCopy_get_buffStride), _SE(js_gfx_BufferTextureCopy_set_buffStride));
     cls->defineProperty("buffTexHeight", _SE(js_gfx_BufferTextureCopy_get_buffTexHeight), _SE(js_gfx_BufferTextureCopy_set_buffTexHeight));
     cls->defineProperty("texOffset", _SE(js_gfx_BufferTextureCopy_get_texOffset), _SE(js_gfx_BufferTextureCopy_set_texOffset));

--- a/native/cocos/core/assets/BitmapFont.cpp
+++ b/native/cocos/core/assets/BitmapFont.cpp
@@ -175,6 +175,7 @@ gfx::Texture *BitmapFontFace::loadTexture(const ccstd::string &path) {
     gfx::BufferDataList buffers{image->getData()};
     gfx::BufferTextureCopyList regions = {{0U,
                                            0U,
+                                           0U,
                                            {0U, 0U, 0U},
                                            {width, height, 1U},
                                            {0U, 0U, 1U}}};

--- a/native/cocos/core/assets/FreeTypeFont.cpp
+++ b/native/cocos/core/assets/FreeTypeFont.cpp
@@ -281,6 +281,7 @@ void FreeTypeFontFace::updateTexture(uint32_t page, uint32_t x, uint32_t y, uint
     gfx::BufferDataList buffers{buffer};
     gfx::BufferTextureCopyList regions = {{0U,
                                            0U,
+                                           0U,
                                            {static_cast<int32_t>(x), static_cast<int32_t>(y), 0U},
                                            {width, height, 1U},
                                            {0U, 0U, 1U}}};

--- a/native/cocos/renderer/gfx-agent/DeviceAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/DeviceAgent.cpp
@@ -80,7 +80,7 @@ bool DeviceAgent::doInit(const DeviceInfo &info) {
 
     // NOTE: C++17 is required when enable alignment
     // TODO(PatriceJiang): replace with: _mainMessageQueue = ccnew MessageQueue;
-    _mainMessageQueue = ccnew_placement(CC_MALLOC_ALIGN(sizeof(MessageQueue), alignof(MessageQueue))) MessageQueue; //NOLINT
+    _mainMessageQueue = ccnew_placement(CC_MALLOC_ALIGN(sizeof(MessageQueue), alignof(MessageQueue))) MessageQueue; // NOLINT
 
     static_cast<CommandBufferAgent *>(_cmdBuff)->_queue = _queue;
     static_cast<CommandBufferAgent *>(_cmdBuff)->initAgent();
@@ -285,11 +285,11 @@ void doBufferTextureCopy(const uint8_t *const *buffers, Texture *texture, const 
     for (uint32_t i = 0U; i < count; i++) {
         const BufferTextureCopy &region = regions[i];
 
-        uint32_t size = formatSize(texture->getFormat(), region.texExtent.width, region.texExtent.height, 1);
+        uint32_t size = formatSize(texture->getFormat(), region.texExtent.width, region.texExtent.height, region.texExtent.depth);
         totalSize += size * region.texSubres.layerCount;
     }
 
-    //TODO(PatriceJiang): in C++17 replace with:*allocator = ccnew ThreadSafeLinearAllocator(totalSize);
+    // TODO(PatriceJiang): in C++17 replace with:*allocator = ccnew ThreadSafeLinearAllocator(totalSize);
     auto *memory = CC_MALLOC_ALIGN(sizeof(ThreadSafeLinearAllocator), alignof(ThreadSafeLinearAllocator));
     auto *allocator = ccnew_placement(memory) ThreadSafeLinearAllocator(totalSize);
 
@@ -297,15 +297,38 @@ void doBufferTextureCopy(const uint8_t *const *buffers, Texture *texture, const 
     memcpy(actorRegions, regions, count * sizeof(BufferTextureCopy));
 
     const auto **actorBuffers = allocator->allocate<const uint8_t *>(bufferCount);
+    const auto blockHeight = formatAlignment(texture->getFormat()).second;
     for (uint32_t i = 0U, n = 0U; i < count; i++) {
         const BufferTextureCopy &region = regions[i];
+        uint32_t width = region.texExtent.width;
+        uint32_t height = region.texExtent.height;
+        uint32_t depth = region.texExtent.depth;
 
-        uint32_t size = formatSize(texture->getFormat(), region.texExtent.width, region.texExtent.height, 1);
+        uint32_t rowStride = region.buffStride > 0 ? region.buffStride : region.texExtent.width;
+        uint32_t heightStride = region.buffTexHeight > 0 ? region.buffTexHeight : region.texExtent.height;
+
+        uint32_t rowStrideSize = formatSize(texture->getFormat(), rowStride, 1, 1);
+        uint32_t sliceStrideSize = formatSize(texture->getFormat(), rowStride, heightStride, 1);
+        uint32_t destRowStrideSize = formatSize(texture->getFormat(), width, 1, 1);
+        uint32_t size = formatSize(texture->getFormat(), width, height, depth);
+
         for (uint32_t l = 0; l < region.texSubres.layerCount; l++) {
             auto *buffer = allocator->allocate<uint8_t>(size);
-            memcpy(buffer, buffers[n], size);
+            uint32_t destOffset = 0;
+            uint32_t buffOffset = 0;
+            for (uint32_t d = 0; d < depth; d++) {
+                buffOffset = region.buffOffset + sliceStrideSize * d;
+                for (uint32_t h = 0; h < height; h += blockHeight) {
+                    memcpy(buffer + destOffset, buffers[n] + buffOffset, destRowStrideSize);
+                    destOffset += destRowStrideSize;
+                    buffOffset += rowStrideSize;
+                }
+            }
             actorBuffers[n++] = buffer;
         }
+        actorRegions[i].buffOffset = 0;
+        actorRegions[i].buffStride = 0;
+        actorRegions[i].buffTexHeight = 0;
     }
 
     ENQUEUE_MESSAGE_6(

--- a/native/cocos/renderer/gfx-base/GFXDef-common.h
+++ b/native/cocos/renderer/gfx-base/GFXDef-common.h
@@ -155,7 +155,6 @@ enum class Feature : uint32_t {
     INSTANCED_ARRAYS,
     MULTIPLE_RENDER_TARGETS,
     BLEND_MINMAX,
-    MEMORY_ALIASING,
     COMPUTE_SHADER,
     // This flag indicates whether the device can benefit from subpass-style usages.
     // Specifically, this only differs on the GLES backends: the Framebuffer Fetch
@@ -884,6 +883,7 @@ struct TextureBlit {
 using TextureBlitList = ccstd::vector<TextureBlit>;
 
 struct BufferTextureCopy {
+    uint32_t buffOffset{0};
     uint32_t buffStride{0};
     uint32_t buffTexHeight{0};
     Offset texOffset;


### PR DESCRIPTION
The gfx API copyBuffersToTexture doesn't support buffer offset, this pr adds buffOffset to BufferTextureCopy.

Re: #[11268](https://github.com/cocos/3d-tasks/issues/11268)

## CheckList
- [x] This pr will only change the data of BufferTextureCopy, but will not affect the old use case.
- [x] This pr will change the API of native and web platforms. gfx/base/define.ts was generated by gfx-define-generator. native/core/bindings/auto/jsb_gfx_auto.cpp was generated by tojs/genbindings.js.
- [x] This pr was tested using cocos-test-project on web and native environment.