### PR TITLE
Revert "3.6 fix clang tidy annotation limit"

### DIFF
--- a/.github/workflows/native-linter-android.yml
+++ b/.github/workflows/native-linter-android.yml
@@ -1,8 +1,6 @@
 name: <Native> Linter
 
-on: [pull_request]
-# on:
-  # pull_request_target
+on: pull_request
 
 jobs:
   # Set the job key. The key is displayed as the job name
@@ -23,10 +21,9 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install deps
+      - name: Install python deps
         run: |
           python -m pip install PyYAML==5.4.1 Cheetah3
-          sudo apt install -y ninja-build
       - name: Download external
         run: |
           EXT_VERSION=`node ./.github/workflows/get-native-external-version.js`
@@ -39,6 +36,37 @@ jobs:
           cd ./native/tools/tojs
           python ./genbindings.py
           rm userconf.ini
+      - name: Get changed files
+        uses: PatriceJiang/paths-filter@master
+        id: listchanged
+        with:
+          list-files: shell
+          filters: |
+            source:
+              - added|modified: '**/*.cpp'
+              - added|modified: '**/*.h'
+              - added|modified: '**/*.hpp'
+              - added|modified: '**/*.m'
+              - added|modified: '**/*.mm'
+              - added|modified: '**/*.c'
+              - exclude: 'native/cocos/editor-support/**'
+              - exclude: 'native/cocos/base/etc1.*'
+              - exclude: 'native/cocos/base/etc2.*'
+              - exclude: 'native/cocos/bindings/manual/jsb_global.cpp'
+              - exclude: 'native/cocos/bindings/manual/jsb_dragonbones_manual.cpp'
+              - exclude: 'native/cocos/bindings/manual/jsb_spine_manual.cpp'
+              - exclude: 'native/cocos/bindings/manual/jsb_socketio.cpp'
+              - exclude: 'native/cocos/bindings/manual/jsb_conversions.*'
+              - exclude: 'native/cocos/bindings/jswrapper/v8/debugger/**'
+              - exclude: 'native/cocos/audio/android/audio_utils/**'
+            allChanges:
+              - added|modified|deleted: '**'
+            skipedDebug:
+              - added|modified|deleted: '**'
+              - exclude: 'native/cocos/editor-support/**'
+      - name: Install CMake & Clang Tidy
+        run: |
+          sudo apt install -y cmake llvm clang-tidy-11
 
       - name: Generate Compile database
         shell: bash
@@ -46,20 +74,22 @@ jobs:
           cd native
           ./utils/generate_compile_commands_android.sh
 
-      - uses: shenxianpeng/cpp-linter-action@v1
-        name: Lint action
-        id: linter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          style: file
-          version: 11
-          thread-comments: false
-          ignore: native/cocos/editor-support|native/cocos/bindings/manual|native/cocos/bindings/jswrapper/v8/debugger|native/cocos/audio/android/audio_utils|native/cocos/renderer/gfx-vulkan/volk|native/cocos/bindings/auto
-          database: native
-
-      - name: Fail fast!
-        if: steps.linter.outputs.checks-failed > 0
+      - name: Generate clang-fix.yaml
+        shell: bash
+        if: ${{ steps.listchanged.outputs.source == 'true' }}
         run: |
-          echo "Some files failed the linting checks!"
-          exit 1
+          CPP="${{ steps.listchanged.outputs.source_files }}"
+          FILTERED=`node .github/workflows/filter_by_cdb.js $CPP`
+          if [[ "$FILTERED-xxx" == "-xxx" ]]; then
+            echo "no source files match"
+          else
+            clang-tidy-11 --format-style=file --export-fixes=clang-fixes.yaml $FILTERED
+          fi
+      - name: clang-tidy-action
+        uses: PatriceJiang/clang-tidy-action@master
+        if: hashFiles('clang-fixes.yaml') != ''
+        with:
+          fixesFile: clang-fixes.yaml
+          noFailOnIssue: false
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          error-limit: 200


### PR DESCRIPTION
Reverts cocos/cocos-engine#10989

The github action cpp-linter/cpp-linter-action is not mature.