### PR TITLE
3.5.1 native projects allow user pre-set global cmake vars.

### DIFF
--- a/native/templates/cmake/android.cmake
+++ b/native/templates/cmake/android.cmake
@@ -1,7 +1,7 @@
 
 
 macro(cc_android_before_target target_name)
-    set(CC_ALL_SOURCES ${CC_COMMON_SOURCES} ${CC_PROJ_SOURCES})
+    list(APPEND CC_ALL_SOURCES ${CC_COMMON_SOURCES} ${CC_PROJ_SOURCES})
     cc_common_before_target(${target_name})
 endmacro()
 

--- a/native/templates/cmake/apple.cmake
+++ b/native/templates/cmake/apple.cmake
@@ -1,5 +1,5 @@
 macro(cc_ios_before_target target_name)
-    set(CC_UI_RESOURCES
+    list(APPEND CC_UI_RESOURCES
         ${CC_PROJECT_DIR}/LaunchScreenBackground.png
         ${CC_PROJECT_DIR}/Images.xcassets
         ${CC_PROJECT_DIR}/Base.lproj/Localizable.strings
@@ -34,7 +34,7 @@ macro(cc_ios_before_target target_name)
         ${CC_PROJECT_DIR}/ViewController.h
     )
 
-    set(CC_ALL_SOURCES ${CC_PROJ_SOURCES} ${CC_ASSET_FILES} ${CC_COMMON_SOURCES})
+    list(APPEND CC_ALL_SOURCES ${CC_PROJ_SOURCES} ${CC_ASSET_FILES} ${CC_COMMON_SOURCES})
     cc_common_before_target(${target_name})
 endmacro()
 
@@ -77,7 +77,7 @@ macro(cc_mac_before_target target_name)
 
     set(CMAKE_OSX_DEPLOYMENT_TARGET ${TARGET_OSX_VERSION})
 
-    set(CC_UI_RESOURCES
+    list(APPEND CC_UI_RESOURCES
         ${CC_PROJECT_DIR}/Assets.xcassets
         ${CC_PROJECT_DIR}/Icon.icns
     )
@@ -101,7 +101,7 @@ macro(cc_mac_before_target target_name)
     source_group(TREE ${CC_PROJECT_DIR} PREFIX "Source Files" FILES ${CC_PROJ_SOURCES})
     source_group(TREE ${CC_PROJECT_DIR}/../common PREFIX "Source Files" FILES ${CC_COMMON_SOURCES})
 
-    set(CC_ALL_SOURCES ${CC_PROJ_SOURCES} ${CC_ASSET_FILES} ${CC_COMMON_SOURCES})
+    list(APPEND CC_ALL_SOURCES ${CC_PROJ_SOURCES} ${CC_ASSET_FILES} ${CC_COMMON_SOURCES})
     cc_common_before_target(${target_name})
 endmacro()
 

--- a/native/templates/cmake/linux.cmake
+++ b/native/templates/cmake/linux.cmake
@@ -15,7 +15,7 @@ macro(cc_linux_before_target target_name)
 	
     set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE) 
     set(CMAKE_INSTALL_RPATH "\${ORIGIN}")
-    set(CC_ALL_SOURCES ${CC_PROJ_SOURCES} 
+    list(APPEND CC_ALL_SOURCES ${CC_PROJ_SOURCES} 
         ${CC_COMMON_SOURCES}
         ${CC_ASSET_FILES}
     )

--- a/native/templates/cmake/windows.cmake
+++ b/native/templates/cmake/windows.cmake
@@ -18,7 +18,7 @@ endfunction()
 
 
 macro(cc_windows_before_target target_name)
-    set(CC_UI_RESOURCES
+    list(APPEND CC_UI_RESOURCES
         ${CC_PROJECT_DIR}/game.rc
     )
     list(APPEND CC_PROJ_SOURCES
@@ -27,7 +27,7 @@ macro(cc_windows_before_target target_name)
         ${CC_UI_RESOURCES}
     )
     cc_include_resources(${RES_DIR}/data CC_ASSET_FILES)
-    set(CC_ALL_SOURCES ${CC_PROJ_SOURCES} ${CC_COMMON_SOURCES} ${CC_ASSET_FILES})
+    list(APPEND CC_ALL_SOURCES ${CC_PROJ_SOURCES} ${CC_COMMON_SOURCES} ${CC_ASSET_FILES})
     cc_common_before_target(${target_name})
 endmacro()
 


### PR DESCRIPTION
Re: #

Changelog:
 * bugfix: allow user override default cmake global variables.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->