### PR TITLE
[v3.6][JSB] Revert the count of v8 internal field from 2 to 1, internal field only stores se::Object itself now.

### DIFF
--- a/native/cocos/bindings/jswrapper/State.cpp
+++ b/native/cocos/bindings/jswrapper/State.cpp
@@ -29,18 +29,11 @@
 
 namespace se {
 
-State::State() = default;
-
-State::~State() {
-    SAFE_DEC_REF(_thisObject);
-}
-
-State::State(PrivateObjectBase *privateObject)
-: _privateObject(privateObject) {}
-
-State::State(PrivateObjectBase *privateObject, const ValueArray &args)
-: _privateObject(privateObject),
-  _args(&args) {
+State::State(Object *thisObject)
+: _thisObject(thisObject) {
+    if (_thisObject != nullptr) {
+        _thisObject->incRef();
+    }
 }
 
 State::State(Object *thisObject, const ValueArray &args)
@@ -51,31 +44,15 @@ State::State(Object *thisObject, const ValueArray &args)
     }
 }
 
-State::State(Object *thisObject, PrivateObjectBase *privateObject)
-: _privateObject(privateObject),
-  _thisObject(thisObject) {
-    if (_thisObject != nullptr) {
-        _thisObject->incRef();
-    }
-}
-
-State::State(Object *thisObject, PrivateObjectBase *privateObject, const ValueArray &args)
-: _privateObject(privateObject),
-  _thisObject(thisObject),
-  _args(&args) {
-    if (_thisObject != nullptr) {
-        _thisObject->incRef();
-    }
+State::~State() {
+    SAFE_DEC_REF(_thisObject);
 }
 
 void *State::nativeThisObject() const {
-    return _privateObject ? _privateObject->getRaw() : nullptr;
+    return _thisObject != nullptr ? _thisObject->getPrivateData() : nullptr;
 }
 
 Object *State::thisObject() {
-    if (nullptr == _thisObject && nullptr != _privateObject) {
-        _thisObject = se::Object::getObjectWithPtr(_privateObject->getRaw());
-    }
     // _nativeThisObject in Static method will be nullptr
     //        assert(_thisObject != nullptr);
     return _thisObject;

--- a/native/cocos/bindings/jswrapper/State.h
+++ b/native/cocos/bindings/jswrapper/State.h
@@ -80,8 +80,8 @@ private:
     State &operator=(const State &);
     State &operator=(State &&) noexcept;
 
-    Object *          _thisObject{nullptr}; //weak ref
-    const ValueArray *_args{nullptr};       //weak ref
-    Value             _retVal;              //weak ref
+    Object *_thisObject{nullptr};     //weak ref
+    const ValueArray *_args{nullptr}; //weak ref
+    Value _retVal;                    //weak ref
 };
 } // namespace se

--- a/native/cocos/bindings/jswrapper/State.h
+++ b/native/cocos/bindings/jswrapper/State.h
@@ -68,25 +68,9 @@ public:
          *  @param[in]
          *  @return
          */
-    State();
-
-    /**
-         *  @brief
-         *  @param[in]
-         *  @return
-         */
     ~State();
 
-    explicit State(PrivateObjectBase *privateObject);
-    State(PrivateObjectBase *privateObject, const ValueArray &args);
-    State(Object *thisObject, PrivateObjectBase *privateObject);
-    State(Object *thisObject, PrivateObjectBase *privateObject, const ValueArray &args);
-
-    /**
-         *  @brief
-         *  @param[in]
-         *  @return
-         */
+    explicit State(Object *thisObject);
     State(Object *thisObject, const ValueArray &args);
 
 private:
@@ -96,9 +80,8 @@ private:
     State &operator=(const State &);
     State &operator=(State &&) noexcept;
 
-    PrivateObjectBase *_privateObject{nullptr};
-    Object *_thisObject{nullptr};     //weak ref
-    const ValueArray *_args{nullptr}; //weak ref
-    Value _retVal;                    //weak ref
+    Object *          _thisObject{nullptr}; //weak ref
+    const ValueArray *_args{nullptr};       //weak ref
+    Value             _retVal;              //weak ref
 };
 } // namespace se

--- a/native/cocos/bindings/jswrapper/v8/Base.h
+++ b/native/cocos/bindings/jswrapper/v8/Base.h
@@ -45,5 +45,5 @@
 #include "HelperMacros.h"
 
 namespace se {
-using V8FinalizeFunc = void (*)(PrivateObjectBase *nativeObj);
+using V8FinalizeFunc = void (*)(Object *seObj);
 } // namespace se

--- a/native/cocos/bindings/jswrapper/v8/HelperMacros.h
+++ b/native/cocos/bindings/jswrapper/v8/HelperMacros.h
@@ -106,39 +106,39 @@ void printJSBInvokeAtFrame(int n);
     #define SE_DECLARE_FUNC(funcName) \
         void funcName##Registry(const v8::FunctionCallbackInfo<v8::Value> &v8args)
 
-    #define SE_BIND_FUNC(funcName)                                                                                                              \
-        void funcName##Registry(const v8::FunctionCallbackInfo<v8::Value> &_v8args) {                                                           \
-            JsbInvokeScope(#funcName);                                                                                                          \
-            bool ret = false;                                                                                                                   \
-            v8::Isolate *_isolate = _v8args.GetIsolate();                                                                                       \
-            v8::HandleScope _hs(_isolate);                                                                                                      \
-            se::ValueArray &args = se::gValueArrayPool.get(_v8args.Length());                                                                   \
-            se::CallbackDepthGuard depthGuard{args, se::gValueArrayPool._depth};                                                                \
-            se::internal::jsToSeArgs(_v8args, args);                                                                                            \
-            se::Object* thisObject = se::internal::getPrivate(_isolate, _v8args.This()); \
-            se::State state(thisObject, args);                                                                                   \
-            ret = funcName(state);                                                                                                              \
-            if (!ret) {                                                                                                                         \
-                SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__);                                       \
-            }                                                                                                                                   \
-            se::internal::setReturnValue(state.rval(), _v8args);                                                                                \
+    #define SE_BIND_FUNC(funcName)                                                                        \
+        void funcName##Registry(const v8::FunctionCallbackInfo<v8::Value> &_v8args) {                     \
+            JsbInvokeScope(#funcName);                                                                    \
+            bool ret = false;                                                                             \
+            v8::Isolate *_isolate = _v8args.GetIsolate();                                                 \
+            v8::HandleScope _hs(_isolate);                                                                \
+            se::ValueArray &args = se::gValueArrayPool.get(_v8args.Length());                             \
+            se::CallbackDepthGuard depthGuard{args, se::gValueArrayPool._depth};                          \
+            se::internal::jsToSeArgs(_v8args, args);                                                      \
+            se::Object *thisObject = se::internal::getPrivate(_isolate, _v8args.This());                  \
+            se::State state(thisObject, args);                                                            \
+            ret = funcName(state);                                                                        \
+            if (!ret) {                                                                                   \
+                SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__); \
+            }                                                                                             \
+            se::internal::setReturnValue(state.rval(), _v8args);                                          \
         }
 
-    #define SE_BIND_FUNC_FAST(funcName)                                                                                        \
-        void funcName##Registry(const v8::FunctionCallbackInfo<v8::Value> &_v8args) {                                          \
-            auto *thisObject = static_cast<se::Object*>(_v8args.This()->GetAlignedPointerFromInternalField(0)); \
-            auto *nativeObject = thisObject != nullptr ? thisObject->getPrivateData() : nullptr; \
-            funcName(nativeObject);                                                                                 \
+    #define SE_BIND_FUNC_FAST(funcName)                                                                          \
+        void funcName##Registry(const v8::FunctionCallbackInfo<v8::Value> &_v8args) {                            \
+            auto *thisObject = static_cast<se::Object *>(_v8args.This()->GetAlignedPointerFromInternalField(0)); \
+            auto *nativeObject = thisObject != nullptr ? thisObject->getPrivateData() : nullptr;                 \
+            funcName(nativeObject);                                                                              \
         }
 
     #define SE_BIND_FINALIZE_FUNC(funcName)                                                               \
-        void funcName##Registry(se::Object* thisObject) {                                   \
+        void funcName##Registry(se::Object *thisObject) {                                                 \
             JsbInvokeScope(#funcName);                                                                    \
-            if (thisObject == nullptr)                                                                 \
+            if (thisObject == nullptr)                                                                    \
                 return;                                                                                   \
             auto se = se::ScriptEngine::getInstance();                                                    \
             se->_setGarbageCollecting(true);                                                              \
-            se::State state(thisObject);                                                               \
+            se::State state(thisObject);                                                                  \
             bool ret = funcName(state);                                                                   \
             if (!ret) {                                                                                   \
                 SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__); \
@@ -147,7 +147,7 @@ void printJSBInvokeAtFrame(int n);
         }
 
     #define SE_DECLARE_FINALIZE_FUNC(funcName) \
-        void funcName##Registry(se::Object* thisObject);
+        void funcName##Registry(se::Object *thisObject);
 
     // v8 doesn't need to create a new JSObject in SE_BIND_CTOR while SpiderMonkey needs.
     #define SE_BIND_CTOR(funcName, cls, finalizeCb)                                                       \
@@ -172,19 +172,19 @@ void printJSBInvokeAtFrame(int n);
             if (_found) _property.toObject()->call(args, thisObject);                                     \
         }
 
-    #define SE_BIND_PROP_GET_IMPL(funcName, postFix)                                                                                            \
-        void funcName##postFix##Registry(v8::Local<v8::Name> /*_property*/, const v8::PropertyCallbackInfo<v8::Value> &_v8args) {               \
-            JsbInvokeScope(#funcName);                                                                                                          \
-            v8::Isolate *_isolate = _v8args.GetIsolate();                                                                                       \
-            v8::HandleScope _hs(_isolate);                                                                                                      \
-            bool ret = true;                                                                                                                    \
-            se::Object* thisObject = se::internal::getPrivate(_isolate, _v8args.This()); \
-            se::State state(thisObject);                                                                                         \
-            ret = funcName(state);                                                                                                              \
-            if (!ret) {                                                                                                                         \
-                SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__);                                       \
-            }                                                                                                                                   \
-            se::internal::setReturnValue(state.rval(), _v8args);                                                                                \
+    #define SE_BIND_PROP_GET_IMPL(funcName, postFix)                                                                              \
+        void funcName##postFix##Registry(v8::Local<v8::Name> /*_property*/, const v8::PropertyCallbackInfo<v8::Value> &_v8args) { \
+            JsbInvokeScope(#funcName);                                                                                            \
+            v8::Isolate *_isolate = _v8args.GetIsolate();                                                                         \
+            v8::HandleScope _hs(_isolate);                                                                                        \
+            bool ret = true;                                                                                                      \
+            se::Object *thisObject = se::internal::getPrivate(_isolate, _v8args.This());                                          \
+            se::State state(thisObject);                                                                                          \
+            ret = funcName(state);                                                                                                \
+            if (!ret) {                                                                                                           \
+                SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__);                         \
+            }                                                                                                                     \
+            se::internal::setReturnValue(state.rval(), _v8args);                                                                  \
         }
 
     #define SE_BIND_PROP_GET(funcName)         SE_BIND_PROP_GET_IMPL(funcName, )
@@ -196,12 +196,12 @@ void printJSBInvokeAtFrame(int n);
             v8::Isolate *_isolate = _v8args.GetIsolate();                                                                                                 \
             v8::HandleScope _hs(_isolate);                                                                                                                \
             bool ret = true;                                                                                                                              \
-            se::Object* thisObject = se::internal::getPrivate(_isolate, _v8args.This()); \
+            se::Object *thisObject = se::internal::getPrivate(_isolate, _v8args.This());                                                                  \
             se::ValueArray &args = se::gValueArrayPool.get(1);                                                                                            \
             se::CallbackDepthGuard depthGuard{args, se::gValueArrayPool._depth};                                                                          \
             se::Value &data{args[0]};                                                                                                                     \
             se::internal::jsToSeValue(_isolate, _value, &data);                                                                                           \
-            se::State state(thisObject, args);                                                                                             \
+            se::State state(thisObject, args);                                                                                                            \
             ret = funcName(state);                                                                                                                        \
             if (!ret) {                                                                                                                                   \
                 SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__);                                                 \

--- a/native/cocos/bindings/jswrapper/v8/HelperMacros.h
+++ b/native/cocos/bindings/jswrapper/v8/HelperMacros.h
@@ -115,9 +115,8 @@ void printJSBInvokeAtFrame(int n);
             se::ValueArray &args = se::gValueArrayPool.get(_v8args.Length());                                                                   \
             se::CallbackDepthGuard depthGuard{args, se::gValueArrayPool._depth};                                                                \
             se::internal::jsToSeArgs(_v8args, args);                                                                                            \
-            se::PrivateObjectBase *privateObject = static_cast<se::PrivateObjectBase *>(se::internal::getPrivate(_isolate, _v8args.This(), 0)); \
-            se::Object *thisObject = reinterpret_cast<se::Object *>(se::internal::getPrivate(_isolate, _v8args.This(), 1));                     \
-            se::State state(thisObject, privateObject, args);                                                                                   \
+            se::Object* thisObject = se::internal::getPrivate(_isolate, _v8args.This()); \
+            se::State state(thisObject, args);                                                                                   \
             ret = funcName(state);                                                                                                              \
             if (!ret) {                                                                                                                         \
                 SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__);                                       \
@@ -127,18 +126,19 @@ void printJSBInvokeAtFrame(int n);
 
     #define SE_BIND_FUNC_FAST(funcName)                                                                                        \
         void funcName##Registry(const v8::FunctionCallbackInfo<v8::Value> &_v8args) {                                          \
-            auto *privateObject = static_cast<se::PrivateObjectBase *>(_v8args.This()->GetAlignedPointerFromInternalField(0)); \
-            funcName(privateObject->getRaw());                                                                                 \
+            auto *thisObject = static_cast<se::Object*>(_v8args.This()->GetAlignedPointerFromInternalField(0)); \
+            auto *nativeObject = thisObject != nullptr ? thisObject->getPrivateData() : nullptr; \
+            funcName(nativeObject);                                                                                 \
         }
 
     #define SE_BIND_FINALIZE_FUNC(funcName)                                                               \
-        void funcName##Registry(se::PrivateObjectBase *privateObject) {                                   \
+        void funcName##Registry(se::Object* thisObject) {                                   \
             JsbInvokeScope(#funcName);                                                                    \
-            if (privateObject == nullptr)                                                                 \
+            if (thisObject == nullptr)                                                                 \
                 return;                                                                                   \
             auto se = se::ScriptEngine::getInstance();                                                    \
             se->_setGarbageCollecting(true);                                                              \
-            se::State state(privateObject);                                                               \
+            se::State state(thisObject);                                                               \
             bool ret = funcName(state);                                                                   \
             if (!ret) {                                                                                   \
                 SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__); \
@@ -147,7 +147,7 @@ void printJSBInvokeAtFrame(int n);
         }
 
     #define SE_DECLARE_FINALIZE_FUNC(funcName) \
-        void funcName##Registry(se::PrivateObjectBase *nativeThisObject);
+        void funcName##Registry(se::Object* thisObject);
 
     // v8 doesn't need to create a new JSObject in SE_BIND_CTOR while SpiderMonkey needs.
     #define SE_BIND_CTOR(funcName, cls, finalizeCb)                                                       \
@@ -178,9 +178,8 @@ void printJSBInvokeAtFrame(int n);
             v8::Isolate *_isolate = _v8args.GetIsolate();                                                                                       \
             v8::HandleScope _hs(_isolate);                                                                                                      \
             bool ret = true;                                                                                                                    \
-            se::PrivateObjectBase *privateObject = static_cast<se::PrivateObjectBase *>(se::internal::getPrivate(_isolate, _v8args.This(), 0)); \
-            se::Object *thisObject = reinterpret_cast<se::Object *>(se::internal::getPrivate(_isolate, _v8args.This(), 1));                     \
-            se::State state(thisObject, privateObject);                                                                                         \
+            se::Object* thisObject = se::internal::getPrivate(_isolate, _v8args.This()); \
+            se::State state(thisObject);                                                                                         \
             ret = funcName(state);                                                                                                              \
             if (!ret) {                                                                                                                         \
                 SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__);                                       \
@@ -197,13 +196,12 @@ void printJSBInvokeAtFrame(int n);
             v8::Isolate *_isolate = _v8args.GetIsolate();                                                                                                 \
             v8::HandleScope _hs(_isolate);                                                                                                                \
             bool ret = true;                                                                                                                              \
-            se::PrivateObjectBase *privateObject = static_cast<se::PrivateObjectBase *>(se::internal::getPrivate(_isolate, _v8args.This(), 0));           \
-            se::Object *thisObject = reinterpret_cast<se::Object *>(se::internal::getPrivate(_isolate, _v8args.This(), 1));                               \
+            se::Object* thisObject = se::internal::getPrivate(_isolate, _v8args.This()); \
             se::ValueArray &args = se::gValueArrayPool.get(1);                                                                                            \
             se::CallbackDepthGuard depthGuard{args, se::gValueArrayPool._depth};                                                                          \
             se::Value &data{args[0]};                                                                                                                     \
             se::internal::jsToSeValue(_isolate, _value, &data);                                                                                           \
-            se::State state(thisObject, privateObject, args);                                                                                             \
+            se::State state(thisObject, args);                                                                                             \
             ret = funcName(state);                                                                                                                        \
             if (!ret) {                                                                                                                                   \
                 SE_LOGE("[ERROR] Failed to invoke %s, location: %s:%d\n", #funcName, __FILE__, __LINE__);                                                 \

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -84,10 +84,11 @@ void Object::nativeObjectFinalizeHook(Object *seObj) {
     }
 
     if (seObj->_finalizeCb != nullptr) {
-        seObj->_finalizeCb(seObj->_privateObject);
-    } else {
+        seObj->_finalizeCb(seObj);
+    }
+    else {
         if (seObj->_getClass() != nullptr && seObj->_getClass()->_finalizeFunc != nullptr) {
-            seObj->_getClass()->_finalizeFunc(seObj->_privateObject);
+            seObj->_getClass()->_finalizeFunc(seObj);
         }
     }
     seObj->decRef();
@@ -111,21 +112,17 @@ void Object::cleanup() {
     for (const auto &e : nativePtrToObjectMap) {
         nativeObj = e.first;
         obj = e.second;
-        PrivateObjectBase *privateObject = obj->getPrivateObject();
+
         if (obj->_finalizeCb != nullptr) {
-            obj->_finalizeCb(privateObject);
+            obj->_finalizeCb(obj);
         } else {
             if (obj->_getClass() != nullptr) {
                 if (obj->_getClass()->_finalizeFunc != nullptr) {
-                    obj->_getClass()->_finalizeFunc(privateObject);
+                    obj->_getClass()->_finalizeFunc(obj);
                 }
             }
         }
-        // internal data should only be freed in Object::cleanup, since in other case, it is freed in ScriptEngine::privateDataFinalize
-        if (obj->_internalData != nullptr) {
-            free(obj->_internalData);
-            obj->_internalData = nullptr;
-        }
+
         obj->decRef();
     }
 
@@ -576,7 +573,7 @@ void Object::setPrivateObject(PrivateObjectBase *data) {
         }
     }
     #endif
-    internal::setPrivate(__isolate, _obj, data, this, &_internalData);
+    internal::setPrivate(__isolate, _obj, this);
     _privateObject = data;
 
     if (data != nullptr) {
@@ -585,9 +582,6 @@ void Object::setPrivateObject(PrivateObjectBase *data) {
 }
 
 PrivateObjectBase *Object::getPrivateObject() const {
-    if (_privateObject == nullptr) {
-        const_cast<Object *>(this)->_privateObject = static_cast<PrivateObjectBase *>(internal::getPrivate(__isolate, const_cast<Object *>(this)->_obj.handle(__isolate)));
-    }
     return _privateObject;
 }
 

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -85,8 +85,7 @@ void Object::nativeObjectFinalizeHook(Object *seObj) {
 
     if (seObj->_finalizeCb != nullptr) {
         seObj->_finalizeCb(seObj);
-    }
-    else {
+    } else {
         if (seObj->_getClass() != nullptr && seObj->_getClass()->_finalizeFunc != nullptr) {
             seObj->_getClass()->_finalizeFunc(seObj);
         }

--- a/native/cocos/bindings/jswrapper/v8/Object.h
+++ b/native/cocos/bindings/jswrapper/v8/Object.h
@@ -50,10 +50,6 @@ namespace se {
 class Class;
 class ScriptEngine;
 
-namespace internal {
-struct PrivateData;
-}
-
 /**
      * se::Object represents JavaScript Object.
      */
@@ -460,7 +456,7 @@ private:
 
     PrivateObjectBase *_privateObject{nullptr};
     V8FinalizeFunc _finalizeCb{nullptr};
-    internal::PrivateData *_internalData{nullptr};
+
     bool _clearMappingInFinalizer{true};
 
     #if CC_DEBUG && CC_DEBUG_JS_OBJECT_ID

--- a/native/cocos/bindings/jswrapper/v8/ObjectWrap.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ObjectWrap.cpp
@@ -79,13 +79,13 @@ void ObjectWrap::setFinalizeCallback(FinalizeFunc finalizeCb) {
 /*static*/
 void *ObjectWrap::unwrap(v8::Local<v8::Object> handle, uint32_t fieldIndex) {
     CC_ASSERT(!handle.IsEmpty());
-    CC_ASSERT(handle->InternalFieldCount() > 1);
-    CC_ASSERT(fieldIndex >= 0 && fieldIndex < 2);
+    CC_ASSERT(handle->InternalFieldCount() > 0);
+    CC_ASSERT(fieldIndex >= 0 && fieldIndex < 1);
     return handle->GetAlignedPointerFromInternalField(static_cast<int>(fieldIndex));
 }
 void ObjectWrap::wrap(void *nativeObj, uint32_t fieldIndex) {
-    CC_ASSERT(handle()->InternalFieldCount() > 1);
-    CC_ASSERT(fieldIndex >= 0 && fieldIndex < 2);
+    CC_ASSERT(handle()->InternalFieldCount() > 0);
+    CC_ASSERT(fieldIndex >= 0 && fieldIndex < 1);
     handle()->SetAlignedPointerInInternalField(static_cast<int>(fieldIndex), nativeObj);
 }
 

--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
@@ -458,18 +458,6 @@ void ScriptEngine::onPromiseRejectCallback(v8::PromiseRejectMessage msg) {
     }
 }
 
-void ScriptEngine::privateDataFinalize(PrivateObjectBase *privateObj) {
-    auto *p = static_cast<internal::PrivateData *>(privateObj->getRaw());
-
-    Object::nativeObjectFinalizeHook(p->seObj);
-
-    CC_ASSERT(p->seObj->getRefCount() == 1);
-
-    p->seObj->decRef();
-
-    free(p);
-}
-
 ScriptEngine *ScriptEngine::getInstance() {
     if (gSriptEngineInstance == nullptr) {
         gSriptEngineInstance = ccnew ScriptEngine();

--- a/native/cocos/bindings/jswrapper/v8/Utils.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Utils.cpp
@@ -124,8 +124,9 @@ void jsToSeValue(v8::Isolate *isolate, v8::Local<v8::Value> jsval, Value *v) {
     } else if (jsval->IsObject()) {
         v8::MaybeLocal<v8::Object> jsObj = jsval->ToObject(isolate->GetCurrentContext());
         if (!jsObj.IsEmpty()) {
-            PrivateObjectBase *privateObject = static_cast<PrivateObjectBase *>(internal::getPrivate(isolate, jsObj.ToLocalChecked(), 0));
-            void *nativePtr = privateObject ? privateObject->getRaw() : nullptr;
+            auto* seObj = internal::getPrivate(isolate, jsObj.ToLocalChecked());
+            PrivateObjectBase *privateObject = seObj != nullptr ? seObj->getPrivateObject() : nullptr;
+            void *nativePtr = privateObject != nullptr ? privateObject->getRaw() : nullptr;
             Object *obj = nullptr;
             if (nativePtr != nullptr) {
                 obj = Object::getObjectWithPtr(nativePtr);
@@ -178,41 +179,26 @@ bool hasPrivate(v8::Isolate * /*isolate*/, v8::Local<v8::Value> value) {
     return obj->InternalFieldCount() > 0;
 }
 
-void setPrivate(v8::Isolate *isolate, ObjectWrap &wrap, PrivateObjectBase *data, Object *thizObj, PrivateData **outInternalData) {
+void setPrivate(v8::Isolate *isolate, ObjectWrap &wrap, Object *thizObj) {
     v8::Local<v8::Object> obj = wrap.handle(isolate);
     int c = obj->InternalFieldCount();
-    CC_ASSERT(c > 1);
-    if (c > 1) {
-        wrap.wrap(data, 0);
-        wrap.wrap(thizObj, 1);
-        //                SE_LOGD("setPrivate1: %p\n", data);
-        if (outInternalData != nullptr) {
-            *outInternalData = nullptr;
-        }
+    CC_ASSERT(c > 0);
+    if (c > 0) {
+        wrap.wrap(thizObj, 0);
     }
 }
 
-void *getPrivate(v8::Isolate *isolate, v8::Local<v8::Value> value, uint32_t index /* = 0*/) {
+Object *getPrivate(v8::Isolate *isolate, v8::Local<v8::Value> value) {
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
     v8::MaybeLocal<v8::Object> obj = value->ToObject(context);
     if (obj.IsEmpty()) {
         return nullptr;
     }
 
-    CC_ASSERT(index >= 0 && index < 2);
-    if (index > 1) {
-        return nullptr;
-    }
-
     v8::Local<v8::Object> objChecked = obj.ToLocalChecked();
     int c = objChecked->InternalFieldCount();
-    if (c > 1) {
-        void *nativeObj = nullptr;
-        if (index >= 0 && index < 2) {
-            nativeObj = ObjectWrap::unwrap(objChecked, index);
-        }
-        //                SE_LOGD("getPrivate1: %p\n", nativeObj);
-        return nativeObj;
+    if (c > 0) {
+        return static_cast<Object*>(ObjectWrap::unwrap(objChecked, 0));
     }
 
     return nullptr;
@@ -221,9 +207,8 @@ void *getPrivate(v8::Isolate *isolate, v8::Local<v8::Value> value, uint32_t inde
 void clearPrivate(v8::Isolate *isolate, ObjectWrap &wrap) {
     v8::Local<v8::Object> obj = wrap.handle(isolate);
     int c = obj->InternalFieldCount();
-    if (c > 1) {
+    if (c > 0) {
         wrap.wrap(nullptr, 0);
-        wrap.wrap(nullptr, 1);
     }
 }
 

--- a/native/cocos/bindings/jswrapper/v8/Utils.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Utils.cpp
@@ -124,7 +124,7 @@ void jsToSeValue(v8::Isolate *isolate, v8::Local<v8::Value> jsval, Value *v) {
     } else if (jsval->IsObject()) {
         v8::MaybeLocal<v8::Object> jsObj = jsval->ToObject(isolate->GetCurrentContext());
         if (!jsObj.IsEmpty()) {
-            auto* seObj = internal::getPrivate(isolate, jsObj.ToLocalChecked());
+            auto *seObj = internal::getPrivate(isolate, jsObj.ToLocalChecked());
             PrivateObjectBase *privateObject = seObj != nullptr ? seObj->getPrivateObject() : nullptr;
             void *nativePtr = privateObject != nullptr ? privateObject->getRaw() : nullptr;
             Object *obj = nullptr;
@@ -198,7 +198,7 @@ Object *getPrivate(v8::Isolate *isolate, v8::Local<v8::Value> value) {
     v8::Local<v8::Object> objChecked = obj.ToLocalChecked();
     int c = objChecked->InternalFieldCount();
     if (c > 0) {
-        return static_cast<Object*>(ObjectWrap::unwrap(objChecked, 0));
+        return static_cast<Object *>(ObjectWrap::unwrap(objChecked, 0));
     }
 
     return nullptr;

--- a/native/cocos/bindings/jswrapper/v8/Utils.h
+++ b/native/cocos/bindings/jswrapper/v8/Utils.h
@@ -38,7 +38,7 @@ namespace se {
 
 namespace internal {
 
-void jsToSeArgs(const v8::FunctionCallbackInfo<v8::Value> &_v8args, ValueArray &outArr);
+void jsToSeArgs(const v8::FunctionCallbackInfo<v8::Value> &v8args, ValueArray &outArr);
 void jsToSeValue(v8::Isolate *isolate, v8::Local<v8::Value> jsval, Value *v);
 void seToJsArgs(v8::Isolate *isolate, const ValueArray &args, v8::Local<v8::Value> *outArr);
 void seToJsValue(v8::Isolate *isolate, const Value &v, v8::Local<v8::Value> *outJsVal);

--- a/native/cocos/bindings/jswrapper/v8/Utils.h
+++ b/native/cocos/bindings/jswrapper/v8/Utils.h
@@ -38,11 +38,6 @@ namespace se {
 
 namespace internal {
 
-struct PrivateData {
-    PrivateObjectBase *data{nullptr};
-    Object *seObj{nullptr};
-};
-
 void jsToSeArgs(const v8::FunctionCallbackInfo<v8::Value> &_v8args, ValueArray &outArr);
 void jsToSeValue(v8::Isolate *isolate, v8::Local<v8::Value> jsval, Value *v);
 void seToJsArgs(v8::Isolate *isolate, const ValueArray &args, v8::Local<v8::Value> *outArr);
@@ -52,8 +47,8 @@ void setReturnValue(const Value &data, const v8::FunctionCallbackInfo<v8::Value>
 void setReturnValue(const Value &data, const v8::PropertyCallbackInfo<v8::Value> &argv);
 
 bool hasPrivate(v8::Isolate *isolate, v8::Local<v8::Value> value);
-void setPrivate(v8::Isolate *isolate, ObjectWrap &wrap, PrivateObjectBase *data, Object *obj, PrivateData **outInternalData);
-void *getPrivate(v8::Isolate *isolate, v8::Local<v8::Value> value, uint32_t index = 0);
+void setPrivate(v8::Isolate *isolate, ObjectWrap &wrap, Object *obj);
+Object *getPrivate(v8::Isolate *isolate, v8::Local<v8::Value> value);
 void clearPrivate(v8::Isolate *isolate, ObjectWrap &wrap);
 
 } // namespace internal


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/11365

Changelog:
 * 

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->