### PR TITLE
support gamepad input on web && NS

### DIFF
--- a/@types/jsb.d.ts
+++ b/@types/jsb.d.ts
@@ -69,6 +69,25 @@ declare namespace jsb {
     export let onTouchEnd: TouchEventCallback | undefined;
     export let onTouchCancel: TouchEventCallback | undefined;
 
+    export interface ControllerInfo {
+        id: number;
+        axisInfoList: AxisInfo[],
+        buttonInfoList: ButtonInfo[],
+    }
+
+    export interface AxisInfo {
+        code: number,
+        value: number,
+    }
+
+    export interface ButtonInfo {
+        code: number,
+        isPressed: boolean,
+    }
+
+    export let onControllerInput: (infoList: ControllerInfo[]) => void | undefined;
+    export let onControllerChange: (controllerIds: number[]) => void | undefined;
+
     export interface KeyboardEvent {
         altKey: boolean;
         ctrlKey: boolean;

--- a/@types/pal/input.d.ts
+++ b/@types/pal/input.d.ts
@@ -32,11 +32,13 @@ declare module 'pal/input' {
         public on (eventType: import('cocos/input/types/event-enum').InputEventType, callback: KeyboardCallback, target?: any);
     }
 
+    export type GamepadCallback = (res: import('cocos/input/types/event').EventGamepad) => void;
+
     /**
      * Class designed for gamepad input
      */
     export class GamepadInputSource {
-        // TODO: add more details for GamepadInputSource class
+        public on (eventType: import('cocos/input/types/event-enum').InputEventType, cb: GamepadCallback, target?: any);
     }
 
     type AccelerometerCallback = (res: import('cocos/input/types').EventAcceleration) => void;

--- a/cocos/input/input.ts
+++ b/cocos/input/input.ts
@@ -24,14 +24,12 @@
  THE SOFTWARE.
 */
 
-
-
 import { EDITOR, NATIVE } from 'internal:constants';
-import { TouchInputSource, MouseInputSource, KeyboardInputSource, AccelerometerInputSource } from 'pal/input';
+import { TouchInputSource, MouseInputSource, KeyboardInputSource, AccelerometerInputSource, GamepadInputSource } from 'pal/input';
 import { touchManager } from '../../pal/input/touch-manager';
 import { sys } from '../core/platform/sys';
 import { EventTarget } from '../core/event/event-target';
-import { Event, EventAcceleration, EventKeyboard, EventMouse, EventTouch, Touch } from './types';
+import { Event, EventAcceleration, EventGamepad, EventKeyboard, EventMouse, EventTouch, Touch } from './types';
 import { InputEventType } from './types/event-enum';
 
 export enum EventDispatcherPriority {
@@ -88,6 +86,8 @@ interface InputEventMap {
     [Input.EventType.KEY_PRESSING]: (event: EventKeyboard) => void,
     [Input.EventType.KEY_UP]: (event: EventKeyboard) => void,
     [Input.EventType.DEVICEMOTION]: (event: EventAcceleration) => void,
+    [Input.EventType.GAMEPAD_CHANGE]: (event: EventGamepad) => void,
+    [Input.EventType.GAMEPAD_INPUT]: (event: EventGamepad) => void,
 }
 
 /**
@@ -129,11 +129,13 @@ export class Input {
     private _mouseInput = new MouseInputSource();
     private _keyboardInput = new KeyboardInputSource();
     private _accelerometerInput = new AccelerometerInputSource();
+    private _gamepadInput = new GamepadInputSource();
 
     private _eventTouchList: EventTouch[] = [];
     private _eventMouseList: EventMouse[] = [];
     private _eventKeyboardList: EventKeyboard[] = [];
     private _eventAccelerationList: EventAcceleration[] = [];
+    private _eventGamepadList: EventGamepad[] = [];
 
     private _needSimulateTouchMoveEvent = false;
 
@@ -301,6 +303,12 @@ export class Input {
         if (sys.hasFeature(sys.Feature.EVENT_ACCELEROMETER)) {
             const eventAccelerationList = this._eventAccelerationList;
             this._accelerometerInput.on(InputEventType.DEVICEMOTION, (event) => { this._dispatchOrPushEvent(event, eventAccelerationList); });
+        }
+
+        if (sys.hasFeature(sys.Feature.EVENT_GAMEPAD)) {
+            const eventGamepadList = this._eventGamepadList;
+            this._gamepadInput.on(InputEventType.GAMEPAD_CHANGE, (event) => { this._dispatchOrPushEvent(event, eventGamepadList); });
+            this._gamepadInput.on(InputEventType.GAMEPAD_INPUT, (event) => { this._dispatchOrPushEvent(event, eventGamepadList); });
         }
     }
 

--- a/cocos/input/input.ts
+++ b/cocos/input/input.ts
@@ -376,6 +376,13 @@ export class Input {
             this._emitEvent(eventAcceleration);
         }
 
+        const eventGamepadList = this._eventGamepadList;
+        // TODO: culling event queue
+        for (let i = 0, length = eventGamepadList.length; i < length; ++i) {
+            const eventGamepad = eventGamepadList[i];
+            this._emitEvent(eventGamepad);
+        }
+
         this._clearEvents();
     }
 }

--- a/cocos/input/types/event-enum.ts
+++ b/cocos/input/types/event-enum.ts
@@ -377,6 +377,9 @@ export enum InputEventType {
      * 重力感应
      */
     DEVICEMOTION = 'devicemotion',
+
+    GAMEPAD_INPUT = 'gamepad-input',
+    GAMEPAD_CHANGE = 'gamepad-change',
 }
 
 export type SystemEventTypeUnion = SystemEventType | NodeEventType | InputEventType | string;

--- a/cocos/input/types/event/event-gamepad.ts
+++ b/cocos/input/types/event/event-gamepad.ts
@@ -1,0 +1,48 @@
+/*
+ Copyright (c) 2013-2016 Chukong Technologies Inc.
+ Copyright (c) 2017-2020 Xiamen Yaji Software Co., Ltd.
+
+ http://www.cocos.com
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated engine source code (the "Software"), a limited,
+ worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+ to use Cocos Creator solely to develop games on your target platforms. You shall
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
+
+ The software or tools in this License Agreement are licensed, not sold.
+ Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+/**
+ * @packageDocumentation
+ * @module event
+ */
+
+import { Gamepad } from '../gamepad';
+import { Event } from './event';
+
+/**
+  * @en
+  * The gamepad event.
+  * @zh
+  * 手柄事件。
+  */
+export class EventGamepad extends Event {
+    public gamepads: Gamepad[] = [];
+
+    constructor (type: string, gamepads: Gamepad[]) {
+        super(type, false);
+        this.gamepads = gamepads;
+    }
+}

--- a/cocos/input/types/event/index.ts
+++ b/cocos/input/types/event/index.ts
@@ -3,3 +3,4 @@ export * from './event-acceleration';
 export * from './event-keyboard';
 export * from './event-mouse';
 export * from './event-touch';
+export * from './event-gamepad';

--- a/cocos/input/types/gamepad-code.ts
+++ b/cocos/input/types/gamepad-code.ts
@@ -23,4 +23,8 @@ export enum GamepadCode {
     AXIS_LEFT_STICK_Y = 19,
     AXIS_RIGHT_STICK_X = 20,
     AXIS_RIGHT_STICK_Y = 21,
+
+    // NS
+    NS_PLUS,
+    NS_MINUS,
 }

--- a/cocos/input/types/gamepad-code.ts
+++ b/cocos/input/types/gamepad-code.ts
@@ -1,0 +1,26 @@
+export enum GamepadCode {
+    // buttons
+    A = 0,
+    B = 1,
+    X = 2,
+    Y = 3,
+    L1 = 4,
+    R1 = 5,
+    L2 = 6,
+    R2 = 7,
+    SHARE = 8,
+    OPTIONS = 9,
+    L3 = 10,
+    R3 = 11,
+    DPAD_UP = 12,
+    DPAD_DOWN = 13,
+    DPAD_LEFT = 14,
+    DPAD_RIGHT = 15,
+    HOME = 16,
+    TOUCHPAD = 17,
+    // axes
+    AXIS_LEFT_STICK_X = 18,
+    AXIS_LEFT_STICK_Y = 19,
+    AXIS_RIGHT_STICK_X = 20,
+    AXIS_RIGHT_STICK_Y = 21,
+}

--- a/cocos/input/types/gamepad.ts
+++ b/cocos/input/types/gamepad.ts
@@ -1,0 +1,58 @@
+/*
+ Copyright (c) 2013-2016 Chukong Technologies Inc.
+ Copyright (c) 2017-2020 Xiamen Yaji Software Co., Ltd.
+
+ http://www.cocos.com
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated engine source code (the "Software"), a limited,
+ worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+ to use Cocos Creator solely to develop games on your target platforms. You shall
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
+
+ The software or tools in this License Agreement are licensed, not sold.
+ Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+import { GamepadCode } from './gamepad-code';
+
+export class Gamepad {
+    public get id () {
+        return this._id;
+    }
+    public get connected () {
+        return this._connected;
+    }
+
+    private _id: number;
+    private _codeMap: Record<GamepadCode, number>;
+    private _connected = false;
+
+    constructor (id: number, connected: boolean, codeMap?: Record<GamepadCode, number>) {
+        this._id = id;
+        this._connected = connected;
+        if (codeMap) {
+            this._codeMap = codeMap;
+        } else {
+            // @ts-expect-error missing properties
+            this._codeMap = {};
+            Object.keys(GamepadCode).forEach((code) => {
+                this._codeMap[code] = 0;
+            });
+        }
+    }
+
+    public getValue (code: GamepadCode) {
+        return this._codeMap[code];
+    }
+}

--- a/cocos/input/types/index.ts
+++ b/cocos/input/types/index.ts
@@ -2,4 +2,6 @@ export * from './event/index';
 export * from './acceleration';
 export { SystemEventType } from './event-enum';
 export * from './key-code';
+export * from './gamepad-code';
 export * from './touch';
+export * from './gamepad';

--- a/pal/input/native/gamepad-input.ts
+++ b/pal/input/native/gamepad-input.ts
@@ -1,7 +1,132 @@
+import { GamepadCallback } from 'pal/input';
+import { systemInfo } from 'pal/system-info';
+import { InputEventType } from '../../../cocos/input/types/event-enum';
+import { Feature } from '../../system-info/enum-type';
+import { GamepadCode } from '../../../cocos/input/types/gamepad-code';
+import { EventTarget } from '../../../cocos/core/event/event-target';
+import { Gamepad, EventGamepad } from '../../../cocos/input/types';
+
+const _nativeButtonMap = {
+    1: GamepadCode.Y,  // NS_A
+    2: GamepadCode.B,  // NS_B
+    3: GamepadCode.A,  // NS_X
+    4: GamepadCode.X,  // NS_Y
+    5: GamepadCode.L1,
+    6: GamepadCode.R1,
+    7: GamepadCode.NS_MINUS,
+    8: GamepadCode.NS_PLUS,
+    9: GamepadCode.L3,
+    10: GamepadCode.R3,
+};
+
+const _nativeAxisMap = {
+    // 1: GamepadCode.DPAD_LEFT | GamepadCode.DPAD_RIGHT,
+    // 2: GamepadCode.DPAD_UP | GamepadCode.DPAD_DOWN,
+    3: GamepadCode.AXIS_LEFT_STICK_X,
+    4: GamepadCode.AXIS_LEFT_STICK_Y,
+    5: GamepadCode.AXIS_RIGHT_STICK_X,
+    6: GamepadCode.AXIS_RIGHT_STICK_Y,
+    7: GamepadCode.L2,
+    8: GamepadCode.R2,
+};
+
+type CodeMap = Record<GamepadCode, number>;
+
+interface ICodeMapList {
+    [id: number]: CodeMap;
+}
+
 export class GamepadInputSource {
-    support: boolean;
+    private _eventTarget: EventTarget = new EventTarget();
+    private _codeMapList: ICodeMapList = [];
 
     constructor () {
-        this.support = false;
+        if (!systemInfo.hasFeature(Feature.EVENT_GAMEPAD)) {
+            return;
+        }
+        this._registerEvent();
+    }
+
+    public on (eventType: InputEventType, cb: GamepadCallback, target?: any) {
+        this._eventTarget.on(eventType, cb, target);
+    }
+
+    private _registerEvent () {
+        jsb.onControllerInput = (infoList: jsb.ControllerInfo[]) => {
+            const gamepads: Gamepad[] = [];
+            for (let i = 0; i < infoList.length; ++i) {
+                const info = infoList[i];
+                const gamepad = new Gamepad(info.id, true, this._genCodeMap(info));
+                gamepads.push(gamepad);
+            }
+            this._eventTarget.emit(InputEventType.GAMEPAD_INPUT, new EventGamepad(InputEventType.GAMEPAD_INPUT, gamepads));
+        };
+
+        jsb.onControllerChange = (controllerIds) => {
+            const gamepads: Gamepad[] = [];
+            for (let i = 0; i < controllerIds.length; ++i) {
+                const id = controllerIds[i];
+                const gamepad = new Gamepad(id, true, this._genCodeMapFromId(id));
+                gamepads.push(gamepad);
+            }
+            this._eventTarget.emit(InputEventType.GAMEPAD_CHANGE, new EventGamepad(InputEventType.GAMEPAD_CHANGE, gamepads));
+        };
+    }
+
+    private _createCodeMap (): CodeMap {
+        // @ts-expect-error missing properties
+        const codeMap: CodeMap = {};
+        Object.keys(GamepadCode).forEach((code) => {
+            codeMap[code] = 0;
+        });
+        return codeMap;
+    }
+
+    private _genCodeMap (info: jsb.ControllerInfo): Record<GamepadCode, number> {
+        const codeMap: CodeMap = this._codeMapList[info.id] = this._codeMapList[info.id] || this._createCodeMap();
+
+        const buttonInfoList = info.buttonInfoList;
+        for (let i = 0; i < buttonInfoList.length; ++i) {
+            const buttonInfo = buttonInfoList[i];
+            const code = _nativeButtonMap[buttonInfo.code];
+            codeMap[code] = buttonInfo.isPressed ? 1 : 0;
+        }
+
+        const axisInfoList = info.axisInfoList;
+        for (let i = 0; i < axisInfoList.length; ++i) {
+            const axisInfo = axisInfoList[i];
+            let code: number;
+            let value: number;
+            if (axisInfo.code === 1) {
+                if (axisInfo.value > 0) {
+                    codeMap[GamepadCode.DPAD_RIGHT] = Math.abs(axisInfo.value);
+                    codeMap[GamepadCode.DPAD_LEFT] = 0;
+                } else {
+                    codeMap[GamepadCode.DPAD_LEFT] = Math.abs(axisInfo.value);
+                    codeMap[GamepadCode.DPAD_RIGHT] = 0;
+                }
+                value = Math.abs(axisInfo.value);
+            } else if (axisInfo.code === 2) {
+                if (axisInfo.value > 0) {
+                    codeMap[GamepadCode.DPAD_UP] = Math.abs(axisInfo.value);
+                    codeMap[GamepadCode.DPAD_DOWN] = 0;
+                } else {
+                    codeMap[GamepadCode.DPAD_DOWN] = Math.abs(axisInfo.value);
+                    codeMap[GamepadCode.DPAD_UP] = 0;
+                }
+            } else {
+                code = _nativeAxisMap[axisInfo.code];
+                value = axisInfo.value;
+                codeMap[code] = value;
+            }
+        }
+        return codeMap;
+    }
+
+    private _genCodeMapFromId (id: number) {
+        if (!this._codeMapList[id]) {
+            this._codeMapList[id] = this._createCodeMap();
+        }
+        return this._codeMapList[id];
     }
 }

--- a/pal/input/web/gamepad-input.ts
+++ b/pal/input/web/gamepad-input.ts
@@ -10,10 +10,16 @@ import { Feature } from '../../system-info/enum-type';
 const EPSILON = 0.01;
 type WebGamepad = Gamepad;
 
+type CodeMap = Record<GamepadCode, number>;
+
+interface ICodeMapList {
+    [id: number]: CodeMap;
+}
+
 export class GamepadInputSource {
     private _cachedWebGamepads: (WebGamepad | null)[] = [];
     private _eventTarget: EventTarget = new EventTarget();
-
+    private _codeMapList: ICodeMapList = {};
     private _intervalId = -1;
 
     constructor () {
@@ -109,8 +115,7 @@ export class GamepadInputSource {
     }
 
     private _genCodeMap (webGamepad: WebGamepad): Record<GamepadCode, number> {
-        // @ts-expect-error missing properties
-        const codeMap: Record<GamepadCode, number> = {};
+        const codeMap: CodeMap = this._codeMapList[webGamepad.index] = this._codeMapList[webGamepad.index] || {};
 
         const buttons = webGamepad.buttons;
         for (let i = 0; i < buttons.length; ++i) {

--- a/pal/input/web/gamepad-input.ts
+++ b/pal/input/web/gamepad-input.ts
@@ -19,7 +19,7 @@ interface ICodeMapList {
 export class GamepadInputSource {
     private _cachedWebGamepads: (WebGamepad | null)[] = [];
     private _eventTarget: EventTarget = new EventTarget();
-    private _codeMapList: ICodeMapList = {};
+    private _codeMapList: ICodeMapList = [];
     private _intervalId = -1;
 
     constructor () {

--- a/pal/input/web/gamepad-input.ts
+++ b/pal/input/web/gamepad-input.ts
@@ -1,7 +1,142 @@
+import { GamepadCallback } from 'pal/input';
+import { systemInfo } from 'pal/system-info';
+import { InputEventType } from '../../../cocos/input/types/event-enum';
+import { GamepadCode } from '../../../cocos/input/types/gamepad-code';
+import { EventTarget } from '../../../cocos/core/event/event-target';
+import { Gamepad as CocosGamepad, EventGamepad } from '../../../cocos/input/types';
+import legacyCC from '../../../predefine';
+import { Feature } from '../../system-info/enum-type';
+
+const EPSILON = 0.01;
+type WebGamepad = Gamepad;
+
 export class GamepadInputSource {
-    support: boolean;
+    private _cachedWebGamepads: (WebGamepad | null)[] = [];
+    private _eventTarget: EventTarget = new EventTarget();
+
+    private _intervalId = -1;
 
     constructor () {
-        this.support = false;
+        if (!systemInfo.hasFeature(Feature.EVENT_GAMEPAD)) {
+            return;
+        }
+        this._registerEvent();
+    }
+
+    public on (eventType: InputEventType, cb: GamepadCallback, target?: any) {
+        this._eventTarget.on(eventType, cb, target);
+    }
+
+    private _ensureDirectorDefined () {
+        return new Promise<void>((resolve) => {
+            this._intervalId = setInterval(() => {
+                if (legacyCC.director && legacyCC.Director) {
+                    clearInterval(this._intervalId);
+                    this._intervalId = -1;
+                    resolve();
+                }
+            }, 50);
+        });
+    }
+
+    private _registerEvent () {
+        this._ensureDirectorDefined().then(() => {
+            legacyCC.director.on(legacyCC.Director.EVENT_BEGIN_FRAME, this._scanGamepads, this);
+        }).catch((e) => {});
+        window.addEventListener('gamepadconnected', (e) => {
+            this._cachedWebGamepads[e.gamepad.index] = e.gamepad;
+            const coocsGamepad = new CocosGamepad(e.gamepad.index, true);
+            this._eventTarget.emit(InputEventType.GAMEPAD_CHANGE, new EventGamepad(InputEventType.GAMEPAD_CHANGE, [coocsGamepad]));
+        });
+        window.addEventListener('gamepaddisconnected', (e) => {
+            this._cachedWebGamepads[e.gamepad.index] = null;
+            const coocsGamepad = new CocosGamepad(e.gamepad.index, false);
+            this._eventTarget.emit(InputEventType.GAMEPAD_CHANGE, new EventGamepad(InputEventType.GAMEPAD_CHANGE, [coocsGamepad]));
+        });
+    }
+    private _scanGamepads () {
+        const webGamepads = this._getWebGamePads();
+        if (!webGamepads) {
+            return;
+        }
+        const cocosGamepads: CocosGamepad[] = [];
+        for (let i = 0; i < webGamepads.length; ++i) {
+            const webGamepad = webGamepads?.[i];
+            if (!webGamepad) {
+                continue;
+            }
+            const cachedWebGamepad = this._cachedWebGamepads[webGamepad.index];
+            // TODO: what if cachedWebGamepad is null
+            if (cachedWebGamepad) {
+                let cacheUpdated = false;
+
+                const cachedButtons = cachedWebGamepad.buttons;
+                for (let j = 0; j < cachedButtons.length; ++j) {
+                    const cachedButton = cachedButtons[j];
+                    const button = webGamepad.buttons[j];
+                    if (Math.abs(cachedButton.value - button.value) > EPSILON) {
+                        cocosGamepads.push(new CocosGamepad(webGamepad.index, true, this._genCodeMap(webGamepad)));
+                        cacheUpdated = true;
+                        break;
+                    }
+                }
+                if (cacheUpdated) {
+                    // update cache
+                    this._cachedWebGamepads[webGamepad.index] = webGamepad;
+                    continue;
+                }
+
+                const cachedAxes = cachedWebGamepad.axes;
+                for (let j = 0; j < cachedAxes.length; ++j) {
+                    const cachedAxisValue = cachedAxes[j];
+                    const axisValue = webGamepad.axes[j];
+                    if (Math.abs(cachedAxisValue - axisValue) > EPSILON) {
+                        cocosGamepads.push(new CocosGamepad(webGamepad.index, true, this._genCodeMap(webGamepad)));
+                        cacheUpdated = true;
+                        break;
+                    }
+                }
+                if (cacheUpdated) {
+                    // update cache
+                    this._cachedWebGamepads[webGamepad.index] = webGamepad;
+                    continue;
+                }
+            }
+        }
+        if (cocosGamepads.length > 0) {
+            this._eventTarget.emit(InputEventType.GAMEPAD_INPUT, new EventGamepad(InputEventType.GAMEPAD_INPUT, cocosGamepads));
+        }
+    }
+
+    private _genCodeMap (webGamepad: WebGamepad): Record<GamepadCode, number> {
+        // @ts-expect-error missing properties
+        const codeMap: Record<GamepadCode, number> = {};
+
+        const buttons = webGamepad.buttons;
+        for (let i = 0; i < buttons.length; ++i) {
+            const button = buttons[i];
+            codeMap[i] = button.value;
+        }
+
+        const axes = webGamepad.axes;
+        for (let i = 0; i < axes.length; ++i) {
+            let axisValue = axes[i];
+            if (i === 1 || i === 3) {
+                axisValue = -axisValue;  // revert y axis
+            }
+            codeMap[18 + i] = axisValue;
+        }
+        return codeMap;
+    }
+
+    private _getWebGamePads () {
+        if (typeof navigator.getGamepads === 'function') {
+            return navigator.getGamepads();
+            // @ts-expect-error Property 'webkitGetGamepads' does not exist on type 'Navigator'
+        } else if (typeof navigator.webkitGetGamepads === 'function') {
+            // @ts-expect-error Property 'webkitGetGamepads' does not exist on type 'Navigator'
+            return navigator.webkitGetGamepads() as (Gamepad | null)[];
+        }
+        return [];
     }
 }

--- a/pal/system-info/enum-type/feature.ts
+++ b/pal/system-info/enum-type/feature.ts
@@ -56,4 +56,10 @@ export enum Feature {
      * @zh 是否支持派发 EventAcceleration。
      */
     EVENT_ACCELEROMETER = 'EVENT_ACCELEROMETER',
+
+    /**
+     * @en Feature to support dispatching EventGamepad.
+     * @zh 是否支持派发 EventGamepad.
+     */
+    EVENT_GAMEPAD = 'EVENT_GAMEPAD',
 }

--- a/pal/system-info/minigame/system-info.ts
+++ b/pal/system-info/minigame/system-info.ts
@@ -115,6 +115,7 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_MOUSE]: isPCWechat,
             [Feature.EVENT_TOUCH]: true,
             [Feature.EVENT_ACCELEROMETER]: !isPCWechat,
+            [Feature.EVENT_GAMEPAD]: false,
         };
 
         this._registerEvent();

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -87,7 +87,7 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_MOUSE]: !this.isMobile,
             [Feature.EVENT_TOUCH]: true,
             [Feature.EVENT_ACCELEROMETER]: this.isMobile,
-            [Feature.EVENT_GAMEPAD]: false,
+            [Feature.EVENT_GAMEPAD]: true,
         };
 
         this._registerEvent();

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -87,6 +87,7 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_MOUSE]: !this.isMobile,
             [Feature.EVENT_TOUCH]: true,
             [Feature.EVENT_ACCELEROMETER]: this.isMobile,
+            [Feature.EVENT_GAMEPAD]: false,
         };
 
         this._registerEvent();

--- a/pal/system-info/web/system-info.ts
+++ b/pal/system-info/web/system-info.ts
@@ -179,6 +179,8 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_MOUSE]: supportMouse,
             [Feature.EVENT_TOUCH]: supportTouch || supportMouse,
             [Feature.EVENT_ACCELEROMETER]: (window.DeviceMotionEvent !== undefined || window.DeviceOrientationEvent !== undefined),
+            // @ts-expect-error undefined webkitGetGamepads
+            [Feature.EVENT_GAMEPAD]: (navigator.getGamepads !== undefined || navigator.webkitGetGamepads !== undefined),
         };
 
         this._registerEvent();


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/10330

### ChangeLog
- support gamepad input on Web platform
- support gamepad input on NS platform

### Usage

```ts
// game input event
input.on(Input.EventType.GAMEPAD_INPUT, (e: EventGamepad) {
    const gamepad = e.gamepads[0];
    gamepad.getValue(GamepadCode.R1);  // [0, 1]
    gamepad.getValue(GamepadCode.R2);  // 0 ~ 1
    gamepad.getValue(GamepadCode.A); // [0, 1]
    gamepad.getValue(GamepadCode.AXIS_LEFT_STICK_X);  // -1 ~ 1
});

// connect and disconnect gamepad
input.on(Input.EventType.GAMEPAD_CHANGE, (e) => {
    const gamepad = e.gamepads[0];
    console.log(gamepad.id, gamepad.connected);
});
```

### Test Case

https://github.com/cocos/cocos-test-projects/pull/613