### PR TITLE
keep the group displayOrder

### DIFF
--- a/editor/inspector/components/class.js
+++ b/editor/inspector/components/class.js
@@ -68,12 +68,7 @@ exports.methods = {
     },
     appendChildByDisplayOrder(parent, newChild, displayOrder = 0) {
         const children = Array.from(parent.children);
-        const child = children.find((child) => {
-            if (child.dump && child.displayOrder > displayOrder) {
-                return child;
-            }
-            return null;
-        });
+        const child = children.find(child => child.dump && child.displayOrder > displayOrder);
         if (child) {
             child.before(newChild);
         } else {
@@ -119,7 +114,8 @@ async function update(dump) {
             $prop.setAttribute('type', 'dump');
             $panel.$propList[id] = $prop;
 
-            $prop.displayOrder = info.displayOrder === undefined ? index : Number(info.displayOrder);
+            const _displayOrder = info.displayOrder || info.group?.displayOrder;
+            $prop.displayOrder = _displayOrder === undefined ? index : Number(_displayOrder);
 
             if (info.group && dump.groups) {
                 const key = info.group.id || 'default';
@@ -142,7 +138,13 @@ async function update(dump) {
                 $panel.appendChildByDisplayOrder($section, $prop, $prop.displayOrder);
             }
         } else if (!$prop.isConnected || !$prop.parentElement) {
-            $panel.appendChildByDisplayOrder($section, $prop, $prop.displayOrder);
+            if (info.group && dump.groups) {
+                const key = info.group.id || 'default';
+                const name = info.group.name;
+                $panel.appendChildByDisplayOrder($panel.$groups[key].tabs[name], $prop, $prop.displayOrder);
+            } else {
+                $panel.appendChildByDisplayOrder($section, $prop, $prop.displayOrder);
+            }
         }
         $prop.render(info);
     });

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -156,7 +156,7 @@ exports.listeners = {
     },
 };
 
-exports.template = `
+exports.template = /* html*/`
 <ui-drag-area class="container">
     <section class="prefab" hidden missing>
         <ui-label value="Prefab"></ui-label>


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12191

Changelog:
 * keep the group displayOrder

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->