### PR TITLE
Instantiate all FastDefined objects as value type

### DIFF
--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -406,14 +406,15 @@ export function CCClass<TFunction> (options: {
  * 检查构造函数是否由 `Class` 创建。
  * @method _isCCClass
  * @param {Function} constructor
+ * @param {Boolean} [allowFastDefined=false]
  * @return {Boolean}
  * @private
  */
-CCClass._isCCClass = function isCCClass (constructor): boolean {
+CCClass._isCCClass = function isCCClass (constructor, allowFastDefined = false): boolean {
     // Does not support fastDefined class (ValueType).
     // Use `instanceof ValueType` if necessary.
     // eslint-disable-next-line no-prototype-builtins, @typescript-eslint/no-unsafe-return
-    return constructor?.hasOwnProperty?.('__ctors__');     // __ctors__ is not inherited
+    return constructor?.hasOwnProperty?.(allowFastDefined ? '__values__' : '__ctors__');     // __ctors__ is not inherited
 };
 
 //

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -440,7 +440,7 @@ CCClass.attr = attributeUtils.attr;
 
 /**
  * Returns if the class is a cc-class or is fast defined.
- * @param constructor The constructor of the class
+ * @param constructor The constructor of the class.
  * @returns Judge result.
  */
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -24,8 +24,6 @@
  THE SOFTWARE.
 */
 
-
-
 import { DEV, EDITOR, SUPPORT_JIT, TEST } from 'internal:constants';
 import { errorID, warnID, error } from '../platform/debug';
 import * as js from '../utils/js';
@@ -406,15 +404,14 @@ export function CCClass<TFunction> (options: {
  * 检查构造函数是否由 `Class` 创建。
  * @method _isCCClass
  * @param {Function} constructor
- * @param {Boolean} [allowFastDefined=false]
  * @return {Boolean}
  * @private
  */
-CCClass._isCCClass = function isCCClass (constructor, allowFastDefined = false): boolean {
+CCClass._isCCClass = function isCCClass (constructor): boolean {
     // Does not support fastDefined class (ValueType).
     // Use `instanceof ValueType` if necessary.
     // eslint-disable-next-line no-prototype-builtins, @typescript-eslint/no-unsafe-return
-    return constructor?.hasOwnProperty?.(allowFastDefined ? '__values__' : '__ctors__');     // __ctors__ is not inherited
+    return constructor?.hasOwnProperty?.('__ctors__');     // __ctors__ is not inherited
 };
 
 //
@@ -440,6 +437,17 @@ CCClass.fastDefine = function (className, constructor, serializableFields) {
 
 CCClass.Attr = attributeUtils;
 CCClass.attr = attributeUtils.attr;
+
+/**
+ * Returns if the class is a cc-class or is fast defined.
+ * @param constructor The constructor of the class
+ * @returns Judge result.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function isCCClassOrFastDefined<T> (constructor: Constructor<T>) {
+    // eslint-disable-next-line no-prototype-builtins, @typescript-eslint/no-unsafe-return
+    return  constructor?.hasOwnProperty?.('__values__');
+}
 
 /**
  * Return all super classes.

--- a/cocos/core/data/instantiate-jit.ts
+++ b/cocos/core/data/instantiate-jit.ts
@@ -423,7 +423,7 @@ class Parser {
     // codeArray - the source code array for this object
     public enumerateObject (codeArray, obj) {
         const klass = obj.constructor;
-        if (isCCClassOrFastDefined(klass, true)) {
+        if (isCCClassOrFastDefined(klass)) {
             this.enumerateCCClass(codeArray, obj, klass);
         } else {
             // primitive javascript object

--- a/cocos/core/data/instantiate-jit.ts
+++ b/cocos/core/data/instantiate-jit.ts
@@ -24,13 +24,11 @@
  THE SOFTWARE.
 */
 
-
-
 // Some helper methods for compile instantiation code
 
 import { TEST } from 'internal:constants';
 import * as js from '../utils/js';
-import { CCClass } from './class';
+import { CCClass, isCCClassOrFastDefined } from './class';
 import { CCObject } from './object';
 import * as Attr from './utils/attribute';
 import { flattenCodeArray } from './utils/compiler';
@@ -425,7 +423,7 @@ class Parser {
     // codeArray - the source code array for this object
     public enumerateObject (codeArray, obj) {
         const klass = obj.constructor;
-        if (legacyCC.Class._isCCClass(klass, true)) {
+        if (isCCClassOrFastDefined(klass, true)) {
             this.enumerateCCClass(codeArray, obj, klass);
         } else {
             // primitive javascript object
@@ -460,7 +458,7 @@ class Parser {
 
         let createCode;
         const ctor = obj.constructor;
-        if (legacyCC.Class._isCCClass(ctor, true)) {
+        if (isCCClassOrFastDefined(ctor)) {
             if (this.parent) {
                 if (this.parent instanceof legacyCC.Component) {
                     if (obj instanceof legacyCC._BaseNode || obj instanceof legacyCC.Component) {

--- a/cocos/core/data/instantiate-jit.ts
+++ b/cocos/core/data/instantiate-jit.ts
@@ -425,7 +425,7 @@ class Parser {
     // codeArray - the source code array for this object
     public enumerateObject (codeArray, obj) {
         const klass = obj.constructor;
-        if (legacyCC.Class._isCCClass(klass)) {
+        if (legacyCC.Class._isCCClass(klass, true)) {
             this.enumerateCCClass(codeArray, obj, klass);
         } else {
             // primitive javascript object
@@ -460,7 +460,7 @@ class Parser {
 
         let createCode;
         const ctor = obj.constructor;
-        if (legacyCC.Class._isCCClass(ctor)) {
+        if (legacyCC.Class._isCCClass(ctor, true)) {
             if (this.parent) {
                 if (this.parent instanceof legacyCC.Component) {
                     if (obj instanceof legacyCC._BaseNode || obj instanceof legacyCC.Component) {

--- a/cocos/core/data/instantiate.ts
+++ b/cocos/core/data/instantiate.ts
@@ -24,8 +24,6 @@
  THE SOFTWARE.
 */
 
-
-
 import { DEV } from 'internal:constants';
 import { isDomNode } from '../utils/misc';
 import { ValueType } from '../value-types';
@@ -35,6 +33,7 @@ import { getError, warn } from '../platform/debug';
 import { legacyCC } from '../global-exports';
 import { Prefab } from '../assets/prefab';
 import { Node } from '../scene-graph/node';
+import { isCCClassOrFastDefined } from './class';
 
 const Destroyed = CCObject.Flags.Destroyed;
 const PersistentMask = CCObject.Flags.PersistentMask;
@@ -193,7 +192,7 @@ function enumerateObject (obj, clone, parent) {
     js.value(obj, '_iN$t', clone, true);
     objsToClearTmpVar.push(obj);
     const klass = obj.constructor;
-    if (legacyCC.Class._isCCClass(klass, true)) {
+    if (isCCClassOrFastDefined(klass)) {
         enumerateCCClass(klass, obj, clone, parent);
     } else {
         // primitive javascript object
@@ -266,7 +265,7 @@ function instantiateObj (obj, parent) {
     }
 
     const ctor = obj.constructor;
-    if (legacyCC.Class._isCCClass(ctor, true)) {
+    if (isCCClassOrFastDefined(ctor)) {
         if (parent) {
             if (parent instanceof legacyCC.Component) {
                 if (obj instanceof legacyCC._BaseNode || obj instanceof legacyCC.Component) {

--- a/cocos/core/data/instantiate.ts
+++ b/cocos/core/data/instantiate.ts
@@ -193,7 +193,7 @@ function enumerateObject (obj, clone, parent) {
     js.value(obj, '_iN$t', clone, true);
     objsToClearTmpVar.push(obj);
     const klass = obj.constructor;
-    if (legacyCC.Class._isCCClass(klass)) {
+    if (legacyCC.Class._isCCClass(klass, true)) {
         enumerateCCClass(klass, obj, clone, parent);
     } else {
         // primitive javascript object
@@ -266,7 +266,7 @@ function instantiateObj (obj, parent) {
     }
 
     const ctor = obj.constructor;
-    if (legacyCC.Class._isCCClass(ctor)) {
+    if (legacyCC.Class._isCCClass(ctor, true)) {
         if (parent) {
             if (parent instanceof legacyCC.Component) {
                 if (obj instanceof legacyCC._BaseNode || obj instanceof legacyCC.Component) {

--- a/tests/core/instantiate.test.ts
+++ b/tests/core/instantiate.test.ts
@@ -1,0 +1,9 @@
+import { instantiate } from "../../cocos/core";
+import { CurveRange } from "../../cocos/particle";
+
+test('Bugfix cocos/3d-tasks#12248; Instantiate a property of fast defined type', () => {
+    const curveRange = new CurveRange();
+    const curveRange2 = instantiate(curveRange);
+    expect(curveRange.spline).not.toBe(curveRange2.spline);
+    expect(curveRange.curve._internalCurve).not.toBe(curveRange2.curve._internalCurve);
+});


### PR DESCRIPTION
Re: [#12248](https://github.com/cocos/3d-tasks/issues/12248)

This is an unproven fix because it will deep instantiate all fast defined object.
**Please look for all classes registered with fastDefine, such as RenderPipeline?**
And make sure they are not referenced by CCClass property, so that multiple copies are not accidentally instantiated when copying scene nodes.

* Instantiate all FastDefined object as value type

Compatibility Impact:
* Change instantiate behaviour for user custom classes defined with `fastDefine`.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->