### PR TITLE
correct format feature table

### DIFF
--- a/cocos/core/gfx/webgl/webgl-device.ts
+++ b/cocos/core/gfx/webgl/webgl-device.ts
@@ -268,9 +268,7 @@ export class WebGLDevice extends Device {
         this._textureExclusive[Format.RGB5A1] = false;
 
         this._formatFeatures[Format.DEPTH] = FormatFeatureBit.RENDER_TARGET;
-        this._textureExclusive[Format.DEPTH] = false;
         this._formatFeatures[Format.DEPTH_STENCIL] = FormatFeatureBit.RENDER_TARGET;
-        this._textureExclusive[Format.DEPTH_STENCIL] = false;
 
         this._formatFeatures[Format.R8I] |= FormatFeatureBit.VERTEX_ATTRIBUTE;
         this._formatFeatures[Format.RG8I] |= FormatFeatureBit.VERTEX_ATTRIBUTE;
@@ -310,27 +308,27 @@ export class WebGLDevice extends Device {
         }
 
         if (exts.WEBGL_color_buffer_float) {
-            this._formatFeatures[Format.RGB32F] |= FormatFeatureBit.RENDER_TARGET;
-            this._formatFeatures[Format.RGBA32F] |= FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RGB32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RGBA32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
             this._textureExclusive[Format.RGB32F] = false;
             this._textureExclusive[Format.RGBA32F] = false;
         }
 
         if (exts.EXT_color_buffer_half_float) {
-            this._formatFeatures[Format.RGB16F] |= FormatFeatureBit.RENDER_TARGET;
-            this._formatFeatures[Format.RGBA16F] |= FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RGB16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RGBA16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
             this._textureExclusive[Format.RGB16F] = false;
             this._textureExclusive[Format.RGBA16F] = false;
         }
 
         if (exts.OES_texture_float) {
-            this._formatFeatures[Format.RGB32F] |= FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.SAMPLED_TEXTURE;
-            this._formatFeatures[Format.RGBA32F] |= FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.SAMPLED_TEXTURE;
+            this._formatFeatures[Format.RGB32F] |= FormatFeatureBit.SAMPLED_TEXTURE;
+            this._formatFeatures[Format.RGBA32F] |= FormatFeatureBit.SAMPLED_TEXTURE;
         }
 
         if (exts.OES_texture_half_float) {
-            this._formatFeatures[Format.RGB16F] |= FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.SAMPLED_TEXTURE;
-            this._formatFeatures[Format.RGBA16F] |= FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.SAMPLED_TEXTURE;
+            this._formatFeatures[Format.RGB16F] |= FormatFeatureBit.SAMPLED_TEXTURE;
+            this._formatFeatures[Format.RGBA16F] |= FormatFeatureBit.SAMPLED_TEXTURE;
         }
 
         if (exts.OES_texture_float_linear) {

--- a/cocos/core/gfx/webgl2/webgl2-device.ts
+++ b/cocos/core/gfx/webgl2/webgl2-device.ts
@@ -258,48 +258,41 @@ export class WebGL2Device extends Device {
         this._formatFeatures[Format.RGB8] = tempFeature;
         this._formatFeatures[Format.RGBA8] = tempFeature;
 
-        tempFeature = FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.SAMPLED_TEXTURE
-            | FormatFeatureBit.STORAGE_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
+        tempFeature = FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.STORAGE_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
 
         this._formatFeatures[Format.R8SN] = tempFeature;
         this._formatFeatures[Format.RG8SN] = tempFeature;
         this._formatFeatures[Format.RGB8SN] = tempFeature;
         this._formatFeatures[Format.RGBA8SN] = tempFeature;
+        this._formatFeatures[Format.RGB9E5] = tempFeature;
+        this._formatFeatures[Format.SRGB8] = tempFeature;
+        this._formatFeatures[Format.R11G11B10F] = FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.STORAGE_TEXTURE;
+
+        tempFeature = FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.SAMPLED_TEXTURE
+            | FormatFeatureBit.STORAGE_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
+
         this._formatFeatures[Format.R5G6B5] = tempFeature;
         this._formatFeatures[Format.RGBA4] = tempFeature;
         this._formatFeatures[Format.RGB5A1] = tempFeature;
         this._formatFeatures[Format.RGB10A2] = tempFeature;
-
-        this._formatFeatures[Format.SRGB8] = tempFeature;
         this._formatFeatures[Format.SRGB8_A8] = tempFeature;
-
-        this._formatFeatures[Format.R11G11B10F] = tempFeature;
-        this._formatFeatures[Format.RGB9E5] = tempFeature;
-
         this._formatFeatures[Format.DEPTH] = tempFeature;
         this._formatFeatures[Format.DEPTH_STENCIL] = tempFeature;
+        this._formatFeatures[Format.RGB10A2UI] = tempFeature;
 
-        this._formatFeatures[Format.RGB10A2UI] = FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.STORAGE_TEXTURE
-            | FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
-
-        tempFeature = FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.SAMPLED_TEXTURE
-            | FormatFeatureBit.STORAGE_TEXTURE | FormatFeatureBit.VERTEX_ATTRIBUTE;
+        tempFeature = FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.STORAGE_TEXTURE | FormatFeatureBit.VERTEX_ATTRIBUTE;
 
         this._formatFeatures[Format.R16F] = tempFeature;
         this._formatFeatures[Format.RG16F] = tempFeature;
         this._formatFeatures[Format.RGB16F] = tempFeature;
         this._formatFeatures[Format.RGBA16F] = tempFeature;
 
-        tempFeature = FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.STORAGE_TEXTURE
-            | FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.VERTEX_ATTRIBUTE;
+        tempFeature = FormatFeatureBit.STORAGE_TEXTURE | FormatFeatureBit.VERTEX_ATTRIBUTE;
 
         this._formatFeatures[Format.R32F] = tempFeature;
         this._formatFeatures[Format.RG32F] = tempFeature;
         this._formatFeatures[Format.RGB32F] = tempFeature;
         this._formatFeatures[Format.RGBA32F] = tempFeature;
-
-        this._formatFeatures[Format.RGB10A2UI] = FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.STORAGE_TEXTURE
-            | FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
 
         tempFeature = FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.STORAGE_TEXTURE
             | FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER | FormatFeatureBit.VERTEX_ATTRIBUTE;
@@ -318,19 +311,22 @@ export class WebGL2Device extends Device {
         this._formatFeatures[Format.RG32I] = tempFeature;
         this._formatFeatures[Format.RG32UI] = tempFeature;
 
-        this._formatFeatures[Format.RGB8I] = tempFeature;
-        this._formatFeatures[Format.RGB8UI] = tempFeature;
-        this._formatFeatures[Format.RGB16I] = tempFeature;
-        this._formatFeatures[Format.RGB16UI] = tempFeature;
-        this._formatFeatures[Format.RGB32I] = tempFeature;
-        this._formatFeatures[Format.RGB32UI] = tempFeature;
-
         this._formatFeatures[Format.RGBA8I] = tempFeature;
         this._formatFeatures[Format.RGBA8UI] = tempFeature;
         this._formatFeatures[Format.RGBA16I] = tempFeature;
         this._formatFeatures[Format.RGBA16UI] = tempFeature;
         this._formatFeatures[Format.RGBA32I] = tempFeature;
         this._formatFeatures[Format.RGBA32UI] = tempFeature;
+
+        tempFeature = FormatFeatureBit.STORAGE_TEXTURE | FormatFeatureBit.SAMPLED_TEXTURE
+            | FormatFeatureBit.LINEAR_FILTER | FormatFeatureBit.VERTEX_ATTRIBUTE;
+
+        this._formatFeatures[Format.RGB8I] = tempFeature;
+        this._formatFeatures[Format.RGB8UI] = tempFeature;
+        this._formatFeatures[Format.RGB16I] = tempFeature;
+        this._formatFeatures[Format.RGB16UI] = tempFeature;
+        this._formatFeatures[Format.RGB32I] = tempFeature;
+        this._formatFeatures[Format.RGB32UI] = tempFeature;
 
         this._textureExclusive[Format.R8] = false;
         this._textureExclusive[Format.RG8] = false;
@@ -369,29 +365,43 @@ export class WebGL2Device extends Device {
         this._textureExclusive[Format.DEPTH_STENCIL] = false;
 
         if (exts.EXT_color_buffer_float) {
+            this._formatFeatures[Format.R16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RG16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RGBA16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.R32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RG32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RGBA32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.R11G11B10F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+
+            this._textureExclusive[Format.R16F] = false;
+            this._textureExclusive[Format.RG16F] = false;
+            this._textureExclusive[Format.RGBA16F] = false;
             this._textureExclusive[Format.R32F] = false;
             this._textureExclusive[Format.RG32F] = false;
             this._textureExclusive[Format.RGBA32F] = false;
+            this._textureExclusive[Format.R11G11B10F] = false;
         }
 
         if (exts.EXT_color_buffer_half_float) {
-            this._textureExclusive[Format.R16F] = false;
-            this._textureExclusive[Format.RG16F] = false;
+            this._formatFeatures[Format.RGB16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RGBA16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.RENDER_TARGET;
+
+            this._textureExclusive[Format.RGB16F] = false;
             this._textureExclusive[Format.RGBA16F] = false;
         }
 
         if (exts.OES_texture_float_linear) {
-            this._formatFeatures[Format.RGB32F] |= FormatFeatureBit.LINEAR_FILTER;
-            this._formatFeatures[Format.RGBA32F] |= FormatFeatureBit.LINEAR_FILTER;
-            this._formatFeatures[Format.R32F] |= FormatFeatureBit.LINEAR_FILTER;
-            this._formatFeatures[Format.RG32F] |= FormatFeatureBit.LINEAR_FILTER;
+            this._formatFeatures[Format.RGB32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
+            this._formatFeatures[Format.RGBA32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
+            this._formatFeatures[Format.R32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
+            this._formatFeatures[Format.RG32F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
         }
 
         if (exts.OES_texture_half_float_linear) {
-            this._formatFeatures[Format.RGB16F] |= FormatFeatureBit.LINEAR_FILTER;
-            this._formatFeatures[Format.RGBA16F] |= FormatFeatureBit.LINEAR_FILTER;
-            this._formatFeatures[Format.R16F] |= FormatFeatureBit.LINEAR_FILTER;
-            this._formatFeatures[Format.RG16F] |= FormatFeatureBit.LINEAR_FILTER;
+            this._formatFeatures[Format.RGB16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
+            this._formatFeatures[Format.RGBA16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
+            this._formatFeatures[Format.R16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
+            this._formatFeatures[Format.RG16F] |= FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
         }
 
         const compressedFeature: FormatFeature = FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;

--- a/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -315,10 +315,7 @@ void GLES2Device::initFormatFeature() {
     }
 
     _formatFeatures[toNumber(Format::DEPTH)] |= FormatFeature::RENDER_TARGET;
-    _textureExclusive[toNumber(Format::DEPTH)] = false;
-
     _formatFeatures[toNumber(Format::DEPTH_STENCIL)] |= FormatFeature::RENDER_TARGET;
-    _textureExclusive[toNumber(Format::DEPTH_STENCIL)] = false;
 
     if (checkExtension("EXT_sRGB")) {
         _formatFeatures[toNumber(Format::SRGB8)] |= completeFeature;
@@ -332,32 +329,32 @@ void GLES2Device::initFormatFeature() {
     }
 
     if (checkExtension("texture_float")) {
-        _formatFeatures[toNumber(Format::RGB32F)] |= FormatFeature::RENDER_TARGET | FormatFeature::SAMPLED_TEXTURE;
-        _formatFeatures[toNumber(Format::RGBA32F)] |= FormatFeature::RENDER_TARGET | FormatFeature::SAMPLED_TEXTURE;
+        _formatFeatures[toNumber(Format::RGB32F)] |= FormatFeature::SAMPLED_TEXTURE;
+        _formatFeatures[toNumber(Format::RGBA32F)] |= FormatFeature::SAMPLED_TEXTURE;
         if (checkExtension("texture_rg")) {
-            _formatFeatures[toNumber(Format::R32F)] |= FormatFeature::RENDER_TARGET | FormatFeature::SAMPLED_TEXTURE;
-            _formatFeatures[toNumber(Format::RG32F)] |= FormatFeature::RENDER_TARGET | FormatFeature::SAMPLED_TEXTURE;
+            _formatFeatures[toNumber(Format::R32F)] |= FormatFeature::SAMPLED_TEXTURE;
+            _formatFeatures[toNumber(Format::RG32F)] |= FormatFeature::SAMPLED_TEXTURE;
         }
     }
 
     if (checkExtension("texture_half_float")) {
-        _formatFeatures[toNumber(Format::RGB16F)] |= FormatFeature::RENDER_TARGET | FormatFeature::SAMPLED_TEXTURE;
-        _formatFeatures[toNumber(Format::RGBA16F)] |= FormatFeature::RENDER_TARGET | FormatFeature::SAMPLED_TEXTURE;
+        _formatFeatures[toNumber(Format::RGB16F)] |= FormatFeature::SAMPLED_TEXTURE;
+        _formatFeatures[toNumber(Format::RGBA16F)] |= FormatFeature::SAMPLED_TEXTURE;
         if (checkExtension("texture_rg")) {
-            _formatFeatures[toNumber(Format::R16F)] |= FormatFeature::RENDER_TARGET | FormatFeature::SAMPLED_TEXTURE;
-            _formatFeatures[toNumber(Format::RG16F)] |= FormatFeature::RENDER_TARGET | FormatFeature::SAMPLED_TEXTURE;
+            _formatFeatures[toNumber(Format::R16F)] |= FormatFeature::SAMPLED_TEXTURE;
+            _formatFeatures[toNumber(Format::RG16F)] |= FormatFeature::SAMPLED_TEXTURE;
         }
     }
 
     if (checkExtension("color_buffer_half_float")) {
-        _formatFeatures[toNumber(Format::RGB16F)] |= FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RGB16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
         _textureExclusive[toNumber(Format::RGB16F)] = false;
-        _formatFeatures[toNumber(Format::RGBA16F)] |= FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RGBA16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
         _textureExclusive[toNumber(Format::RGBA16F)] = false;
         if (checkExtension("texture_rg")) {
-            _formatFeatures[toNumber(Format::R16F)] |= FormatFeature::RENDER_TARGET;
+            _formatFeatures[toNumber(Format::R16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
             _textureExclusive[toNumber(Format::R16F)] = false;
-            _formatFeatures[toNumber(Format::RG16F)] |= FormatFeature::RENDER_TARGET;
+            _formatFeatures[toNumber(Format::RG16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
             _textureExclusive[toNumber(Format::RG16F)] = false;
         }
     }

--- a/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -283,43 +283,42 @@ void GLES3Device::initFormatFeature() {
     _formatFeatures[toNumber(Format::RGB8)]  = tempFeature;
     _formatFeatures[toNumber(Format::RGBA8)] = tempFeature;
 
+    tempFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER | FormatFeature::STORAGE_TEXTURE;
+
+    _formatFeatures[toNumber(Format::R8SN)]       = tempFeature;
+    _formatFeatures[toNumber(Format::RG8SN)]      = tempFeature;
+    _formatFeatures[toNumber(Format::RGB8SN)]     = tempFeature;
+    _formatFeatures[toNumber(Format::RGBA8SN)]    = tempFeature;
+    _formatFeatures[toNumber(Format::RGB9E5)]     = tempFeature;
+    _formatFeatures[toNumber(Format::SRGB8)]      = tempFeature;
+    _formatFeatures[toNumber(Format::R11G11B10F)] = FormatFeature::SAMPLED_TEXTURE | FormatFeature::STORAGE_TEXTURE;
+
     tempFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET | FormatFeature::LINEAR_FILTER | FormatFeature::STORAGE_TEXTURE;
 
-    _formatFeatures[toNumber(Format::R8SN)]    = tempFeature;
-    _formatFeatures[toNumber(Format::RG8SN)]   = tempFeature;
-    _formatFeatures[toNumber(Format::RGB8SN)]  = tempFeature;
-    _formatFeatures[toNumber(Format::RGBA8SN)] = tempFeature;
-    _formatFeatures[toNumber(Format::R5G6B5)]  = tempFeature;
-    _formatFeatures[toNumber(Format::RGBA4)]   = tempFeature;
-    _formatFeatures[toNumber(Format::RGB5A1)]  = tempFeature;
-    _formatFeatures[toNumber(Format::RGB10A2)] = tempFeature;
-
-    _formatFeatures[toNumber(Format::SRGB8)]    = tempFeature;
-    _formatFeatures[toNumber(Format::SRGB8_A8)] = tempFeature;
-
-    _formatFeatures[toNumber(Format::R11G11B10F)] = tempFeature;
-    _formatFeatures[toNumber(Format::RGB9E5)]     = tempFeature;
-
+    _formatFeatures[toNumber(Format::R5G6B5)]        = tempFeature;
+    _formatFeatures[toNumber(Format::RGBA4)]         = tempFeature;
+    _formatFeatures[toNumber(Format::RGB5A1)]        = tempFeature;
+    _formatFeatures[toNumber(Format::RGB10A2)]       = tempFeature;
+    _formatFeatures[toNumber(Format::SRGB8_A8)]      = tempFeature;
     _formatFeatures[toNumber(Format::DEPTH)]         = tempFeature;
     _formatFeatures[toNumber(Format::DEPTH_STENCIL)] = tempFeature;
+    _formatFeatures[toNumber(Format::RGB10A2UI)]     = tempFeature;
 
-    tempFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET | FormatFeature::LINEAR_FILTER | FormatFeature::STORAGE_TEXTURE | FormatFeature::VERTEX_ATTRIBUTE;
+    tempFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::STORAGE_TEXTURE | FormatFeature::VERTEX_ATTRIBUTE;
 
     _formatFeatures[toNumber(Format::R16F)]    = tempFeature;
     _formatFeatures[toNumber(Format::RG16F)]   = tempFeature;
     _formatFeatures[toNumber(Format::RGB16F)]  = tempFeature;
     _formatFeatures[toNumber(Format::RGBA16F)] = tempFeature;
 
-    tempFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET | FormatFeature::STORAGE_TEXTURE | FormatFeature::VERTEX_ATTRIBUTE;
+    tempFeature = FormatFeature::STORAGE_TEXTURE | FormatFeature::VERTEX_ATTRIBUTE;
 
     _formatFeatures[toNumber(Format::R32F)]    = tempFeature;
     _formatFeatures[toNumber(Format::RG32F)]   = tempFeature;
     _formatFeatures[toNumber(Format::RGB32F)]  = tempFeature;
     _formatFeatures[toNumber(Format::RGBA32F)] = tempFeature;
 
-    _formatFeatures[toNumber(Format::RGB10A2UI)] = FormatFeature::RENDER_TARGET | FormatFeature::LINEAR_FILTER | FormatFeature::STORAGE_TEXTURE;
-
-    tempFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET | FormatFeature::LINEAR_FILTER | FormatFeature::STORAGE_TEXTURE | FormatFeature::VERTEX_ATTRIBUTE;
+    tempFeature = FormatFeature::RENDER_TARGET | FormatFeature::STORAGE_TEXTURE | FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER | FormatFeature::VERTEX_ATTRIBUTE;
 
     _formatFeatures[toNumber(Format::R8I)]   = tempFeature;
     _formatFeatures[toNumber(Format::R8UI)]  = tempFeature;
@@ -335,19 +334,21 @@ void GLES3Device::initFormatFeature() {
     _formatFeatures[toNumber(Format::RG32I)]  = tempFeature;
     _formatFeatures[toNumber(Format::RG32UI)] = tempFeature;
 
-    _formatFeatures[toNumber(Format::RGB8I)]   = tempFeature;
-    _formatFeatures[toNumber(Format::RGB8UI)]  = tempFeature;
-    _formatFeatures[toNumber(Format::RGB16I)]  = tempFeature;
-    _formatFeatures[toNumber(Format::RGB16UI)] = tempFeature;
-    _formatFeatures[toNumber(Format::RGB32I)]  = tempFeature;
-    _formatFeatures[toNumber(Format::RGB32UI)] = tempFeature;
-
     _formatFeatures[toNumber(Format::RGBA8I)]   = tempFeature;
     _formatFeatures[toNumber(Format::RGBA8UI)]  = tempFeature;
     _formatFeatures[toNumber(Format::RGBA16I)]  = tempFeature;
     _formatFeatures[toNumber(Format::RGBA16UI)] = tempFeature;
     _formatFeatures[toNumber(Format::RGBA32I)]  = tempFeature;
     _formatFeatures[toNumber(Format::RGBA32UI)] = tempFeature;
+
+    tempFeature = FormatFeature::STORAGE_TEXTURE | FormatFeature::VERTEX_ATTRIBUTE | FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
+
+    _formatFeatures[toNumber(Format::RGB8I)]   = tempFeature;
+    _formatFeatures[toNumber(Format::RGB8UI)]  = tempFeature;
+    _formatFeatures[toNumber(Format::RGB16I)]  = tempFeature;
+    _formatFeatures[toNumber(Format::RGB16UI)] = tempFeature;
+    _formatFeatures[toNumber(Format::RGB32I)]  = tempFeature;
+    _formatFeatures[toNumber(Format::RGB32UI)] = tempFeature;
 
     _textureExclusive[toNumber(Format::R8)]     = false;
     _textureExclusive[toNumber(Format::RG8)]    = false;
@@ -395,12 +396,28 @@ void GLES3Device::initFormatFeature() {
     }
 
     if (checkExtension("color_buffer_float")) {
-        _textureExclusive[toNumber(Format::R32F)]    = false;
-        _textureExclusive[toNumber(Format::RG32F)]   = false;
-        _textureExclusive[toNumber(Format::RGB32F)]  = false;
-        _textureExclusive[toNumber(Format::RGBA32F)] = false;
+        _formatFeatures[toNumber(Format::R16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RG16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RGBA16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::R32F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RG32F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RGBA32F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::R11G11B10F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+
+        _textureExclusive[toNumber(Format::R16F)]       = false;
+        _textureExclusive[toNumber(Format::RG16F)]      = false;
+        _textureExclusive[toNumber(Format::RGBA16F)]    = false;
+        _textureExclusive[toNumber(Format::R32F)]       = false;
+        _textureExclusive[toNumber(Format::RG32F)]      = false;
+        _textureExclusive[toNumber(Format::RGBA32F)]    = false;
+        _textureExclusive[toNumber(Format::R11G11B10F)] = false;
     }
     if (checkExtension("color_buffer_half_float")) {
+        _formatFeatures[toNumber(Format::R16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RG16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RGB16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RGBA16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET;
+
         _textureExclusive[toNumber(Format::R16F)]    = false;
         _textureExclusive[toNumber(Format::RG16F)]   = false;
         _textureExclusive[toNumber(Format::RGB16F)]  = false;
@@ -408,17 +425,17 @@ void GLES3Device::initFormatFeature() {
     }
 
     if (checkExtension("texture_float_linear")) {
-        _formatFeatures[toNumber(Format::RGB32F)] |= FormatFeature::LINEAR_FILTER;
-        _formatFeatures[toNumber(Format::RGBA32F)] |= FormatFeature::LINEAR_FILTER;
-        _formatFeatures[toNumber(Format::R32F)] |= FormatFeature::LINEAR_FILTER;
-        _formatFeatures[toNumber(Format::RG32F)] |= FormatFeature::LINEAR_FILTER;
+        _formatFeatures[toNumber(Format::RGB32F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
+        _formatFeatures[toNumber(Format::RGBA32F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
+        _formatFeatures[toNumber(Format::R32F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
+        _formatFeatures[toNumber(Format::RG32F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
     }
 
     if (checkExtension("texture_half_float_linear")) {
-        _formatFeatures[toNumber(Format::RGB16F)] |= FormatFeature::LINEAR_FILTER;
-        _formatFeatures[toNumber(Format::RGBA16F)] |= FormatFeature::LINEAR_FILTER;
-        _formatFeatures[toNumber(Format::R16F)] |= FormatFeature::LINEAR_FILTER;
-        _formatFeatures[toNumber(Format::RG16F)] |= FormatFeature::LINEAR_FILTER;
+        _formatFeatures[toNumber(Format::RGB16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
+        _formatFeatures[toNumber(Format::RGBA16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
+        _formatFeatures[toNumber(Format::R16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
+        _formatFeatures[toNumber(Format::RG16F)] |= FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;
     }
 
     const FormatFeature compressedFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::LINEAR_FILTER;


### PR DESCRIPTION
Re: #

There exists some wrong information in format features, this PR provides corrections to format features.

clarify:
1. RENDER_TARGET -> texture | renderbuffer.
2. SAMPLED_TEXTURE -> filterable texture | renderbuffer.
3. LINEAR_FILTER -> linear filter
4. STORAGE_TEXTURE -> storage texture
5. VERTEX_ATTRIBUTE -> vertex attribute format

texture_exclusive: 
1. true: support renderbuffer & doesn't support texture
2. false: (support texture and renderbuffer) or (support texture, doesn't support renderbuffer) 