### PR TITLE
feat: keep group display order

### DIFF
--- a/editor/inspector/components/class.js
+++ b/editor/inspector/components/class.js
@@ -68,12 +68,7 @@ exports.methods = {
     },
     appendChildByDisplayOrder(parent, newChild, displayOrder = 0) {
         const children = Array.from(parent.children);
-        const child = children.find((child) => {
-            if (child.dump && child.displayOrder > displayOrder) {
-                return child;
-            }
-            return null;
-        });
+        const child = children.find(child => child.dump && child.displayOrder > displayOrder);
         if (child) {
             child.before(newChild);
         } else {
@@ -119,30 +114,35 @@ async function update(dump) {
             $prop.setAttribute('type', 'dump');
             $panel.$propList[id] = $prop;
 
-            $prop.displayOrder = info.displayOrder === undefined ? index : Number(info.displayOrder);
+            const _displayOrder = info.group?.displayOrder || info.displayOrder;
+            $prop.displayOrder = _displayOrder === undefined ? index : Number(_displayOrder);
 
             if (info.group && dump.groups) {
-                const key = info.group.id || 'default';
-                const name = info.group.name;
-                if (!$panel.$groups[key] && dump.groups[key]) {
-                    if (dump.groups[key].style === 'tab') {
-                        $panel.$groups[key] = $panel.createTabGroup(dump.groups[key]);
+                const { id = 'default', name } = info.group;
+                if (!$panel.$groups[id] && dump.groups[id]) {
+                    if (dump.groups[id].style === 'tab') {
+                        $panel.$groups[id] = $panel.createTabGroup(dump.groups[id]);
                     }
                 }
-                if ($panel.$groups[key]) {
-                    if (!$panel.$groups[key].isConnected) {
-                        $panel.appendChildByDisplayOrder($section, $panel.$groups[key], dump.groups[key].displayOrder);
+                if ($panel.$groups[id]) {
+                    if (!$panel.$groups[id].isConnected) {
+                        $panel.appendChildByDisplayOrder($section, $panel.$groups[id], dump.groups[id].displayOrder);
                     }
-                    if (dump.groups[key].style === 'tab') {
-                        $panel.appendToTabGroup($panel.$groups[key], name);
+                    if (dump.groups[id].style === 'tab') {
+                        $panel.appendToTabGroup($panel.$groups[id], name);
                     }
                 }
-                $panel.appendChildByDisplayOrder($panel.$groups[key].tabs[name], $prop, $prop.displayOrder);
+                $panel.appendChildByDisplayOrder($panel.$groups[id].tabs[name], $prop, $prop.displayOrder);
             } else {
                 $panel.appendChildByDisplayOrder($section, $prop, $prop.displayOrder);
             }
         } else if (!$prop.isConnected || !$prop.parentElement) {
-            $panel.appendChildByDisplayOrder($section, $prop, $prop.displayOrder);
+            if (info.group && dump.groups) {
+                const { id = 'default', name } = info.group;
+                $panel.appendChildByDisplayOrder($panel.$groups[id].tabs[name], $prop, $prop.displayOrder);
+            } else {
+                $panel.appendChildByDisplayOrder($section, $prop, $prop.displayOrder);
+            }
         }
         $prop.render(info);
     });

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -156,7 +156,7 @@ exports.listeners = {
     },
 };
 
-exports.template = `
+exports.template = /* html*/`
 <ui-drag-area class="container">
     <section class="prefab" hidden missing>
         <ui-label value="Prefab"></ui-label>

--- a/editor/inspector/utils/prop.js
+++ b/editor/inspector/utils/prop.js
@@ -221,7 +221,8 @@ exports.updatePropByDump = function(panel, dump) {
                 $prop.setAttribute('type', 'dump');
             }
 
-            $prop.displayOrder = info.displayOrder === undefined ? index : Number(info.displayOrder);
+            const _displayOrder = info.group?.displayOrder || info.displayOrder;
+            $prop.displayOrder = _displayOrder === undefined ? index : Number(_displayOrder);
 
             if (element && element.displayOrder !== undefined) {
                 $prop.displayOrder = element.displayOrder;
@@ -229,8 +230,7 @@ exports.updatePropByDump = function(panel, dump) {
 
             if (!element || !element.isAppendToParent || element.isAppendToParent.call(panel)) {
                 if (info.group && dump.groups) {
-                    const id = info.group.id || 'default';
-                    const name = info.group.name;
+                    const { id = 'default', name } = info.group;
 
                     if (!panel.$groups[id] && dump.groups[id]) {
                         if (dump.groups[id].style === 'tab') {
@@ -255,7 +255,12 @@ exports.updatePropByDump = function(panel, dump) {
             }
         } else if (!$prop.isConnected || !$prop.parentElement) {
             if (!element || !element.isAppendToParent || element.isAppendToParent.call(panel)) {
-                exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop, $prop.displayOrder);
+                if (info.group && dump.groups) {
+                    const { id = 'default', name } = info.group;
+                    exports.appendChildByDisplayOrder(panel.$groups[id].tabs[name], $prop, $prop.displayOrder);
+                } else {
+                    exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop, $prop.displayOrder);
+                }
             }
         }
         $prop.render(info);


### PR DESCRIPTION
Re: #
Resolves: cocos/3d-tasks#12191

### Changelog

* keep group display order

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->