### PR TITLE
fix format feature for Float32 for gles3 and webgl2.

### DIFF
--- a/cocos/core/gfx/webgl2/webgl2-device.ts
+++ b/cocos/core/gfx/webgl2/webgl2-device.ts
@@ -290,8 +290,7 @@ export class WebGL2Device extends Device {
         this._formatFeatures[Format.RGB16F] = tempFeature;
         this._formatFeatures[Format.RGBA16F] = tempFeature;
 
-        tempFeature = FormatFeatureBit.RENDER_TARGET | FormatFeatureBit.STORAGE_TEXTURE
-            | FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.VERTEX_ATTRIBUTE;
+        tempFeature = FormatFeatureBit.STORAGE_TEXTURE | FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.VERTEX_ATTRIBUTE;
 
         this._formatFeatures[Format.R32F] = tempFeature;
         this._formatFeatures[Format.RG32F] = tempFeature;
@@ -369,6 +368,10 @@ export class WebGL2Device extends Device {
         this._textureExclusive[Format.DEPTH_STENCIL] = false;
 
         if (exts.EXT_color_buffer_float) {
+            this._formatFeatures[Format.R32F] |= FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RG32F] |= FormatFeatureBit.RENDER_TARGET;
+            this._formatFeatures[Format.RGBA32F] |= FormatFeatureBit.RENDER_TARGET;
+
             this._textureExclusive[Format.R32F] = false;
             this._textureExclusive[Format.RG32F] = false;
             this._textureExclusive[Format.RGBA32F] = false;

--- a/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -310,7 +310,7 @@ void GLES3Device::initFormatFeature() {
     _formatFeatures[toNumber(Format::RGB16F)]  = tempFeature;
     _formatFeatures[toNumber(Format::RGBA16F)] = tempFeature;
 
-    tempFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::RENDER_TARGET | FormatFeature::STORAGE_TEXTURE | FormatFeature::VERTEX_ATTRIBUTE;
+    tempFeature = FormatFeature::SAMPLED_TEXTURE | FormatFeature::STORAGE_TEXTURE | FormatFeature::VERTEX_ATTRIBUTE;
 
     _formatFeatures[toNumber(Format::R32F)]    = tempFeature;
     _formatFeatures[toNumber(Format::RG32F)]   = tempFeature;
@@ -395,9 +395,12 @@ void GLES3Device::initFormatFeature() {
     }
 
     if (checkExtension("color_buffer_float")) {
+        _formatFeatures[toNumber(Format::R32F)] |= FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RG32F)] |= FormatFeature::RENDER_TARGET;
+        _formatFeatures[toNumber(Format::RGBA32F)] |= FormatFeature::RENDER_TARGET;
+
         _textureExclusive[toNumber(Format::R32F)]    = false;
         _textureExclusive[toNumber(Format::RG32F)]   = false;
-        _textureExclusive[toNumber(Format::RGB32F)]  = false;
         _textureExclusive[toNumber(Format::RGBA32F)] = false;
     }
     if (checkExtension("color_buffer_half_float")) {


### PR DESCRIPTION
Re: #nothing

### Changelog

Float 32 formats like R32F, RG32F and RGBA32F can't be used as RENDER_TARGET by default unless they have the 'color_buffer_float' extension enabled.

* disable RENDER_TARGET for R32F, RG32F and RGBA32F on gles3 and webgl2.
* enable RENDER_TARGET fot R32F, RG32F and RGBA32F if `color_buffer_float` is enabled.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->