### PR TITLE
feat: hide addComponent button when scene is active

### DIFF
--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -220,7 +220,7 @@ exports.template = `
     <section class="section-missing"></section>
 
     <footer class="footer">
-        <ui-button>
+        <ui-button class="add-component">
             <ui-label value="i18n:ENGINE.components.add_component"></ui-label>
         </ui-button>
     </footer>
@@ -273,7 +273,7 @@ exports.$ = {
     sectionAsset: '.section-asset',
 
     footer: '.footer',
-    componentAdd: '.footer > ui-button',
+    componentAdd: '.footer .add-component',
 };
 
 const Elements = {
@@ -572,8 +572,10 @@ const Elements = {
             const panel = this;
 
             if (!panel.dump || !panel.dump.isScene) {
+                panel.$.componentAdd.style.display = 'block';
                 return;
             }
+            panel.$.componentAdd.style.display = 'none';
 
             panel.$this.setAttribute('sub-type', 'scene');
             panel.$.container.removeAttribute('droppable');


### PR DESCRIPTION
Resolves: cocos/3d-tasks#12277

### Changelog

* hide addComponent button when scene is active

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->