### PR TITLE
refactor startup/shutdown of file system

### DIFF
--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -96,8 +96,7 @@ namespace cc {
 
 Engine::Engine() {
     _scheduler = std::make_shared<Scheduler>();
-    FileUtils::getInstance()->addSearchPath("Resources", true);
-    FileUtils::getInstance()->addSearchPath("data", true);
+    _fs = createFileUtils();
     EventDispatcher::init();
     se::ScriptEngine::getInstance();
 
@@ -136,10 +135,10 @@ Engine::~Engine() {
 #endif
     ProgramLib::destroyInstance();
     BuiltinResMgr::destroyInstance();
-    FileUtils::destroyInstance();
 
     CCObject::deferredDestroy();
     gfx::DeviceManager::destroy();
+    delete _fs;
 }
 
 int32_t Engine::init() {

--- a/native/cocos/engine/Engine.h
+++ b/native/cocos/engine/Engine.h
@@ -36,6 +36,8 @@
 
 namespace cc {
 
+class FileUtils;
+
 #define NANOSECONDS_PER_SECOND 1000000000
 #define NANOSECONDS_60FPS      16666667L
 
@@ -128,6 +130,9 @@ private:
     cc::Vec2 _viewLogicalSize{0, 0};
     bool _needRestart{false};
     bool _inited{false};
+    
+    // Subsystems
+    FileUtils *_fs{nullptr};
 
     std::map<OSEventType, EventCb> _eventCallbacks;
     CC_DISALLOW_COPY_MOVE_ASSIGN(Engine);

--- a/native/cocos/platform/FileUtils.cpp
+++ b/native/cocos/platform/FileUtils.cpp
@@ -478,8 +478,11 @@ bool FileUtils::writeToFile(const ValueMap &dict, const ccstd::string &fullPath)
 // Implement FileUtils
 FileUtils *FileUtils::sharedFileUtils = nullptr;
 
+FileUtils *FileUtils::getInstance() {
+    return FileUtils::sharedFileUtils;
+}
+
 void FileUtils::destroyInstance() {
-    CC_SAFE_DELETE(FileUtils::sharedFileUtils);
 }
 
 void FileUtils::setDelegate(FileUtils *delegate) {
@@ -487,9 +490,14 @@ void FileUtils::setDelegate(FileUtils *delegate) {
     FileUtils::sharedFileUtils = delegate;
 }
 
-FileUtils::FileUtils() = default;
+FileUtils::FileUtils() {
+    init();
+    FileUtils::sharedFileUtils = this;
+}
 
-FileUtils::~FileUtils() = default;
+FileUtils::~FileUtils() {
+    FileUtils::sharedFileUtils = nullptr;
+}
 
 bool FileUtils::writeStringToFile(const ccstd::string &dataStr, const ccstd::string &fullPath) {
     Data data;
@@ -527,6 +535,8 @@ bool FileUtils::writeDataToFile(const Data &data, const ccstd::string &fullPath)
 }
 
 bool FileUtils::init() {
+    addSearchPath("Resources", true);
+    addSearchPath("data", true);
     _searchPathArray.push_back(_defaultResRootPath);
     return true;
 }

--- a/native/cocos/platform/FileUtils.cpp
+++ b/native/cocos/platform/FileUtils.cpp
@@ -491,7 +491,6 @@ void FileUtils::setDelegate(FileUtils *delegate) {
 }
 
 FileUtils::FileUtils() {
-    init();
     FileUtils::sharedFileUtils = this;
 }
 

--- a/native/cocos/platform/FileUtils.h
+++ b/native/cocos/platform/FileUtils.h
@@ -35,11 +35,6 @@
 
 namespace cc {
 
-/**
- * @addtogroup platform
- * @{
- */
-
 class ResizableBuffer {
 public:
     ~ResizableBuffer() = default;
@@ -116,6 +111,7 @@ public:
     /**
      *  Destroys the instance of FileUtils.
      */
+    CC_DEPRECATED(3.6.0)
     static void destroyInstance();
 
     /**
@@ -129,14 +125,16 @@ public:
      * to this function.
      *
      * @warning It will delete previous delegate
-     * @lua NA
      */
     static void setDelegate(FileUtils *delegate);
+    
+    /**
+     *  The default constructor.
+     */
+    FileUtils();
 
     /**
      *  The destructor of FileUtils.
-     * @js NA
-     * @lua NA
      */
     virtual ~FileUtils();
 
@@ -315,8 +313,6 @@ public:
      *  @param searchPaths The array contains search paths.
      *  @see fullPathForFilename(const char*)
      *  @since v2.1
-     *  In js:var setSearchPaths(var jsval);
-     *  @lua NA
      */
     virtual void setSearchPaths(const ccstd::vector<ccstd::string> &searchPaths);
 
@@ -345,7 +341,6 @@ public:
      *        But since we should not break the compatibility, we keep using the old logic.
      *        Therefore, If you want to get the original search paths, please call 'getOriginalSearchPaths()' instead.
      *  @see fullPathForFilename(const char*).
-     *  @lua NA
      */
     virtual const ccstd::vector<ccstd::string> &getSearchPaths() const;
 
@@ -549,11 +544,6 @@ public:
 
 protected:
     /**
-     *  The default constructor.
-     */
-    FileUtils();
-
-    /**
      *  Initializes the instance of FileUtils. It will set _searchPathArray and _searchResolutionsOrderArray to default values.
      *
      *  @note When you are porting Cocos2d-x to a new platform, you may need to take care of this method.
@@ -641,7 +631,7 @@ protected:
     virtual void valueVectorCompact(ValueVector &valueVector);
 };
 
-// end of support group
-/** @} */
+// Can remove this function when refactoring file system.
+FileUtils *createFileUtils();
 
 } // namespace cc

--- a/native/cocos/platform/android/FileUtils-android.cpp
+++ b/native/cocos/platform/android/FileUtils-android.cpp
@@ -51,6 +51,10 @@ namespace cc {
 AAssetManager *FileUtilsAndroid::assetmanager = nullptr;
 ZipFile *FileUtilsAndroid::obbfile = nullptr;
 
+FileUtils *createFileUtils() {
+    return ccnew FileUtilsAndroid();
+}
+
 void FileUtilsAndroid::setassetmanager(AAssetManager *a) {
     if (nullptr == a) {
         LOGD("setassetmanager : received unexpected nullptr parameter");
@@ -60,25 +64,8 @@ void FileUtilsAndroid::setassetmanager(AAssetManager *a) {
     cc::FileUtilsAndroid::assetmanager = a;
 }
 
-FileUtils *FileUtils::getInstance() {
-    if (FileUtils::sharedFileUtils == nullptr) {
-        FileUtils::sharedFileUtils = ccnew FileUtilsAndroid();
-        if (!FileUtils::sharedFileUtils->init()) {
-            delete FileUtils::sharedFileUtils;
-            FileUtils::sharedFileUtils = nullptr;
-            CC_LOG_DEBUG("ERROR: Could not init CCFileUtilsAndroid");
-        }
-    }
-    return FileUtils::sharedFileUtils;
-}
-
-FileUtilsAndroid::FileUtilsAndroid() = default;
-
 FileUtilsAndroid::~FileUtilsAndroid() {
-    if (obbfile) {
-        delete obbfile;
-        obbfile = nullptr;
-    }
+    CC_SAFE_DELETE(obbfile);
 }
 
 bool FileUtilsAndroid::init() {

--- a/native/cocos/platform/android/FileUtils-android.cpp
+++ b/native/cocos/platform/android/FileUtils-android.cpp
@@ -64,6 +64,10 @@ void FileUtilsAndroid::setassetmanager(AAssetManager *a) {
     cc::FileUtilsAndroid::assetmanager = a;
 }
 
+FileUtilsAndroid::FileUtilsAndroid() {
+    init();
+}
+
 FileUtilsAndroid::~FileUtilsAndroid() {
     CC_SAFE_DELETE(obbfile);
 }

--- a/native/cocos/platform/android/FileUtils-android.h
+++ b/native/cocos/platform/android/FileUtils-android.h
@@ -47,7 +47,7 @@ class CC_DLL FileUtilsAndroid : public FileUtils {
     friend class FileUtils;
 
 public:
-    FileUtilsAndroid() = default;
+    FileUtilsAndroid();
     ~FileUtilsAndroid() override;
 
     static void setassetmanager(AAssetManager *a);

--- a/native/cocos/platform/android/FileUtils-android.h
+++ b/native/cocos/platform/android/FileUtils-android.h
@@ -47,11 +47,7 @@ class CC_DLL FileUtilsAndroid : public FileUtils {
     friend class FileUtils;
 
 public:
-    FileUtilsAndroid();
-    /**
-     * @js NA
-     * @lua NA
-     */
+    FileUtilsAndroid() = default;
     ~FileUtilsAndroid() override;
 
     static void setassetmanager(AAssetManager *a);

--- a/native/cocos/platform/apple/FileUtils-apple.h
+++ b/native/cocos/platform/apple/FileUtils-apple.h
@@ -26,8 +26,7 @@
  THE SOFTWARE.
 ****************************************************************************/
 
-#ifndef __CC_FILEUTILS_APPLE_H__
-#define __CC_FILEUTILS_APPLE_H__
+#pragma once
 
 #include <memory>
 #include "base/std/container/string.h"
@@ -37,44 +36,35 @@
 
 namespace cc {
 
-/**
- * @addtogroup platform
- * @{
- */
-
 //! @brief  Helper class to handle file operations
 class CC_DLL FileUtilsApple : public FileUtils {
 public:
     FileUtilsApple();
-    virtual ~FileUtilsApple();
+    ~FileUtilsApple() override = default;
     /* override functions */
-    virtual ccstd::string getWritablePath() const override;
-    virtual ccstd::string getFullPathForDirectoryAndFilename(const ccstd::string &directory, const ccstd::string &filename) const override;
+    ccstd::string getWritablePath() const override;
+    ccstd::string getFullPathForDirectoryAndFilename(const ccstd::string &directory, const ccstd::string &filename) const override;
 
-    virtual ValueMap getValueMapFromFile(const ccstd::string &filename) override;
-    virtual ValueMap getValueMapFromData(const char *filedata, int filesize) override;
-    virtual bool writeToFile(const ValueMap &dict, const ccstd::string &fullPath) override;
+    ValueMap getValueMapFromFile(const ccstd::string &filename) override;
+    ValueMap getValueMapFromData(const char *filedata, int filesize) override;
+    bool writeToFile(const ValueMap &dict, const ccstd::string &fullPath) override;
 
-    virtual ValueVector getValueVectorFromFile(const ccstd::string &filename) override;
+    ValueVector getValueVectorFromFile(const ccstd::string &filename) override;
 #if CC_FILEUTILS_APPLE_ENABLE_OBJC
     void setBundle(NSBundle *bundle);
 #endif
 
-    virtual bool createDirectory(const ccstd::string &path) override;
+    bool createDirectory(const ccstd::string &path) override;
 
 private:
-    virtual bool isFileExistInternal(const ccstd::string &filePath) const override;
-    virtual bool removeDirectory(const ccstd::string &dirPath) override;
-    virtual void valueMapCompact(ValueMap &valueMap) override;
-    virtual void valueVectorCompact(ValueVector &valueVector) override;
+    bool isFileExistInternal(const ccstd::string &filePath) const override;
+    bool removeDirectory(const ccstd::string &dirPath) override;
+    void valueMapCompact(ValueMap &valueMap) override;
+    void valueVectorCompact(ValueVector &valueVector) override;
 
     struct IMPL;
     std::unique_ptr<IMPL> pimpl_;
 };
 
-// end of platform group
-/// @}
 
 } // namespace cc
-
-#endif // __CC_FILEUTILS_APPLE_H__

--- a/native/cocos/platform/apple/FileUtils-apple.mm
+++ b/native/cocos/platform/apple/FileUtils-apple.mm
@@ -183,6 +183,7 @@ FileUtils *createFileUtils() {
 }
 
 FileUtilsApple::FileUtilsApple() : pimpl_(ccnew IMPL([NSBundle mainBundle])) {
+    init();
 }
 
 #if CC_FILEUTILS_APPLE_ENABLE_OBJC

--- a/native/cocos/platform/apple/FileUtils-apple.mm
+++ b/native/cocos/platform/apple/FileUtils-apple.mm
@@ -178,10 +178,12 @@ static void addCCValueToNSDictionary(const ccstd::string &key, const Value &valu
     [dict setObject:convertCCValueToNSObject(value) forKey:NSkey];
 }
 
-FileUtilsApple::FileUtilsApple() : pimpl_(ccnew IMPL([NSBundle mainBundle])) {
+FileUtils *createFileUtils() {
+    return ccnew FileUtilsApple();
 }
 
-FileUtilsApple::~FileUtilsApple() = default;
+FileUtilsApple::FileUtilsApple() : pimpl_(ccnew IMPL([NSBundle mainBundle])) {
+}
 
 #if CC_FILEUTILS_APPLE_ENABLE_OBJC
 void FileUtilsApple::setBundle(NSBundle *bundle) {
@@ -192,18 +194,6 @@ void FileUtilsApple::setBundle(NSBundle *bundle) {
 #pragma mark - FileUtils
 
 static NSFileManager *s_fileManager = [NSFileManager defaultManager];
-
-FileUtils *FileUtils::getInstance() {
-    if (FileUtils::sharedFileUtils == nullptr) {
-        FileUtils::sharedFileUtils = ccnew FileUtilsApple();
-        if (!FileUtils::sharedFileUtils->init()) {
-            delete FileUtils::sharedFileUtils;
-            FileUtils::sharedFileUtils = nullptr;
-            CC_LOG_DEBUG("ERROR: Could not init CCFileUtilsApple");
-        }
-    }
-    return FileUtils::sharedFileUtils;
-}
 
 ccstd::string FileUtilsApple::getWritablePath() const {
     if (_writablePath.length()) {

--- a/native/cocos/platform/linux/FileUtils-linux.cpp
+++ b/native/cocos/platform/linux/FileUtils-linux.cpp
@@ -39,9 +39,7 @@
 namespace cc {
 
 FileUtils *createFileUtils() {
-    auto *fileUtils = ccnew FileUtilsLinux();
-    fileUtils->init();
-    return fileUtils;
+    return ccnew FileUtilsLinux();
 }
 
 bool FileUtilsLinux::init() {

--- a/native/cocos/platform/linux/FileUtils-linux.cpp
+++ b/native/cocos/platform/linux/FileUtils-linux.cpp
@@ -38,16 +38,10 @@
 
 namespace cc {
 
-FileUtils *FileUtils::getInstance() {
-    if (FileUtils::sharedFileUtils == nullptr) {
-        FileUtils::sharedFileUtils = ccnew FileUtilsLinux();
-        if (!FileUtils::sharedFileUtils->init()) {
-            delete FileUtils::sharedFileUtils;
-            FileUtils::sharedFileUtils = nullptr;
-            CC_LOG_DEBUG("ERROR: Could not init CCFileUtilsLinux");
-        }
-    }
-    return FileUtils::sharedFileUtils;
+FileUtils *createFileUtils() {
+    auto *fileUtils = ccnew FileUtilsLinux();
+    fileUtils->init();
+    return fileUtils;
 }
 
 bool FileUtilsLinux::init() {

--- a/native/cocos/platform/linux/FileUtils-linux.cpp
+++ b/native/cocos/platform/linux/FileUtils-linux.cpp
@@ -42,6 +42,10 @@ FileUtils *createFileUtils() {
     return ccnew FileUtilsLinux();
 }
 
+FileUtilsLinux::FileUtilsLinux() {
+    init();
+}
+
 bool FileUtilsLinux::init() {
     // get application path
     char fullpath[256] = {0};

--- a/native/cocos/platform/linux/FileUtils-linux.h
+++ b/native/cocos/platform/linux/FileUtils-linux.h
@@ -29,7 +29,9 @@
 namespace cc {
 class CC_DLL FileUtilsLinux : public FileUtils {
 public:
-    friend class FileUtils;
+	FileUtilsLinux();
+	~FileUtilsLinux() override = default;
+
     bool isFileExistInternal(const ccstd::string &filename) const override;
     ccstd::string getWritablePath() const override;
     bool init() override;

--- a/native/cocos/platform/ohos/FileUtils-ohos.cpp
+++ b/native/cocos/platform/ohos/FileUtils-ohos.cpp
@@ -73,6 +73,10 @@ void printRawfiles(ResourceManager *mgr, const ccstd::string &path) {
 }
 } // namespace
 
+FileUtils *createFileUtils() {
+    return ccnew FileUtilsOHOS();
+}
+
 bool FileUtilsOHOS::initResourceManager(ResourceManager *mgr, const ccstd::string &assetPath, const ccstd::string &moduleName) {
     CC_ASSERT(mgr);
     ohosResourceMgr = mgr;

--- a/native/cocos/platform/ohos/FileUtils-ohos.cpp
+++ b/native/cocos/platform/ohos/FileUtils-ohos.cpp
@@ -99,16 +99,8 @@ ResourceManager *FileUtilsOHOS::getResourceManager() {
     return ohosResourceMgr;
 }
 
-FileUtils *FileUtils::getInstance() {
-    if (FileUtils::sharedFileUtils == nullptr) {
-        FileUtils::sharedFileUtils = ccnew FileUtilsOHOS();
-        if (!FileUtils::sharedFileUtils->init()) {
-            delete FileUtils::sharedFileUtils;
-            FileUtils::sharedFileUtils = nullptr;
-            CC_LOG_DEBUG("ERROR: Could not init CCFileUtilsAndroid");
-        }
-    }
-    return FileUtils::sharedFileUtils;
+FileUtilsOHOS::FileUtilsOHOS() {
+    init();
 }
 
 bool FileUtilsOHOS::init() {

--- a/native/cocos/platform/ohos/FileUtils-ohos.h
+++ b/native/cocos/platform/ohos/FileUtils-ohos.h
@@ -37,14 +37,14 @@ namespace cc {
 
 class CC_DLL FileUtilsOHOS : public FileUtils {
 public:
-    //        FileUtilsOHOS();
-    //        virtual ~FileUtilsOHOS();
-
     static bool initResourceManager(ResourceManager *mgr, const ccstd::string &assetPath, const ccstd::string &moduleName);
 
     static void setRawfilePrefix(const ccstd::string &prefix);
 
     static ResourceManager *getResourceManager();
+
+    FileUtilsOHOS();
+    ~FileUtilsOHOS() override = default;
 
     bool init() override;
 

--- a/native/cocos/platform/qnx/FileUtils-qnx.cpp
+++ b/native/cocos/platform/qnx/FileUtils-qnx.cpp
@@ -43,6 +43,10 @@ FileUtils *createFileUtils() {
     return ccnew FileUtilsQNX();
 }
 
+FileUtilsQNX::FileUtilsQNX() {
+    init();
+}
+
 bool FileUtilsQNX::init() {
     // get application path
     // In QNX /proc/self/exefile is not a symbolic link; It's a regular file.

--- a/native/cocos/platform/qnx/FileUtils-qnx.cpp
+++ b/native/cocos/platform/qnx/FileUtils-qnx.cpp
@@ -39,16 +39,8 @@
 
 namespace cc {
 
-FileUtils *FileUtils::getInstance() {
-    if (FileUtils::sharedFileUtils == nullptr) {
-        FileUtils::sharedFileUtils = ccnew FileUtilsQNX();
-        if (!FileUtils::sharedFileUtils->init()) {
-            delete FileUtils::sharedFileUtils;
-            FileUtils::sharedFileUtils = nullptr;
-            CC_LOG_DEBUG("ERROR: Could not init CCFileUtilsQNX");
-        }
-    }
-    return FileUtils::sharedFileUtils;
+FileUtils *createFileUtils() {
+    return ccnew FileUtilsQNX();
 }
 
 bool FileUtilsQNX::init() {

--- a/native/cocos/platform/qnx/FileUtils-qnx.h
+++ b/native/cocos/platform/qnx/FileUtils-qnx.h
@@ -30,6 +30,9 @@ namespace cc {
 class CC_DLL FileUtilsQNX : public FileUtils {
 public:
     friend class FileUtils;
+    FileUtilsQNX();
+    ~FileUtils() override = default;
+ 
     bool isFileExistInternal(const ccstd::string &filename) const override;
     ccstd::string getWritablePath() const override;
     bool init() override;

--- a/native/cocos/platform/qnx/FileUtils-qnx.h
+++ b/native/cocos/platform/qnx/FileUtils-qnx.h
@@ -31,7 +31,7 @@ class CC_DLL FileUtilsQNX : public FileUtils {
 public:
     friend class FileUtils;
     FileUtilsQNX();
-    ~FileUtils() override = default;
+    ~FileUtilsQNX() override = default;
  
     bool isFileExistInternal(const ccstd::string &filename) const override;
     ccstd::string getWritablePath() const override;

--- a/native/cocos/platform/win32/FileUtils-win32.cpp
+++ b/native/cocos/platform/win32/FileUtils-win32.cpp
@@ -72,16 +72,8 @@ static void _checkPath() {
     }
 }
 
-FileUtils *FileUtils::getInstance() {
-    if (FileUtils::sharedFileUtils == nullptr) {
-        FileUtils::sharedFileUtils = ccnew FileUtilsWin32();
-        if (!FileUtils::sharedFileUtils->init()) {
-            delete FileUtils::sharedFileUtils;
-            FileUtils::sharedFileUtils = nullptr;
-            CC_LOG_DEBUG("ERROR: Could not init CCFileUtilsWin32");
-        }
-    }
-    return FileUtils::sharedFileUtils;
+FileUtils *createFileUtils() {
+    return ccnew FileUtilsWin32();
 }
 
 FileUtilsWin32::FileUtilsWin32() {

--- a/native/cocos/platform/win32/FileUtils-win32.cpp
+++ b/native/cocos/platform/win32/FileUtils-win32.cpp
@@ -77,6 +77,7 @@ FileUtils *createFileUtils() {
 }
 
 FileUtilsWin32::FileUtilsWin32() {
+    init();
 }
 
 bool FileUtilsWin32::init() {

--- a/native/cocos/platform/win32/FileUtils-win32.h
+++ b/native/cocos/platform/win32/FileUtils-win32.h
@@ -25,37 +25,27 @@
  THE SOFTWARE.
 ****************************************************************************/
 
-#ifndef __CC_FILEUTILS_WIN32_H__
-#define __CC_FILEUTILS_WIN32_H__
+#pragma once
 
-#if CC_PLATFORM == CC_PLATFORM_WINDOWS
-
-    #include "base/Macros.h"
-    #include "base/std/container/string.h"
-    #include "platform/FileUtils.h"
+#include "base/Macros.h"
+#include "base/std/container/string.h"
+#include "platform/FileUtils.h"
 
 namespace cc {
 
-/**
- * @addtogroup platform
- * @{
- */
-
 //! @brief  Helper class to handle file operations
 class CC_DLL FileUtilsWin32 : public FileUtils {
-    friend class FileUtils;
-    FileUtilsWin32();
-
 public:
+    FileUtilsWin32();
     /* override functions */
     bool init();
-    virtual ccstd::string getWritablePath() const override;
-    virtual bool isAbsolutePath(const ccstd::string &strPath) const override;
-    virtual ccstd::string getSuitableFOpen(const ccstd::string &filenameUtf8) const override;
-    virtual long getFileSize(const ccstd::string &filepath);
+    ccstd::string getWritablePath() const override;
+    bool isAbsolutePath(const ccstd::string &strPath) const override;
+    ccstd::string getSuitableFOpen(const ccstd::string &filenameUtf8) const override;
+    long getFileSize(const ccstd::string &filepath);
 
 protected:
-    virtual bool isFileExistInternal(const ccstd::string &strFilePath) const override;
+    bool isFileExistInternal(const ccstd::string &strFilePath) const override;
 
     /**
     *  Renames a file under the given directory.
@@ -65,7 +55,7 @@ protected:
     *  @param name     The new name of the file.
     *  @return True if the file have been renamed successfully, false if not.
     */
-    virtual bool renameFile(const ccstd::string &path, const ccstd::string &oldname, const ccstd::string &name) override;
+    bool renameFile(const ccstd::string &path, const ccstd::string &oldname, const ccstd::string &name) override;
 
     /**
     *  Renames a file under the given directory.
@@ -74,14 +64,14 @@ protected:
     *  @param newfullpath  The new path + name of the file.
     *  @return True if the file have been renamed successfully, false if not.
     */
-    virtual bool renameFile(const ccstd::string &oldfullpath, const ccstd::string &newfullpath) override;
+    bool renameFile(const ccstd::string &oldfullpath, const ccstd::string &newfullpath) override;
 
     /**
     *  Checks whether a directory exists without considering search paths and resolution orders.
     *  @param dirPath The directory (with absolute path) to look up for
     *  @return Returns true if the directory found at the given absolute path, otherwise returns false
     */
-    virtual bool isDirectoryExistInternal(const ccstd::string &dirPath) const override;
+    bool isDirectoryExistInternal(const ccstd::string &dirPath) const override;
 
     /**
     *  Removes a file.
@@ -89,7 +79,7 @@ protected:
     *  @param filepath The full path of the file, it must be an absolute path.
     *  @return True if the file have been removed successfully, false if not.
     */
-    virtual bool removeFile(const ccstd::string &filepath) override;
+    bool removeFile(const ccstd::string &filepath) override;
 
     /**
     *  Creates a directory.
@@ -97,7 +87,7 @@ protected:
     *  @param dirPath The path of the directory, it must be an absolute path.
     *  @return True if the directory have been created successfully, false if not.
     */
-    virtual bool createDirectory(const ccstd::string &dirPath) override;
+    bool createDirectory(const ccstd::string &dirPath) override;
 
     /**
     *  Removes a directory.
@@ -105,9 +95,9 @@ protected:
     *  @param dirPath  The full path of the directory, it must be an absolute path.
     *  @return True if the directory have been removed successfully, false if not.
     */
-    virtual bool removeDirectory(const ccstd::string &dirPath) override;
+    bool removeDirectory(const ccstd::string &dirPath) override;
 
-    virtual FileUtils::Status getContents(const ccstd::string &filename, ResizableBuffer *buffer) override;
+    FileUtils::Status getContents(const ccstd::string &filename, ResizableBuffer *buffer) override;
 
     /**
      *  Gets full path for filename, resolution directory and search path.
@@ -116,7 +106,7 @@ protected:
      *  @param searchPath The search path.
      *  @return The full path of the file. It will return an empty string if the full path of the file doesn't exist.
      */
-    virtual ccstd::string getPathForFilename(const ccstd::string &filename, const ccstd::string &searchPath) const override;
+    ccstd::string getPathForFilename(const ccstd::string &filename, const ccstd::string &searchPath) const override;
 
     /**
      *  Gets full path for the directory and the filename.
@@ -128,14 +118,7 @@ protected:
      *  @param filename  The name of the file.
      *  @return The full path of the file, if the file can't be found, it will return an empty string.
      */
-    virtual ccstd::string getFullPathForDirectoryAndFilename(const ccstd::string &directory, const ccstd::string &filename) const override;
+    ccstd::string getFullPathForDirectoryAndFilename(const ccstd::string &directory, const ccstd::string &filename) const override;
 };
 
-// end of platform group
-/// @}
-
 } // namespace cc
-
-#endif // CC_PLATFORM == CC_PLATFORM_WINDOWS
-
-#endif // __CC_FILEUTILS_WIN32_H__

--- a/native/tools/tojs/cocos.ini
+++ b/native/tools/tojs/cocos.ini
@@ -77,7 +77,7 @@ base_classes_to_skip = RefCounted Clonable
 
 # classes that create no constructor
 # Set is special and we will use a hand-written constructor
-abstract_classes = SAXParser Device ICanvasRenderingContext2D ICanvasGradient OSInterface
+abstract_classes = SAXParser Device ICanvasRenderingContext2D ICanvasGradient OSInterface FileUtils
 
 persistent_classes = FileUtils
 


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/11027

### Changelog

* do not use `FileUtils::getInstance()` to initialize FileUtils, `FileUtils::getInstance()` only returns the singleton, after we implements RTTI, will deprecated `FileUtils::getInstance()` and use `engine->getSubSystem()` instead
* deprecated `FileUtils::destroyInstance()`, just delete the singleton in engine.