### PR TITLE
don't push data if debug is not enabled. 

### DIFF
--- a/cocos/core/animation/marionette/clip-motion.ts
+++ b/cocos/core/animation/marionette/clip-motion.ts
@@ -81,7 +81,9 @@ class ClipMotionEval implements MotionEval {
         if (weight === 0.0) {
             return;
         }
-        pushWeight(this._state.name, weight);
+        if (GRAPH_DEBUG_ENABLED) {
+          pushWeight(this._state.name, weight);
+        }
         const time = this._state.duration * progress;
         this._state.time = time;
         this._state.weight = weight;

--- a/cocos/core/animation/marionette/clip-motion.ts
+++ b/cocos/core/animation/marionette/clip-motion.ts
@@ -82,7 +82,7 @@ class ClipMotionEval implements MotionEval {
             return;
         }
         if (GRAPH_DEBUG_ENABLED) {
-          pushWeight(this._state.name, weight);
+            pushWeight(this._state.name, weight);
         }
         const time = this._state.duration * progress;
         this._state.time = time;


### PR DESCRIPTION
Re: #

### Changelog
 Only push weight data if Graph Debugging is enabled. If it is not enabled, clear is never called on the array and the data builds up forever.
* 

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [X ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->