### PR TITLE
Subsystem startup shutdown

### DIFF
--- a/native/cocos/core/builtin/BuiltinResMgr.cpp
+++ b/native/cocos/core/builtin/BuiltinResMgr.cpp
@@ -119,15 +119,15 @@ BuiltinResMgr *BuiltinResMgr::instance = nullptr;
 
 /* static */
 BuiltinResMgr *BuiltinResMgr::getInstance() {
-    if (BuiltinResMgr::instance == nullptr) {
-        BuiltinResMgr::instance = ccnew BuiltinResMgr();
-        BuiltinResMgr::instance->addRef();
-    }
-    return instance;
+    return BuiltinResMgr::instance;
 }
 
-void BuiltinResMgr::destroyInstance() {
-    CC_SAFE_RELEASE_NULL(BuiltinResMgr::instance);
+BuiltinResMgr::BuiltinResMgr() {
+    BuiltinResMgr::instance = this;
+}
+
+BuiltinResMgr::~BuiltinResMgr() {
+    BuiltinResMgr::instance = nullptr;
 }
 
 void BuiltinResMgr::addAsset(const ccstd::string &uuid, Asset *asset) {

--- a/native/cocos/core/builtin/BuiltinResMgr.h
+++ b/native/cocos/core/builtin/BuiltinResMgr.h
@@ -39,10 +39,12 @@ class Device;
 class Material;
 class Asset;
 
-class BuiltinResMgr final : public RefCounted {
+class BuiltinResMgr final {
 public:
     static BuiltinResMgr *getInstance();
-    static void destroyInstance();
+    
+    BuiltinResMgr();
+    ~BuiltinResMgr();
 
     bool initBuiltinRes(gfx::Device *device);
     inline bool isInitialized() const { return _isInitialized; }
@@ -56,9 +58,6 @@ public:
     }
 
 private:
-    explicit BuiltinResMgr() = default;
-    ~BuiltinResMgr() override = default;
-
     void initMaterials();
     void tryCompileAllPasses();
     void initTexture2DWithUuid(const ccstd::string &uuid, const uint8_t *data, size_t dataBytes, uint32_t width, uint32_t height);
@@ -66,7 +65,6 @@ private:
 
     static BuiltinResMgr *instance;
 
-    gfx::Device *_device{nullptr};
     Record<ccstd::string, IntrusivePtr<Asset>> _resources;
     ccstd::vector<IntrusivePtr<Material>> _materialsToBeCompiled;
     bool _isInitialized{false};

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -97,6 +97,7 @@ namespace cc {
 Engine::Engine() {
     _scheduler = std::make_shared<Scheduler>();
     _fs = createFileUtils();
+    _programLib = ccnew ProgramLib();
     _builtinResMgr = ccnew BuiltinResMgr;
     // May create gfx device in render subsystem in future.
     _gfxDevice = gfx::DeviceManager::create();
@@ -141,10 +142,10 @@ Engine::~Engine() {
 #if CC_USE_MIDDLEWARE
     cc::middleware::MiddlewareManager::destroyInstance();
 #endif
-    ProgramLib::destroyInstance();
     
     CCObject::deferredDestroy();
     delete _builtinResMgr;
+    delete _programLib;
     CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
     delete _fs;
 }
@@ -298,7 +299,11 @@ int32_t Engine::restartVM() {
     _scriptEngine->cleanup();
     CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
     cc::EventDispatcher::destroy();
-    ProgramLib::destroyInstance();
+    
+    // Should re-create ProgramLib as shaders may change after restart. For example,
+    // program update resources and do restart.
+    delete _programLib;
+    _programLib = ccnew ProgramLib;
 
     // Should reinitialize builtin resources as _programLib will be re-created.
     delete _builtinResMgr;

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -97,6 +97,7 @@ namespace cc {
 Engine::Engine() {
     _scheduler = std::make_shared<Scheduler>();
     _fs = createFileUtils();
+    _builtinResMgr = ccnew BuiltinResMgr;
     // May create gfx device in render subsystem in future.
     _gfxDevice = gfx::DeviceManager::create();
     _scriptEngine = ccnew se::ScriptEngine();
@@ -141,10 +142,9 @@ Engine::~Engine() {
     cc::middleware::MiddlewareManager::destroyInstance();
 #endif
     ProgramLib::destroyInstance();
-    BuiltinResMgr::destroyInstance();
-
-    CCObject::deferredDestroy();
     
+    CCObject::deferredDestroy();
+    delete _builtinResMgr;
     CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
     delete _fs;
 }
@@ -299,7 +299,11 @@ int32_t Engine::restartVM() {
     CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
     cc::EventDispatcher::destroy();
     ProgramLib::destroyInstance();
-    BuiltinResMgr::destroyInstance();
+
+    // Should reinitialize builtin resources as _programLib will be re-created.
+    delete _builtinResMgr;
+    _builtinResMgr = ccnew BuiltinResMgr;
+
     CCObject::deferredDestroy();
 
     // remove all listening events

--- a/native/cocos/engine/Engine.h
+++ b/native/cocos/engine/Engine.h
@@ -48,6 +48,7 @@ class FileUtils;
 class DebugRenderer;
 class Profiler;
 class BuiltinResMgr;
+class ProgramLib;
 
 #define NANOSECONDS_PER_SECOND 1000000000
 #define NANOSECONDS_60FPS      16666667L
@@ -154,6 +155,7 @@ private:
     
     // Should move them into material system in future.
     BuiltinResMgr *_builtinResMgr{nullptr};
+    ProgramLib *_programLib{nullptr};
 
     std::map<OSEventType, EventCb> _eventCallbacks;
     CC_DISALLOW_COPY_MOVE_ASSIGN(Engine);

--- a/native/cocos/engine/Engine.h
+++ b/native/cocos/engine/Engine.h
@@ -47,6 +47,7 @@ class Device;
 class FileUtils;
 class DebugRenderer;
 class Profiler;
+class BuiltinResMgr;
 
 #define NANOSECONDS_PER_SECOND 1000000000
 #define NANOSECONDS_60FPS      16666667L
@@ -141,14 +142,18 @@ private:
     bool _needRestart{false};
     bool _inited{false};
     
-    // Subsystems
+    // Some global objects.
     FileUtils *_fs{nullptr};
 #if CC_USE_PROFILER
 	Profiler *_profiler{nullptr};
 #endif
     DebugRenderer *_debugRenderer{nullptr};
     se::ScriptEngine *_scriptEngine{nullptr};
+    // Should move to renderer system in future.
     gfx::Device *_gfxDevice{nullptr};
+    
+    // Should move them into material system in future.
+    BuiltinResMgr *_builtinResMgr{nullptr};
 
     std::map<OSEventType, EventCb> _eventCallbacks;
     CC_DISALLOW_COPY_MOVE_ASSIGN(Engine);

--- a/native/cocos/renderer/core/ProgramLib.cpp
+++ b/native/cocos/renderer/core/ProgramLib.cpp
@@ -271,9 +271,13 @@ void IProgramInfo::copyFrom(const IShaderInfo &o) {
     subpassInputs = o.subpassInputs;
 }
 
-ProgramLib::ProgramLib() = default;
+ProgramLib::ProgramLib() {
+    ProgramLib::instance = this;
+}
 
-ProgramLib::~ProgramLib() = default;
+ProgramLib::~ProgramLib() {
+    ProgramLib::instance = nullptr;
+}
 
 //
 /*static*/
@@ -281,17 +285,7 @@ ProgramLib::~ProgramLib() = default;
 ProgramLib *ProgramLib::instance = nullptr;
 
 ProgramLib *ProgramLib::getInstance() {
-    if (!ProgramLib::instance) {
-        ProgramLib::instance = ccnew ProgramLib();
-    }
     return ProgramLib::instance;
-}
-
-void ProgramLib::destroyInstance() {
-    if (ProgramLib::instance) {
-        delete ProgramLib::instance;
-        ProgramLib::instance = nullptr;
-    }
 }
 
 void ProgramLib::registerEffect(EffectAsset *effect) {

--- a/native/cocos/renderer/core/ProgramLib.h
+++ b/native/cocos/renderer/core/ProgramLib.h
@@ -84,7 +84,9 @@ const char *getDeviceShaderVersion(const gfx::Device *device);
 class ProgramLib final {
 public:
     static ProgramLib *getInstance();
-    static void destroyInstance();
+    
+    ProgramLib();
+    ~ProgramLib();
 
     void registerEffect(EffectAsset *effect);
 
@@ -157,8 +159,6 @@ public:
 
 private:
     CC_DISALLOW_COPY_MOVE_ASSIGN(ProgramLib);
-    ProgramLib();
-    ~ProgramLib();
 
     static ProgramLib *instance;
     Record<ccstd::string, IProgramInfo> _templates; // per shader


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/11027

### Changelog

* refactor startup/shutdown process of BuiltinResMgr and ProgramLib
* As BuiltinResMgr and ProgramLib are added in v3.6.0, so there is not problem to delete destroyInstance method