### PR TITLE
`boost::hash_range` returns `size_t` which is 64bit on 64bit devices, so need to cast it to uint64_t.

### DIFF
--- a/native/cocos/3d/assets/Mesh.cpp
+++ b/native/cocos/3d/assets/Mesh.cpp
@@ -198,7 +198,7 @@ uint64_t Mesh::getHash() {
     if (_hash == 0) {
         std::size_t seed = 666;
         boost::hash_range(seed, _data.buffer()->getData(), _data.buffer()->getData() + _data.length());
-        _hash = static_cast<uint32_t>(seed);
+        _hash = static_cast<uint64_t>(seed);
     }
 
     return _hash;

--- a/native/cocos/3d/assets/Skeleton.cpp
+++ b/native/cocos/3d/assets/Skeleton.cpp
@@ -56,7 +56,7 @@ uint64_t Skeleton::getHash() {
         ccstd::string str{sstr.str()};
         std::size_t seed = 666;
         boost::hash_range(seed, str.begin(), str.end());
-        _hash = static_cast<uint32_t>(seed);
+        _hash = static_cast<uint64_t>(seed);
     }
     return _hash;
 }

--- a/native/cocos/core/assets/TextureBase.cpp
+++ b/native/cocos/core/assets/TextureBase.cpp
@@ -46,7 +46,7 @@ TextureBase::TextureBase() {
     _gfxDevice = getGFXDevice();
     std::size_t seed = 666;
     boost::hash_range(seed, _id.begin(), _id.end());
-    _textureHash = static_cast<uint32_t>(seed);
+    _textureHash = static_cast<uint64_t>(seed);
 }
 
 TextureBase::~TextureBase() = default;

--- a/native/cocos/core/assets/TextureBase.h
+++ b/native/cocos/core/assets/TextureBase.h
@@ -253,7 +253,7 @@ protected:
     gfx::Sampler *_gfxSampler{nullptr};
     gfx::Device *_gfxDevice{nullptr};
 
-    uint32_t _textureHash{0};
+    uint64_t _textureHash{0};
 
 private:
     CC_DISALLOW_COPY_MOVE_ASSIGN(TextureBase);

--- a/native/cocos/scene/Pass.cpp
+++ b/native/cocos/scene/Pass.cpp
@@ -118,7 +118,7 @@ uint64_t Pass::getPassHash(Pass *pass) {
     ccstd::string str{res.str()};
     std::size_t seed = 666;
     boost::hash_range(seed, str.begin(), str.end());
-    return static_cast<uint32_t>(seed);
+    return static_cast<uint64_t>(seed);
 }
 
 Pass::Pass() : Pass(Root::getInstance()) {}


### PR DESCRIPTION
This issue was caused by https://github.com/cocos/cocos-engine/commit/0952f8f8383ee0d350733c4401ad9781b39c10a2


-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->