### PR TITLE
do not handle Root in engine

### DIFF
--- a/native/cocos/core/Root.cpp
+++ b/native/cocos/core/Root.cpp
@@ -62,8 +62,9 @@ Root::Root(gfx::Device *device)
 }
 
 Root::~Root() {
-    instance = nullptr;
+    destroy();
     CC_SAFE_DELETE(_eventProcessor);
+    instance = nullptr;
 }
 
 void Root::initialize(gfx::Swapchain *swapchain) {

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -57,12 +57,10 @@
 #include "application/BaseApplication.h"
 #include "base/Scheduler.h"
 #include "network/HttpClient.h"
-#include "core/Root.h"
 #include "core/assets/FreeTypeFont.h"
 #include "platform/interfaces/modules/ISystemWindow.h"
 #include "profiler/DebugRenderer.h"
 #include "profiler/Profiler.h"
-#include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 
 namespace {
 
@@ -125,7 +123,6 @@ Engine::~Engine() {
 
     EventDispatcher::destroy();
     network::HttpClient::destroyInstance();
-    Root::getInstance()->destroy();
 
 #if CC_USE_PROFILER
     delete _profiler;
@@ -281,8 +278,6 @@ void Engine::tick() {
 
 int32_t Engine::restartVM() {
     cc::EventDispatcher::dispatchRestartVM();
-
-    Root::getInstance()->getPipeline()->destroy();
 
     cc::DeferredReleasePool::clear();
 #if CC_USE_AUDIO


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/11027

### Changelog
* Root is created by TS, and ScriptEngine::cleanup() will handle it, so remove redundant codes.