### PR TITLE
V3.6.0 ios input box

### DIFF
--- a/native/cocos/bindings/event/EventDispatcher.cpp
+++ b/native/cocos/bindings/event/EventDispatcher.cpp
@@ -144,6 +144,7 @@ void EventDispatcher::dispatchTouchEvent(const TouchEvent &touchEvent) {
     se::ValueArray args;
     args.emplace_back(se::Value(jsTouchObjArray));
     EventDispatcher::doDispatchJsEvent(eventName, args);
+    EventDispatcher::dispatchCustomEvent(eventName,0);
 }
 
 void EventDispatcher::dispatchMouseEvent(const MouseEvent &mouseEvent) {
@@ -289,6 +290,7 @@ void EventDispatcher::dispatchOrientationChangeEvent(int orientation) {
         args.emplace_back(se::Value(jsOrientationEventObj));
         func.toObject()->call(args, nullptr);
     }
+    EventDispatcher::dispatchCustomEvent("orientation_changed", 0);
 }
 
 void EventDispatcher::dispatchEnterBackgroundEvent() {

--- a/native/cocos/bindings/event/EventDispatcher.cpp
+++ b/native/cocos/bindings/event/EventDispatcher.cpp
@@ -290,7 +290,6 @@ void EventDispatcher::dispatchOrientationChangeEvent(int orientation) {
         args.emplace_back(se::Value(jsOrientationEventObj));
         func.toObject()->call(args, nullptr);
     }
-    EventDispatcher::dispatchCustomEvent("orientation_changed", 0);
 }
 
 void EventDispatcher::dispatchEnterBackgroundEvent() {

--- a/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
+++ b/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
@@ -277,14 +277,21 @@ public class CocosEditBoxActivity extends Activity {
             extras = intent.getExtras();
         }
         if(extras == null){
-            extras = new Bundle();
-        }
-        show(extras.getString("defaultValue"),
+            show("",
+                10,
+                false,
+                false,
+                "done",
+                "text"
+                );
+        } else {
+            show(extras.getString("defaultValue"),
                 extras.getInt("maxLength"),
                 extras.getBoolean("isMultiline"),
                 extras.getBoolean("confirmHold"),
                 extras.getString("confirmType"),
                 extras.getString("inputType"));
+        }
     }
 
     /***************************************************************************************

--- a/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
+++ b/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
@@ -264,7 +264,14 @@ public class CocosEditBoxActivity extends Activity {
 
         this.addItems(frameLayout);
 
-        Bundle extras = getIntent().getExtras();
+        Intent intent = getIntent();
+        Bundle extras = null;
+        if (null != intent) {
+            extras = intent.getExtras();
+        }
+        if(extras == null){
+            extras = new Bundle();
+        }
         show(extras.getString("defaultValue"),
                 extras.getInt("maxLength"),
                 extras.getBoolean("isMultiline"),

--- a/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
+++ b/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
@@ -260,6 +260,13 @@ public class CocosEditBoxActivity extends Activity {
                         ViewGroup.LayoutParams.MATCH_PARENT);
         RelativeLayout frameLayout = new RelativeLayout(this);
         frameLayout.setLayoutParams(frameLayoutParams);
+        frameLayout.setClickable(true);
+        frameLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                CocosEditBoxActivity.this.hide();
+            }
+        });
         setContentView(frameLayout);
 
         this.addItems(frameLayout);

--- a/native/cocos/platform/ios/View.mm
+++ b/native/cocos/platform/ios/View.mm
@@ -28,7 +28,6 @@
 #include <UIKit/UIScreen.h>
 #import "platform/ios/AppDelegateBridge.h"
 #include "platform/ios/IOSPlatform.h"
-#include "cocos/ui/edit-box/EditBox.h"
 
 namespace {
 } // namespace
@@ -91,7 +90,6 @@ namespace {
         return;
 
     [self dispatchTouchEvent:cc::TouchEvent::Type::BEGAN withEvent:touches];
-    cc::EditBox::complete();
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {

--- a/native/cocos/platform/ios/View.mm
+++ b/native/cocos/platform/ios/View.mm
@@ -28,6 +28,7 @@
 #include <UIKit/UIScreen.h>
 #import "platform/ios/AppDelegateBridge.h"
 #include "platform/ios/IOSPlatform.h"
+#include "cocos/ui/edit-box/EditBox.h"
 
 namespace {
 } // namespace
@@ -90,6 +91,7 @@ namespace {
         return;
 
     [self dispatchTouchEvent:cc::TouchEvent::Type::BEGAN withEvent:touches];
+    cc::EditBox::complete();
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -275,6 +275,12 @@ static ButtonHandler*           btnHandler = nil;
 @property(readwrite) id inputDelegate;
 @end
 @implementation InputBoxPair
+- (void)dealloc {
+    [super dealloc];
+    [_inputOnView release];
+    [_inputOnToolbar release];
+    [_inputDelegate release];
+}
 @end
 
 @implementation EditboxManager

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -211,8 +211,11 @@ void onParentViewTouched(const cc::CustomEvent &touchEvent){
     if (self = [super init]) {
         tViewOnView = inputOnView;
         tViewOnToolbar = inputOnToolbar;
+        return self;
+    } else {
+        [self release];
+        return nil;
     }
-    return self;
 }
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
     // REFINE: check length limit before text changed
@@ -239,8 +242,12 @@ void onParentViewTouched(const cc::CustomEvent &touchEvent){
     if (self = [super init]) {
         textFieldOnView = inputOnView;
         textFieldOntoolbar = inputOnToolbar;
+        return self;
+    } else {
+        [self release];
+        return nil;
     }
-    return self;
+    
 }
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     // REFINE: check length limit before text changed
@@ -295,6 +302,9 @@ static EditboxManager *instance = nil;
     static dispatch_once_t pred = 0;
     dispatch_once(&pred, ^{
         instance = [[super allocWithZone:NULL] init];
+        if (instance == nil) {
+            CC_LOG_ERROR("Editbox manager init failed, plz check if you have enough space left");
+        }
     });
     return instance;
 }
@@ -311,7 +321,12 @@ static EditboxManager *instance = nil;
 }
 - (id)init {
     if (self = [super init]) {
+        
         textInputDictionnary = [NSMutableDictionary new];
+        if (textInputDictionnary == nil) {
+            [self release];
+            return nil;
+        }
         
         cc::EventDispatcher::addCustomEventListener(EVENT_RESIZE, [&](const cc::CustomEvent& event) -> void {
                 [[EditboxManager sharedInstance] onOrientationChanged];

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -211,11 +211,8 @@ void onParentViewTouched(const cc::CustomEvent &touchEvent){
     if (self = [super init]) {
         tViewOnView = inputOnView;
         tViewOnToolbar = inputOnToolbar;
-        return self;
-    } else {
-        [self release];
-        return nil;
     }
+    return self;
 }
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
     // REFINE: check length limit before text changed
@@ -242,12 +239,9 @@ void onParentViewTouched(const cc::CustomEvent &touchEvent){
     if (self = [super init]) {
         textFieldOnView = inputOnView;
         textFieldOntoolbar = inputOnToolbar;
-        return self;
-    } else {
-        [self release];
-        return nil;
+        
     }
-    
+    return self;
 }
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     // REFINE: check length limit before text changed

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -272,6 +272,7 @@ static ButtonHandler*           btnHandler = nil;
 @interface InputBoxPair : NSObject
 @property(readwrite) id inputOnView;
 @property(readwrite) id inputOnToolbar;
+@property(readwrite) id inputDelegate;
 @end
 @implementation InputBoxPair
 @end
@@ -364,6 +365,7 @@ static EditboxManager *instance = nil;
     textView.clipsToBounds = YES;
     textView.text = [NSString stringWithUTF8String:showInfo->defaultValue.c_str()];
     TextViewDelegate* delegate = [[TextViewDelegate alloc] initWithPairs:[inputbox inputOnView] and:textView];
+    inputbox.inputDelegate = delegate;
     textView.delegate = delegate;
     UIBarButtonItem *textViewItem = [[UIBarButtonItem alloc] initWithCustomView:textView];
     
@@ -391,6 +393,12 @@ static EditboxManager *instance = nil;
     ((UITextView*)[inputbox inputOnView]).inputAccessoryView = toolbar;
     
     [inputbox setInputOnToolbar:textViewBarButtonItem.customView];
+    //release for NON ARC ENV
+    [toolbar release];
+    [textView release];
+    [confirmBtn release];
+    [textViewItem release];
+    [confirm release];
     
 }
 - (void) addInputAccessoryViewForTextField: (InputBoxPair*)inputbox
@@ -410,6 +418,7 @@ static EditboxManager *instance = nil;
     textField.text = [NSString stringWithUTF8String:showInfo->defaultValue.c_str()];
     TextFieldDelegate* delegate = [[TextFieldDelegate alloc] initWithPairs:[inputbox inputOnView] and:textField];
     textField.delegate = delegate;
+    inputbox.inputDelegate = delegate;
     [textField addTarget:delegate action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
     UIBarButtonItem *textFieldItem = [[UIBarButtonItem alloc] initWithCustomView:textField];
     
@@ -438,6 +447,13 @@ static EditboxManager *instance = nil;
     UIBarButtonItem* textFieldBarButtonItem = [self setInputWidthOf:toolbar];
     ((UITextField*)[inputbox inputOnView]).inputAccessoryView = toolbar;
     [inputbox setInputOnToolbar:textFieldBarButtonItem.customView];
+    
+    //release for NON ARC ENV
+    [toolbar release];
+    [textField release];
+    [confirmBtn release];
+    [textFieldItem release];
+    [confirm release];
 }
 
 - (id) createTextView:    (const cc::EditBox::ShowInfo *)showInfo {

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -192,7 +192,7 @@ CGRect getSafeAreaRect() {
 }
 
 //TODO: Get hash with different type of showInfo, for example different inputAccessoryView
-NSString *getHash(const cc::EditBox::ShowInfo* showInfo) {
+NSString* getTextInputType(const cc::EditBox::ShowInfo* showInfo) {
     return showInfo->isMultiline?@"textView":@"textField";
 }
 void onParentViewTouched(const cc::CustomEvent &touchEvent){
@@ -208,9 +208,10 @@ void onParentViewTouched(const cc::CustomEvent &touchEvent){
     UITextView* tViewOnToolbar;
 }
 - (id) initWithPairs:(UITextView*) inputOnView and:(UITextView*) inputOnToolbar {
-    self = [super init];
-    tViewOnView = inputOnView;
-    tViewOnToolbar = inputOnToolbar;
+    if (self = [super init]) {
+        tViewOnView = inputOnView;
+        tViewOnToolbar = inputOnToolbar;
+    }
     return self;
 }
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
@@ -235,9 +236,10 @@ void onParentViewTouched(const cc::CustomEvent &touchEvent){
 }
 
 - (id) initWithPairs:(UITextField*) inputOnView and:(UITextField*) inputOnToolbar {
-    self = [super init];
-    textFieldOnView = inputOnView;
-    textFieldOntoolbar = inputOnToolbar;
+    if (self = [super init]) {
+        textFieldOnView = inputOnView;
+        textFieldOntoolbar = inputOnToolbar;
+    }
     return self;
 }
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
@@ -303,22 +305,21 @@ static EditboxManager *instance = nil;
     cc::EditBox::complete();
 }
 - (id)init {
-    self          = [super init];
-    textInputDictionnary = [NSMutableDictionary new];
-    
-    cc::EventDispatcher::addCustomEventListener(EVENT_RESIZE, [&](const cc::CustomEvent& event) -> void {
-            [[EditboxManager sharedInstance] onOrientationChanged];
-    });
-    cc::EventDispatcher::addCustomEventListener("onTouchStart", [&](const cc::CustomEvent& event) -> void {
-        cc::EditBox::complete();
-    });
-    
+    if (self = [super init]) {
+        textInputDictionnary = [NSMutableDictionary new];
+        
+        cc::EventDispatcher::addCustomEventListener(EVENT_RESIZE, [&](const cc::CustomEvent& event) -> void {
+                [[EditboxManager sharedInstance] onOrientationChanged];
+        });
+        //"onTouchStart" is a sub event for TouchEvent, so we can only add listener for this sub event rather than TouchEvent itself.
+        cc::EventDispatcher::addCustomEventListener("onTouchStart", [&](const cc::CustomEvent& event) -> void {
+            cc::EditBox::complete();
+        });
+    }
     return self;
 }
 - (void)dealloc {
-    for (id textInput : textInputDictionnary) {
-        [textInput release];
-    }
+    [textInputDictionnary release];
     [super dealloc];
 }
 - (UIBarButtonItem*) setInputWidthOf: (UIToolbar*)toolbar{
@@ -444,7 +445,7 @@ static EditboxManager *instance = nil;
     CGRect viewRect = UIApplication.sharedApplication.delegate.window.rootViewController.view.frame;
     
     //TODO: object for key with real hash value
-    NSString* hash = getHash(showInfo);
+    NSString* hash = getTextInputType(showInfo);
     
     if ((ret = [textInputDictionnary objectForKey:hash])) {
         [[ret inputOnView] setFrame:CGRectMake(showInfo->x,
@@ -476,7 +477,7 @@ static EditboxManager *instance = nil;
     CGRect viewRect = UIApplication.sharedApplication.delegate.window.rootViewController.view.frame;
     
     //TODO: object for key with real hash value
-    NSString* hash = getHash(showInfo);
+    NSString* hash = getTextInputType(showInfo);
     
     if ((ret = [textInputDictionnary objectForKey:hash])) {
         [[ret inputOnView] setFrame:CGRectMake(showInfo->x,
@@ -569,7 +570,7 @@ void EditBox::hide() {
 
 bool EditBox::complete() {
     if(!EditBox::_isShown)
-        return;
+        return true;
     NSString *text = [[EditboxManager sharedInstance] getCurrentText];
     callJSFunc("complete", [text UTF8String]);
     EditBox::hide();

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -289,8 +289,6 @@ static EditboxManager *instance = nil;
     dispatch_once(&pred, ^{
         instance = [[super allocWithZone:NULL] init];
     });
-    
-
     return instance;
 }
 + (id)allocWithZone:(struct _NSZone*)zone {
@@ -314,6 +312,9 @@ static EditboxManager *instance = nil;
         //"onTouchStart" is a sub event for TouchEvent, so we can only add listener for this sub event rather than TouchEvent itself.
         cc::EventDispatcher::addCustomEventListener("onTouchStart", [&](const cc::CustomEvent& event) -> void {
             cc::EditBox::complete();
+        });
+        cc::EventDispatcher::addCustomEventListener(EVENT_CLOSE, [&](const cc::CustomEvent& event) -> void {
+            [[EditboxManager sharedInstance] dealloc];
         });
     }
     return self;

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -462,9 +462,9 @@ static EditboxManager *instance = nil;
     CGRect viewRect = UIApplication.sharedApplication.delegate.window.rootViewController.view.frame;
     
     //TODO: object for key with real hash value
-    NSString* hash = getTextInputType(showInfo);
+    NSString* inputType = getTextInputType(showInfo);
     
-    if ((ret = [textInputDictionnary objectForKey:hash])) {
+    if ((ret = [textInputDictionnary objectForKey:inputType])) {
         [[ret inputOnView] setFrame:CGRectMake(showInfo->x,
                                  viewRect.size.height - showInfo->y - showInfo->height,
                                  showInfo->width,
@@ -482,7 +482,7 @@ static EditboxManager *instance = nil;
                                         viewRect.size.height - showInfo->y - showInfo->height,
                                         showInfo->width,
                                         showInfo->height)]];
-        [textInputDictionnary setValue:ret forKey:hash];
+        [textInputDictionnary setValue:ret forKey:inputType];
         [self addInputAccessoryViewForTextView:ret with:showInfo];
     }
     ((UITextView*)[ret inputOnToolbar]).text = [NSString stringWithUTF8String:showInfo->defaultValue.c_str()];
@@ -494,9 +494,9 @@ static EditboxManager *instance = nil;
     CGRect viewRect = UIApplication.sharedApplication.delegate.window.rootViewController.view.frame;
     
     //TODO: object for key with real hash value
-    NSString* hash = getTextInputType(showInfo);
+    NSString* inputType = getTextInputType(showInfo);
     
-    if ((ret = [textInputDictionnary objectForKey:hash])) {
+    if ((ret = [textInputDictionnary objectForKey:inputType])) {
         [[ret inputOnView] setFrame:CGRectMake(showInfo->x,
                                  viewRect.size.height - showInfo->y - showInfo->height,
                                  showInfo->width,
@@ -514,7 +514,7 @@ static EditboxManager *instance = nil;
                                          viewRect.size.height - showInfo->y - showInfo->height,
                                          showInfo->width,
                                          showInfo->height)]];
-        [textInputDictionnary setValue:ret forKey:hash];
+        [textInputDictionnary setValue:ret forKey:inputType];
         [self addInputAccessoryViewForTextField:ret with:showInfo];
     }
     ((UITextField*)[ret inputOnToolbar]).text = [NSString stringWithUTF8String:showInfo->defaultValue.c_str()];

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -27,6 +27,7 @@
 #include "cocos/bindings/jswrapper/SeApi.h"
 #include "cocos/bindings/manual/jsb_global.h"
 
+
 #import <UIKit/UIKit.h>
 
 #define TEXT_LINE_HEIGHT         40
@@ -43,71 +44,74 @@
 
 // MARK: class declaration
 
-@interface ButtonHandler : NSObject
-- (IBAction)buttonTapped:(UIButton *)button;
-@end
 
-@interface KeyboardEventHandler : NSObject
+/*******************************
+ TODO: New implementation of iOS inputbox
+ UI Structure:
+    ==[|             ][done]== >>> inputAccessoryView
+    = q w e r t y u i o p =
+    = a s d f g h j k l ; '' =
+    = virtual [    ] keyboard = >>> inputView
+ 
+ Further needs:
+    Customization of inputbox, developer DIY toolbar.
+    The principle idea is to set inputAccessoryView from JS where developer can bind selector with js callback.
+    JS API:
+        uibutton sendBtn;
+        sendBtn.onclick = () => {...}
+        uiInputField inputFld;
+        inputFld.oninput = () => {...}
+        jsb.inputbox ibox;
+        ibox.addComponent(sendBtn); //automatically set as the last element.
+        ibox.setLayout(sendBtn, inputFld);
+    JSB binding:
+        jsb_addComponent(se::Value){
+            ...
+            inputBox.addComponent(cpt);
+        }
+    Native API:
+    class InputBox{
+        ...
+        addComponent(UIView* cpt);
+        setLayout(UIView*[] views);
+        createInputBox();
+    }
+
+ *******************************/
+
+
+//TODO: A mecanism to store each customize UITextView or UITextField. For example, if keyboard and toolbar is customized, should give a hash value and store in the map with a hash value calculated.
+
+
+// Customize inputbox
+@interface Inputbox : NSObject {
+@public UITextView  *g_inputView;
+@public UITextField *g_inputField;
+}
+
+- (void) createTextField:   (const cc::EditBox::ShowInfo*)showInfo;
+- (void) createTextView:    (const cc::EditBox::ShowInfo*)showInfo;
+
+- (void) addComponent: (UIView*) component;
+- (void) setLayout: (UIView*[]) components;
+- (void) show: (const cc::EditBox::ShowInfo*)showInfo;
+//TODO: move all handlers into inputbox implementation
+- (IBAction)buttonTapped:(UIButton *)button;
 - (void)keyboardWillShow:(NSNotification *)notification;
 - (void)keyboardWillHide:(NSNotification *)notification;
-@end
-
-@interface TextFieldDelegate : NSObject <UITextFieldDelegate>
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string;
 - (void)textFieldDidChange:(UITextField *)textField;
 - (BOOL)textFieldShouldReturn:(UITextField *)textField;
-@end
-
-@interface TextViewDelegate : NSObject <UITextViewDelegate>
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text;
 - (void)textViewDidChange:(UITextView *)textView;
 @end
 
+
+static Inputbox *g_inputbox = nil;
 /*************************************************************************
- Global variables and functions.
+ Global variables and functions relative to script engine.
  ************************************************************************/
-
-// MARK: global variables and functions
-
 namespace {
-bool g_isMultiline = false;
-bool g_confirmHold = false;
-unsigned int g_maxLength = INT_MAX;
-KeyboardEventHandler *g_keyboardHandler = nil;
-
-// "#1fa014", a color of dark green, was used for confirm button background
-static UIColor *g_darkGreen = [UIColor colorWithRed:31 / 255.0 green:160 / 255.0 blue:20 / 255.0 alpha:0.8];
-
-UITextField *g_textField = nil;
-TextFieldDelegate *g_textFieldDelegate = nil;
-UIButton *g_textFieldConfirmButton = nil;
-ButtonHandler *g_textFieldConfirmButtonHandler = nil;
-
-UITextView *g_textView = nil;
-TextViewDelegate *g_textViewDelegate = nil;
-UIButton *g_textViewConfirmButton = nil;
-ButtonHandler *g_textViewConfirmButtonHander = nil;
-
-UIView *getCurrentView() {
-    if (g_isMultiline)
-        return g_textView;
-    else
-        return g_textField;
-}
-
-NSString *getCurrentText() {
-    if (g_isMultiline)
-        return g_textView.text;
-    else
-        return g_textField.text;
-}
-
-void setText(NSString *text) {
-    if (g_isMultiline)
-        g_textView.text = text;
-    else
-        g_textField.text = text;
-}
 
 se::Value textInputCallback;
 
@@ -136,46 +140,13 @@ void callJSFunc(const ccstd::string &type, const ccstd::string &text) {
     textInputCallback.toObject()->call(args, nullptr);
 }
 
-int getTextInputHeight() {
-    if (g_isMultiline)
+int getTextInputHeight(bool isMultiline) {
+    if (isMultiline)
         return TEXT_LINE_HEIGHT * TEXT_VIEW_MAX_LINE_SHOWN;
     else
         return TEXT_LINE_HEIGHT;
 }
 
-void createButton(UIButton **button, ButtonHandler **buttonHandler, const CGRect &viewRect, const ccstd::string &title) {
-    ButtonHandler *btnHandler = [[ButtonHandler alloc] init];
-    UIButton *btn = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    [btn addTarget:btnHandler
-                  action:@selector(buttonTapped:)
-        forControlEvents:UIControlEventTouchUpInside];
-    btn.frame = CGRectMake(0, 0, BUTTON_WIDTH, BUTTON_HIGHT);
-    btn.backgroundColor = g_darkGreen;
-    [btn setTitle:[NSString stringWithUTF8String:title.c_str()]
-         forState:UIControlStateNormal];
-    [btn setTitleColor:[UIColor whiteColor]
-              forState:UIControlStateNormal];
-
-    *button = btn;
-    *buttonHandler = btnHandler;
-}
-
-void setTexFiledKeyboardType(UITextField *textField, const ccstd::string &inputType) {
-    if (0 == inputType.compare("password")) {
-        textField.secureTextEntry = TRUE;
-        textField.keyboardType = UIKeyboardTypeDefault;
-    } else {
-        textField.secureTextEntry = FALSE;
-        if (0 == inputType.compare("email"))
-            textField.keyboardType = UIKeyboardTypeEmailAddress;
-        else if (0 == inputType.compare("number"))
-            textField.keyboardType = UIKeyboardTypeDecimalPad;
-        else if (0 == inputType.compare("url"))
-            textField.keyboardType = UIKeyboardTypeURL;
-        else if (0 == inputType.compare("text"))
-            textField.keyboardType = UIKeyboardTypeDefault;
-    }
-}
 
 void setTextFieldReturnType(UITextField *textField, const ccstd::string &returnType) {
     if (0 == returnType.compare("done"))
@@ -195,47 +166,20 @@ NSString *getConfirmButtonTitle(const ccstd::string &returnType) {
     return NSLocalizedString(titleKey, nil); // get i18n string to be the title
 }
 
-void initTextField(const CGRect &rect, const cc::EditBox::ShowInfo &showInfo) {
-    if (!g_textField) {
-        g_textField = [[UITextField alloc] initWithFrame:rect];
-        g_textField.textColor = [UIColor blackColor];
-        g_textField.backgroundColor = [UIColor whiteColor];
-        [g_textField setBorderStyle:UITextBorderStyleLine];
-        g_textField.backgroundColor = [UIColor whiteColor];
-
-        g_textFieldDelegate = [[TextFieldDelegate alloc] init];
-        g_textField.delegate = g_textFieldDelegate;
-
-        // Assign the overlay button to a stored text field
-        createButton(&g_textFieldConfirmButton, &g_textFieldConfirmButtonHandler, rect, showInfo.confirmType);
-        g_textField.rightView = g_textFieldConfirmButton;
-        g_textField.rightViewMode = UITextFieldViewModeAlways;
-        [g_textField addTarget:g_textFieldDelegate action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
+void initTextField(const cc::EditBox::ShowInfo &showInfo) {
+    if(!g_inputbox) {
+        g_inputbox = [[Inputbox alloc] init];
     }
-
-    g_textField.frame = rect;
-    setTextFieldReturnType(g_textField, showInfo.confirmType);
-    setTexFiledKeyboardType(g_textField, showInfo.inputType);
-    g_textField.text = [NSString stringWithUTF8String:showInfo.defaultValue.c_str()];
-    [g_textFieldConfirmButton setTitle:getConfirmButtonTitle(showInfo.confirmType) forState:UIControlStateNormal];
+    [g_inputbox createTextField:&showInfo];
+    return;
 }
 
-void initTextView(const CGRect &viewRect, const CGRect &btnRect, const cc::EditBox::ShowInfo &showInfo) {
-    if (!g_textView) {
-        g_textView = [[UITextView alloc] initWithFrame:btnRect];
-        g_textView.textColor = [UIColor blackColor];
-        g_textView.backgroundColor = [UIColor whiteColor];
-        g_textViewDelegate = [[TextViewDelegate alloc] init];
-        g_textView.delegate = g_textViewDelegate;
-
-        createButton(&g_textViewConfirmButton, &g_textViewConfirmButtonHander, btnRect, showInfo.confirmType);
-        g_textViewConfirmButton.frame = CGRectMake(viewRect.size.width - BUTTON_WIDTH, 0, BUTTON_WIDTH, BUTTON_HIGHT);
-        [g_textView addSubview:g_textViewConfirmButton];
+void initTextView(const cc::EditBox::ShowInfo &showInfo) {
+    if(!g_inputbox) {
+        g_inputbox = [[Inputbox alloc] init];
     }
-
-    g_textView.frame = btnRect;
-    g_textView.text = [NSString stringWithUTF8String:showInfo.defaultValue.c_str()];
-    [g_textViewConfirmButton setTitle:getConfirmButtonTitle(showInfo.confirmType) forState:UIControlStateNormal];
+    [g_inputbox createTextView:&showInfo];
+    return;
 }
 
 CGRect getSafeAreaRect() {
@@ -258,87 +202,102 @@ CGRect getSafeAreaRect() {
 
     return viewRect;
 }
+UIView *getCurrentView(bool isMultiline) {
+    if(isMultiline)
+        return g_inputbox->g_inputView;
+    return g_inputbox->g_inputField;
+}
 
+NSString* getCurrentText(bool isMultiline){
+    if(isMultiline)
+        return g_inputbox->g_inputView.text;
+    return g_inputbox->g_inputField.text;
+}
 void addTextInput(const cc::EditBox::ShowInfo &showInfo) {
     auto safeAreaRect = getSafeAreaRect();
-    int height = getTextInputHeight();
-    CGRect rect = CGRectMake(safeAreaRect.origin.x,
-                             safeAreaRect.size.height - height,
+    int height = getTextInputHeight(showInfo.isMultiline);
+    CGRect btnRect = CGRectMake(safeAreaRect.origin.x,
+                             safeAreaRect.size.height - height/2,
                              safeAreaRect.size.width,
                              height);
     if (showInfo.isMultiline)
-        initTextView(safeAreaRect, rect, showInfo);
+        initTextView(showInfo);
     else
-        initTextField(rect, showInfo);
+        initTextField(showInfo);
 
-    UIView *textInput = getCurrentView();
+    UIView *textInput = getCurrentView(showInfo.isMultiline);
     UIView *view = UIApplication.sharedApplication.delegate.window.rootViewController.view;
     [view addSubview:textInput];
     [textInput becomeFirstResponder];
 }
 
 void addKeyboardEventLisnters() {
-    if (!g_keyboardHandler)
-        g_keyboardHandler = [[KeyboardEventHandler alloc] init];
 
-    [[NSNotificationCenter defaultCenter] addObserver:g_keyboardHandler
-                                             selector:@selector(keyboardWillShow:)
-                                                 name:UIKeyboardWillShowNotification
-                                               object:nil];
-
-    [[NSNotificationCenter defaultCenter] addObserver:g_keyboardHandler
-                                             selector:@selector(keyboardWillHide:)
-                                                 name:UIKeyboardWillHideNotification
-                                               object:nil];
 }
 
 void removeKeyboardEventLisnters() {
-    if (!g_keyboardHandler)
-        return;
 
-    [[NSNotificationCenter defaultCenter] removeObserver:g_keyboardHandler];
 }
 } // namespace
 
 /*************************************************************************
  Class implementations.
  ************************************************************************/
+@implementation Inputbox
+{
 
-// MARK: class implementation
-
-@implementation KeyboardEventHandler
-- (void)keyboardWillShow:(NSNotification *)notification {
-    UIView *textView = getCurrentView();
-    if (!textView)
-        return;
-
-    NSDictionary *keyboardInfo = [notification userInfo];
-    NSValue *keyboardFrame = [keyboardInfo objectForKey:UIKeyboardFrameEndUserInfoKey];
-    CGSize kbSize = [keyboardFrame CGRectValue].size;
-
-    int textHeight = getTextInputHeight();
-
-    CGRect screenRect = getSafeAreaRect();
-    textView.frame = CGRectMake(screenRect.origin.x,
-                                screenRect.size.height - textHeight - kbSize.height,
-                                screenRect.size.width,
-                                textHeight);
 }
-
-- (void)keyboardWillHide:(NSNotification *)notification {
-    NSDictionary *info = [notification userInfo];
-
-    CGRect beginKeyboardRect = [[info objectForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue];
-    CGRect endKeyboardRect = [[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
-    CGFloat yOffset = endKeyboardRect.origin.y - beginKeyboardRect.origin.y;
-
-    if (yOffset <= 0) {
-        cc::EditBox::hide();
+- (void) createTextView:    (const cc::EditBox::ShowInfo *)showInfo{
+    g_inputView = [[UITextView alloc]
+                   initWithFrame:CGRectMake(showInfo->x,
+                                            showInfo->y,
+                                            showInfo->width,
+                                            showInfo->height)];
+    //TODO: bind with specified inputView and inputAccessoryView
+    return;
+}
+- (void) createTextField:    (const cc::EditBox::ShowInfo*)showInfo{
+    g_inputField = [[UITextField alloc]
+                   initWithFrame:CGRectMake(showInfo->x,
+                                            showInfo->y,
+                                            showInfo->width,
+                                            showInfo->height)];
+    //TODO: bind with specified inputView and inputAccessoryView
+    return;
+}
+- (void) show: (const cc::EditBox::ShowInfo*)showInfo {
+    if (showInfo->isMultiline) {
+        createTextField:showInfo;
+    } else {
+        createTextView:showInfo;
     }
+        
 }
-@end
+- (void) hide {
+    
+}
+- (id) init {
+    self = [super init];
+    return self;
+}
+- (void) addComponent:(UIView *)component {
+    //TODO: Add component into inputAccessoryView
+    return;
+}
 
-@implementation TextFieldDelegate
+
+- (void) setLayout:(UIView *[])components {
+    //TODO: Set layout of inputAccessoryView
+    return;
+}
+
+- (void)keyboardWillShow:(NSNotification *)notification {
+
+}
+- (void)keyboardWillHide:(NSNotification *)notification {
+    
+}
+
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     // REFINE: check length limit before text changed
     return YES;
@@ -349,10 +308,10 @@ void removeKeyboardEventLisnters() {
         return;
 
     // check length limit after text changed, a little rude
-    if (textField.text.length > g_maxLength) {
-        NSRange rangeIndex = [textField.text rangeOfComposedCharacterSequenceAtIndex:g_maxLength];
-        textField.text = [textField.text substringToIndex:rangeIndex.location];
-    }
+//    if (textField.text.length > g_maxLength) {
+//        NSRange rangeIndex = [textField.text rangeOfComposedCharacterSequenceAtIndex:g_maxLength];
+//        textField.text = [textField.text substringToIndex:rangeIndex.location];
+//    }
 
     callJSFunc("input", [textField.text UTF8String]);
 }
@@ -361,18 +320,14 @@ void removeKeyboardEventLisnters() {
     cc::EditBox::complete();
     return YES;
 }
-@end
 
-@implementation ButtonHandler
 - (IBAction)buttonTapped:(UIButton *)button {
-    const ccstd::string text([getCurrentText() UTF8String]);
-    callJSFunc("confirm", text);
-    if (!g_confirmHold)
-        cc::EditBox::complete();
-}
-@end
 
-@implementation TextViewDelegate
+    callJSFunc("confirm", "sss");
+
+    cc::EditBox::complete();
+}
+
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
     // REFINE: check length limit before text changed
     return YES;
@@ -383,8 +338,6 @@ void removeKeyboardEventLisnters() {
         return;
 
     // check length limit after text changed, a little rude
-    if (textView.text.length > g_maxLength)
-        textView.text = [textView.text substringToIndex:g_maxLength];
 
     callJSFunc("input", [textView.text UTF8String]);
 }
@@ -396,39 +349,24 @@ void removeKeyboardEventLisnters() {
 
 // MARK: EditBox
 
-namespace cc {
-
+namespace cc{
 bool EditBox::_isShown = false;
-
 void EditBox::show(const cc::EditBox::ShowInfo &showInfo) {
-    // Should initialize them at first.
-    g_maxLength = showInfo.maxLength;
-    g_isMultiline = showInfo.isMultiline;
-    g_confirmHold = showInfo.confirmHold;
-
-    addKeyboardEventLisnters();
-    addTextInput(showInfo);
-
-    _isShown = true;
+    if(!g_inputbox){
+        g_inputbox = [[Inputbox alloc] init];
+    }
+    [g_inputbox show:&showInfo];
 }
 
 void EditBox::hide() {
-    removeKeyboardEventLisnters();
-
-    UIView *view = getCurrentView();
-    if (view) {
-        [view removeFromSuperview];
-        [view resignFirstResponder];
-    }
-
-    _isShown = false;
+    [g_inputbox hide];
 }
 
 bool EditBox::complete() {
     if (!_isShown)
         return false;
 
-    NSString *text = getCurrentText();
+    NSString *text = getCurrentText(sinfo.isMultiline);
     callJSFunc("complete", [text UTF8String]);
     EditBox::hide();
 

--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -329,9 +329,9 @@ static EditboxManager *instance = nil;
         if ((view = [barButtonItem valueForKey:@"view"])) {
             if ([view isKindOfClass:[UITextView class]] || [view isKindOfClass:[UITextField class]]) {
                 textViewBarButtonItem = barButtonItem;
-            } else if (view.bounds.size.width > 0) {
+            } else if ([view isKindOfClass:[UIButton class]]) {
                 // Docs say width can be negative for variable size items
-                totalItemsWidth += view.frame.size.width + ITEM_MARGIN_WIDTH;
+                totalItemsWidth += BUTTON_WIDTH + ITEM_MARGIN_WIDTH;
             }
         } else {
             totalItemsWidth += barButtonItem.width + ITEM_MARGIN_WIDTH;
@@ -451,6 +451,11 @@ static EditboxManager *instance = nil;
                                  viewRect.size.height - showInfo->y - showInfo->height,
                                  showInfo->width,
                                  showInfo->height)];
+        CGRect safeArea = getSafeAreaRect();
+        [[[ret inputOnView] inputAccessoryView] setFrame:CGRectMake(0,
+                                                                           0,
+                                                                           safeArea.size.width,
+                                                                    getTextInputHeight(g_isMultiline) + ITEM_MARGIN_HEIGHT)];
         [self setInputWidthOf:[[ret inputOnView] inputAccessoryView] ];
     } else {
         ret = [[InputBoxPair alloc] init];
@@ -478,6 +483,11 @@ static EditboxManager *instance = nil;
                                  viewRect.size.height - showInfo->y - showInfo->height,
                                  showInfo->width,
                                  showInfo->height)];
+        CGRect safeArea = getSafeAreaRect();
+        [[[ret inputOnView] inputAccessoryView] setFrame:CGRectMake(0,
+                                                                           0,
+                                                                    safeArea.size.width,
+                                                                    getTextInputHeight(g_isMultiline) + ITEM_MARGIN_HEIGHT)];
         [self setInputWidthOf:[[ret inputOnView] inputAccessoryView] ];
     } else {
         ret = [[InputBoxPair alloc] init];


### PR DESCRIPTION
Re: internal
* https://github.com/cocos/3d-tasks/issues/11051
* https://github.com/cocos/3d-tasks/issues/9517
* https://github.com/cocos/3d-tasks/issues/10605

### Changelog

* A better view for input box on IOS. Now we're using InputAccessoryView to draw the textView and textField instead, it's fully supported by Apple and we don't need to configure the position of it.
![image](https://user-images.githubusercontent.com/43355299/173276365-46459bb9-6794-4626-954f-c897dea95a2d.png)
![image](https://user-images.githubusercontent.com/43355299/173276444-a3f6c453-1406-4896-944c-a4a086ed3eec.png)
* The inputbox(textView and textField) will automatically hide once orientation changed.
* The inputbox(textView and textField) will automatically hide once the user click outside of the keyboard, on Android and IOS
* NULL detection for Android Editbox
* No public api or file structure is changed.
-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->