### PR TITLE
[BUG fix] Fix a logic error in RenderWindow.cpp

### DIFF
--- a/native/cocos/scene/RenderWindow.cpp
+++ b/native/cocos/scene/RenderWindow.cpp
@@ -75,15 +75,13 @@ bool RenderWindow::initialize(gfx::Device *device, IRenderWindowInfo &info) {
                                        _width,
                                        _height}));
         }
-    }
-
-    // Use the sign bit to indicate depth attachment
-    if (info.renderPassInfo.depthStencilAttachment.format != gfx::Format::UNKNOWN) {
-        _depthStencilTexture = device->createTexture({gfx::TextureType::TEX2D,
-                                                      gfx::TextureUsageBit::DEPTH_STENCIL_ATTACHMENT | gfx::TextureUsageBit::SAMPLED,
-                                                      info.renderPassInfo.depthStencilAttachment.format,
-                                                      _width,
-                                                      _height});
+        if (info.renderPassInfo.depthStencilAttachment.format != gfx::Format::UNKNOWN) {
+            _depthStencilTexture = device->createTexture({gfx::TextureType::TEX2D,
+                                                          gfx::TextureUsageBit::DEPTH_STENCIL_ATTACHMENT | gfx::TextureUsageBit::SAMPLED,
+                                                          info.renderPassInfo.depthStencilAttachment.format,
+                                                          _width,
+                                                          _height});
+        }
     }
 
     _frameBuffer = device->createFramebuffer(gfx::FramebufferInfo{


### PR DESCRIPTION
Re: #none

### Changelog

* Fix the logic error that the RenderWindow's FBO uses a user-defined depth attachment but not the swapchain's depth attachment regardless of the swapchain's state.
* https://github.com/yiwenxue/engine/blob/01a68d2f8f0fddf9000450f825e967e60bdf6e1b/cocos/core/renderer/core/render-window.ts#L142
-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->