### PR TITLE
fix restart buffer & shader leak and add prompts

### DIFF
--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -292,23 +292,24 @@ int32_t Engine::restartVM() {
     _scheduler->unscheduleAll();
 
     _scriptEngine->cleanup();
-    CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
     cc::EventDispatcher::destroy();
-
-    // Should re-create ProgramLib as shaders may change after restart. For example,
-    // program update resources and do restart.
-    delete _programLib;
-    _programLib = ccnew ProgramLib;
-
-    // Should reinitialize builtin resources as _programLib will be re-created.
-    delete _builtinResMgr;
-    _builtinResMgr = ccnew BuiltinResMgr;
-
+    
     CCObject::deferredDestroy();
+    
+    delete _programLib;
+    delete _builtinResMgr;
+    CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
 
+    
     // remove all listening events
     offAll();
     // start
+    _gfxDevice = gfx::DeviceManager::create();
+    // Should reinitialize builtin resources as _programLib will be re-created.
+    _programLib = ccnew ProgramLib;
+    // Should re-create ProgramLib as shaders may change after restart. For example,
+    // program update resources and do restart.
+    _builtinResMgr = ccnew BuiltinResMgr;
     cc::EventDispatcher::init();
     CC_CURRENT_APPLICATION()->init();
 

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -293,14 +293,12 @@ int32_t Engine::restartVM() {
 
     _scriptEngine->cleanup();
     cc::EventDispatcher::destroy();
-    
     CCObject::deferredDestroy();
-    
+
     delete _programLib;
     delete _builtinResMgr;
     CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
 
-    
     // remove all listening events
     offAll();
     // start

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -305,10 +305,10 @@ int32_t Engine::restartVM() {
     offAll();
     // start
     _gfxDevice = gfx::DeviceManager::create();
-    // Should reinitialize builtin resources as _programLib will be re-created.
-    _programLib = ccnew ProgramLib;
     // Should re-create ProgramLib as shaders may change after restart. For example,
     // program update resources and do restart.
+    _programLib = ccnew ProgramLib;
+    // Should reinitialize builtin resources as _programLib will be re-created.
     _builtinResMgr = ccnew BuiltinResMgr;
     cc::EventDispatcher::init();
     CC_CURRENT_APPLICATION()->init();

--- a/native/cocos/renderer/core/ProgramLib.cpp
+++ b/native/cocos/renderer/core/ProgramLib.cpp
@@ -277,6 +277,13 @@ ProgramLib::ProgramLib() {
 
 ProgramLib::~ProgramLib() {
     ProgramLib::instance = nullptr;
+#if CC_DEBUG
+    for (const auto& cache : _cache) {
+        if (cache.second->getRefCount() > 1) {
+            CC_LOG_WARNING("ProgramLib cache: %s ref_count is %d and may leak", cache.second->getName().c_str(), cache.second->getRefCount() );
+         }
+    }
+#endif
 }
 
 //

--- a/native/cocos/scene/Skybox.cpp
+++ b/native/cocos/scene/Skybox.cpp
@@ -270,6 +270,10 @@ void Skybox::activate() {
             skyboxMaterial->release();
             skyboxMaterial = nullptr;
         });
+        EventDispatcher::addCustomEventListener(EVENT_RESTART_VM, [](const CustomEvent & /*unused*/) {
+            skyboxMaterial->release();
+            skyboxMaterial = nullptr;
+        });
     }
 
     if (_enabled) {


### PR DESCRIPTION
https://github.com/cocos/cocos-engine/issues/11106
### Changelog

* fix restart buffer leak
* fix restart shader leak
* add leak prompts in ~PorgramLib()
-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->