### PR TITLE
fixed #11091: Don't need configure classes_need_extend in binding configuration file (.ini)

### DIFF
--- a/native/tools/tojs/spine.ini
+++ b/native/tools/tojs/spine.ini
@@ -26,7 +26,7 @@ replace_headers = spine-cocos2dx.h::spine-creator-support/spine-cocos2dx.h
 
 classes = SkeletonRenderer SkeletonAnimation VertexEffectDelegate  Animation TrackEntry AnimationState AnimationStateData Attachment AttachmentTimeline BoundingBoxAttachment Bone BoneData ClippingAttachment Color ColorTimeline CurveTimeline DeformTimeline DrawOrderTimeline Event EventData EventTimeline IkConstraint IkConstraintData IkConstraintTimeline MeshAttachment Polygon PathAttachment PathConstraint PathConstraintData PathConstraintMixTimeline PathConstraintPositionTimeline PathConstraintSpacingTimeline PointAttachment RegionAttachment RotateTimeline ScaleTimeline ShearTimeline Skeleton Slot Skin SkeletonBounds SkeletonData SlotData Timeline TransformConstraint TransformConstraintData TransformConstraintTimeline TranslateTimeline TwoColorTimeline VertexAttachment VertexEffect JitterVertexEffect SwirlVertexEffect SkeletonDataMgr SkeletonCacheAnimation SkeletonCacheMgr ConstraintData
 
-classes_need_extend = SkeletonAnimation
+classes_need_extend =
 
 skip =	SkeletonRenderer::[create initWithJsonFile initWithBinaryFile createWithData initWithData createWithSkeleton createWithFile getRenderOrder],
 		SkeletonAnimation::[createWithData onTrackEntryEvent onAnimationStateEvent],


### PR DESCRIPTION
Re: #11091

### Changelog

* fixed #11091: Don't need configure classes_need_extend in binding configuration file (.ini)

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->