### PR TITLE
fix multi quotations bug and supplement unit tests

### DIFF
--- a/tests/ui/richtext.test.ts
+++ b/tests/ui/richtext.test.ts
@@ -35,8 +35,28 @@ test('parse-richtext', () => {
     expect(htmlAttrArray[0].style.imageHeight).toStrictEqual(89);
     expect(htmlAttrArray[0].style.imageAlign).toStrictEqual('top');
     expect(htmlAttrArray[1].text).toStrictEqual('   前面有三个空格，这是一段文本');
-
-    attribute = "<img src='1 23'/>";
+    
+    attribute = "<img src=   '12 3' width  =  80 height= 89 align  =top click='onClick' />文本中有两组单引号，但是图片名仅包含在第一组单引号内";
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(2);
+    expect(htmlAttrArray[0].style.src).toStrictEqual('12 3');
+    expect(htmlAttrArray[0].style.imageWidth).toStrictEqual(80);
+    expect(htmlAttrArray[0].style.imageHeight).toStrictEqual(89);
+    expect(htmlAttrArray[0].style.imageAlign).toStrictEqual('top');
+    expect(htmlAttrArray[0].style.event.click).toStrictEqual('onClick');
+    expect(htmlAttrArray[1].text).toStrictEqual('文本中有两组单引号，但是图片名仅包含在第一组单引号内');
+    
+    attribute = "<img src=\"12 3\" width  =  80 height= 89 align  =top click='onClick' />文本中有一组单引号和一组双引号，但是图片名仅包含在前面这组双引号内";
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(2);
+    expect(htmlAttrArray[0].style.src).toStrictEqual('12 3');
+    expect(htmlAttrArray[0].style.imageWidth).toStrictEqual(80);
+    expect(htmlAttrArray[0].style.imageHeight).toStrictEqual(89);
+    expect(htmlAttrArray[0].style.imageAlign).toStrictEqual('top');
+    expect(htmlAttrArray[0].style.event.click).toStrictEqual('onClick');
+    expect(htmlAttrArray[1].text).toStrictEqual('文本中有一组单引号和一组双引号，但是图片名仅包含在前面这组双引号内');
+    
+    attribute = "<img src =  '1 23'/>";
     htmlAttrArray = htmlTextParser.parse(attribute);
     expect(htmlAttrArray.length).toStrictEqual(1);
     expect(htmlAttrArray[0].style.src).toStrictEqual('1 23');

--- a/tests/ui/richtext.test.ts
+++ b/tests/ui/richtext.test.ts
@@ -61,6 +61,11 @@ test('parse-richtext', () => {
     expect(htmlAttrArray.length).toStrictEqual(1);
     expect(htmlAttrArray[0].style.src).toStrictEqual('1 23');
 
+    attribute = "<img src = click = 'onclick' />文本中没有图片名，无法生成style对象";
+    htmlAttrArray = htmlTextParser.parse(attribute);
+    expect(htmlAttrArray.length).toStrictEqual(1);
+    expect(htmlAttrArray[0].text).toStrictEqual('文本中没有图片名，无法生成style对象');
+    
     // following tests are exceptional writing
 
     attribute = "<img ='1 23'/>"; // 'src' missing 


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12312

### Changelog

* fix multi quotations bug: it should detect the first pair of quotations instead of single quotations or double quotations
* supplement unit tests

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->