### PR TITLE
fix terrain index buffer sharing bug

### DIFF
--- a/cocos/core/assets/rendering-sub-mesh.ts
+++ b/cocos/core/assets/rendering-sub-mesh.ts
@@ -109,12 +109,15 @@ export class RenderingSubMesh {
 
     private _iaInfo: InputAssemblerInfo;
 
+    private _isOwnerOfIndexBuffer = true;
+
     private _init () {
     }
 
     constructor (
         vertexBuffers: Buffer[], attributes: Attribute[], primitiveMode: PrimitiveMode,
         indexBuffer: Buffer | null = null, indirectBuffer: Buffer | null = null,
+        isOwnerOfIndexBuffer = true,
     ) {
         this._attributes = attributes;
         this._vertexBuffers = vertexBuffers;
@@ -122,6 +125,7 @@ export class RenderingSubMesh {
         this._indirectBuffer = indirectBuffer;
         this._primitiveMode = primitiveMode;
         this._iaInfo = new InputAssemblerInfo(attributes, vertexBuffers, indexBuffer, indirectBuffer);
+        this._isOwnerOfIndexBuffer = isOwnerOfIndexBuffer;
         this._init();
     }
 
@@ -306,7 +310,9 @@ export class RenderingSubMesh {
         }
         this.vertexBuffers.length = 0;
         if (this._indexBuffer) {
-            this._indexBuffer.destroy();
+            if (this._isOwnerOfIndexBuffer) {
+                this._indexBuffer.destroy();
+            }
             this._indexBuffer = null;
         }
         if (this._jointMappedBuffers && this._jointMappedBufferIndices) {

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -393,7 +393,7 @@ export class TerrainBlock {
         ];
 
         this._renderable._meshData = new RenderingSubMesh([vertexBuffer], gfxAttributes,
-            PrimitiveMode.TRIANGLE_LIST, this._terrain._getSharedIndexBuffer());
+            PrimitiveMode.TRIANGLE_LIST, this._terrain._getSharedIndexBuffer(), null, false);
         this._renderable._model = (legacyCC.director.root as Root).createModel(scene.Model);
         this._renderable._model.createBoundingShape(this._bbMin, this._bbMax);
         this._renderable._model.node = this._renderable._model.transform = this._node;


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/pull/11200

when RenderingSubMesh not owning the index buffer, it should not destroy the content of the index buffer.


### Changelog

* added isOwnerOfIndexBuffer member to RenderingSubMesh.
* changed RenderingSubMesh constructor, added isOwnerOfIndexBuffer with default value.
* terrain.ts will indicate terrain is the owner of the index buffer.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->