### PR TITLE
fix dragonbone animation stop function with paramter null

### DIFF
--- a/native/cocos/editor-support/dragonbones/animation/Animation.h
+++ b/native/cocos/editor-support/dragonbones/animation/Animation.h
@@ -118,7 +118,7 @@ public:
      * @version DragonBones 3.0
      * @language zh_CN
      */
-    void stop(const std::string& animationName);
+    void stop(const std::string& animationName = "");
     /**
      * - Play animation with a specific animation config.
      * The API is still in the experimental phase and may encounter bugs or stability or compatibility issues when used.


### PR DESCRIPTION
添加默认空字符串参数，使绑定时支持0参数