### PR TITLE
fix skeletalAnimation memory leak

### DIFF
--- a/native/cocos/core/animation/SkeletalAnimationUtils.cpp
+++ b/native/cocos/core/animation/SkeletalAnimationUtils.cpp
@@ -29,8 +29,8 @@
 namespace cc {
 
 namespace {
-ccstd::vector<IJointTransform *> stack; //cjh TODO: how to release ?
-ccstd::unordered_map<ccstd::string, IJointTransform *> pool;
+ccstd::vector<IntrusivePtr<IJointTransform>> stack;
+ccstd::unordered_map<ccstd::string, IntrusivePtr<IJointTransform>> pool;
 } // namespace
 
 Mat4 getWorldMatrix(IJointTransform *transform, int32_t stamp) {
@@ -74,13 +74,9 @@ IJointTransform *getTransform(Node *node, Node *root) {
             break;
         }
         // TODO(): object reuse
-        joint = pool[id] = ccnew IJointTransform{
-            node,
-            Mat4(),
-            Mat4(),
-            -1,
-            nullptr};
-
+        joint = ccnew IJointTransform;
+        joint->node = node;
+        pool[id] = joint;
         stack.resize(i + 1);
         stack[i++] = joint;
         node = node->getParent();
@@ -106,7 +102,6 @@ void deleteTransform(Node *node) {
     while (transform != nullptr) {
         iter = pool.find(transform->node->getUuid());
         if (iter != pool.end()) {
-            //            delete iter->second;
             pool.erase(iter);
         }
         transform = transform->parent;

--- a/native/cocos/core/animation/SkeletalAnimationUtils.h
+++ b/native/cocos/core/animation/SkeletalAnimationUtils.h
@@ -25,18 +25,20 @@
 
 #pragma once
 
+#include "base/Ptr.h"
+#include "base/RefCounted.h"
 #include "math/Mat4.h"
 
 namespace cc {
 
 class Node;
 
-struct IJointTransform {
+struct IJointTransform : RefCounted {
     Node *node{nullptr};
     Mat4 local;
     Mat4 world;
     int stamp{-1};
-    struct IJointTransform *parent{nullptr};
+    IntrusivePtr<IJointTransform> parent;
 };
 
 Mat4 getWorldMatrix(IJointTransform *transform, int32_t stamp);


### PR DESCRIPTION
https://github.com/cocos/cocos-engine/issues/11221#
### Changelog

* fix skeletalAnimation memory leak when call `getTransform`

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->