### PR TITLE
3.6 fix seval_to_Data accept arraybuffer

### DIFF
--- a/native/cocos/bindings/manual/jsb_conversions_spec.cpp
+++ b/native/cocos/bindings/manual/jsb_conversions_spec.cpp
@@ -442,10 +442,16 @@ bool sevals_variadic_to_ccvaluevector(const se::ValueArray &args, cc::ValueVecto
 // NOLINTNEXTLINE(readability-identifier-naming)
 bool seval_to_Data(const se::Value &v, cc::Data *ret) {
     CC_ASSERT(ret != nullptr);
-    SE_PRECONDITION2(v.isObject() && v.toObject()->isTypedArray(), false, "Convert parameter to Data failed!");
+    SE_PRECONDITION2(v.isObject() && (v.toObject()->isTypedArray() || v.toObject()->isArrayBuffer()), false, "Convert parameter to Data failed!");
     uint8_t *ptr = nullptr;
     size_t length = 0;
-    bool ok = v.toObject()->getTypedArrayData(&ptr, &length);
+    se::Object *buffer = v.toObject();
+    bool ok = false;
+    if (buffer->isTypedArray()) {
+        ok = buffer->getTypedArrayData(&ptr, &length);
+    } else {
+        ok = buffer->getArrayBufferData(&ptr, &length);
+    }
     if (ok) {
         ret->copy(ptr, static_cast<int32_t>(length));
     } else {


### PR DESCRIPTION
Re: #

In 2.x `cc::Data` was mapped to `Uint8Array` and that had changed to `ArrayBuffer` in 3.x.  

The PR fixes the potential issue that `seval_to_Data` only accepts `Uint8Array` which does not match `Data_to_seval`.  

Document fix for upgrading from v2.x https://github.com/cocos/cocos-docs/pull/2141

### Changelog

* `seval_to_Data` convert js value to `cc::Data` accept both ArrayBuffer & ArrayBufferView

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check // Manual trigger with `@cocos-robot run test cases` afterward

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->