### PR TITLE
don't force top align editbox placeholder label

### DIFF
--- a/cocos/ui/editbox/edit-box-impl.ts
+++ b/cocos/ui/editbox/edit-box-impl.ts
@@ -465,7 +465,8 @@ export class EditBoxImpl extends EditBoxImplBase {
             // elem.placeholder = delegate.placeholder;
 
             this._updateTextLabel(delegate.textLabel);
-            this._updatePlaceholderLabel(delegate.placeholderLabel);
+            // we don't show placeholder any more when editBox is editing
+            // this._updatePlaceholderLabel(delegate.placeholderLabel);
         }
     }
 

--- a/cocos/ui/editbox/edit-box-impl.ts
+++ b/cocos/ui/editbox/edit-box-impl.ts
@@ -461,11 +461,10 @@ export class EditBoxImpl extends EditBoxImplBase {
         const elem = this._edTxt;
         if (elem && delegate) {
             elem.value = delegate.string;
+            this._updateTextLabel(delegate.textLabel);
+
             // NOTE: we don't show placeholder any more when editBox is editing
             // elem.placeholder = delegate.placeholder;
-
-            this._updateTextLabel(delegate.textLabel);
-            // we don't show placeholder any more when editBox is editing
             // this._updatePlaceholderLabel(delegate.placeholderLabel);
         }
     }

--- a/cocos/ui/editbox/edit-box-impl.ts
+++ b/cocos/ui/editbox/edit-box-impl.ts
@@ -461,7 +461,8 @@ export class EditBoxImpl extends EditBoxImplBase {
         const elem = this._edTxt;
         if (elem && delegate) {
             elem.value = delegate.string;
-            elem.placeholder = delegate.placeholder;
+            // NOTE: we don't show placeholder any more when editBox is editing
+            // elem.placeholder = delegate.placeholder;
 
             this._updateTextLabel(delegate.textLabel);
             this._updatePlaceholderLabel(delegate.placeholderLabel);

--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -617,7 +617,6 @@ export class EditBox extends Component {
         const transform = this._placeholderLabel!.node._uiProps.uiTransformComp;
         transform!.setAnchorPoint(0, 1);
         if (this._inputMode === InputMode.ANY) {
-            placeholderLabel.verticalAlign = VerticalTextAlignment.TOP;
             placeholderLabel.enableWrapText = true;
         } else {
             placeholderLabel.enableWrapText = false;
@@ -737,9 +736,6 @@ export class EditBox extends Component {
             placeholderLabel.node._uiProps.uiTransformComp!.setContentSize(size.width - LEFT_PADDING, size.height);
             placeholderLabel.lineHeight = size.height;
             placeholderLabel.node.setPosition(offX + LEFT_PADDING, offY + size.height, placeholderLabel.node.position.z);
-            if (this._inputMode === InputMode.ANY) {
-                placeholderLabel.verticalAlign = VerticalTextAlignment.TOP;
-            }
             placeholderLabel.enableWrapText = this._inputMode === InputMode.ANY;
         }
     }


### PR DESCRIPTION
Re: https://forum.cocos.org/t/topic/135888

### Changelog

* don't force top align editbox placeholder label
* don't show placeholder when editbox is editing

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
