### PR TITLE
[v3.6] Don't rename webview& video c++ destuctor to destroy in webview/video.ini, add a 'destroy' method and bind it instead.

### DIFF
--- a/native/cocos/ui/videoplayer/VideoPlayer-ios.mm
+++ b/native/cocos/ui/videoplayer/VideoPlayer-ios.mm
@@ -298,8 +298,13 @@ VideoPlayer::VideoPlayer()
 }
 
 VideoPlayer::~VideoPlayer() {
-    if (_videoView) {
-        [((UIVideoViewWrapperIos *)_videoView) dealloc];
+    destroy();
+}
+
+void VideoPlayer::destroy() {
+    if (_videoView != nil) {
+        [((UIVideoViewWrapperIos *)_videoView) release];
+        _videoView = nil;
     }
 }
 

--- a/native/cocos/ui/videoplayer/VideoPlayer-java.cpp
+++ b/native/cocos/ui/videoplayer/VideoPlayer-java.cpp
@@ -82,8 +82,21 @@ VideoPlayer::VideoPlayer()
 }
 
 VideoPlayer::~VideoPlayer() {
-    sAllVideoPlayers.erase(_videoPlayerIndex);
-    JniHelper::callStaticVoidMethod(VIDEO_HELPER_CLASS_NAME, "removeVideoWidget", _videoPlayerIndex);
+    destroy();
+}
+
+void VideoPlayer::destroy() {
+    if (_videoPlayerIndex != -1) {
+        auto iter = sAllVideoPlayers.find(_videoPlayerIndex);
+        if (iter != sAllVideoPlayers.end()) {
+            sAllVideoPlayers.erase(iter);
+        }
+
+        JniHelper::callStaticVoidMethod(VIDEO_HELPER_CLASS_NAME, "removeVideoWidget",
+                                        _videoPlayerIndex);
+
+        _videoPlayerIndex = -1;
+    }
 }
 
 void VideoPlayer::setURL(const ccstd::string &videoUrl) {

--- a/native/cocos/ui/videoplayer/VideoPlayer.h
+++ b/native/cocos/ui/videoplayer/VideoPlayer.h
@@ -66,6 +66,12 @@ public:
     };
 
     VideoPlayer();
+    ~VideoPlayer();
+
+    /**
+     * Destroy VideoPlayer, remove it from parent
+     */
+    void destroy();
 
     /**
      * A callback which will be called after specific VideoPlayer event happens.
@@ -151,7 +157,6 @@ public:
     virtual void setFrame(float x, float y, float width, float height);
 
 protected:
-    ~VideoPlayer() override;
 
     enum class Source {
         FILENAME = 0,

--- a/native/cocos/ui/videoplayer/VideoPlayer.h
+++ b/native/cocos/ui/videoplayer/VideoPlayer.h
@@ -50,7 +50,7 @@ namespace cc {
  * It's mean VideoPlayer displays a video file above all graphical elements of cocos2d-x.
  * @js NA
  */
-class VideoPlayer : public RefCounted {
+class VideoPlayer {
 public:
     /**
      * Videoplayer play event type.

--- a/native/cocos/ui/videoplayer/VideoPlayer.h
+++ b/native/cocos/ui/videoplayer/VideoPlayer.h
@@ -50,7 +50,7 @@ namespace cc {
  * It's mean VideoPlayer displays a video file above all graphical elements of cocos2d-x.
  * @js NA
  */
-class VideoPlayer {
+class VideoPlayer final {
 public:
     /**
      * Videoplayer play event type.

--- a/native/cocos/ui/videoplayer/VideoPlayer.h
+++ b/native/cocos/ui/videoplayer/VideoPlayer.h
@@ -157,7 +157,6 @@ public:
     virtual void setFrame(float x, float y, float width, float height);
 
 protected:
-
     enum class Source {
         FILENAME = 0,
         URL

--- a/native/cocos/ui/webview/WebView-inl.h
+++ b/native/cocos/ui/webview/WebView-inl.h
@@ -58,75 +58,118 @@ WebView *WebView::create() {
     return nullptr;
 }
 
+void WebView::destroy() {
+    if (_impl != nullptr) {
+        _impl->destroy();
+        _impl = nullptr;
+    }
+}
+
 void WebView::setJavascriptInterfaceScheme(const ccstd::string &scheme) {
-    _impl->setJavascriptInterfaceScheme(scheme);
+    if (_impl != nullptr) {
+        _impl->setJavascriptInterfaceScheme(scheme);
+    }
 }
 
 void WebView::loadData(const cc::Data &data,
                        const ccstd::string &MIMEType,
                        const ccstd::string &encoding,
                        const ccstd::string &baseURL) {
-    _impl->loadData(data, MIMEType, encoding, baseURL);
+    if (_impl != nullptr) {
+        _impl->loadData(data, MIMEType, encoding, baseURL);
+    }
 }
 
 void WebView::loadHTMLString(const ccstd::string &string, const ccstd::string &baseURL) {
-    _impl->loadHTMLString(string, baseURL);
+    if (_impl != nullptr) {
+        _impl->loadHTMLString(string, baseURL);
+    }
 }
 
 void WebView::loadURL(const ccstd::string &url) {
-    _impl->loadURL(url);
+    if (_impl != nullptr) {
+        _impl->loadURL(url);
+    }
 }
 
 void WebView::loadFile(const ccstd::string &fileName) {
-    _impl->loadFile(fileName);
+    if (_impl != nullptr) {
+        _impl->loadFile(fileName);
+    }
 }
 
 void WebView::stopLoading() {
-    _impl->stopLoading();
+    if (_impl != nullptr) {
+        _impl->stopLoading();
+    }
 }
 
 void WebView::reload() {
-    _impl->reload();
+    if (_impl != nullptr) {
+        _impl->reload();
+    }
 }
 
 bool WebView::canGoBack() {
-    return _impl->canGoBack();
+    if (_impl != nullptr) {
+        return _impl->canGoBack();
+    }
+    return false;
 }
 
 bool WebView::canGoForward() {
-    return _impl->canGoForward();
+    if (_impl != nullptr) {
+        return _impl->canGoForward();
+    }
+    return false;
 }
 
 void WebView::goBack() {
-    _impl->goBack();
+    if (_impl != nullptr) {
+        _impl->goBack();
+    }
 }
 
 void WebView::goForward() {
-    _impl->goForward();
+    if (_impl != nullptr) {
+        _impl->goForward();
+    }
 }
 
 void WebView::evaluateJS(const ccstd::string &js) {
-    _impl->evaluateJS(js);
+    if (_impl != nullptr) {
+        _impl->evaluateJS(js);
+    }
 }
 
 void WebView::setScalesPageToFit(bool scalesPageToFit) {
-    _impl->setScalesPageToFit(scalesPageToFit);
+    if (_impl != nullptr) {
+        _impl->setScalesPageToFit(scalesPageToFit);
+    }
 }
 
 void WebView::setVisible(bool visible) {
-    _impl->setVisible(visible);
+    if (_impl != nullptr) {
+        _impl->setVisible(visible);
+    }
 }
 
 void WebView::setFrame(float x, float y, float width, float height) {
-    _impl->setFrame(x, y, width, height);
+    if (_impl != nullptr) {
+        _impl->setFrame(x, y, width, height);
+    }
 }
 
 void WebView::setBounces(bool bounces) {
-    _impl->setBounces(bounces);
+    if (_impl != nullptr) {
+        _impl->setBounces(bounces);
+    }
 }
 
 void WebView::setBackgroundTransparent(bool isTransparent) {
-    _impl->setBackgroundTransparent(isTransparent);
+    if (_impl != nullptr) {
+        _impl->setBackgroundTransparent(isTransparent);
+    }
 }
 
 void WebView::setOnDidFailLoading(const ccWebViewCallback &callback) {

--- a/native/cocos/ui/webview/WebView-inl.h
+++ b/native/cocos/ui/webview/WebView-inl.h
@@ -59,10 +59,7 @@ WebView *WebView::create() {
 }
 
 void WebView::destroy() {
-    if (_impl != nullptr) {
-        _impl->destroy();
-        _impl = nullptr;
-    }
+    CC_SAFE_DESTROY(_impl);
 }
 
 void WebView::setJavascriptInterfaceScheme(const ccstd::string &scheme) {

--- a/native/cocos/ui/webview/WebView.h
+++ b/native/cocos/ui/webview/WebView.h
@@ -48,12 +48,17 @@ class WebViewImpl;
  * It's mean WebView displays web pages above all graphical elements of cocos2d-x.
  * @js NA
  */
-class WebView : public RefCounted {
+class WebView {
 public:
     /**
          * Allocates and initializes a WebView.
          */
     static WebView *create();
+
+    /**
+     * Destroy webview, remove it from its parent
+     */
+    void destroy();
 
     /**
          * Set javascript interface scheme.
@@ -232,7 +237,7 @@ protected:
     /**
          * Default destructor.
          */
-    ~WebView() override;
+    ~WebView();
 
 private:
     WebViewImpl *_impl;

--- a/native/cocos/ui/webview/WebView.h
+++ b/native/cocos/ui/webview/WebView.h
@@ -48,7 +48,7 @@ class WebViewImpl;
  * It's mean WebView displays web pages above all graphical elements of cocos2d-x.
  * @js NA
  */
-class WebView {
+class WebView final {
 public:
     /**
          * Allocates and initializes a WebView.

--- a/native/cocos/ui/webview/WebViewImpl-android.cpp
+++ b/native/cocos/ui/webview/WebViewImpl-android.cpp
@@ -166,8 +166,18 @@ WebViewImpl::WebViewImpl(WebView *webView) : _viewTag(-1),
 }
 
 WebViewImpl::~WebViewImpl() {
-    JniHelper::callStaticVoidMethod(CLASS_NAME, "removeWebView", _viewTag);
-    sWebViewImpls.erase(_viewTag);
+    destroy();
+}
+
+void WebViewImpl::destroy() {
+    if (_viewTag != -1) {
+        JniHelper::callStaticVoidMethod(CLASS_NAME, "removeWebView", _viewTag);
+        auto iter = sWebViewImpls.find(_viewTag);
+        if (iter != sWebViewImpls.end()) {
+            sWebViewImpls.erase(iter);
+        }
+        _viewTag = -1;
+    }
 }
 
 void WebViewImpl::loadData(const Data &data, const ccstd::string &mimeType,

--- a/native/cocos/ui/webview/WebViewImpl-android.cpp
+++ b/native/cocos/ui/webview/WebViewImpl-android.cpp
@@ -180,7 +180,7 @@ void WebViewImpl::destroy() {
     }
 }
 
-void WebViewImpl::loadData(const Data &data, const ccstd::string &mimeType, // NOLINT
+void WebViewImpl::loadData(const Data &data, const ccstd::string &mimeType,               // NOLINT
                            const ccstd::string &encoding, const ccstd::string &baseURL) { // NOLINT
     ccstd::string dataString(reinterpret_cast<char *>(data.getBytes()),
                              static_cast<unsigned int>(data.getSize()));

--- a/native/cocos/ui/webview/WebViewImpl-android.cpp
+++ b/native/cocos/ui/webview/WebViewImpl-android.cpp
@@ -180,7 +180,7 @@ void WebViewImpl::destroy() {
     }
 }
 
-void WebViewImpl::loadData(const Data &data, const ccstd::string &mimeType,
+void WebViewImpl::loadData(const Data &data, const ccstd::string &mimeType, // NOLINT
                            const ccstd::string &encoding, const ccstd::string &baseURL) { // NOLINT
     ccstd::string dataString(reinterpret_cast<char *>(data.getBytes()),
                              static_cast<unsigned int>(data.getSize()));

--- a/native/cocos/ui/webview/WebViewImpl-android.cpp
+++ b/native/cocos/ui/webview/WebViewImpl-android.cpp
@@ -72,7 +72,7 @@ extern "C" {
 JNIEXPORT jboolean JNICALL
 Java_com_cocos_lib_CocosWebViewHelper_shouldStartLoading(JNIEnv *env, jclass, jint index, //NOLINT
                                                          jstring jurl) {
-    auto charUrl = env->GetStringUTFChars(jurl, nullptr);
+    const auto *charUrl = env->GetStringUTFChars(jurl, nullptr);
     ccstd::string url = charUrl;
     env->ReleaseStringUTFChars(jurl, charUrl);
     return cc::WebViewImpl::shouldStartLoading(index, url);
@@ -87,7 +87,7 @@ JNIEXPORT void JNICALL
 Java_com_cocos_lib_CocosWebViewHelper_didFinishLoading(JNIEnv *env, jclass, jint index, //NOLINT
                                                        jstring jurl) {
     // LOGD("didFinishLoading");
-    auto charUrl = env->GetStringUTFChars(jurl, nullptr);
+    const auto * charUrl = env->GetStringUTFChars(jurl, nullptr);
     ccstd::string url = charUrl;
     env->ReleaseStringUTFChars(jurl, charUrl);
     cc::WebViewImpl::didFinishLoading(index, url);
@@ -102,7 +102,7 @@ JNIEXPORT void JNICALL
 Java_com_cocos_lib_CocosWebViewHelper_didFailLoading(JNIEnv *env, jclass, jint index, //NOLINT
                                                      jstring jurl) {
     // LOGD("didFailLoading");
-    auto charUrl = env->GetStringUTFChars(jurl, nullptr);
+    const auto * charUrl = env->GetStringUTFChars(jurl, nullptr);
     ccstd::string url = charUrl;
     env->ReleaseStringUTFChars(jurl, charUrl);
     cc::WebViewImpl::didFailLoading(index, url);
@@ -117,7 +117,7 @@ JNIEXPORT void JNICALL
 Java_com_cocos_lib_CocosWebViewHelper_onJsCallback(JNIEnv *env, jclass, jint index, //NOLINT
                                                    jstring jmessage) {
     // LOGD("jsCallback");
-    auto charMessage = env->GetStringUTFChars(jmessage, nullptr);
+    const auto * charMessage = env->GetStringUTFChars(jmessage, nullptr);
     ccstd::string message = charMessage;
     env->ReleaseStringUTFChars(jmessage, charMessage);
     cc::WebViewImpl::onJsCallback(index, message);
@@ -181,60 +181,60 @@ void WebViewImpl::destroy() {
 }
 
 void WebViewImpl::loadData(const Data &data, const ccstd::string &mimeType,
-                           const ccstd::string &encoding, const ccstd::string &baseURL) {
+                           const ccstd::string &encoding, const ccstd::string &baseURL) { // NOLINT
     ccstd::string dataString(reinterpret_cast<char *>(data.getBytes()),
                              static_cast<unsigned int>(data.getSize()));
     JniHelper::callStaticVoidMethod(CLASS_NAME, "setJavascriptInterfaceScheme", _viewTag,
                                     dataString, mimeType, encoding, baseURL);
 }
 
-void WebViewImpl::loadHTMLString(const ccstd::string &string, const ccstd::string &baseURL) {
+void WebViewImpl::loadHTMLString(const ccstd::string &string, const ccstd::string &baseURL) { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "loadHTMLString", _viewTag, string, baseURL);
 }
 
-void WebViewImpl::loadURL(const ccstd::string &url) {
+void WebViewImpl::loadURL(const ccstd::string &url) { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "loadUrl", _viewTag, url);
 }
 
-void WebViewImpl::loadFile(const ccstd::string &fileName) {
+void WebViewImpl::loadFile(const ccstd::string &fileName) { // NOLINT
     auto fullPath = getUrlStringByFileName(fileName);
     JniHelper::callStaticVoidMethod(CLASS_NAME, "loadFile", _viewTag, fullPath);
 }
 
-void WebViewImpl::stopLoading() {
+void WebViewImpl::stopLoading() { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "stopLoading", _viewTag);
 }
 
-void WebViewImpl::reload() {
+void WebViewImpl::reload() { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "reload", _viewTag);
 }
 
-bool WebViewImpl::canGoBack() {
+bool WebViewImpl::canGoBack() { // NOLINT
     return JniHelper::callStaticBooleanMethod(CLASS_NAME, "canGoBack", _viewTag);
 }
 
-bool WebViewImpl::canGoForward() {
+bool WebViewImpl::canGoForward() { // NOLINT
     return JniHelper::callStaticBooleanMethod(CLASS_NAME, "canGoForward", _viewTag);
 }
 
-void WebViewImpl::goBack() {
+void WebViewImpl::goBack() { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "goBack", _viewTag);
 }
 
-void WebViewImpl::goForward() {
+void WebViewImpl::goForward() { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "goForward", _viewTag);
 }
 
-void WebViewImpl::setJavascriptInterfaceScheme(const ccstd::string &scheme) {
+void WebViewImpl::setJavascriptInterfaceScheme(const ccstd::string &scheme) { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "setJavascriptInterfaceScheme", _viewTag,
                                     scheme);
 }
 
-void WebViewImpl::evaluateJS(const ccstd::string &js) {
+void WebViewImpl::evaluateJS(const ccstd::string &js) { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "evaluateJS", _viewTag, js);
 }
 
-void WebViewImpl::setScalesPageToFit(bool scalesPageToFit) {
+void WebViewImpl::setScalesPageToFit(bool scalesPageToFit) { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "setScalesPageToFit", _viewTag, scalesPageToFit);
 }
 
@@ -242,7 +242,7 @@ bool WebViewImpl::shouldStartLoading(int viewTag, const ccstd::string &url) {
     bool allowLoad = true;
     auto it = sWebViewImpls.find(viewTag);
     if (it != sWebViewImpls.end()) {
-        auto webView = it->second->_webView;
+        auto *webView = it->second->_webView;
         if (webView->_onShouldStartLoading) {
             allowLoad = webView->_onShouldStartLoading(webView, url);
         }
@@ -253,7 +253,7 @@ bool WebViewImpl::shouldStartLoading(int viewTag, const ccstd::string &url) {
 void WebViewImpl::didFinishLoading(int viewTag, const ccstd::string &url) {
     auto it = sWebViewImpls.find(viewTag);
     if (it != sWebViewImpls.end()) {
-        auto webView = it->second->_webView;
+        auto *webView = it->second->_webView;
         if (webView->_onDidFinishLoading) {
             webView->_onDidFinishLoading(webView, url);
         }
@@ -263,7 +263,7 @@ void WebViewImpl::didFinishLoading(int viewTag, const ccstd::string &url) {
 void WebViewImpl::didFailLoading(int viewTag, const ccstd::string &url) {
     auto it = sWebViewImpls.find(viewTag);
     if (it != sWebViewImpls.end()) {
-        auto webView = it->second->_webView;
+        auto *webView = it->second->_webView;
         if (webView->_onDidFailLoading) {
             webView->_onDidFailLoading(webView, url);
         }
@@ -273,18 +273,18 @@ void WebViewImpl::didFailLoading(int viewTag, const ccstd::string &url) {
 void WebViewImpl::onJsCallback(int viewTag, const ccstd::string &message) {
     auto it = sWebViewImpls.find(viewTag);
     if (it != sWebViewImpls.end()) {
-        auto webView = it->second->_webView;
+        auto *webView = it->second->_webView;
         if (webView->_onJSCallback) {
             webView->_onJSCallback(webView, message);
         }
     }
 }
 
-void WebViewImpl::setVisible(bool visible) {
+void WebViewImpl::setVisible(bool visible) { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "setVisible", _viewTag, visible);
 }
 
-void WebViewImpl::setFrame(float x, float y, float width, float height) {
+void WebViewImpl::setFrame(float x, float y, float width, float height) { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "setWebViewRect", _viewTag,
                                     static_cast<int>(x), static_cast<int>(y), static_cast<int>(width), static_cast<int>(height));
 }
@@ -293,7 +293,7 @@ void WebViewImpl::setBounces(bool bounces) {
     // empty function as this was mainly a fix for iOS
 }
 
-void WebViewImpl::setBackgroundTransparent(bool isTransparent) {
+void WebViewImpl::setBackgroundTransparent(bool isTransparent) { // NOLINT
     JniHelper::callStaticVoidMethod(CLASS_NAME, "setBackgroundTransparent", _viewTag,
                                     isTransparent);
 }

--- a/native/cocos/ui/webview/WebViewImpl-android.cpp
+++ b/native/cocos/ui/webview/WebViewImpl-android.cpp
@@ -87,7 +87,7 @@ JNIEXPORT void JNICALL
 Java_com_cocos_lib_CocosWebViewHelper_didFinishLoading(JNIEnv *env, jclass, jint index, //NOLINT
                                                        jstring jurl) {
     // LOGD("didFinishLoading");
-    const auto * charUrl = env->GetStringUTFChars(jurl, nullptr);
+    const auto *charUrl = env->GetStringUTFChars(jurl, nullptr);
     ccstd::string url = charUrl;
     env->ReleaseStringUTFChars(jurl, charUrl);
     cc::WebViewImpl::didFinishLoading(index, url);
@@ -102,7 +102,7 @@ JNIEXPORT void JNICALL
 Java_com_cocos_lib_CocosWebViewHelper_didFailLoading(JNIEnv *env, jclass, jint index, //NOLINT
                                                      jstring jurl) {
     // LOGD("didFailLoading");
-    const auto * charUrl = env->GetStringUTFChars(jurl, nullptr);
+    const auto *charUrl = env->GetStringUTFChars(jurl, nullptr);
     ccstd::string url = charUrl;
     env->ReleaseStringUTFChars(jurl, charUrl);
     cc::WebViewImpl::didFailLoading(index, url);
@@ -117,7 +117,7 @@ JNIEXPORT void JNICALL
 Java_com_cocos_lib_CocosWebViewHelper_onJsCallback(JNIEnv *env, jclass, jint index, //NOLINT
                                                    jstring jmessage) {
     // LOGD("jsCallback");
-    const auto * charMessage = env->GetStringUTFChars(jmessage, nullptr);
+    const auto *charMessage = env->GetStringUTFChars(jmessage, nullptr);
     ccstd::string message = charMessage;
     env->ReleaseStringUTFChars(jmessage, charMessage);
     cc::WebViewImpl::onJsCallback(index, message);

--- a/native/cocos/ui/webview/WebViewImpl-ios.h
+++ b/native/cocos/ui/webview/WebViewImpl-ios.h
@@ -38,11 +38,13 @@ class Data;
 
 class WebView;
 
-class WebViewImpl {
+class WebViewImpl final {
 public:
-    WebViewImpl(WebView *webView);
+    explicit WebViewImpl(WebView *webView);
 
-    virtual ~WebViewImpl();
+    ~WebViewImpl();
+
+    void destroy();
 
     void setJavascriptInterfaceScheme(const ccstd::string &scheme);
 
@@ -73,9 +75,9 @@ public:
 
     void setScalesPageToFit(const bool scalesPageToFit);
 
-    virtual void setVisible(bool visible);
+    void setVisible(bool visible);
 
-    virtual void setFrame(float x, float y, float width, float height);
+    void setFrame(float x, float y, float width, float height);
 
     void setBounces(bool bounces);
 

--- a/native/cocos/ui/webview/WebViewImpl-ios.mm
+++ b/native/cocos/ui/webview/WebViewImpl-ios.mm
@@ -312,8 +312,15 @@ WebViewImpl::WebViewImpl(WebView *webView)
 }
 
 WebViewImpl::~WebViewImpl() {
-    [_uiWebViewWrapper release];
-    _uiWebViewWrapper = nullptr;
+   destroy();
+}
+
+WebViewImpl::destroy() {
+    if (_uiWebViewWrapper != nil)
+    {
+        [_uiWebViewWrapper release];
+        _uiWebViewWrapper = nil;
+    }
 }
 
 void WebViewImpl::setJavascriptInterfaceScheme(const ccstd::string &scheme) {

--- a/native/cocos/ui/webview/WebViewImpl-ios.mm
+++ b/native/cocos/ui/webview/WebViewImpl-ios.mm
@@ -315,7 +315,7 @@ WebViewImpl::~WebViewImpl() {
    destroy();
 }
 
-WebViewImpl::destroy() {
+void WebViewImpl::destroy() {
     if (_uiWebViewWrapper != nil) {
         [_uiWebViewWrapper release];
         _uiWebViewWrapper = nil;
@@ -462,7 +462,7 @@ void WebViewImpl::setBackgroundTransparent(bool isTransparent) {
     if (_uiWebViewWrapper == nil) {
         return;
     }
-    
+
     [_uiWebViewWrapper setBackgroundTransparent:isTransparent];
 }
 } //namespace cc

--- a/native/cocos/ui/webview/WebViewImpl-ios.mm
+++ b/native/cocos/ui/webview/WebViewImpl-ios.mm
@@ -316,14 +316,17 @@ WebViewImpl::~WebViewImpl() {
 }
 
 WebViewImpl::destroy() {
-    if (_uiWebViewWrapper != nil)
-    {
+    if (_uiWebViewWrapper != nil) {
         [_uiWebViewWrapper release];
         _uiWebViewWrapper = nil;
     }
 }
 
 void WebViewImpl::setJavascriptInterfaceScheme(const ccstd::string &scheme) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper setJavascriptInterfaceScheme:scheme];
 }
 
@@ -331,64 +334,122 @@ void WebViewImpl::loadData(const Data &data,
                            const ccstd::string &MIMEType,
                            const ccstd::string &encoding,
                            const ccstd::string &baseURL) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     ccstd::string dataString(reinterpret_cast<char *>(data.getBytes()), static_cast<unsigned int>(data.getSize()));
     [_uiWebViewWrapper loadData:dataString MIMEType:MIMEType textEncodingName:encoding baseURL:baseURL];
 }
 
 void WebViewImpl::loadHTMLString(const ccstd::string &string, const ccstd::string &baseURL) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper loadHTMLString:string baseURL:baseURL];
 }
 
 void WebViewImpl::loadURL(const ccstd::string &url) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper loadUrl:url];
 }
 
 void WebViewImpl::loadFile(const ccstd::string &fileName) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     auto fullPath = cc::FileUtils::getInstance()->fullPathForFilename(fileName);
     [_uiWebViewWrapper loadFile:fullPath];
 }
 
 void WebViewImpl::stopLoading() {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper stopLoading];
 }
 
 void WebViewImpl::reload() {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper reload];
 }
 
 bool WebViewImpl::canGoBack() {
+    if (_uiWebViewWrapper == nil) {
+        return false;
+    }
     return _uiWebViewWrapper.canGoBack;
 }
 
 bool WebViewImpl::canGoForward() {
+    if (_uiWebViewWrapper == nil) {
+        return false;
+    }
     return _uiWebViewWrapper.canGoForward;
 }
 
 void WebViewImpl::goBack() {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper goBack];
 }
 
 void WebViewImpl::goForward() {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper goForward];
 }
 
 void WebViewImpl::evaluateJS(const ccstd::string &js) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper evaluateJS:js];
 }
 
 void WebViewImpl::setBounces(bool bounces) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper setBounces:bounces];
 }
 
 void WebViewImpl::setScalesPageToFit(bool scalesPageToFit) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper setScalesPageToFit:scalesPageToFit];
 }
 
 void WebViewImpl::setVisible(bool visible) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     [_uiWebViewWrapper setVisible:visible];
 }
 
 void WebViewImpl::setFrame(float x, float y, float width, float height) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+
     UIView *view = UIApplication.sharedApplication.delegate.window.rootViewController.view;
     auto scaleFactor = [view contentScaleFactor];
     [_uiWebViewWrapper setFrameWithX:x / scaleFactor
@@ -398,6 +459,10 @@ void WebViewImpl::setFrame(float x, float y, float width, float height) {
 }
 
 void WebViewImpl::setBackgroundTransparent(bool isTransparent) {
+    if (_uiWebViewWrapper == nil) {
+        return;
+    }
+    
     [_uiWebViewWrapper setBackgroundTransparent:isTransparent];
 }
 } //namespace cc

--- a/native/cocos/ui/webview/WebViewImpl-java.h
+++ b/native/cocos/ui/webview/WebViewImpl-java.h
@@ -42,6 +42,8 @@ public:
 
     virtual ~WebViewImpl();
 
+    void destroy();
+
     void setJavascriptInterfaceScheme(const ccstd::string &scheme);
 
     void loadData(const cc::Data &data, const ccstd::string &mimeType,

--- a/native/cocos/ui/webview/WebViewImpl-java.h
+++ b/native/cocos/ui/webview/WebViewImpl-java.h
@@ -36,11 +36,11 @@ namespace cc {
 
 class WebView;
 
-class WebViewImpl {
+class WebViewImpl final {
 public:
     explicit WebViewImpl(WebView *webView);
 
-    virtual ~WebViewImpl();
+    ~WebViewImpl();
 
     void destroy();
 
@@ -71,9 +71,9 @@ public:
 
     void setScalesPageToFit(bool scalesPageToFit);
 
-    virtual void setVisible(bool visible);
+    void setVisible(bool visible);
 
-    virtual void setFrame(float x, float y, float width, float height);
+    void setFrame(float x, float y, float width, float height);
 
     void setBounces(bool bounces);
 

--- a/native/cocos/ui/webview/WebViewImpl-ohos.cpp
+++ b/native/cocos/ui/webview/WebViewImpl-ohos.cpp
@@ -168,8 +168,18 @@ WebViewImpl::WebViewImpl(WebView *webView) : _viewTag(-1),
 }
 
 WebViewImpl::~WebViewImpl() {
-    JniHelper::callStaticVoidMethod(CLASS_NAME, "removeWebView", _viewTag);
-    sWebViewImpls.erase(_viewTag);
+    destroy();
+}
+
+void WebViewImpl::destroy() {
+    if (_viewTag != -1) {
+        JniHelper::callStaticVoidMethod(CLASS_NAME, "removeWebView", _viewTag);
+        auto iter = sWebViewImpls.find(_viewTag);
+        if (iter != sWebViewImpls.end()) {
+            sWebViewImpls.erase(iter);
+        }
+        _viewTag = -1;
+    }
 }
 
 void WebViewImpl::loadData(const Data &data, const ccstd::string &mimeType,

--- a/native/tools/tojs/video.ini
+++ b/native/tools/tojs/video.ini
@@ -42,7 +42,7 @@ classes = VideoPlayer
 
 skip =
 
-rename_functions = VideoPlayer::[~VideoPlayer=destroy]
+rename_functions = 
 
 rename_classes =
 

--- a/native/tools/tojs/webview.ini
+++ b/native/tools/tojs/webview.ini
@@ -41,7 +41,7 @@ classes = WebView
 
 skip =
 
-rename_functions = WebView::[~WebView=destroy]
+rename_functions = 
 
 rename_classes =
 


### PR DESCRIPTION
### Changelog

* 

-------

### Continuous Integration

This pull request:

* [X] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
