### PR TITLE
fixed #11339 : [v3.6] Crash after hot update by invoking cc.game.restart().

### DIFF
--- a/native/cocos/base/threading/MessageQueue.cpp
+++ b/native/cocos/base/threading/MessageQueue.cpp
@@ -124,8 +124,7 @@ void MessageQueue::runConsumerThread() noexcept {
     _reader.terminateConsumerThread = false;
     _reader.flushingFinished = false;
 
-    std::thread consumerThread(&MessageQueue::consumerThreadLoop, this);
-    consumerThread.detach();
+    _consumerThread = ccnew std::thread(&MessageQueue::consumerThreadLoop, this);
     _workerAttached = true;
 }
 
@@ -141,6 +140,10 @@ void MessageQueue::terminateConsumerThread() noexcept {
 
     kick();
     event.wait();
+
+    if (_consumerThread->joinable()) {
+        _consumerThread->join();
+    }
 }
 
 void MessageQueue::finishWriting() noexcept {

--- a/native/cocos/base/threading/MessageQueue.cpp
+++ b/native/cocos/base/threading/MessageQueue.cpp
@@ -141,9 +141,12 @@ void MessageQueue::terminateConsumerThread() noexcept {
     kick();
     event.wait();
 
-    if (_consumerThread->joinable()) {
-        _consumerThread->join();
+    if (_consumerThread != nullptr) {
+        if (_consumerThread->joinable()) {
+            _consumerThread->join();
+        }
     }
+    CC_SAFE_DELETE(_consumerThread);
 }
 
 void MessageQueue::finishWriting() noexcept {

--- a/native/cocos/base/threading/MessageQueue.h
+++ b/native/cocos/base/threading/MessageQueue.h
@@ -179,6 +179,7 @@ private:
     bool _immediateMode{true};
     bool _workerAttached{false};
     bool _freeChunksByUser{true}; // recycled chunks will be stashed until explicit free instruction
+    std::thread *_consumerThread{nullptr};
 
     friend class MemoryChunkSwitchMessage;
 };


### PR DESCRIPTION
MessageQueue::terminateConsumerThread needs to wait consumer thread to exit. So don't detach consumer thread and we need to join the thread at the end of terminateConsumerThread.

Re: #11339

### Changelog

* Fix a crash after hot update by invoking cc.game.restart().

-------

### Continuous Integration

This pull request:

* [X] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
