### PR TITLE
fixed #11148: Crash when delete ScriptEngine in exit process.

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -107,10 +107,10 @@ void Object::cleanup() {
     Object *obj = nullptr;
     Class *cls = nullptr;
 
-    const auto &nativePtrToObjectMap = NativePtrToObjectMap::instance();
-    for (const auto &e : nativePtrToObjectMap) {
-        nativeObj = e.first;
-        obj = e.second;
+    auto iter = NativePtrToObjectMap::begin();
+    while (iter != NativePtrToObjectMap::end()) {
+        nativeObj = iter->first;
+        obj = iter->second;
 
         if (obj->_finalizeCb != nullptr) {
             obj->_finalizeCb(obj);
@@ -123,9 +123,10 @@ void Object::cleanup() {
         }
 
         obj->decRef();
+        iter = NativePtrToObjectMap::erase(iter);
     }
 
-    NativePtrToObjectMap::clear();
+    SE_ASSERT(NativePtrToObjectMap::size() == 0, "NativePtrToObjectMap should be empty!");
 
     if (__objectMap) {
         ccstd::vector<Object *> toReleaseObjects;

--- a/native/cocos/bindings/manual/jsb_spine_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_spine_manual.cpp
@@ -24,7 +24,6 @@
 ****************************************************************************/
 
 #include "jsb_spine_manual.h"
-#include "platform/FileUtils.h"
 #include "base/Data.h"
 #include "base/memory/Memory.h"
 #include "bindings/auto/jsb_spine_auto.h"
@@ -35,6 +34,7 @@
 #include "editor-support/spine-creator-support/spine-cocos2dx.h"
 #include "editor-support/spine/spine.h"
 #include "middleware-adapter.h"
+#include "platform/FileUtils.h"
 #include "spine-creator-support/SkeletonDataMgr.h"
 #include "spine-creator-support/SkeletonRenderer.h"
 #include "spine-creator-support/spine-cocos2dx.h"

--- a/native/cocos/bindings/manual/jsb_spine_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_spine_manual.cpp
@@ -240,7 +240,7 @@ bool register_all_spine_manual(se::Object *obj) {
             // Otherwise, it may trigger 'assertion' in se::Object::setPrivateData later
             // since native obj is already released and the new native object may be assigned with
             // the same address.
-            iter->second->setClearMappingInFinalizer(false);
+            seObj->setClearMappingInFinalizer(false);
             se::NativePtrToObjectMap::erase(iter);
         }
     });


### PR DESCRIPTION
Re: #11148 , #11279

### Changelog

* fixed #11148: Crash when delete ScriptEngine in exit process.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
