### PR TITLE
rename adapters

### DIFF
--- a/native/cocos/application/BaseGame.cpp
+++ b/native/cocos/application/BaseGame.cpp
@@ -61,7 +61,7 @@ int BaseGame::init() {
     }
 
     setXXTeaKey(_xxteaKey);
-    runScript("jsb-adapter/jsb-builtin.js");
+    runScript("jsb-adapter/web-adapter.js");
     runScript("main.js");
     return 0;
 }

--- a/native/tools/simulator/frameworks/runtime-src/Classes/Game.cpp
+++ b/native/tools/simulator/frameworks/runtime-src/Classes/Game.cpp
@@ -87,7 +87,7 @@ int Game::init() {
 
     setXXTeaKey("");
 
-    runScript("jsb-adapter/jsb-builtin.js");
+    runScript("jsb-adapter/web-adapter.js");
     runScript("main.js");
 
     // Runtime end

--- a/native/tools/simulator/libsimulator/lib/runtime/Runtime.cpp
+++ b/native/tools/simulator/libsimulator/lib/runtime/Runtime.cpp
@@ -215,7 +215,7 @@ void RuntimeEngine::start() {
     }
 
     setupRuntime();
-    //startScript("jsb-adapter/jsb-builtin.js");
+    //startScript("jsb-adapter/web-adapter.js");
     //startScript("");
 }
 

--- a/templates/alipay-mini-game/game.ejs
+++ b/templates/alipay-mini-game/game.ejs
@@ -1,4 +1,4 @@
-require('./builtin');
+require('./web-adapter');
 
 <% if(polyfillsBundleFile) { %>
 // Polyfills bundle.

--- a/templates/baidu-mini-game/game.ejs
+++ b/templates/baidu-mini-game/game.ejs
@@ -1,4 +1,4 @@
-require('./builtin');
+require('./web-adapter');
 
 <% if(polyfillsBundleFile) { %>
 // Polyfills bundle.

--- a/templates/bytedance-mini-game/game.ejs
+++ b/templates/bytedance-mini-game/game.ejs
@@ -39,7 +39,7 @@ loadCC();
 <% } %>
 
 function loadCC() {
-    require('./builtin');
+    require('./web-adapter');
 
     // Polyfills bundle.
     require("<%= polyfillsBundleFile %>");

--- a/templates/native/index.ejs
+++ b/templates/native/index.ejs
@@ -24,7 +24,7 @@ System.import('<%= applicationJs %>').then(({ createApplication }) => {
     });
 }).then((application) => {
     return application.import('cc').then((cc) => {
-        require('jsb-adapter/jsb-engine.js');
+        require('jsb-adapter/engine-adapter.js');
         cc.macro.CLEANUP_IMAGE_CACHE = false;
     }).then(() => {
         return application.start({

--- a/templates/wechatgame/game.ejs
+++ b/templates/wechatgame/game.ejs
@@ -1,5 +1,5 @@
 function __initApp () {  // init app
-require('./builtin');
+require('./web-adapter');
 const firstScreen = require('./first-screen');
 
 <%- include(cocosTemplate, {}) %>

--- a/templates/xiaomi-quick-game/game.ejs
+++ b/templates/xiaomi-quick-game/game.ejs
@@ -1,4 +1,4 @@
-require('./builtin');
+require('./web-adapter');
 
 <% if(polyfillsBundleFile) { %>
 // Polyfills bundle.


### PR DESCRIPTION
### Changelog

* on WeChat Baidu Xiaomi ByteDance Alipay platforms，`builtin.js` is renamed to `web-adapter.js`
* on Native platforms, `jsb-engine.js` is renamed to `engine-adapter.js`,  `jsb-builtin.js` is renamed to `web-adapter.js`

@yanOO1497 please help update the adapter copy workflow in PlatformExtension

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
