### PR TITLE
add limitation for job system on iOS

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -93,6 +93,13 @@ if(USE_JOB_SYSTEM_TASKFLOW AND USE_JOB_SYSTEM_TBB)
     set(USE_JOB_SYSTEM_TBB      OFF)
 endif()
 
+if(USE_JOB_SYSTEM_TASKFLOW)
+    set(CMAKE_CXX_STANDARD 17)
+    if(IOS AND "${TARGET_IOS_VERSION}" VERSION_LESS "12.0")
+        message(FATAL_ERROR "Target iOS version requires 12.0+ when enable taskflow")
+    endif()
+endif()
+
 if(ANDROID)
     if(CCACHE_EXECUTABLE AND USE_CCACHE)
         set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_EXECUTABLE}")


### PR DESCRIPTION
As job system depends on iOS 12.0+, so should add the limitation back.
