### PR TITLE
Ignoring mipmaps when raw assets are absent

### DIFF
--- a/cocos/core/assets/image-asset.ts
+++ b/cocos/core/assets/image-asset.ts
@@ -25,8 +25,8 @@
 
 // @ts-check
 import { ccclass, override } from 'cc.decorator';
-import { EDITOR, MINIGAME, ALIPAY, XIAOMI, JSB, TEST, BAIDU } from 'internal:constants';
-import { Device, Feature, Format, FormatFeatureBit } from '../gfx';
+import { EDITOR, ALIPAY, XIAOMI, JSB, TEST, BAIDU } from 'internal:constants';
+import { Device, Format, FormatFeatureBit } from '../gfx';
 import { Asset } from './asset';
 import { PixelFormat } from './asset-enum';
 import { legacyCC } from '../global-exports';

--- a/cocos/core/assets/texture-2d.ts
+++ b/cocos/core/assets/texture-2d.ts
@@ -144,7 +144,15 @@ export class Texture2D extends SimpleTexture {
     public _mipmaps: ImageAsset[] = [];
 
     public initialize () {
-        this.mipmaps = this._mipmaps;
+        const mip0 = this._mipmaps[0];
+        // Only assign validated mipmaps
+        if (mip0.validate()) {
+            this.mipmaps = this._mipmaps;
+        } else {
+            // Normally prebuilt mipmaps are only generated for compressed texture format
+            // For png or jpg files, we should use GPU to generate mipmaps directly
+            this.mipmaps = [];
+        }
     }
 
     public onLoaded () {


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/10876#issuecomment-1150601036

### Changelog

* Ignoring mipmaps when raw assets are absent

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
