### PR TITLE
use 'visible' decorator to control the visibility of property

### DIFF
--- a/cocos/particle/animator/limit-velocity-overtime.ts
+++ b/cocos/particle/animator/limit-velocity-overtime.ts
@@ -23,7 +23,7 @@
  THE SOFTWARE.
  */
 
-import { ccclass, tooltip, displayOrder, range, type, serializable } from 'cc.decorator';
+import { ccclass, tooltip, displayOrder, range, type, serializable, visible } from 'cc.decorator';
 import { lerp, pseudoRandom, Vec3, Mat4, Quat } from '../../core/math';
 import { Space, ModuleRandSeed } from '../enum';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
@@ -62,6 +62,9 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
     @range([-1, 1])
     @displayOrder(4)
     @tooltip('i18n:limitVelocityOvertimeModule.limitX')
+    @visible(function (this: LimitVelocityOvertimeModule): boolean {
+        return this.separateAxes;
+    })
     public limitX = new CurveRange();
 
     /**
@@ -72,6 +75,9 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
     @range([-1, 1])
     @displayOrder(5)
     @tooltip('i18n:limitVelocityOvertimeModule.limitY')
+    @visible(function (this: LimitVelocityOvertimeModule): boolean {
+        return this.separateAxes;
+    })
     public limitY = new CurveRange();
 
     /**
@@ -82,6 +88,9 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
     @range([-1, 1])
     @displayOrder(6)
     @tooltip('i18n:limitVelocityOvertimeModule.limitZ')
+    @visible(function (this: LimitVelocityOvertimeModule): boolean {
+        return this.separateAxes;
+    })
     public limitZ = new CurveRange();
 
     /**
@@ -92,6 +101,9 @@ export default class LimitVelocityOvertimeModule extends ParticleModuleBase {
     @range([-1, 1])
     @displayOrder(3)
     @tooltip('i18n:limitVelocityOvertimeModule.limit')
+    @visible(function (this: LimitVelocityOvertimeModule): boolean {
+        return !this.separateAxes;
+    })
     public limit = new CurveRange();
 
     /**

--- a/cocos/particle/animator/rotation-overtime.ts
+++ b/cocos/particle/animator/rotation-overtime.ts
@@ -24,7 +24,7 @@
  THE SOFTWARE.
  */
 
-import { ccclass, tooltip, displayOrder, range, type, radian, serializable } from 'cc.decorator';
+import { ccclass, tooltip, displayOrder, range, type, radian, serializable, visible } from 'cc.decorator';
 import { Mat4, pseudoRandom, Quat, Vec4, Vec3 } from '../../core/math';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
 import CurveRange from './curve-range';
@@ -76,6 +76,7 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
     @radian
     @displayOrder(2)
     @tooltip('i18n:rotationOvertimeModule.x')
+    @visible(function (this: RotationOvertimeModule): boolean { return this.separateAxes; })
     public x = new CurveRange();
 
     /**
@@ -87,6 +88,7 @@ export default class RotationOvertimeModule extends ParticleModuleBase {
     @radian
     @displayOrder(3)
     @tooltip('i18n:rotationOvertimeModule.y')
+    @visible(function (this: RotationOvertimeModule): boolean { return this.separateAxes; })
     public y = new CurveRange();
 
     /**

--- a/cocos/particle/animator/size-overtime.ts
+++ b/cocos/particle/animator/size-overtime.ts
@@ -23,7 +23,7 @@
  THE SOFTWARE.
  */
 
-import { ccclass, tooltip, displayOrder, type, serializable, range } from 'cc.decorator';
+import { ccclass, tooltip, displayOrder, type, serializable, range, visible } from 'cc.decorator';
 import { pseudoRandom, Vec3 } from '../../core/math';
 import { Particle, ParticleModuleBase, PARTICLE_MODULE_NAME } from '../particle';
 import CurveRange from './curve-range';
@@ -66,6 +66,7 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     @range([0, 1])
     @displayOrder(2)
     @tooltip('i18n:sizeOvertimeModule.size')
+    @visible(function (this: SizeOvertimeModule): boolean { return !this.separateAxes; })
     public size = new CurveRange();
 
     /**
@@ -76,6 +77,7 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     @range([0, 1])
     @displayOrder(3)
     @tooltip('i18n:sizeOvertimeModule.x')
+    @visible(function (this: SizeOvertimeModule): boolean { return this.separateAxes; })
     public x = new CurveRange();
 
     /**
@@ -86,6 +88,7 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     @range([0, 1])
     @displayOrder(4)
     @tooltip('i18n:sizeOvertimeModule.y')
+    @visible(function (this: SizeOvertimeModule): boolean { return this.separateAxes; })
     public y = new CurveRange();
 
     /**
@@ -96,6 +99,7 @@ export default class SizeOvertimeModule extends ParticleModuleBase {
     @range([0, 1])
     @displayOrder(5)
     @tooltip('i18n:sizeOvertimeModule.z')
+    @visible(function (this: SizeOvertimeModule): boolean { return this.separateAxes; })
     public z = new CurveRange();
 
     public name = PARTICLE_MODULE_NAME.SIZE;

--- a/cocos/particle/emitter/shape-module.ts
+++ b/cocos/particle/emitter/shape-module.ts
@@ -35,6 +35,16 @@ import { ParticleSystem } from '../particle-system';
 const _intermediVec = new Vec3(0, 0, 0);
 const _intermediArr: number[] = [];
 const _unitBoxExtent = new Vec3(0.5, 0.5, 0.5);
+function getShapeTypeEnumName(enumValue: number): keyof typeof ShapeType {
+    let enumName = '';
+    for (const key in ShapeType) {
+        if (ShapeType[key] === enumValue) {
+            enumName = key;
+            break;
+        }
+    }
+    return enumName as keyof typeof ShapeType;
+}
 
 @ccclass('cc.ShapeModule')
 export default class ShapeModule {
@@ -82,7 +92,12 @@ export default class ShapeModule {
      */
     @displayOrder(6)
     @tooltip('i18n:shapeModule.arc')
-    get arc () {
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Cone', 'Circle'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
+    get arc() {
         return toDegree(this._arc);
     }
 
@@ -96,7 +111,12 @@ export default class ShapeModule {
      */
     @displayOrder(5)
     @tooltip('i18n:shapeModule.angle')
-    get angle () {
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Cone'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
+    get angle() {
         return Math.round(toDegree(this._angle) * 100) / 100;
     }
 
@@ -165,6 +185,11 @@ export default class ShapeModule {
     @serializable
     @displayOrder(2)
     @tooltip('i18n:shapeModule.emitFrom')
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Box', 'Cone', 'Sphere', 'Hemisphere'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
     public emitFrom = EmitLocation.Volume;
 
     /**
@@ -205,6 +230,11 @@ export default class ShapeModule {
     @serializable
     @displayOrder(3)
     @tooltip('i18n:shapeModule.radius')
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Circle', 'Cone', 'Sphere', 'Hemisphere'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
     public radius = 1;
 
     /**
@@ -216,6 +246,11 @@ export default class ShapeModule {
     @serializable
     @displayOrder(4)
     @tooltip('i18n:shapeModule.radiusThickness')
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Circle', 'Cone', 'Sphere', 'Hemisphere'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
     public radiusThickness = 1;
 
     /**
@@ -225,6 +260,11 @@ export default class ShapeModule {
     @serializable
     @displayOrder(7)
     @tooltip('i18n:shapeModule.arcMode')
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Cone', 'Circle'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
     public arcMode = ArcMode.Random;
 
     /**
@@ -234,6 +274,11 @@ export default class ShapeModule {
     @serializable
     @displayOrder(9)
     @tooltip('i18n:shapeModule.arcSpread')
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Cone', 'Circle'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
     public arcSpread = 0;
 
     /**
@@ -245,6 +290,11 @@ export default class ShapeModule {
     @serializable
     @displayOrder(10)
     @tooltip('i18n:shapeModule.arcSpeed')
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Cone', 'Circle'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
     public arcSpeed = new CurveRange();
 
     /**
@@ -254,6 +304,11 @@ export default class ShapeModule {
     @serializable
     @displayOrder(11)
     @tooltip('i18n:shapeModule.length')
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Cone'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
     public length = 5;
 
     /**
@@ -262,6 +317,11 @@ export default class ShapeModule {
     @serializable
     @displayOrder(12)
     @tooltip('i18n:shapeModule.boxThickness')
+    @visible(function (this: ShapeModule) {
+        const subset: Array<keyof typeof ShapeType> = ['Box'];
+        const enumName = getShapeTypeEnumName(this.shapeType);
+        return subset.includes(enumName);
+    })
     public boxThickness = new Vec3(0, 0, 0);
 
     @serializable

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -24,7 +24,7 @@
  */
 
 // eslint-disable-next-line max-len
-import { ccclass, help, executeInEditMode, executionOrder, menu, tooltip, displayOrder, type, range, displayName, formerlySerializedAs, override, radian, serializable, inspector, boolean, visible, slide, rangeStep } from 'cc.decorator';
+import { ccclass, help, executeInEditMode, executionOrder, menu, tooltip, displayOrder, type, range, displayName, formerlySerializedAs, override, radian, serializable, visible } from 'cc.decorator';
 import { EDITOR } from 'internal:constants';
 import { RenderableComponent } from '../core/components/renderable-component';
 import { Material } from '../core/assets/material';
@@ -123,6 +123,7 @@ export class ParticleSystem extends RenderableComponent {
     @range([0, 1])
     @displayOrder(10)
     @tooltip('i18n:particle_system.startSizeY')
+    @visible(function (this: ParticleSystem): boolean { return this.startSize3D; })
     public startSizeY = new CurveRange();
 
     /**
@@ -133,6 +134,7 @@ export class ParticleSystem extends RenderableComponent {
     @range([0, 1])
     @displayOrder(10)
     @tooltip('i18n:particle_system.startSizeZ')
+    @visible(function (this: ParticleSystem): boolean { return this.startSize3D; })
     public startSizeZ = new CurveRange();
 
     /**
@@ -159,6 +161,7 @@ export class ParticleSystem extends RenderableComponent {
     @radian
     @displayOrder(12)
     @tooltip('i18n:particle_system.startRotationX')
+    @visible(function (this: ParticleSystem): boolean { return this.startRotation3D; })
     public startRotationX = new CurveRange();
 
     /**
@@ -170,6 +173,7 @@ export class ParticleSystem extends RenderableComponent {
     @radian
     @displayOrder(12)
     @tooltip('i18n:particle_system.startRotationY')
+    @visible(function (this: ParticleSystem): boolean { return this.startRotation3D; })
     public startRotationY = new CurveRange();
 
     /**
@@ -181,6 +185,7 @@ export class ParticleSystem extends RenderableComponent {
     @radian
     @displayOrder(12)
     @tooltip('i18n:particle_system.startRotationZ')
+    @visible(function (this: ParticleSystem): boolean { return this.startRotation3D; })
     public startRotationZ = new CurveRange();
 
     /**


### PR DESCRIPTION
Re: #

### Changelog

* Use decorators to modify the visibility of particle system properties

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
