### PR TITLE
fix websocket onError not call onClose on Android

### DIFF
--- a/native/cocos/network/WebSocket-okhttp.cpp
+++ b/native/cocos/network/WebSocket-okhttp.cpp
@@ -226,8 +226,10 @@ void WebSocketImpl::onClose(int /*code*/) {
 void WebSocketImpl::onError(int code, const std::string & /*reason*/) {
     CC_LOG_DEBUG("WebSocket (%p) onError, state: %d ...", this, (int)_readyState);
     if (_readyState != WebSocket::State::CLOSED) {
+        _readyState = WebSocket::State::CLOSED; // update state -> CLOSED
         _delegate->onError(_socket, static_cast<WebSocket::ErrorCode>(code));
     }
+    onClose(code);
 }
 
 void WebSocketImpl::onBinaryMessage(const uint8_t *buf, size_t len) {


### PR DESCRIPTION
Re: #https://forum.cocos.org/t/topic/135943/2

### Changelog

* fix websocket onError not call onClose on Android

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
