### PR TITLE
add support to vk 1.3 for spirvutils

### DIFF
--- a/native/cocos/renderer/gfx-base/SPIRVUtils.cpp
+++ b/native/cocos/renderer/gfx-base/SPIRVUtils.cpp
@@ -51,11 +51,16 @@ EShLanguage getShaderStage(ShaderStageFlagBit type) {
     }
 }
 
+#include <glslang/build_info.h>
+
 glslang::EShTargetClientVersion getClientVersion(int vulkanMinorVersion) {
     switch (vulkanMinorVersion) {
         case 0: return glslang::EShTargetVulkan_1_0;
         case 1: return glslang::EShTargetVulkan_1_1;
         case 2: return glslang::EShTargetVulkan_1_2;
+#if GLSLANG_VERSION_LESS_OR_EQUAL_TO(11, 10, 0)
+        case 3: return glslang::EShTargetVulkan_1_3;
+#endif
         default: {
             CC_ASSERT(false);
             return glslang::EShTargetVulkan_1_0;
@@ -68,6 +73,9 @@ glslang::EShTargetLanguageVersion getTargetVersion(int vulkanMinorVersion) {
         case 0: return glslang::EShTargetSpv_1_0;
         case 1: return glslang::EShTargetSpv_1_3;
         case 2: return glslang::EShTargetSpv_1_5;
+#if GLSLANG_VERSION_LESS_OR_EQUAL_TO(11, 10, 0)
+        case 3: return glslang::EShTargetSpv_1_6;
+#endif
         default: {
             CC_ASSERT(false);
             return glslang::EShTargetSpv_1_0;
@@ -129,7 +137,7 @@ void SPIRVUtils::compileGLSL(ShaderStageFlagBit type, const ccstd::string &sourc
     spvOptions.disableOptimizer = false;
     spvOptions.optimizeSize = true;
 #if CC_DEBUG > 0
-    //spvOptions.validate = true;
+    // spvOptions.validate = true;
 #else
     spvOptions.stripDebugInfo = true;
 #endif


### PR DESCRIPTION
Re: #nothing

### Changelog

* add support to vk 1.3 for spirvutils, newer glslang required to take effect
* still support the old glslang version

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
