### PR TITLE
fix nested prefab children id  problem

### DIFF
--- a/cocos/core/utils/prefab/utils.ts
+++ b/cocos/core/utils/prefab/utils.ts
@@ -401,7 +401,8 @@ export function expandPrefabInstanceNode (node: Node, recursively = false) {
     const prefabInstance = prefabInfo?.instance;
     if (prefabInstance) {
         createNodeWithPrefab(node);
-        applyNodeAndComponentId(node, node.uuid);
+        // nested prefab children's id will be the same: 3dtask#12511
+        // applyNodeAndComponentId(node, node.uuid);
 
         const targetMap: Record<string, any | Node | Component> = {};
         prefabInstance.targetMap = targetMap;


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12511

### Changelog

*  Comment applyNodeAndComponentId method,the origin issue should implement with other way.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
