### PR TITLE
fix crash if reset texture property of a Material

### DIFF
--- a/cocos/core/assets/material.jsb.ts
+++ b/cocos/core/assets/material.jsb.ts
@@ -148,7 +148,14 @@ matProto.setProperty = function (name: string, val: MaterialPropertyFull | Mater
         wrapSetProperty(this.setPropertyTextureBase, this, name, val, passIdx);
     } else if (val instanceof Texture) {
         wrapSetProperty(this.setPropertyGFXTexture, this, name, val, passIdx);
-    } else {
+    } else if (val === null) {
+        if (passIdx) {
+            this.setPropertyNull(name, passIdx);
+        } else {
+            this.setPropertyNull(name);
+        }
+    }
+     else {
         legacyCC.error(`Material.setProperty Unknown type: ${val}`);
     }
 };

--- a/cocos/core/renderer/core/pass.ts
+++ b/cocos/core/renderer/core/pass.ts
@@ -435,8 +435,8 @@ export class Pass {
         const samplerInfo = info && info.samplerHash !== undefined
             ? Sampler.unpackFromHash(info.samplerHash) : textureBase && textureBase.getSamplerInfo();
         const sampler = this._device.getSampler(samplerInfo);
-        this._descriptorSet.bindSampler(binding, sampler, index);
-        this._descriptorSet.bindTexture(binding, texture, index);
+        this._descriptorSet.bindSampler(binding, sampler, index || 0);
+        this._descriptorSet.bindTexture(binding, texture, index || 0);
     }
 
     /**

--- a/native/cocos/core/assets/Material.cpp
+++ b/native/cocos/core/assets/Material.cpp
@@ -160,6 +160,11 @@ void Material::setProperty(const ccstd::string &name, const MaterialPropertyVari
     }
 }
 
+void Material::setPropertyNull(const ccstd::string &name, index_t passIdx) {
+    MaterialPropertyVariant val;
+    setProperty(name, val);
+}
+
 #define CC_MATERIAL_SETPROPERTY_IMPL(funcNameSuffix, type)                                                                     \
     void Material::setProperty##funcNameSuffix(const ccstd::string &name, type val, index_t passIdx /* = CC_INVALID_INDEX*/) { \
         setProperty(name, val, passIdx);                                                                                       \

--- a/native/cocos/core/assets/Material.cpp
+++ b/native/cocos/core/assets/Material.cpp
@@ -162,7 +162,7 @@ void Material::setProperty(const ccstd::string &name, const MaterialPropertyVari
 
 void Material::setPropertyNull(const ccstd::string &name, index_t passIdx) {
     MaterialPropertyVariant val;
-    setProperty(name, val);
+    setProperty(name, val, passIdx);
 }
 
 #define CC_MATERIAL_SETPROPERTY_IMPL(funcNameSuffix, type)                                                                     \

--- a/native/cocos/core/assets/Material.h
+++ b/native/cocos/core/assets/Material.h
@@ -172,6 +172,7 @@ public:
      */
     void setProperty(const ccstd::string &name, const MaterialPropertyVariant &val, index_t passIdx = CC_INVALID_INDEX);
 
+    void setPropertyNull(const ccstd::string &name, index_t passIdx = CC_INVALID_INDEX);
     void setPropertyFloat32(const ccstd::string &name, float val, index_t passIdx = CC_INVALID_INDEX);
     void setPropertyInt32(const ccstd::string &name, int32_t val, index_t passIdx = CC_INVALID_INDEX);
     void setPropertyVec2(const ccstd::string &name, const Vec2 &val, index_t passIdx = CC_INVALID_INDEX);

--- a/native/cocos/scene/Pass.cpp
+++ b/native/cocos/scene/Pass.cpp
@@ -316,7 +316,11 @@ void Pass::resetUniform(const ccstd::string &name) {
     _rootBufferDirty = true;
 }
 
-void Pass::resetTexture(const ccstd::string &name, index_t index /* = CC_INVALID_INDEX */) {
+void Pass::resetTexture(const ccstd::string &name) {
+    resetTexture(name, 0);
+}
+
+void Pass::resetTexture(const ccstd::string &name, index_t index) {
     const uint32_t handle = getHandle(name);
     if (0 == handle) {
         return;

--- a/native/cocos/scene/Pass.h
+++ b/native/cocos/scene/Pass.h
@@ -225,11 +225,13 @@ public:
      */
     void resetUniform(const ccstd::string &name);
 
+    void resetTexture(const ccstd::string &name);
+
     /**
      * @en Resets the value of the given texture by name to the default value in [[EffectAsset]].
      * @zh 重置指定贴图为 [[EffectAsset]] 默认值。
      */
-    void resetTexture(const ccstd::string &name, index_t index = CC_INVALID_INDEX);
+    void resetTexture(const ccstd::string &name, index_t index);
 
     /**
      * @en Resets all uniform buffer objects to the default values in [[EffectAsset]]


### PR DESCRIPTION
This issue fix the crash if reset Material's texture property.

Steps to reproduce the issue:
- run test case 3d
- click `mipMapCheck`
- it will crash after a while on macOS

The reasons are:
- native implementation of `Material.setProperty()` doesn't handle null value
- `Pass::resetTexture()` may pass negative index to `DescriptorSet::bindTexture()` which doesn't reset texture correctly, then the descriptor set will hold a released texture and cause crash.

The web implementation of `Pass.resetTexture()` also has similar issue, it doesn't handle undefined value.