### PR TITLE
[Optimized] Implement rich text sprite container for node tree batch render flows

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -129,9 +129,9 @@ let RichText = cc.Class({
     },
 
     editor: CC_EDITOR && {
-        // menu: 'i18n:MAIN_MENU.component.renderers/RichText',
-        // help: 'i18n:COMPONENT.help_url.richtext',
-        // inspector: 'packages://inspector/inspectors/comps/richtext.js',
+        menu: 'i18n:MAIN_MENU.component.renderers/RichText',
+        help: 'i18n:COMPONENT.help_url.richtext',
+        inspector: 'packages://inspector/inspectors/comps/richtext.js',
         executeInEditMode: true
     },
 


### PR DESCRIPTION
Re: #

### Changelog
Add a new container for `cc.RichText` component for easier batch render by an organized node tree.

With `cc.RichText` now only has 2 draw calls
![draw-call](https://user-images.githubusercontent.com/55046591/173139533-7d01a3a3-cc9d-4f25-8e1c-6b7524d477c8.png)
![draw-call-spector](https://user-images.githubusercontent.com/55046591/173139527-ef308a6b-603f-414f-b191-5a3e6504618f.png)

`New Node` will render sprite first along with other sprites before `cc.RichText`'s Labels
![node-tree](https://user-images.githubusercontent.com/55046591/173140394-2dadfe5e-5c83-450d-b886-38c715280b84.png)

* 

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [x] Your pull request title is using English, it's precise and appropriate.
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
