### PR TITLE
use windowSize instead of screenSize for minigame platforms

### DIFF
--- a/pal/input/minigame/touch-input.ts
+++ b/pal/input/minigame/touch-input.ts
@@ -27,9 +27,7 @@ export class TouchInputSource {
         return (event: any) => {
             const handleTouches: Touch[] = [];
             const windowSize = screenAdapter.windowSize;
-            // NOTE: touch position on vivo platform is in physical pixel.
-            // No need to multiply with DPR.
-            const dpr = VIVO ? 1 : screenAdapter.devicePixelRatio;
+            const dpr = screenAdapter.devicePixelRatio;
             const length = event.changedTouches.length;
             for (let i = 0; i < length; ++i) {
                 const changedTouch = event.changedTouches[i];

--- a/pal/minigame/runtime.ts
+++ b/pal/minigame/runtime.ts
@@ -42,16 +42,7 @@ Object.defineProperty(minigame, 'orientation', {
     },
 });
 
-if (VIVO) {
-    // TODO: need to be handled in ral lib.
-    minigame.getSystemInfoSync = function () {
-        const sys = ral.getSystemInfoSync() as SystemInfo;
-        // on VIVO, windowWidth should be windowHeight when it is landscape
-        sys.windowWidth = sys.screenWidth;
-        sys.windowHeight = sys.screenHeight;
-        return sys;
-    };
-} else if (LINKSURE || COCOSPLAY) {
+if (LINKSURE || COCOSPLAY) {
     // TODO: update system info when view resized, currently the resize callback is not supported.
     let cachedSystemInfo = ral.getSystemInfoSync() as SystemInfo;
     minigame.onWindowResize?.(() => {

--- a/pal/screen-adapter/minigame/screen-adapter.ts
+++ b/pal/screen-adapter/minigame/screen-adapter.ts
@@ -45,11 +45,9 @@ class ScreenAdapter extends EventTarget {
 
     public get windowSize (): Size {
         const sysInfo = minigame.getSystemInfoSync();
-        // NOTE: screen size info on these platforms is in physical pixel.
-        // No need to multiply with DPR.
-        const dpr = VIVO ? 1 : this.devicePixelRatio;
-        let screenWidth = sysInfo.screenWidth;
-        let screenHeight = sysInfo.screenHeight;
+        const dpr = this.devicePixelRatio;
+        let screenWidth = sysInfo.windowWidth;
+        let screenHeight = sysInfo.windowHeight;
         if (ALIPAY && rotateLandscape  && screenWidth < screenHeight) {
             const temp = screenWidth;
             screenWidth = screenHeight;


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12069

### Changelog

* use windowSize instead of screenSize for minigame platforms

related PR: https://github.com/cocos/cocos-engine/pull/10166

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
