### PR TITLE
support audio PCMData and sampleRate getter

### DIFF
--- a/@types/jsb.d.ts
+++ b/@types/jsb.d.ts
@@ -91,7 +91,7 @@ declare namespace jsb {
     export function openURL(url: string): void;
     export function garbageCollect(): void;
     enum AudioFormat {
-        UNKNOWN = 0,
+        UNKNOWN,
         SIGNED_8,
         UNSIGNED_8,
         SIGNED_16,

--- a/@types/pal/audio.d.ts
+++ b/@types/pal/audio.d.ts
@@ -123,7 +123,7 @@ declare module 'pal/audio' {
         get sampleRate (): number;
 
         /**
-         * Get buffer from specified channel.
+         * Get pcm data view from specified channel.
          * @param channelIndex The channel index. 0 is left channel, 1 is right channel.
          */
         public getPCMData (channelIndex: number): import('pal/audio/type').AudioPCMDataView | undefined;

--- a/@types/pal/audio.d.ts
+++ b/@types/pal/audio.d.ts
@@ -123,16 +123,10 @@ declare module 'pal/audio' {
         get sampleRate (): number;
 
         /**
-         * Get the bit depth.
-         * In some platform which not support accessing bit depth, this getter will return 1.
-         */
-        get bitDepth (): number;
-
-        /**
          * Get buffer from specified channel.
          * @param channelIndex The channel index. 0 is left channel, 1 is right channel.
          */
-        public getPCMBuffer (channelIndex: number): import('pal/audio/type').AudioArrayBuffer | undefined;
+        public getPCMData (channelIndex: number): import('pal/audio/type').AudioPCMDataView | undefined;
 
         /**
          * Asynchronously seeks the player's playing time onto specified location.

--- a/@types/pal/audio.d.ts
+++ b/@types/pal/audio.d.ts
@@ -118,6 +118,23 @@ declare module 'pal/audio' {
         get currentTime (): number;
 
         /**
+         * Get the sample rate.
+         */
+        get sampleRate (): number;
+
+        /**
+         * Get the bit depth.
+         * In some platform which not support accessing bit depth, this getter will return 1.
+         */
+        get bitDepth (): number;
+
+        /**
+         * Get buffer from specified channel.
+         * @param channelIndex The channel index. 0 is left channel, 1 is right channel.
+         */
+        public getPCMBuffer (channelIndex: number): import('pal/audio/type').AudioArrayBuffer | undefined;
+
+        /**
          * Asynchronously seeks the player's playing time onto specified location.
          * @param time Desired playing time.
          */

--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -25,12 +25,14 @@
 
 import { AudioPlayer } from 'pal/audio';
 import { ccclass, help, menu, tooltip, type, range, serializable } from 'cc.decorator';
-import { AudioState } from '../../pal/audio/type';
+import { AudioArrayBuffer, AudioState } from '../../pal/audio/type';
 import { Component } from '../core/components/component';
 import { clamp } from '../core/math';
 import { AudioClip } from './audio-clip';
 import { audioManager } from './audio-manager';
 import { Node } from '../core';
+
+const _LOADED_EVENT = 'audiosource-loaded';
 
 enum AudioSourceEventType {
     STARTED = 'started',
@@ -138,6 +140,7 @@ export class AudioSource extends Component {
                 audioManager.addPlaying(player);
             });
             this._syncStates();
+            this.node.emit(_LOADED_EVENT);
         }).catch((e) => {});
     }
 
@@ -222,6 +225,80 @@ export class AudioSource extends Component {
         this.stop();
         this._player?.destroy();
         this._player = null;
+    }
+    /**
+     * @en
+     * Get PCM buffer from specified channel.
+     * Currently it is only available in Native platform and Web Audio (including Web and ByteDance platforms).
+     *
+     * @zh
+     * 通过指定的通道获取音频的 PCM buffer。
+     * 目前仅在原生平台和 Web Audio（包括 Web 和 字节平台）中可用。
+     *
+     * @param channelIndex The channel index. 0 is left channel, 1 is right channel.
+     * @returns A Promise to get the buffer after audio is loaded.
+     */
+    public getPCMBuffer (channelIndex: number): Promise<AudioArrayBuffer | undefined> {
+        return new Promise((resolve) => {
+            if (channelIndex !== 0 && channelIndex !== 1) {
+                console.warn('Only support channel index 0 or 1 to get buffer');
+                resolve(undefined);
+                return;
+            }
+            if (this._player) {
+                resolve(this._player.getPCMBuffer(channelIndex));
+            } else {
+                this.node.once(_LOADED_EVENT, () => {
+                    resolve(this._player!.getPCMBuffer(channelIndex));
+                });
+            }
+        });
+    }
+
+    /**
+     * @en
+     * Get the bit depth of the audio, currently it is only available in Native platform.
+     * In some platform which not support accessing bit depth, this getter will return 1.
+     *
+     * @zh
+     * 获取音频的位深，目前仅在原生平台支持。
+     * 在一些不支持获取位深的平台，返回 1。
+     *
+     * @returns A Promise to get the bit depth after audio is loaded.
+     */
+    public getBitDepth (): Promise<number> {
+        return new Promise((resolve) => {
+            if (this._player) {
+                resolve(this._player.bitDepth);
+            } else {
+                this.node.once(_LOADED_EVENT, () => {
+                    resolve(this._player!.bitDepth);
+                });
+            }
+        });
+    }
+
+    /**
+     * @en
+     * Get the sample rate of audio.
+     * Currently it is only available in Native platform and Web Audio (including Web and ByteDance platforms).
+     *
+     * @zh
+     * 获取音频的采样率。
+     * 目前仅在原生平台和 Web Audio（包括 Web 和 字节平台）中可用。
+     *
+     * @returns A Promise to get the sample rate after audio is loaded.
+     */
+    public getSampleRate (): Promise<number> {
+        return new Promise((resolve) => {
+            if (this._player) {
+                resolve(this._player.sampleRate);
+            } else {
+                this.node.once(_LOADED_EVENT, () => {
+                    resolve(this._player!.sampleRate);
+                });
+            }
+        });
     }
 
     private _getRootNode (): Node | null | undefined {

--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -25,7 +25,7 @@
 
 import { AudioPlayer } from 'pal/audio';
 import { ccclass, help, menu, tooltip, type, range, serializable } from 'cc.decorator';
-import { AudioArrayBuffer, AudioState } from '../../pal/audio/type';
+import { AudioPCMDataView, AudioState } from '../../pal/audio/type';
 import { Component } from '../core/components/component';
 import { clamp } from '../core/math';
 import { AudioClip } from './audio-clip';
@@ -228,17 +228,17 @@ export class AudioSource extends Component {
     }
     /**
      * @en
-     * Get PCM buffer from specified channel.
+     * Get PCM data from specified channel.
      * Currently it is only available in Native platform and Web Audio (including Web and ByteDance platforms).
      *
      * @zh
-     * 通过指定的通道获取音频的 PCM buffer。
+     * 通过指定的通道获取音频的 PCM data。
      * 目前仅在原生平台和 Web Audio（包括 Web 和 字节平台）中可用。
      *
      * @param channelIndex The channel index. 0 is left channel, 1 is right channel.
-     * @returns A Promise to get the buffer after audio is loaded.
+     * @returns A Promise to get the PCM data after audio is loaded.
      */
-    public getPCMBuffer (channelIndex: number): Promise<AudioArrayBuffer | undefined> {
+    public getPCMData (channelIndex: number): Promise<AudioPCMDataView | undefined> {
         return new Promise((resolve) => {
             if (channelIndex !== 0 && channelIndex !== 1) {
                 console.warn('Only support channel index 0 or 1 to get buffer');
@@ -246,33 +246,10 @@ export class AudioSource extends Component {
                 return;
             }
             if (this._player) {
-                resolve(this._player.getPCMBuffer(channelIndex));
+                resolve(this._player.getPCMData(channelIndex));
             } else {
                 this.node.once(_LOADED_EVENT, () => {
-                    resolve(this._player!.getPCMBuffer(channelIndex));
-                });
-            }
-        });
-    }
-
-    /**
-     * @en
-     * Get the bit depth of the audio, currently it is only available in Native platform.
-     * In some platform which not support accessing bit depth, this getter will return 1.
-     *
-     * @zh
-     * 获取音频的位深，目前仅在原生平台支持。
-     * 在一些不支持获取位深的平台，返回 1。
-     *
-     * @returns A Promise to get the bit depth after audio is loaded.
-     */
-    public getBitDepth (): Promise<number> {
-        return new Promise((resolve) => {
-            if (this._player) {
-                resolve(this._player.bitDepth);
-            } else {
-                this.node.once(_LOADED_EVENT, () => {
-                    resolve(this._player!.bitDepth);
+                    resolve(this._player?.getPCMData(channelIndex));
                 });
             }
         });

--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -237,6 +237,16 @@ export class AudioSource extends Component {
      *
      * @param channelIndex The channel index. 0 is left channel, 1 is right channel.
      * @returns A Promise to get the PCM data after audio is loaded.
+     *
+     * @example
+     * ```ts
+     * audioSource.getPCMData(0).then(dataView => {
+     *   if (!dataView)  return;
+     *   for (let i = 0; i < dataView.length; ++i) {
+     *     console.log('data: ' + dataView.getData(i));
+     *   }
+     * });
+     * ```
      */
     public getPCMData (channelIndex: number): Promise<AudioPCMDataView | undefined> {
         return new Promise((resolve) => {

--- a/cocos/audio/index.ts
+++ b/cocos/audio/index.ts
@@ -33,7 +33,7 @@ import './deprecated';
 export { AudioClip } from './audio-clip';
 
 export { AudioSource };
-export type { AudioArrayBuffer } from '../../pal/audio/type';
+export { AudioPCMDataView } from '../../pal/audio/type';
 
 export { AudioSource as AudioSourceComponent };
 legacyCC.AudioSourceComponent = AudioSource;

--- a/cocos/audio/index.ts
+++ b/cocos/audio/index.ts
@@ -33,6 +33,7 @@ import './deprecated';
 export { AudioClip } from './audio-clip';
 
 export { AudioSource };
+export type { AudioArrayBuffer } from '../../pal/audio/type';
 
 export { AudioSource as AudioSourceComponent };
 legacyCC.AudioSourceComponent = AudioSource;

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -1,7 +1,7 @@
 import { minigame } from 'pal/minigame';
 import { systemInfo } from 'pal/system-info';
 import { EventTarget } from '../../../cocos/core/event';
-import { AudioEvent, AudioState, AudioType } from '../type';
+import { AudioArrayBuffer, AudioEvent, AudioState, AudioType } from '../type';
 import { clamp, clamp01 } from '../../../cocos/core';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
 
@@ -212,6 +212,18 @@ export class AudioPlayerMinigame implements OperationQueueable {
         // on Baidu: currentTime returns without numbers on decimal places
         // on WeChat iOS: we can't reset currentTime to 0 when stop audio
         return this._innerAudioContext.currentTime;
+    }
+
+    get sampleRate (): number {
+        return 0;
+    }
+
+    get bitDepth (): number {
+        return 1;
+    }
+
+    getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined {
+        return undefined;
     }
 
     @enqueueOperation

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -1,7 +1,7 @@
 import { minigame } from 'pal/minigame';
 import { systemInfo } from 'pal/system-info';
 import { EventTarget } from '../../../cocos/core/event';
-import { AudioArrayBuffer, AudioEvent, AudioState, AudioType } from '../type';
+import { AudioEvent, AudioPCMDataView, AudioState, AudioType } from '../type';
 import { clamp, clamp01 } from '../../../cocos/core';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
 
@@ -218,11 +218,7 @@ export class AudioPlayerMinigame implements OperationQueueable {
         return 0;
     }
 
-    get bitDepth (): number {
-        return 1;
-    }
-
-    getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined {
+    public getPCMData (channelIndex: number): AudioPCMDataView | undefined {
         return undefined;
     }
 

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -5,7 +5,7 @@ import { EventTarget } from '../../../cocos/core/event';
 import { audioBufferManager } from '../audio-buffer-manager';
 import AudioTimer from '../audio-timer';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
-import { AudioArrayBuffer, AudioEvent, AudioState, AudioType } from '../type';
+import { AudioEvent, AudioPCMDataView, AudioState, AudioType } from '../type';
 
 declare const fsUtils: any;
 const audioContext = minigame.tt?.getAudioContext?.();
@@ -201,12 +201,8 @@ export class AudioPlayerWeb implements OperationQueueable {
         return this._audioBuffer.sampleRate;
     }
 
-    get bitDepth (): number {
-        return 1;
-    }
-
-    public getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined {
-        return this._audioBuffer.getChannelData(channelIndex);
+    public getPCMData (channelIndex: number): AudioPCMDataView | undefined {
+        return new AudioPCMDataView(this._audioBuffer.getChannelData(channelIndex), 1);
     }
 
     @enqueueOperation

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -5,7 +5,7 @@ import { EventTarget } from '../../../cocos/core/event';
 import { audioBufferManager } from '../audio-buffer-manager';
 import AudioTimer from '../audio-timer';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
-import { AudioEvent, AudioState, AudioType } from '../type';
+import { AudioArrayBuffer, AudioEvent, AudioState, AudioType } from '../type';
 
 declare const fsUtils: any;
 const audioContext = minigame.tt?.getAudioContext?.();
@@ -195,6 +195,18 @@ export class AudioPlayerWeb implements OperationQueueable {
     }
     get currentTime (): number {
         return this._audioTimer.currentTime;
+    }
+
+    get sampleRate (): number {
+        return this._audioBuffer.sampleRate;
+    }
+
+    get bitDepth (): number {
+        return 1;
+    }
+
+    public getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined {
+        return this._audioBuffer.getChannelData(channelIndex);
     }
 
     @enqueueOperation

--- a/pal/audio/minigame/player.ts
+++ b/pal/audio/minigame/player.ts
@@ -1,7 +1,6 @@
 import { minigame } from 'pal/minigame';
-import { warnID } from '../../../cocos/core';
 import { legacyCC } from '../../../cocos/core/global-exports';
-import { AudioLoadOptions, AudioType, AudioState, AudioArrayBuffer } from '../type';
+import { AudioLoadOptions, AudioType, AudioState, AudioPCMDataView } from '../type';
 import { AudioPlayerMinigame, OneShotAudioMinigame } from './player-minigame';
 import { AudioPlayerWeb, OneShotAudioWeb } from './player-web';
 
@@ -90,8 +89,7 @@ export class AudioPlayer {
     get duration (): number { return this._player.duration; }
     get currentTime (): number { return this._player.currentTime; }
     get sampleRate (): number { return this._player.sampleRate; }
-    get bitDepth (): number { return this._player.bitDepth; }
-    getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined { return this._player.getPCMBuffer(channelIndex); }
+    getPCMData (channelIndex: number): AudioPCMDataView | undefined { return this._player.getPCMData(channelIndex); }
     seek (time: number): Promise<void> { return this._player.seek(time); }
 
     play (): Promise<void> { return this._player.play(); }

--- a/pal/audio/minigame/player.ts
+++ b/pal/audio/minigame/player.ts
@@ -1,7 +1,7 @@
 import { minigame } from 'pal/minigame';
 import { warnID } from '../../../cocos/core';
 import { legacyCC } from '../../../cocos/core/global-exports';
-import { AudioLoadOptions, AudioType, AudioState } from '../type';
+import { AudioLoadOptions, AudioType, AudioState, AudioArrayBuffer } from '../type';
 import { AudioPlayerMinigame, OneShotAudioMinigame } from './player-minigame';
 import { AudioPlayerWeb, OneShotAudioWeb } from './player-web';
 
@@ -89,6 +89,9 @@ export class AudioPlayer {
     set volume (val: number) { this._player.volume = val; }
     get duration (): number { return this._player.duration; }
     get currentTime (): number { return this._player.currentTime; }
+    get sampleRate (): number { return this._player.sampleRate; }
+    get bitDepth (): number { return this._player.bitDepth; }
+    getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined { return this._player.getPCMBuffer(channelIndex); }
     seek (time: number): Promise<void> { return this._player.seek(time); }
 
     play (): Promise<void> { return this._player.play(); }

--- a/pal/audio/type.ts
+++ b/pal/audio/type.ts
@@ -28,3 +28,5 @@ export enum AudioState {
     STOPPED,
     INTERRUPTED,
 }
+
+export type AudioArrayBuffer = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;

--- a/pal/audio/type.ts
+++ b/pal/audio/type.ts
@@ -29,4 +29,32 @@ export enum AudioState {
     INTERRUPTED,
 }
 
-export type AudioArrayBuffer = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
+export type AudioBufferView = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
+
+export class AudioPCMDataView {
+    private _bufferView: AudioBufferView;
+    private _normalizeFactor = 1;
+
+    constructor (arrayBufferView: AudioBufferView, normalizeFactor: number);
+    constructor (arrayBuffer: ArrayBuffer, Ctor: Constructor<AudioBufferView>, normalizeFactor: number);
+    constructor (...args: any[]) {
+        if (args.length === 2) {
+            this._bufferView = args[0] as AudioBufferView;
+            this._normalizeFactor = args[1] as number;
+        } else {
+            const arrayBuffer = args[0] as ArrayBuffer;
+            const Ctor = args[1] as Constructor<AudioBufferView>;
+            const normalizeFactor = args[2] as number;
+            this._bufferView = new Ctor(arrayBuffer);
+            this._normalizeFactor = normalizeFactor;
+        }
+    }
+
+    get length () {
+        return this._bufferView.length;
+    }
+
+    public getData (offset: number) {
+        return this._bufferView[offset] * this._normalizeFactor;
+    }
+}

--- a/pal/audio/web/player-dom.ts
+++ b/pal/audio/web/player-dom.ts
@@ -1,5 +1,5 @@
 import { systemInfo } from 'pal/system-info';
-import { AudioArrayBuffer, AudioEvent, AudioState, AudioType } from '../type';
+import { AudioEvent, AudioState, AudioPCMDataView, AudioType } from '../type';
 import { EventTarget } from '../../../cocos/core/event';
 import { clamp, clamp01 } from '../../../cocos/core';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
@@ -201,11 +201,7 @@ export class AudioPlayerDOM implements OperationQueueable {
         return 0;
     }
 
-    get bitDepth (): number {
-        return 1;
-    }
-
-    public getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined {
+    public getPCMData (channelIndex: number): AudioPCMDataView | undefined {
         return undefined;
     }
 

--- a/pal/audio/web/player-dom.ts
+++ b/pal/audio/web/player-dom.ts
@@ -1,5 +1,5 @@
 import { systemInfo } from 'pal/system-info';
-import { AudioEvent, AudioState, AudioType } from '../type';
+import { AudioArrayBuffer, AudioEvent, AudioState, AudioType } from '../type';
 import { EventTarget } from '../../../cocos/core/event';
 import { clamp, clamp01 } from '../../../cocos/core';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
@@ -195,6 +195,18 @@ export class AudioPlayerDOM implements OperationQueueable {
     }
     get currentTime (): number {
         return this._domAudio.currentTime;
+    }
+
+    get sampleRate (): number {
+        return 0;
+    }
+
+    get bitDepth (): number {
+        return 1;
+    }
+
+    public getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined {
+        return undefined;
     }
 
     @enqueueOperation

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -1,6 +1,6 @@
 import { EDITOR } from 'internal:constants';
 import { systemInfo } from 'pal/system-info';
-import { AudioArrayBuffer, AudioEvent, AudioState, AudioType } from '../type';
+import { AudioPCMDataView, AudioEvent, AudioState, AudioType } from '../type';
 import { EventTarget } from '../../../cocos/core/event';
 import { clamp01 } from '../../../cocos/core';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
@@ -242,12 +242,8 @@ export class AudioPlayerWeb implements OperationQueueable {
         return this._audioBuffer.sampleRate;
     }
 
-    get bitDepth (): number {
-        return 1;
-    }
-
-    public getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined {
-        return this._audioBuffer.getChannelData(channelIndex);
+    public getPCMData (channelIndex: number): AudioPCMDataView | undefined {
+        return new AudioPCMDataView(this._audioBuffer.getChannelData(channelIndex), 1);
     }
 
     private _onHide () {

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -1,6 +1,6 @@
 import { EDITOR } from 'internal:constants';
 import { systemInfo } from 'pal/system-info';
-import { AudioEvent, AudioState, AudioType } from '../type';
+import { AudioArrayBuffer, AudioEvent, AudioState, AudioType } from '../type';
 import { EventTarget } from '../../../cocos/core/event';
 import { clamp01 } from '../../../cocos/core';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
@@ -236,6 +236,18 @@ export class AudioPlayerWeb implements OperationQueueable {
                 resolve(oneShotAudio);
             }).catch(reject);
         });
+    }
+
+    get sampleRate (): number {
+        return this._audioBuffer.sampleRate;
+    }
+
+    get bitDepth (): number {
+        return 1;
+    }
+
+    public getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined {
+        return this._audioBuffer.getChannelData(channelIndex);
     }
 
     private _onHide () {

--- a/pal/audio/web/player.ts
+++ b/pal/audio/web/player.ts
@@ -1,5 +1,5 @@
 import { warnID } from '../../../cocos/core';
-import { AudioLoadOptions, AudioType, AudioState } from '../type';
+import { AudioLoadOptions, AudioType, AudioState, AudioArrayBuffer } from '../type';
 import { AudioPlayerDOM, OneShotAudioDOM } from './player-dom';
 import { AudioContextAgent, AudioPlayerWeb, OneShotAudioWeb } from './player-web';
 
@@ -90,6 +90,9 @@ export class AudioPlayer {
     set volume (val: number) { this._player.volume = val; }
     get duration (): number { return this._player.duration; }
     get currentTime (): number { return this._player.currentTime; }
+    get sampleRate (): number { return this._player.sampleRate; }
+    get bitDepth (): number { return this._player.bitDepth; }
+    getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined { return this._player.getPCMBuffer(channelIndex); }
     seek (time: number): Promise<void> { return this._player.seek(time); }
 
     play (): Promise<void> { return this._player.play(); }

--- a/pal/audio/web/player.ts
+++ b/pal/audio/web/player.ts
@@ -1,5 +1,5 @@
 import { warnID } from '../../../cocos/core';
-import { AudioLoadOptions, AudioType, AudioState, AudioArrayBuffer } from '../type';
+import { AudioLoadOptions, AudioType, AudioState, AudioPCMDataView } from '../type';
 import { AudioPlayerDOM, OneShotAudioDOM } from './player-dom';
 import { AudioContextAgent, AudioPlayerWeb, OneShotAudioWeb } from './player-web';
 
@@ -91,8 +91,7 @@ export class AudioPlayer {
     get duration (): number { return this._player.duration; }
     get currentTime (): number { return this._player.currentTime; }
     get sampleRate (): number { return this._player.sampleRate; }
-    get bitDepth (): number { return this._player.bitDepth; }
-    getPCMBuffer (channelIndex: number): AudioArrayBuffer | undefined { return this._player.getPCMBuffer(channelIndex); }
+    getPCMData (channelIndex: number): AudioPCMDataView | undefined { return this._player.getPCMData(channelIndex); }
     seek (time: number): Promise<void> { return this._player.seek(time); }
 
     play (): Promise<void> { return this._player.play(); }


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12482

### Changelog

* support audio PCMBuffer, bitDepth and sampleRate getter

## Native Impementation

 https://github.com/cocos/cocos-engine/pull/11521

### Usage

```ts
await audioSource.getSampleRate();
await audioSource.getPCMData(0);  // left channel
let dataView = await audioSource.getPCMData(1);  // right channel

for (let i = 0; i < dataView.length; ++i) {
    console.log('data: ' + dataView.getData(i));
}
```

### Test Cases

https://github.com/cocos/cocos-test-projects/pull/637

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
