### PR TITLE
optimize UI component deprecated info

### DIFF
--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -283,3 +283,20 @@ markAsWarning = (owner: object, ownerName: string, properties: IMarkItem[]) => {
 //     removePropertyLog = () => { };
 //     markAsWarningLog = () => { };
 // }
+
+interface ITopLevelDeprecate {
+    [type: string]: string;
+}
+
+const topLevelDeprecateList: ITopLevelDeprecate = {
+    ButtonComponent: 'Button',
+};
+
+export function __checkObsolete__ (checkList: string[]) {
+    for (let checkItem of checkList) {
+        const replaceItem = topLevelDeprecateList[checkItem];
+        if (replaceItem) {
+            warn(`'%s' is deprecated, please use '%s' instead.`, checkItem, replaceItem);
+        }
+    }
+}


### PR DESCRIPTION
Re: 
https://github.com/cocos/cocos-engine/issues/10821
https://github.com/cocos/cocos-engine/issues/10819

### Changelog

* optimize UI component deprecated info

### now it should work like this

<img width="323" alt="1" src="https://user-images.githubusercontent.com/17872773/173225192-5ab59814-54ba-42bb-ac7f-aa58fe1b6b80.png">


### The breaking change is
```ts
button instanceof ButtonComponent  // comes to false

buttonComponent instanceof Button  // true
```

using `instanceof Button` is safe




-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
