### PR TITLE
fixed #11481: [JSB] Support std::string_view conversion

### DIFF
--- a/native/cocos/bindings/jswrapper/Value.cpp
+++ b/native/cocos/bindings/jswrapper/Value.cpp
@@ -365,7 +365,7 @@ void Value::setString(const ccstd::string &v) {
     *_u._string = v;
 }
 
-void Value::setString(const std::string_view& v) {
+void Value::setString(const std::string_view &v) {
     reset(Type::String);
     _u._string->assign(v.data(), 0, v.length());
 }

--- a/native/cocos/bindings/jswrapper/Value.cpp
+++ b/native/cocos/bindings/jswrapper/Value.cpp
@@ -365,6 +365,11 @@ void Value::setString(const ccstd::string &v) {
     *_u._string = v;
 }
 
+void Value::setString(const std::string_view& v) {
+    reset(Type::String);
+    _u._string->assign(v.data(), 0, v.length());
+}
+
 void Value::setObject(Object *object, bool autoRootUnroot /* = false*/) {
     if (object == nullptr) {
         reset(Type::Null);

--- a/native/cocos/bindings/jswrapper/Value.h
+++ b/native/cocos/bindings/jswrapper/Value.h
@@ -30,6 +30,7 @@
 #include "base/Macros.h"
 #include "base/std/container/string.h"
 #include "base/std/container/vector.h"
+#include <string_view>
 
 namespace se {
 
@@ -301,6 +302,12 @@ public:
          *  @param[in] v The string value to be set.
          */
     void setString(const ccstd::string &v);
+
+    /**
+         *  @brief Sets se::Value to string value by string_view.
+         *  @param[in] v The string_view
+         */
+    void setString(const std::string_view& v);
 
     /**
          *  @brief Sets se::Value to se::Object value.

--- a/native/cocos/bindings/jswrapper/Value.h
+++ b/native/cocos/bindings/jswrapper/Value.h
@@ -26,11 +26,11 @@
 
 #pragma once
 
+#include <string_view>
 #include "HandleObject.h"
 #include "base/Macros.h"
 #include "base/std/container/string.h"
 #include "base/std/container/vector.h"
-#include <string_view>
 
 namespace se {
 
@@ -307,7 +307,7 @@ public:
          *  @brief Sets se::Value to string value by string_view.
          *  @param[in] v The string_view
          */
-    void setString(const std::string_view& v);
+    void setString(const std::string_view &v);
 
     /**
          *  @brief Sets se::Value to se::Object value.

--- a/native/cocos/bindings/manual/jsb_conversions_spec.h
+++ b/native/cocos/bindings/manual/jsb_conversions_spec.h
@@ -172,6 +172,13 @@ inline bool sevalue_to_native(const se::Value &from, ccstd::string *to, se::Obje
     return true;
 }
 
+inline bool sevalue_to_native(const se::Value &from, std::string_view *to, se::Object * /*ctx*/) { // NOLINT(readability-identifier-naming)
+    if (from.isString()) {
+        *to = from.toString();
+    }
+    return true;
+}
+
 ///// integers
 inline bool sevalue_to_native(const se::Value &from, bool *to, se::Object * /*ctx*/) { // NOLINT(readability-identifier-naming)
     *to = from.isNullOrUndefined() ? false : (from.isNumber() ? from.toDouble() != 0 : from.toBoolean());
@@ -324,7 +331,9 @@ inline bool sevalue_to_native(const se::Value &from, void **to, se::Object * /*c
 }
 
 inline bool sevalue_to_native(const se::Value &from, ccstd::string **to, se::Object * /*ctx*/) { // NOLINT(readability-identifier-naming)
-    **to = from.toString();
+    if (to != nullptr && *to != nullptr) {
+        **to = from.toString();
+    }
     return true;
 }
 
@@ -456,6 +465,11 @@ inline bool nativevalue_to_se(long from, se::Value &to, se::Object * /*ctx*/) { 
 #endif
 
 inline bool nativevalue_to_se(const ccstd::string &from, se::Value &to, se::Object * /*ctx*/) { // NOLINT(readability-identifier-naming)
+    to.setString(from);
+    return true;
+}
+
+inline bool nativevalue_to_se(const std::string_view &from, se::Value &to, se::Object * /*ctx*/) { // NOLINT(readability-identifier-naming)
     to.setString(from);
     return true;
 }


### PR DESCRIPTION
Re: #11481

### Changelog

* [JSB] Support std::string_view conversion

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
