### PR TITLE
V3.6.0 okhttp fix url parsing, trim space

### DIFF
--- a/native/cocos/platform/android/java/src/com/cocos/lib/websocket/CocosWebSocket.java
+++ b/native/cocos/platform/android/java/src/com/cocos/lib/websocket/CocosWebSocket.java
@@ -127,7 +127,7 @@ public class CocosWebSocket extends WebSocketListener {
         Log.d(_TAG, "connect ws url: '" + url + "' ,protocols: '" + protocols + "' ,ca_: '" + caFilePath + "'");
         Request.Builder requestBuilder = new Request.Builder().url(url);
         try {
-            requestBuilder = requestBuilder.url(url);
+            requestBuilder = requestBuilder.url(url.trim());
         } catch (NullPointerException | IllegalArgumentException e) {
             synchronized (_wsContext) {
                 nativeOnError("invalid url", _wsContext.identifier,
@@ -143,6 +143,10 @@ public class CocosWebSocket extends WebSocketListener {
                 requestBuilder.header(_header[index], _header[index + 1]);
             }
         }
+
+        String origin = url.replace("ws://", "http://").replace("wss://", "https://");
+        requestBuilder.addHeader("Origin", origin);
+
         Request request = requestBuilder.build();
 
         if(dispatcher == null) {


### PR DESCRIPTION
Re: #

Decrease behavioral differences compare to libwebsockets

### Changelog

* WebSocket URL trim space
* Add Origin header allow CORS check

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
