### PR TITLE
Component activation/inactivation should resume/pause animation

### DIFF
--- a/cocos/3d/skeletal-animation/skeletal-animation.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation.ts
@@ -185,6 +185,16 @@ export class SkeletalAnimation extends Animation {
         this._removeAllUsers();
     }
 
+    public onEnable () {
+        super.onEnable();
+        this._currentBakedState?.resume();
+    }
+
+    public onDisable () {
+        super.onDisable();
+        this._currentBakedState?.pause();
+    }
+
     public start () {
         this.sockets = this._sockets;
         this.useBakedAnimation = this._useBakedAnimation;

--- a/tests/animation/skeletal-animation.test.ts
+++ b/tests/animation/skeletal-animation.test.ts
@@ -198,3 +198,25 @@ describe('Skeletal animation state', () => {
         state = skeletalAnimation.getState('Anim');
     });
 });
+
+describe('Skeletal animation component', () => {
+    test('Bugfix cocos/cocos-engine#11507 - Activation/Inactivation should resume/pause animation', () => {
+        const clip = new AnimationClip('meow');
+        clip.duration = 1.0;
+        const node = new Node();
+        const skeletalAnimation = node.addComponent(SkeletalAnimation) as SkeletalAnimation;
+        skeletalAnimation.clips = [clip];
+        const scene = new Scene('');
+        scene.addChild(node);
+        director.runSceneImmediate(scene);
+
+        const state = skeletalAnimation.getState('meow');
+
+        skeletalAnimation.play('meow');
+        expect(state.isPlaying && !state.isPaused).toBe(true);
+        skeletalAnimation.enabled = false;
+        expect(state.isPlaying && state.isPaused).toBe(true);
+        skeletalAnimation.enabled = true;
+        expect(state.isPlaying && !state.isPaused).toBe(true);
+    });
+});


### PR DESCRIPTION
This resolves #11507 .

### Changelog

* Activation/Inactivation of skeletal animation component should resume/pause animation.

This has been always holding for `Animation` but not for `SkeletonAnimation`.  Now just fix it.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
