### PR TITLE
[JSB] Fix some performance issues for 3.6.0 branch

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -1,6 +1,6 @@
 {
     "$schema": "./cc.config.schema.json",
-    
+
     "features": {
         "base": { "modules": [ "base" ], "dependentAssets": ["0835f102-5471-47a3-9a76-01c07ac9cdb2", "b5475517-23b9-4873-bc1a-968d96616081", "0ed97c56-390e-4dd1-96b7-e7f2d93a98ed", "b23391b6-52eb-46a6-8da1-6244d9d315fb"] },
         "gfx-webgl": { "modules": [ "gfx-webgl" ] },
@@ -65,8 +65,8 @@
                 "cocos/core/renderer/core/render-scene.ts": "cocos/core/renderer/core/render-scene.jsb.ts",
                 "cocos/core/renderer/scene/submodel.ts": "cocos/core/renderer/scene/submodel.jsb.ts",
                 "cocos/core/renderer/scene/index.ts": "cocos/core/renderer/scene/index.jsb.ts",
+                "cocos/core/gfx/base/pipeline-state.ts": "cocos/core/gfx/base/pipeline-state.jsb.ts",
                 "cocos/core/gfx/index.ts": "cocos/core/gfx/index.jsb.ts",
-                "cocos/core/gfx/pipeline-state.ts": "cocos/core/gfx/pipeline-state.jsb.ts",
                 "cocos/spine/index.ts": "cocos/spine/index.jsb.ts",
                 "cocos/dragon-bones/index.ts": "cocos/dragon-bones/index.jsb.ts",
                 "cocos/physics/physx/instantiate.ts": "cocos/physics/physx/instantiate.jsb.ts",

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -25,6 +25,7 @@
 
 import { ccclass, help, executeInEditMode, executionOrder, menu, tooltip, visible, type,
     formerlySerializedAs, serializable, editable, disallowAnimation } from 'cc.decorator';
+import { JSB } from 'internal:constants';
 import { Texture2D } from '../../core/assets';
 import { Material } from '../../core/assets/material';
 import { Mesh } from '../assets/mesh';
@@ -41,7 +42,6 @@ import { legacyCC } from '../../core/global-exports';
 import { assertIsTrue } from '../../core/data/utils/asserts';
 import { CCFloat } from '../../core/data/utils/attribute';
 import { property } from '../../core/data/class-decorator';
-import { JSB } from 'internal:constants';
 
 /**
  * @en Shadow projection mode.

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -474,7 +474,7 @@ export class MeshRenderer extends ModelRenderer {
         if (JSB) {
             (this.model as any)._setInstancedAttribute(name, value);
         } else {
-            const {attributes, views} = this.model.instancedAttributes;
+            const { attributes, views } = this.model.instancedAttributes;
             for (let i = 0; i < attributes.length; i++) {
                 if (attributes[i].name === name) {
                     views[i].set(value);

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -41,6 +41,7 @@ import { legacyCC } from '../../core/global-exports';
 import { assertIsTrue } from '../../core/data/utils/asserts';
 import { CCFloat } from '../../core/data/utils/attribute';
 import { property } from '../../core/data/class-decorator';
+import { JSB } from '../../core/default-constants';
 
 /**
  * @en Shadow projection mode.
@@ -466,12 +467,19 @@ export class MeshRenderer extends ModelRenderer {
     }
 
     public setInstancedAttribute (name: string, value: ArrayLike<number>) {
-        if (!this.model) { return; }
-        const { attributes, views } = this.model.instancedAttributes;
-        for (let i = 0; i < attributes.length; i++) {
-            if (attributes[i].name === name) {
-                views[i].set(value);
-                break;
+        if (!this.model) {
+            return;
+        }
+
+        if (JSB) {
+            (this.model as any)._setInstancedAttribute(name, value);
+        } else {
+            const {attributes, views} = this.model.instancedAttributes;
+            for (let i = 0; i < attributes.length; i++) {
+                if (attributes[i].name === name) {
+                    views[i].set(value);
+                    break;
+                }
             }
         }
     }

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -41,7 +41,7 @@ import { legacyCC } from '../../core/global-exports';
 import { assertIsTrue } from '../../core/data/utils/asserts';
 import { CCFloat } from '../../core/data/utils/attribute';
 import { property } from '../../core/data/class-decorator';
-import { JSB } from '../../core/default-constants';
+import { JSB } from 'internal:constants';
 
 /**
  * @en Shadow projection mode.

--- a/cocos/core/gfx/base/pipeline-state.jsb.ts
+++ b/cocos/core/gfx/base/pipeline-state.jsb.ts
@@ -42,7 +42,7 @@ import {
     ShadeModel,
     StencilOp,
     Color,
-} from './base/define';
+} from './define';
 export class RasterizerState {
     protected _nativeObj;
     protected _isDiscard: boolean = false;

--- a/cocos/core/gfx/index.jsb.ts
+++ b/cocos/core/gfx/index.jsb.ts
@@ -66,14 +66,6 @@ polyfillCC.CommandBuffer = gfx.CommandBuffer;
 polyfillCC.Queue = gfx.Queue;
 legacyCC.gfx = polyfillCC;
 
-// TODO: remove these after state info refactor
-// export const BlendTarget = pso.BlendTarget;
-// export const BlendState = pso.BlendState;
-// export const RasterizerState = pso.RasterizerState;
-// export const DepthStencilState = pso.DepthStencilState;
-// export const PipelineState = pso.PipelineState;
-// export const PipelineStateInfo = pso.PipelineStateInfo;
-
 polyfillCC.BlendTarget = pso.BlendTarget;
 polyfillCC.BlendState = pso.BlendState;
 polyfillCC.RasterizerState = pso.RasterizerState;

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -504,22 +504,22 @@ bool Object::isTypedArray() const {
 Object::TypedArrayType Object::getTypedArrayType() const {
     v8::Local<v8::Value> value = const_cast<Object *>(this)->_obj.handle(__isolate);
     TypedArrayType ret = TypedArrayType::NONE;
-    if (value->IsInt8Array()) {
-        ret = TypedArrayType::INT8;
-    } else if (value->IsInt16Array()) {
-        ret = TypedArrayType::INT16;
-    } else if (value->IsInt32Array()) {
-        ret = TypedArrayType::INT32;
-    } else if (value->IsUint8Array()) {
-        ret = TypedArrayType::UINT8;
-    } else if (value->IsUint8ClampedArray()) {
-        ret = TypedArrayType::UINT8_CLAMPED;
-    } else if (value->IsUint16Array()) {
-        ret = TypedArrayType::UINT16;
+    if (value->IsFloat32Array()) {
+        ret = TypedArrayType::FLOAT32;
     } else if (value->IsUint32Array()) {
         ret = TypedArrayType::UINT32;
-    } else if (value->IsFloat32Array()) {
-        ret = TypedArrayType::FLOAT32;
+    } else if (value->IsUint16Array()) {
+        ret = TypedArrayType::UINT16;
+    } else if (value->IsUint8Array()) {
+        ret = TypedArrayType::UINT8;
+    } else if (value->IsInt32Array()) {
+        ret = TypedArrayType::INT32;
+    } else if (value->IsInt16Array()) {
+        ret = TypedArrayType::INT16;
+    } else if (value->IsInt8Array()) {
+        ret = TypedArrayType::INT8;
+    } else if (value->IsUint8ClampedArray()) {
+        ret = TypedArrayType::UINT8_CLAMPED;
     } else if (value->IsFloat64Array()) {
         ret = TypedArrayType::FLOAT64;
     }

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -694,29 +694,8 @@ bool Object::getArrayLength(uint32_t *length) const {
     CC_ASSERT(length != nullptr);
     auto *thiz = const_cast<Object *>(this);
 
-    v8::MaybeLocal<v8::String> lengthStr = ScriptEngine::getInstance()->_getStringPool().get(__isolate, "length");
-    if (lengthStr.IsEmpty()) {
-        *length = 0;
-        return false;
-    }
-    v8::Local<v8::Context> context = __isolate->GetCurrentContext();
-
-    v8::MaybeLocal<v8::Value> val = thiz->_obj.handle(__isolate)->Get(context, lengthStr.ToLocalChecked());
-    if (val.IsEmpty()) {
-        return false;
-    }
-
-    v8::MaybeLocal<v8::Object> obj = val.ToLocalChecked()->ToObject(context);
-    if (obj.IsEmpty()) {
-        return false;
-    }
-
-    v8::Maybe<uint32_t> mbLen = obj.ToLocalChecked()->Uint32Value(context);
-    if (mbLen.IsNothing()) {
-        return false;
-    }
-
-    *length = mbLen.FromJust();
+    v8::Local<v8::Array> v8Arr = v8::Local<v8::Array>::Cast(thiz->_obj.handle(__isolate));
+    *length = v8Arr->Length();
     return true;
 }
 

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -868,11 +868,11 @@ static bool js_Model_setInstancedAttribute(se::State &s) // NOLINT(readability-i
                 val.toObject()->getArrayLength(&len);
 
                 se::Value dataVal;
-                ccstd::array<float, 32> stackData;
+                ccstd::array<float, 64> stackData;
                 float *pData = nullptr;
                 bool needFree = false;
 
-                if (len <= 32) {
+                if (len <= static_cast<uint32_t>(stackData.size())) {
                     pData = stackData.data();
                 } else {
                     pData = static_cast<float *>(CC_MALLOC(len));

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -876,6 +876,7 @@ static bool js_Model_setInstancedAttribute(se::State &s) // NOLINT(readability-i
                     pData = stackData.data();
                 } else {
                     pData = static_cast<float *>(CC_MALLOC(len));
+                    needFree = true;
                 }
 
                 for (uint32_t i = 0; i < len; ++i) {

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -900,7 +900,7 @@ static bool js_Model_setInstancedAttribute(se::State &s) // NOLINT(readability-i
                         uint8_t *data = nullptr;
                         size_t byteLength = 0;
                         if (val.toObject()->getTypedArrayData(&data, &byteLength) && data != nullptr && byteLength > 0) {
-                            cobj->setInstancedAttribute(name, reinterpret_cast<const float *>(data), byteLength);
+                            cobj->setInstancedAttribute(name, reinterpret_cast<const float *>(data), static_cast<uint32_t>(byteLength));
                         }
                     } break;
 

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -848,11 +848,11 @@ static bool js_scene_RenderScene_root_getter(se::State &s) { // NOLINT(readabili
 }
 SE_BIND_PROP_GET(js_scene_RenderScene_root_getter)
 
-static bool js_Model_setInstancedAttribute(se::State& s) // NOLINT(readability-identifier-naming)
+static bool js_Model_setInstancedAttribute(se::State &s) // NOLINT(readability-identifier-naming)
 {
     auto *cobj = SE_THIS_OBJECT<cc::scene::Model>(s);
     SE_PRECONDITION2(cobj, false, "js_Model_setInstancedAttribute : Invalid Native Object");
-    const auto& args = s.args();
+    const auto &args = s.args();
     size_t argc = args.size();
     auto *thiz = s.thisObject();
     CC_UNUSED bool ok = true;
@@ -861,7 +861,7 @@ static bool js_Model_setInstancedAttribute(se::State& s) // NOLINT(readability-i
         ok &= sevalue_to_native(args[0], &name, s.thisObject());
         SE_PRECONDITION2(ok, false, "js_Model_setInstancedAttribute : Error processing arguments");
 
-        auto& val = args[1];
+        auto &val = args[1];
         if (val.isObject()) {
             if (val.toObject()->isArray()) {
                 uint32_t len = 0;
@@ -875,7 +875,7 @@ static bool js_Model_setInstancedAttribute(se::State& s) // NOLINT(readability-i
                 if (len <= 32) {
                     pData = stackData.data();
                 } else {
-                    pData = static_cast<float*>(CC_MALLOC(len));
+                    pData = static_cast<float *>(CC_MALLOC(len));
                 }
 
                 for (uint32_t i = 0; i < len; ++i) {
@@ -893,15 +893,13 @@ static bool js_Model_setInstancedAttribute(se::State& s) // NOLINT(readability-i
             } else if (val.toObject()->isTypedArray()) {
                 se::Object::TypedArrayType type = val.toObject()->getTypedArrayType();
                 switch (type) {
-                    case se::Object::TypedArrayType::FLOAT32:
-                    {
+                    case se::Object::TypedArrayType::FLOAT32: {
                         uint8_t *data = nullptr;
                         size_t byteLength = 0;
                         if (val.toObject()->getTypedArrayData(&data, &byteLength) && data != nullptr && byteLength > 0) {
-                            cobj->setInstancedAttribute(name, reinterpret_cast<const float*>(data), byteLength);
+                            cobj->setInstancedAttribute(name, reinterpret_cast<const float *>(data), byteLength);
                         }
-                    }
-                        break;
+                    } break;
 
                     default:
                         // FIXME:

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -848,6 +848,78 @@ static bool js_scene_RenderScene_root_getter(se::State &s) { // NOLINT(readabili
 }
 SE_BIND_PROP_GET(js_scene_RenderScene_root_getter)
 
+static bool js_Model_setInstancedAttribute(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto *cobj = SE_THIS_OBJECT<cc::scene::Model>(s);
+    SE_PRECONDITION2(cobj, false, "js_Model_setInstancedAttribute : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    auto *thiz = s.thisObject();
+    CC_UNUSED bool ok = true;
+    if (argc == 2) {
+        ccstd::string name;
+        ok &= sevalue_to_native(args[0], &name, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_Model_setInstancedAttribute : Error processing arguments");
+
+        auto& val = args[1];
+        if (val.isObject()) {
+            if (val.toObject()->isArray()) {
+                uint32_t len = 0;
+                val.toObject()->getArrayLength(&len);
+
+                se::Value dataVal;
+                ccstd::array<float, 32> stackData;
+                float *pData = nullptr;
+                bool needFree = false;
+
+                if (len <= 32) {
+                    pData = stackData.data();
+                } else {
+                    pData = static_cast<float*>(CC_MALLOC(len));
+                }
+
+                for (uint32_t i = 0; i < len; ++i) {
+                    ok = val.toObject()->getArrayElement(i, &dataVal);
+                    CC_ASSERT(ok && dataVal.isNumber());
+                    pData[i] = dataVal.toFloat();
+                }
+
+                cobj->setInstancedAttribute(name, pData, len * sizeof(float));
+
+                if (needFree) {
+                    CC_FREE(pData);
+                }
+                return true;
+            } else if (val.toObject()->isTypedArray()) {
+                se::Object::TypedArrayType type = val.toObject()->getTypedArrayType();
+                switch (type) {
+                    case se::Object::TypedArrayType::FLOAT32:
+                    {
+                        uint8_t *data = nullptr;
+                        size_t byteLength = 0;
+                        if (val.toObject()->getTypedArrayData(&data, &byteLength) && data != nullptr && byteLength > 0) {
+                            cobj->setInstancedAttribute(name, reinterpret_cast<const float*>(data), byteLength);
+                        }
+                    }
+                        break;
+
+                    default:
+                        // FIXME:
+                        CC_ASSERT(false); // NOLINT
+                        break;
+                }
+                return true;
+            }
+        }
+
+        SE_REPORT_ERROR("js_Model_setInstancedAttribute : Error processing arguments");
+        return false;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_Model_setInstancedAttribute)
+
 static bool js_Model_registerListeners(se::State &s) // NOLINT(readability-identifier-naming)
 {
     auto *cobj = SE_THIS_OBJECT<cc::scene::Model>(s);
@@ -995,6 +1067,8 @@ bool register_all_scene_manual(se::Object *obj) // NOLINT(readability-identifier
     __jsb_cc_scene_Pass_proto->defineProperty("blocks", _SE(js_scene_Pass_blocks_getter), nullptr);
 
     __jsb_cc_scene_RenderScene_proto->defineProperty("root", _SE(js_scene_RenderScene_root_getter), nullptr);
+
+    __jsb_cc_scene_Model_proto->defineFunction("_setInstancedAttribute", _SE(js_Model_setInstancedAttribute));
 
     __jsb_cc_scene_Model_proto->defineFunction("_registerListeners", _SE(js_Model_registerListeners));
     __jsb_cc_MaterialInstance_proto->defineFunction("_registerListeners", _SE(js_assets_MaterialInstance_registerListeners));

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -861,7 +861,7 @@ static bool js_Model_setInstancedAttribute(se::State &s) // NOLINT(readability-i
         ok &= sevalue_to_native(args[0], &name, s.thisObject());
         SE_PRECONDITION2(ok, false, "js_Model_setInstancedAttribute : Error processing arguments");
 
-        auto &val = args[1];
+        const auto &val = args[1];
         if (val.isObject()) {
             if (val.toObject()->isArray()) {
                 uint32_t len = 0;
@@ -891,7 +891,9 @@ static bool js_Model_setInstancedAttribute(se::State &s) // NOLINT(readability-i
                     CC_FREE(pData);
                 }
                 return true;
-            } else if (val.toObject()->isTypedArray()) {
+            }
+
+            if (val.toObject()->isTypedArray()) {
                 se::Object::TypedArrayType type = val.toObject()->getTypedArrayType();
                 switch (type) {
                     case se::Object::TypedArrayType::FLOAT32: {

--- a/native/cocos/renderer/pipeline/InstancedBuffer.cpp
+++ b/native/cocos/renderer/pipeline/InstancedBuffer.cpp
@@ -130,7 +130,7 @@ void InstancedBuffer::merge(const scene::Model *model, const scene::SubModel *su
         static_cast<uint>(stride),
     });
 
-    const auto& instancedAttributes = model->getInstanceAttributes();
+    const auto &instancedAttributes = model->getInstanceAttributes();
     auto vertexBuffers = sourceIA->getVertexBuffers();
     auto attributes = sourceIA->getAttributes();
     auto *indexBuffer = sourceIA->getIndexBuffer();

--- a/native/cocos/renderer/pipeline/InstancedBuffer.cpp
+++ b/native/cocos/renderer/pipeline/InstancedBuffer.cpp
@@ -130,11 +130,13 @@ void InstancedBuffer::merge(const scene::Model *model, const scene::SubModel *su
         static_cast<uint>(stride),
     });
 
+    const auto& instancedAttributes = model->getInstanceAttributes();
     auto vertexBuffers = sourceIA->getVertexBuffers();
     auto attributes = sourceIA->getAttributes();
     auto *indexBuffer = sourceIA->getIndexBuffer();
 
-    for (const auto &attribute : model->getInstanceAttributes()) {
+    attributes.reserve(instancedAttributes.size());
+    for (const auto &attribute : instancedAttributes) {
         attributes.emplace_back(gfx::Attribute{
             attribute.name,
             attribute.format,

--- a/native/cocos/scene/Model.cpp
+++ b/native/cocos/scene/Model.cpp
@@ -427,6 +427,9 @@ void Model::updateInstancedAttributes(const ccstd::vector<gfx::Attribute> &attri
     attrs.buffer = Uint8Array(size);
     attrs.views.clear();
     attrs.attributes.clear();
+    attrs.views.reserve(attributes.size());
+    attrs.attributes.reserve(attributes.size());
+
     uint32_t offset = 0;
 
     for (const gfx::Attribute &attribute : attributes) {

--- a/native/cocos/scene/Model.cpp
+++ b/native/cocos/scene/Model.cpp
@@ -511,5 +511,40 @@ void Model::updateLocalShadowBias() {
     _localDataUpdated = true;
 }
 
+void Model::setInstancedAttribute(const ccstd::string& name, const float* value, uint32_t byteLength) {
+    const auto& attributes = getInstancedAttributeBlock().attributes;
+    auto& views = getInstancedAttributeBlock().views;
+
+    for (size_t i = 0, len = attributes.size(); i < len; ++i) {
+        const auto& attribute = attributes[i];
+        if (attribute.name == name) {
+            const auto& info = gfx::GFX_FORMAT_INFOS[static_cast<uint32_t>(attribute.format)];
+            switch (info.type) {
+                case gfx::FormatType::NONE:
+                case gfx::FormatType::UNORM:
+                case gfx::FormatType::SNORM:
+                case gfx::FormatType::UINT:
+                case gfx::FormatType::INT:
+                {
+                    CC_ASSERT(false); // NOLINT
+                }
+                    break;
+                case gfx::FormatType::FLOAT:
+                case gfx::FormatType::UFLOAT:
+                {
+                    CC_ASSERT(ccstd::holds_alternative<Float32Array>(views[i]));
+                    auto& view = ccstd::get<Float32Array>(views[i]);
+                    float *dstData = reinterpret_cast<float*>(view.buffer()->getData() + view.byteOffset());
+                    CC_ASSERT(byteLength <= view.byteLength());
+                    memcpy(dstData, value, byteLength);
+                }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+
 } // namespace scene
 } // namespace cc

--- a/native/cocos/scene/Model.cpp
+++ b/native/cocos/scene/Model.cpp
@@ -511,34 +511,30 @@ void Model::updateLocalShadowBias() {
     _localDataUpdated = true;
 }
 
-void Model::setInstancedAttribute(const ccstd::string& name, const float* value, uint32_t byteLength) {
-    const auto& attributes = getInstancedAttributeBlock().attributes;
-    auto& views = getInstancedAttributeBlock().views;
+void Model::setInstancedAttribute(const ccstd::string &name, const float *value, uint32_t byteLength) {
+    const auto &attributes = getInstancedAttributeBlock().attributes;
+    auto &views = getInstancedAttributeBlock().views;
 
     for (size_t i = 0, len = attributes.size(); i < len; ++i) {
-        const auto& attribute = attributes[i];
+        const auto &attribute = attributes[i];
         if (attribute.name == name) {
-            const auto& info = gfx::GFX_FORMAT_INFOS[static_cast<uint32_t>(attribute.format)];
+            const auto &info = gfx::GFX_FORMAT_INFOS[static_cast<uint32_t>(attribute.format)];
             switch (info.type) {
                 case gfx::FormatType::NONE:
                 case gfx::FormatType::UNORM:
                 case gfx::FormatType::SNORM:
                 case gfx::FormatType::UINT:
-                case gfx::FormatType::INT:
-                {
+                case gfx::FormatType::INT: {
                     CC_ASSERT(false); // NOLINT
-                }
-                    break;
+                } break;
                 case gfx::FormatType::FLOAT:
-                case gfx::FormatType::UFLOAT:
-                {
+                case gfx::FormatType::UFLOAT: {
                     CC_ASSERT(ccstd::holds_alternative<Float32Array>(views[i]));
-                    auto& view = ccstd::get<Float32Array>(views[i]);
-                    float *dstData = reinterpret_cast<float*>(view.buffer()->getData() + view.byteOffset());
+                    auto &view = ccstd::get<Float32Array>(views[i]);
+                    float *dstData = reinterpret_cast<float *>(view.buffer()->getData() + view.byteOffset());
                     CC_ASSERT(byteLength <= view.byteLength());
                     memcpy(dstData, value, byteLength);
-                }
-                    break;
+                } break;
                 default:
                     break;
             }

--- a/native/cocos/scene/Model.cpp
+++ b/native/cocos/scene/Model.cpp
@@ -534,7 +534,7 @@ void Model::setInstancedAttribute(const ccstd::string &name, const float *value,
                 case gfx::FormatType::UFLOAT: {
                     CC_ASSERT(ccstd::holds_alternative<Float32Array>(views[i]));
                     auto &view = ccstd::get<Float32Array>(views[i]);
-                    float *dstData = reinterpret_cast<float *>(view.buffer()->getData() + view.byteOffset());
+                    auto *dstData = reinterpret_cast<float *>(view.buffer()->getData() + view.byteOffset());
                     CC_ASSERT(byteLength <= view.byteLength());
                     memcpy(dstData, value, byteLength);
                 } break;

--- a/native/cocos/scene/Model.h
+++ b/native/cocos/scene/Model.h
@@ -184,6 +184,8 @@ public:
     inline void setModelBounds(geometry::AABB *bounds) { _modelBounds = bounds; }
     inline bool isModelImplementedInJS() const { return (_type != Type::DEFAULT && _type != Type::SKINNING && _type != Type::BAKED_SKINNING); };
 
+    void setInstancedAttribute(const ccstd::string& name, const float* value, uint32_t byteLength);
+
 protected:
     static void uploadMat4AsVec4x3(const Mat4 &mat, Float32Array &v1, Float32Array &v2, Float32Array &v3);
 

--- a/native/cocos/scene/Model.h
+++ b/native/cocos/scene/Model.h
@@ -184,7 +184,7 @@ public:
     inline void setModelBounds(geometry::AABB *bounds) { _modelBounds = bounds; }
     inline bool isModelImplementedInJS() const { return (_type != Type::DEFAULT && _type != Type::SKINNING && _type != Type::BAKED_SKINNING); };
 
-    void setInstancedAttribute(const ccstd::string& name, const float* value, uint32_t byteLength);
+    void setInstancedAttribute(const ccstd::string &name, const float *value, uint32_t byteLength);
 
 protected:
     static void uploadMat4AsVec4x3(const Mat4 &mat, Float32Array &v1, Float32Array &v2, Float32Array &v3);


### PR DESCRIPTION
* Fix wrong path of pipeline-state.ts in cc.config.json which causes pipeline-state.jsb.ts takes no effect.  https://github.com/cocos/cocos-engine/pull/11165  
* Optimize MeshRenderer.setInstancedAttribute for native. Avoid to generate temporary JSB objects.
* Optimize se::Object::getArrayLength.
* Reorder typedarray type in Object::getTypedArrayType, check Float32Array first since we use Float32Array and unsigned integer much more frequently.
* More std::vector.reserve in InstancedBuffer.cpp & Model.cpp

### Changelog

-------

### Continuous Integration

This pull request:

* [X] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
