### PR TITLE
V3.5.2 CI Android NDK  set version to 21 (#11448) (#11492)

### DIFF
--- a/.github/workflows/native-bindings.yml
+++ b/.github/workflows/native-bindings.yml
@@ -15,8 +15,14 @@ jobs:
           EXT_VERSION=`grep version native/external-config.json  |awk -F'"' '{print $4}'`
           git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos-creator/engine-native-external native/external
           rm -rf native/external/.git
-
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Run genbindings.py
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python3 -m pip install PyYAML==5.4.1 Cheetah3
           python3 ./native/tools/tojs/genbindings.py

--- a/.github/workflows/native-compile-linux.yml
+++ b/.github/workflows/native-compile-linux.yml
@@ -13,7 +13,14 @@ jobs:
         run: |
           EXT_VERSION=`grep version native/external-config.json  |awk -F'"' '{print $4}'`
           git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos-creator/engine-native-external native/external
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate bindings
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python3 -m pip install PyYAML==5.4.1 Cheetah3
           python3 ./native/tools/tojs/genbindings.py

--- a/.github/workflows/native-compile-platforms.yml
+++ b/.github/workflows/native-compile-platforms.yml
@@ -22,8 +22,15 @@ jobs:
         run: |
           choco install --forcex86 vulkan-sdk
           python -m pip install PyYAML==5.4.1 Cheetah3
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate bindings
         shell: bash
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python -V
           cd ./native/tools/tojs
@@ -63,7 +70,14 @@ jobs:
         run: |
           EXT_VERSION=`grep version native/external-config.json  |awk -F'"' '{print $4}'`
           git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos-creator/engine-native-external native/external
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate bindings
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python3 -m pip install PyYAML==5.4.1 Cheetah3
           python3 ./native/tools/tojs/genbindings.py
@@ -123,7 +137,14 @@ jobs:
         run: |
           EXT_VERSION=`grep version native/external-config.json  |awk -F'"' '{print $4}'`
           git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos-creator/engine-native-external native/external
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate bindings
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python -m pip install PyYAML==5.4.1 Cheetah3
           python ./native/tools/tojs/genbindings.py
@@ -176,7 +197,14 @@ jobs:
         run: |
           EXT_VERSION=`grep version native/external-config.json  |awk -F'"' '{print $4}'`
           git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos-creator/engine-native-external native/external
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate bindings
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python -m pip install PyYAML==5.4.1 Cheetah3
           python ./native/tools/tojs/genbindings.py
@@ -230,7 +258,14 @@ jobs:
         run: |
           EXT_VERSION=`grep version native/external-config.json  |awk -F'"' '{print $4}'`
           git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos-creator/engine-native-external native/external
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate bindings
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python -m pip install PyYAML==5.4.1  Cheetah3
           python ./native/tools/tojs/genbindings.py

--- a/.github/workflows/native-linter-android.yml
+++ b/.github/workflows/native-linter-android.yml
@@ -28,9 +28,16 @@ jobs:
         run: |
           EXT_VERSION=`grep version native/external-config.json  |awk -F'"' '{print $4}'`
           git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos-creator/engine-native-external native/external
-
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate bindings
         shell: bash
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+
         run: |
           python -V
           cd ./native/tools/tojs

--- a/.github/workflows/native-simulator.yml
+++ b/.github/workflows/native-simulator.yml
@@ -29,11 +29,18 @@ jobs:
       - name: install vulkan-sdk
         run: |
           choco install vulkan-sdk
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: pip install
         run: |
           python -m pip install PyYAML==5.4.1 Cheetah3
       - name: generate bindings glue codes
         shell: bash
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python -V
           cd ./tools/tojs

--- a/.github/workflows/native-unit-test.yml
+++ b/.github/workflows/native-unit-test.yml
@@ -20,9 +20,15 @@ jobs:
           npm install
           npm install gulp -g
           node ./utils/download-deps.js
-
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate bindings
         shell: bash
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python -m pip install PyYAML==5.4.1 Cheetah3
           python ./tools/tojs/genbindings.py


### PR DESCRIPTION
Re: #

### Changelog

* Specify NDK version in CI

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
