### PR TITLE
3.6 fix inspector on android target sdk 30+

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/debugger/inspector_socket_server.cpp
+++ b/native/cocos/bindings/jswrapper/v8/debugger/inspector_socket_server.cpp
@@ -120,7 +120,7 @@ void PrintDebuggerReadyMessage(const std::string &host,
             SE_LOGE("failed to get addresses %s\n", strerror(errno));
         }
 
-        printf("Number of interfaces: %d\n", count);
+        SE_LOGD("Number of interfaces: %d\n", count);
         while (i--) {
             auto &network_interface = info[i];
 
@@ -130,6 +130,13 @@ void PrintDebuggerReadyMessage(const std::string &host,
             }
         }
         uv_free_interface_addresses(info, count);
+    }
+    // failed to query device interfaces,
+    if (ipList.empty()) {
+    #if ANDROID
+        SE_LOGD("Please query IP by running the following command in terminal: adb shell ip -4 -br addr\n");
+    #endif
+        ipList.emplace_back("none", false, "IP_ADDR_OF_THIS_DEVICE");
     }
 
     for (const std::string &id : ids) {

--- a/native/cocos/bindings/manual/jsb_global_init.cpp
+++ b/native/cocos/bindings/manual/jsb_global_init.cpp
@@ -81,9 +81,7 @@ static int selectPort(int port) {
         uv_interface_addresses(&info, &count);
         if (count == 0) {
             SE_LOGE("Failed to accquire interfaces, error: %s\n Re-select port after 37000", strerror(errno));
-            //  cat /proc/sys/net/ipv4/ip_local_port_range
-            //  37000   50000
-            startPort = 37000 + port % 1000;
+            startPort = 37000 + port;
         }
         if (info) {
             uv_free_interface_addresses(info, count);

--- a/native/cocos/bindings/manual/jsb_global_init.cpp
+++ b/native/cocos/bindings/manual/jsb_global_init.cpp
@@ -74,14 +74,15 @@ static int selectPort(int port) {
     int tryTimes = 200;
     int startPort = port;
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-    if (startPort < 37000) {
+    constexpr int localPortMin = 37000; // query from /proc/sys/net/ipv4/ip_local_port_range
+    if (startPort < localPortMin) {
         uv_interface_address_t *info = nullptr;
         int count = 0;
 
         uv_interface_addresses(&info, &count);
         if (count == 0) {
             SE_LOGE("Failed to accquire interfaces, error: %s\n Re-select port after 37000", strerror(errno));
-            startPort = 37000 + port;
+            startPort = localPortMin + port;
         }
         if (info) {
             uv_free_interface_addresses(info, count);


### PR DESCRIPTION
When setting Android target API level >= 30, v8 inspector may failed to query interface & bind low port number.


### Changelog

* Add log when failed to query network interface / device ip.
* Re select port greater than 37000

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
