### PR TITLE
Animation graph negative speed

### DIFF
--- a/cocos/core/animation/marionette/graph-eval.ts
+++ b/cocos/core/animation/marionette/graph-eval.ts
@@ -232,8 +232,13 @@ export interface MotionStateStatus {
     /**
      * @en
      * The normalized time of the state.
+     * It would be `elapsed-time / duration` if elapsed time is non-negative,
+     * and would be `(elapsed-time / duration) + 1.0` otherwise.
+     * This is **NOT** the clip's progress if the state is not a clip motion or its wrap mode isn't loop.
      * @zh
-     * 状态的规范化进度。
+     * 状态的规范化时间。
+     * 如果流逝的时间是非负的，它就是 `流逝时间 / 周期`；否则，它是 `(流逝时间 / 周期) + 1.0`。
+     * 它并不一定代表剪辑的进度，因为该状态可能并不是一个剪辑动作，或者它的循环模式并非循环。
      */
     progress: number;
 }
@@ -1335,7 +1340,8 @@ function calcProgressUpdate (currentProgress: number, duration: number, deltaTim
 }
 
 function normalizeProgress (progress: number) {
-    return progress - Math.trunc(progress);
+    const signedFrac = progress - Math.trunc(progress);
+    return signedFrac >= 0.0 ? signedFrac : (1.0 + signedFrac);
 }
 
 interface MotionEvalPort {

--- a/cocos/core/animation/marionette/graph-eval.ts
+++ b/cocos/core/animation/marionette/graph-eval.ts
@@ -232,12 +232,12 @@ export interface MotionStateStatus {
     /**
      * @en
      * The normalized time of the state.
-     * It would be `elapsed-time / duration` if elapsed time is non-negative,
-     * and would be `(elapsed-time / duration) + 1.0` otherwise.
+     * It would be the fraction part of `elapsed-time / duration` if elapsed time is non-negative,
+     * and would be 1 plus the fraction part of `(elapsed-time / duration)` otherwise.
      * This is **NOT** the clip's progress if the state is not a clip motion or its wrap mode isn't loop.
      * @zh
      * 状态的规范化时间。
-     * 如果流逝的时间是非负的，它就是 `流逝时间 / 周期`；否则，它是 `(流逝时间 / 周期) + 1.0`。
+     * 如果流逝的时间是非负的，它就是 `流逝时间 / 周期` 的小数部分；否则，它是 `(流逝时间 / 周期)` 的小数部分加 1。
      * 它并不一定代表剪辑的进度，因为该状态可能并不是一个剪辑动作，或者它的循环模式并非循环。
      */
     progress: number;


### PR DESCRIPTION
This resolves #11159.

### Changelog

* This PR formally authorizes the usage of negative motion speed in animation graphs, from both motion speed constant, and motion speed multiplier.

We support negative speed as is since the borning of animation graph but I had not reviewed that behaviour before. I have now added some unit tests on this and defined what `MotionStateStatus.progress` should be if the motion has a negative speed.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
