### PR TITLE
Animation graph transition priority

### DIFF
--- a/cocos/core/animation/marionette/animation-graph.ts
+++ b/cocos/core/animation/marionette/animation-graph.ts
@@ -18,6 +18,7 @@ import { move } from '../../algorithm/move';
 import { onAfterDeserializedTag } from '../../data/deserialize-symbols';
 import { CLASS_NAME_PREFIX_ANIM } from '../define';
 import { StateMachineComponent } from './state-machine-component';
+import { clamp } from '../../math';
 
 export { State };
 
@@ -225,9 +226,12 @@ export class StateMachine extends EditorExtendable {
     }
 
     /**
-     * Gets all outgoing transitions of specified state.
-     * @param to The state.
-     * @returns Result transitions.
+     * @en
+     * Gets all transitions outgoing from specified state.
+     * @zh
+     * 获取从指定状态引出的所有过渡。
+     * @param from @en The state. @zh 指定状态。
+     * @returns @en Iterable to result transitions, in priority order. @zh 到结果过渡的迭代器，按优先级顺序。
      */
     public getOutgoings (from: State): Iterable<Transition> {
         assertsOwnedBy(from, this);
@@ -421,6 +425,46 @@ export class StateMachine extends EditorExtendable {
     public eraseTransitionsIncludes (state: State) {
         this.eraseIncomings(state);
         this.eraseOutgoings(state);
+    }
+
+    /**
+     * @en
+     * Adjusts the priority of a transition.
+     *
+     * To demonstrate, one can imagine a transition array sorted by their priority.
+     * - If `diff` is zero, nothing's gonna happen.
+     * - Negative `diff` raises the priority:
+     *   `diff` number of transitions originally having higher priority than `adjusting`
+     *   will then have lower priority than `adjusting`.
+     * - Positive `diff` reduce the priority:
+     *   `|diff|` number of transitions originally having lower priority than `adjusting`
+     *   will then have higher priority than `adjusting`.
+     *
+     * If the number of transitions indicated by `diff`
+     * is more than the actual one, the actual number would be taken.
+     * @zh
+     * 调整过渡的优先级。
+     *
+     * 为了说明，可以想象一个由优先级排序的过渡数组。
+     * - 如果 `diff` 是 0，无事发生。
+     * - 负的 `diff` 会提升该过渡的优先级：原本优先于 `adjusting` 的 `diff` 条过渡的优先级会设置为低于 `adjusting`。
+     * - 正的 `diff` 会降低该过渡的优先级：原本优先级低于 `adjusting` 的 `|diff|` 条过渡会设置为优先于 `adjusting`。
+     *
+     * 如果 `diff` 指示的过渡数量比实际多，则会使用实际数量。
+     *
+     * @param adjusting @en The transition to adjust the priority. @zh 需要调整优先级的过渡。
+     * @param diff @en Indicates how to adjust the priority. @zh 指示如何调整优先级。
+     */
+    public adjustTransitionPriority (adjusting: Transition, diff: number) {
+        const { from } = adjusting;
+        if (diff === 0) {
+            return;
+        }
+        const outgoings = from[outgoingsSymbol];
+        const iAdjusting = outgoings.indexOf(adjusting);
+        assertIsTrue(iAdjusting >= 0);
+        const iOver = clamp(iAdjusting + diff, 0, outgoings.length - 1);
+        move(outgoings, iAdjusting, iOver);
     }
 
     public clone () {


### PR DESCRIPTION
### Changelog

* Add an interface to allow editing the priorities of transitions sourced from same state.

This is also a prerequisite for transition interruption, see #11158.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
