### PR TITLE
refine setOnTaskProgress paramaters to avoid error

### DIFF
--- a/native/cocos/network/Downloader-curl.h
+++ b/native/cocos/network/Downloader-curl.h
@@ -39,12 +39,12 @@ struct DownloaderHints;
 
 class DownloaderCURL : public IDownloaderImpl {
 public:
-    DownloaderCURL(const DownloaderHints &hints);
-    virtual ~DownloaderCURL();
+    explicit DownloaderCURL(const DownloaderHints &hints);
+     ~DownloaderCURL() override;
 
-    virtual IDownloadTask *createCoTask(std::shared_ptr<const DownloadTask> &task) override;
+     IDownloadTask *createCoTask(std::shared_ptr<const DownloadTask> &task) override;
 
-    virtual void abort(const std::unique_ptr<IDownloadTask> &task) override;
+     void abort(const std::unique_ptr<IDownloadTask> &task) override;
 
 protected:
     class Impl;
@@ -52,10 +52,10 @@ protected:
 
     // for transfer data on schedule
     DownloadTaskCURL *_currTask; // temp ref
-    std::function<int64_t(void *, int64_t)> _transferDataToBuffer;
+    std::function<uint32_t(void *, uint32_t)> _transferDataToBuffer;
 
     // scheduler for update processing and finished task in main schedule
-    void _onSchedule(float);
+    void onSchedule(float);
     ccstd::string _schedulerKey;
     std::weak_ptr<Scheduler> _scheduler;
 };

--- a/native/cocos/network/Downloader-java.cpp
+++ b/native/cocos/network/Downloader-java.cpp
@@ -207,7 +207,7 @@ void DownloaderJava::abort(const std::unique_ptr<IDownloadTask> &task) {
     DLLOG("DownloaderJava:abort");
 }
 
-void DownloaderJava::onProcessImpl(int taskId, int64_t dl, int64_t dlNow, int64_t dlTotal) {
+void DownloaderJava::onProcessImpl(int taskId, uint32_t dl, uint32_t dlNow, uint32_t dlTotal) {
     DLLOG("DownloaderJava::onProgress(taskId: %d, dl: %lld, dlnow: %lld, dltotal: %lld)", taskId, dl, dlNow, dlTotal);
     auto iter = _taskMap.find(taskId);
     if (_taskMap.end() == iter) {
@@ -215,7 +215,7 @@ void DownloaderJava::onProcessImpl(int taskId, int64_t dl, int64_t dlNow, int64_
         return;
     }
     DownloadTaskAndroid *coTask = iter->second;
-    std::function<int64_t(void *, int64_t)> transferDataToBuffer;
+    std::function<uint32_t(void *, uint32_t)> transferDataToBuffer;
     onTaskProgress(*coTask->task, dl, dlNow, dlTotal, transferDataToBuffer);
 }
 
@@ -250,7 +250,7 @@ JNIEXPORT void JNICALL JNI_DOWNLOADER(nativeOnProgress)(JNIEnv * /*env*/, jclass
             DLLOG("_nativeOnProgress can't find downloader by key: %p for task: %d", clazz, id);
             return;
         }
-        downloader->onProcessImpl((int)taskId, (int64_t)dl, (int64_t)dlnow, (int64_t)dltotal);
+        downloader->onProcessImpl((int)taskId, (uint32_t)dl, (uint32_t)dlnow, (uint32_t)dltotal);
     };
     CC_CURRENT_ENGINE()->getScheduler()->performFunctionInCocosThread(func);
 }

--- a/native/cocos/network/Downloader-java.h
+++ b/native/cocos/network/Downloader-java.h
@@ -45,7 +45,7 @@ public:
     void abort(const std::unique_ptr<IDownloadTask> &task) override;
 
     // designed called by internal
-    void onProcessImpl(int taskId, int64_t dl, int64_t dlNow, int64_t dlTotal);
+    void onProcessImpl(int taskId, uint32_t dl, uint32_t dlNow, uint32_t dlTotal);
     void onFinishImpl(int taskId, int errCode, const char *errStr, const ccstd::vector<unsigned char> &data);
 
 protected:

--- a/native/cocos/network/Downloader-java.h
+++ b/native/cocos/network/Downloader-java.h
@@ -28,7 +28,7 @@
 
 #include "network/DownloaderImpl.h"
 
-class _jobject;
+class _jobject; // NOLINT(bugprone-reserved-identifier)
 
 namespace cc {
 namespace network {

--- a/native/cocos/network/Downloader.cpp
+++ b/native/cocos/network/Downloader.cpp
@@ -73,10 +73,10 @@ Downloader::Downloader(const DownloaderHints &hints) {
     DLLOG("Construct Downloader %p", this);
     _impl = std::make_unique<DownloaderImpl>(hints);
     _impl->onTaskProgress = [this](const DownloadTask &task,
-                                   int64_t bytesReceived,
-                                   int64_t totalBytesReceived,
-                                   int64_t totalBytesExpected,
-                                   std::function<int64_t(void *buffer, int64_t len)> & /*transferDataToBuffer*/) {
+                                   uint32_t bytesReceived,
+                                   uint32_t totalBytesReceived,
+                                   uint32_t totalBytesExpected,
+                                   std::function<uint32_t(void *buffer, uint32_t len)> & /*transferDataToBuffer*/) {
         if (onTaskProgress) {
             onTaskProgress(task, bytesReceived, totalBytesReceived, totalBytesExpected);
         }

--- a/native/cocos/network/Downloader.h
+++ b/native/cocos/network/Downloader.h
@@ -81,9 +81,9 @@ public:
     std::function<void(const DownloadTask &task)> onFileTaskSuccess;
 
     std::function<void(const DownloadTask &task,
-                       int64_t bytesReceived,
-                       int64_t totalBytesReceived,
-                       int64_t totalBytesExpected)>
+                       uint32_t bytesReceived,
+                       uint32_t totalBytesReceived,
+                       uint32_t totalBytesExpected)>
         onTaskProgress;
 
     std::function<void(const DownloadTask &task,
@@ -95,9 +95,9 @@ public:
     void setOnFileTaskSuccess(const std::function<void(const DownloadTask &task)> &callback) { onFileTaskSuccess = callback; };
 
     void setOnTaskProgress(const std::function<void(const DownloadTask &task,
-                                                    int64_t bytesReceived,
-                                                    int64_t totalBytesReceived,
-                                                    int64_t totalBytesExpected)> &callback) { onTaskProgress = callback; };
+                                                    uint32_t bytesReceived,
+                                                    uint32_t totalBytesReceived,
+                                                    uint32_t totalBytesExpected)> &callback) { onTaskProgress = callback; };
 
     void setOnTaskError(const std::function<void(const DownloadTask &task,
                                                  int errorCode,

--- a/native/cocos/network/DownloaderImpl-apple.mm
+++ b/native/cocos/network/DownloaderImpl-apple.mm
@@ -149,8 +149,8 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
 
 - (void)addData:(NSData *)data {
     [_dataArray addObject:data];
-    self.bytesReceived += data.length;
-    self.totalBytesReceived += data.length;
+    self.bytesReceived += static_cast<uint32_t>(data.length);
+    self.totalBytesReceived += static_cast<uint32_t>(data.length);
 }
 
 - (uint32_t)transferDataToBuffer:(void *)buffer lengthOfBuffer:(uint32_t)len {
@@ -567,7 +567,7 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
         _outer->onTaskProgress(*[wrapper get],
                                wrapper.bytesReceived,
                                wrapper.totalBytesReceived,
-                               dataTask.countOfBytesExpectedToReceive,
+                               static_cast<uint32_t>(dataTask.countOfBytesExpectedToReceive),
                                transferDataToBuffer);
     }
 }
@@ -661,9 +661,9 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
 // @optional
 /* Sent periodically to notify the delegate of download progress. */
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask
-                 didWriteData:(uint32_t)bytesWritten
-            totalBytesWritten:(uint32_t)totalBytesWritten
-    totalBytesExpectedToWrite:(uint32_t)totalBytesExpectedToWrite {
+                 didWriteData:(int64_t)bytesWritten
+            totalBytesWritten:(int64_t)totalBytesWritten
+    totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
     //    NSLog(@"DownloaderAppleImpl downloadTask: \"%@\" received: %lld total: %lld", downloadTask.originalRequest.URL, totalBytesWritten, totalBytesExpectedToWrite);
 
     if (nullptr == _outer) {
@@ -673,7 +673,7 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
     DownloadTaskWrapper *wrapper = [self.taskDict objectForKey:downloadTask];
     std::function<uint32_t(void *, uint32_t)> transferDataToBuffer; // just a placeholder
     if (wrapper) {
-        _outer->onTaskProgress(*[wrapper get], bytesWritten, totalBytesWritten, totalBytesExpectedToWrite, transferDataToBuffer);
+        _outer->onTaskProgress(*[wrapper get], static_cast<uint32_t>(bytesWritten), static_cast<uint32_t>(totalBytesWritten), static_cast<uint32_t>(totalBytesExpectedToWrite), transferDataToBuffer);
     }
 }
 
@@ -683,8 +683,8 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
  * data.
  */
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask
-     didResumeAtOffset:(uint32_t)fileOffset
-    expectedTotalBytes:(uint32_t)expectedTotalBytes {
+     didResumeAtOffset:(int64_t)fileOffset
+    expectedTotalBytes:(int64_t)expectedTotalBytes {
     NSLog(@"[REFINE]DownloaderAppleImpl downloadTask: \"%@\" didResumeAtOffset: %lld", downloadTask.originalRequest.URL, fileOffset);
 }
 

--- a/native/cocos/network/DownloaderImpl-apple.mm
+++ b/native/cocos/network/DownloaderImpl-apple.mm
@@ -41,13 +41,13 @@
     NSMutableArray *_dataArray;
 }
 // temp vars for dataTask: didReceivedData callback
-@property (nonatomic) int64_t bytesReceived;
-@property (nonatomic) int64_t totalBytesReceived;
+@property (nonatomic) uint32_t bytesReceived;
+@property (nonatomic) uint32_t totalBytesReceived;
 
 - (id)init:(std::shared_ptr<const cc::network::DownloadTask> &)t;
 - (const cc::network::DownloadTask *)get;
 - (void)addData:(NSData *)data;
-- (int64_t)transferDataToBuffer:(void *)buffer lengthOfBuffer:(int64_t)len;
+- (uint32_t)transferDataToBuffer:(void *)buffer lengthOfBuffer:(uint32_t)len;
 
 @end
 
@@ -153,8 +153,8 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
     self.totalBytesReceived += data.length;
 }
 
-- (int64_t)transferDataToBuffer:(void *)buffer lengthOfBuffer:(int64_t)len {
-    int64_t bytesReceived = 0;
+- (uint32_t)transferDataToBuffer:(void *)buffer lengthOfBuffer:(uint32_t)len {
+    uint32_t bytesReceived = 0;
     int receivedDataObject = 0;
 
     __block char *p = (char *)buffer;
@@ -431,9 +431,9 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
  * information is also available as properties of the task.
  */
 //- (void)URLSession:(NSURLSession *)session task :(NSURLSessionTask *)task
-//                                 didSendBodyData:(int64_t)bytesSent
-//                                  totalBytesSent:(int64_t)totalBytesSent
-//                        totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
+//                                 didSendBodyData:(uint32_t)bytesSent
+//                                  totalBytesSent:(uint32_t)totalBytesSent
+//                        totalBytesExpectedToSend:(uint32_t)totalBytesExpectedToSend;
 
 /* Sent as the last message related to a specific task.  Error may be
  * nil, which implies that no error occurred and this task is complete.
@@ -466,7 +466,7 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
                 // (for a file download task, callback is called in didFinishDownloadingToURL)
                 ccstd::string errorString;
 
-                const int64_t buflen = [wrapper totalBytesReceived];
+                const uint32_t buflen = [wrapper totalBytesReceived];
                 ccstd::vector<unsigned char> data((size_t)buflen);
                 char *buf = (char *)data.data();
                 [wrapper transferDataToBuffer:buf lengthOfBuffer:buflen];
@@ -558,8 +558,8 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
     DownloadTaskWrapper *wrapper = [self.taskDict objectForKey:dataTask];
     [wrapper addData:data];
 
-    std::function<int64_t(void *, int64_t)> transferDataToBuffer =
-        [wrapper](void *buffer, int64_t bufLen) -> int64_t {
+    std::function<uint32_t(void *, uint32_t)> transferDataToBuffer =
+        [wrapper](void *buffer, uint32_t bufLen) -> uint32_t {
         return [wrapper transferDataToBuffer:buffer lengthOfBuffer:bufLen];
     };
 
@@ -661,9 +661,9 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
 // @optional
 /* Sent periodically to notify the delegate of download progress. */
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask
-                 didWriteData:(int64_t)bytesWritten
-            totalBytesWritten:(int64_t)totalBytesWritten
-    totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
+                 didWriteData:(uint32_t)bytesWritten
+            totalBytesWritten:(uint32_t)totalBytesWritten
+    totalBytesExpectedToWrite:(uint32_t)totalBytesExpectedToWrite {
     //    NSLog(@"DownloaderAppleImpl downloadTask: \"%@\" received: %lld total: %lld", downloadTask.originalRequest.URL, totalBytesWritten, totalBytesExpectedToWrite);
 
     if (nullptr == _outer) {
@@ -671,7 +671,7 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
     }
 
     DownloadTaskWrapper *wrapper = [self.taskDict objectForKey:downloadTask];
-    std::function<int64_t(void *, int64_t)> transferDataToBuffer; // just a placeholder
+    std::function<uint32_t(void *, uint32_t)> transferDataToBuffer; // just a placeholder
     if (wrapper) {
         _outer->onTaskProgress(*[wrapper get], bytesWritten, totalBytesWritten, totalBytesExpectedToWrite, transferDataToBuffer);
     }
@@ -683,8 +683,8 @@ void DownloaderApple::abort(const std::unique_ptr<IDownloadTask> &task) {
  * data.
  */
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask
-     didResumeAtOffset:(int64_t)fileOffset
-    expectedTotalBytes:(int64_t)expectedTotalBytes {
+     didResumeAtOffset:(uint32_t)fileOffset
+    expectedTotalBytes:(uint32_t)expectedTotalBytes {
     NSLog(@"[REFINE]DownloaderAppleImpl downloadTask: \"%@\" didResumeAtOffset: %lld", downloadTask.originalRequest.URL, fileOffset);
 }
 

--- a/native/cocos/network/DownloaderImpl.h
+++ b/native/cocos/network/DownloaderImpl.h
@@ -49,18 +49,18 @@ class DownloadTask;
 
 class CC_DLL IDownloadTask {
 public:
-    virtual ~IDownloadTask() {}
+    virtual ~IDownloadTask() = default;
 };
 
 class IDownloaderImpl {
 public:
-    virtual ~IDownloaderImpl() {}
+    virtual ~IDownloaderImpl() = default;
 
     std::function<void(const DownloadTask &task,
-                       int64_t bytesReceived,
-                       int64_t totalBytesReceived,
-                       int64_t totalBytesExpected,
-                       std::function<int64_t(void *buffer, int64_t len)> &transferDataToBuffer)>
+                       uint32_t bytesReceived,
+                       uint32_t totalBytesReceived,
+                       uint32_t totalBytesExpected,
+                       std::function<uint32_t(void *buffer, uint32_t len)> &transferDataToBuffer)>
         onTaskProgress;
 
     std::function<void(const DownloadTask &task,


### PR DESCRIPTION
refine setOnTaskProgress paramaters from BigInt to Number to avoid error when use in ts script.

Re: #

### Changelog

* 

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
