### PR TITLE
Initialize libcurl's environment interface on the NX platform

### DIFF
--- a/native/cocos/network/Downloader-curl.cpp
+++ b/native/cocos/network/Downloader-curl.cpp
@@ -234,6 +234,18 @@ public:
     //        : _thread(nullptr)
     {
         DLLOG("Construct DownloaderCURL::Impl %p", this);
+        #if (CC_PLATFORM == CC_PLATFORM_NX)
+            // This function is thread-safe since libcurl 7.84.0 if curl_version_info
+            // has the CURL_VERSION_THREADSAFE feature bit set (most platforms).
+            // ref:https://curl.se/libcurl/c/curl_global_init.html
+            
+            // At this time, the version used by NX SDK 15.0.0 is 7.64.1.So this version of the interface inot thread safe
+            // This function sets up the program environment that libcurl needs 
+            CURLcode res = curl_global_init(CURL_GLOBAL_DEFAULT);s 
+            if (res != CURLE_OK) {
+                CC_LOG_ERROR("curl_global_init failed. Err: %d\n\n", res);
+            }
+        #endif
     }
 
     ~Impl() {

--- a/native/cocos/network/Downloader-curl.cpp
+++ b/native/cocos/network/Downloader-curl.cpp
@@ -238,9 +238,6 @@ public:
             // This function is thread-safe since libcurl 7.84.0 if curl_version_info
             // has the CURL_VERSION_THREADSAFE feature bit set (most platforms).
             // ref:https://curl.se/libcurl/c/curl_global_init.html
-            
-            // At this time, the version used by NX SDK 15.0.0 is 7.64.1.So this version of the interface inot thread safe
-            // This function sets up the program environment that libcurl needs 
             CURLcode res = curl_global_init(CURL_GLOBAL_DEFAULT);
             if (res != CURLE_OK) {
                 CC_LOG_ERROR("curl_global_init failed. Err: %d\n\n", res);

--- a/native/cocos/network/Downloader-curl.cpp
+++ b/native/cocos/network/Downloader-curl.cpp
@@ -235,6 +235,9 @@ public:
     {
         DLLOG("Construct DownloaderCURL::Impl %p", this);
         #if (CC_PLATFORM == CC_PLATFORM_NX)
+            // If you don't call curl_global_init to initialize, it will crash on the NX platform, but not on other platforms.
+            // Not sure if it's a problem with using different versions or something else.
+            // 
             // This function is thread-safe since libcurl 7.84.0 if curl_version_info
             // has the CURL_VERSION_THREADSAFE feature bit set (most platforms).
             // ref:https://curl.se/libcurl/c/curl_global_init.html

--- a/native/cocos/network/Downloader-curl.cpp
+++ b/native/cocos/network/Downloader-curl.cpp
@@ -241,7 +241,7 @@ public:
             
             // At this time, the version used by NX SDK 15.0.0 is 7.64.1.So this version of the interface inot thread safe
             // This function sets up the program environment that libcurl needs 
-            CURLcode res = curl_global_init(CURL_GLOBAL_DEFAULT);s 
+            CURLcode res = curl_global_init(CURL_GLOBAL_DEFAULT);
             if (res != CURLE_OK) {
                 CC_LOG_ERROR("curl_global_init failed. Err: %d\n\n", res);
             }


### PR DESCRIPTION
Add curl_global_init to initialize libcurl's environment interface