### PR TITLE
set persist node's hideFlags to DontSave when switch scene

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1623,7 +1623,7 @@ Failed to load prefab asset for node '%s'
 
 ### 3800
 
-The target can not be made persist because it's not a cc.Node or it doesn't have _id property.
+The target can not be made persist because it's not a cc.Node or it doesn't have _id property or it's not in current scene.
 
 ### 3801
 

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1623,7 +1623,7 @@ Failed to load prefab asset for node '%s'
 
 ### 3800
 
-The target can not be made persist because it's not a cc.Node or it doesn't have _id property or it's not in current scene.
+The target can not be made persist because it's not a cc.Node or it doesn't have _id property or it's not in the current scene.
 
 ### 3801
 

--- a/cocos/core/director.ts
+++ b/cocos/core/director.ts
@@ -345,9 +345,13 @@ export class Director extends EventTarget {
             if (existNode) {
                 // scene also contains the persist node, select the old one
                 const index = existNode.getSiblingIndex();
+                // restore to the old saving flag
+                node.hideFlags &= ~CCObject.Flags.DontSave;
+                node.hideFlags |= CCObject.Flags.DontSave & existNode.hideFlags;
                 existNode._destroyImmediate();
                 scene.insertChild(node, index);
             } else {
+                node.hideFlags |= CCObject.Flags.DontSave;
                 // @ts-expect-error insert to new scene
                 node.parent = scene;
             }

--- a/cocos/core/game.ts
+++ b/cocos/core/game.ts
@@ -688,7 +688,7 @@ export class Game extends EventTarget {
      * @param node - The node to be made persistent
      */
     public addPersistRootNode (node: Node) {
-        if (!legacyCC.Node.isNode(node) || !node.uuid) {
+        if (!legacyCC.Node.isNode(node) || !node.uuid || node.scene !== legacyCC.director._scene) {
             debug.warnID(3800);
             return;
         }

--- a/native/cocos/core/builtin/DebugInfos.cpp
+++ b/native/cocos/core/builtin/DebugInfos.cpp
@@ -161,7 +161,7 @@ ccstd::unordered_map<int, ccstd::string> debugInfos = {
 { 3660, "You are explicitly specifying `undefined` type to cc property '%s' of cc class '%s'.\nIs this intended? If not, this may indicate a circular reference.\nFor example:\n\n \n// foo.ts\nimport { _decorator } from 'cc';\nimport { Bar } from './bar';  // Given that './bar' also reference 'foo.ts'.\n                              // When importing './bar', execution of './bar' is hung on to wait execution of 'foo.ts',\n                              // the `Bar` imported here is `undefined` until './bar' finish its execution.\n                              // It leads to that\n@_decorator.ccclass           //  ↓\nexport class Foo {            //  ↓\n    @_decorator.type(Bar)     //  → is equivalent to `@_decorator.type(undefined)`\n    public bar: Bar;          // To eliminate this error, either:\n                              // - Refactor your module structure(recommended), or\n                              // - specify the type as cc class name: `@_decorator.type('Bar'/* or any name you specified for `Bar` */)`\n}" },
 { 3700, "internal error: _prefab is undefined" },
 { 3701, "Failed to load prefab asset for node '%s'" },
-{ 3800, "The target can not be made persist because it's not a cc.Node or it doesn't have _id property." },
+{ 3800, "The target can not be made persist because it's not a cc.Node or it doesn't have _id property or it's not in current scene" },
 { 3801, "The node can not be made persist because it's not under root node." },
 { 3802, "The node can not be made persist because it's not in current scene." },
 { 3803, "The target can not be made persist because it's not a cc.Node or it doesn't have _id property." },

--- a/native/cocos/core/builtin/DebugInfos.cpp
+++ b/native/cocos/core/builtin/DebugInfos.cpp
@@ -161,7 +161,7 @@ ccstd::unordered_map<int, ccstd::string> debugInfos = {
 { 3660, "You are explicitly specifying `undefined` type to cc property '%s' of cc class '%s'.\nIs this intended? If not, this may indicate a circular reference.\nFor example:\n\n \n// foo.ts\nimport { _decorator } from 'cc';\nimport { Bar } from './bar';  // Given that './bar' also reference 'foo.ts'.\n                              // When importing './bar', execution of './bar' is hung on to wait execution of 'foo.ts',\n                              // the `Bar` imported here is `undefined` until './bar' finish its execution.\n                              // It leads to that\n@_decorator.ccclass           //  ↓\nexport class Foo {            //  ↓\n    @_decorator.type(Bar)     //  → is equivalent to `@_decorator.type(undefined)`\n    public bar: Bar;          // To eliminate this error, either:\n                              // - Refactor your module structure(recommended), or\n                              // - specify the type as cc class name: `@_decorator.type('Bar'/* or any name you specified for `Bar` */)`\n}" },
 { 3700, "internal error: _prefab is undefined" },
 { 3701, "Failed to load prefab asset for node '%s'" },
-{ 3800, "The target can not be made persist because it's not a cc.Node or it doesn't have _id property or it's not in current scene" },
+{ 3800, "The target can not be made persist because it's not a cc.Node or it doesn't have _id property or it's not in the current scene" },
 { 3801, "The node can not be made persist because it's not under root node." },
 { 3802, "The node can not be made persist because it's not in current scene." },
 { 3803, "The target can not be made persist because it's not a cc.Node or it doesn't have _id property." },


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12413

### Changelog

* 

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
