### PR TITLE
use reference count to share objects

### DIFF
--- a/native/cocos/base/RefVector.h
+++ b/native/cocos/base/RefVector.h
@@ -224,7 +224,7 @@ public:
         return _data[idx];
     }
 
-    T operator[](uint32_t idx) const {
+    const T&operator[](uint32_t idx) const {
         return _data[idx];
     }
 

--- a/native/cocos/base/RefVector.h
+++ b/native/cocos/base/RefVector.h
@@ -37,7 +37,7 @@
 #include "base/Random.h"
 #include "base/RefCounted.h"
 #include "base/memory/Memory.h"
-#include "core/TypedArray.h"
+#include "base/std/container/vector.h"
 
 namespace cc {
 

--- a/native/cocos/base/RefVector.h
+++ b/native/cocos/base/RefVector.h
@@ -220,6 +220,14 @@ public:
         return *this;
     }
 
+    T &operator[](uint32_t idx) {
+        return _data[idx];
+    }
+
+    T operator[](uint32_t idx) const {
+        return _data[idx];
+    }
+
     /**
      * Requests that the vector capacity be at least enough to contain n elements.
      * @param capacity Minimum capacity requested of the Vector.

--- a/native/cocos/renderer/gfx-base/GFXFramebuffer.cpp
+++ b/native/cocos/renderer/gfx-base/GFXFramebuffer.cpp
@@ -24,6 +24,7 @@
 ****************************************************************************/
 
 #include "GFXFramebuffer.h"
+#include "GFXRenderPass.h"
 #include "GFXTexture.h"
 #include "base/Utils.h"
 

--- a/native/cocos/renderer/gfx-base/GFXFramebuffer.h
+++ b/native/cocos/renderer/gfx-base/GFXFramebuffer.h
@@ -52,7 +52,7 @@ protected:
     virtual void doDestroy() = 0;
 
     IntrusivePtr<RenderPass> _renderPass;
-    // To keep compatibility, so don't use IntrusievePtr.
+    // To keep compatibility, so don't use IntrusivePtr.
     RefVector<Texture *> _colorTextures;
     IntrusivePtr<Texture> _depthStencilTexture;
 };

--- a/native/cocos/renderer/gfx-base/GFXFramebuffer.h
+++ b/native/cocos/renderer/gfx-base/GFXFramebuffer.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include "GFXObject.h"
+#include "base/Ptr.h"
 #include "base/RefCounted.h"
+#include "base/RefVector.h"
 
 namespace cc {
 namespace gfx {
@@ -42,16 +44,17 @@ public:
     void destroy();
 
     inline RenderPass *getRenderPass() const { return _renderPass; }
-    inline const TextureList &getColorTextures() const { return _colorTextures; }
+    inline const TextureList &getColorTextures() const { return _colorTextures.get(); }
     inline Texture *getDepthStencilTexture() const { return _depthStencilTexture; }
 
 protected:
     virtual void doInit(const FramebufferInfo &info) = 0;
     virtual void doDestroy() = 0;
 
-    RenderPass *_renderPass = nullptr;
-    TextureList _colorTextures;
-    Texture *_depthStencilTexture = nullptr;
+    IntrusivePtr<RenderPass> _renderPass;
+    // To keep compatibility, so don't use IntrusievePtr.
+    RefVector<Texture *> _colorTextures;
+    IntrusivePtr<Texture> _depthStencilTexture;
 };
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-gles2/GLES2Framebuffer.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Framebuffer.cpp
@@ -44,7 +44,7 @@ GLES2Framebuffer::~GLES2Framebuffer() {
 
 void GLES2Framebuffer::doInit(const FramebufferInfo & /*info*/) {
     _gpuFBO = ccnew GLES2GPUFramebuffer;
-    _gpuFBO->gpuRenderPass = static_cast<GLES2RenderPass *>(_renderPass)->gpuRenderPass();
+    _gpuFBO->gpuRenderPass = static_cast<GLES2RenderPass *>(_renderPass.get())->gpuRenderPass();
 
     _gpuFBO->gpuColorTextures.resize(_colorTextures.size());
     for (size_t i = 0; i < _colorTextures.size(); ++i) {
@@ -55,7 +55,7 @@ void GLES2Framebuffer::doInit(const FramebufferInfo & /*info*/) {
     }
 
     if (_depthStencilTexture) {
-        auto *depthTexture = static_cast<GLES2Texture *>(_depthStencilTexture);
+        auto *depthTexture = static_cast<GLES2Texture *>(_depthStencilTexture.get());
         _gpuFBO->gpuDepthStencilTexture = depthTexture->gpuTexture();
         _gpuFBO->lodLevel = depthTexture->getViewInfo().baseLevel;
         GLES2Device::getInstance()->framebufferHub()->connect(depthTexture->gpuTexture(), _gpuFBO);
@@ -73,7 +73,7 @@ void GLES2Framebuffer::doDestroy() {
             GLES2Device::getInstance()->framebufferHub()->disengage(colorTexture->gpuTexture(), _gpuFBO);
         }
         if (_depthStencilTexture) {
-            auto *depthTexture = static_cast<GLES2Texture *>(_depthStencilTexture);
+            auto *depthTexture = static_cast<GLES2Texture *>(_depthStencilTexture.get());
             GLES2Device::getInstance()->framebufferHub()->disengage(depthTexture->gpuTexture(), _gpuFBO);
         }
 

--- a/native/cocos/renderer/gfx-gles3/GLES3Framebuffer.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Framebuffer.cpp
@@ -44,7 +44,7 @@ GLES3Framebuffer::~GLES3Framebuffer() {
 
 void GLES3Framebuffer::doInit(const FramebufferInfo & /*info*/) {
     _gpuFBO = ccnew GLES3GPUFramebuffer;
-    _gpuFBO->gpuRenderPass = static_cast<GLES3RenderPass *>(_renderPass)->gpuRenderPass();
+    _gpuFBO->gpuRenderPass = static_cast<GLES3RenderPass *>(_renderPass.get())->gpuRenderPass();
 
     _gpuFBO->gpuColorViews.resize(_colorTextures.size());
     for (size_t i = 0; i < _colorTextures.size(); ++i) {
@@ -54,7 +54,7 @@ void GLES3Framebuffer::doInit(const FramebufferInfo & /*info*/) {
     }
 
     if (_depthStencilTexture) {
-        auto *depthTexture = static_cast<GLES3Texture *>(_depthStencilTexture);
+        auto *depthTexture = static_cast<GLES3Texture *>(_depthStencilTexture.get());
         _gpuFBO->gpuDepthStencilView = depthTexture->gpuTextureView();
         GLES3Device::getInstance()->framebufferHub()->connect(depthTexture->gpuTexture(), _gpuFBO);
     }
@@ -71,7 +71,7 @@ void GLES3Framebuffer::doDestroy() {
             GLES3Device::getInstance()->framebufferHub()->disengage(colorTexture->gpuTexture(), _gpuFBO);
         }
         if (_depthStencilTexture) {
-            auto *depthTexture = static_cast<GLES3Texture *>(_depthStencilTexture);
+            auto *depthTexture = static_cast<GLES3Texture *>(_depthStencilTexture.get());
             GLES3Device::getInstance()->framebufferHub()->disengage(depthTexture->gpuTexture(), _gpuFBO);
         }
 

--- a/native/cocos/renderer/gfx-metal/MTLFramebuffer.mm
+++ b/native/cocos/renderer/gfx-metal/MTLFramebuffer.mm
@@ -50,7 +50,7 @@ void CCMTLFramebuffer::doInit(const FramebufferInfo&) {
     }
 
     if (_depthStencilTexture) {
-        auto* ccTex = static_cast<CCMTLTexture*>(_depthStencilTexture);
+        auto* ccTex = static_cast<CCMTLTexture*>(_depthStencilTexture.get());
         if (ccTex->swapChain()) {
             _swapChain = ccTex->swapChain();
             _isOffscreen = false;

--- a/native/cocos/renderer/gfx-vulkan/VKFramebuffer.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKFramebuffer.cpp
@@ -42,7 +42,7 @@ CCVKFramebuffer::~CCVKFramebuffer() {
 
 void CCVKFramebuffer::doInit(const FramebufferInfo & /*info*/) {
     _gpuFBO = ccnew CCVKGPUFramebuffer;
-    _gpuFBO->gpuRenderPass = static_cast<CCVKRenderPass *>(_renderPass)->gpuRenderPass();
+    _gpuFBO->gpuRenderPass = static_cast<CCVKRenderPass *>(_renderPass.get())->gpuRenderPass();
 
     _gpuFBO->gpuColorViews.resize(_colorTextures.size());
     for (size_t i = 0; i < _colorTextures.size(); ++i) {
@@ -52,7 +52,7 @@ void CCVKFramebuffer::doInit(const FramebufferInfo & /*info*/) {
     }
 
     if (_depthStencilTexture) {
-        auto *depthTex = static_cast<CCVKTexture *>(_depthStencilTexture);
+        auto *depthTex = static_cast<CCVKTexture *>(_depthStencilTexture.get());
         _gpuFBO->gpuDepthStencilView = depthTex->gpuTextureView();
         CCVKDevice::getInstance()->gpuFramebufferHub()->connect(depthTex->gpuTexture(), _gpuFBO);
     }
@@ -68,7 +68,7 @@ void CCVKFramebuffer::doDestroy() {
         }
 
         if (_depthStencilTexture) {
-            auto *depthTex = static_cast<CCVKTexture *>(_depthStencilTexture);
+            auto *depthTex = static_cast<CCVKTexture *>(_depthStencilTexture.get());
             CCVKDevice::getInstance()->gpuFramebufferHub()->disengage(depthTex->gpuTexture(), _gpuFBO);
         }
 

--- a/native/cocos/scene/RenderWindow.h
+++ b/native/cocos/scene/RenderWindow.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "base/Macros.h"
+#include "base/Ptr.h"
 #include "base/RefVector.h"
 #include "base/std/optional.h"
 #include "renderer/gfx-base/GFXDef-common.h"


### PR DESCRIPTION
`render pass/depth stencil texture/color textures` will be shared outside, so use reference count
