### PR TITLE
3.6 bugfix build template replace proj_name

### DIFF
--- a/scripts/native-pack-tool/source/base/default.ts
+++ b/scripts/native-pack-tool/source/base/default.ts
@@ -83,6 +83,10 @@ export abstract class NativePackTool {
     init(params: CocosParams<Object>) {
         this.params = new CocosParams(params);
         this.paths = new Paths(params);
+
+        this.setEnv('NATIVE_DIR', this.paths.platformTemplateDirInPrj);
+        this.setEnv('COMMON_DIR', this.paths.commonDirInPrj);
+        this.setEnv('PROJECT_NAME', this.params.projectName);
     }
 
     protected parseVersion(content: string, key: string, def: number): number {
@@ -352,6 +356,8 @@ export abstract class NativePackTool {
     }
 
     protected async excuteTemplateTask(tasks: CocosProjectTasks) {
+        console.log("------------ excuteTemplateTask");
+        console.log(tasks);
         if (tasks.appendFile) {
             await Promise.all(tasks.appendFile.map((task) => {
                 const dest = cchelper.replaceEnvVariables(task.to);

--- a/scripts/native-pack-tool/source/base/default.ts
+++ b/scripts/native-pack-tool/source/base/default.ts
@@ -356,8 +356,6 @@ export abstract class NativePackTool {
     }
 
     protected async excuteTemplateTask(tasks: CocosProjectTasks) {
-        console.log("------------ excuteTemplateTask");
-        console.log(tasks);
         if (tasks.appendFile) {
             await Promise.all(tasks.appendFile.map((task) => {
                 const dest = cchelper.replaceEnvVariables(task.to);

--- a/scripts/native-pack-tool/source/utils.ts
+++ b/scripts/native-pack-tool/source/utils.ts
@@ -280,6 +280,7 @@ export class cchelper {
     static async replaceInFile(patterns: { reg: string, text: string }[], filepath: string) {
         filepath = this.replaceEnvVariables(filepath);
         if (!fs.existsSync(filepath)) {
+            console.log(`While replace template content, file ${filepath}`);
             return;
         }
         // console.log(`replace ${filepath} with ${JSON.stringify(patterns)}`);


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12707

Missing contents from 

https://github.com/cocos-creator/editor-3d/blob/d35434cbe2fbb03e9fd997cdce0b6f6dab003c9c/app/platforms/internal/native/source/console/pluginNew.ts#L29-L31


### Changelog

* Fix Android App Name

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
