### PR TITLE
The clantidy problem of the android platform

### DIFF
--- a/.github/workflows/native-linter-android.yml
+++ b/.github/workflows/native-linter-android.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Generate Compile database
         shell: bash
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           cd native
           ./utils/generate_compile_commands_android.sh


### PR DESCRIPTION
In 3.6, it was merged by the following PR, because other content was included, so it was added manually
https://github.com/cocos/cocos-engine/pull/11397/files