### PR TITLE
[v3.6] Fix that JS object is not in 'Weak' state if it is unrooted.

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/ObjectWrap.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ObjectWrap.cpp
@@ -64,11 +64,9 @@ ObjectWrap::~ObjectWrap() {
 bool ObjectWrap::init(v8::Local<v8::Object> handle, Object *parent, bool registerWeak) {
     CC_ASSERT(persistent().IsEmpty());
     _parent = parent;
-    _registerWeak = registerWeak;
+    _registerWeakCallback = registerWeak;
     persistent().Reset(v8::Isolate::GetCurrent(), handle);
-    if (_registerWeak) {
-        makeWeak();
-    }
+    makeWeak();
     return true;
 }
 
@@ -114,7 +112,11 @@ void ObjectWrap::makeWeak() {
     // the reason is that kFinalizer will trigger weak callback when some assets are
     // still being used, jsbinding code will get a dead se::Object pointer that was
     // freed by weak callback. According V8 documentation, kParameter is a better option.
-    persistent().SetWeak(_parent, weakCallback, v8::WeakCallbackType::kParameter);
+    if (_registerWeakCallback) {
+        persistent().SetWeak(_parent, weakCallback, v8::WeakCallbackType::kParameter);
+    } else {
+        persistent().SetWeak();
+    }
     //        persistent().MarkIndependent();
 }
 
@@ -128,7 +130,7 @@ void ObjectWrap::unref() {
     CC_ASSERT(!persistent().IsEmpty());
     CC_ASSERT(!persistent().IsWeak());
     CC_ASSERT(_refs > 0);
-    if (--_refs == 0 && _registerWeak) {
+    if (--_refs == 0) {
         makeWeak();
     }
 }

--- a/native/cocos/bindings/jswrapper/v8/ObjectWrap.h
+++ b/native/cocos/bindings/jswrapper/v8/ObjectWrap.h
@@ -97,7 +97,7 @@ private:
     FinalizeFunc _finalizeCb{nullptr};
     Object *_parent{nullptr};
 
-    bool _registerWeak{false};
+    bool _registerWeakCallback{false};
 };
 
 } // namespace se


### PR DESCRIPTION
Without this patch, plain js objects may be leaked.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
