### PR TITLE
dispatch cancel event when node is destroyed while it's being touching

### DIFF
--- a/cocos/core/scene-graph/node-event-processor.ts
+++ b/cocos/core/scene-graph/node-event-processor.ts
@@ -24,7 +24,7 @@
 */
 
 import { CallbacksInvoker } from '../event/callbacks-invoker';
-import { Event, EventMouse, EventTouch } from '../../input/types';
+import { Event, EventMouse, EventTouch, Touch } from '../../input/types';
 import { Vec2 } from '../math/vec2';
 import { BaseNode } from './base-node';
 import { Node } from './node';
@@ -131,6 +131,9 @@ export class NodeEventProcessor {
      */
     public shouldHandleEventTouch = false;
 
+    // Whether dispatch cancel event when node is destroyed.
+    private _dispatchingTouch: Touch | null = null;
+
     private _isEnabled = false;
     private _node: Node;
 
@@ -182,6 +185,13 @@ export class NodeEventProcessor {
         if (this.capturingTarget) this.capturingTarget.clear();
         if (this.bubblingTarget) this.bubblingTarget.clear();
         NodeEventProcessor.callbacksInvoker.emit(DispatcherEventType.REMOVE_POINTER_EVENT_PROCESSOR, this);
+        if (this._dispatchingTouch) {
+            // Dispatch touch cancel event when node is destroyed.
+            const cancelEvent = new EventTouch([this._dispatchingTouch], true, InputEventType.TOUCH_CANCEL);
+            cancelEvent.touch = this._dispatchingTouch;
+            this.dispatchEvent(cancelEvent);
+            this._dispatchingTouch = null;
+        }
     }
 
     public on (type: NodeEventType, callback: AnyFunction, target?: unknown, useCapture?: boolean) {
@@ -591,6 +601,7 @@ export class NodeEventProcessor {
         if (node._uiProps.uiTransformComp.hitTest(pos)) {
             event.type = NodeEventType.TOUCH_START;
             event.bubbles = true;
+            this._dispatchingTouch = event.touch;
             node.dispatchEvent(event);
             return true;
         }
@@ -606,6 +617,7 @@ export class NodeEventProcessor {
 
         event.type = NodeEventType.TOUCH_MOVE;
         event.bubbles = true;
+        this._dispatchingTouch = event.touch;
         node.dispatchEvent(event);
         return true;
     }
@@ -625,6 +637,7 @@ export class NodeEventProcessor {
         }
         event.bubbles = true;
         node.dispatchEvent(event);
+        this._dispatchingTouch = null;
     }
 
     private _handleTouchCancel (event: EventTouch) {

--- a/cocos/core/scene-graph/node-event-processor.ts
+++ b/cocos/core/scene-graph/node-event-processor.ts
@@ -133,7 +133,6 @@ export class NodeEventProcessor {
 
     // Whether dispatch cancel event when node is destroyed.
     private _dispatchingTouch: Touch | null = null;
-
     private _isEnabled = false;
     private _node: Node;
 


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/8927

### Changelog

* dispatch cancel event when node is destroyed while it's being touching

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
