### PR TITLE
fix forceUpdate

### DIFF
--- a/native/cocos/renderer/gfx-agent/DescriptorSetAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/DescriptorSetAgent.cpp
@@ -88,6 +88,17 @@ void DescriptorSetAgent::update() {
         });
 }
 
+void DescriptorSetAgent::forceUpdate() {
+    _isDirty = false;
+    ENQUEUE_MESSAGE_1(
+        DeviceAgent::getInstance()->getMessageQueue(),
+        DescriptorSetForceUpdate,
+        actor, getActor(),
+        {
+            actor->forceUpdate();
+        });
+}
+
 void DescriptorSetAgent::bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index) {
     DescriptorSet::bindBuffer(binding, buffer, index);
 

--- a/native/cocos/renderer/gfx-agent/DescriptorSetAgent.h
+++ b/native/cocos/renderer/gfx-agent/DescriptorSetAgent.h
@@ -37,6 +37,7 @@ public:
     ~DescriptorSetAgent() override;
 
     void update() override;
+    void forceUpdate() override;
 
     void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index) override;
     void bindTexture(uint32_t binding, Texture *texture, uint32_t index) override;

--- a/native/cocos/renderer/gfx-base/GFXDescriptorSet.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDescriptorSet.cpp
@@ -48,11 +48,6 @@ void DescriptorSet::initialize(const DescriptorSetInfo &info) {
     doInit(info);
 }
 
-void DescriptorSet::forceUpdate() {
-    _isDirty = true;
-    update();
-}
-
 void DescriptorSet::destroy() {
     doDestroy();
 

--- a/native/cocos/renderer/gfx-base/GFXDescriptorSet.h
+++ b/native/cocos/renderer/gfx-base/GFXDescriptorSet.h
@@ -40,7 +40,7 @@ public:
     void destroy();
 
     virtual void update() = 0;
-    void forceUpdate();
+    virtual void forceUpdate() = 0;
 
     virtual void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index);
     virtual void bindTexture(uint32_t binding, Texture *texture, uint32_t index);

--- a/native/cocos/renderer/gfx-empty/EmptyDescriptorSet.cpp
+++ b/native/cocos/renderer/gfx-empty/EmptyDescriptorSet.cpp
@@ -37,5 +37,8 @@ void EmptyDescriptorSet::doDestroy() {
 void EmptyDescriptorSet::update() {
 }
 
+void EmptyDescriptorSet::forceUpdate() {
+}
+
 } // namespace gfx
 } // namespace cc

--- a/native/cocos/renderer/gfx-empty/EmptyDescriptorSet.h
+++ b/native/cocos/renderer/gfx-empty/EmptyDescriptorSet.h
@@ -33,6 +33,7 @@ namespace gfx {
 class CC_DLL EmptyDescriptorSet final : public DescriptorSet {
 public:
     void update() override;
+    void forceUpdate() override;
 
 protected:
     void doInit(const DescriptorSetInfo &info) override;

--- a/native/cocos/renderer/gfx-gles2/GLES2DescriptorSet.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2DescriptorSet.cpp
@@ -94,5 +94,10 @@ void GLES2DescriptorSet::update() {
     }
 }
 
+void GLES2DescriptorSet::forceUpdate() {
+    _isDirty = true;
+    update();
+}
+
 } // namespace gfx
 } // namespace cc

--- a/native/cocos/renderer/gfx-gles2/GLES2DescriptorSet.h
+++ b/native/cocos/renderer/gfx-gles2/GLES2DescriptorSet.h
@@ -39,6 +39,7 @@ public:
     ~GLES2DescriptorSet() override;
 
     void update() override;
+    void forceUpdate() override;
 
     inline GLES2GPUDescriptorSet *gpuDescriptorSet() const { return _gpuDescriptorSet; }
 

--- a/native/cocos/renderer/gfx-gles3/GLES3DescriptorSet.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3DescriptorSet.cpp
@@ -86,5 +86,10 @@ void GLES3DescriptorSet::update() {
     }
 }
 
+void GLES3DescriptorSet::forceUpdate() {
+    _isDirty = true;
+    update();
+}
+
 } // namespace gfx
 } // namespace cc

--- a/native/cocos/renderer/gfx-gles3/GLES3DescriptorSet.h
+++ b/native/cocos/renderer/gfx-gles3/GLES3DescriptorSet.h
@@ -39,6 +39,7 @@ public:
     ~GLES3DescriptorSet() override;
 
     void update() override;
+    void forceUpdate() override;
 
     inline GLES3GPUDescriptorSet *gpuDescriptorSet() const { return _gpuDescriptorSet; }
 

--- a/native/cocos/renderer/gfx-metal/MTLDescriptorSet.h
+++ b/native/cocos/renderer/gfx-metal/MTLDescriptorSet.h
@@ -42,6 +42,7 @@ public:
     CCMTLDescriptorSet &operator=(CCMTLDescriptorSet &&) = delete;
 
     void update() override;
+    void forceUpdate() override;
 
     inline CCMTLGPUDescriptorSet *gpuDescriptorSet() const { return _gpuDescriptorSet; }
 

--- a/native/cocos/renderer/gfx-metal/MTLDescriptorSet.mm
+++ b/native/cocos/renderer/gfx-metal/MTLDescriptorSet.mm
@@ -86,5 +86,11 @@ void CCMTLDescriptorSet::update() {
         _isDirty = false;
     }
 }
+
+void CCMTLDescriptorSet::forceUpdate() {
+    _isDirty = true;
+    update();
+}
+
 } // namespace gfx
 } // namespace cc

--- a/native/cocos/renderer/gfx-validator/DescriptorSetValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/DescriptorSetValidator.cpp
@@ -105,6 +105,7 @@ void DescriptorSetValidator::update() {
 }
 
 void DescriptorSetValidator::forceUpdate() {
+    _isDirty = true;
     _actor->forceUpdate();
     _isDirty = false;
 }

--- a/native/cocos/renderer/gfx-validator/DescriptorSetValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/DescriptorSetValidator.cpp
@@ -104,6 +104,11 @@ void DescriptorSetValidator::update() {
     _isDirty = false;
 }
 
+void DescriptorSetValidator::forceUpdate() {
+    _actor->forceUpdate();
+    _isDirty = false;
+}
+
 void DescriptorSetValidator::updateReferenceStamp() {
     _referenceStamp = DeviceValidator::getInstance()->currentFrame();
 }

--- a/native/cocos/renderer/gfx-validator/DescriptorSetValidator.h
+++ b/native/cocos/renderer/gfx-validator/DescriptorSetValidator.h
@@ -37,6 +37,7 @@ public:
     ~DescriptorSetValidator() override;
 
     void update() override;
+    void forceUpdate() override;
 
     void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index) override;
     void bindTexture(uint32_t binding, Texture *texture, uint32_t index) override;

--- a/native/cocos/renderer/gfx-vulkan/VKDescriptorSet.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKDescriptorSet.cpp
@@ -258,5 +258,10 @@ void CCVKDescriptorSet::update() {
     }
 }
 
+void CCVKDescriptorSet::forceUpdate() {
+    _isDirty = true;
+    update();
+}
+
 } // namespace gfx
 } // namespace cc

--- a/native/cocos/renderer/gfx-vulkan/VKDescriptorSet.h
+++ b/native/cocos/renderer/gfx-vulkan/VKDescriptorSet.h
@@ -39,6 +39,7 @@ public:
     ~CCVKDescriptorSet() override;
 
     void update() override;
+    void forceUpdate() override;
 
     inline CCVKGPUDescriptorSet *gpuDescriptorSet() const { return _gpuDescriptorSet; }
 


### PR DESCRIPTION
Fixes forceUpdate. 
Currently gfx has multiple instance of DescriptorSet(DescriptorSetAgent, DescriptorSetValidator, Derived class of DescriptorSet).  
We must implement forceUpdate on all backend and delegators. This is required by the gfx architecture.

### Changelog

* added forceUpdate to all backends

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
