### PR TITLE
Introduce real array tracks

### DIFF
--- a/cocos/core/animation/animation.ts
+++ b/cocos/core/animation/animation.ts
@@ -26,6 +26,7 @@
 import './embedded-player/embedded-player';
 import './embedded-player/embedded-animation-clip-player';
 import './embedded-player/embedded-particle-system-player';
+import './tracks/array-track';
 
 export * from './target-path';
 export * from './value-proxy';

--- a/cocos/core/animation/tracks/array-track.ts
+++ b/cocos/core/animation/tracks/array-track.ts
@@ -1,0 +1,78 @@
+import { ccclass, serializable } from 'cc.decorator';
+import { RealCurve } from '../../curves';
+import { CLASS_NAME_PREFIX_ANIM, createEvalSymbol } from '../define';
+import { Channel, RealChannel, RuntimeBinding, Track } from './track';
+
+/**
+ * @en
+ * A real array track animates a real array attribute of target(such as morph weights of mesh renderer).
+ * Every element in the array is corresponding to a real channel.
+ * @zh
+ * 实数数组轨道描述目标上某个实数数组属性（例如网格渲染器的形变权重）的动画。
+ * 数组中的每个元素都对应一条实数通道。
+ */
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}RealArrayTrack`)
+export class RealArrayTrack extends Track {
+    /**
+     * @en The number of elements in the array which this track produces.
+     * If you increased the count, there will be new empty real channels appended.
+     * Otherwise if you decreased the count, the last specified number channels would be removed.
+     * @zh 此轨道产生的数组元素的数量。
+     * 当你增加数量时，会增加新的空实数通道；当你减少数量时，最后几个指定数量的通道会被移除。
+     */
+    get elementCount () {
+        return this._channels.length;
+    }
+
+    set elementCount (value) {
+        const { _channels: channels } = this;
+        const nChannels = channels.length;
+        if (value < nChannels) {
+            this._channels.splice(value);
+        } else if (value > nChannels) {
+            this._channels.push(
+                ...Array.from({ length: value - nChannels },
+                    () => new Channel<RealCurve>(new RealCurve())),
+            );
+        }
+    }
+
+    /**
+     * @en The channels of the track.
+     * @zh 返回此轨道的所有通道的数组。
+     */
+    public channels () {
+        return this._channels;
+    }
+
+    /**
+     * @internal
+     */
+    public [createEvalSymbol] () {
+        return new RealArrayTrackEval(this._channels.map(({ curve }) => curve));
+    }
+
+    @serializable
+    private _channels: RealChannel[] = [];
+}
+
+export class RealArrayTrackEval {
+    constructor (
+        private _curves: RealCurve[],
+    ) {
+        this._result = new Array(_curves.length).fill(0.0);
+    }
+
+    public evaluate (time: number, _runtimeBinding: RuntimeBinding) {
+        const {
+            _result: result,
+        } = this;
+        const nElements = result.length;
+        for (let iElement = 0; iElement < nElements; ++iElement) {
+            result[iElement] = this._curves[iElement].evaluate(time);
+        }
+        return this._result;
+    }
+
+    private declare _result: number[];
+}

--- a/editor/exports/exotic-animation.ts
+++ b/editor/exports/exotic-animation.ts
@@ -6,3 +6,7 @@ export {
 export {
     ExoticAnimation,
 } from '../../cocos/core/animation/exotic-animation/exotic-animation';
+
+export {
+    RealArrayTrack,
+} from '../../cocos/core/animation/tracks/array-track';

--- a/tests/animation/tracks/real-array-track.test.ts
+++ b/tests/animation/tracks/real-array-track.test.ts
@@ -1,0 +1,27 @@
+import { RealArrayTrack } from "../../../cocos/core/animation/tracks/array-track";
+
+describe('Real array track', () => {
+    test('Length', () => {
+        const track = new RealArrayTrack();
+        expect(track.elementCount).toBe(0);
+        expect(track.channels()).toHaveLength(0);
+
+        track.elementCount = 0;
+        expect(track.elementCount).toBe(0);
+        expect(track.channels()).toHaveLength(0);
+
+        track.elementCount = 2;
+        expect(track.elementCount).toBe(2);
+        expect(track.channels()).toHaveLength(2);
+        expect(track.channels()[0].curve.keyFramesCount).toBe(0);
+        expect(track.channels()[1].curve.keyFramesCount).toBe(0);
+
+        track.channels()[0].curve.assignSorted([
+            [0.0, 3.14],
+        ]);
+        track.elementCount = 1;
+        expect(track.elementCount).toBe(1);
+        expect(track.channels()).toHaveLength(1);
+        expect(track.channels()[0].curve.getKeyframeValue(0).value).toBe(3.14);
+    });
+});


### PR DESCRIPTION
Re: #

### Changelog

* This PR introduces a new type of track: real array track. As suggested by its name, the real array track yields real array, i.e `number[]` values. For example, morph weights of mesh renderer component are subjected to this type.

Previously, a morph animation on mesh creates `n * m` real tracks, where `n` is the number of morph targets and `m` is the number of sub-meshes in the mesh. This leads to `n * m` calls to `MeshRenderer.prototype.setWeight()` and then lead to `n * m` number of vertex displacement calculation. With real array tracks, we can create only one real array track and call to `MeshRenderer.prototype.setWeights()` only `m` times.

This PR does leave the new track class as editor-only under the consideration of the stability.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
