### PR TITLE
use IntrusivePtr to share object

### DIFF
--- a/native/cocos/base/Agent.h
+++ b/native/cocos/base/Agent.h
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include "Macros.h"
+#include "base/Ptr.h"
 
 namespace cc {
 
@@ -51,7 +52,7 @@ public:
     inline Actor *getActor() const noexcept { return _actor; }
 
 protected:
-    Actor *_actor{nullptr};
+    IntrusivePtr<Actor> _actor;
 };
 
 } // namespace cc

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -171,7 +171,7 @@ void Engine::destroy() {
 
     delete _builtinResMgr;
     delete _programLib;
-    CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
+    CC_SAFE_DELETE(_gfxDevice);
     delete _fs;
     _scheduler.reset();
 

--- a/native/cocos/renderer/gfx-agent/BufferAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/BufferAgent.cpp
@@ -43,7 +43,7 @@ BufferAgent::~BufferAgent() {
         BufferDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/CommandBufferAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/CommandBufferAgent.cpp
@@ -83,7 +83,7 @@ CommandBufferAgent::~CommandBufferAgent() {
         DeviceAgent::getInstance()->getMessageQueue(), CommandBufferDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/DescriptorSetAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/DescriptorSetAgent.cpp
@@ -45,7 +45,7 @@ DescriptorSetAgent::~DescriptorSetAgent() {
         DescriptorSetDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/DescriptorSetLayoutAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/DescriptorSetLayoutAgent.cpp
@@ -42,7 +42,7 @@ DescriptorSetLayoutAgent::~DescriptorSetLayoutAgent() {
         DescriptorSetLayoutDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/DeviceAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/DeviceAgent.cpp
@@ -59,7 +59,7 @@ DeviceAgent::DeviceAgent(Device *device) : Agent(device) {
 }
 
 DeviceAgent::~DeviceAgent() {
-    CC_SAFE_DELETE(_actor);
+    destroy();
     DeviceAgent::instance = nullptr;
 }
 
@@ -83,8 +83,8 @@ bool DeviceAgent::doInit(const DeviceInfo &info) {
     // TODO(PatriceJiang): replace with: _mainMessageQueue = ccnew MessageQueue;
     _mainMessageQueue = ccnew_placement(CC_MALLOC_ALIGN(sizeof(MessageQueue), alignof(MessageQueue))) MessageQueue; // NOLINT
 
-    static_cast<CommandBufferAgent *>(_cmdBuff)->_queue = _queue;
-    static_cast<CommandBufferAgent *>(_cmdBuff)->initAgent();
+    static_cast<CommandBufferAgent *>(_cmdBuff.get())->_queue = _queue;
+    static_cast<CommandBufferAgent *>(_cmdBuff.get())->initAgent();
 
     setMultithreaded(true);
 
@@ -96,33 +96,28 @@ void DeviceAgent::doDestroy() {
         _mainMessageQueue, DeviceDestroy,
         actor, _actor,
         {
-            actor->destroy();
+            if (actor) {
+                actor->destroy();
+            }
         });
 
     if (_cmdBuff) {
-        static_cast<CommandBufferAgent *>(_cmdBuff)->destroyAgent();
-        static_cast<CommandBufferAgent *>(_cmdBuff)->_actor = nullptr;
-        delete _cmdBuff;
+        static_cast<CommandBufferAgent *>(_cmdBuff.get())->destroyAgent();
         _cmdBuff = nullptr;
     }
-    if (_queryPool) {
-        static_cast<QueryPoolAgent *>(_queryPool)->_actor = nullptr;
-        delete _queryPool;
-        _queryPool = nullptr;
-    }
-    if (_queue) {
-        static_cast<QueueAgent *>(_queue)->_actor = nullptr;
-        delete _queue;
-        _queue = nullptr;
-    }
 
-    _mainMessageQueue->terminateConsumerThread();
+    _queryPool = nullptr;
+    _queue = nullptr;
 
-    // NOTE: C++17 required when enable alignment
-    // TODO(PatriceJiang): replace with: CC_SAFE_DELETE(_mainMessageQueue);
-    _mainMessageQueue->~MessageQueue();
-    CC_FREE_ALIGN(_mainMessageQueue);
-    _mainMessageQueue = nullptr;
+    if (_mainMessageQueue) {
+        _mainMessageQueue->terminateConsumerThread();
+        
+        // NOTE: C++17 required when enable alignment
+        // TODO(PatriceJiang): replace with: CC_SAFE_DELETE(_mainMessageQueue);
+        _mainMessageQueue->~MessageQueue();
+        CC_FREE_ALIGN(_mainMessageQueue);
+        _mainMessageQueue = nullptr;
+    }
 }
 
 void DeviceAgent::acquire(Swapchain *const *swapchains, uint32_t count) {
@@ -357,11 +352,11 @@ void doBufferTextureCopy(const uint8_t *const *buffers, Texture *texture, const 
 }
 
 void DeviceAgent::copyBuffersToTexture(const uint8_t *const *buffers, Texture *dst, const BufferTextureCopy *regions, uint32_t count) {
-    doBufferTextureCopy(buffers, dst, regions, count, _mainMessageQueue, _actor);
+    doBufferTextureCopy(buffers, dst, regions, count, _mainMessageQueue, _actor.get());
 }
 
 void CommandBufferAgent::copyBuffersToTexture(const uint8_t *const *buffers, Texture *texture, const BufferTextureCopy *regions, uint32_t count) {
-    doBufferTextureCopy(buffers, texture, regions, count, _messageQueue, _actor);
+    doBufferTextureCopy(buffers, texture, regions, count, _messageQueue, _actor.get());
 }
 
 void DeviceAgent::copyTextureToBuffers(Texture *srcTexture, uint8_t *const *buffers, const BufferTextureCopy *regions, uint32_t count) {

--- a/native/cocos/renderer/gfx-agent/FramebufferAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/FramebufferAgent.cpp
@@ -44,7 +44,7 @@ FramebufferAgent::~FramebufferAgent() {
         FramebufferDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/InputAssemblerAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/InputAssemblerAgent.cpp
@@ -43,7 +43,7 @@ InputAssemblerAgent::~InputAssemblerAgent() {
         InputAssemblerDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/PipelineLayoutAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/PipelineLayoutAgent.cpp
@@ -43,7 +43,7 @@ PipelineLayoutAgent::~PipelineLayoutAgent() {
         PipelineLayoutDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/PipelineStateAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/PipelineStateAgent.cpp
@@ -45,7 +45,7 @@ PipelineStateAgent::~PipelineStateAgent() {
         PipelineStateDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/QueryPoolAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/QueryPoolAgent.cpp
@@ -46,7 +46,7 @@ QueryPoolAgent::~QueryPoolAgent() {
         QueryDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/QueueAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/QueueAgent.cpp
@@ -44,7 +44,7 @@ QueueAgent::~QueueAgent() {
         QueueDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/RenderPassAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/RenderPassAgent.cpp
@@ -42,7 +42,7 @@ RenderPassAgent::~RenderPassAgent() {
         RenderPassDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/ShaderAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/ShaderAgent.cpp
@@ -42,7 +42,7 @@ ShaderAgent::~ShaderAgent() {
         ShaderDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/SwapchainAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/SwapchainAgent.cpp
@@ -43,7 +43,7 @@ SwapchainAgent::~SwapchainAgent() {
         DeviceAgent::getInstance()->getMessageQueue(), SwapchainDestruct,
         actor, _actor,
         {
-            CC_SAFE_DELETE(actor);
+            actor = nullptr;
         });
 }
 

--- a/native/cocos/renderer/gfx-agent/TextureAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/TextureAgent.cpp
@@ -45,7 +45,7 @@ TextureAgent::~TextureAgent() {
             TextureDestruct,
             actor, _actor,
             {
-                CC_SAFE_DELETE(actor);
+                actor = nullptr;
             });
     }
 }

--- a/native/cocos/renderer/gfx-base/GFXDevice.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDevice.cpp
@@ -61,11 +61,7 @@ bool Device::initialize(const DeviceInfo &info) {
     static_assert(sizeof(void *) == 8, "pointer size assumption broken");
 #endif
 
-    bool result = doInit(info);
-    _cmdBuff->addRef();
-    _queue->addRef();
-
-    return result;
+    return doInit(info);
 }
 
 void Device::destroy() {

--- a/native/cocos/renderer/gfx-base/GFXDevice.h
+++ b/native/cocos/renderer/gfx-base/GFXDevice.h
@@ -173,9 +173,9 @@ protected:
     ccstd::array<bool, static_cast<size_t>(Feature::COUNT)> _features;
     ccstd::array<FormatFeature, static_cast<size_t>(Format::COUNT)> _formatFeatures;
 
-    Queue *_queue{nullptr};
-    QueryPool *_queryPool{nullptr};
-    CommandBuffer *_cmdBuff{nullptr};
+    IntrusivePtr<Queue> _queue;
+    IntrusivePtr<QueryPool> _queryPool;
+    IntrusivePtr<CommandBuffer> _cmdBuff;
     Executable *_onAcquire{nullptr};
 
     uint32_t _numDrawCalls{0U};

--- a/native/cocos/renderer/gfx-base/GFXQueryPool.h
+++ b/native/cocos/renderer/gfx-base/GFXQueryPool.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <mutex>
 #include "GFXObject.h"
+#include "base/RefCounted.h"
 #include "base/std/container/unordered_map.h"
 
 namespace cc {
@@ -46,7 +47,7 @@ namespace gfx {
  *  completeQueryPool
  */
 
-class CC_DLL QueryPool : public GFXObject {
+class CC_DLL QueryPool : public GFXObject, public RefCounted {
 public:
     QueryPool();
     ~QueryPool() override;

--- a/native/cocos/renderer/gfx-base/GFXSwapchain.h
+++ b/native/cocos/renderer/gfx-base/GFXSwapchain.h
@@ -27,12 +27,13 @@
 
 #include "GFXTexture.h"
 #include "base/Ptr.h"
+#include "base/RefCounted.h"
 #include "gfx-base/GFXDef-common.h"
 
 namespace cc {
 namespace gfx {
 
-class CC_DLL Swapchain : public GFXObject {
+class CC_DLL Swapchain : public GFXObject, public RefCounted {
 public:
     Swapchain();
     ~Swapchain() override;

--- a/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -228,9 +228,10 @@ void GLES2Device::doDestroy() {
     CC_ASSERT(!_memoryStatus.bufferSize);  // Buffer memory leaked.
     CC_ASSERT(!_memoryStatus.textureSize); // Texture memory leaked.
 
-    CC_SAFE_DESTROY_AND_DELETE(_cmdBuff)
-    CC_SAFE_DESTROY_AND_DELETE(_queryPool)
-    CC_SAFE_DESTROY_AND_DELETE(_queue)
+    _queryPool = nullptr;
+    _queue = nullptr;
+    _cmdBuff = nullptr;
+
     CC_SAFE_DESTROY_AND_DELETE(_gpuContext)
 }
 
@@ -245,7 +246,7 @@ void GLES2Device::acquire(Swapchain *const *swapchains, uint32_t count) {
 
 void GLES2Device::present() {
     CC_PROFILE(GLES2DevicePresent);
-    auto *queue = static_cast<GLES2Queue *>(_queue);
+    auto *queue = static_cast<GLES2Queue *>(_queue.get());
     _numDrawCalls = queue->_numDrawCalls;
     _numInstances = queue->_numInstances;
     _numTriangles = queue->_numTriangles;

--- a/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -236,9 +236,9 @@ void GLES3Device::doDestroy() {
     CC_ASSERT(!_memoryStatus.bufferSize);  // Buffer memory leaked
     CC_ASSERT(!_memoryStatus.textureSize); // Texture memory leaked
 
-    CC_SAFE_DESTROY_AND_DELETE(_cmdBuff)
-    CC_SAFE_DESTROY_AND_DELETE(_queryPool)
-    CC_SAFE_DESTROY_AND_DELETE(_queue)
+    _cmdBuff = nullptr;
+    _queryPool = nullptr;
+    _queue = nullptr;
     CC_SAFE_DESTROY_AND_DELETE(_gpuContext)
 }
 
@@ -253,7 +253,7 @@ void GLES3Device::acquire(Swapchain *const *swapchains, uint32_t count) {
 
 void GLES3Device::present() {
     CC_PROFILE(GLES3DevicePresent);
-    auto *queue = static_cast<GLES3Queue *>(_queue);
+    auto *queue = static_cast<GLES3Queue *>(_queue.get());
     _numDrawCalls = queue->_numDrawCalls;
     _numInstances = queue->_numInstances;
     _numTriangles = queue->_numTriangles;

--- a/native/cocos/renderer/gfx-metal/MTLDevice.mm
+++ b/native/cocos/renderer/gfx-metal/MTLDevice.mm
@@ -156,9 +156,9 @@ void CCMTLDevice::doDestroy() {
 
     CC_SAFE_DELETE(_gpuDeviceObj);
 
-    CC_SAFE_DESTROY_AND_DELETE(_queryPool)
-    CC_SAFE_DESTROY_AND_DELETE(_queue);
-    CC_SAFE_DESTROY_AND_DELETE(_cmdBuff);
+    _queryPool = nullptr;
+    _queue = nullptr;
+    _cmdBuff = nullptr;
 
     CCMTLGPUGarbageCollectionPool::getInstance()->flush();
 
@@ -193,7 +193,7 @@ void CCMTLDevice::acquire(Swapchain *const *swapchains, uint32_t count) {
     }
 
     // Clear queue stats
-    CCMTLQueue *queue = static_cast<CCMTLQueue *>(_queue);
+    CCMTLQueue *queue = static_cast<CCMTLQueue *>(_queue.get());
     queue->gpuQueueObj()->numDrawCalls = 0;
     queue->gpuQueueObj()->numInstances = 0;
     queue->gpuQueueObj()->numTriangles = 0;
@@ -201,7 +201,7 @@ void CCMTLDevice::acquire(Swapchain *const *swapchains, uint32_t count) {
 
 void CCMTLDevice::present() {
     CC_PROFILE(CCMTLDevicePresent);
-    CCMTLQueue *queue = (CCMTLQueue *)_queue;
+    CCMTLQueue *queue = static_cast<CCMTLQueue *>(_queue.get());
     _numDrawCalls = queue->gpuQueueObj()->numDrawCalls;
     _numInstances = queue->gpuQueueObj()->numInstances;
     _numTriangles = queue->gpuQueueObj()->numTriangles;
@@ -313,12 +313,12 @@ void CCMTLDevice::copyBuffersToTexture(const uint8_t *const *buffers, Texture *t
     // the wiggle room to leverage immediate update vs. copy-upload strategies without
     // breaking compatibilities. When we reached some conclusion on this subject,
     // getting rid of this interface all together may become a better option.
-    static_cast<CCMTLCommandBuffer *>(_cmdBuff)->copyBuffersToTexture(buffers, texture, regions, count);
+    static_cast<CCMTLCommandBuffer *>(_cmdBuff.get())->copyBuffersToTexture(buffers, texture, regions, count);
 }
 
 void CCMTLDevice::copyTextureToBuffers(Texture *src, uint8_t *const *buffers, const BufferTextureCopy *region, uint32_t count) {
     CC_PROFILE(CCMTLDeviceCopyTextureToBuffers);
-    static_cast<CCMTLCommandBuffer *>(_cmdBuff)->copyTextureToBuffers(src, buffers, region, count);
+    static_cast<CCMTLCommandBuffer *>(_cmdBuff.get())->copyTextureToBuffers(src, buffers, region, count);
 }
 
 void CCMTLDevice::getQueryPoolResults(QueryPool *queryPool) {

--- a/native/cocos/renderer/gfx-validator/BufferValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/BufferValidator.cpp
@@ -34,13 +34,11 @@ namespace gfx {
 
 BufferValidator::BufferValidator(Buffer *actor)
 : Agent<Buffer>(actor) {
-    CC_SAFE_ADD_REF(actor);
     _typedID = actor->getTypedID();
 }
 
 BufferValidator::~BufferValidator() {
     DeviceResourceTracker<Buffer>::erase(this);
-    CC_SAFE_RELEASE(_actor);
 
     uint64_t lifeTime = DeviceValidator::getInstance()->currentFrame() - _creationFrame;
     // skip those that have never been updated

--- a/native/cocos/renderer/gfx-validator/CommandBufferValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/CommandBufferValidator.cpp
@@ -50,7 +50,6 @@ CommandBufferValidator::CommandBufferValidator(CommandBuffer *actor)
 
 CommandBufferValidator::~CommandBufferValidator() {
     DeviceResourceTracker<CommandBuffer>::erase(this);
-    CC_SAFE_DELETE(_actor);
 }
 
 void CommandBufferValidator::initValidator() {

--- a/native/cocos/renderer/gfx-validator/DescriptorSetLayoutValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/DescriptorSetLayoutValidator.cpp
@@ -36,13 +36,11 @@ namespace gfx {
 
 DescriptorSetLayoutValidator::DescriptorSetLayoutValidator(DescriptorSetLayout *actor)
 : Agent<DescriptorSetLayout>(actor) {
-    CC_SAFE_ADD_REF(actor);
     _typedID = actor->getTypedID();
 }
 
 DescriptorSetLayoutValidator::~DescriptorSetLayoutValidator() {
     DeviceResourceTracker<DescriptorSetLayout>::erase(this);
-    CC_SAFE_RELEASE(_actor);
 }
 
 void DescriptorSetLayoutValidator::doInit(const DescriptorSetLayoutInfo &info) {

--- a/native/cocos/renderer/gfx-validator/DescriptorSetValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/DescriptorSetValidator.cpp
@@ -38,13 +38,11 @@ namespace gfx {
 
 DescriptorSetValidator::DescriptorSetValidator(DescriptorSet *actor)
 : Agent<DescriptorSet>(actor) {
-    CC_SAFE_ADD_REF(actor);
     _typedID = actor->getTypedID();
 }
 
 DescriptorSetValidator::~DescriptorSetValidator() {
     DeviceResourceTracker<DescriptorSet>::erase(this);
-    CC_SAFE_RELEASE(_actor);
 }
 
 void DescriptorSetValidator::doInit(const DescriptorSetInfo &info) {

--- a/native/cocos/renderer/gfx-validator/DeviceValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/DeviceValidator.cpp
@@ -60,7 +60,7 @@ DeviceValidator::DeviceValidator(Device *device) : Agent(device) {
 }
 
 DeviceValidator::~DeviceValidator() {
-    CC_SAFE_DELETE(_actor);
+    destroy();
     DeviceValidator::instance = nullptr;
 }
 
@@ -89,14 +89,14 @@ bool DeviceValidator::doInit(const DeviceInfo &info) {
     memcpy(_features.data(), _actor->_features.data(), static_cast<uint32_t>(Feature::COUNT) * sizeof(bool));
     memcpy(_formatFeatures.data(), _actor->_formatFeatures.data(), static_cast<uint32_t>(Format::COUNT) * sizeof(FormatFeatureBit));
 
-    static_cast<QueueValidator *>(_queue)->_inited = true;
-    static_cast<QueryPoolValidator *>(_queryPool)->_inited = true;
-    static_cast<CommandBufferValidator *>(_cmdBuff)->_queue = _queue;
-    static_cast<CommandBufferValidator *>(_cmdBuff)->initValidator();
+    static_cast<QueueValidator *>(_queue.get())->_inited = true;
+    static_cast<QueryPoolValidator *>(_queryPool.get())->_inited = true;
+    static_cast<CommandBufferValidator *>(_cmdBuff.get())->_queue = _queue;
+    static_cast<CommandBufferValidator *>(_cmdBuff.get())->initValidator();
 
-    DeviceResourceTracker<CommandBuffer>::push(_cmdBuff);
-    DeviceResourceTracker<QueryPool>::push(_queryPool);
-    DeviceResourceTracker<Queue>::push(_queue);
+    DeviceResourceTracker<CommandBuffer>::push(_cmdBuff.get());
+    DeviceResourceTracker<QueryPool>::push(_queryPool.get());
+    DeviceResourceTracker<Queue>::push(_queue.get());
 
     CC_LOG_INFO("Device validator enabled.");
 
@@ -105,21 +105,12 @@ bool DeviceValidator::doInit(const DeviceInfo &info) {
 
 void DeviceValidator::doDestroy() {
     if (_cmdBuff) {
-        static_cast<CommandBufferValidator *>(_cmdBuff)->destroyValidator();
-        static_cast<CommandBufferValidator *>(_cmdBuff)->_actor = nullptr;
-        delete _cmdBuff;
+        static_cast<CommandBufferValidator *>(_cmdBuff.get())->destroyValidator();
         _cmdBuff = nullptr;
     }
-    if (_queryPool) {
-        static_cast<QueryPoolValidator *>(_queryPool)->_actor = nullptr;
-        delete _queryPool;
-        _queryPool = nullptr;
-    }
-    if (_queue) {
-        static_cast<QueueValidator *>(_queue)->_actor = nullptr;
-        delete _queue;
-        _queue = nullptr;
-    }
+    
+    _queryPool = nullptr;
+    _queue = nullptr;
 
     DeviceResourceTracker<CommandBuffer>::checkEmpty();
     DeviceResourceTracker<QueryPool>::checkEmpty();
@@ -137,7 +128,9 @@ void DeviceValidator::doDestroy() {
     DeviceResourceTracker<PipelineLayout>::checkEmpty();
     DeviceResourceTracker<PipelineState>::checkEmpty();
 
-    _actor->destroy();
+    if (_actor) {
+        _actor->destroy();
+    }
 }
 
 void DeviceValidator::acquire(Swapchain *const *swapchains, uint32_t count) {

--- a/native/cocos/renderer/gfx-validator/FramebufferValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/FramebufferValidator.cpp
@@ -37,13 +37,11 @@ namespace gfx {
 
 FramebufferValidator::FramebufferValidator(Framebuffer *actor)
 : Agent<Framebuffer>(actor) {
-    CC_SAFE_ADD_REF(actor);
     _typedID = actor->getTypedID();
 }
 
 FramebufferValidator::~FramebufferValidator() {
     DeviceResourceTracker<Framebuffer>::erase(this);
-    CC_SAFE_RELEASE(_actor);
 }
 
 void FramebufferValidator::doInit(const FramebufferInfo &info) {

--- a/native/cocos/renderer/gfx-validator/InputAssemblerValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/InputAssemblerValidator.cpp
@@ -35,13 +35,11 @@ namespace gfx {
 
 InputAssemblerValidator::InputAssemblerValidator(InputAssembler *actor)
 : Agent<InputAssembler>(actor) {
-    CC_SAFE_ADD_REF(actor);
     _typedID = actor->getTypedID();
 }
 
 InputAssemblerValidator::~InputAssemblerValidator() {
     DeviceResourceTracker<InputAssembler>::erase(this);
-    CC_SAFE_RELEASE(_actor);
 }
 
 void InputAssemblerValidator::doInit(const InputAssemblerInfo &info) {

--- a/native/cocos/renderer/gfx-validator/PipelineLayoutValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/PipelineLayoutValidator.cpp
@@ -41,7 +41,6 @@ PipelineLayoutValidator::PipelineLayoutValidator(PipelineLayout *actor)
 
 PipelineLayoutValidator::~PipelineLayoutValidator() {
     DeviceResourceTracker<PipelineLayout>::erase(this);
-    CC_SAFE_DELETE(_actor);
 }
 
 void PipelineLayoutValidator::doInit(const PipelineLayoutInfo &info) {

--- a/native/cocos/renderer/gfx-validator/PipelineStateValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/PipelineStateValidator.cpp
@@ -42,7 +42,6 @@ PipelineStateValidator::PipelineStateValidator(PipelineState *actor)
 
 PipelineStateValidator::~PipelineStateValidator() {
     DeviceResourceTracker<PipelineState>::erase(this);
-    CC_SAFE_DELETE(_actor);
 }
 
 void PipelineStateValidator::doInit(const PipelineStateInfo &info) {

--- a/native/cocos/renderer/gfx-validator/QueryPoolValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/QueryPoolValidator.cpp
@@ -40,7 +40,6 @@ QueryPoolValidator::QueryPoolValidator(QueryPool *actor)
 
 QueryPoolValidator::~QueryPoolValidator() {
     DeviceResourceTracker<QueryPool>::erase(this);
-    CC_SAFE_DELETE(_actor);
 }
 
 void QueryPoolValidator::doInit(const QueryPoolInfo &info) {

--- a/native/cocos/renderer/gfx-validator/QueueValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/QueueValidator.cpp
@@ -38,7 +38,6 @@ QueueValidator::QueueValidator(Queue *actor)
 
 QueueValidator::~QueueValidator() {
     DeviceResourceTracker<Queue>::erase(this);
-    CC_SAFE_DELETE(_actor);
 }
 
 void QueueValidator::doInit(const QueueInfo &info) {

--- a/native/cocos/renderer/gfx-validator/RenderPassValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/RenderPassValidator.cpp
@@ -34,13 +34,11 @@ namespace gfx {
 
 RenderPassValidator::RenderPassValidator(RenderPass *actor)
 : Agent<RenderPass>(actor) {
-    CC_SAFE_ADD_REF(actor);
     _typedID = actor->getTypedID();
 }
 
 RenderPassValidator::~RenderPassValidator() {
     DeviceResourceTracker<RenderPass>::erase(this);
-    CC_SAFE_RELEASE(_actor);
 }
 
 void RenderPassValidator::doInit(const RenderPassInfo &info) {

--- a/native/cocos/renderer/gfx-validator/ShaderValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/ShaderValidator.cpp
@@ -34,13 +34,11 @@ namespace gfx {
 
 ShaderValidator::ShaderValidator(Shader *actor)
 : Agent<Shader>(actor) {
-    CC_SAFE_ADD_REF(actor);
     _typedID = actor->getTypedID();
 }
 
 ShaderValidator::~ShaderValidator() {
     DeviceResourceTracker<Shader>::erase(this);
-    CC_SAFE_RELEASE(_actor);
 }
 
 void ShaderValidator::doInit(const ShaderInfo &info) {

--- a/native/cocos/renderer/gfx-validator/SwapchainValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/SwapchainValidator.cpp
@@ -40,7 +40,6 @@ SwapchainValidator::SwapchainValidator(Swapchain *actor)
 
 SwapchainValidator::~SwapchainValidator() {
     DeviceResourceTracker<Swapchain>::erase(this);
-    CC_SAFE_DELETE(_actor);
 }
 
 void SwapchainValidator::doInit(const SwapchainInfo &info) {

--- a/native/cocos/renderer/gfx-validator/TextureValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/TextureValidator.cpp
@@ -45,13 +45,11 @@ ccstd::unordered_map<Format, Feature, EnumHasher> featureCheckMap{};
 
 TextureValidator::TextureValidator(Texture *actor)
 : Agent<Texture>(actor) {
-    CC_SAFE_ADD_REF(actor);
     _typedID = actor->getTypedID();
 }
 
 TextureValidator::~TextureValidator() {
     DeviceResourceTracker<Texture>::erase(this);
-    if (_ownTheActor) CC_SAFE_RELEASE(_actor);
 }
 
 void TextureValidator::doInit(const TextureInfo &info) {

--- a/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -391,7 +391,7 @@ bool CCVKDevice::doInit(const DeviceInfo & /*info*/) {
     }
 
     _gpuBufferHub = ccnew CCVKGPUBufferHub(_gpuDevice);
-    _gpuTransportHub = ccnew CCVKGPUTransportHub(_gpuDevice, static_cast<CCVKQueue *>(_queue)->gpuQueue());
+    _gpuTransportHub = ccnew CCVKGPUTransportHub(_gpuDevice, static_cast<CCVKQueue *>(_queue.get())->gpuQueue());
     _gpuDescriptorHub = ccnew CCVKGPUDescriptorHub(_gpuDevice);
     _gpuSemaphorePool = ccnew CCVKGPUSemaphorePool(_gpuDevice);
     _gpuBarrierManager = ccnew CCVKGPUBarrierManager(_gpuDevice);
@@ -490,9 +490,10 @@ void CCVKDevice::doDestroy() {
     }
     _depthStencilTextures.clear();
 
-    CC_SAFE_DESTROY_AND_DELETE(_queryPool)
-    CC_SAFE_DESTROY_AND_DELETE(_queue)
-    CC_SAFE_DESTROY_AND_DELETE(_cmdBuff)
+    _queryPool = nullptr;
+    _queue = nullptr;
+    _cmdBuff = nullptr;
+
 
     CC_SAFE_DELETE(_gpuBufferHub)
     CC_SAFE_DELETE(_gpuTransportHub)
@@ -601,7 +602,7 @@ VkImageMemoryBarrier presentBarrier{
 void CCVKDevice::acquire(Swapchain *const *swapchains, uint32_t count) {
     if (_onAcquire) _onAcquire->execute();
 
-    auto *queue = static_cast<CCVKQueue *>(_queue);
+    auto *queue = static_cast<CCVKQueue *>(_queue.get());
     queue->gpuQueue()->lastSignaledSemaphores.clear();
     vkSwapchainIndices.clear();
     gpuSwapchains.clear();
@@ -651,7 +652,7 @@ void CCVKDevice::acquire(Swapchain *const *swapchains, uint32_t count) {
 
 void CCVKDevice::present() {
     CC_PROFILE(CCVKDevicePresent);
-    auto *queue = static_cast<CCVKQueue *>(_queue);
+    auto *queue = static_cast<CCVKQueue *>(_queue.get());
     _numDrawCalls = queue->_numDrawCalls;
     _numInstances = queue->_numInstances;
     _numTriangles = queue->_numTriangles;


### PR DESCRIPTION
- _actor uses IntrusivePtr
- _cmdBuff, _queryPool and _queue defined in gfx::Device use IntrusivePtr
- make some `doDestroy()` to be reentrant
