### PR TITLE
feat: when editor mode is animation need hide add component button

### DIFF
--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -1729,9 +1729,9 @@ exports.ready = async function ready() {
     }
 
     this.replaceAssetUuidInNodesBind = this.replaceAssetUuidInNodes.bind(this);
-    this.handlerSceneChangeMode = this.handlerSceneChangeMode.bind(this);
+    this.handlerSceneChangeModeBind = this.handlerSceneChangeMode.bind(this);
     Editor.Message.addBroadcastListener('inspector:replace-asset-uuid-in-nodes', this.replaceAssetUuidInNodesBind);
-    Editor.Message.addBroadcastListener('scene:change-mode', this.handlerSceneChangeMode);
+    Editor.Message.addBroadcastListener('scene:change-mode', this.handlerSceneChangeModeBind);
 };
 
 exports.close = async function close() {
@@ -1745,7 +1745,7 @@ exports.close = async function close() {
     }
 
     Editor.Message.removeBroadcastListener('inspector:replace-asset-uuid-in-nodes', this.replaceAssetUuidInNodesBind);
-    Editor.Message.removeBroadcastListener('scene:change-mode', this.handlerSceneChangeMode);
+    Editor.Message.removeBroadcastListener('scene:change-mode', this.handlerSceneChangeModeBind);
 };
 
 exports.beforeClose = async function beforeClose() {

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -673,10 +673,10 @@ const Elements = {
             const panel = this;
 
             if (!panel.dump || !panel.dump.isScene) {
-                panel.$.componentAdd.style.display = 'inline-block';
+                panel.toggleShowAddComponentBtn(true);
                 return;
             }
-            panel.$.componentAdd.style.display = 'none';
+            panel.toggleShowAddComponentBtn(false);
 
             panel.$this.setAttribute('sub-type', 'scene');
             panel.$.container.removeAttribute('droppable');
@@ -1680,6 +1680,13 @@ exports.methods = {
             console.error(error);
         }
     },
+    toggleShowAddComponentBtn(show) {
+        this.$.componentAdd.style.display = show ? 'inline-block' : 'none';
+    },
+    handlerSceneChangeMode() {
+        const mode = Editor.EditMode.getMode();
+        this.toggleShowAddComponentBtn(mode !== 'animation'); // 动画编辑模式下，要隐藏按钮
+    },
 };
 
 exports.update = async function update(uuidList, renderMap, dropConfig, typeManager, renderManager) {
@@ -1722,7 +1729,9 @@ exports.ready = async function ready() {
     }
 
     this.replaceAssetUuidInNodesBind = this.replaceAssetUuidInNodes.bind(this);
+    this.handlerSceneChangeMode = this.handlerSceneChangeMode.bind(this);
     Editor.Message.addBroadcastListener('inspector:replace-asset-uuid-in-nodes', this.replaceAssetUuidInNodesBind);
+    Editor.Message.addBroadcastListener('scene:change-mode', this.handlerSceneChangeMode);
 };
 
 exports.close = async function close() {
@@ -1736,6 +1745,7 @@ exports.close = async function close() {
     }
 
     Editor.Message.removeBroadcastListener('inspector:replace-asset-uuid-in-nodes', this.replaceAssetUuidInNodesBind);
+    Editor.Message.removeBroadcastListener('scene:change-mode', this.handlerSceneChangeMode);
 };
 
 exports.beforeClose = async function beforeClose() {


### PR DESCRIPTION
Resolves: cocos/3d-tasks#12277 

### Changelog

* when editor mode is animation need hide add component button

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
