### PR TITLE
Don't depend on libuv, revert to use c++17 std::shared_mutex in ReadWriteLock.h

### DIFF
--- a/native/cocos/base/threading/ReadWriteLock.h
+++ b/native/cocos/base/threading/ReadWriteLock.h
@@ -25,57 +25,33 @@
 
 #pragma once
 
-// clang-format off
-#include "base/Macros.h"
-// clang-format on
-
-#include <uv.h>
-#include <functional>
+#include <shared_mutex>
 
 namespace cc {
 
 class ReadWriteLock final {
 public:
-    ReadWriteLock() {
-        uv_rwlock_init(&_lock);
-    };
-    ~ReadWriteLock() {
-        uv_rwlock_destroy(&_lock);
-    }
+    ReadWriteLock() = default;
 
     template <typename Function, typename... Args>
-    auto lockRead(Function &&func, Args &&... args) noexcept -> decltype(func(std::forward<Args>(args)...));
+    auto lockRead(Function &&func, Args &&...args) noexcept -> decltype(func(std::forward<Args>(args)...));
 
     template <typename Function, typename... Args>
-    auto lockWrite(Function &&func, Args &&... args) noexcept -> decltype(func(std::forward<Args>(args)...));
+    auto lockWrite(Function &&func, Args &&...args) noexcept -> decltype(func(std::forward<Args>(args)...));
 
 private:
-    uv_rwlock_t _lock;
-
-    struct Defer final {
-        explicit Defer(std::function<void()> &&f) : fn(f) {}
-        ~Defer() {
-            fn();
-        }
-        std::function<void()> fn;
-    };
+    std::shared_mutex _mutex;
 };
 
 template <typename Function, typename... Args>
-auto ReadWriteLock::lockRead(Function &&func, Args &&... args) noexcept -> decltype(func(std::forward<Args>(args)...)) {
-    uv_rwlock_rdlock(&_lock);
-    auto defer = Defer([&]() {
-        uv_rwlock_rdunlock(&_lock);
-    });
+auto ReadWriteLock::lockRead(Function &&func, Args &&...args) noexcept -> decltype(func(std::forward<Args>(args)...)) {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
     return func(std::forward<Args>(args)...);
 }
 
 template <typename Function, typename... Args>
-auto ReadWriteLock::lockWrite(Function &&func, Args &&... args) noexcept -> decltype(func(std::forward<Args>(args)...)) {
-    uv_rwlock_wrlock(&_lock);
-    auto defer = Defer([&]() {
-        uv_rwlock_wrunlock(&_lock);
-    });
+auto ReadWriteLock::lockWrite(Function &&func, Args &&...args) noexcept -> decltype(func(std::forward<Args>(args)...)) {
+    std::lock_guard<std::shared_mutex> lock(_mutex);
     return func(std::forward<Args>(args)...);
 }
 


### PR DESCRIPTION
Re: #

### Changelog

* 

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
