### PR TITLE
Fix fogEnd value issue in native

### DIFF
--- a/native/cocos/scene/Fog.h
+++ b/native/cocos/scene/Fog.h
@@ -334,7 +334,7 @@ public:
     // @serializable
     float _fogStart{0.5F};
     // @serializable
-    float _fogEnd{0.5F};
+    float _fogEnd{300.F};
     // @serializable
     float _fogAtten{5.F};
     // @serializable


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12911

### Changelog

* [Native] Fix fog using wrong configurations when default values are used

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.

  > Manual trigger with `@cocos-robot run test cases` afterward.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
