### PR TITLE
Add Allow Data Access Option.

### DIFF
--- a/editor/i18n/en/assets.js
+++ b/editor/i18n/en/assets.js
@@ -252,7 +252,7 @@ module.exports = {
                 original: 'Original',
             },
             limitMaterialDumpDir: 'The extracted path needs to be scoped to the project path.',
-            legacyOptions:'Legacy Options',
+            legacyOptions: 'Legacy Options',
             legacyFbxImporter: {
                 name: 'Compatible with v1.*',
                 title: 'Whether this importer should be compatible with its behaviour prior to Cocos Creator version 1.* .',
@@ -269,6 +269,12 @@ module.exports = {
                     'component) will not be used, this option can be checked to improve performance. But note that <br> ' +
                     'toggling this would update the corresponding prefab, so all the references in the scene should be <br>' +
                     'updated as well to accompany that. To be removed in further refactors.',
+            },
+            allowDataAccess: {
+                name: 'Allow Data Access',
+                title:
+                    'Indicate whether the mesh data in this model could be read or write.<br>' +
+                    'If it is unchecked, the mesh data will be released after it is uploaded to ',
             },
             meshOptimizer: {
                 name: 'Mesh Optimizer',

--- a/editor/i18n/en/assets.js
+++ b/editor/i18n/en/assets.js
@@ -270,7 +270,7 @@ module.exports = {
                     'toggling this would update the corresponding prefab, so all the references in the scene should be <br>' +
                     'updated as well to accompany that. To be removed in further refactors.',
             },
-            allowDataAccess: {
+            allowMeshDataAccess: {
                 name: 'Allow Data Access',
                 title:
                     'Indicate whether the mesh data in this model could be read or write.<br>' +

--- a/editor/i18n/en/assets.js
+++ b/editor/i18n/en/assets.js
@@ -274,7 +274,7 @@ module.exports = {
                 name: 'Allow Data Access',
                 title:
                     'Indicate whether the mesh data in this model could be read or write.<br>' +
-                    'If it is unchecked, the mesh data will be released after it is uploaded to ',
+                    'If it is unchecked, the mesh data will be released after it is uploaded to GPU',
             },
             meshOptimizer: {
                 name: 'Mesh Optimizer',

--- a/editor/i18n/zh/assets.js
+++ b/editor/i18n/zh/assets.js
@@ -26,9 +26,9 @@ module.exports = {
             StartChar: 'Start Char',
             FontSize: 'Font Size',
         },
-        particle:{
-            spriteFrame:'Sprite Frame',
-            spriteFrameTip:'Sprite Frame',
+        particle: {
+            spriteFrame: 'Sprite Frame',
+            spriteFrameTip: 'Sprite Frame',
         },
         erpTextureCube: {
             anisotropy: 'Anisotropy',
@@ -160,8 +160,8 @@ module.exports = {
             modelPreview: '模型预览',
             material: '材质',
             fbx: 'FBX',
-            no_model_tips:'没有模型可供预览',
-            drag_model_tips:'可将模型拖到这里进行预览',
+            no_model_tips: '没有模型可供预览',
+            drag_model_tips: '可将模型拖到这里进行预览',
             GlTFUserData: {
                 normals: {
                     name: '法线',
@@ -253,7 +253,7 @@ module.exports = {
                 original: '原始',
             },
             limitMaterialDumpDir: '提取的路径需要限定在项目路径范围内',
-            legacyOptions:'旧版本遗留',
+            legacyOptions: '旧版本遗留',
             legacyFbxImporter: {
                 name: '与 1.* 版本兼容',
                 title: '此导入器是否应该与其在 Cocos Creator 1.* 之前版本的导入方式兼容。',
@@ -262,12 +262,13 @@ module.exports = {
             disableMeshSplit: {
                 name: '是否禁用 Mesh 拆分',
                 title:
-                    '为了解决实时骨骼动画系统下 uniform vector 数量限制问题，<br> ' +
-                    '目前在资源导入期会根据骨骼数量做拆分，这会对其他系统也产生影响。<br>' +
-                    '如果确定不会使用实时计算模式 (对应 SkeletalAnimation 组件的 <br> ' +
-                    'useBakedAnimation 选项未勾选时)，可以勾选此项以提升性能。<br>' +
-                    '但注意改变此选项会影响生成的 prefab 内容，需要对应更新场景中的引用。<br>' +
-                    '后续重构会移除此流程。',
+                    '标识此模型中的所有网格的数据是',
+            },
+            allowDataAccess: {
+                name: '允许数据访问',
+                title:
+                    '标识此模型中的所有网格的数据是否可被读写，此接口只对静态网格资源生效，<br> ' +
+                    '若不勾选，网格数据被提交到 GPU 后会被自动释放。<br>',
             },
             meshOptimizer: {
                 name: 'Mesh Optimizer',
@@ -343,7 +344,7 @@ module.exports = {
             wrapModeT: 'Wrap Mode T',
             wrapModeTTip: 'Wrap Mode T',
             modeWarn:
-            '警告：WebGL 1.0 平台不支持非 2 次幂贴图的 repeat 过滤模式，运行时会自动改为 clamp-to-edge 模式，这会使材质的 tilingOffset 等属性完全失效。',
+                '警告：WebGL 1.0 平台不支持非 2 次幂贴图的 repeat 过滤模式，运行时会自动改为 clamp-to-edge 模式，这会使材质的 tilingOffset 等属性完全失效。',
         },
         material: {
             'fail-to-load-custom-inspector': 'material: 自定义 effect {effect} 的 inspector 加载失败',

--- a/editor/i18n/zh/assets.js
+++ b/editor/i18n/zh/assets.js
@@ -262,9 +262,14 @@ module.exports = {
             disableMeshSplit: {
                 name: '是否禁用 Mesh 拆分',
                 title:
-                    '标识此模型中的所有网格的数据是',
+                    '为了解决实时骨骼动画系统下 uniform vector 数量限制问题，<br> ' +
+                    '目前在资源导入期会根据骨骼数量做拆分，这会对其他系统也产生影响。<br>' +
+                    '如果确定不会使用实时计算模式 (对应 SkeletalAnimation 组件的 <br> ' +
+                    'useBakedAnimation 选项未勾选时)，可以勾选此项以提升性能。<br>' +
+                    '但注意改变此选项会影响生成的 prefab 内容，需要对应更新场景中的引用。<br>' +
+                    '后续重构会移除此流程。',
             },
-            allowDataAccess: {
+            allowMeshDataAccess: {
                 name: '允许数据访问',
                 title:
                     '标识此模型中的所有网格的数据是否可被读写，此接口只对静态网格资源生效，<br> ' +

--- a/editor/inspector/assets/fbx/model.js
+++ b/editor/inspector/assets/fbx/model.js
@@ -22,6 +22,10 @@ exports.template = `
         <ui-label slot="label" value="i18n:ENGINE.assets.fbx.disableMeshSplit.name" tooltip="i18n:ENGINE.assets.fbx.disableMeshSplit.title"></ui-label>
         <ui-checkbox slot="content" class="disableMeshSplit-checkbox"></ui-checkbox>
     </ui-prop>
+    <ui-prop>
+        <ui-label slot="label" value="i18n:ENGINE.assets.fbx.allowDataAccess.name" tooltip="i18n:ENGINE.assets.fbx.allowDataAccess.title"></ui-label>
+        <ui-checkbox slot="content" class="allowDataAccess-checkbox"></ui-checkbox>
+    </ui-prop>
     <ui-section class="ins-object config" expand cache-expand="fbx-model-mesh-optimizer">
         <div slot="header" class="header">
             <ui-checkbox slot="content" class="meshOptimizer-checkbox"></ui-checkbox>
@@ -95,6 +99,7 @@ exports.$ = {
     morphNormalsSelect: '.morphNormals-select',
     skipValidationCheckbox: '.skipValidation-checkbox',
     disableMeshSplitCheckbox: '.disableMeshSplit-checkbox',
+    allowDataAccessCheckbox: '.allowDataAccess-checkbox',
     meshOptimizerCheckbox: '.meshOptimizer-checkbox',
     meshOptimizerSISlider: '.meshOptimizer-si-slider',
     meshOptimizerSACheckbox: '.meshOptimizer-sa-checkbox',
@@ -210,6 +215,21 @@ const Elements = {
             panel.updateReadonly(panel.$.disableMeshSplitCheckbox);
         },
     },
+    allowDataAccess: {
+        ready() {
+            const panel = this;
+
+            panel.$.allowDataAccessCheckbox.addEventListener('change', panel.setProp.bind(panel, 'allowDataAccess'));
+        },
+        update() {
+            const panel = this;
+
+            panel.$.allowDataAccessCheckbox.value = panel.getDefault(panel.meta.userData.allowDataAccess, false);
+
+            panel.updateInvalid(panel.$.allowDataAccessCheckbox, 'allowDataAccess');
+            panel.updateReadonly(panel.$.allowDataAccessCheckbox);
+        },
+    },
     meshOptimizer: {
         ready() {
             const panel = this;
@@ -317,7 +337,7 @@ const Elements = {
     },
 };
 
-exports.update = function(assetList, metaList) {
+exports.update = function (assetList, metaList) {
     this.assetList = assetList;
     this.metaList = metaList;
     this.asset = assetList[0];
@@ -331,7 +351,7 @@ exports.update = function(assetList, metaList) {
     }
 };
 
-exports.ready = function() {
+exports.ready = function () {
     for (const prop in Elements) {
         const element = Elements[prop];
         if (element.ready) {
@@ -340,7 +360,7 @@ exports.ready = function() {
     }
 };
 
-exports.close = function() {
+exports.close = function () {
     for (const prop in Elements) {
         const element = Elements[prop];
         if (element.close) {

--- a/editor/inspector/assets/fbx/model.js
+++ b/editor/inspector/assets/fbx/model.js
@@ -224,7 +224,7 @@ const Elements = {
         update() {
             const panel = this;
 
-            panel.$.allowMeshDataAccessCheckbox.value = panel.getDefault(panel.meta.userData.allowMeshDataAccess, false);
+            panel.$.allowMeshDataAccessCheckbox.value = panel.getDefault(panel.meta.userData.allowMeshDataAccess, true);
 
             panel.updateInvalid(panel.$.allowMeshDataAccessCheckbox, 'allowMeshDataAccess');
             panel.updateReadonly(panel.$.allowMeshDataAccessCheckbox);

--- a/editor/inspector/assets/fbx/model.js
+++ b/editor/inspector/assets/fbx/model.js
@@ -23,8 +23,8 @@ exports.template = `
         <ui-checkbox slot="content" class="disableMeshSplit-checkbox"></ui-checkbox>
     </ui-prop>
     <ui-prop>
-        <ui-label slot="label" value="i18n:ENGINE.assets.fbx.allowDataAccess.name" tooltip="i18n:ENGINE.assets.fbx.allowDataAccess.title"></ui-label>
-        <ui-checkbox slot="content" class="allowDataAccess-checkbox"></ui-checkbox>
+        <ui-label slot="label" value="i18n:ENGINE.assets.fbx.allowMeshDataAccess.name" tooltip="i18n:ENGINE.assets.fbx.allowMeshDataAccess.title"></ui-label>
+        <ui-checkbox slot="content" class="allowMeshDataAccess-checkbox"></ui-checkbox>
     </ui-prop>
     <ui-section class="ins-object config" expand cache-expand="fbx-model-mesh-optimizer">
         <div slot="header" class="header">
@@ -99,7 +99,7 @@ exports.$ = {
     morphNormalsSelect: '.morphNormals-select',
     skipValidationCheckbox: '.skipValidation-checkbox',
     disableMeshSplitCheckbox: '.disableMeshSplit-checkbox',
-    allowDataAccessCheckbox: '.allowDataAccess-checkbox',
+    allowMeshDataAccessCheckbox: '.allowMeshDataAccess-checkbox',
     meshOptimizerCheckbox: '.meshOptimizer-checkbox',
     meshOptimizerSISlider: '.meshOptimizer-si-slider',
     meshOptimizerSACheckbox: '.meshOptimizer-sa-checkbox',
@@ -215,19 +215,19 @@ const Elements = {
             panel.updateReadonly(panel.$.disableMeshSplitCheckbox);
         },
     },
-    allowDataAccess: {
+    allowMeshDataAccess: {
         ready() {
             const panel = this;
 
-            panel.$.allowDataAccessCheckbox.addEventListener('change', panel.setProp.bind(panel, 'allowDataAccess'));
+            panel.$.allowMeshDataAccessCheckbox.addEventListener('change', panel.setProp.bind(panel, 'allowMeshDataAccess'));
         },
         update() {
             const panel = this;
 
-            panel.$.allowDataAccessCheckbox.value = panel.getDefault(panel.meta.userData.allowDataAccess, false);
+            panel.$.allowMeshDataAccessCheckbox.value = panel.getDefault(panel.meta.userData.allowMeshDataAccess, false);
 
-            panel.updateInvalid(panel.$.allowDataAccessCheckbox, 'allowDataAccess');
-            panel.updateReadonly(panel.$.allowDataAccessCheckbox);
+            panel.updateInvalid(panel.$.allowMeshDataAccessCheckbox, 'allowMeshDataAccess');
+            panel.updateReadonly(panel.$.allowMeshDataAccessCheckbox);
         },
     },
     meshOptimizer: {


### PR DESCRIPTION
Re: #

### Changelog

* Add Allow Data Access Option.

-------

### Continuous Integration

This pull request:
https://github.com/cocos/3d-tasks/issues/12940
* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
