### PR TITLE
V3.6 fix warning log & space in path

### DIFF
--- a/scripts/native-pack-tool/source/base/default.ts
+++ b/scripts/native-pack-tool/source/base/default.ts
@@ -133,7 +133,7 @@ export abstract class NativePackTool {
     protected tryReadProjectTemplateVersion(): { version: string, skipCheck: boolean | undefined } | null {
         const versionJsonPath = this.projEngineVersionPath;
         if (!fs.existsSync(versionJsonPath)) {
-            console.warn(`${versionJsonPath} not exists`);
+            console.log(`warning: ${versionJsonPath} not exists`);
             return null;
         }
         try {
@@ -255,7 +255,7 @@ export abstract class NativePackTool {
 
             const newerThanEngineVersion = this.versionParser.parse(`>${engineVersion}`);
             if (newerThanEngineVersion.match(projEngineVersion)) {
-                console.warn(`warning: ${projEngineVersion} is newer than engine version ${engineVersion}`);
+                console.log(`warning: ${projEngineVersion} is newer than engine version ${engineVersion}`);
             }
             return true;
         }

--- a/scripts/native-pack-tool/source/platforms/ios.ts
+++ b/scripts/native-pack-tool/source/platforms/ios.ts
@@ -98,7 +98,7 @@ export class IOSPackTool extends MacOSPackTool {
         this.appendCmakeResDirArgs(ext);
 
         const ver = toolHelper.getXcodeMajorVerion() >= 12 ? "12" : "1";
-        await toolHelper.runCmake(['-S', `${this.paths.platformTemplateDirInPrj}`, '-GXcode', `-B${nativePrjDir}`, '-T', `buildsystem=${ver}`,
+        await toolHelper.runCmake(['-S', `"${this.paths.platformTemplateDirInPrj}"`, '-GXcode', `-B"${nativePrjDir}"`, '-T', `buildsystem=${ver}`,
                                     '-DCMAKE_SYSTEM_NAME=iOS'].concat(ext));
 
         await this.skipUpdateXcodeProject();
@@ -269,7 +269,7 @@ export class IOSPackTool extends MacOSPackTool {
 
     async runIosDevice(): Promise<boolean> {
         const buildDir = this.paths.nativePrjDir;
-        const foundApps = execSync(`find ${buildDir} -name "*.app"`)
+        const foundApps = execSync(`find "${buildDir}" -name "*.app"`)
             .toString('utf-8')
             .split('\n')
             .filter((x) => x.trim().length > 0);
@@ -281,7 +281,7 @@ export class IOSPackTool extends MacOSPackTool {
         if (foundApps.length > 0) {
             const cwd = fs.mkdtempSync(ps.join(os.tmpdir(), this.params.projectName));
             await cchelper.runCmd(
-               'xcrun', ['xctrace', 'record', '--template', `'App Launch'`, '--device', `'${deviceId}'`, '--launch', '--', `${foundApps[0]}`],
+               'xcrun', ['xctrace', 'record', '--template', `'App Launch'`, '--device', `'${deviceId}'`, '--launch', '--', `"${foundApps[0]}"`],
                false, cwd);
         }
         return true;
@@ -294,7 +294,7 @@ export class IOSPackTool extends MacOSPackTool {
         console.log(` - build dir ${buildDir} - simId ${simId}`);
         console.log(` - bundle id ${bundleId}`);
 
-        const foundApps = execSync(`find ${buildDir} -name "*.app"`)
+        const foundApps = execSync(`find "${buildDir}" -name "*.app"`)
             .toString('utf-8')
             .split('\n')
             .filter((x) => x.trim().length > 0);
@@ -305,7 +305,7 @@ export class IOSPackTool extends MacOSPackTool {
                 'open', ['`xcode-select -p`/Applications/Simulator.app'], true);
             await cchelper.runCmd('xcrun', ['simctl', 'boot', simId], true);
             await cchelper.runCmd(
-                'xcrun', ['simctl', 'install', simId, foundApps[0].trim()], false);
+                'xcrun', ['simctl', 'install', simId, `"${foundApps[0].trim()}"`], false);
             await cchelper.runCmd(
                 'xcrun', ['simctl', 'launch', simId, `"${bundleId}"`], false);
         }

--- a/scripts/native-pack-tool/source/platforms/ios.ts
+++ b/scripts/native-pack-tool/source/platforms/ios.ts
@@ -137,7 +137,7 @@ export class IOSPackTool extends MacOSPackTool {
             }
         }
         else {
-            const projCompileParams = `--build ${nativePrjDir} --config ${this.params.debug ? 'Debug' : 'Release'} -- -allowProvisioningUpdates -quiet`;
+            const projCompileParams = `--build "${nativePrjDir}" --config ${this.params.debug ? 'Debug' : 'Release'} -- -allowProvisioningUpdates -quiet`;
             if (options.iphoneos) {
                 await toolHelper.runCmake([projCompileParams, '-sdk', 'iphoneos', `-arch arm64`]);
             }

--- a/scripts/native-pack-tool/source/platforms/mac.ts
+++ b/scripts/native-pack-tool/source/platforms/mac.ts
@@ -59,7 +59,7 @@ export class MacPackTool extends MacOSPackTool {
     private macOpen(app: string) {
         return new Promise<void>((resolve, reject) => {
             console.log(`open ${app}`);
-            const cp = spawn(`open`, [app], {
+            const cp = spawn(`open`, [`"${app}"`], {
                 shell: true,
                 env: process.env,
             });

--- a/scripts/native-pack-tool/source/platforms/mac.ts
+++ b/scripts/native-pack-tool/source/platforms/mac.ts
@@ -33,8 +33,8 @@ export class MacPackTool extends MacOSPackTool {
         }
 
         const ver = toolHelper.getXcodeMajorVerion() >= 12 ? "12" : "1";
-        const cmakeArgs = ['-S', `${this.paths.platformTemplateDirInPrj}`, '-GXcode', '-T', `buildsystem=${ver}`,
-                           `-B${nativePrjDir}`, '-DCMAKE_SYSTEM_NAME=Darwin'];
+        const cmakeArgs = ['-S', `"${this.paths.platformTemplateDirInPrj}"`, '-GXcode', '-T', `buildsystem=${ver}`,
+                           `-B"${nativePrjDir}"`, '-DCMAKE_SYSTEM_NAME=Darwin'];
         this.appendCmakeResDirArgs(cmakeArgs);
 
         await toolHelper.runCmake(cmakeArgs);
@@ -47,7 +47,7 @@ export class MacPackTool extends MacOSPackTool {
         const nativePrjDir = this.paths.nativePrjDir;
 
         const platform = this.isAppleSilicon() ? `-arch arm64` : `-arch x86_64`;
-        await toolHelper.runCmake(["--build", `${nativePrjDir}`, "--config", this.params.debug ? 'Debug' : 'Release', "--", "-quiet", platform]);
+        await toolHelper.runCmake(["--build", `"${nativePrjDir}"`, "--config", this.params.debug ? 'Debug' : 'Release', "--", "-quiet", platform]);
         return true;
     }
 

--- a/scripts/native-pack-tool/source/utils.ts
+++ b/scripts/native-pack-tool/source/utils.ts
@@ -90,7 +90,7 @@ export class cchelper {
                 await this.copyFileAsync(srcDir, dst);
             } catch (e) {
                 await this.delay(10);
-                // console.warn(`error: retry copying ${srcDir} -> to ${dst} ... ${e}`);
+                // console.log(`error: retry copying ${srcDir} -> to ${dst} ... ${e}`);
                 await this.copyFileAsync(srcDir, dst);
             }
         }
@@ -146,7 +146,7 @@ export class cchelper {
                     if (fs.existsSync(srcFile)) {
                         copyAsync(srcFile, ps.join(dstDir, f));
                     } else {
-                        console.warn(`warning: copyFile: ${srcFile} not exists!`);
+                        console.log(`warning: copyFile: ${srcFile} not exists!`);
                     }
                 }
                 if (files.length === 0 && runningTasks === 0) {
@@ -359,7 +359,7 @@ export class cchelper {
 
     static checkJavaHome(): boolean {
         if (!process.env.JAVA_HOME) {
-            console.warn('$JAVA_HOME is not set!');
+            console.log('warning: $JAVA_HOME is not set!');
         }
         const javaPath = cchelper.which('java');
         if (!javaPath) {
@@ -442,10 +442,20 @@ export const toolHelper = {
                 shell: true,
             });
             cp.stdout.on('data', (data: any) => {
-                console.log(`[cmake] ${iconv.decode(data, 'gbk').toString()}`);
+                const msg = iconv.decode(data, 'gbk').toString();
+                if(/warning/i.test(msg)) {
+                    console.warn(`[cmake-warn] ${msg}`);
+                } else {
+                    console.log(`[cmake] ${msg}`);
+                }
             });
             cp.stderr.on('data', (data: any) => {
-                console.error(`[cmake-err] ${iconv.decode(data, 'gbk').toString()}`);
+                const msg = iconv.decode(data, 'gbk').toString();
+                if(/CMake Warning/.test(msg) || /warning/i.test(msg)) {
+                    console.warn(`[cmake-warn] ${msg}`);
+                }else{
+                    console.error(`[cmake-err] ${msg}`);
+                }
             });
             cp.on('close', (code: number, sig: any) => {
                 if (code !== 0) {


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12872

### Changelog

* fix space in path
* fix warning log

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
