### PR TITLE
Fix windows crash when first entering into AudioBuffer scene

### DIFF
--- a/native/cocos/audio/AudioEngine.cpp
+++ b/native/cocos/audio/AudioEngine.cpp
@@ -594,9 +594,11 @@ bool AudioEngine::isEnabled() {
 }
 
 PCMHeader AudioEngine::getPCMHeader(const char *url) {
+    lazyInit();
     return sAudioEngineImpl->getPCMHeader(url);
 }
 ccstd::vector<uint8_t> AudioEngine::getOriginalPCMBuffer(const char *url, uint32_t channelID) {
+    lazyInit();
     return sAudioEngineImpl->getOriginalPCMBuffer(url, channelID);
 }
 } // namespace cc

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -593,9 +593,9 @@ ccstd::vector<uint8_t> AudioEngineImpl::getOriginalPCMBuffer(const char *url, ui
         uint32_t totalFrames = decoder->getTotalFrames();
         uint32_t remainingFrames = totalFrames;
         uint32_t framesRead = 0;
-        uint32_t framesToReadOnce = std::min(totalFrames, static_cast<uint32_t>(decoder->getSampleRate() * QUEUEBUFFER_TIME_STEP * QUEUEBUFFER_NUM));
+        uint32_t framesToReadOnce = std::min(remainingFrames, static_cast<uint32_t>(decoder->getSampleRate() * QUEUEBUFFER_TIME_STEP * QUEUEBUFFER_NUM));
         AudioDataFormat type = audioInfo.dataFormat;
-        auto tmpBuf = static_cast<char *>(malloc(framesToReadOnce * bytesPerChannelInFrame));
+        char *tmpBuf = static_cast<char *>(malloc(framesToReadOnce * audioInfo.bytesPerFrame));
         pcmData.resize(bytesPerChannelInFrame * audioInfo.totalFrames);
         uint8_t *p = pcmData.data();
         while (remainingFrames > 0) {
@@ -616,7 +616,9 @@ ccstd::vector<uint8_t> AudioEngineImpl::getOriginalPCMBuffer(const char *url, ui
             tmpBuf = static_cast<char *>(malloc(audioInfo.bytesPerFrame * framesToReadOnce));
             do {
                 framesRead = decoder->read(framesToReadOnce, tmpBuf); //read one by one to easy divide
-                pcmData.reserve(totalFrames + framesRead);
+                pcmData.resize(bytesPerChannelInFrame * (audioInfo.totalFrames+ framesRead));
+                p = pcmData.data();
+                p += bytesPerChannelInFrame * audioInfo.totalFrames;
                 if (framesRead > 0) { // Adjust frames exist
                     for (int itr = 0; itr < framesRead; itr++) {
                         memcpy(p, tmpBuf + itr * audioInfo.bytesPerFrame + channelID * bytesPerChannelInFrame, bytesPerChannelInFrame);

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -610,25 +610,6 @@ ccstd::vector<uint8_t> AudioEngineImpl::getOriginalPCMBuffer(const char *url, ui
             
         };
         free(tmpBuf);
-        // Adjust total frames by setting position to the end of frames and try to read more data.
-        // This is a workaround for https://github.com/cocos2d/cocos2d-x/issues/16938
-        if (decoder->seek(totalFrames)) {
-            tmpBuf = static_cast<char *>(malloc(audioInfo.bytesPerFrame * framesToReadOnce));
-            do {
-                framesRead = decoder->read(framesToReadOnce, tmpBuf); //read one by one to easy divide
-                pcmData.resize(bytesPerChannelInFrame * (audioInfo.totalFrames+ framesRead));
-                p = pcmData.data();
-                p += bytesPerChannelInFrame * audioInfo.totalFrames;
-                if (framesRead > 0) { // Adjust frames exist
-                    for (int itr = 0; itr < framesRead; itr++) {
-                        memcpy(p, tmpBuf + itr * audioInfo.bytesPerFrame + channelID * bytesPerChannelInFrame, bytesPerChannelInFrame);
-                        p += bytesPerChannelInFrame;
-                    }
-                }
-            } while (framesRead > 0);
-            free(tmpBuf);
-        }
-        BREAK_IF_ERR_LOG(!decoder->seek(0), "AudioDecoder::seek(0) failed!");
     } while (false);
     AudioDecoderManager::destroyDecoder(decoder);
     return pcmData;


### PR DESCRIPTION
Re: #

### Changelog

* lazy init if first time use AudioEngine
* fix crash when alloc with less memory

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
