### PR TITLE
[3.6.0]show failure after throw error on windows and ohos

### DIFF
--- a/scripts/native-pack-tool/source/platforms/ohos.ts
+++ b/scripts/native-pack-tool/source/platforms/ohos.ts
@@ -152,13 +152,11 @@ export class OHOSPackTool extends NativePackTool {
         const hapFile = this.selectHap(projectDir, outputMode);
 
         if (!fs.existsSync(hapFile)) {
-            console.error(`File ${hapFile} does not exist!`);
-            return false;
+            throw new Error(`[ohos run] File ${hapFile} does not exist!`);
         }
         const hdc = this.hdcPath;
         if (!hdc) {
-            console.error(`Failed to locate hdc`);
-            return false;
+            throw new Error(`[ohos run] Failed to locate hdc!`);
         }
 
         const tmpdir = `/sdcard/${this.randString(32)}`;

--- a/scripts/native-pack-tool/source/platforms/windows.ts
+++ b/scripts/native-pack-tool/source/platforms/windows.ts
@@ -139,8 +139,7 @@ export class WindowsPackTool extends NativePackTool {
             this.paths.nativePrjDir, this.params.debug ? 'Debug' : 'Release',
             `${this.params.projectName}.exe`);
         if (!fs.existsSync(destPath)) {
-            console.error('exe file not found at' + destPath);
-            return false;
+            throw new Error(`[windows run] exe file not found at' + destPath!`);
         }
         await cchelper.runCmd(destPath, [], false);
         return true;


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12709

### Changelog

* Windows and ohos platforms fail to run and throw error

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
