### PR TITLE
Fix global ds manager

### DIFF
--- a/cocos/core/pipeline/forward/forward-stage.ts
+++ b/cocos/core/pipeline/forward/forward-stage.ts
@@ -148,6 +148,7 @@ export class ForwardStage extends RenderStage {
             }
         }
 
+        this._instancedQueue.sort();
         this._renderQueues.forEach(renderQueueSortFunc);
 
         const cmdBuff = pipeline.commandBuffers[0];

--- a/cocos/core/pipeline/render-instanced-queue.ts
+++ b/cocos/core/pipeline/render-instanced-queue.ts
@@ -89,7 +89,7 @@ export class RenderInstancedQueue {
      */
     public recordCommandBuffer (device: Device, renderPass: RenderPass, cmdBuff: CommandBuffer,
         descriptorSet: DescriptorSet | null = null, dynamicOffsets?: Readonly<number[]>) {
-        const it = this._renderQueue.values(); let res = it.next();
+        const it = this._renderQueue.length === 0 ? this.queue.values() : this._renderQueue.values(); let res = it.next();
         while (!res.done) {
             const { instances, pass, hasPendingModels } = res.value;
             if (hasPendingModels) {

--- a/cocos/core/pipeline/render-instanced-queue.ts
+++ b/cocos/core/pipeline/render-instanced-queue.ts
@@ -89,8 +89,7 @@ export class RenderInstancedQueue {
      */
     public recordCommandBuffer (device: Device, renderPass: RenderPass, cmdBuff: CommandBuffer,
         descriptorSet: DescriptorSet | null = null, dynamicOffsets?: Readonly<number[]>) {
-
-        const it = this._renderQueue.length === 0 ? this.queue.values() : this._renderQueue.values(); 
+        const it = this._renderQueue.length === 0 ? this.queue.values() : this._renderQueue.values();
         let res = it.next();
 
         while (!res.done) {

--- a/native/cocos/renderer/pipeline/GlobalDescriptorSetManager.cpp
+++ b/native/cocos/renderer/pipeline/GlobalDescriptorSetManager.cpp
@@ -59,6 +59,12 @@ void GlobalDSManager::activate(gfx::Device *device) {
     SkinningJointCapacity::jointUniformCapacity = maxJoints;
     UBOSkinning::initLayout(maxJoints);
 
+    _defaultTexture = _device->createTexture({gfx::TextureType::TEX2D,
+                                              gfx::TextureUsageBit::COLOR_ATTACHMENT | gfx::TextureUsageBit::SAMPLED,
+                                              gfx::Format::RGBA8,
+                                              2,
+                                              2});
+
     setDescriptorSetLayout();
     _descriptorSetLayout = device->createDescriptorSetLayout({globalDescriptorSetLayout.bindings});
     _globalDescriptorSet = device->createDescriptorSet({_descriptorSetLayout});
@@ -89,6 +95,7 @@ void GlobalDSManager::bindSampler(uint32_t binding, gfx::Sampler *sampler) {
 }
 
 void GlobalDSManager::bindTexture(uint32_t binding, gfx::Texture *texture) {
+    if (!texture) texture = _defaultTexture.get();
     if (_globalDescriptorSet != nullptr) {
         _globalDescriptorSet->bindTexture(binding, texture);
     }
@@ -159,6 +166,8 @@ void GlobalDSManager::destroy() {
     _globalDescriptorSet = nullptr;
     _linearSampler = nullptr;
     _pointSampler = nullptr;
+
+    _defaultTexture = nullptr;
 }
 
 void GlobalDSManager::setDescriptorSetLayout() {

--- a/native/cocos/renderer/pipeline/GlobalDescriptorSetManager.h
+++ b/native/cocos/renderer/pipeline/GlobalDescriptorSetManager.h
@@ -72,6 +72,8 @@ private:
     gfx::Sampler *_linearSampler{nullptr};
     gfx::Sampler *_pointSampler{nullptr};
 
+    IntrusivePtr<gfx::Texture> _defaultTexture;
+
     IntrusivePtr<gfx::DescriptorSetLayout> _descriptorSetLayout;
     IntrusivePtr<gfx::DescriptorSet> _globalDescriptorSet;
     ccstd::vector<IntrusivePtr<gfx::Buffer>> _shadowUBOs;

--- a/native/cocos/renderer/pipeline/forward/ForwardStage.cpp
+++ b/native/cocos/renderer/pipeline/forward/ForwardStage.cpp
@@ -134,6 +134,8 @@ void ForwardStage::dispenseRenderObject2Queues() {
         }
     }
 
+    _instancedQueue->sort();
+
     for (auto *queue : _renderQueues) {
         queue->sort();
     }

--- a/native/cocos/renderer/pipeline/shadow/ShadowFlow.cpp
+++ b/native/cocos/renderer/pipeline/shadow/ShadowFlow.cpp
@@ -26,13 +26,13 @@
 #include "ShadowFlow.h"
 
 #include "CSMLayers.h"
+#include "ShadowStage.h"
+#include "gfx-base/GFXDevice.h"
 #include "pipeline//Define.h"
 #include "pipeline/GlobalDescriptorSetManager.h"
 #include "pipeline/PipelineSceneData.h"
 #include "pipeline/RenderPipeline.h"
 #include "pipeline/SceneCulling.h"
-#include "ShadowStage.h"
-#include "gfx-base/GFXDevice.h"
 #include "profiler/Profiler.h"
 #include "scene/Camera.h"
 #include "scene/DirectionalLight.h"
@@ -118,7 +118,7 @@ void ShadowFlow::render(scene::Camera *camera) {
 
         if (!shadowFramebufferMap.count(light)) {
             initShadowFrameBuffer(_pipeline, light);
-        }else {
+        } else {
             if (shadowInfo->isShadowMapDirty()) {
                 resizeShadowMap(light, ds);
             }
@@ -230,7 +230,7 @@ void ShadowFlow::resizeShadowMap(const scene::Light *light, gfx::DescriptorSet *
         width,
         height,
     });
-    
+
     auto *oldDepthStencilTexture = framebuffer->getDepthStencilTexture();
     const auto iter = std::find(_usedTextures.begin(), _usedTextures.end(), oldDepthStencilTexture);
     _usedTextures.erase(iter);
@@ -244,7 +244,7 @@ void ShadowFlow::resizeShadowMap(const scene::Light *light, gfx::DescriptorSet *
     });
 }
 
-void ShadowFlow::initShadowFrameBuffer(const RenderPipeline* pipeline, const scene::Light* light) {
+void ShadowFlow::initShadowFrameBuffer(const RenderPipeline *pipeline, const scene::Light *light) {
     auto *device = gfx::Device::getInstance();
     const auto *sceneData = _pipeline->getPipelineSceneData();
     const auto *shadowInfo = sceneData->getShadows();
@@ -317,6 +317,9 @@ void ShadowFlow::initShadowFrameBuffer(const RenderPipeline* pipeline, const sce
 }
 
 void ShadowFlow::destroy() {
+    _pipeline->getGlobalDSManager()->bindTexture(SHADOWMAP::BINDING, nullptr);
+    _pipeline->getGlobalDSManager()->bindTexture(SPOTSHADOWMAP::BINDING, nullptr);
+
     _renderPass = nullptr;
     renderPassHashMap.clear();
     _usedTextures.clear();


### PR DESCRIPTION
Re: #

### Changelog

* now global dsManager->bindTexture(binding, nullptr); will reset the corresponding binding to use the default texture.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
