### PR TITLE
fix: PhysX collision filter needs unsigned int (32bit)(#12970)

### DIFF
--- a/cocos/physics/physx/physx-shared-body.ts
+++ b/cocos/physics/physx/physx-shared-body.ts
@@ -339,6 +339,7 @@ export class PhysXSharedBody {
     }
 
     setGroup (v: number): void {
+        v >>>= 0; //convert to unsigned int(32bit) for physx
         this._filterData.word0 = v;
         this.updateFilterData();
     }
@@ -348,17 +349,19 @@ export class PhysXSharedBody {
     }
 
     addGroup (v: number): void {
+        v >>>= 0; //convert to unsigned int(32bit) for physx
         this._filterData.word0 |= v;
         this.updateFilterData();
     }
 
     removeGroup (v: number): void {
+        v >>>= 0; //convert to unsigned int(32bit) for physx
         this._filterData.word0 &= ~v;
         this.updateFilterData();
     }
 
     setMask (v: number): void {
-        if (v === -1) v = 0xffffffff;
+        v >>>= 0; //convert to unsigned int(32bit) for physx
         this._filterData.word1 = v;
         this.updateFilterData();
     }
@@ -368,11 +371,13 @@ export class PhysXSharedBody {
     }
 
     addMask (v: number): void {
+        v >>>= 0; //convert to unsigned int(32bit) for physx
         this._filterData.word1 |= v;
         this.updateFilterData();
     }
 
     removeMask (v: number): void {
+        v >>>= 0; //convert to unsigned int(32bit) for physx
         this._filterData.word1 &= ~v;
         this.updateFilterData();
     }


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/12970

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
