### PR TITLE
V3.6.0 batcher2d mask to native

### DIFF
--- a/cocos/2d/components/mask.ts
+++ b/cocos/2d/components/mask.ts
@@ -376,10 +376,13 @@ export class Mask extends UIRenderer {
         }
 
         if (JSB) {
-            if (this.renderEntity && this.renderData && this._graphics) {
-                this.renderEntity.setIsMask(true);
+            if (!this._renderEntity) {
+                this.initRenderEntity();
+            }
+            if (this._renderEntity && this.renderData && this._graphics) {
+                this._renderEntity.setIsMask(true);
                 this._graphics.renderEntity!.setIsSubMask(true);
-                this.renderEntity.setIsMaskInverted(this._inverted);
+                this._renderEntity.setIsMaskInverted(this._inverted);
                 this.renderData.renderDrawInfo.setIsMeshBuffer(true);
             }
         }

--- a/cocos/2d/components/mask.ts
+++ b/cocos/2d/components/mask.ts
@@ -147,10 +147,11 @@ export class Mask extends UIRenderer {
         if (this._type !== MaskType.IMAGE_STENCIL) {
             this._spriteFrame = null;
             this._updateGraphics();
-            if (this.renderData) {
-                this.destroyRenderData();
-                this.renderData = null;
-            }
+            // keep renderData to transport renderDrawInfo
+            // if (this.renderData) {
+            //     this.destroyRenderData();
+            //     this.renderData = null;
+            // }
         } else {
             this._useRenderData();
 
@@ -375,10 +376,11 @@ export class Mask extends UIRenderer {
         }
 
         if (JSB) {
-            if (this.renderEntity && this._graphics) {
+            if (this.renderEntity && this.renderData && this._graphics) {
                 this.renderEntity.setIsMask(true);
-                this._graphics.renderEntity?.setIsSubMask(true);
+                this._graphics.renderEntity!.setIsSubMask(true);
                 this.renderEntity.setIsMaskInverted(this._inverted);
+                this.renderData.renderDrawInfo.setIsMeshBuffer(true);
             }
         }
     }
@@ -649,7 +651,8 @@ export class Mask extends UIRenderer {
     }
 
     protected _useRenderData () {
-        if (this._type === MaskType.IMAGE_STENCIL && !this.renderData) {
+        //if (this._type === MaskType.IMAGE_STENCIL && !this.renderData) {
+        if (!this.renderData) {
             if (this._assembler && this._assembler.createData) {
                 this.renderData = this._assembler.createData(this);
                 this.markForUpdateRenderData();

--- a/cocos/2d/renderer/native-2d.ts
+++ b/cocos/2d/renderer/native-2d.ts
@@ -3,138 +3,147 @@ import { Attribute, Device, Sampler, Texture } from '../../core/gfx';
 import { Node } from '../../core/scene-graph';
 import { Model } from '../../core/renderer/scene';
 
-export  declare class NativeRenderDrawInfo {
-    constructor (batcher: NativeBatcher2d);
+export declare class NativeRenderDrawInfo {
+    constructor(batcher: NativeBatcher2d);
 
     // get batcher ():NativeBatcher2d { return new NativeBatcher2d(); }
     // set batcher (batcher: NativeBatcher2d) {}
 
-    get accId (): number;
-    set accId (accId: number);
+    get accId(): number;
+    set accId(accId: number);
 
-    get bufferId (): number;
-    set bufferId (bufferId: number);
+    get bufferId(): number;
+    set bufferId(bufferId: number);
 
-    get vertexOffset (): number;
-    set vertexOffset (vertexOffset: number);
+    get vertexOffset(): number;
+    set vertexOffset(vertexOffset: number);
 
-    get indexOffset (): number;
-    set indexOffset (indexOffset: number);
+    get indexOffset(): number;
+    set indexOffset(indexOffset: number);
 
-    get vbBuffer (): ArrayBufferLike;
-    set vbBuffer (vbBuffer: ArrayBufferLike);
+    get vbBuffer(): ArrayBufferLike;
+    set vbBuffer(vbBuffer: ArrayBufferLike);
 
-    get ibBuffer (): ArrayBufferLike;
-    set ibBuffer (ibBuffer: ArrayBufferLike);
+    get ibBuffer(): ArrayBufferLike;
+    set ibBuffer(ibBuffer: ArrayBufferLike);
 
-    get vDataBuffer (): ArrayBufferLike;
-    set vDataBuffer (vDataBuffer: ArrayBufferLike);
+    get vDataBuffer(): ArrayBufferLike;
+    set vDataBuffer(vDataBuffer: ArrayBufferLike);
 
-    get iDataBuffer (): ArrayBufferLike;
-    set iDataBuffer (iDataBuffer: ArrayBufferLike);
+    get iDataBuffer(): ArrayBufferLike;
+    set iDataBuffer(iDataBuffer: ArrayBufferLike);
 
-    get vbCount (): number;
-    set vbCount (vbCount: number);
+    get vbCount(): number;
+    set vbCount(vbCount: number);
 
-    get ibCount (): number;
-    set ibCount (ibCount: number);
+    get ibCount(): number;
+    set ibCount(ibCount: number);
 
-    get vertDirty (): boolean;
-    set vertDirty (val: boolean);
+    get vertDirty(): boolean;
+    set vertDirty(val: boolean);
 
-    get dataHash (): number;
-    set dataHash (dataHash: number);
+    get dataHash(): number;
+    set dataHash(dataHash: number);
 
-    get isMeshBuffer (): boolean;
-    set isMeshBuffer (isMeshBuffer: boolean);
+    get isMeshBuffer(): boolean;
+    set isMeshBuffer(isMeshBuffer: boolean);
 
-    get material (): Material | null;
-    set material (material: Material | null);
+    get material(): Material | null;
+    set material(material: Material | null);
 
-    get texture (): Texture | null;
-    set texture (texture: Texture | null);
+    get texture(): Texture | null;
+    set texture(texture: Texture | null);
 
-    get textureHash (): number;
-    set textureHash (textureHash: number);
+    get textureHash(): number;
+    set textureHash(textureHash: number);
 
-    get sampler (): Sampler | null;
-    set sampler (sampler: Sampler | null);
+    get sampler(): Sampler | null;
+    set sampler(sampler: Sampler | null);
 
-    get blendHash (): number;
-    set blendHash (blendHash: number);
+    get blendHash(): number;
+    set blendHash(blendHash: number);
 
-    get model (): Model | null;
-    set model (model: Model | null);
+    get model(): Model | null;
+    set model(model: Model | null);
 
-    setRender2dBufferToNative (data: TypedArray, stride: number, size: number);
-    syncSharedBufferToNative (data: TypedArray);
-    getAttrSharedBufferForJS (): ArrayBufferLike;
+    setRender2dBufferToNative(data: TypedArray, stride: number, size: number);
+    syncSharedBufferToNative(data: TypedArray);
+    getAttrSharedBufferForJS(): ArrayBufferLike;
 }
 
 export declare class NativeRenderEntity {
-    constructor (batcher: NativeBatcher2d);
+    constructor(batcher: NativeBatcher2d);
 
-    addDynamicRenderDrawInfo (drawInfo: NativeRenderDrawInfo);
-    setDynamicRenderDrawInfo (drawInfo: NativeRenderDrawInfo, index: number);
-    removeDynamicRenderDrawInfo ();
+    addDynamicRenderDrawInfo(drawInfo: NativeRenderDrawInfo);
+    setDynamicRenderDrawInfo(drawInfo: NativeRenderDrawInfo, index: number);
+    removeDynamicRenderDrawInfo();
 
-    get node (): Node | null;
-    set node (node: Node | null);
+    get isMask(): boolean;
+    set isMask(val: boolean);
 
-    get stencilStage ():number;
-    set stencilStage (stage:number);
+    get isSubMask(): boolean;
+    set isSubMask(val: boolean);
 
-    get customMaterial ():Material;
-    set customMaterial (mat:Material);
+    get isMaskInverted():boolean;
+    set isMaskInverted(val:boolean);
 
-    get commitModelMaterial ():Material;
-    set commitModelMaterial (mat:Material);
+    get node(): Node | null;
+    set node(node: Node | null);
 
-    get staticDrawInfoSize (): number;
-    set staticDrawInfoSize (size: number);
+    get stencilStage(): number;
+    set stencilStage(stage: number);
 
-    setRenderEntityType (type: number);
-    getStaticRenderDrawInfo (index: number): NativeRenderDrawInfo;
-    getEntitySharedBufferForJS (): ArrayBufferLike;
+    get customMaterial(): Material;
+    set customMaterial(mat: Material);
+
+    get commitModelMaterial(): Material;
+    set commitModelMaterial(mat: Material);
+
+    get staticDrawInfoSize(): number;
+    set staticDrawInfoSize(size: number);
+
+    setRenderEntityType(type: number);
+    getStaticRenderDrawInfo(index: number): NativeRenderDrawInfo;
+    getEntitySharedBufferForJS(): ArrayBufferLike;
 }
 
 export declare class NativeUIMeshBuffer {
-    get vData (): Float32Array;
-    set vData (val: Float32Array);
-    get iData (): Uint16Array;
-    set iData (val: Uint16Array);
+    get vData(): Float32Array;
+    set vData(val: Float32Array);
+    get iData(): Uint16Array;
+    set iData(val: Uint16Array);
 
-    syncSharedBufferToNative (data: TypedArray);
+    syncSharedBufferToNative(data: TypedArray);
 
-    initialize (device: Device, attrs: Attribute[], vFloatCount: number, iCount: number);
-    reset ();
-    destroy ();
-    setDirty ();
-    recycleIA ();
-    uploadBuffers ();
+    initialize(device: Device, attrs: Attribute[], vFloatCount: number, iCount: number);
+    reset();
+    destroy();
+    setDirty();
+    recycleIA();
+    uploadBuffers();
 }
 
 export declare class NativeBatcher2d {
-    syncMeshBuffersToNative (accId: number, buffers: NativeUIMeshBuffer[]);
-    update ();
-    uploadBuffers ();
-    reset ();
-    addRootNode (node: Node);
-    releaseDescriptorSetCache (texture: Texture, sampler: Sampler);
+    syncMeshBuffersToNative(accId: number, buffers: NativeUIMeshBuffer[]);
+    update();
+    uploadBuffers();
+    reset();
+    addRootNode(node: Node);
+    releaseDescriptorSetCache(texture: Texture, sampler: Sampler);
 }
 
 export declare class NativeUIModelProxy {
-    initModel (node);
-    activeSubModel (index: number);
-    uploadData ();
-    destroy ();
-    clear ();
-    updateModels (model);
-    attachDrawInfo ();
-    attachNode (node);
+    initModel(node);
+    activeSubModel(index: number);
+    uploadData();
+    destroy();
+    clear();
+    updateModels(model);
+    attachDrawInfo();
+    attachNode(node);
 }
 
 export declare class NativeStencilManager {
-    setStencilStage (stageIndex:number);
-    getStencilSharedBufferForJS (): ArrayBufferLike;
+    setStencilStage(stageIndex: number);
+    getStencilSharedBufferForJS(): ArrayBufferLike;
 }

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -191,13 +191,17 @@ export class BaseRenderData {
             if (!this._renderDrawInfo) {
                 return;
             }
-            this._renderDrawInfo.setBufferId(this.chunk.bufferId);
-            this._renderDrawInfo.setVertexOffset(this.chunk.vertexOffset);
-            this._renderDrawInfo.setIndexOffset(this.chunk.meshBuffer.indexOffset);
-            this._renderDrawInfo.setVB(this.chunk.vb);
-            this._renderDrawInfo.setIB(this.chunk.ib);
-            this._renderDrawInfo.setVData(this.chunk.meshBuffer.vData.buffer);
-            this._renderDrawInfo.setIData(this.chunk.meshBuffer.iData.buffer);
+            if (this.chunk) {
+                this._renderDrawInfo.setBufferId(this.chunk.bufferId);
+                this._renderDrawInfo.setVertexOffset(this.chunk.vertexOffset);
+                this._renderDrawInfo.setVB(this.chunk.vb);
+                this._renderDrawInfo.setIB(this.chunk.ib);
+                if (this.chunk.meshBuffer) {
+                    this._renderDrawInfo.setIndexOffset(this.chunk.meshBuffer.indexOffset);
+                    this._renderDrawInfo.setVData(this.chunk.meshBuffer.vData.buffer);
+                    this._renderDrawInfo.setIData(this.chunk.meshBuffer.iData.buffer);
+                }
+            }
             this._renderDrawInfo.setVBCount(this._vc);
             this._renderDrawInfo.setIBCount(this._ic);
 
@@ -376,26 +380,6 @@ export class RenderData extends BaseRenderData {
             this._renderDrawInfo.setTextureHash(this.textureHash);
             this._renderDrawInfo.setSampler(this.frame ? this.frame.getGFXSampler() : null);
             this._renderDrawInfo.setBlendHash(this.blendHash);
-        }
-    }
-
-    public fillDrawInfoAttributes (drawInfo : RenderDrawInfo) {
-        if (JSB) {
-            if (!drawInfo) {
-                return;
-            }
-            drawInfo.setAccId(this._accessor.id);
-            drawInfo.setBufferId(this.chunk.bufferId);
-            drawInfo.setVertexOffset(this.chunk.vertexOffset);
-            drawInfo.setIndexOffset(this.chunk.meshBuffer.indexOffset);
-            drawInfo.setVB(this.chunk.vb);
-            drawInfo.setIB(this.chunk.ib);
-            drawInfo.setVData(this.chunk.meshBuffer.vData.buffer);
-            drawInfo.setIData(this.chunk.meshBuffer.iData.buffer);
-            drawInfo.setVBCount(this._vc);
-            drawInfo.setIBCount(this._ic);
-            drawInfo.setDataHash(this.dataHash);
-            drawInfo.setIsMeshBuffer(this.isMeshBuffer);
         }
     }
 

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -383,6 +383,26 @@ export class RenderData extends BaseRenderData {
         }
     }
 
+    public fillDrawInfoAttributes (drawInfo : RenderDrawInfo) {
+        if (JSB) {
+            if (!drawInfo) {
+                return;
+            }
+            drawInfo.setAccId(this._accessor.id);
+            drawInfo.setBufferId(this.chunk.bufferId);
+            drawInfo.setVertexOffset(this.chunk.vertexOffset);
+            drawInfo.setIndexOffset(this.chunk.meshBuffer.indexOffset);
+            drawInfo.setVB(this.chunk.vb);
+            drawInfo.setIB(this.chunk.ib);
+            drawInfo.setVData(this.chunk.meshBuffer.vData.buffer);
+            drawInfo.setIData(this.chunk.meshBuffer.iData.buffer);
+            drawInfo.setVBCount(this._vc);
+            drawInfo.setIBCount(this._ic);
+            drawInfo.setDataHash(this.dataHash);
+            drawInfo.setIsMeshBuffer(this.isMeshBuffer);
+        }
+    }
+
     // Initial advance render data for native
     protected syncRender2dBuffer () {
         if (JSB && this.multiOwner === false) {

--- a/cocos/2d/renderer/render-entity.ts
+++ b/cocos/2d/renderer/render-entity.ts
@@ -189,7 +189,7 @@ export class RenderEntity {
     setIsSubMask (val:boolean) {
         if (JSB) {
             if (this._isSubMask !== val) {
-                this._isSubMask = val;
+                this._nativeObj.isSubMask = val;
             }
         }
         this._isSubMask = val;
@@ -198,7 +198,7 @@ export class RenderEntity {
     setIsMaskInverted (val:boolean) {
         if (JSB) {
             if (this._isMaskInverted !== val) {
-                this._isMaskInverted = val;
+                this._nativeObj.isMaskInverted = val;
             }
         }
         this._isMaskInverted = val;

--- a/cocos/2d/renderer/render-entity.ts
+++ b/cocos/2d/renderer/render-entity.ts
@@ -36,6 +36,13 @@ export class RenderEntity {
     protected _customMaterial: Material | null = null;
     protected _commitModelMaterial: Material | null = null;
 
+    // is it entity a mask node
+    protected _isMask = false;
+    // is it entity a sub mask node
+    protected _isSubMask = false;
+    // is mask inverted
+    protected _isMaskInverted = false;
+
     protected declare _sharedBuffer: Float32Array;
 
     private declare _nativeObj: NativeRenderEntity;
@@ -168,6 +175,33 @@ export class RenderEntity {
             this.setNode(comp.node);
             this.enabled = comp.enabled;
         }
+    }
+
+    setIsMask (val:boolean) {
+        if (JSB) {
+            if (this._isMask !== val) {
+                this._nativeObj.isMask = val;
+            }
+        }
+        this._isMask = val;
+    }
+
+    setIsSubMask (val:boolean) {
+        if (JSB) {
+            if (this._isSubMask !== val) {
+                this._isSubMask = val;
+            }
+        }
+        this._isSubMask = val;
+    }
+
+    setIsMaskInverted (val:boolean) {
+        if (JSB) {
+            if (this._isMaskInverted !== val) {
+                this._isMaskInverted = val;
+            }
+        }
+        this._isMaskInverted = val;
     }
 
     setNode (node: Node | null) {

--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -191,6 +191,11 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
         resetRenderStates();
 
         // stencil stage
+        gfx::DepthStencilState* depthStencil = nullptr;
+        ccstd::hash_t dssHash = 0;
+        Material* commitModelMat = entity->getCommitModelMaterial();
+        Material* finalMat = drawInfo->getMaterial();
+
         bool isMask = entity->getIsMask();
         bool isSubMask = entity->getIsSubMask();
         bool isMaskInverted = entity->getIsMaskInverted();
@@ -198,6 +203,7 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
             //Mask node
             _stencilManager->pushMask();
             _stencilManager->clear(entity);
+            finalMat = commitModelMat;
 
         } else if (isSubMask) {
             //Mask graphics
@@ -208,9 +214,6 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
         }
         _currStencilStage = _stencilManager->getStencilStage();
 
-        gfx::DepthStencilState* depthStencil = nullptr;
-        ccstd::hash_t dssHash = 0;
-        Material* commitModelMat = entity->getCommitModelMaterial();
         if (commitModelMat) {
             StencilStage entityStage = entity->getEnumStencilStage();
             if (entityStage == StencilStage::ENABLED || entityStage == StencilStage::DISABLED) {
@@ -236,7 +239,7 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
             curdrawBatch->setDescriptorSet(submodel->getDescriptorSet());
             curdrawBatch->setUseLocalFlag(nullptr);
 
-            curdrawBatch->fillPass(drawInfo->getMaterial(), depthStencil, dssHash, nullptr, 0, &(submodel->getPatches()));
+            curdrawBatch->fillPass(finalMat, depthStencil, dssHash, nullptr, 0, &(submodel->getPatches()));
             _batches.push_back(curdrawBatch);
         }
     } else {

--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -126,6 +126,10 @@ void Batcher2d::handlePostRender(RenderEntity* entity) {
     bool isMask = entity->getIsMask();
     bool isSubMask = entity->getIsSubMask();
     if (isMask) {
+        //generate batch
+        generateBatch(_currEntity, _currDrawInfo);
+        resetRenderStates();
+
         _stencilManager->exitMask();
     } else if (isSubMask) {
         _stencilManager->enableMask();

--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -33,11 +33,13 @@
 namespace cc {
 Batcher2d::Batcher2d() : Batcher2d(nullptr) {
     _device = Root::getInstance()->getDevice();
+    _stencilManager = StencilManager::getInstance();
 }
 
 Batcher2d::Batcher2d(Root* root) : _drawBatchPool([]() { return ccnew scene::DrawBatch2D(); }, 10U) {
     _root = root;
     _device = Root::getInstance()->getDevice();
+    _stencilManager = StencilManager::getInstance();
 }
 
 Batcher2d::~Batcher2d() {
@@ -113,6 +115,21 @@ void Batcher2d::walk(Node* node) { // NOLINT(misc-no-recursion)
         }
         walk(child);
     }
+
+    // post assembler
+    if (_stencilManager->getMaskStackSize() > 0 && entity && entity->isEnabled()) {
+        handlePostRender(entity);
+    }
+}
+
+void Batcher2d::handlePostRender(RenderEntity* entity) {
+    bool isMask = entity->getIsMask();
+    bool isSubMask = entity->getIsSubMask();
+    if (isMask) {
+        _stencilManager->exitMask();
+    } else if (isSubMask) {
+        _stencilManager->enableMask();
+    }
 }
 
 void Batcher2d::handleStaticDrawInfo(RenderEntity* entity, RenderDrawInfo* drawInfo, Node* curNode) {
@@ -122,7 +139,7 @@ void Batcher2d::handleStaticDrawInfo(RenderEntity* entity, RenderDrawInfo* drawI
             dataHash = 0;
         }
 
-        entity->setEnumStencilStage(StencilManager::getInstance()->getStencilStage());
+        entity->setEnumStencilStage(_stencilManager->getStencilStage());
         auto tempStage = static_cast<StencilStage>(entity->getStencilStage());
 
         if (_currHash != dataHash || dataHash == 0 || _currMaterial != drawInfo->getMaterial() || _currStencilStage != tempStage) {
@@ -174,18 +191,36 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
         resetRenderStates();
 
         // stencil stage
+        bool isMask = entity->getIsMask();
+        bool isSubMask = entity->getIsSubMask();
+        bool isMaskInverted = entity->getIsMaskInverted();
+        if (isMask) {
+            //Mask node
+            _stencilManager->pushMask();
+            _stencilManager->clear(entity);
+
+        } else if (isSubMask) {
+            //Mask graphics
+            _stencilManager->enterLevel(entity);
+
+        } else {
+            //other comps
+        }
+        _currStencilStage = _stencilManager->getStencilStage();
+
         Material* commitModelMat = entity->getCommitModelMaterial();
         if (commitModelMat) {
             StencilStage entityStage = entity->getEnumStencilStage();
             if (entityStage == StencilStage::ENABLED || entityStage == StencilStage::DISABLED) {
-                entity->setEnumStencilStage(StencilManager::getInstance()->getStencilStage());
+                entity->setEnumStencilStage(_stencilManager->getStencilStage());
             }
             gfx::DepthStencilState* depthStencil;
             ccstd::hash_t dssHash = 0;
-            depthStencil = StencilManager::getInstance()->getDepthStencilState(entityStage, commitModelMat);
-            dssHash = StencilManager::getInstance()->getStencilHash(entityStage);
+            depthStencil = _stencilManager->getDepthStencilState(entityStage, commitModelMat);
+            dssHash = _stencilManager->getStencilHash(entityStage);
         }
 
+        // Model
         auto* model = drawInfo->getModel();
         if (model == nullptr) return;
         auto stamp = CC_CURRENT_ENGINE()->getTotalFrames();
@@ -207,8 +242,8 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
     } else {
         generateBatch(_currEntity, _currDrawInfo);
         uint32_t dataHash = drawInfo->getDataHash();
-        entity->setEnumStencilStage(StencilManager::getInstance()->getStencilStage());
-        auto tempStage = static_cast<StencilStage>(entity->getStencilStage());
+        entity->setEnumStencilStage(_stencilManager->getStencilStage());
+        StencilStage tempStage = static_cast<StencilStage>(entity->getStencilStage());
         _currHash = dataHash;
         _currMaterial = drawInfo->getMaterial();
         _currStencilStage = tempStage;
@@ -237,11 +272,11 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
         ccstd::hash_t dssHash = 0;
         StencilStage entityStage = entity->getEnumStencilStage();
         if (entity->getCustomMaterial() != nullptr) {
-            depthStencil = StencilManager::getInstance()->getDepthStencilState(entityStage, _currMaterial);
+            depthStencil = _stencilManager->getDepthStencilState(entityStage, _currMaterial);
         } else {
-            depthStencil = StencilManager::getInstance()->getDepthStencilState(entityStage);
+            depthStencil = _stencilManager->getDepthStencilState(entityStage);
         }
-        dssHash = StencilManager::getInstance()->getStencilHash(entityStage);
+        dssHash = _stencilManager->getStencilHash(entityStage);
 
         auto* curdrawBatch = _drawBatchPool.alloc();
         curdrawBatch->setVisFlags(_currLayer);
@@ -299,11 +334,11 @@ void Batcher2d::generateBatch(RenderEntity* entity, RenderDrawInfo* drawInfo) {
     ccstd::hash_t dssHash = 0;
     StencilStage entityStage = entity->getEnumStencilStage();
     if (entity->getCustomMaterial() != nullptr) {
-        depthStencil = StencilManager::getInstance()->getDepthStencilState(entityStage, _currMaterial);
+        depthStencil = _stencilManager->getDepthStencilState(entityStage, _currMaterial);
     } else {
-        depthStencil = StencilManager::getInstance()->getDepthStencilState(entityStage);
+        depthStencil = _stencilManager->getDepthStencilState(entityStage);
     }
-    dssHash = StencilManager::getInstance()->getStencilHash(entityStage);
+    dssHash = _stencilManager->getStencilHash(entityStage);
 
     auto* curdrawBatch = _drawBatchPool.alloc();
     curdrawBatch->setVisFlags(_currLayer);

--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -208,14 +208,14 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
         }
         _currStencilStage = _stencilManager->getStencilStage();
 
+        gfx::DepthStencilState* depthStencil = nullptr;
+        ccstd::hash_t dssHash = 0;
         Material* commitModelMat = entity->getCommitModelMaterial();
         if (commitModelMat) {
             StencilStage entityStage = entity->getEnumStencilStage();
             if (entityStage == StencilStage::ENABLED || entityStage == StencilStage::DISABLED) {
                 entity->setEnumStencilStage(_stencilManager->getStencilStage());
             }
-            gfx::DepthStencilState* depthStencil;
-            ccstd::hash_t dssHash = 0;
             depthStencil = _stencilManager->getDepthStencilState(entityStage, commitModelMat);
             dssHash = _stencilManager->getStencilHash(entityStage);
         }
@@ -236,7 +236,7 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
             curdrawBatch->setDescriptorSet(submodel->getDescriptorSet());
             curdrawBatch->setUseLocalFlag(nullptr);
 
-            curdrawBatch->fillPass(drawInfo->getMaterial(), nullptr, 0, nullptr, 0, &(submodel->getPatches()));
+            curdrawBatch->fillPass(drawInfo->getMaterial(), depthStencil, dssHash, nullptr, 0, &(submodel->getPatches()));
             _batches.push_back(curdrawBatch);
         }
     } else {
@@ -268,7 +268,7 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
         ia->setIndexCount(drawInfo->getIbCount());
 
         // stencilstage
-        gfx::DepthStencilState* depthStencil;
+        gfx::DepthStencilState* depthStencil = nullptr;
         ccstd::hash_t dssHash = 0;
         StencilStage entityStage = entity->getEnumStencilStage();
         if (entity->getCustomMaterial() != nullptr) {
@@ -282,7 +282,7 @@ void Batcher2d::handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* draw
         curdrawBatch->setVisFlags(_currLayer);
         curdrawBatch->setInputAssembler(ia);
         curdrawBatch->setUseLocalFlag(nullptr); // todo usLocal
-        curdrawBatch->fillPass(_currMaterial, nullptr, 0, nullptr, 0);
+        curdrawBatch->fillPass(_currMaterial, depthStencil, dssHash, nullptr, 0);
         const auto& pass = curdrawBatch->getPasses().at(0);
 
         curdrawBatch->setDescriptorSet(getDescriptorSet(_currTexture, _currSampler, pass->getLocalSetLayout()));
@@ -330,7 +330,7 @@ void Batcher2d::generateBatch(RenderEntity* entity, RenderDrawInfo* drawInfo) {
     _currMeshBuffer = nullptr;
 
     // stencilStage
-    gfx::DepthStencilState* depthStencil;
+    gfx::DepthStencilState* depthStencil = nullptr;
     ccstd::hash_t dssHash = 0;
     StencilStage entityStage = entity->getEnumStencilStage();
     if (entity->getCustomMaterial() != nullptr) {
@@ -344,7 +344,7 @@ void Batcher2d::generateBatch(RenderEntity* entity, RenderDrawInfo* drawInfo) {
     curdrawBatch->setVisFlags(_currLayer);
     curdrawBatch->setInputAssembler(ia);
     curdrawBatch->setUseLocalFlag(nullptr); // todo usLocal
-    curdrawBatch->fillPass(_currMaterial, nullptr, 0, nullptr, 0);
+    curdrawBatch->fillPass(_currMaterial, depthStencil, dssHash, nullptr, 0);
     const auto& pass = curdrawBatch->getPasses().at(0);
 
     curdrawBatch->setDescriptorSet(getDescriptorSet(_currTexture, _currSampler, pass->getLocalSetLayout()));

--- a/native/cocos/2d/renderer/Batcher2d.h
+++ b/native/cocos/2d/renderer/Batcher2d.h
@@ -63,6 +63,7 @@ public:
 
     void fillBuffersAndMergeBatches();
     void walk(Node* node);
+    void handlePostRender(RenderEntity* entity);
     void handleColor(RenderEntity* entity, RenderDrawInfo* drawInfo, Node* curNode);
     void handleStaticDrawInfo(RenderEntity* entity, RenderDrawInfo* drawInfo, Node* curNode);
     void handleDynamicDrawInfo(RenderEntity* entity, RenderDrawInfo* drawInfo);
@@ -136,6 +137,8 @@ private:
     }
 
     gfx::DescriptorSet* getDescriptorSet(gfx::Texture* texture, gfx::Sampler* sampler, gfx::DescriptorSetLayout* dsLayout);
+
+    StencilManager* _stencilManager{nullptr};
 
     // weak reference
     Root* _root{nullptr};

--- a/native/cocos/2d/renderer/RenderEntity.cpp
+++ b/native/cocos/2d/renderer/RenderEntity.cpp
@@ -54,6 +54,15 @@ void RenderEntity::removeDynamicRenderDrawInfo() {
     if (_dynamicDrawInfos.empty()) return;
     _dynamicDrawInfos.pop_back(); // warning: memory leaking & crash
 }
+void RenderEntity::setIsMask(bool isMask) {
+    _isMask = isMask;
+}
+void RenderEntity::setIsSubMask(bool isSubMask) {
+    _isSubMask = isSubMask;
+}
+void RenderEntity::setIsMaskInverted(bool isMaskInverted) {
+    _isMaskInverted = isMaskInverted;
+}
 void RenderEntity::setNode(Node* node) {
     if (_node) {
         _node->setUserData(nullptr);

--- a/native/cocos/2d/renderer/RenderEntity.h
+++ b/native/cocos/2d/renderer/RenderEntity.h
@@ -62,13 +62,13 @@ public:
     void setDynamicRenderDrawInfo(RenderDrawInfo* drawInfo, uint32_t index);
     void removeDynamicRenderDrawInfo();
 
-    inline bool getIsMask() { return _isMask; }
+    inline bool getIsMask() const { return _isMask; }
     void setIsMask(bool isMask);
 
-    inline bool getIsSubMask() { return _isSubMask; }
+    inline bool getIsSubMask() const { return _isSubMask; }
     void setIsSubMask(bool isSubMask);
 
-    inline bool getIsMaskInverted() { return _isMaskInverted; }
+    inline bool getIsMaskInverted() const { return _isMaskInverted; }
     void setIsMaskInverted(bool isMaskInverted);
 
     inline Node* getNode() const { return _node; }

--- a/native/cocos/2d/renderer/RenderEntity.h
+++ b/native/cocos/2d/renderer/RenderEntity.h
@@ -62,6 +62,15 @@ public:
     void setDynamicRenderDrawInfo(RenderDrawInfo* drawInfo, uint32_t index);
     void removeDynamicRenderDrawInfo();
 
+    inline bool getIsMask() { return _isMask; }
+    void setIsMask(bool isMask);
+
+    inline bool getIsSubMask() { return _isSubMask; }
+    void setIsSubMask(bool isSubMask);
+
+    inline bool getIsMaskInverted() { return _isMaskInverted; }
+    void setIsMaskInverted(bool isMaskInverted);
+
     inline Node* getNode() const { return _node; }
     void setNode(Node* node);
 
@@ -117,6 +126,11 @@ private:
 
     EntityAttrLayout _entityAttrLayout;
     ArrayBuffer::Ptr _entitySharedBuffer;
-    float _opacity{1.0F};
+
+    float _opacity{1.0f};
+
+    bool _isMask{false};
+    bool _isSubMask{false};
+    bool _isMaskInverted{false};
 };
 } // namespace cc

--- a/native/cocos/2d/renderer/StencilManager.cpp
+++ b/native/cocos/2d/renderer/StencilManager.cpp
@@ -24,6 +24,7 @@
 ****************************************************************************/
 
 #include "StencilManager.h"
+#include "2d/renderer/RenderEntity.h"
 
 namespace cc {
 namespace {
@@ -51,6 +52,16 @@ StencilManager::~StencilManager() {
     for (auto pair : _cacheStateMapWithDepth) {
         CC_SAFE_DELETE(pair.second);
     }
+}
+
+void StencilManager::clear(RenderEntity* entity) {
+    bool inverted = entity->getIsMaskInverted();
+    entity->setEnumStencilStage(inverted ? StencilStage::CLEAR_INVERTED : StencilStage::CLEAR);
+}
+
+void StencilManager::enterLevel(RenderEntity* entity) {
+    bool inverted = entity->getIsMaskInverted();
+    entity->setEnumStencilStage(inverted ? StencilStage::ENTER_LEVEL_INVERTED : StencilStage::ENTER_LEVEL);
 }
 
 gfx::DepthStencilState* StencilManager::getDepthStencilState(StencilStage stage, Material* mat) {

--- a/native/cocos/2d/renderer/StencilManager.cpp
+++ b/native/cocos/2d/renderer/StencilManager.cpp
@@ -146,7 +146,9 @@ void StencilManager::setDepthStencilStateFromStage(StencilStage stage) {
         } else if (stage == StencilStage::CLEAR) {
             pattern.func = gfx::ComparisonFunc::NEVER;
             pattern.failOp = gfx::StencilOp::ZERO;
-            pattern.writeMask = pattern.stencilMask = pattern.ref = getWriteMask();
+            pattern.writeMask = getWriteMask();
+            pattern.stencilMask = getWriteMask();
+            pattern.ref = getWriteMask();
         } else if (stage == StencilStage::CLEAR_INVERTED) {
             pattern.func = gfx::ComparisonFunc::NEVER;
             pattern.failOp = gfx::StencilOp::REPLACE;

--- a/native/cocos/2d/renderer/StencilManager.cpp
+++ b/native/cocos/2d/renderer/StencilManager.cpp
@@ -82,7 +82,7 @@ gfx::DepthStencilState* StencilManager::getDepthStencilState(StencilStage stage,
         if (dss->depthWrite) {
             depthWriteValue = 1;
         }
-        key = (depthTestValue) | (depthWriteValue << 1) | (static_cast<uint32_t>(dss->depthFunc) << 2) | (static_cast<uint32_t>(_stage) << 6) | (_maskStackSize << 9);
+        key = (depthTestValue) | (depthWriteValue << 1) | (static_cast<uint32_t>(dss->depthFunc) << 2) | (static_cast<uint32_t>(stage) << 6) | (_maskStackSize << 9);
 
         depthTest = dss->depthTest;
         depthWrite = static_cast<uint32_t>(dss->depthWrite);
@@ -93,7 +93,7 @@ gfx::DepthStencilState* StencilManager::getDepthStencilState(StencilStage stage,
         key = ((static_cast<uint32_t>(stage)) << 16) | (_maskStackSize);
     }
 
-    auto iter = cacheMap->find(0);
+    auto iter = cacheMap->find(key);
     if (iter != cacheMap->end()) {
         return iter->second;
     }
@@ -130,7 +130,7 @@ gfx::DepthStencilState* StencilManager::getDepthStencilState(StencilStage stage,
 void StencilManager::setDepthStencilStateFromStage(StencilStage stage) {
     StencilEntity& pattern = _stencilPattern;
 
-    if (_stage == StencilStage::DISABLED) {
+    if (stage == StencilStage::DISABLED) {
         pattern.stencilTest = false;
         pattern.func = gfx::ComparisonFunc::ALWAYS;
         pattern.failOp = gfx::StencilOp::KEEP;

--- a/native/cocos/2d/renderer/StencilManager.h
+++ b/native/cocos/2d/renderer/StencilManager.h
@@ -78,7 +78,7 @@ public:
     inline void setMaskStackSize(uint32_t size) { _maskStackSize = size; } 
 
     inline void pushMask() {
-        _maskStackSize++;
+        ++_maskStackSize;
     }
 
     void clear(RenderEntity* entity);
@@ -93,7 +93,7 @@ public:
             return;
         }
 
-        _maskStackSize--;
+        --_maskStackSize;
         if (_maskStackSize == 0) {
             _stage = StencilStage::DISABLED;
         } else {

--- a/native/cocos/2d/renderer/StencilManager.h
+++ b/native/cocos/2d/renderer/StencilManager.h
@@ -75,7 +75,9 @@ public:
     void setDepthStencilStateFromStage(StencilStage stage);
 
     inline uint32_t getMaskStackSize() const { return _maskStackSize; }
-    inline void setMaskStackSize(uint32_t size) { _maskStackSize = size; } 
+    inline void setMaskStackSize(uint32_t size) {
+        _maskStackSize = size;
+    } 
 
     inline void pushMask() {
         ++_maskStackSize;

--- a/native/cocos/2d/renderer/StencilManager.h
+++ b/native/cocos/2d/renderer/StencilManager.h
@@ -34,6 +34,7 @@
 #include "scene/Pass.h"
 
 namespace cc {
+class RenderEntity;
 enum class StencilStage {
     // Stencil disabled
     DISABLED = 0,
@@ -73,12 +74,41 @@ public:
     gfx::DepthStencilState* getDepthStencilState(StencilStage stage, Material* mat = nullptr);
     void setDepthStencilStateFromStage(StencilStage stage);
 
+    inline uint32_t getMaskStackSize() const { return _maskStackSize; }
+    inline void setMaskStackSize(uint32_t size) { _maskStackSize = size; } 
+
+    inline void pushMask() {
+        _maskStackSize++;
+    }
+
+    void clear(RenderEntity* entity);
+    void enterLevel(RenderEntity* entity);
+
+    inline void enableMask() {
+        _stage = StencilStage::ENABLED;
+    }
+
+    inline void exitMask() {
+        if (_maskStackSize == 0) {
+            return;
+        }
+
+        _maskStackSize--;
+        if (_maskStackSize == 0) {
+            _stage = StencilStage::DISABLED;
+        } else {
+            _stage = StencilStage::ENABLED;
+        }
+    }
+
     inline uint32_t getWriteMask() const {
         return 1 << (_maskStackSize - 1);
     }
+
     inline uint32_t getExitWriteMask() const {
         return 1 << _maskStackSize;
     }
+
     inline uint32_t getStencilRef() const {
         uint32_t result = 0;
         for (uint32_t i = 0; i < _maskStackSize; i++) {
@@ -86,6 +116,7 @@ public:
         }
         return result;
     }
+
     inline uint32_t getStencilHash(StencilStage stage) const {
         return ((static_cast<uint32_t>(stage)) << 8) | _maskStackSize;
     }

--- a/native/cocos/bindings/auto/jsb_2d_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_2d_auto.cpp
@@ -506,7 +506,7 @@ static bool js_2d_RenderDrawInfo_getModel(se::State& s) // NOLINT(readability-id
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
     return false;
 }
-SE_BIND_FUNC(js_2d_RenderDrawInfo_getModel)
+SE_BIND_FUNC_AS_PROP_GET(js_2d_RenderDrawInfo_getModel)
 
 static bool js_2d_RenderDrawInfo_getSampler(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -925,7 +925,7 @@ static bool js_2d_RenderDrawInfo_setModel(se::State& s) // NOLINT(readability-id
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
     return false;
 }
-SE_BIND_FUNC(js_2d_RenderDrawInfo_setModel)
+SE_BIND_FUNC_AS_PROP_SET(js_2d_RenderDrawInfo_setModel)
 
 static bool js_2d_RenderDrawInfo_setRender2dBufferToNative(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -1203,12 +1203,11 @@ bool js_register_2d_RenderDrawInfo(se::Object* obj) // NOLINT(readability-identi
     cls->defineProperty("textureHash", _SE(js_2d_RenderDrawInfo_getTextureHash_asGetter), _SE(js_2d_RenderDrawInfo_setTextureHash_asSetter));
     cls->defineProperty("sampler", _SE(js_2d_RenderDrawInfo_getSampler_asGetter), _SE(js_2d_RenderDrawInfo_setSampler_asSetter));
     cls->defineProperty("blendHash", _SE(js_2d_RenderDrawInfo_getBlendHash_asGetter), _SE(js_2d_RenderDrawInfo_setBlendHash_asSetter));
+    cls->defineProperty("model", _SE(js_2d_RenderDrawInfo_getModel_asGetter), _SE(js_2d_RenderDrawInfo_setModel_asSetter));
     cls->defineFunction("getAttrSharedBufferForJS", _SE(js_2d_RenderDrawInfo_getAttrSharedBufferForJS));
     cls->defineFunction("getMeshBuffer", _SE(js_2d_RenderDrawInfo_getMeshBuffer));
-    cls->defineFunction("getModel", _SE(js_2d_RenderDrawInfo_getModel));
     cls->defineFunction("requestIA", _SE(js_2d_RenderDrawInfo_requestIA));
     cls->defineFunction("resetMeshIA", _SE(js_2d_RenderDrawInfo_resetMeshIA));
-    cls->defineFunction("setModel", _SE(js_2d_RenderDrawInfo_setModel));
     cls->defineFunction("setRender2dBufferToNative", _SE(js_2d_RenderDrawInfo_setRender2dBufferToNative));
     cls->defineFunction("uploadBuffers", _SE(js_2d_RenderDrawInfo_uploadBuffers));
     cls->defineFinalizeFunction(_SE(js_cc_RenderDrawInfo_finalize));

--- a/native/cocos/bindings/auto/jsb_2d_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_2d_auto.cpp
@@ -1225,6 +1225,78 @@ bool js_register_2d_RenderDrawInfo(se::Object* obj) // NOLINT(readability-identi
 se::Object* __jsb_cc_StencilManager_proto = nullptr; // NOLINT
 se::Class* __jsb_cc_StencilManager_class = nullptr;  // NOLINT
 
+static bool js_2d_StencilManager_clear(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_StencilManager_clear : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<cc::RenderEntity*, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_2d_StencilManager_clear : Error processing arguments");
+        cobj->clear(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC(js_2d_StencilManager_clear)
+
+static bool js_2d_StencilManager_enableMask(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_StencilManager_enableMask : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    if (argc == 0) {
+        cobj->enableMask();
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_2d_StencilManager_enableMask)
+
+static bool js_2d_StencilManager_enterLevel(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_StencilManager_enterLevel : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<cc::RenderEntity*, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_2d_StencilManager_enterLevel : Error processing arguments");
+        cobj->enterLevel(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC(js_2d_StencilManager_enterLevel)
+
+static bool js_2d_StencilManager_exitMask(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_StencilManager_exitMask : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    if (argc == 0) {
+        cobj->exitMask();
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_2d_StencilManager_exitMask)
+
 static bool js_2d_StencilManager_getDepthStencilState(se::State& s) // NOLINT(readability-identifier-naming)
 {
     auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
@@ -1279,6 +1351,26 @@ static bool js_2d_StencilManager_getExitWriteMask(se::State& s) // NOLINT(readab
     return false;
 }
 SE_BIND_FUNC(js_2d_StencilManager_getExitWriteMask)
+
+static bool js_2d_StencilManager_getMaskStackSize(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_StencilManager_getMaskStackSize : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        unsigned int result = cobj->getMaskStackSize();
+        ok &= nativevalue_to_se(result, s.rval(), nullptr /*ctx*/);
+        SE_PRECONDITION2(ok, false, "js_2d_StencilManager_getMaskStackSize : Error processing arguments");
+        SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_2d_StencilManager_getMaskStackSize)
 
 static bool js_2d_StencilManager_getStencilHash(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -1383,6 +1475,22 @@ static bool js_2d_StencilManager_getWriteMask(se::State& s) // NOLINT(readabilit
 }
 SE_BIND_FUNC(js_2d_StencilManager_getWriteMask)
 
+static bool js_2d_StencilManager_pushMask(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_StencilManager_pushMask : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    if (argc == 0) {
+        cobj->pushMask();
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_2d_StencilManager_pushMask)
+
 static bool js_2d_StencilManager_setDepthStencilStateFromStage(se::State& s) // NOLINT(readability-identifier-naming)
 {
     auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
@@ -1402,6 +1510,26 @@ static bool js_2d_StencilManager_setDepthStencilStateFromStage(se::State& s) // 
     return false;
 }
 SE_BIND_FUNC(js_2d_StencilManager_setDepthStencilStateFromStage)
+
+static bool js_2d_StencilManager_setMaskStackSize(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::StencilManager>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_StencilManager_setMaskStackSize : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<unsigned int, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_2d_StencilManager_setMaskStackSize : Error processing arguments");
+        cobj->setMaskStackSize(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC(js_2d_StencilManager_setMaskStackSize)
 
 static bool js_2d_StencilManager_setStencilStage(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -1463,14 +1591,21 @@ bool js_register_2d_StencilManager(se::Object* obj) // NOLINT(readability-identi
 #if CC_DEBUG
     cls->defineStaticProperty("isJSBClass", _SE(js_2d_getter_return_true), nullptr);
 #endif
+    cls->defineFunction("clear", _SE(js_2d_StencilManager_clear));
+    cls->defineFunction("enableMask", _SE(js_2d_StencilManager_enableMask));
+    cls->defineFunction("enterLevel", _SE(js_2d_StencilManager_enterLevel));
+    cls->defineFunction("exitMask", _SE(js_2d_StencilManager_exitMask));
     cls->defineFunction("getDepthStencilState", _SE(js_2d_StencilManager_getDepthStencilState));
     cls->defineFunction("getExitWriteMask", _SE(js_2d_StencilManager_getExitWriteMask));
+    cls->defineFunction("getMaskStackSize", _SE(js_2d_StencilManager_getMaskStackSize));
     cls->defineFunction("getStencilHash", _SE(js_2d_StencilManager_getStencilHash));
     cls->defineFunction("getStencilRef", _SE(js_2d_StencilManager_getStencilRef));
     cls->defineFunction("getStencilSharedBufferForJS", _SE(js_2d_StencilManager_getStencilSharedBufferForJS));
     cls->defineFunction("getStencilStage", _SE(js_2d_StencilManager_getStencilStage));
     cls->defineFunction("getWriteMask", _SE(js_2d_StencilManager_getWriteMask));
+    cls->defineFunction("pushMask", _SE(js_2d_StencilManager_pushMask));
     cls->defineFunction("setDepthStencilStateFromStage", _SE(js_2d_StencilManager_setDepthStencilStateFromStage));
+    cls->defineFunction("setMaskStackSize", _SE(js_2d_StencilManager_setMaskStackSize));
     cls->defineFunction("setStencilStage", _SE(js_2d_StencilManager_setStencilStage));
     cls->defineStaticFunction("getInstance", _SE(js_2d_StencilManager_getInstance_static));
     cls->defineFinalizeFunction(_SE(js_cc_StencilManager_finalize));
@@ -1566,6 +1701,66 @@ static bool js_2d_RenderEntity_getEntitySharedBufferForJS(se::State& s) // NOLIN
     return false;
 }
 SE_BIND_FUNC(js_2d_RenderEntity_getEntitySharedBufferForJS)
+
+static bool js_2d_RenderEntity_getIsMask(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::RenderEntity>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_RenderEntity_getIsMask : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        bool result = cobj->getIsMask();
+        ok &= nativevalue_to_se(result, s.rval(), nullptr /*ctx*/);
+        SE_PRECONDITION2(ok, false, "js_2d_RenderEntity_getIsMask : Error processing arguments");
+        SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_GET(js_2d_RenderEntity_getIsMask)
+
+static bool js_2d_RenderEntity_getIsMaskInverted(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::RenderEntity>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_RenderEntity_getIsMaskInverted : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        bool result = cobj->getIsMaskInverted();
+        ok &= nativevalue_to_se(result, s.rval(), nullptr /*ctx*/);
+        SE_PRECONDITION2(ok, false, "js_2d_RenderEntity_getIsMaskInverted : Error processing arguments");
+        SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_GET(js_2d_RenderEntity_getIsMaskInverted)
+
+static bool js_2d_RenderEntity_getIsSubMask(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::RenderEntity>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_RenderEntity_getIsSubMask : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        bool result = cobj->getIsSubMask();
+        ok &= nativevalue_to_se(result, s.rval(), nullptr /*ctx*/);
+        SE_PRECONDITION2(ok, false, "js_2d_RenderEntity_getIsSubMask : Error processing arguments");
+        SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_GET(js_2d_RenderEntity_getIsSubMask)
 
 static bool js_2d_RenderEntity_getLocalOpacity(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -1808,6 +2003,66 @@ static bool js_2d_RenderEntity_setDynamicRenderDrawInfo(se::State& s) // NOLINT(
 }
 SE_BIND_FUNC(js_2d_RenderEntity_setDynamicRenderDrawInfo)
 
+static bool js_2d_RenderEntity_setIsMask(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::RenderEntity>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_RenderEntity_setIsMask : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<bool, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_2d_RenderEntity_setIsMask : Error processing arguments");
+        cobj->setIsMask(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_SET(js_2d_RenderEntity_setIsMask)
+
+static bool js_2d_RenderEntity_setIsMaskInverted(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::RenderEntity>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_RenderEntity_setIsMaskInverted : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<bool, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_2d_RenderEntity_setIsMaskInverted : Error processing arguments");
+        cobj->setIsMaskInverted(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_SET(js_2d_RenderEntity_setIsMaskInverted)
+
+static bool js_2d_RenderEntity_setIsSubMask(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::RenderEntity>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_RenderEntity_setIsSubMask : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<bool, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_2d_RenderEntity_setIsSubMask : Error processing arguments");
+        cobj->setIsSubMask(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC_AS_PROP_SET(js_2d_RenderEntity_setIsSubMask)
+
 static bool js_2d_RenderEntity_setNode(se::State& s) // NOLINT(readability-identifier-naming)
 {
     auto* cobj = SE_THIS_OBJECT<cc::RenderEntity>(s);
@@ -1955,6 +2210,9 @@ bool js_register_2d_RenderEntity(se::Object* obj) // NOLINT(readability-identifi
     cls->defineProperty("stencilStage", _SE(js_2d_RenderEntity_getStencilStage_asGetter), _SE(js_2d_RenderEntity_setStencilStage_asSetter));
     cls->defineProperty("customMaterial", _SE(js_2d_RenderEntity_getCustomMaterial_asGetter), _SE(js_2d_RenderEntity_setCustomMaterial_asSetter));
     cls->defineProperty("commitModelMaterial", _SE(js_2d_RenderEntity_getCommitModelMaterial_asGetter), _SE(js_2d_RenderEntity_setCommitModelMaterial_asSetter));
+    cls->defineProperty("isMask", _SE(js_2d_RenderEntity_getIsMask_asGetter), _SE(js_2d_RenderEntity_setIsMask_asSetter));
+    cls->defineProperty("isSubMask", _SE(js_2d_RenderEntity_getIsSubMask_asGetter), _SE(js_2d_RenderEntity_setIsSubMask_asSetter));
+    cls->defineProperty("isMaskInverted", _SE(js_2d_RenderEntity_getIsMaskInverted_asGetter), _SE(js_2d_RenderEntity_setIsMaskInverted_asSetter));
     cls->defineFunction("addDynamicRenderDrawInfo", _SE(js_2d_RenderEntity_addDynamicRenderDrawInfo));
     cls->defineFunction("getEntitySharedBufferForJS", _SE(js_2d_RenderEntity_getEntitySharedBufferForJS));
     cls->defineFunction("getLocalOpacity", _SE(js_2d_RenderEntity_getLocalOpacity));
@@ -2045,6 +2303,26 @@ static bool js_2d_Batcher2d_handleDynamicDrawInfo(se::State& s) // NOLINT(readab
     return false;
 }
 SE_BIND_FUNC(js_2d_Batcher2d_handleDynamicDrawInfo)
+
+static bool js_2d_Batcher2d_handlePostRender(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    auto* cobj = SE_THIS_OBJECT<cc::Batcher2d>(s);
+    // SE_PRECONDITION2(cobj, false, "js_2d_Batcher2d_handlePostRender : Invalid Native Object");
+    if (nullptr == cobj) return true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 1) {
+        HolderType<cc::RenderEntity*, false> arg0 = {};
+        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
+        SE_PRECONDITION2(ok, false, "js_2d_Batcher2d_handlePostRender : Error processing arguments");
+        cobj->handlePostRender(arg0.value());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC(js_2d_Batcher2d_handlePostRender)
 
 static bool js_2d_Batcher2d_handleStaticDrawInfo(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -2227,6 +2505,7 @@ bool js_register_2d_Batcher2d(se::Object* obj) // NOLINT(readability-identifier-
     cls->defineFunction("addRootNode", _SE(js_2d_Batcher2d_addRootNode));
     cls->defineFunction("handleColor", _SE(js_2d_Batcher2d_handleColor));
     cls->defineFunction("handleDynamicDrawInfo", _SE(js_2d_Batcher2d_handleDynamicDrawInfo));
+    cls->defineFunction("handlePostRender", _SE(js_2d_Batcher2d_handlePostRender));
     cls->defineFunction("handleStaticDrawInfo", _SE(js_2d_Batcher2d_handleStaticDrawInfo));
     cls->defineFunction("initialize", _SE(js_2d_Batcher2d_initialize));
     cls->defineFunction("releaseDescriptorSetCache", _SE(js_2d_Batcher2d_releaseDescriptorSetCache));

--- a/native/cocos/bindings/auto/jsb_2d_auto.h
+++ b/native/cocos/bindings/auto/jsb_2d_auto.h
@@ -41,10 +41,8 @@ bool js_register_cc_RenderDrawInfo(se::Object *obj); // NOLINT
 
 SE_DECLARE_FUNC(js_2d_RenderDrawInfo_getAttrSharedBufferForJS);
 SE_DECLARE_FUNC(js_2d_RenderDrawInfo_getMeshBuffer);
-SE_DECLARE_FUNC(js_2d_RenderDrawInfo_getModel);
 SE_DECLARE_FUNC(js_2d_RenderDrawInfo_requestIA);
 SE_DECLARE_FUNC(js_2d_RenderDrawInfo_resetMeshIA);
-SE_DECLARE_FUNC(js_2d_RenderDrawInfo_setModel);
 SE_DECLARE_FUNC(js_2d_RenderDrawInfo_setRender2dBufferToNative);
 SE_DECLARE_FUNC(js_2d_RenderDrawInfo_uploadBuffers);
 SE_DECLARE_FUNC(js_2d_RenderDrawInfo_RenderDrawInfo);

--- a/native/cocos/bindings/auto/jsb_2d_auto.h
+++ b/native/cocos/bindings/auto/jsb_2d_auto.h
@@ -54,14 +54,21 @@ extern se::Class * __jsb_cc_StencilManager_class; // NOLINT
 
 bool js_register_cc_StencilManager(se::Object *obj); // NOLINT
 
+SE_DECLARE_FUNC(js_2d_StencilManager_clear);
+SE_DECLARE_FUNC(js_2d_StencilManager_enableMask);
+SE_DECLARE_FUNC(js_2d_StencilManager_enterLevel);
+SE_DECLARE_FUNC(js_2d_StencilManager_exitMask);
 SE_DECLARE_FUNC(js_2d_StencilManager_getDepthStencilState);
 SE_DECLARE_FUNC(js_2d_StencilManager_getExitWriteMask);
+SE_DECLARE_FUNC(js_2d_StencilManager_getMaskStackSize);
 SE_DECLARE_FUNC(js_2d_StencilManager_getStencilHash);
 SE_DECLARE_FUNC(js_2d_StencilManager_getStencilRef);
 SE_DECLARE_FUNC(js_2d_StencilManager_getStencilSharedBufferForJS);
 SE_DECLARE_FUNC(js_2d_StencilManager_getStencilStage);
 SE_DECLARE_FUNC(js_2d_StencilManager_getWriteMask);
+SE_DECLARE_FUNC(js_2d_StencilManager_pushMask);
 SE_DECLARE_FUNC(js_2d_StencilManager_setDepthStencilStateFromStage);
+SE_DECLARE_FUNC(js_2d_StencilManager_setMaskStackSize);
 SE_DECLARE_FUNC(js_2d_StencilManager_setStencilStage);
 SE_DECLARE_FUNC(js_2d_StencilManager_getInstance);
 SE_DECLARE_FUNC(js_2d_StencilManager_StencilManager);
@@ -92,6 +99,7 @@ bool js_register_cc_Batcher2d(se::Object *obj); // NOLINT
 SE_DECLARE_FUNC(js_2d_Batcher2d_addRootNode);
 SE_DECLARE_FUNC(js_2d_Batcher2d_handleColor);
 SE_DECLARE_FUNC(js_2d_Batcher2d_handleDynamicDrawInfo);
+SE_DECLARE_FUNC(js_2d_Batcher2d_handlePostRender);
 SE_DECLARE_FUNC(js_2d_Batcher2d_handleStaticDrawInfo);
 SE_DECLARE_FUNC(js_2d_Batcher2d_initialize);
 SE_DECLARE_FUNC(js_2d_Batcher2d_releaseDescriptorSetCache);

--- a/native/tools/tojs/2d.ini
+++ b/native/tools/tojs/2d.ini
@@ -57,7 +57,7 @@ rename_functions =
 
 getter_setter = RenderDrawInfo::[bufferId accId vertexOffset indexOffset vbBuffer ibBuffer vDataBuffer iDataBuffer vbCount ibCount vertDirty dataHash isMeshBuffer material texture textureHash sampler blendHash],
                 UIMeshBuffer::[vData iData],
-                RenderEntity::[node staticDrawInfoSize stencilStage customMaterial commitModelMaterial]
+                RenderEntity::[node staticDrawInfoSize stencilStage customMaterial commitModelMaterial isMask isSubMask isMaskInverted]
 
 field = 
 

--- a/native/tools/tojs/2d.ini
+++ b/native/tools/tojs/2d.ini
@@ -55,7 +55,7 @@ skip =  RenderDrawInfo::[getBatcher setBatcher parseAttrLayout getRender2dLayout
 
 rename_functions = 
 
-getter_setter = RenderDrawInfo::[bufferId accId vertexOffset indexOffset vbBuffer ibBuffer vDataBuffer iDataBuffer vbCount ibCount vertDirty dataHash isMeshBuffer material texture textureHash sampler blendHash],
+getter_setter = RenderDrawInfo::[bufferId accId vertexOffset indexOffset vbBuffer ibBuffer vDataBuffer iDataBuffer vbCount ibCount vertDirty dataHash isMeshBuffer material texture textureHash sampler blendHash model],
                 UIMeshBuffer::[vData iData],
                 RenderEntity::[node staticDrawInfoSize stencilStage customMaterial commitModelMaterial isMask isSubMask isMaskInverted]
 


### PR DESCRIPTION
Re: #
related PR
https://github.com/cocos/cocos-engine/pull/11592

### Changelog

* mask to native

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
