### PR TITLE
fix the validation errors about renderpass and swapchain

### DIFF
--- a/native/cocos/renderer/gfx-base/GFXDef.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDef.cpp
@@ -28,6 +28,7 @@
 #include "base/std/hash/hash.h"
 
 #include "GFXDef.h"
+#include "GFXRenderPass.h"
 #include "GFXTexture.h"
 
 namespace cc {
@@ -114,25 +115,31 @@ ccstd::hash_t Hasher<FramebufferInfo>::operator()(const FramebufferInfo &info) c
     // render pass is mostly irrelevant
     ccstd::hash_t seed;
     if (info.depthStencilTexture) {
-        seed = (static_cast<uint32_t>(info.colorTextures.size()) + 1) * 3;
+        seed = (static_cast<uint32_t>(info.colorTextures.size()) + 1) * 3 + 2;
         ccstd::hash_combine(seed, info.depthStencilTexture);
         ccstd::hash_combine(seed, info.depthStencilTexture->getRaw());
         ccstd::hash_combine(seed, info.depthStencilTexture->getHash());
     } else {
-        seed = static_cast<uint32_t>(info.colorTextures.size()) * 3;
+        seed = static_cast<uint32_t>(info.colorTextures.size()) * 3 + 2;
     }
     for (auto *colorTexture : info.colorTextures) {
         ccstd::hash_combine(seed, colorTexture);
         ccstd::hash_combine(seed, colorTexture->getRaw());
         ccstd::hash_combine(seed, colorTexture->getHash());
     }
+    ccstd::hash_combine(seed, info.renderPass);
+    ccstd::hash_combine(seed, info.renderPass->getHash());
     return seed;
 }
 
 bool operator==(const FramebufferInfo &lhs, const FramebufferInfo &rhs) {
     // render pass is mostly irrelevant
     bool res = false;
-    res = lhs.colorTextures == rhs.colorTextures;
+    res = lhs.renderPass == rhs.renderPass;
+
+    if (res) {
+        res = lhs.colorTextures == rhs.colorTextures;
+    }
 
     if (res) {
         res = lhs.depthStencilTexture == rhs.depthStencilTexture;
@@ -146,6 +153,7 @@ bool operator==(const FramebufferInfo &lhs, const FramebufferInfo &rhs) {
                 break;
             }
         }
+        res = lhs.renderPass->getHash() == rhs.renderPass->getHash();
         if (res) {
             res = lhs.depthStencilTexture->getRaw() == rhs.depthStencilTexture->getRaw() &&
                   lhs.depthStencilTexture->getHash() == rhs.depthStencilTexture->getHash();

--- a/native/cocos/renderer/gfx-base/GFXDef.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDef.cpp
@@ -115,19 +115,18 @@ ccstd::hash_t Hasher<FramebufferInfo>::operator()(const FramebufferInfo &info) c
     // render pass is mostly irrelevant
     ccstd::hash_t seed;
     if (info.depthStencilTexture) {
-        seed = (static_cast<uint32_t>(info.colorTextures.size()) + 1) * 3 + 2;
+        seed = (static_cast<uint32_t>(info.colorTextures.size()) + 1) * 3 + 1;
         ccstd::hash_combine(seed, info.depthStencilTexture);
         ccstd::hash_combine(seed, info.depthStencilTexture->getRaw());
         ccstd::hash_combine(seed, info.depthStencilTexture->getHash());
     } else {
-        seed = static_cast<uint32_t>(info.colorTextures.size()) * 3 + 2;
+        seed = static_cast<uint32_t>(info.colorTextures.size()) * 3 + 1;
     }
     for (auto *colorTexture : info.colorTextures) {
         ccstd::hash_combine(seed, colorTexture);
         ccstd::hash_combine(seed, colorTexture->getRaw());
         ccstd::hash_combine(seed, colorTexture->getHash());
     }
-    ccstd::hash_combine(seed, info.renderPass);
     ccstd::hash_combine(seed, info.renderPass->getHash());
     return seed;
 }
@@ -135,11 +134,7 @@ ccstd::hash_t Hasher<FramebufferInfo>::operator()(const FramebufferInfo &info) c
 bool operator==(const FramebufferInfo &lhs, const FramebufferInfo &rhs) {
     // render pass is mostly irrelevant
     bool res = false;
-    res = lhs.renderPass == rhs.renderPass;
-
-    if (res) {
-        res = lhs.colorTextures == rhs.colorTextures;
-    }
+    res = lhs.colorTextures == rhs.colorTextures;
 
     if (res) {
         res = lhs.depthStencilTexture == rhs.depthStencilTexture;

--- a/native/cocos/renderer/gfx-base/GFXRenderPass.cpp
+++ b/native/cocos/renderer/gfx-base/GFXRenderPass.cpp
@@ -43,12 +43,10 @@ RenderPass::~RenderPass() = default;
 ccstd::hash_t RenderPass::computeHash() {
     ccstd::hash_t seed = static_cast<uint32_t>(_colorAttachments.size()) * 2 + 3;
     for (const ColorAttachment &ca : _colorAttachments) {
-        ccstd::hash_combine(seed, ca.format);
-        ccstd::hash_combine(seed, ca.sampleCount);
+        ccstd::hash_combine(seed, ca);
     }
     const auto &ds = _depthStencilAttachment;
-    ccstd::hash_combine(seed, ds.format);
-    ccstd::hash_combine(seed, ds.sampleCount);
+    ccstd::hash_combine(seed, ds);
 
     ccstd::hash_combine(seed, _subpasses);
     return seed;

--- a/native/cocos/renderer/gfx-vulkan/VKSwapchain.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKSwapchain.cpp
@@ -193,6 +193,7 @@ void CCVKSwapchain::doInit(const SwapchainInfo &info) {
     _gpuSwapchain->createInfo.imageExtent = imageExtent;
     _gpuSwapchain->createInfo.imageUsage = imageUsage;
     _gpuSwapchain->createInfo.imageArrayLayers = 1;
+    _gpuSwapchain->createInfo.preTransform = surfaceCapabilities.currentTransform;
     _gpuSwapchain->createInfo.compositeAlpha = compositeAlpha;
     _gpuSwapchain->createInfo.presentMode = swapchainPresentMode;
     _gpuSwapchain->createInfo.clipped = VK_TRUE; // Setting clipped to VK_TRUE allows the implementation to discard rendering outside of the surface area


### PR DESCRIPTION
Re: #

### Changelog

* fix vulkan validation error about renderpass and swapchain

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
