### PR TITLE
Fix access to application class on exit

### DIFF
--- a/native/cocos/bindings/manual/jsb_global.cpp
+++ b/native/cocos/bindings/manual/jsb_global.cpp
@@ -577,8 +577,16 @@ bool jsb_global_load_image(const ccstd::string &path, const se::Value &callbackV
             if (loadSucceed) {
                 imgInfo = createImageInfo(img);
             }
-
-            CC_CURRENT_ENGINE()->getScheduler()->performFunctionInCocosThread([=]() {
+            std::this_thread::sleep_for(std::chrono::seconds(3));
+            auto application = CC_CURRENT_APPLICATION();
+            if (!application) {
+                delete imgInfo;
+                delete img;
+                return;
+            }
+            auto engine = application->getEngine();
+            CC_ASSERT(engine != nullptr);
+            engine->getScheduler()->performFunctionInCocosThread([=]() {
                 se::AutoHandleScope hs;
                 se::ValueArray seArgs;
 

--- a/native/cocos/bindings/manual/jsb_global.cpp
+++ b/native/cocos/bindings/manual/jsb_global.cpp
@@ -577,14 +577,13 @@ bool jsb_global_load_image(const ccstd::string &path, const se::Value &callbackV
             if (loadSucceed) {
                 imgInfo = createImageInfo(img);
             }
-            std::this_thread::sleep_for(std::chrono::seconds(3));
-            auto application = CC_CURRENT_APPLICATION();
-            if (!application) {
+            auto app = CC_CURRENT_APPLICATION();
+            if (!app) {
                 delete imgInfo;
                 delete img;
                 return;
             }
-            auto engine = application->getEngine();
+            auto engine = app->getEngine();
             CC_ASSERT(engine != nullptr);
             engine->getScheduler()->performFunctionInCocosThread([=]() {
                 se::AutoHandleScope hs;


### PR DESCRIPTION
The design idea is to release resources through destructors to avoid manually calling resource release. Therefore, it is more difficult to modify the release process.

In this case, calling the application to operate on anything is unreasonable. Because when the program exits, calling the application to complete other operations may cause unexpected errors