### PR TITLE
3.6.0-throw error when build fail

### DIFF
--- a/scripts/native-pack-tool/source/platforms/android.ts
+++ b/scripts/native-pack-tool/source/platforms/android.ts
@@ -72,7 +72,7 @@ export class AndroidPackTool extends NativePackTool {
 
         const projDir: string = this.paths.nativePrjDir;
         if (!fs.existsSync(projDir)) {
-            console.error(`dir ${projDir} not exits`);
+            throw new Error(`dir ${projDir} not exits`);
             return false;
         }
         let gradle = 'gradlew';
@@ -230,12 +230,12 @@ export class AndroidPackTool extends NativePackTool {
         }
         const manifestPath = cchelper.join(this.paths.platformTemplateDirInPrj, 'instantapp/AndroidManifest.xml');
         if (!fs.existsSync(manifestPath)) {
-            console.error(`${manifestPath} not found`);
+            throw new Error(`${manifestPath} not found`);
             return;
         }
         const urlInfo = URL.parse(url);
         if (!urlInfo.host) {
-            console.error(`parse url ${url} fail`);
+            throw new Error(`parse url ${url} fail`);
             return;
         }
         let manifest = fs.readFileSync(manifestPath, 'utf8');
@@ -261,7 +261,7 @@ export class AndroidPackTool extends NativePackTool {
         let apkName = `${this.params.projectName}-${suffix}.apk`;
         let apkPath = ps.join(this.paths.nativePrjDir, `build/${this.params.projectName}/outputs/apk/${suffix}/${apkName}`);
         if (!fs.existsSync(apkPath)) {
-            console.error('apk not found at ', apkPath);
+            throw new Error(`apk not found at ${apkPath}`);
             return false;
         }
         fs.copyFileSync(apkPath, ps.join(destDir, apkName));
@@ -269,7 +269,7 @@ export class AndroidPackTool extends NativePackTool {
             apkName = `instantapp-${suffix}.apk`;
             apkPath = ps.join(this.paths.nativePrjDir, `build/instantapp/outputs/apk/${suffix}/${apkName}`);
             if (!fs.existsSync(apkPath)) {
-                console.error('instant apk not found at ', apkPath);
+                throw new Error(`instant apk not found at ${apkPath}`);
                 return false;
             }
             fs.copyFileSync(apkPath, ps.join(destDir, apkName));
@@ -279,7 +279,7 @@ export class AndroidPackTool extends NativePackTool {
             apkName = `${this.params.projectName}-${suffix}.aab`;
             apkPath = ps.join(this.paths.nativePrjDir, `build/${this.params.projectName}/outputs/bundle/${suffix}/${apkName}`);
             if (!fs.existsSync(apkPath)) {
-                console.error('instant apk not found at ', apkPath);
+                throw new Error(`instant apk not found at ${apkPath}`);
                 return false;
             }
             fs.copyFileSync(apkPath, ps.join(destDir, apkName));
@@ -315,12 +315,12 @@ export class AndroidPackTool extends NativePackTool {
         const adbPath = this.getAdbPath();
 
         if (!fs.existsSync(apkPath)) {
-            console.error('can not find apk at', apkPath);
+            throw new Error(`can not find apk at ${apkPath}`);
             return false;
         }
 
         if (!fs.existsSync(adbPath)) {
-            console.error('can not find adb at', adbPath);
+            throw new Error(`can not find adb at ${adbPath}`);
             return false;
         }
 

--- a/scripts/native-pack-tool/source/platforms/ios.ts
+++ b/scripts/native-pack-tool/source/platforms/ios.ts
@@ -242,7 +242,7 @@ export class IOSPackTool extends MacOSPackTool {
                 }
             }
         } else {
-            console.error(`Info.plist not found ${infoPlist}`);
+            throw new Error(`Info.plist not found ${infoPlist}`)
         }
         return null;
     }

--- a/scripts/native-pack-tool/source/platforms/mac-os.ts
+++ b/scripts/native-pack-tool/source/platforms/mac-os.ts
@@ -76,7 +76,7 @@ export abstract class MacOSPackTool extends NativePackTool {
         const xcode = require(ps.join(this.params.enginePath, 'scripts/native-pack-tool/xcode'));
         const projs = fs.readdirSync(nativePrjDir).filter((x) => x.endsWith('.xcodeproj')).map((x) => ps.join(nativePrjDir, x));
         if (projs.length === 0) {
-            console.error(`can not find xcode project file in ${nativePrjDir}`);
+            throw new Error(`can not find xcode project file in ${nativePrjDir}`);
         } else {
             try {
                 for (const proj of projs) {

--- a/scripts/native-pack-tool/source/platforms/windows.ts
+++ b/scripts/native-pack-tool/source/platforms/windows.ts
@@ -139,7 +139,7 @@ export class WindowsPackTool extends NativePackTool {
             this.paths.nativePrjDir, this.params.debug ? 'Debug' : 'Release',
             `${this.params.projectName}.exe`);
         if (!fs.existsSync(destPath)) {
-            throw new Error(`[windows run] exe file not found at' + destPath!`);
+            throw new Error(`[windows run] exe file not found at ' + ${destPath}!`);
         }
         await cchelper.runCmd(destPath, [], false);
         return true;


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/13185

### Changelog

*throw error when build fail, change console.error to throw error

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
