### PR TITLE
Handle destination start time on empty transitions

### DIFF
--- a/cocos/core/animation/marionette/animation-graph.ts
+++ b/cocos/core/animation/marionette/animation-graph.ts
@@ -155,6 +155,14 @@ export class EmptyStateTransition extends Transition {
      */
     @serializable
     public duration = 0.3;
+
+    /**
+     * @en The start time of (final) destination motion state when this transition starts.
+     * Its unit is the duration of destination motion state.
+     * @zh 此过渡开始时，（最终）目标动作状态的起始时间。其单位是目标动作状态的周期。
+     */
+    @serializable
+    public destinationStart = 0.0;
 }
 
 @ccclass('cc.animation.StateMachine')

--- a/cocos/core/animation/marionette/graph-eval.ts
+++ b/cocos/core/animation/marionette/graph-eval.ts
@@ -513,6 +513,7 @@ class LayerEval {
                     transitionEval.interruption = outgoing.interruptionSource;
                 } else if (outgoing instanceof EmptyStateTransition) {
                     transitionEval.duration = outgoing.duration;
+                    transitionEval.destinationStart = outgoing.destinationStart;
                 }
 
                 transitionEval.conditions.forEach((conditionEval, iCondition) => {


### PR DESCRIPTION
Re: #

### Changelog

* Handle destination start time on empty transitions as well

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
