### PR TITLE
support number type of engine constant

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -395,7 +395,7 @@
             "comment": "Running in the server mode.",
             "type": "boolean",
             "value": false,
-            "internal": false
+            "internal": true
         },
 
 
@@ -447,7 +447,7 @@
             "comment": "The network access mode.\n- 0 Client\n- 1 ListenServer\n- 2 HostServer",
             "type": "number",
             "value": 0,
-            "internal": true
+            "internal": false
         }
     }
 }

--- a/cc.config.json
+++ b/cc.config.json
@@ -426,8 +426,7 @@
             "type": "boolean",
             "value": "!($MINIGAME || $RUNTIME_BASED)",
             "ccGlobal": true,
-            "internal": false,
-            "dynamic": true
+            "internal": false
         },
         "JSB": {
             "comment": "Running in environment where using JSB as the JavaScript interface binding scheme.",

--- a/cc.config.json
+++ b/cc.config.json
@@ -261,78 +261,91 @@
     "constants": {
         "HTML5": {
             "comment": "Running in Web platform",
+            "type": "boolean",
             "value": false,
             "internal": false,
             "dynamic": true
         },
         "NATIVE": {
             "comment": "Running in native platform (mobile app, desktop app, or simulator).",
+            "type": "boolean",
             "value": false,
             "internal": false,
             "dynamic": true
         },
         "WECHAT": {
             "comment": "Running in the Wechat's mini game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "BAIDU": {
             "comment": "Running in the baidu's mini game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "XIAOMI": {
             "comment": "Running in the xiaomi's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "ALIPAY": {
             "comment": "Running in the alipay's mini game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "BYTEDANCE": {
             "comment": "Running in the ByteDance's mini game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "OPPO": {
             "comment": "Running in the oppo's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "VIVO": {
             "comment": "Running in the vivo's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "HUAWEI": {
             "comment": "Running in the huawei's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "COCOSPLAY": {
             "comment": "Running in the cocosplay.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "QTT": {
             "comment": "Running in the qtt's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "LINKSURE": {
             "comment": "Running in the linksure's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
@@ -340,6 +353,7 @@
 
         "EDITOR": {
             "comment": "Running in the editor.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false,
@@ -347,6 +361,7 @@
         },
         "PREVIEW": {
             "comment": "Preview in browser or simulator.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false,
@@ -354,12 +369,14 @@
         },
         "BUILD": {
             "comment": "Running in published project.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "TEST": {
             "comment": "Running in the engine's unit test.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false,
@@ -369,12 +386,14 @@
 
         "DEBUG": {
             "comment": "Running debug mode.",
+            "type": "boolean",
             "value": true,
             "ccGlobal": true,
             "internal": false
         },
         "SERVER_MODE": {
             "comment": "Running in the server mode.",
+            "type": "boolean",
             "value": false,
             "internal": false
         },
@@ -382,6 +401,7 @@
 
         "DEV": {
             "comment": "Running in the editor or preview.",
+            "type": "boolean",
             "value": "$EDITOR || $PREVIEW || $TEST",
             "ccGlobal": true,
             "internal": false,
@@ -389,18 +409,21 @@
         },
         "MINIGAME": {
             "comment": "Running in mini game.",
+            "type": "boolean",
             "value": "$WECHAT || $BAIDU || $XIAOMI || $ALIPAY || $BYTEDANCE",
             "ccGlobal": true,
             "internal": false
         },
         "RUNTIME_BASED": {
             "comment": "Running in runtime based environment.",
+            "type": "boolean",
             "value": "$OPPO || $VIVO || $HUAWEI || $COCOSPLAY || $QTT || $LINKSURE",
             "ccGlobal": true,
             "internal": false
         },
         "SUPPORT_JIT": {
             "comment": "Support JIT.",
+            "type": "boolean",
             "value": "!($MINIGAME || $RUNTIME_BASED)",
             "ccGlobal": true,
             "internal": false,
@@ -408,6 +431,7 @@
         },
         "JSB": {
             "comment": "Running in environment where using JSB as the JavaScript interface binding scheme.",
+            "type": "boolean",
             "value": "$NATIVE",
             "ccGlobal": true,
             "internal": false,
@@ -415,7 +439,14 @@
         },
         "NOT_PACK_PHYSX_LIBS": {
             "comment": "This is an internal constant to determine whether pack physx libs.",
+            "type": "boolean",
             "value": false,
+            "internal": true
+        },
+        "NET_MODE": {
+            "comment": "The network access mode.\n- 0 Client\n- 1 ListenServer\n- 2 HostServer",
+            "type": "number",
+            "value": 0,
             "internal": true
         }
     }

--- a/cc.config.schema.json
+++ b/cc.config.schema.json
@@ -38,7 +38,6 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Construct a type with a set of properties K of type T",
                 "type": "object"
               },
               "test": {
@@ -61,6 +60,13 @@
         "constants"
       ],
       "type": "object"
+    },
+    "ConstantTypeName": {
+      "enum": [
+        "boolean",
+        "number"
+      ],
+      "type": "string"
     },
     "Feature": {
       "additionalProperties": false,
@@ -111,16 +117,22 @@
           "description": "Whether exported to developer. If true, it's only exported to engine.",
           "type": "boolean"
         },
+        "type": {
+          "$ref": "#/definitions/ConstantTypeName",
+          "description": "The type of the constant for generating consts.d.ts file."
+        },
         "value": {
-          "description": "The default value of the constant. It can be a boolean or string. When it's a string type, the value is the result of eval().",
+          "description": "The default value of the constant. It can be a boolean, number or string. When it's a string type, the value is the result of eval().",
           "type": [
             "boolean",
-            "string"
+            "string",
+            "number"
           ]
         }
       },
       "required": [
         "comment",
+        "type",
         "value",
         "internal"
       ],
@@ -144,7 +156,6 @@
             },
             "type": "object"
           },
-          "description": "Construct a type with a set of properties K of type T",
           "type": "object"
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "@cocos/build-engine": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.3.10.tgz",
-      "integrity": "sha512-0UXMGivu+5S6tjBbEp2AjzfHSusRCi1+GU+27gDAM1hLTEMPhfjrJdPjxAHH7VuLDDIO27CNZEbtjNMYF0zIBQ==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@cocos/build-engine/-/build-engine-4.3.14.tgz",
+      "integrity": "sha512-YIeGAV/kqN0LHT2Sx09+D6jHmd66iWwwtGVeSUvvXSgGj/EK4FXlPV10a92T3VSKKR5A2sfpUC/RDCBKJSXpbQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.13.10",
@@ -1803,20 +1803,29 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
           }
         },
         "color-convert": {
@@ -1834,11 +1843,15 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
         },
         "fs-extra": {
           "version": "8.1.0",
@@ -1865,6 +1878,12 @@
           "requires": {
             "has": "^1.0.3"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "json5": {
           "version": "2.2.1",
@@ -1903,12 +1922,12 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-          "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+          "version": "1.22.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+          "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
           "dev": true,
           "requires": {
-            "is-core-module": "^2.8.1",
+            "is-core-module": "^2.9.0",
             "path-parse": "^1.0.7",
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
@@ -1923,65 +1942,23 @@
           }
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "tfig": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/tfig/-/tfig-3.2.5.tgz",
-          "integrity": "sha512-IGizsIrOow7IFCSqGWFEX+vjO7jI5dZg8ASkNUb0Vl/Q7Yl7VcwWcmgdCeTTLLJPt/k2/yYOPpGgVu/QB/2UhA==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^7.0.1",
-            "typescript": "^4.2.3",
-            "yargs": "^13.2.2"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-              "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-              }
-            },
-            "yargs": {
-              "version": "13.3.2",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-              "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-              "dev": true,
-              "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.2"
-              }
-            }
+            "ansi-regex": "^5.0.1"
           }
         },
         "which-module": {
@@ -1991,14 +1968,14 @@
           "dev": true
         },
         "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "y18n": {
@@ -2024,103 +2001,12 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-              "dev": true
-            },
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "cliui": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-              "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-              "dev": true,
-              "requires": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^6.2.0"
-              }
-            },
-            "emoji-regex": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-              "dev": true
-            },
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "dev": true,
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-              "dev": true
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-              "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            },
-            "wrap-ansi": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-              "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-              }
-            },
-            "yargs-parser": {
-              "version": "18.1.3",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-              "dev": true,
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         },
         "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1804,13 +1804,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
@@ -1819,7 +1819,7 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
           "requires": {
@@ -1830,7 +1830,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -1839,13 +1839,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
@@ -1855,7 +1855,7 @@
         },
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
@@ -1866,13 +1866,13 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "resolved": "https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
           "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "is-core-module": {
           "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+          "resolved": "https://registry.npmmirror.com/is-core-module/-/is-core-module-2.9.0.tgz",
           "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
           "dev": true,
           "requires": {
@@ -1881,19 +1881,19 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "json5": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "resolved": "https://registry.npmmirror.com/json5/-/json5-2.2.1.tgz",
           "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
           "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
@@ -1902,7 +1902,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
@@ -1911,19 +1911,19 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "resolve": {
           "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+          "resolved": "https://registry.npmmirror.com/resolve/-/resolve-1.22.1.tgz",
           "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
           "dev": true,
           "requires": {
@@ -1934,7 +1934,7 @@
         },
         "semver": {
           "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "resolved": "https://registry.npmmirror.com/semver/-/semver-7.3.7.tgz",
           "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
@@ -1943,7 +1943,7 @@
         },
         "string-width": {
           "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
@@ -1954,7 +1954,7 @@
         },
         "strip-ansi": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
           "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
@@ -1963,13 +1963,13 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
           "dev": true
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
@@ -1980,13 +1980,13 @@
         },
         "y18n": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "resolved": "https://registry.npmmirror.com/y18n/-/y18n-4.0.3.tgz",
           "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "resolved": "https://registry.npmmirror.com/yargs/-/yargs-15.4.1.tgz",
           "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "dev": true,
           "requires": {
@@ -2005,7 +2005,7 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "resolved": "https://registry.npmmirror.com/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
@@ -18231,6 +18231,125 @@
       "resolved": "https://registry.npm.taobao.org/text-table/download/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "tfig": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/tfig/-/tfig-3.2.5.tgz",
+      "integrity": "sha512-IGizsIrOow7IFCSqGWFEX+vjO7jI5dZg8ASkNUb0Vl/Q7Yl7VcwWcmgdCeTTLLJPt/k2/yYOPpGgVu/QB/2UhA==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.1",
+        "typescript": "^4.2.3",
+        "yargs": "^13.2.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "throat": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.3.10",
+    "@cocos/build-engine": "4.3.13",
     "@types/fs-extra": "^5.0.4",
     "@types/jest": "^24.9.1",
     "@types/yargs": "^12.0.14",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "7.8.7",
     "@cocos/babel-preset-cc": "2.2.0",
-    "@cocos/build-engine": "4.3.13",
+    "@cocos/build-engine": "4.3.14",
     "@types/fs-extra": "^5.0.4",
     "@types/jest": "^24.9.1",
     "@types/yargs": "^12.0.14",

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.3.13",
+  "version": "4.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.3.10",
+  "version": "4.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2543,6 +2543,12 @@
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://repo.huaweicloud.com/repository/npm/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.30",
@@ -6117,6 +6123,12 @@
       "resolved": "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://repo.huaweicloud.com/repository/npm/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "dev": true
+    },
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npm.taobao.org/semver/download/semver-7.3.2.tgz",
@@ -6528,6 +6540,40 @@
           "version": "20.2.9",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true
+        }
+      }
+    },
+    "ts-json-schema-generator": {
+      "version": "1.0.0",
+      "resolved": "https://repo.huaweicloud.com/repository/npm/ts-json-schema-generator/-/ts-json-schema-generator-1.0.0.tgz",
+      "integrity": "sha512-F5VofsyMhNSXKII32NDS8/Ur8o2K3Sh5i/U2ke3UgCKf26ybgm2cZeT2x7VJPl1trML/9QLzz/82l0mvzmb3Vw==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "commander": "^9.0.0",
+        "glob": "^7.2.0",
+        "json5": "^2.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "typescript": "~4.6.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.3.0",
+          "resolved": "https://repo.huaweicloud.com/repository/npm/commander/-/commander-9.3.0.tgz",
+          "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.2.1",
+          "resolved": "https://repo.huaweicloud.com/repository/npm/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "4.6.4",
+          "resolved": "https://repo.huaweicloud.com/repository/npm/typescript/-/typescript-4.6.4.tgz",
+          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
           "dev": true
         }
       }

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.3.12",
+  "version": "4.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.3.11",
+  "version": "4.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -49,7 +49,8 @@
     "@types/semver": "^7.3.4",
     "@types/yargs": "^15.0.4",
     "jest": "^28.1.1",
-    "ts-jest": "^28.0.4"
+    "ts-jest": "^28.0.4",
+    "ts-json-schema-generator": "~1.0.0"
   },
   "peerDependencies": {
     "typescript": "^3.7.2"
@@ -58,6 +59,7 @@
     "build": "npx tsc",
     "clear": "node ./scripts/clear.mjs",
     "prepublishOnly": "npm run clear & npm run build",
+    "gen-config-json-schema": "npx ts-json-schema-generator -t Config -p ./src/config-interface.ts -o ./cc.config.schema.json",
     "test": "jest"
   },
   "author": "",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.3.12",
+  "version": "4.3.13",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.3.11",
+  "version": "4.3.12",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.3.10",
+  "version": "4.3.11",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.3.13",
+  "version": "4.3.14",
   "description": "",
   "repository": {
     "type": "git",

--- a/scripts/build-engine/src/config-interface.ts
+++ b/scripts/build-engine/src/config-interface.ts
@@ -66,6 +66,7 @@ export interface Context {
     buildTimeConstants?: Object;
 }
 
+export type ConstantTypeName = 'boolean' | 'number';
 
 export interface IConstantInfo {
     /**
@@ -74,11 +75,15 @@ export interface IConstantInfo {
      */
     readonly comment: string;
     /**
+     * The type of the constant for generating consts.d.ts file.
+     */
+    readonly type: ConstantTypeName;
+    /**
      * The default value of the constant.
-     * It can be a boolean or string.
+     * It can be a boolean, number or string.
      * When it's a string type, the value is the result of eval().
      */
-    value: boolean | string,
+    value: boolean | string | number,
     /**
      * Whether exported to global as a `CC_XXXX` constant.
      * eg. WECHAT is exported to global.CC_WECHAT

--- a/scripts/build-engine/src/constant-manager.ts
+++ b/scripts/build-engine/src/constant-manager.ts
@@ -6,8 +6,8 @@ export type ModeType = 'EDITOR' | 'PREVIEW' | 'BUILD' | 'TEST';
 export type PlatformType = 'HTML5' | 'NATIVE' |
         'WECHAT' | 'BAIDU' | 'XIAOMI' | 'ALIPAY' | 'BYTEDANCE' |
         'OPPO' | 'VIVO' | 'HUAWEI' | 'COCOSPLAY' | 'QTT' | 'LINKSURE';
-export type InternalFlagType = 'SERVER_MODE' | 'NOT_PACK_PHYSX_LIBS' | 'NET_MODE';
-export type PublicFlagType = 'DEBUG';
+export type InternalFlagType = 'SERVER_MODE' | 'NOT_PACK_PHYSX_LIBS';
+export type PublicFlagType = 'DEBUG' | 'NET_MODE';
 export type FlagType = InternalFlagType | PublicFlagType;
 
 export type ValueType = number | boolean;

--- a/scripts/build-engine/src/constant-manager.ts
+++ b/scripts/build-engine/src/constant-manager.ts
@@ -8,13 +8,14 @@ export type PlatformType = 'HTML5' | 'NATIVE' |
         'OPPO' | 'VIVO' | 'HUAWEI' | 'COCOSPLAY' | 'QTT' | 'LINKSURE';
 export type FlagType = 'DEBUG' | 'SERVER_MODE';
 
+export type ValueType = number | boolean;
 export interface ConstantOptions {
     mode: ModeType;
     platform: PlatformType;
-    flags: Partial<Record<FlagType, boolean>>;
+    flags: Partial<Record<FlagType, ValueType>>;
 }
+export type BuildTimeConstants = Record<PlatformType | ModeType | FlagType, ValueType>;
 
-export type BuildTimeConstants = Record<PlatformType | ModeType | FlagType, boolean>
 
 export class ConstantManager {
     private _engineRoot: string;
@@ -51,7 +52,7 @@ export class ConstantManager {
             console.warn(`Unknown platform: ${platform}`);
         }
         for (const key in flags) {
-            const value = flags[key as FlagType] as boolean;
+            const value = flags[key as FlagType]!;
             if (config[key]) {
                 config[key].value = value;
             } else {
@@ -103,7 +104,7 @@ export class ConstantManager {
             console.warn(`Unknown platform: ${platform}`);
         }
         for (const key in flags) {
-            const value = flags[key as FlagType] as boolean;
+            const value = flags[key as FlagType]!;
             if (config[key]) {
                 config[key].value = value;
             } else {
@@ -120,10 +121,10 @@ export class ConstantManager {
         }
 
         // generate json object
-        const jsonObj: Record<string, boolean> = {};
+        const jsonObj: Record<string, ValueType> = {};
         for (const key in config) {
             const info = config[key];
-            jsonObj[key] = info.value as boolean;
+            jsonObj[key] = info.value as ValueType;
         }
         return jsonObj as BuildTimeConstants;
     }
@@ -152,7 +153,7 @@ export class ConstantManager {
             console.warn(`Unknown platform: ${platform}`);
         }
         for (const key in flags) {
-            const value = flags[key as FlagType] as boolean;
+            const value = flags[key as FlagType]!;
             if (config[key]) {
                 config[key].value = value;
             } else {
@@ -222,7 +223,7 @@ export class ConstantManager {
             result += `\t * ${comment}\n`;
         }
         result += '\t */\n';
-        result += `\texport const ${name}: boolean;\n\n`
+        result += `\texport const ${name}: ${info.type};\n\n`
         return result;
     }
     //#endregion declaration

--- a/scripts/build-engine/src/constant-manager.ts
+++ b/scripts/build-engine/src/constant-manager.ts
@@ -75,7 +75,7 @@ export class ConstantManager {
         for (const key in config) {
             const info = config[key];
             const value = info.value;
-            if (info.dynamic) {
+            if (info.dynamic || info.internal) {
                 continue;
             }
             result += `export const ${key} = ${value};\n`;

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -29,7 +29,7 @@ import { filePathToModuleRequest } from './utils';
 import { assetRef as rpAssetRef, pathToAssetRefURL } from './rollup-plugins/asset-ref';
 import { codeAsset } from './rollup-plugins/code-asset';
 
-export { ModeType, PlatformType, FlagType, ConstantOptions, BuildTimeConstants } from './constant-manager';
+export { ModeType, PlatformType, FlagType, ConstantOptions, BuildTimeConstants, CCEnvConstants } from './constant-manager';
 export { StatsQuery };
 export { ModuleOption, enumerateModuleOptionReps, parseModuleOption };
 

--- a/scripts/build-engine/tests/stats-query/__snapshots__/constant-manager.test.ts.snap
+++ b/scripts/build-engine/tests/stats-query/__snapshots__/constant-manager.test.ts.snap
@@ -70,6 +70,10 @@ tryDefineGlobal('CC_MINIGAME', true);
 export const RUNTIME_BASED = false;
 tryDefineGlobal('CC_RUNTIME_BASED', false);
 
+export const NOT_PACK_PHYSX_LIBS = false;
+
+export const NET_MODE = 0;
+
 "
 `;
 
@@ -152,6 +156,10 @@ tryDefineGlobal('CC_SUPPORT_JIT', false);
 export const JSB = false;
 tryDefineGlobal('CC_JSB', false);
 
+export const NOT_PACK_PHYSX_LIBS = false;
+
+export const NET_MODE = 0;
+
 "
 `;
 
@@ -188,17 +196,17 @@ exports[`generateCCEnv 1`] = `
 	export const ALIPAY: boolean;
 
 	/**
-	 * Running in the ByteDance's quick game.
+	 * Running in the ByteDance's mini game.
 	 */
 	export const BYTEDANCE: boolean;
 
 	/**
-	 * Running in the oppo's mini game.
+	 * Running in the oppo's quick game.
 	 */
 	export const OPPO: boolean;
 
 	/**
-	 * Running in the vivo's mini game.
+	 * Running in the vivo's quick game.
 	 */
 	export const VIVO: boolean;
 
@@ -273,7 +281,7 @@ exports[`generateCCEnv 1`] = `
 	export const SUPPORT_JIT: boolean;
 
 	/**
-	 * Running in native platform (mobile app, desktop app, or simulator).
+	 * Running in environment where using JSB as the JavaScript interface binding scheme.
 	 */
 	export const JSB: boolean;
 
@@ -314,17 +322,17 @@ exports[`generateInternalConstants 1`] = `
 	export const ALIPAY: boolean;
 
 	/**
-	 * Running in the ByteDance's quick game.
+	 * Running in the ByteDance's mini game.
 	 */
 	export const BYTEDANCE: boolean;
 
 	/**
-	 * Running in the oppo's mini game.
+	 * Running in the oppo's quick game.
 	 */
 	export const OPPO: boolean;
 
 	/**
-	 * Running in the vivo's mini game.
+	 * Running in the vivo's quick game.
 	 */
 	export const VIVO: boolean;
 
@@ -399,9 +407,22 @@ exports[`generateInternalConstants 1`] = `
 	export const SUPPORT_JIT: boolean;
 
 	/**
-	 * Running in native platform (mobile app, desktop app, or simulator).
+	 * Running in environment where using JSB as the JavaScript interface binding scheme.
 	 */
 	export const JSB: boolean;
+
+	/**
+	 * This is an internal constant to determine whether pack physx libs.
+	 */
+	export const NOT_PACK_PHYSX_LIBS: boolean;
+
+	/**
+	 * The network access mode.
+	 * - 0 Client
+	 * - 1 ListenServer
+	 * - 2 HostServer
+	 */
+	export const NET_MODE: number;
 
 }
 "

--- a/scripts/build-engine/tests/stats-query/__snapshots__/constant-manager.test.ts.snap
+++ b/scripts/build-engine/tests/stats-query/__snapshots__/constant-manager.test.ts.snap
@@ -62,15 +62,11 @@ tryDefineGlobal('CC_BUILD', true);
 export const DEBUG = true;
 tryDefineGlobal('CC_DEBUG', true);
 
-export const SERVER_MODE = false;
-
 export const MINIGAME = true;
 tryDefineGlobal('CC_MINIGAME', true);
 
 export const RUNTIME_BASED = false;
 tryDefineGlobal('CC_RUNTIME_BASED', false);
-
-export const NOT_PACK_PHYSX_LIBS = false;
 
 export const NET_MODE = 0;
 
@@ -256,11 +252,6 @@ exports[`generateCCEnv 1`] = `
 	export const DEBUG: boolean;
 
 	/**
-	 * Running in the server mode.
-	 */
-	export const SERVER_MODE: boolean;
-
-	/**
 	 * Running in the editor or preview.
 	 */
 	export const DEV: boolean;
@@ -284,6 +275,14 @@ exports[`generateCCEnv 1`] = `
 	 * Running in environment where using JSB as the JavaScript interface binding scheme.
 	 */
 	export const JSB: boolean;
+
+	/**
+	 * The network access mode.
+	 * - 0 Client
+	 * - 1 ListenServer
+	 * - 2 HostServer
+	 */
+	export const NET_MODE: number;
 
 }
 "

--- a/scripts/build-engine/tests/stats-query/cc.config.json
+++ b/scripts/build-engine/tests/stats-query/cc.config.json
@@ -302,7 +302,7 @@
             "comment": "Running in the server mode.",
             "type": "boolean",
             "value": false,
-            "internal": false
+            "internal": true
         },
 
 
@@ -354,7 +354,7 @@
             "comment": "The network access mode.\n- 0 Client\n- 1 ListenServer\n- 2 HostServer",
             "type": "number",
             "value": 0,
-            "internal": true
+            "internal": false
         }
     }
 }

--- a/scripts/build-engine/tests/stats-query/cc.config.json
+++ b/scripts/build-engine/tests/stats-query/cc.config.json
@@ -168,78 +168,91 @@
     "constants": {
         "HTML5": {
             "comment": "Running in Web platform",
+            "type": "boolean",
             "value": false,
             "internal": false,
             "dynamic": true
         },
         "NATIVE": {
             "comment": "Running in native platform (mobile app, desktop app, or simulator).",
+            "type": "boolean",
             "value": false,
             "internal": false,
             "dynamic": true
         },
         "WECHAT": {
             "comment": "Running in the Wechat's mini game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "BAIDU": {
             "comment": "Running in the baidu's mini game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "XIAOMI": {
             "comment": "Running in the xiaomi's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "ALIPAY": {
             "comment": "Running in the alipay's mini game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "BYTEDANCE": {
-            "comment": "Running in the ByteDance's quick game.",
+            "comment": "Running in the ByteDance's mini game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "OPPO": {
-            "comment": "Running in the oppo's mini game.",
+            "comment": "Running in the oppo's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "VIVO": {
-            "comment": "Running in the vivo's mini game.",
+            "comment": "Running in the vivo's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "HUAWEI": {
             "comment": "Running in the huawei's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "COCOSPLAY": {
             "comment": "Running in the cocosplay.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "QTT": {
             "comment": "Running in the qtt's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "LINKSURE": {
             "comment": "Running in the linksure's quick game.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
@@ -247,6 +260,7 @@
 
         "EDITOR": {
             "comment": "Running in the editor.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false,
@@ -254,6 +268,7 @@
         },
         "PREVIEW": {
             "comment": "Preview in browser or simulator.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false,
@@ -261,12 +276,14 @@
         },
         "BUILD": {
             "comment": "Running in published project.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false
         },
         "TEST": {
             "comment": "Running in the engine's unit test.",
+            "type": "boolean",
             "value": false,
             "ccGlobal": true,
             "internal": false,
@@ -276,12 +293,14 @@
 
         "DEBUG": {
             "comment": "Running debug mode.",
+            "type": "boolean",
             "value": true,
             "ccGlobal": true,
             "internal": false
         },
         "SERVER_MODE": {
             "comment": "Running in the server mode.",
+            "type": "boolean",
             "value": false,
             "internal": false
         },
@@ -289,6 +308,7 @@
 
         "DEV": {
             "comment": "Running in the editor or preview.",
+            "type": "boolean",
             "value": "$EDITOR || $PREVIEW || $TEST",
             "ccGlobal": true,
             "internal": false,
@@ -296,29 +316,45 @@
         },
         "MINIGAME": {
             "comment": "Running in mini game.",
+            "type": "boolean",
             "value": "$WECHAT || $BAIDU || $XIAOMI || $ALIPAY || $BYTEDANCE",
             "ccGlobal": true,
             "internal": false
         },
         "RUNTIME_BASED": {
             "comment": "Running in runtime based environment.",
+            "type": "boolean",
             "value": "$OPPO || $VIVO || $HUAWEI || $COCOSPLAY || $QTT || $LINKSURE",
             "ccGlobal": true,
             "internal": false
         },
         "SUPPORT_JIT": {
             "comment": "Support JIT.",
+            "type": "boolean",
             "value": "!($MINIGAME || $RUNTIME_BASED)",
             "ccGlobal": true,
             "internal": false,
             "dynamic": true
         },
         "JSB": {
-            "comment": "Running in native platform (mobile app, desktop app, or simulator).",
+            "comment": "Running in environment where using JSB as the JavaScript interface binding scheme.",
+            "type": "boolean",
             "value": "$NATIVE",
             "ccGlobal": true,
             "internal": false,
             "dynamic": true
+        },
+        "NOT_PACK_PHYSX_LIBS": {
+            "comment": "This is an internal constant to determine whether pack physx libs.",
+            "type": "boolean",
+            "value": false,
+            "internal": true
+        },
+        "NET_MODE": {
+            "comment": "The network access mode.\n- 0 Client\n- 1 ListenServer\n- 2 HostServer",
+            "type": "number",
+            "value": 0,
+            "internal": true
         }
     }
 }

--- a/scripts/build-engine/tests/stats-query/constant-manager.test.ts
+++ b/scripts/build-engine/tests/stats-query/constant-manager.test.ts
@@ -48,6 +48,8 @@ test('genBuildTimeConstants', () => {
           "LINKSURE": false,
           "MINIGAME": false,
           "NATIVE": true,
+          "NET_MODE": 0,
+          "NOT_PACK_PHYSX_LIBS": false,
           "OPPO": false,
           "PREVIEW": false,
           "QTT": false,


### PR DESCRIPTION
https://github.com/cocos/3d-tasks/issues/12646
https://github.com/cocos/3d-tasks/issues/12807

## changeLog
- support number type of build time constant
- support `constantManager.genCCEnvConstants()`, which is different with `constantManager.genBuildTimeConstants()`，editor related PR: https://github.com/cocos/cocos-editor/pull/575, build time constants includes some engine private constants, which should not be public
- fix builder warning `Unknown flag: 'NET_MODE'` https://github.com/cocos/3d-tasks/issues/12646
- support `gen-config-json-schema` workflow in `@cocos/build-engine`
- change `SERVER_MODE` to internal, and add `NET_MODE` as public
- `SUPPORT_JIT` should not be dynamic constant

## test case 
https://github.com/cocos/cocos-test-projects/pull/667

## editor releated PR
https://github.com/cocos/cocos-editor/pull/575