### PR TITLE
Check passes length in Shadow.getPlanarShader & getPlanarInstanceShader.

### DIFF
--- a/cocos/core/renderer/scene/shadows.ts
+++ b/cocos/core/renderer/scene/shadows.ts
@@ -23,6 +23,7 @@
  THE SOFTWARE.
  */
 
+import { DEBUG } from 'internal:constants';
 import { Material } from '../../assets/material';
 import { Sphere } from '../../geometry';
 import { Color, Mat4, Vec3, Vec2 } from '../../math';
@@ -31,6 +32,7 @@ import { Enum } from '../../value-types';
 import type { ShadowsInfo } from '../../scene-graph/scene-globals';
 import { IMacroPatch } from '../core/pass';
 import { Shader } from '../../gfx';
+import { assert } from '../../platform/debug';
 
 /**
  * @zh 阴影贴图分辨率。
@@ -347,6 +349,9 @@ export class Shadows {
         }
 
         const passes = this._material.passes;
+        if (DEBUG) {
+            assert(passes.length > 0, 'passes should not be empty!');
+        }
         return passes.length > 0 ? passes[0].getShaderVariant(patches) : null;
     }
 
@@ -363,6 +368,9 @@ export class Shadows {
         }
 
         const passes = this._instancingMaterial.passes;
+        if (DEBUG) {
+            assert(passes.length > 0, 'passes should not be empty!');
+        }
         return passes.length > 0 ? passes[0].getShaderVariant(patches) : null;
     }
 

--- a/cocos/core/renderer/scene/shadows.ts
+++ b/cocos/core/renderer/scene/shadows.ts
@@ -346,7 +346,8 @@ export class Shadows {
             this._material.initialize({ effectName: 'pipeline/planar-shadow' });
         }
 
-        return this._material.passes[0].getShaderVariant(patches);
+        const passes = this._material.passes;
+        return passes.length > 0 ? passes[0].getShaderVariant(patches) : null;
     }
 
     /**
@@ -361,7 +362,8 @@ export class Shadows {
             this._instancingMaterial.initialize({ effectName: 'pipeline/planar-shadow', defines: { USE_INSTANCING: true } });
         }
 
-        return this._instancingMaterial.passes[0].getShaderVariant(patches);
+        const passes = this._instancingMaterial.passes;
+        return passes.length > 0 ? passes[0].getShaderVariant(patches) : null;
     }
 
     public initialize (shadowsInfo: ShadowsInfo) {

--- a/native/cocos/scene/Shadow.cpp
+++ b/native/cocos/scene/Shadow.cpp
@@ -91,7 +91,7 @@ void ShadowsInfo::setShadowMapSize(float value) {
     }
 }
 
-void ShadowsInfo::setPlaneFromNode(const Node* node) {
+void ShadowsInfo::setPlaneFromNode(const Node *node) {
     const auto &qt = node->getWorldRotation();
     _normal = Vec3::UNIT_Y;
     _normal.transformQuat(qt);
@@ -117,7 +117,7 @@ void Shadows::initialize(const ShadowsInfo &shadowsInfo) {
         setSize(Vec2(shadowsInfo.getShadowMapSize(), shadowsInfo.getShadowMapSize()));
         _shadowMapDirty = true;
     }
-    
+
     setShadowColor(shadowsInfo.getShadowColor());
 }
 

--- a/native/cocos/scene/Shadow.cpp
+++ b/native/cocos/scene/Shadow.cpp
@@ -139,6 +139,7 @@ gfx::Shader *Shadows::getPlanarShader(const ccstd::vector<IMacroPatch> &patches)
     }
 
     const auto &passes = _material->getPasses();
+    CC_ASSERT(passes && !passes->empty());
     return (passes && !passes->empty()) ? passes->at(0)->getShaderVariant(patches) : nullptr;
 }
 
@@ -148,6 +149,7 @@ gfx::Shader *Shadows::getPlanarInstanceShader(const ccstd::vector<IMacroPatch> &
     }
 
     const auto &passes = _instancingMaterial->getPasses();
+    CC_ASSERT(passes && !passes->empty());
     return (passes && !passes->empty()) ? passes->at(0)->getShaderVariant(patches) : nullptr;
 }
 

--- a/native/cocos/scene/Shadow.cpp
+++ b/native/cocos/scene/Shadow.cpp
@@ -138,8 +138,8 @@ gfx::Shader *Shadows::getPlanarShader(const ccstd::vector<IMacroPatch> &patches)
         createMaterial();
     }
 
-    const auto &passes = *_material->getPasses();
-    return passes[0]->getShaderVariant(patches);
+    const auto &passes = _material->getPasses();
+    return passes && !passes->empty() ? passes->at(0)->getShaderVariant(patches) : nullptr;
 }
 
 gfx::Shader *Shadows::getPlanarInstanceShader(const ccstd::vector<IMacroPatch> &patches) {
@@ -147,8 +147,8 @@ gfx::Shader *Shadows::getPlanarInstanceShader(const ccstd::vector<IMacroPatch> &
         createInstanceMaterial();
     }
 
-    const auto &passes = *_instancingMaterial->getPasses();
-    return passes[0]->getShaderVariant(patches);
+    const auto &passes = _instancingMaterial->getPasses();
+    return passes && !passes->empty() ? passes->at(0)->getShaderVariant(patches) : nullptr;
 }
 
 void Shadows::activate() {

--- a/native/cocos/scene/Shadow.cpp
+++ b/native/cocos/scene/Shadow.cpp
@@ -139,7 +139,7 @@ gfx::Shader *Shadows::getPlanarShader(const ccstd::vector<IMacroPatch> &patches)
     }
 
     const auto &passes = _material->getPasses();
-    return passes && !passes->empty() ? passes->at(0)->getShaderVariant(patches) : nullptr;
+    return (passes && !passes->empty()) ? passes->at(0)->getShaderVariant(patches) : nullptr;
 }
 
 gfx::Shader *Shadows::getPlanarInstanceShader(const ccstd::vector<IMacroPatch> &patches) {
@@ -148,7 +148,7 @@ gfx::Shader *Shadows::getPlanarInstanceShader(const ccstd::vector<IMacroPatch> &
     }
 
     const auto &passes = _instancingMaterial->getPasses();
-    return passes && !passes->empty() ? passes->at(0)->getShaderVariant(patches) : nullptr;
+    return (passes && !passes->empty()) ? passes->at(0)->getShaderVariant(patches) : nullptr;
 }
 
 void Shadows::activate() {


### PR DESCRIPTION
If developer doesn't check `Project Settings -> Feature Cropping -> 3D -> Basic 3D Features
`  for a 2D game.
, game will crash on native platforms or throw exception on web.

This PR make sure there are not crashes or exceptions.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
