### PR TITLE
Fix bug when JsbBridge test case close window

### DIFF
--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -222,7 +222,6 @@ void Engine::close() { // NOLINT
     cc::DeferredReleasePool::clear();
     _scheduler->removeAllFunctionsToBePerformedInCocosThread();
     _scheduler->unscheduleAll();
-    cc::EventDispatcher::dispatchCloseEvent();
     BasePlatform::getPlatform()->setHandleEventCallback(nullptr);
 
 

--- a/native/cocos/platform/apple/JsbBridgeWrapper.mm
+++ b/native/cocos/platform/apple/JsbBridgeWrapper.mm
@@ -117,7 +117,7 @@ static ICallback cb = ^void(NSString* _event, NSString* _arg) {
         }
         [jb setCallback:cb];
         cc::EventDispatcher::addCustomEventListener(EVENT_CLOSE, [&](const cc::CustomEvent& event){
-            [[JsbBridge sharedInstance] release];
+            [[JsbBridgeWrapper sharedInstance] release];
         });
     }
     return self;


### PR DESCRIPTION
* engine-close will not dispatchCloseEvent as it's already dispatch otherwhere
* jsbBridgeWrapper will now release JsbBridgeWrapper sharedInstance rather than jsbBridge