### PR TITLE
add protect condition of kerningDict and fontDefDictionary are undefined

### DIFF
--- a/cocos/2d/assembler/label/bmfontUtils.ts
+++ b/cocos/2d/assembler/label/bmfontUtils.ts
@@ -163,7 +163,7 @@ export const bmfontUtils = {
         shareLabelInfo.fontAtlas = fontAsset.fontDefDictionary;
         if (!shareLabelInfo.fontAtlas) {
             if (comp.cacheMode === CacheMode.CHAR) {
-                shareLabelInfo.fontAtlas = new LetterAtlas(1024, 1024);
+                shareLabelInfo.fontAtlas = new LetterAtlas(64, 64);
             } else {
                 shareLabelInfo.fontAtlas = new FontAtlas(null);
             }

--- a/cocos/2d/assembler/label/bmfontUtils.ts
+++ b/cocos/2d/assembler/label/bmfontUtils.ts
@@ -32,6 +32,7 @@ import { HorizontalTextAlignment, VerticalTextAlignment, Label, Overflow } from 
 import { UITransform } from '../../framework/ui-transform';
 import { shareLabelInfo } from './font-utils';
 import { dynamicAtlasManager } from '../../utils/dynamic-atlas/atlas-manager';
+import { warn } from '../../../core';
 
 class LetterInfo {
     public char = '';
@@ -161,6 +162,9 @@ export const bmfontUtils = {
         _spriteFrame = fontAsset.spriteFrame;
         _fntConfig = fontAsset.fntConfig;
         shareLabelInfo.fontAtlas = fontAsset.fontDefDictionary;
+        if (!shareLabelInfo.fontAtlas) {
+            console.warn(`The fontAtlas is null, please check the data integrity of the font named '${fontAsset.name}'`);
+        }
 
         dynamicAtlasManager.packToDynamicAtlas(comp, _spriteFrame);
         // TODO update material and uv

--- a/cocos/2d/assembler/label/bmfontUtils.ts
+++ b/cocos/2d/assembler/label/bmfontUtils.ts
@@ -43,6 +43,8 @@ class LetterInfo {
 }
 
 const _tmpRect = new Rect();
+const _defaultLetterAtlas = new LetterAtlas(64, 64);
+const _defaultFontAtlas = new FontAtlas(null);
 
 let _comp: Label | null = null;
 let _uiTrans: UITransform | null = null;
@@ -163,9 +165,9 @@ export const bmfontUtils = {
         shareLabelInfo.fontAtlas = fontAsset.fontDefDictionary;
         if (!shareLabelInfo.fontAtlas) {
             if (comp.cacheMode === CacheMode.CHAR) {
-                shareLabelInfo.fontAtlas = new LetterAtlas(64, 64);
+                shareLabelInfo.fontAtlas = _defaultLetterAtlas;
             } else {
-                shareLabelInfo.fontAtlas = new FontAtlas(null);
+                shareLabelInfo.fontAtlas = _defaultFontAtlas;
             }
         }
 

--- a/cocos/2d/assembler/label/bmfontUtils.ts
+++ b/cocos/2d/assembler/label/bmfontUtils.ts
@@ -224,6 +224,10 @@ export const bmfontUtils = {
         const kerningDict = _fntConfig!.kerningDict;
         const horizontalKerning = _horizontalKerning;
 
+        if (!kerningDict) {
+            return;
+        }
+
         let prev = -1;
         for (let i = 0; i < stringLen; ++i) {
             const key = string.charCodeAt(i);
@@ -277,7 +281,7 @@ export const bmfontUtils = {
                     this._recordPlaceholderInfo(letterIndex, character);
                     continue;
                 }
-                letterDef = shareLabelInfo.fontAtlas!.getLetterDefinitionForChar(character, shareLabelInfo);
+                letterDef = shareLabelInfo.fontAtlas?.getLetterDefinitionForChar(character, shareLabelInfo);
                 if (!letterDef) {
                     this._recordPlaceholderInfo(letterIndex, character);
                     console.log(`Can't find letter definition in texture atlas ${
@@ -387,7 +391,7 @@ export const bmfontUtils = {
         }
 
         let len = 1;
-        let letterDef = shareLabelInfo.fontAtlas!.getLetterDefinitionForChar(character, shareLabelInfo);
+        let letterDef = shareLabelInfo.fontAtlas?.getLetterDefinitionForChar(character, shareLabelInfo);
         if (!letterDef) {
             return len;
         }
@@ -396,7 +400,7 @@ export const bmfontUtils = {
         for (let index = startIndex + 1; index < textLen; ++index) {
             character = text.charAt(index);
 
-            letterDef = shareLabelInfo.fontAtlas!.getLetterDefinitionForChar(character, shareLabelInfo);
+            letterDef = shareLabelInfo.fontAtlas?.getLetterDefinitionForChar(character, shareLabelInfo);
             if (!letterDef) {
                 break;
             }
@@ -450,7 +454,7 @@ export const bmfontUtils = {
         _lettersInfo[letterIndex].line = lineIndex;
         _lettersInfo[letterIndex].char = character;
         _lettersInfo[letterIndex].hash = key;
-        _lettersInfo[letterIndex].valid = shareLabelInfo.fontAtlas!.getLetter(key).valid;
+        _lettersInfo[letterIndex].valid = shareLabelInfo.fontAtlas?.getLetter(key).valid;
         _lettersInfo[letterIndex].x = letterPosition.x;
         _lettersInfo[letterIndex].y = letterPosition.y;
     },
@@ -542,7 +546,7 @@ export const bmfontUtils = {
         for (let ctr = 0, l = _string.length; ctr < l; ++ctr) {
             const letterInfo = _lettersInfo[ctr];
             if (letterInfo.valid) {
-                const letterDef = shareLabelInfo.fontAtlas!.getLetterDefinitionForChar(letterInfo.char, shareLabelInfo);
+                const letterDef = shareLabelInfo.fontAtlas?.getLetterDefinitionForChar(letterInfo.char, shareLabelInfo);
                 if (!letterDef) {
                     continue;
                 }
@@ -585,7 +589,7 @@ export const bmfontUtils = {
             return false;
         }
 
-        const texture =  _spriteFrame ? _spriteFrame.texture : shareLabelInfo.fontAtlas!.getTexture();
+        const texture =  _spriteFrame ? _spriteFrame.texture : shareLabelInfo.fontAtlas?.getTexture();
         const renderData = _comp.renderData!;
         renderData.dataLength = 0;
         renderData.resize(0, 0);
@@ -598,7 +602,7 @@ export const bmfontUtils = {
         for (let ctr = 0, l = _string.length; ctr < l; ++ctr) {
             const letterInfo = _lettersInfo[ctr];
             if (!letterInfo.valid) { continue; }
-            const letterDef = shareLabelInfo.fontAtlas!.getLetter(letterInfo.hash);
+            const letterDef = shareLabelInfo.fontAtlas?.getLetter(letterInfo.hash);
             if (!letterDef) {
                 console.warn('Can\'t find letter in this bitmap-font');
                 continue;


### PR DESCRIPTION
Re: [#13071](https://github.com/cocos/3d-tasks/issues/13071)

### Changelog

* kerningDict is undefined caused crash in _computeHorizontalKerningForText
* fontDefDictionary is undefined caused crash in _getFirstWordLen
* create a new fontAtlas when the parameter is null 
* newly created label-atlas which doesn't have its spriteFrame is dragged to scene, and the data in fontConfig are not initialized. This is the reason of these 2 point above.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
