### PR TITLE
[3.6.0] Support device vs design aspect ratio in Splash Screen

### DIFF
--- a/cocos/core/splash-screen.ts
+++ b/cocos/core/splash-screen.ts
@@ -173,13 +173,17 @@ export class SplashScreen {
             device.capabilities.clipSpaceSignY, swapchain.surfaceTransform);
         const dw = swapchain.width; const dh = swapchain.height;
         const refW = dw < dh ? dw : dh;
+        const deviceAspect = dw / dh;
+        const designRes = window._CCSettings.designResolution;
+        const designtAspect = designRes.width / designRes.height;
+        const ratio = deviceAspect / designtAspect;
         // update logo uniform
         this._curTime += deltaTime * 1000;
         const percent = clamp01(this._curTime / settings.totalTime);
         let u_p = easing.cubicOut(percent);
         if (settings.effect === 'NONE') u_p = 1.0;
         const logoTW = this.logoTexture.width; const logoTH = this.logoTexture.height;
-        const logoW = refW * settings.displayRatio;
+        const logoW = refW * settings.displayRatio * ratio;
         let scaleX = logoW * logoTW / logoTH;
         let scaleY = logoW;
         if (swapchain.surfaceTransform === SurfaceTransform.ROTATE_90

--- a/cocos/core/splash-screen.ts
+++ b/cocos/core/splash-screen.ts
@@ -35,7 +35,7 @@ import {
 import { PipelineStateManager } from './pipeline';
 import { legacyCC } from './global-exports';
 import { SetIndex } from './pipeline/define';
-import { Mat4, Vec2 } from './math';
+import { Mat4, Vec2, Size } from './math';
 import { Settings, settings } from './settings';
 
 const v2_0 = new Vec2();
@@ -48,6 +48,7 @@ interface ISplashSetting {
     clearColor: Color;
     displayRatio: number;
     displayWatermark: boolean;
+    designResolution: Size;
 }
 
 type Writable<T> = { -readonly [K in keyof T]: T[K] };
@@ -97,6 +98,7 @@ export class SplashScreen {
             clearColor: settings.querySettings<Color>(Settings.Category.SPLASH_SCREEN, 'clearColor') ?? new Color(0.88, 0.88, 0.88, 1),
             displayRatio: settings.querySettings<number>(Settings.Category.SPLASH_SCREEN, 'displayRatio') ?? 0.4,
             displayWatermark: settings.querySettings<boolean>(Settings.Category.SPLASH_SCREEN, 'displayWatermark') ?? true,
+            designResolution: settings.querySettings<Size>(Settings.Category.SCREEN, 'designResolution') ?? new Size(1280, 760),
         };
         this._curTime = 0;
 
@@ -174,7 +176,7 @@ export class SplashScreen {
         const dw = swapchain.width; const dh = swapchain.height;
         const refW = dw < dh ? dw : dh;
         const deviceAspect = dw / dh;
-        const designRes = window._CCSettings.designResolution;
+        const designRes = this.settings.designResolution;
         const designAspect = designRes.width / designRes.height;
         const ratio = deviceAspect / designAspect;
         // update logo uniform

--- a/cocos/core/splash-screen.ts
+++ b/cocos/core/splash-screen.ts
@@ -175,8 +175,8 @@ export class SplashScreen {
         const refW = dw < dh ? dw : dh;
         const deviceAspect = dw / dh;
         const designRes = window._CCSettings.designResolution;
-        const designtAspect = designRes.width / designRes.height;
-        const ratio = deviceAspect / designtAspect;
+        const designAspect = designRes.width / designRes.height;
+        const ratio = deviceAspect / designAspect;
         // update logo uniform
         this._curTime += deltaTime * 1000;
         const percent = clamp01(this._curTime / settings.totalTime);


### PR DESCRIPTION
Currently the Splash Screen in the engine uses a hard coded displayRatio setting in the build configuration and I guess that's trying to fill the role of what I actually need. I need this value to be dynamic based on the device that's running the game.

Mobile web devices come in various aspect ratios that may or may not match the design ratio. We need to compare the design aspect ratio to the device aspect ratio and use that as a multiplier on the splash screen to ensure it fits. Previously iPhone had 1.77 aspect ratio but newer devices seem to be 2.16. 

Typically designers would be designing for a 1.77 aspect ratio, so we would need a ratio modifier based on the device it runs on. It would be 1.0 for older devices and 1.22 for newer. But rather than hard code these values, I want to use the aspect ratio of the device and the aspect ratio of the design resolution to calculate it dynamically.
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
