### PR TITLE
Fix spine memory leak when restarting game and fix memory leaks in js_se_setExceptionCallback and nativevalue_to_se(const cc::Data &from, ...)

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/Class.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Class.cpp
@@ -119,7 +119,7 @@ bool Class::init(const ccstd::string &clsName, Object *parent, Object *parentPro
     }
 
     _ctorTemplate.Get(__isolate)->SetClassName(jsNameVal.ToLocalChecked());
-    _ctorTemplate.Get(__isolate)->InstanceTemplate()->SetInternalFieldCount(2);
+    _ctorTemplate.Get(__isolate)->InstanceTemplate()->SetInternalFieldCount(1);
 
     return true;
 }

--- a/native/cocos/bindings/jswrapper/v8/Class.h
+++ b/native/cocos/bindings/jswrapper/v8/Class.h
@@ -151,6 +151,7 @@ private:
 
     friend class ScriptEngine;
     friend class Object;
+    friend class JSBPersistentHandleVisitor;
 };
 
 } // namespace se

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -155,7 +155,7 @@ void Object::setup() {
 void Object::cleanup() {
     JSBPersistentHandleVisitor jsbVisitor;
     __isolate->VisitHandlesWithClassIds(&jsbVisitor);
-    NativePtrToObjectMap::clear();
+    SE_ASSERT(NativePtrToObjectMap::size() == 0, "NativePtrToObjectMap should be empty!");
 
     if (__objectMap) {
         for (const auto &e : *__objectMap) {

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -71,7 +71,7 @@ public:
             return;
         }
 
-        Object *obj = reinterpret_cast<Object *>(ptr);
+        auto *obj = reinterpret_cast<Object *>(ptr);
         auto *nativeObj = obj->getPrivateData();
         if (nativeObj == nullptr) {
             // Not a JSB binding object

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -78,6 +78,13 @@ class JSBPersistentHandleVisitor : public v8::PersistentHandleVisitor {
             return;
         }
 
+        // Remove mapping
+        auto iter = se::NativePtrToObjectMap::find(nativeObj);
+        if (iter != se::NativePtrToObjectMap::end()) {
+            se::NativePtrToObjectMap::erase(iter);
+        }
+
+        // Invoke finalize callback
         if (obj->_finalizeCb != nullptr) {
             obj->_finalizeCb(obj);
         } else {

--- a/native/cocos/bindings/jswrapper/v8/Object.h
+++ b/native/cocos/bindings/jswrapper/v8/Object.h
@@ -466,7 +466,9 @@ private:
     #if JSB_TRACK_OBJECT_CREATION
     ccstd::string _objectCreationStackFrame;
     #endif
+
     friend class ScriptEngine;
+    friend class JSBPersistentHandleVisitor;
 };
 // NOLINTNEXTLINE
 extern std::unique_ptr<ccstd::unordered_map<Object *, void *>> __objectMap; // Currently, the value `void*` is always nullptr

--- a/native/cocos/bindings/jswrapper/v8/ObjectWrap.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ObjectWrap.cpp
@@ -85,6 +85,11 @@ void ObjectWrap::wrap(void *nativeObj, uint32_t fieldIndex) {
     CC_ASSERT(handle()->InternalFieldCount() > 0);
     CC_ASSERT(fieldIndex >= 0 && fieldIndex < 1);
     handle()->SetAlignedPointerInInternalField(static_cast<int>(fieldIndex), nativeObj);
+    if (nativeObj) {
+        persistent().SetWrapperClassId(MAGIC_CLASS_ID_JSB);
+    } else {
+        persistent().SetWrapperClassId(0);
+    }
 }
 
 v8::Local<v8::Object> ObjectWrap::handle() {

--- a/native/cocos/bindings/jswrapper/v8/ObjectWrap.h
+++ b/native/cocos/bindings/jswrapper/v8/ObjectWrap.h
@@ -57,6 +57,8 @@ namespace se {
 
 class ObjectWrap {
 public:
+    static constexpr uint16_t MAGIC_CLASS_ID_JSB = 0x1234;
+
     ObjectWrap();
     ~ObjectWrap();
 

--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.cpp
@@ -663,6 +663,11 @@ void ScriptEngine::cleanup() {
     for (const auto &hook : _afterCleanupHookArray) {
         hook();
     }
+
+    // Cleanup all hooks
+    _beforeInitHookArray.clear();
+    _afterInitHookArray.clear();
+    _beforeCleanupHookArray.clear();
     _afterCleanupHookArray.clear();
 
     _isInCleanup = false;

--- a/native/cocos/bindings/manual/jsb_cocos_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_cocos_manual.cpp
@@ -651,6 +651,11 @@ static bool js_se_setExceptionCallback(se::State &s) { // NOLINT(readability-ide
         jsArgs[2] = se::Value(stack);
         objFunc->call(jsArgs, nullptr);
     });
+
+    se::ScriptEngine::getInstance()->addBeforeCleanupHook([objFunc]{
+        objFunc->decRef();
+    });
+
     return true;
 }
 SE_BIND_FUNC(js_se_setExceptionCallback) // NOLINT(readability-identifier-naming)

--- a/native/cocos/bindings/manual/jsb_cocos_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_cocos_manual.cpp
@@ -652,7 +652,7 @@ static bool js_se_setExceptionCallback(se::State &s) { // NOLINT(readability-ide
         objFunc->call(jsArgs, nullptr);
     });
 
-    se::ScriptEngine::getInstance()->addBeforeCleanupHook([objFunc]{
+    se::ScriptEngine::getInstance()->addBeforeCleanupHook([objFunc] {
         objFunc->decRef();
     });
 

--- a/native/cocos/bindings/manual/jsb_conversions_spec.cpp
+++ b/native/cocos/bindings/manual/jsb_conversions_spec.cpp
@@ -1514,7 +1514,7 @@ bool nativevalue_to_se(const spine::Vector<spine::String> &v, se::Value &ret, se
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 bool nativevalue_to_se(const cc::Data &from, se::Value &to, se::Object * /*unused*/) {
-    se::Object *buffer = se::Object::createArrayBufferObject(from.getBytes(), from.getSize());
+    se::HandleObject buffer{se::Object::createArrayBufferObject(from.getBytes(), from.getSize())};
     to.setObject(buffer);
     return true;
 }

--- a/native/cocos/core/TypedArray.h
+++ b/native/cocos/core/TypedArray.h
@@ -136,6 +136,11 @@ public:
             _byteOffset = o._byteOffset;
             _byteLength = o._byteLength;
             _byteEndPos = o._byteEndPos;
+
+            if (_jsTypedArray != nullptr) {
+                _jsTypedArray->unroot();
+                _jsTypedArray->decRef();
+            }
             _jsTypedArray = o._jsTypedArray;
 
             o._buffer = nullptr;

--- a/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
@@ -66,6 +66,14 @@ public:
 
 SkeletonDataMgr *SkeletonDataMgr::instance = nullptr;
 
+SkeletonDataMgr::~SkeletonDataMgr() {
+    _destroyCallback = nullptr;
+    for (auto& e : _dataMap) {
+        delete e.second;
+    }
+    _dataMap.clear();
+}
+
 bool SkeletonDataMgr::hasSkeletonData(const std::string &uuid) {
     auto it = _dataMap.find(uuid);
     return it != _dataMap.end();

--- a/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
@@ -68,7 +68,7 @@ SkeletonDataMgr *SkeletonDataMgr::instance = nullptr;
 
 SkeletonDataMgr::~SkeletonDataMgr() {
     _destroyCallback = nullptr;
-    for (auto& e : _dataMap) {
+    for (auto &e : _dataMap) {
         delete e.second;
     }
     _dataMap.clear();

--- a/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
@@ -44,7 +44,7 @@ class SkeletonDataInfo;
 /**
  * Cache skeleton data.
  */
-class SkeletonDataMgr {
+class SkeletonDataMgr final {
 public:
     static SkeletonDataMgr *getInstance() {
         if (instance == nullptr) {
@@ -61,10 +61,8 @@ public:
     }
 
     SkeletonDataMgr() = default;
+    ~SkeletonDataMgr();
 
-    virtual ~SkeletonDataMgr() {
-        _destroyCallback = nullptr;
-    }
     bool hasSkeletonData(const std::string &uuid);
     void setSkeletonData(const std::string &uuid, SkeletonData *data, Atlas *atlas, AttachmentLoader *attachmentLoader, const std::vector<int> &texturesIndex);
     // equal to 'findByUUID'


### PR DESCRIPTION


-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
