### PR TITLE
[Optimize] Optimizing 'GCObject' call performance

### DIFF
--- a/cocos/core/data/garbage-collection.ts
+++ b/cocos/core/data/garbage-collection.ts
@@ -41,12 +41,11 @@ class GarbageCollectionManager {
                     if (property === targetSymbol) {
                         return target;
                     }
-                    let val = target[property];
+                    let val = Reflect.get(target, property);
                     if (typeof val === 'function' && property !== 'constructor') {
                         const original = val;
                         val = function newFunc () {
-                            // @ts-expect-error this is referenced to proxy
-                            return original.apply(this[targetSymbol], arguments) as unknown;
+                            return Reflect.apply(original, target, arguments) as unknown;
                         };
                     }
                     return val as unknown;

--- a/cocos/core/data/garbage-collection.ts
+++ b/cocos/core/data/garbage-collection.ts
@@ -45,7 +45,7 @@ class GarbageCollectionManager {
                     if (typeof val === 'function' && property !== 'constructor') {
                         const original = val;
                         val = function newFunc () {
-                             // @ts-expect-error this is referenced to proxy
+                            // @ts-expect-error this is referenced to proxy
                              return original.apply(this[targetSymbol], arguments) as unknown;
                         };
                     }

--- a/cocos/core/data/garbage-collection.ts
+++ b/cocos/core/data/garbage-collection.ts
@@ -45,7 +45,8 @@ class GarbageCollectionManager {
                     if (typeof val === 'function' && property !== 'constructor') {
                         const original = val;
                         val = function newFunc () {
-                            return Reflect.apply(original, target, arguments) as unknown;
+                             // @ts-expect-error this is referenced to proxy
+                             return original.apply(this[targetSymbol], arguments) as unknown;
                         };
                     }
                     return val as unknown;

--- a/cocos/core/data/garbage-collection.ts
+++ b/cocos/core/data/garbage-collection.ts
@@ -46,7 +46,7 @@ class GarbageCollectionManager {
                         const original = val;
                         val = function newFunc () {
                             // @ts-expect-error this is referenced to proxy
-                             return original.apply(this[targetSymbol], arguments) as unknown;
+                            return original.apply(this[targetSymbol], arguments) as unknown;
                         };
                     }
                     return val as unknown;


### PR DESCRIPTION
Re: #

### Changelog

* Optimizing 'GCObject' call performance
before
<img width="782" alt="企业微信截图_07d1b566-87a9-4432-9266-76170dd5268d" src="https://user-images.githubusercontent.com/7113508/180996654-39103be7-8eab-4a99-bd1c-64bb3b666d0d.png">
after
<img width="878" alt="企业微信截图_2c44dbd0-7f14-4d71-aaae-9b0e61086a7f" src="https://user-images.githubusercontent.com/7113508/180996738-cb213dff-4764-45c9-b4ca-6371920aec05.png">


-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
