### PR TITLE
Fix Object::clearPrivateData doesn't set _privateData to nullptr

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -617,6 +617,7 @@ void Object::clearPrivateData(bool clearMapping) {
         internal::clearPrivate(__isolate, _obj);
         delete _privateObject;
         _privateObject = nullptr;
+        _privateData = nullptr;
     }
 }
 


### PR DESCRIPTION
This issue is triggered after merging https://github.com/cocos/cocos-engine/pull/12039
Currently, this bug is not triggered since only one place invoking clearPrivateData and setPrivateData immediately.
```c++
template <typename T>
inline bool nativevalue_to_se(const ccstd::vector<T> &from, se::Value &to, se::Object *ctx) { // NOLINT(readability-identifier-naming)
    se::HandleObject array(se::Object::createArrayObject(from.size()));
    se::Value tmp;
    for (size_t i = 0; i < from.size(); i++) {
        // If from[i] is on stack, then should create a new object, or
        // JS will hold a freed object.
        if CC_CONSTEXPR (!std::is_pointer<T>::value && is_jsb_object_v<T>) {
            auto *pFrom = ccnew T(from[i]);
            nativevalue_to_se(pFrom, tmp, ctx);
            tmp.toObject()->clearPrivateData(); // _privateData is dangerous 
            tmp.toObject()->setPrivateData(pFrom); // Override _privateData with new value
        } else {
            nativevalue_to_se(from[i], tmp, ctx);
        }

        array->setArrayElement(static_cast<uint32_t>(i), tmp);
    }
    to.setObject(array, true);
    return true;
}
```

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
