### PR TITLE
Fix the crash after the behavior of Data_to_seval changed from returning TypedArray to returning ArrayBuffer.

### DIFF
--- a/native/cocos/bindings/manual/jsb_assets_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_assets_manual.cpp
@@ -47,8 +47,11 @@ static bool js_assets_ImageAsset_setData(se::State &s) // NOLINT(readability-ide
         if (args[0].isObject()) {
             if (args[0].toObject()->isTypedArray()) {
                 args[0].toObject()->getTypedArrayData(&data, nullptr);
+            } else if (args[0].toObject()->isArrayBuffer()) {
+                args[0].toObject()->getArrayBufferData(&data, nullptr);
             } else {
                 auto *dataHolder = static_cast<cc::JSBNativeDataHolder *>(args[0].toObject()->getPrivateData());
+                CC_ASSERT(dataHolder != nullptr);
                 data = dataHolder->getData();
             }
         } else {

--- a/native/cocos/bindings/manual/jsb_gfx_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_gfx_manual.cpp
@@ -152,7 +152,7 @@ bool js_gfx_Device_copyTexImagesToTexture(se::State &s) { // NOLINT(readability-
         cc::gfx::BufferDataList arg0;
         cc::gfx::Texture *arg1 = nullptr;
         cc::gfx::BufferTextureCopyList arg2;
-        CC_UNUSED size_t dataLength = 0;
+
         if (args[0].isObject()) {
             se::Object *dataObj = args[0].toObject();
             SE_PRECONDITION2(dataObj->isArray(), false, "Buffers must be an array!");
@@ -164,15 +164,18 @@ bool js_gfx_Device_copyTexImagesToTexture(se::State &s) { // NOLINT(readability-
             for (uint32_t i = 0; i < length; ++i) {
                 if (dataObj->getArrayElement(i, &value)) {
                     if (value.isObject()) {
+                        CC_UNUSED size_t dataLength = 0;
+                        uint8_t *buffer{nullptr};
                         if (value.toObject()->isTypedArray()) {
-                            uint8_t *address = nullptr;
-                            value.toObject()->getTypedArrayData(&address, &dataLength);
-                            arg0[i] = address;
+                            value.toObject()->getTypedArrayData(&buffer, &dataLength);
+                        } else if (value.toObject()->isArrayBuffer()) {
+                            value.toObject()->getArrayBufferData(&buffer, &dataLength);
                         } else {
                             auto *dataHolder = static_cast<cc::JSBNativeDataHolder *>(value.toObject()->getPrivateData());
-                            uint8_t *data = dataHolder->getData();
-                            arg0[i] = data;
+                            CC_ASSERT(dataHolder != nullptr);
+                            buffer = dataHolder->getData();
                         }
+                        arg0[i] = buffer;
                     } else {
                         CC_ASSERT(false);
                     }


### PR DESCRIPTION
This bug was taken in by the PR ( https://github.com/cocos/cocos-engine/pull/12155 )
<img width="1062" alt="Screen Shot 2022-07-28 at 23 07 27" src="https://user-images.githubusercontent.com/493372/181572642-c42f1d52-376b-40f8-83f9-3d1608bfca58.png">

```c++
bool nativevalue_to_se(const cc::Data &from, se::Value &to, se::Object * /*unused*/) {
// Change to  arraybuffer now. Break the compatibility of Data_to_seval.
    se::HandleObject buffer{se::Object::createArrayBufferObject(from.getBytes(), from.getSize())};
    to.setObject(buffer);
    return true;
}
```

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
