### PR TITLE
fix: animation mode hide add-commonent-btn

### DIFF
--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -684,11 +684,12 @@ const Elements = {
             const panel = this;
 
             if (!panel.dump || !panel.dump.isScene) {
-                if (panel.handlerSceneChangeMode()) {
+                if (!panel.isAnimationMode()) {
                     panel.toggleShowAddComponentBtn(true);
                 }
                 return;
             }
+            // 场景模式要隐藏按钮
             panel.toggleShowAddComponentBtn(false);
 
             panel.$this.setAttribute('sub-type', 'scene');
@@ -1698,10 +1699,11 @@ exports.methods = {
     toggleShowAddComponentBtn(show) {
         this.$.componentAdd.style.display = show ? 'inline-block' : 'none';
     },
+    isAnimationMode() {
+        return Editor.EditMode.getMode() === 'animation';
+    },
     handlerSceneChangeMode() {
-        const show = Editor.EditMode.getMode() !== 'animation';
-        this.toggleShowAddComponentBtn(show); // 动画编辑模式下，要隐藏按钮
-        return show;
+        this.toggleShowAddComponentBtn(!this.isAnimationMode()); // 动画编辑模式下，要隐藏按钮
     },
 };
 

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -684,7 +684,9 @@ const Elements = {
             const panel = this;
 
             if (!panel.dump || !panel.dump.isScene) {
-                panel.toggleShowAddComponentBtn(true);
+                if (Editor.EditMode.getMode() !== 'animation') {
+                    panel.toggleShowAddComponentBtn(true);
+                }
                 return;
             }
             panel.toggleShowAddComponentBtn(false);

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -684,7 +684,7 @@ const Elements = {
             const panel = this;
 
             if (!panel.dump || !panel.dump.isScene) {
-                if (Editor.EditMode.getMode() !== 'animation') {
+                if (panel.handlerSceneChangeMode()) {
                     panel.toggleShowAddComponentBtn(true);
                 }
                 return;
@@ -1699,8 +1699,9 @@ exports.methods = {
         this.$.componentAdd.style.display = show ? 'inline-block' : 'none';
     },
     handlerSceneChangeMode() {
-        const mode = Editor.EditMode.getMode();
-        this.toggleShowAddComponentBtn(mode !== 'animation'); // 动画编辑模式下，要隐藏按钮
+        const show = Editor.EditMode.getMode() !== 'animation';
+        this.toggleShowAddComponentBtn(show); // 动画编辑模式下，要隐藏按钮
+        return show;
     },
 };
 


### PR DESCRIPTION
Resolves: cocos/3d-tasks#12277

### Changelog

* on animation mode need hide add-commonent-btn

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
