### PR TITLE
fallback to vk 1.2 if a new driver is used

### DIFF
--- a/native/cocos/renderer/gfx-base/SPIRVUtils.cpp
+++ b/native/cocos/renderer/gfx-base/SPIRVUtils.cpp
@@ -59,6 +59,9 @@ glslang::EShTargetClientVersion getClientVersion(int vulkanMinorVersion) {
         case 1: return glslang::EShTargetVulkan_1_1;
         case 2: return glslang::EShTargetVulkan_1_2;
 #if GLSLANG_VERSION_LESS_OR_EQUAL_TO(11, 10, 0)
+            // This macro is defined in glslang/build_info.h. This expression means that the
+            // lib version is greater than or equal to 11.10.0 (not less than or equal to),
+            // which is very counterintuitive. But it's the only way to do it.
         case 3: return glslang::EShTargetVulkan_1_3;
 #else
         case 3: return glslang::EShTargetVulkan_1_2;
@@ -76,6 +79,9 @@ glslang::EShTargetLanguageVersion getTargetVersion(int vulkanMinorVersion) {
         case 1: return glslang::EShTargetSpv_1_3;
         case 2: return glslang::EShTargetSpv_1_5;
 #if GLSLANG_VERSION_LESS_OR_EQUAL_TO(11, 10, 0)
+            // This macro is defined in glslang/build_info.h. This expression means that the
+            // lib version is greater than or equal to 11.10.0 (not less than or equal to),
+            // which is very counterintuitive. But it's the only way to do it.
         case 3: return glslang::EShTargetSpv_1_6;
 #else
         case 3: return glslang::EShTargetSpv_1_5;

--- a/native/cocos/renderer/gfx-base/SPIRVUtils.cpp
+++ b/native/cocos/renderer/gfx-base/SPIRVUtils.cpp
@@ -60,6 +60,8 @@ glslang::EShTargetClientVersion getClientVersion(int vulkanMinorVersion) {
         case 2: return glslang::EShTargetVulkan_1_2;
 #if GLSLANG_VERSION_LESS_OR_EQUAL_TO(11, 10, 0)
         case 3: return glslang::EShTargetVulkan_1_3;
+#else
+        case 3: return glslang::EShTargetVulkan_1_2;
 #endif
         default: {
             CC_ASSERT(false);
@@ -75,6 +77,8 @@ glslang::EShTargetLanguageVersion getTargetVersion(int vulkanMinorVersion) {
         case 2: return glslang::EShTargetSpv_1_5;
 #if GLSLANG_VERSION_LESS_OR_EQUAL_TO(11, 10, 0)
         case 3: return glslang::EShTargetSpv_1_6;
+#else
+        case 3: return glslang::EShTargetSpv_1_5;
 #endif
         default: {
             CC_ASSERT(false);


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/11635, https://github.com/cocos/3d-tasks/issues/13133

### Changelog

* fallback to vk 1.2 if a new driver is used

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
