### PR TITLE
fix: browser video-player doesnot emit click event

### DIFF
--- a/cocos/video/video-player.ts
+++ b/cocos/video/video-player.ts
@@ -390,6 +390,7 @@ export class VideoPlayer extends Component {
         this._impl.componentEventList.set(EventType.STOPPED, this.onStopped.bind(this));
         this._impl.componentEventList.set(EventType.COMPLETED, this.onCompleted.bind(this));
         this._impl.componentEventList.set(EventType.ERROR, this.onError.bind(this));
+        this._impl.componentEventList.set(EventType.CLICKED, this.onClicked.bind(this));
         if (this._playOnAwake && this._impl.loaded) {
             this.play();
         }
@@ -454,6 +455,11 @@ export class VideoPlayer extends Component {
     public onError () {
         ComponentEventHandler.emitEvents(this.videoPlayerEvent, this, EventType.ERROR);
         this.node.emit(EventType.ERROR, this);
+    }
+    
+    public onClicked() {
+        ComponentEventHandler.emitEvents(this.videoPlayerEvent, this, EventType.CLICKED);
+        this.node.emit(EventType.CLICKED, this);
     }
 
     /**


### PR DESCRIPTION
使用creator3.2版本引擎的videoplayer组件，在web上调试中发现不会触发组件的onclick事件，故修改了video-player.ts脚本，修改后测试正常。
切换到3.5.2版本引擎依然存在此问题，请官方合并此fix。