### PR TITLE
Fix timeout timer is not cleared while xhr.abort is invoked

### DIFF
--- a/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
+++ b/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <functional>
 #include <sstream>
+#include "application/ApplicationManager.h"
 #include "base/Config.h"
 #include "base/std/container/string.h"
 #include "base/std/container/unordered_map.h"
@@ -41,9 +42,8 @@
 #include "cocos/base/DeferredReleasePool.h"
 #include "cocos/bindings/jswrapper/SeApi.h"
 #include "cocos/bindings/manual/jsb_conversions.h"
-#include "cocos/network/HttpClient.h"
 #include "cocos/engine/BaseEngine.h"
-#include "application/ApplicationManager.h"
+#include "cocos/network/HttpClient.h"
 
 using namespace cc;          //NOLINT
 using namespace cc::network; //NOLINT
@@ -243,7 +243,7 @@ XMLHttpRequest::XMLHttpRequest()
 XMLHttpRequest::~XMLHttpRequest() {
     if (_scheduler) {
         _scheduler->unscheduleAllForTarget(this);
-    }    
+    }
     // Avoid HttpClient response call a released object!
     _httpRequest->setResponseCallback(nullptr);
     CC_SAFE_RELEASE(_httpRequest);
@@ -506,7 +506,7 @@ void XMLHttpRequest::sendRequest() {
             _isTimeout = true;
             _readyState = ReadyState::UNSENT;
         },
-                                                      this, static_cast<float>(_timeoutInMilliseconds) / 1000.0F, 0, 0.0F, false, "XMLHttpRequest");
+                             this, static_cast<float>(_timeoutInMilliseconds) / 1000.0F, 0, 0.0F, false, "XMLHttpRequest");
     }
     setHttpRequestHeader();
 

--- a/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
+++ b/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
@@ -408,7 +408,6 @@ void XMLHttpRequest::onResponse(HttpClient * /*client*/, HttpResponse *response)
     }
 
     if (_isAborted || _readyState == ReadyState::UNSENT) {
-        CC_LOG_DEBUG("request (%p) is abort", this);
         return;
     }
 

--- a/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
+++ b/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
@@ -318,6 +318,9 @@ void XMLHttpRequest::abort() {
 
     setReadyState(ReadyState::DONE);
 
+    // Unregister timeout timer while abort is invoked.
+    _scheduler->unscheduleAllForTarget(this);
+
     if (onabort != nullptr) {
         onabort();
     }
@@ -405,6 +408,7 @@ void XMLHttpRequest::onResponse(HttpClient * /*client*/, HttpResponse *response)
     }
 
     if (_isAborted || _readyState == ReadyState::UNSENT) {
+        CC_LOG_DEBUG("request (%p) is abort", this);
         return;
     }
 


### PR DESCRIPTION
Otherwise, without this fix, after invoking xhr.abort, ontimeout will still be triggered.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
