### PR TITLE
static drawinfo should be reset when flushing assembler

### DIFF
--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -366,6 +366,7 @@ export class UIRenderer extends Renderer {
         if (!this.renderData) {
             return;
         }
+        this.renderData.removeRenderDrawInfo(this);
         RenderData.remove(this.renderData);
         this._renderData = null;
     }

--- a/cocos/2d/renderer/native-2d.ts
+++ b/cocos/2d/renderer/native-2d.ts
@@ -46,6 +46,7 @@ export declare class NativeRenderEntity {
     setDynamicRenderDrawInfo(drawInfo: NativeRenderDrawInfo, index: number);
     removeDynamicRenderDrawInfo();
     clearDynamicRenderDrawInfos();
+    clearStaticRenderDrawInfos();
 
     get node(): Node | null;
     set node(node: Node | null);

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -189,6 +189,8 @@ export class BaseRenderData {
             const renderEntity: RenderEntity = comp.renderEntity;
             if (renderEntity.renderEntityType === RenderEntityType.DYNAMIC) {
                 renderEntity.removeDynamicRenderDrawInfo();
+            } else if (renderEntity.renderEntityType === RenderEntityType.STATIC) {
+                renderEntity.clearStaticRenderDrawInfos();
             }
         }
     }

--- a/cocos/2d/renderer/render-entity.ts
+++ b/cocos/2d/renderer/render-entity.ts
@@ -152,6 +152,12 @@ export class RenderEntity {
         }
     }
 
+    public clearStaticRenderDrawInfos () {
+        if (JSB) {
+            this._nativeObj.clearStaticRenderDrawInfos();
+        }
+    }
+
     public setDynamicRenderDrawInfo (renderDrawInfo: RenderDrawInfo | null, index: number) {
         if (JSB) {
             if (renderDrawInfo) {

--- a/native/cocos/2d/renderer/RenderDrawInfo.h
+++ b/native/cocos/2d/renderer/RenderDrawInfo.h
@@ -45,7 +45,7 @@ struct Render2dLayout {
     Vec4 color;
 };
 
-enum class RenderDrawInfoType: uint8_t {
+enum class RenderDrawInfoType : uint8_t {
     COMP,
     MODEL,
     IA,
@@ -187,8 +187,8 @@ public:
     }
 
     inline Node* getSubNode() const {
-        CC_ASSERT(_drawInfoAttrs._drawInfoType == RenderDrawInfoType::SUB_NODE); 
-        return _subNode; 
+        CC_ASSERT(_drawInfoAttrs._drawInfoType == RenderDrawInfoType::SUB_NODE);
+        return _subNode;
     }
     inline void setSubNode(Node* node) {
         CC_ASSERT(_drawInfoAttrs._drawInfoType == RenderDrawInfoType::SUB_NODE);
@@ -217,6 +217,33 @@ public:
 
     inline gfx::DescriptorSet* getLocalDes() { return _localDSBF->ds; }
     void updateLocalDescriptorSet(Node* transform, gfx::DescriptorSetLayout* dsLayout);
+
+    inline void resetDrawInfo() {
+        _drawInfoAttrs._bufferId = 0;
+        _drawInfoAttrs._accId = 0;
+        _drawInfoAttrs._vertexOffset = 0;
+        _drawInfoAttrs._indexOffset = 0;
+        _drawInfoAttrs._vbCount = 0;
+        _drawInfoAttrs._ibCount = 0;
+        _drawInfoAttrs._stride = 0;
+        _drawInfoAttrs._dataHash = 0;
+        _drawInfoAttrs._vertDirty = false;
+        _drawInfoAttrs._isMeshBuffer = false;
+
+        _vbBuffer = nullptr;
+        _ibBuffer = nullptr;
+        _vDataBuffer = nullptr;
+        _iDataBuffer = nullptr;
+        _material = nullptr;
+        _texture = nullptr;
+        _sampler = nullptr;
+        _subNode = nullptr;
+        _model = nullptr;
+        _sharedBuffer = nullptr;
+        _iadrawInfo = nullptr;
+        _iaPool = nullptr;
+        _localDSBF = nullptr;
+    }
 
 private:
     CC_DISALLOW_COPY_MOVE_ASSIGN(RenderDrawInfo);
@@ -263,7 +290,7 @@ private:
         scene::Model* _model;
         uint8_t* _sharedBuffer;
     };
-    gfx::InputAssemblerInfo* _iaInfo{nullptr};
+    gfx::InputAssemblerInfo* _iadrawInfo{nullptr};
     ccstd::vector<gfx::InputAssembler*>* _iaPool{nullptr};
     LocalDSBF* _localDSBF{nullptr};
 };

--- a/native/cocos/2d/renderer/RenderDrawInfo.h
+++ b/native/cocos/2d/renderer/RenderDrawInfo.h
@@ -240,7 +240,7 @@ public:
         _subNode = nullptr;
         _model = nullptr;
         _sharedBuffer = nullptr;
-        _iadrawInfo = nullptr;
+        _iaInfo = nullptr;
         _iaPool = nullptr;
         _localDSBF = nullptr;
     }

--- a/native/cocos/2d/renderer/RenderDrawInfo.h
+++ b/native/cocos/2d/renderer/RenderDrawInfo.h
@@ -290,7 +290,7 @@ private:
         scene::Model* _model;
         uint8_t* _sharedBuffer;
     };
-    gfx::InputAssemblerInfo* _iadrawInfo{nullptr};
+    gfx::InputAssemblerInfo* _iaInfo{nullptr};
     ccstd::vector<gfx::InputAssembler*>* _iaPool{nullptr};
     LocalDSBF* _localDSBF{nullptr};
 };

--- a/native/cocos/2d/renderer/RenderEntity.cpp
+++ b/native/cocos/2d/renderer/RenderEntity.cpp
@@ -66,6 +66,11 @@ void RenderEntity::clearDynamicRenderDrawInfos() {
     _dynamicDrawInfos.clear();
 }
 
+void RenderEntity::clearStaticRenderDrawInfos() {
+    CC_ASSERT(_renderEntityType == RenderEntityType::STATIC);
+    _staticDrawInfoSize = 0;
+}
+
 void RenderEntity::setNode(Node* node) {
     if (_node) {
         _node->setUserData(nullptr);

--- a/native/cocos/2d/renderer/RenderEntity.cpp
+++ b/native/cocos/2d/renderer/RenderEntity.cpp
@@ -68,6 +68,11 @@ void RenderEntity::clearDynamicRenderDrawInfos() {
 
 void RenderEntity::clearStaticRenderDrawInfos() {
     CC_ASSERT(_renderEntityType == RenderEntityType::STATIC);
+  
+    for (uint32_t i = 0; i < _staticDrawInfoSize; i++) {
+        RenderDrawInfo& drawInfo = _staticDrawInfos[i];
+        drawInfo.resetDrawInfo();
+    }
     _staticDrawInfoSize = 0;
 }
 

--- a/native/cocos/2d/renderer/RenderEntity.h
+++ b/native/cocos/2d/renderer/RenderEntity.h
@@ -73,6 +73,7 @@ public:
     void setDynamicRenderDrawInfo(RenderDrawInfo* drawInfo, uint32_t index);
     void removeDynamicRenderDrawInfo();
     void clearDynamicRenderDrawInfos();
+    void clearStaticRenderDrawInfos();
 
     inline bool getIsMask() const {
         return static_cast<MaskMode>(_entityAttrLayout.maskMode) == MaskMode::MASK || static_cast<MaskMode>(_entityAttrLayout.maskMode) == MaskMode::MASK_INVERTED;

--- a/native/tools/tojs/2d.ini
+++ b/native/tools/tojs/2d.ini
@@ -46,7 +46,7 @@ classes = RenderDrawInfo UIMeshBuffer Batcher2d RenderEntity UIModelProxy
 # add a single "*" as functions. See bellow for several examples. A special class name is "*", which
 # will apply to all class names. This is a convenience wildcard to be able to skip similar named
 # functions from all classes.
-skip =  RenderDrawInfo::[getBatcher setBatcher parseAttrLayout getRender2dLayout getEnumDrawInfoType],
+skip =  RenderDrawInfo::[getBatcher setBatcher parseAttrLayout getRender2dLayout getEnumDrawInfoType resetDrawInfo],
         Batcher2d::[addVertDirtyRenderer getMeshBuffer getDevice updateDescriptorSet fillBuffersAndMergeBatches walk generateBatch resetRenderStates handleDrawInfo handleComponentDraw handleModelDraw handleIADraw handleSubNode],
         UIMeshBuffer::[requireFreeIA createNewIA recycleIA resetIA parseLayout getByteOffset setByteOffset getVertexOffset setVertexOffset getIndexOffset setIndexOffset getDirty setDirty getFloatsPerVertex setFloatsPerVertex getAttributes],
         RenderEntity::[getDynamicRenderDrawInfo getDynamicRenderDrawInfos getRenderEntityType getColorDirty getColor isEnabled getEnumStencilStage setEnumStencilStage getVBColorDirty setVBColorDirty]

--- a/native/tools/tojs/2d.ini
+++ b/native/tools/tojs/2d.ini
@@ -49,7 +49,7 @@ classes = RenderDrawInfo UIMeshBuffer Batcher2d RenderEntity UIModelProxy
 skip =  RenderDrawInfo::[getBatcher setBatcher parseAttrLayout getRender2dLayout getEnumDrawInfoType resetDrawInfo],
         Batcher2d::[addVertDirtyRenderer getMeshBuffer getDevice updateDescriptorSet fillBuffersAndMergeBatches walk generateBatch resetRenderStates handleDrawInfo handleComponentDraw handleModelDraw handleIADraw handleSubNode],
         UIMeshBuffer::[requireFreeIA createNewIA recycleIA resetIA parseLayout getByteOffset setByteOffset getVertexOffset setVertexOffset getIndexOffset setIndexOffset getDirty setDirty getFloatsPerVertex setFloatsPerVertex getAttributes],
-        RenderEntity::[getDynamicRenderDrawInfo getDynamicRenderDrawInfos getRenderEntityType getColorDirty getColor isEnabled getEnumStencilStage setEnumStencilStage getVBColorDirty setVBColorDirty]
+        RenderEntity::[getDynamicRenderDrawInfo getDynamicRenderDrawInfos getRenderEntityType getColorDirty getColor isEnabled getEnumStencilStage setEnumStencilStage getVBColorDirty setVBColorDirty clearStaticRenderDrawInfos]
 
 rename_functions = 
 


### PR DESCRIPTION
Re: #

### Changelog

* static draw info size is always growing when draw info is allocated, it is incorrect
* the size should be reset when assembler changes

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
