### PR TITLE
fix memory leak and move it into private area

### DIFF
--- a/native/cocos/2d/renderer/RenderDrawInfo.h
+++ b/native/cocos/2d/renderer/RenderDrawInfo.h
@@ -218,7 +218,10 @@ public:
     inline gfx::DescriptorSet* getLocalDes() { return _localDSBF->ds; }
     void updateLocalDescriptorSet(Node* transform, gfx::DescriptorSetLayout* dsLayout);
 
+private:
     inline void resetDrawInfo() {
+        destroy();
+
         _drawInfoAttrs._bufferId = 0;
         _drawInfoAttrs._accId = 0;
         _drawInfoAttrs._vertexOffset = 0;
@@ -240,12 +243,8 @@ public:
         _subNode = nullptr;
         _model = nullptr;
         _sharedBuffer = nullptr;
-        _iaInfo = nullptr;
-        _iaPool = nullptr;
-        _localDSBF = nullptr;
     }
 
-private:
     CC_DISALLOW_COPY_MOVE_ASSIGN(RenderDrawInfo);
     void destroy();
 

--- a/native/cocos/2d/renderer/RenderDrawInfo.h
+++ b/native/cocos/2d/renderer/RenderDrawInfo.h
@@ -218,7 +218,6 @@ public:
     inline gfx::DescriptorSet* getLocalDes() { return _localDSBF->ds; }
     void updateLocalDescriptorSet(Node* transform, gfx::DescriptorSetLayout* dsLayout);
 
-private:
     inline void resetDrawInfo() {
         destroy();
 
@@ -245,6 +244,7 @@ private:
         _sharedBuffer = nullptr;
     }
 
+private:
     CC_DISALLOW_COPY_MOVE_ASSIGN(RenderDrawInfo);
     void destroy();
 


### PR DESCRIPTION
Re: #

### Changelog

* fix memory leak when reseting draw info
-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
