### PR TITLE
[fix] debug view display error with mac, lightmap use correct exposure

### DIFF
--- a/editor/assets/chunks/legacy/shading-standard-base.chunk
+++ b/editor/assets/chunks/legacy/shading-standard-base.chunk
@@ -114,7 +114,13 @@ vec4 CCStandardShadingBase (StandardSurface s, vec4 shadowPos) {
   #endif
 
   #if CC_USE_LIGHTMAP && !USE_BATCHING && !CC_FORWARD_ADD
-    vec3 finalColor = diffuse * s.lightmap.rgb * shadow;
+    vec3 lightmap = s.lightmap.rgb;
+    #if CC_USE_HDR
+        // convert from standard camera exposure parameters to current exposure value
+        // baked in LDR scene still regarded as exposured with standard camera parameters
+        lightmap.rgb *= cc_exposure.w * cc_exposure.x;
+    #endif
+    vec3 finalColor = diffuse * lightmap.rgb * shadow;
   #else
     float NV = max(abs(dot(N, V)), 0.0);
     specular = BRDFApprox(specular, s.roughness, NV);

--- a/editor/assets/chunks/surfaces/module-functions/debug-view.chunk
+++ b/editor/assets/chunks/surfaces/module-functions/debug-view.chunk
@@ -17,7 +17,7 @@ vec4 CCSurfacesDebugDisplayInvalidInputData(vec4 color, vec3 data)
 
 
 #if CC_USE_DEBUG_VIEW == CC_SURFACES_DEBUG_VIEW_SINGLE && !CC_FORWARD_ADD
-  void CCSurfacesDebugViewMeshData(out vec4 color)
+  void CCSurfacesDebugViewMeshData(inout vec4 color)
   {
     vec4 white = vec4(1.0, 1.0, 1.0, 1.0);
     vec4 black = vec4(0.0, 0.0, 0.0, 1.0);
@@ -98,7 +98,7 @@ vec4 CCSurfacesDebugDisplayInvalidInputData(vec4 color, vec3 data)
 
   // Lighting related
 #if CC_USE_DEBUG_VIEW == CC_SURFACES_DEBUG_VIEW_SINGLE
-  bool CCSurfacesDebugViewLightingResult(out vec4 color, in LightingResult lightingResult)
+  bool CCSurfacesDebugViewLightingResult(inout vec4 color, in LightingResult lightingResult)
   {
       bool isDebugMatched = false;
     if (IS_DEBUG_VIEW_SINGLE_MODE(CC_SURFACES_DEBUG_VIEW_DIRECT_DIFFUSE))

--- a/editor/assets/chunks/surfaces/module-functions/standard-fs.chunk
+++ b/editor/assets/chunks/surfaces/module-functions/standard-fs.chunk
@@ -133,7 +133,7 @@ vec4 CCSurfacesShading(in SurfacesMaterialData surfaceData, in LightingResult li
 
 // Debug view
 #if CC_USE_DEBUG_VIEW == CC_SURFACES_DEBUG_VIEW_SINGLE
-void CCSurfacesDebugViewSurfaceData(out vec4 color, in SurfacesMaterialData surfaceData)
+void CCSurfacesDebugViewSurfaceData(inout vec4 color, in SurfacesMaterialData surfaceData)
 {
     vec4 black = vec4(0.0, 0.0, 0.0, 1.0);
     float scalar;

--- a/editor/assets/chunks/surfaces/module-functions/toon-fs.chunk
+++ b/editor/assets/chunks/surfaces/module-functions/toon-fs.chunk
@@ -128,7 +128,7 @@ vec4 CCSurfacesShading(in SurfacesMaterialData surfaceData, in LightingResult li
 
 // Debug view
 #if CC_USE_DEBUG_VIEW == CC_SURFACES_DEBUG_VIEW_SINGLE
-void CCSurfacesDebugViewSurfaceData(out vec4 color, in SurfacesMaterialData surfaceData)
+void CCSurfacesDebugViewSurfaceData(inout vec4 color, in SurfacesMaterialData surfaceData)
 {
     float scalar;
     if (IS_DEBUG_VIEW_SINGLE_MODE(CC_SURFACES_DEBUG_VIEW_FRAGMENT_NORMAL))


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
