### PR TITLE
support specified anisotropy direction for silk material

### DIFF
--- a/editor/assets/chunks/surfaces/default-functions/standard-fs.chunk
+++ b/editor/assets/chunks/surfaces/default-functions/standard-fs.chunk
@@ -38,10 +38,13 @@ void SurfacesFragmentModifyWorldTangentAndBinormal(inout vec3 worldTangent, inou
 #endif
 
 #ifndef CC_SURFACES_FRAGMENT_MODIFY_ANISOTROPY_PARAMS
-// rotation, shape, xx, xx
-vec4 SurfacesFragmentModifyAnisotropyParams()
+// isRotation=1.0: shape(0~1), rotation(0~2PI), 0.0, 0.0
+// or
+// isRotation=0.0: shape(0~1), anisoDir.xyz(-1~1)
+vec4 SurfacesFragmentModifyAnisotropyParams(out float isRotation)
 {
-    return vec4(0.0, 1.0, 0.0, 0.0);
+    isRotation = 1.0;
+    return vec4(1.0, 0.0, 0.0, 0.0);
 }
 #endif
 

--- a/editor/assets/chunks/surfaces/module-functions/standard-fs.chunk
+++ b/editor/assets/chunks/surfaces/module-functions/standard-fs.chunk
@@ -10,9 +10,17 @@ void CCSurfacesFragmentGetMaterialData(inout SurfacesMaterialData surfaceData)
   surfaceData.worldNormal = SurfacesFragmentModifyWorldNormal();
   SurfacesFragmentModifyWorldTangentAndBinormal(surfaceData.worldTangent, surfaceData.worldBinormal, surfaceData.worldNormal);
 #if CC_SURFACES_LIGHTING_ANISOTROPIC
-  vec4 anisotropyParams = SurfacesFragmentModifyAnisotropyParams();
-  surfaceData.anisotropyShape = anisotropyParams.y;
-  RotateTangentAndBinormal(surfaceData.worldTangent, surfaceData.worldBinormal, surfaceData.worldNormal, anisotropyParams.x);
+  float isRotation;
+  vec4 anisotropyParams = SurfacesFragmentModifyAnisotropyParams(isRotation);
+  surfaceData.anisotropyShape = anisotropyParams.x;
+  if (isRotation > 0.0) {
+    RotateTangentAndBinormal(surfaceData.worldTangent, surfaceData.worldBinormal, surfaceData.worldNormal, anisotropyParams.y);
+  } else {
+    vec3 anisoDirTS = anisotropyParams.yzw;
+    vec3 tangentWS = anisoDirTS.x * surfaceData.worldTangent + anisoDirTS.y * surfaceData.worldBinormal + anisoDirTS.z * surfaceData.worldNormal;
+    surfaceData.worldTangent = normalize(tangentWS);
+    surfaceData.worldBinormal = cross(surfaceData.worldNormal, tangentWS);
+  }
 #endif
 
   surfaceData.emissive = SurfacesFragmentModifyEmissive();

--- a/editor/assets/effects/surfaces/standard.effect
+++ b/editor/assets/effects/surfaces/standard.effect
@@ -231,7 +231,7 @@ CCProgram surface-fragment %{
   }
 
   #define CC_SURFACES_FRAGMENT_MODIFY_ANISOTROPY_PARAMS
-  vec4 SurfacesFragmentModifyAnisotropyParams()
+  vec4 SurfacesFragmentModifyAnisotropyParams(out float isRotation)
   {
     float anisotropyRotation = anisotropyParam.y * PI;
     float anisotropyShape = anisotropyParam.x;
@@ -242,7 +242,9 @@ CCProgram surface-fragment %{
       // less value is better for SP exported shape
       anisotropyShape *= tex.x;
     #endif
-      return vec4(anisotropyRotation, anisotropyShape, 0.0, 0.0);
+
+    isRotation = 1.0;
+    return vec4(anisotropyShape, anisotropyRotation, 0.0, 0.0);
   }
 
   #define CC_SURFACES_FRAGMENT_MODIFY_EMISSIVE


### PR DESCRIPTION
Re: #

### Changelog

* support specified anisotropy direction for silk material

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
