### PR TITLE
Fix  the  render component enabled status is wrong after label and pa…

### DIFF
--- a/cocos2d/core/components/CCLabel.js
+++ b/cocos2d/core/components/CCLabel.js
@@ -642,6 +642,18 @@ let Label = cc.Class({
         this._super();
     },
 
+    onRestore: CC_EDITOR && function () {
+        // Because undo/redo will not call onEnable/onDisable,
+        // we need call onEnable/onDisable manually to active/disactive children nodes.
+        if (this.enabledInHierarchy) {
+            this.node._renderComponent = null;
+            this.onEnable();
+        }
+        else {
+            this.onDisable();
+        }
+    },
+
     _nodeSizeChanged () {
         // Because the content size is automatically updated when overflow is NONE.
         // And this will conflict with the alignment of the CCWidget.

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -820,6 +820,18 @@ var ParticleSystem = cc.Class({
         }
     },
 
+    onRestore: CC_EDITOR && function () {
+        // Because undo/redo will not call onEnable/onDisable,
+        // we need call onEnable/onDisable manually to active/disactive children nodes.
+        if (this.enabledInHierarchy) {
+            this.node._renderComponent = null;
+            this.onEnable();
+        }
+        else {
+            this.onDisable();
+        }
+    },
+
     _startPreview: CC_EDITOR && function () {
         if (this.preview) {
             this.resetSystem();


### PR DESCRIPTION
…rticle restore

Fix  the  render component enabled status is wrong after label and particle restore

<img width="700" alt="image" src="https://user-images.githubusercontent.com/7564028/183866394-92f0a3be-3fc3-44ac-aa6d-422deb48fa20.png">

