### PR TITLE
Fallback to builtin 'native/external' folder

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -163,9 +163,24 @@ if(CI_FORCE_MINIMAL_FEATURES)
     set(USE_GEOMETRY_RENDERER OFF)
     set(USE_WEBP OFF)
 endif()
+
+################################# external source code ################################
+set(EXTERNAL_ROOT ${CMAKE_CURRENT_LIST_DIR}/external)
+set(USE_BUILTIN_EXTERNAL OFF)
+if(NOT EXISTS ${EXTERNAL_ROOT}/CMakeLists.txt)
+    if(DEFINED BUILTIN_COCOS_X_PATH)
+        set(EXTERNAL_ROOT ${BUILTIN_COCOS_X_PATH}/external)
+        set(USE_BUILTIN_EXTERNAL ON)
+        message(AUTHOR_WARNING "Directory 'external' not found in '${CMAKE_CURRENT_LIST_DIR}', use builtin directory '${BUILTIN_COCOS_X_PATH}' instead!")
+    else()
+        message(FATAL_ERROR "Please download external libraries! File ${CMAKE_CURRENT_LIST_DIR}/external/CMakeLists.txt not exist!")
+    endif()
+endif()
 ################################# list all option values ##############################
 
 cc_inspect_values(
+    BUILTIN_COCOS_X_PATH
+    USE_BUILTIN_EXTERNAL
     USE_MODULES
     CC_USE_METAL
     CC_USE_GLES3
@@ -196,12 +211,8 @@ cc_inspect_values(
     USE_REMOTE_LOG
 )
 
-################################# external source code ################################
-if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/external/CMakeLists.txt)
-    message(FATAL_ERROR "Please download external libraries! File ${CMAKE_CURRENT_LIST_DIR}/external/CMakeLists.txt not exists!")
-endif()
 
-include(${CMAKE_CURRENT_LIST_DIR}/external/CMakeLists.txt)
+include(${EXTERNAL_ROOT}/CMakeLists.txt)
 
 ##### audio
 if(USE_AUDIO)
@@ -2816,7 +2827,6 @@ else()
     )
 endif()
 
-source_group(TREE ${CWD} PREFIX "Source Files" FILES ${COCOS_SOURCE_LIST})
 
 if(QNX)
     include(${QNX_PATH}/source.cmake)
@@ -3116,4 +3126,14 @@ elseif(LINUX)
         ${CC_EXTERNAL_LIBS}
     )
 endif()
-source_group(TREE ${CWD} PREFIX "Source Files" FILES ${COCOS_SOURCE_LIST})
+
+if(USE_BUILTIN_EXTERNAL)
+    set(EXCLUDE_EXTERANL_LIST ${COCOS_SOURCE_LIST})
+    foreach(x IN LISTS CC_EXTERNAL_SOURCES)
+        list(REMOVE_ITEM EXCLUDE_EXTERANL_LIST ${x})
+    endforeach()
+    source_group(TREE ${CWD} PREFIX "Source Files" FILES ${EXCLUDE_EXTERANL_LIST})
+    source_group(TREE ${EXTERNAL_ROOT} PREFIX "Source Files/external" FILES ${CC_EXTERNAL_SOURCES})
+else()
+    source_group(TREE ${CWD} PREFIX "Source Files" FILES ${COCOS_SOURCE_LIST})
+endif()


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/12090

Depends: https://github.com/cocos/creator-runtime-extensions/pull/257

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
