### PR TITLE
The openharmony audio module is adapted and can be played at present

### DIFF
--- a/native/cocos/audio/openharmony/AudioEngine-inl.cpp
+++ b/native/cocos/audio/openharmony/AudioEngine-inl.cpp
@@ -56,7 +56,9 @@ using namespace cc; //NOLINT
 namespace {
 AudioEngineImpl *gAudioImpl         = nullptr;
 int              outputSampleRate   = 44100;
-int              bufferSizeInFrames = 192;
+// TODO(hack) : There is currently a bug in the opensles module, 
+// so openharmony must configure a fixed size, otherwise the callback will be suspended
+int              bufferSizeInFrames = 2048;
 
 void getAudioInfo() {
     // JNIEnv *  env         = JniHelper::getEnv();

--- a/native/cocos/audio/openharmony/AudioPlayerProvider.cpp
+++ b/native/cocos/audio/openharmony/AudioPlayerProvider.cpp
@@ -135,22 +135,20 @@ IAudioPlayer *AudioPlayerProvider::getAudioPlayer(const std::string &audioFilePa
                 if (!*isReturnFromCache && !*isPreloadFinished) {
                     std::unique_lock<std::mutex> lk(_preloadWaitMutex);
                     // Wait for 2 seconds for the decoding in sub thread finishes.
-                    LOGE("qgh cocos FileInfo1 (%{public}p), Waiting preload (%{public}s) to finish ...",  &info, audioFilePath.c_str());
                     _preloadWaitCond.wait_for(lk, std::chrono::seconds(2));
-                    LOGE("qgh cocos FileInfo2 (%{public}p), Waiting preload (%{public}s) to finish ...",  &info, audioFilePath.c_str());
                 }
 
                 if (*isSucceed) {
                     if (pcmData->isValid()) {
                         player = obtainPcmAudioPlayer(info.url, *pcmData);
                         if(!player) {
-                            LOGE("player is nullptr, path: %{public}s",  audioFilePath.c_str());    
+                            LOGE("player is nullptr, path: %{public}s",  audioFilePath.c_str());
                         }
                     } else {
-                        LOGE("pcm data is invalid, path: %{public}s",  audioFilePath.c_str());  
+                        LOGE("pcm data is invalid, path: %{public}s",  audioFilePath.c_str());
                     }
                 } else {
-                    LOGE("FileInfo (%{public}p), preloadEffect (%{public}s) failed",  &info, audioFilePath.c_str());  
+                    LOGE("FileInfo (%{public}p), preloadEffect (%{public}s) failed",  &info, audioFilePath.c_str());
                 }
             } else {
                 player = createUrlAudioPlayer(info);

--- a/native/cocos/audio/openharmony/PcmAudioService.cpp
+++ b/native/cocos/audio/openharmony/PcmAudioService.cpp
@@ -40,7 +40,7 @@ class SLPcmAudioPlayerCallbackProxy {
 public:
     static void samplePlayerCallback(SLOHBufferQueueItf bq, void *context, SLuint32 size) {
         PcmAudioService *thiz = reinterpret_cast<PcmAudioService *>(context);
-        thiz->bqFetchBufferCallback(bq, size);
+        thiz->bqFetchBufferCallback(bq);
     }
 };
 
@@ -76,7 +76,7 @@ bool PcmAudioService::enqueue() {
     return true;
 }
 
-void PcmAudioService::bqFetchBufferCallback(SLOHBufferQueueItf bq,SLuint32 size) {
+void PcmAudioService::bqFetchBufferCallback(SLOHBufferQueueItf bq) {
     // IDEA: PcmAudioService instance may be destroyed, we need to find a way to wait...
     // It's in sub thread
     enqueue();

--- a/native/cocos/audio/openharmony/PcmAudioService.cpp
+++ b/native/cocos/audio/openharmony/PcmAudioService.cpp
@@ -28,7 +28,6 @@ THE SOFTWARE.
 #include "audio/openharmony/PcmAudioService.h"
 #include "audio/openharmony/AudioMixerController.h"
 #include "bindings/jswrapper/napi/HelperMacros.h"
-//#include "SLES/OpenSLES_OpenHarmony.h"
 #include "SLES/OpenSLES_Platform.h"
 
 namespace cc {
@@ -39,9 +38,9 @@ static std::vector<char> __silenceData;
 
 class SLPcmAudioPlayerCallbackProxy {
 public:
-    static void samplePlayerCallback(SLBufferQueueItf bq, void *context) {
+    static void samplePlayerCallback(SLOHBufferQueueItf bq, void *context, SLuint32 size) {
         PcmAudioService *thiz = reinterpret_cast<PcmAudioService *>(context);
-        thiz->bqFetchBufferCallback(bq);
+        thiz->bqFetchBufferCallback(bq, size);
     }
 };
 
@@ -61,6 +60,7 @@ bool PcmAudioService::enqueue() {
             SLresult r = (*_bufferQueueItf)->Enqueue(_bufferQueueItf, __silenceData.data(), __silenceData.size());
             SL_RETURN_VAL_IF_FAILED(r, false, "enqueue silent data failed!");
         } else {
+            
             _controller->mixOneFrame();
 
             auto current = _controller->current();
@@ -76,7 +76,7 @@ bool PcmAudioService::enqueue() {
     return true;
 }
 
-void PcmAudioService::bqFetchBufferCallback(SLBufferQueueItf bq) {
+void PcmAudioService::bqFetchBufferCallback(SLOHBufferQueueItf bq,SLuint32 size) {
     // IDEA: PcmAudioService instance may be destroyed, we need to find a way to wait...
     // It's in sub thread
     enqueue();
@@ -96,7 +96,7 @@ bool PcmAudioService::init(AudioMixerController *controller, int numChannels, in
 
     SLDataFormat_PCM formatPcm = {
         SL_DATAFORMAT_PCM,
-        (SLuint32)numChannels,
+        (SLuint32)1,  // TODO(hack): 1 channel must be set, there is a problem with dual channels
         (SLuint32)sampleRate * 1000,
         SL_PCMSAMPLEFORMAT_FIXED_16,
         SL_PCMSAMPLEFORMAT_FIXED_16,
@@ -117,7 +117,7 @@ bool PcmAudioService::init(AudioMixerController *controller, int numChannels, in
     const SLInterfaceID ids[] = {
         SL_IID_PLAY,
         SL_IID_VOLUME,
-        SL_IID_BUFFERQUEUE,
+        SL_IID_OH_BUFFERQUEUE,
     };
 
     const SLboolean req[] = {
@@ -140,8 +140,8 @@ bool PcmAudioService::init(AudioMixerController *controller, int numChannels, in
     r = (*_playObj)->GetInterface(_playObj, SL_IID_VOLUME, &_volumeItf);
     SL_RETURN_VAL_IF_FAILED(r, false, "GetInterface SL_IID_VOLUME failed");
 
-    r = (*_playObj)->GetInterface(_playObj, SL_IID_BUFFERQUEUE, &_bufferQueueItf);
-    SL_RETURN_VAL_IF_FAILED(r, false, "GetInterface SL_IID_BUFFERQUEUE failed");
+    r = (*_playObj)->GetInterface(_playObj, SL_IID_OH_BUFFERQUEUE, &_bufferQueueItf);
+    SL_RETURN_VAL_IF_FAILED(r, false, "GetInterface SL_IID_OH_BUFFERQUEUE failed");
 
     r = (*_bufferQueueItf)->RegisterCallback(_bufferQueueItf, SLPcmAudioPlayerCallbackProxy::samplePlayerCallback, this);
     SL_RETURN_VAL_IF_FAILED(r, false, "_bufferQueueItf RegisterCallback failed");

--- a/native/cocos/audio/openharmony/PcmAudioService.h
+++ b/native/cocos/audio/openharmony/PcmAudioService.h
@@ -29,6 +29,10 @@ THE SOFTWARE.
 #include "audio/openharmony/OpenSLHelper.h"
 #include "audio/openharmony/PcmData.h"
 
+#include "SLES/OpenSLES.h"
+#include "SLES/OpenSLES_OpenHarmony.h"
+#include "SLES/OpenSLES_Platform.h"
+
 #include <mutex>
 #include <condition_variable>
 
@@ -51,7 +55,7 @@ private:
 
     bool enqueue();
 
-    void bqFetchBufferCallback(SLBufferQueueItf bq);
+    void bqFetchBufferCallback(SLOHBufferQueueItf bq,SLuint32 size);
 
     void pause();
     void resume();
@@ -63,7 +67,7 @@ private:
     SLObjectItf _playObj;
     SLPlayItf _playItf;
     SLVolumeItf _volumeItf;
-    SLBufferQueueItf _bufferQueueItf;
+    SLOHBufferQueueItf _bufferQueueItf;
 
     int _numChannels;
     int _sampleRate;

--- a/native/cocos/audio/openharmony/PcmAudioService.h
+++ b/native/cocos/audio/openharmony/PcmAudioService.h
@@ -55,7 +55,7 @@ private:
 
     bool enqueue();
 
-    void bqFetchBufferCallback(SLOHBufferQueueItf bq,SLuint32 size);
+    void bqFetchBufferCallback(SLOHBufferQueueItf bq);
 
     void pause();
     void resume();


### PR DESCRIPTION
Re: #

### Changelog

The openharmony audio module is adapted and can be played at present,but several hacks have been used
1. The audio buffer must be within a certain range. If it is too large or too small, there may be problems.
2. Must use a single channel

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
