### PR TITLE
Fix the issue that "node" can not be found when build for Android on Mac host

### DIFF
--- a/native/cmake/predefine.cmake
+++ b/native/cmake/predefine.cmake
@@ -225,6 +225,24 @@ find_program(NODE_EXECUTABLE NAMES node)
 find_program(TSC_EXECUTABLE NAMES tsc)
 find_program(CCACHE_EXECUTABLE NAMES ccache)
 
+if("${NODE_EXECUTABLE}" STREQUAL "NODE_EXECUTABLE-NOTFOUND")
+    if(CMAKE_HOST_APPLE)
+        find_program(NODE_EXECUTABLE NAMES node PATHS "/usr/local/bin" "/opt/homebrew/bin")
+    endif()
+endif()
+
+if("${TSC_EXECUTABLE}" STREQUAL "TSC_EXECUTABLE-NOTFOUND")
+    if(CMAKE_HOST_APPLE)
+        find_program(TSC_EXECUTABLE NAMES tsc PATHS "/usr/local/bin" "/opt/homebrew/bin")
+    endif()
+endif()
+
+if("${CCACHE_EXECUTABLE}" STREQUAL "CCACHE_EXECUTABLE-NOTFOUND")
+    if(CMAKE_HOST_APPLE)
+        find_program(CCACHE_EXECUTABLE NAMES ccache PATHS "/usr/local/bin" "/opt/homebrew/bin")
+    endif()
+endif()
+
 ## predefined configurations for game applications
 include(${CMAKE_CURRENT_LIST_DIR}/../../templates/cmake/common.cmake)
 if(APPLE)


### PR DESCRIPTION
Fix https://github.com/cocos/cocos-engine/issues/12456

When open Android Studio from dashboard,
it can not inherit ENV from shell config (.zshrc / .bashrc / etc.)

So here I make a fallback strategy when node / tsc / ccache not found

Most developer would use Homebrew to install tools for development,
so just search them in "/usr/local/bin" (Intel Mac) and "/opt/homebrew/bin" (Apple silicon Mac)

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [x] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [x] Your pull request title is using English, it's precise and appropriate.
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [x] Document new code with comments in source code based on API docs
- [x] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [x] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
