### PR TITLE
V3.6.1 se::Object private object add interfaces

### DIFF
--- a/native/cocos/bindings/jswrapper/PrivateObject.h
+++ b/native/cocos/bindings/jswrapper/PrivateObject.h
@@ -104,12 +104,12 @@ private:
 };
 
 template <typename T>
-class CCIntrusivePtrPtrPrivateObject final : public TypedPrivateObject<T> {
+class CCIntrusivePtrPrivateObject final : public TypedPrivateObject<T> {
 public:
-    CCIntrusivePtrPtrPrivateObject() = default;
-    explicit CCIntrusivePtrPtrPrivateObject(const cc::IntrusivePtr<T> &p) : _ptr(p) {}
-    explicit CCIntrusivePtrPtrPrivateObject(cc::IntrusivePtr<T> &&p) : _ptr(std::move(p)) {}
-    ~CCIntrusivePtrPtrPrivateObject() override = default;
+    CCIntrusivePtrPrivateObject() = default;
+    explicit CCIntrusivePtrPrivateObject(const cc::IntrusivePtr<T> &p) : _ptr(p) {}
+    explicit CCIntrusivePtrPrivateObject(cc::IntrusivePtr<T> &&p) : _ptr(std::move(p)) {}
+    ~CCIntrusivePtrPrivateObject() override = default;
 
     inline const cc::IntrusivePtr<T>& getData() const { return _ptr; }
     inline cc::IntrusivePtr<T>& getData() { return _ptr; }
@@ -177,7 +177,7 @@ inline std::shared_ptr<T> TypedPrivateObject<T>::share() {
 template <typename T>
 inline cc::IntrusivePtr<T> &TypedPrivateObject<T>::ccShared() {
     CC_ASSERT(isCCIntrusivePtr());
-    return reinterpret_cast<CCIntrusivePtrPtrPrivateObject<T> *>(this)->_ptr;
+    return reinterpret_cast<CCIntrusivePtrPrivateObject<T> *>(this)->_ptr;
 }
 
 #if CC_DEBUG
@@ -199,7 +199,7 @@ inline PrivateObjectBase *make_shared_private_object(T *cobj) { // NOLINT
     inHeap(cobj);
 #endif
     if constexpr (std::is_base_of<cc::RefCounted, T>::value) {
-        return ccnew CCIntrusivePtrPtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
+        return ccnew CCIntrusivePtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
     } else {
         return ccnew SharedPtrPrivateObject<T>(std::shared_ptr<T>(cobj));
     }
@@ -229,11 +229,11 @@ inline PrivateObjectBase *rawref_private_object(T *ptr) { // NOLINT
 template <typename T>
 inline PrivateObjectBase *ccshared_ptr_private_object(const cc::IntrusivePtr<T> &ptr) { // NOLINT
     static_assert(std::is_base_of<cc::RefCounted, T>::value, "cc::RefCounted expected!");
-    return ccnew CCIntrusivePtrPtrPrivateObject<T>(ptr);
+    return ccnew CCIntrusivePtrPrivateObject<T>(ptr);
 }
 template <typename T>
 inline PrivateObjectBase *ccshared_ptr_private_object(T *cobj) { // NOLINT
     static_assert(std::is_base_of<cc::RefCounted, T>::value, "cc::RefCounted expected!");
-    return ccnew CCIntrusivePtrPtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
+    return ccnew CCIntrusivePtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
 }
 } // namespace se

--- a/native/cocos/bindings/jswrapper/PrivateObject.h
+++ b/native/cocos/bindings/jswrapper/PrivateObject.h
@@ -62,7 +62,7 @@ public:
     virtual void tryAllowDestroyInGC() const {}
 
     virtual bool isSharedPtr() const { return false; }
-    virtual bool isCCShared() const { return false; }
+    virtual bool isCCIntrusivePtr() const { return false; }
 
     friend se::Object;
     friend se::State;
@@ -83,15 +83,18 @@ public:
 };
 
 template <typename T>
-class SharedPrivateObject final : public TypedPrivateObject<T> {
+class SharedPtrPrivateObject final : public TypedPrivateObject<T> {
 public:
-    SharedPrivateObject() = default;
-    explicit SharedPrivateObject(const std::shared_ptr<T> &ptr) : _data(ptr) {}
-    explicit SharedPrivateObject(std::shared_ptr<T> &&ptr) : _data(std::move(ptr)) {}
-    inline std::shared_ptr<T> getData() const {
+    SharedPtrPrivateObject() = default;
+    explicit SharedPtrPrivateObject(const std::shared_ptr<T> &ptr) : _data(ptr) {}
+    explicit SharedPtrPrivateObject(std::shared_ptr<T> &&ptr) : _data(std::move(ptr)) {}
+    inline const std::shared_ptr<T>& getData() const {
         return _data;
     }
 
+    inline std::shared_ptr<T>& getData() {
+        return _data;
+    }
     constexpr bool isSharedPtr() const override { return true; }
 
     void *getRaw() const override { return _data.get(); }
@@ -101,19 +104,20 @@ private:
 };
 
 template <typename T>
-class CCSharedPtrPrivateObject final : public TypedPrivateObject<T> {
+class CCIntrusivePtrPtrPrivateObject final : public TypedPrivateObject<T> {
 public:
-    CCSharedPtrPrivateObject() = default;
-    explicit CCSharedPtrPrivateObject(const cc::IntrusivePtr<T> &p) : _ptr(p) {}
-    explicit CCSharedPtrPrivateObject(cc::IntrusivePtr<T> &&p) : _ptr(std::move(p)) {}
-    ~CCSharedPtrPrivateObject() override = default;
+    CCIntrusivePtrPtrPrivateObject() = default;
+    explicit CCIntrusivePtrPtrPrivateObject(const cc::IntrusivePtr<T> &p) : _ptr(p) {}
+    explicit CCIntrusivePtrPtrPrivateObject(cc::IntrusivePtr<T> &&p) : _ptr(std::move(p)) {}
+    ~CCIntrusivePtrPtrPrivateObject() override = default;
 
-    inline cc::IntrusivePtr<T> getData() const { return _ptr; }
+    inline const cc::IntrusivePtr<T>& getData() const { return _ptr; }
+    inline cc::IntrusivePtr<T>& getData() { return _ptr; }
 
     inline void *getRaw() const override {
         return _ptr.get();
     }
-    inline bool isCCShared() const override { return true; }
+    inline bool isCCIntrusivePtr() const override { return true; }
 
 private:
     cc::IntrusivePtr<T> _ptr;
@@ -165,15 +169,15 @@ private:
 template <typename T>
 inline std::shared_ptr<T> TypedPrivateObject<T>::share() {
     if (isSharedPtr()) {
-        return reinterpret_cast<SharedPrivateObject<T> *>(this)->getData();
+        return reinterpret_cast<SharedPtrPrivateObject<T> *>(this)->getData();
     }
     CC_ASSERT(false);
     return std::shared_ptr<T>(nullptr);
 }
 template <typename T>
 inline cc::IntrusivePtr<T> &TypedPrivateObject<T>::ccShared() {
-    CC_ASSERT(isCCShared());
-    return reinterpret_cast<CCSharedPtrPrivateObject<T> *>(this)->_ptr;
+    CC_ASSERT(isCCIntrusivePtr());
+    return reinterpret_cast<CCIntrusivePtrPtrPrivateObject<T> *>(this)->_ptr;
 }
 
 #if CC_DEBUG
@@ -195,21 +199,21 @@ inline PrivateObjectBase *make_shared_private_object(T *cobj) { // NOLINT
     inHeap(cobj);
 #endif
     if constexpr (std::is_base_of<cc::RefCounted, T>::value) {
-        return ccnew CCSharedPtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
+        return ccnew CCIntrusivePtrPtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
     } else {
-        return ccnew SharedPrivateObject<T>(std::shared_ptr<T>(cobj));
+        return ccnew SharedPtrPrivateObject<T>(std::shared_ptr<T>(cobj));
     }
 }
 template <typename T>
-inline PrivateObjectBase *shared_private_object(std::shared_ptr<T> &&ptr) { // NOLINT
+inline PrivateObjectBase *shared_ptr_private_object(std::shared_ptr<T> &&ptr) { // NOLINT
     static_assert(!std::is_base_of<cc::RefCounted, T>::value, "cc::RefCounted is not acceptable for shared_ptr");
-    return ccnew SharedPrivateObject<T>(std::forward<std::shared_ptr<T>>(ptr));
+    return ccnew SharedPtrPrivateObject<T>(std::forward<std::shared_ptr<T>>(ptr));
 }
 
 template <typename T>
-inline PrivateObjectBase *shared_private_object(const std::shared_ptr<T> &ptr) { // NOLINT
+inline PrivateObjectBase *shared_ptr_private_object(const std::shared_ptr<T> &ptr) { // NOLINT
     static_assert(!std::is_base_of<cc::RefCounted, T>::value, "cc::RefCounted is not acceptable for shared_ptr");
-    return ccnew SharedPrivateObject<T>(ptr);
+    return ccnew SharedPtrPrivateObject<T>(ptr);
 }
 
 template <typename T>
@@ -223,13 +227,13 @@ inline PrivateObjectBase *rawref_private_object(T *ptr) { // NOLINT
 }
 
 template <typename T>
-inline PrivateObjectBase *ccshared_private_object(const cc::IntrusivePtr<T> &ptr) { // NOLINT
+inline PrivateObjectBase *ccshared_ptr_private_object(const cc::IntrusivePtr<T> &ptr) { // NOLINT
     static_assert(std::is_base_of<cc::RefCounted, T>::value, "cc::RefCounted expected!");
-    return ccnew CCSharedPtrPrivateObject<T>(ptr);
+    return ccnew CCIntrusivePtrPtrPrivateObject<T>(ptr);
 }
 template <typename T>
-inline PrivateObjectBase *ccshared_private_object(T *cobj) { // NOLINT
+inline PrivateObjectBase *ccshared_ptr_private_object(T *cobj) { // NOLINT
     static_assert(std::is_base_of<cc::RefCounted, T>::value, "cc::RefCounted expected!");
-    return ccnew CCSharedPtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
+    return ccnew CCIntrusivePtrPtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
 }
 } // namespace se

--- a/native/cocos/bindings/jswrapper/PrivateObject.h
+++ b/native/cocos/bindings/jswrapper/PrivateObject.h
@@ -227,12 +227,12 @@ inline PrivateObjectBase *rawref_private_object(T *ptr) { // NOLINT
 }
 
 template <typename T>
-inline PrivateObjectBase *ccshared_ptr_private_object(const cc::IntrusivePtr<T> &ptr) { // NOLINT
+inline PrivateObjectBase *ccintrusive_ptr_private_object(const cc::IntrusivePtr<T> &ptr) { // NOLINT
     static_assert(std::is_base_of<cc::RefCounted, T>::value, "cc::RefCounted expected!");
     return ccnew CCIntrusivePtrPrivateObject<T>(ptr);
 }
 template <typename T>
-inline PrivateObjectBase *ccshared_ptr_private_object(T *cobj) { // NOLINT
+inline PrivateObjectBase *ccintrusive_ptr_private_object(T *cobj) { // NOLINT
     static_assert(std::is_base_of<cc::RefCounted, T>::value, "cc::RefCounted expected!");
     return ccnew CCIntrusivePtrPrivateObject<T>(cc::IntrusivePtr<T>(cobj));
 }

--- a/native/cocos/bindings/jswrapper/v8/Object.h
+++ b/native/cocos/bindings/jswrapper/v8/Object.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include "../config.h"
-#include "PrivateObject.h"
+#include "bindings/jswrapper/PrivateObject.h"
 
 #if SCRIPT_ENGINE_TYPE == SCRIPT_ENGINE_V8
 

--- a/native/cocos/bindings/jswrapper/v8/Object.h
+++ b/native/cocos/bindings/jswrapper/v8/Object.h
@@ -331,7 +331,7 @@ public:
      */
     template <typename T>
     inline void setPrivateData(const cc::IntrusivePtr<T> &data) {
-        setPrivateObject(se::ccshared_private_object(data));
+        setPrivateObject(se::ccshared_ptr_private_object(data));
     }
 
     /**
@@ -342,7 +342,7 @@ public:
      */
     template <typename T>
     inline void setPrivateData(const std::shared_ptr<T> &data) {
-        setPrivateObject(se::shared_private_object(data));
+        setPrivateObject(se::shared_ptr_private_object(data));
     }
 
     /**
@@ -371,7 +371,7 @@ public:
     template <typename T>
     inline std::shared_ptr<T> getPrivateSharedPtr() const {
         assert(_privateObject->isSharedPtr());
-        return static_cast<se::SharedPrivateObject<T> *>(_privateObject)->getData();
+        return static_cast<se::SharedPtrPrivateObject<T> *>(_privateObject)->getData();
     }
 
     /**
@@ -382,8 +382,8 @@ public:
      */
     template <typename T>
     inline cc::IntrusivePtr<T> getPrivateInstrusivePtr() const {
-        assert(_privateObject->isCCShared());
-        return static_cast<se::CCSharedPtrPrivateObject<T> *>(_privateObject)->getData();
+        assert(_privateObject->isCCIntrusivePtr());
+        return static_cast<se::CCIntrusivePtrPtrPrivateObject<T> *>(_privateObject)->getData();
     }
 
     template <typename T>

--- a/native/cocos/bindings/jswrapper/v8/Object.h
+++ b/native/cocos/bindings/jswrapper/v8/Object.h
@@ -383,7 +383,7 @@ public:
     template <typename T>
     inline cc::IntrusivePtr<T> getPrivateInstrusivePtr() const {
         assert(_privateObject->isCCIntrusivePtr());
-        return static_cast<se::CCIntrusivePtrPtrPrivateObject<T> *>(_privateObject)->getData();
+        return static_cast<se::CCIntrusivePtrPrivateObject<T> *>(_privateObject)->getData();
     }
 
     template <typename T>

--- a/native/cocos/bindings/jswrapper/v8/Object.h
+++ b/native/cocos/bindings/jswrapper/v8/Object.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "../config.h"
+#include "PrivateObject.h"
 
 #if SCRIPT_ENGINE_TYPE == SCRIPT_ENGINE_V8
 
@@ -51,33 +52,33 @@ class Class;
 class ScriptEngine;
 
 /**
-     * se::Object represents JavaScript Object.
-     */
+ * se::Object represents JavaScript Object.
+ */
 class Object final : public RefCounter {
 public:
     /**
-         *  @brief Creates a JavaScript Object like `{} or new Object()`.
-         *  @return A JavaScript Object, or nullptr if there is an error.
-         *  @note The return value (non-null) has to be released manually.
-         */
+     *  @brief Creates a JavaScript Object like `{} or new Object()`.
+     *  @return A JavaScript Object, or nullptr if there is an error.
+     *  @note The return value (non-null) has to be released manually.
+     */
     static Object *createPlainObject();
 
     /**
-         *  @brief Creates a JavaScript Array Object like `[] or new Array()`.
-         *  @param[in] length The initical length of array.
-         *  @return A JavaScript Array Object, or nullptr if there is an error.
-         *  @note The return value (non-null) has to be released manually.
-         */
+     *  @brief Creates a JavaScript Array Object like `[] or new Array()`.
+     *  @param[in] length The initical length of array.
+     *  @return A JavaScript Array Object, or nullptr if there is an error.
+     *  @note The return value (non-null) has to be released manually.
+     */
     static Object *createArrayObject(size_t length);
 
     /**
-         *  @brief Creates a JavaScript Typed Array Object with uint8 format from an existing pointer.
-         *  @param[in] bytes A pointer to the byte buffer to be used as the backing store of the Typed Array object.
-         *  @param[in] byteLength The number of bytes pointed to by the parameter bytes.
-         *  @return A JavaScript Typed Array Object whose backing store is the same as the one pointed data, or nullptr if there is an error.
-         *  @note The return value (non-null) has to be released manually.
-         *  @deprecated This method is deprecated, please use `se::Object::createTypedArray` instead.
-         */
+     *  @brief Creates a JavaScript Typed Array Object with uint8 format from an existing pointer.
+     *  @param[in] bytes A pointer to the byte buffer to be used as the backing store of the Typed Array object.
+     *  @param[in] byteLength The number of bytes pointed to by the parameter bytes.
+     *  @return A JavaScript Typed Array Object whose backing store is the same as the one pointed data, or nullptr if there is an error.
+     *  @note The return value (non-null) has to be released manually.
+     *  @deprecated This method is deprecated, please use `se::Object::createTypedArray` instead.
+     */
     SE_DEPRECATED_ATTRIBUTE static Object *createUint8TypedArray(uint8_t *bytes, size_t byteLength);
 
     enum class TypedArrayType {
@@ -119,47 +120,47 @@ public:
     static Object *createTypedArrayWithBuffer(TypedArrayType type, const Object *obj, size_t offset, size_t byteLength);
 
     /**
-         *  @brief Creates a JavaScript Array Buffer object from an existing pointer.
-         *  @param[in] bytes A pointer to the byte buffer to be used as the backing store of the Typed Array object.
-         *  @param[in] byteLength The number of bytes pointed to by the parameter bytes.
-         *  @return A Array Buffer Object whose backing store is the same as the one pointed to data, or nullptr if there is an error.
-         *  @note The return value (non-null) has to be released manually.
-         */
+     *  @brief Creates a JavaScript Array Buffer object from an existing pointer.
+     *  @param[in] bytes A pointer to the byte buffer to be used as the backing store of the Typed Array object.
+     *  @param[in] byteLength The number of bytes pointed to by the parameter bytes.
+     *  @return A Array Buffer Object whose backing store is the same as the one pointed to data, or nullptr if there is an error.
+     *  @note The return value (non-null) has to be released manually.
+     */
     static Object *createArrayBufferObject(const void *data, size_t byteLength);
 
     using BufferContentsFreeFunc = void (*)(void *contents, size_t byteLength, void *userData);
     static Object *createExternalArrayBufferObject(void *contents, size_t byteLength, BufferContentsFreeFunc freeFunc, void *freeUserData = nullptr);
 
     /**
-         *  @brief Creates a JavaScript Object from a JSON formatted string.
-         *  @param[in] jsonStr The utf-8 string containing the JSON string to be parsed.
-         *  @return A JavaScript Object containing the parsed value, or nullptr if the input is invalid.
-         *  @note The return value (non-null) has to be released manually.
-         */
+     *  @brief Creates a JavaScript Object from a JSON formatted string.
+     *  @param[in] jsonStr The utf-8 string containing the JSON string to be parsed.
+     *  @return A JavaScript Object containing the parsed value, or nullptr if the input is invalid.
+     *  @note The return value (non-null) has to be released manually.
+     */
     static Object *createJSONObject(const ccstd::string &jsonStr);
 
     /**
-         *  @brief Creates a JavaScript Native Binding Object from an existing se::Class instance.
-         *  @param[in] cls The se::Class instance which stores native callback informations.
-         *  @return A JavaScript Native Binding Object, or nullptr if there is an error.
-         *  @note The return value (non-null) has to be released manually.
-         */
+     *  @brief Creates a JavaScript Native Binding Object from an existing se::Class instance.
+     *  @param[in] cls The se::Class instance which stores native callback informations.
+     *  @return A JavaScript Native Binding Object, or nullptr if there is an error.
+     *  @note The return value (non-null) has to be released manually.
+     */
     static Object *createObjectWithClass(Class *cls);
 
     /**
-         *  @brief Gets a se::Object from an existing native object pointer.
-         *  @param[in] ptr The native object pointer associated with the se::Object
-         *  @return A JavaScript Native Binding Object, or nullptr if there is an error.
-         *  @note The return value (non-null) has to be released manually.
-         */
+     *  @brief Gets a se::Object from an existing native object pointer.
+     *  @param[in] ptr The native object pointer associated with the se::Object
+     *  @return A JavaScript Native Binding Object, or nullptr if there is an error.
+     *  @note The return value (non-null) has to be released manually.
+     */
     static Object *getObjectWithPtr(void *ptr);
 
     /**
-         *  @brief Gets a property from an object.
-         *  @param[in] name A utf-8 string containing the property's name.
-         *  @param[out] value The property's value if object has the property, otherwise the undefined value.
-         *  @return true if object has the property, otherwise false.
-         */
+     *  @brief Gets a property from an object.
+     *  @param[in] name A utf-8 string containing the property's name.
+     *  @param[out] value The property's value if object has the property, otherwise the undefined value.
+     *  @return true if object has the property, otherwise false.
+     */
     inline bool getProperty(const char *name, Value *data) {
         return getProperty(name, data, false);
     }
@@ -171,11 +172,11 @@ public:
     }
 
     /**
-         *  @brief Sets a property to an object.
-         *  @param[in] name A utf-8 string containing the property's name.
-         *  @param[in] value A value to be used as the property's value.
-         *  @return true if the property is set successfully, otherwise false.
-         */
+     *  @brief Sets a property to an object.
+     *  @param[in] name A utf-8 string containing the property's name.
+     *  @param[in] value A value to be used as the property's value.
+     *  @return true if the property is set successfully, otherwise false.
+     */
     bool setProperty(const char *name, const Value &data);
 
     inline bool setProperty(const ccstd::string &name, const Value &value) {
@@ -183,119 +184,119 @@ public:
     }
 
     /**
-         *  @brief Delete a property of an object.
-         *  @param[in] name A utf-8 string containing the property's name.
-         *  @return true if the property is deleted successfully, otherwise false.
-         */
+     *  @brief Delete a property of an object.
+     *  @param[in] name A utf-8 string containing the property's name.
+     *  @return true if the property is deleted successfully, otherwise false.
+     */
     bool deleteProperty(const char *name);
 
     /**
-         *  @brief Defines a property with native accessor callbacks for an object.
-         *  @param[in] name A utf-8 string containing the property's name.
-         *  @param[in] getter The native callback for getter.
-         *  @param[in] setter The native callback for setter.
-         *  @return true if succeed, otherwise false.
-         */
+     *  @brief Defines a property with native accessor callbacks for an object.
+     *  @param[in] name A utf-8 string containing the property's name.
+     *  @param[in] getter The native callback for getter.
+     *  @param[in] setter The native callback for setter.
+     *  @return true if succeed, otherwise false.
+     */
     bool defineProperty(const char *name, v8::AccessorNameGetterCallback getter, v8::AccessorNameSetterCallback setter);
 
     bool defineOwnProperty(const char *name, const se::Value &value, bool writable = true, bool enumerable = true, bool configurable = true);
 
     /**
-         *  @brief Defines a function with a native callback for an object.
-         *  @param[in] funcName A utf-8 string containing the function name.
-         *  @param[in] func The native callback triggered by JavaScript code.
-         *  @return true if succeed, otherwise false.
-         */
+     *  @brief Defines a function with a native callback for an object.
+     *  @param[in] funcName A utf-8 string containing the function name.
+     *  @param[in] func The native callback triggered by JavaScript code.
+     *  @return true if succeed, otherwise false.
+     */
     bool defineFunction(const char *funcName, v8::FunctionCallback func);
 
     /**
-         *  @brief Tests whether an object can be called as a function.
-         *  @return true if object can be called as a function, otherwise false.
-         */
+     *  @brief Tests whether an object can be called as a function.
+     *  @return true if object can be called as a function, otherwise false.
+     */
     bool isFunction() const;
 
     /**
-         *  @brief Calls an object as a function.
-         *  @param[in] args A se::Value array of arguments to pass to the function. Pass se::EmptyValueArray if argumentCount is 0.
-         *  @param[in] thisObject The object to use as "this," or NULL to use the global object as "this."
-         *  @param[out] rval The se::Value that results from calling object as a function, passing nullptr if return value is ignored.
-         *  @return true if object is a function and there isn't any errors, otherwise false.
-         */
+     *  @brief Calls an object as a function.
+     *  @param[in] args A se::Value array of arguments to pass to the function. Pass se::EmptyValueArray if argumentCount is 0.
+     *  @param[in] thisObject The object to use as "this," or NULL to use the global object as "this."
+     *  @param[out] rval The se::Value that results from calling object as a function, passing nullptr if return value is ignored.
+     *  @return true if object is a function and there isn't any errors, otherwise false.
+     */
     bool call(const ValueArray &args, Object *thisObject, Value *rval = nullptr);
 
     /**
-         *  @brief Tests whether an object is an array.
-         *  @return true if object is an array, otherwise false.
-         */
+     *  @brief Tests whether an object is an array.
+     *  @return true if object is an array, otherwise false.
+     */
     bool isArray() const;
 
     /**
-         *  @brief Gets array length of an array object.
-         *  @param[out] length The array length to be stored. It's set to 0 if there is an error.
-         *  @return true if succeed, otherwise false.
-         */
+     *  @brief Gets array length of an array object.
+     *  @param[out] length The array length to be stored. It's set to 0 if there is an error.
+     *  @return true if succeed, otherwise false.
+     */
     bool getArrayLength(uint32_t *length) const;
 
     /**
-         *  @brief Gets an element from an array object by numeric index.
-         *  @param[in] index An integer value for index.
-         *  @param[out] data The se::Value to be stored for the element in certain index.
-         *  @return true if succeed, otherwise false.
-         */
+     *  @brief Gets an element from an array object by numeric index.
+     *  @param[in] index An integer value for index.
+     *  @param[out] data The se::Value to be stored for the element in certain index.
+     *  @return true if succeed, otherwise false.
+     */
     bool getArrayElement(uint32_t index, Value *data) const;
 
     /**
-         *  @brief Sets an element to an array object by numeric index.
-         *  @param[in] index An integer value for index.
-         *  @param[in] data The se::Value to be set to array with certain index.
-         *  @return true if succeed, otherwise false.
-         */
+     *  @brief Sets an element to an array object by numeric index.
+     *  @param[in] index An integer value for index.
+     *  @param[in] data The se::Value to be set to array with certain index.
+     *  @return true if succeed, otherwise false.
+     */
     bool setArrayElement(uint32_t index, const Value &data);
 
     /** @brief Tests whether an object is a typed array.
-         *  @return true if object is a typed array, otherwise false.
-         */
+     *  @return true if object is a typed array, otherwise false.
+     */
     bool isTypedArray() const;
 
     /**
-         *  @brief Gets the type of a typed array object.
-         *  @return The type of a typed array object.
-         */
+     *  @brief Gets the type of a typed array object.
+     *  @return The type of a typed array object.
+     */
     TypedArrayType getTypedArrayType() const;
 
     /**
-         *  @brief Gets backing store of a typed array object.
-         *  @param[out] ptr A temporary pointer to the backing store of a JavaScript Typed Array object.
-         *  @param[out] length The byte length of a JavaScript Typed Array object.
-         *  @return true if succeed, otherwise false.
-         */
+     *  @brief Gets backing store of a typed array object.
+     *  @param[out] ptr A temporary pointer to the backing store of a JavaScript Typed Array object.
+     *  @param[out] length The byte length of a JavaScript Typed Array object.
+     *  @return true if succeed, otherwise false.
+     */
     bool getTypedArrayData(uint8_t **ptr, size_t *length) const;
 
     /**
-         *  @brief Tests whether an object is an array buffer object.
-         *  @return true if object is an array buffer object, otherwise false.
-         */
+     *  @brief Tests whether an object is an array buffer object.
+     *  @return true if object is an array buffer object, otherwise false.
+     */
     bool isArrayBuffer() const;
 
     /**
-         *  @brief Gets buffer data of an array buffer object.
-         *  @param[out] ptr A pointer to the data buffer that serves as the backing store for a JavaScript Typed Array object.
-         *  @param[out] length The number of bytes in a JavaScript data object.
-         *  @return true if succeed, otherwise false.
-         */
+     *  @brief Gets buffer data of an array buffer object.
+     *  @param[out] ptr A pointer to the data buffer that serves as the backing store for a JavaScript Typed Array object.
+     *  @param[out] length The number of bytes in a JavaScript data object.
+     *  @return true if succeed, otherwise false.
+     */
     bool getArrayBufferData(uint8_t **ptr, size_t *length) const;
 
     /**
-         *  @brief Gets all property names of an object.
-         *  @param[out] allKeys A string vector to store all property names.
-         *  @return true if succeed, otherwise false.
-         */
+     *  @brief Gets all property names of an object.
+     *  @param[out] allKeys A string vector to store all property names.
+     *  @return true if succeed, otherwise false.
+     */
     bool getAllKeys(ccstd::vector<ccstd::string> *allKeys) const;
 
     void setPrivateObject(PrivateObjectBase *data);
     PrivateObjectBase *getPrivateObject() const;
 
-    /**
+    /*
      *  @brief Gets an object's private data.
      *  @return A void* that is the object's private data, if the object has private data, otherwise nullptr.
      */
@@ -304,7 +305,14 @@ public:
     }
 
     /**
-     *  @brief Sets a pointer to private data on an object.
+     *  @brief Sets a pointer to private data on an object and use smart pointer to hold it.
+     *
+     *  If the pointer is an instance of `cc::RefCounted`, an `cc::IntrusivePtr` will be created to hold
+     *  the reference to the object, otherwise a `std::shared_ptr` object will be used. 
+     *  When the JS object is freed by GC, the corresponding smart pointer `IntrusivePtr/shared_ptr` will also be destroyed.
+     * 
+     *  If you do not want the pointer to be released by GC, you can call `setRawPrivateData`.
+     *
      *  @param[in] data A void* to set as the object's private data.
      *  @note This method will associate private data with se::Object by ccstd::unordered_map::emplace.
      *        It's used for search a se::Object via a void* private data.
@@ -313,6 +321,69 @@ public:
     inline void setPrivateData(T *data) {
         static_assert(!std::is_void<T>::value, "void * is not allowed for private data");
         setPrivateObject(se::make_shared_private_object(data));
+    }
+
+    /**
+     * @brief Use a InstrusivePtr to hold private data on the se::Object.
+     *
+     * @tparam T
+     * @param data A intrusive pointer object
+     */
+    template <typename T>
+    inline void setPrivateData(const cc::IntrusivePtr<T> &data) {
+        setPrivateObject(se::ccshared_private_object(data));
+    }
+
+    /**
+     * @brief Use a std::shared_ptr to hold private data on the se::Object.
+     *
+     * @tparam T
+     * @param data A shared_ptr object
+     */
+    template <typename T>
+    inline void setPrivateData(const std::shared_ptr<T> &data) {
+        setPrivateObject(se::shared_private_object(data));
+    }
+
+    /**
+     * @brief Set pointer to the private data on an object and will not use smart pointer to hold it.
+     *
+     * @tparam T
+     * @param data 
+     * @param tryDestroyInGC When GCing the JS object, whether to `delete` the `data` pointer.  
+     */
+    template <typename T>
+    inline void setRawPrivateData(T *data, bool tryDestroyInGC = false) {
+        static_assert(!std::is_void<T>::value, "void * is not allowed for private data");
+        auto *privateObject = se::rawref_private_object(data);
+        if (tryDestroyInGC) {
+            privateObject->tryAllowDestroyInGC();
+        }
+        setPrivateObject(privateObject);
+    }
+
+    /**
+     * @brief Get the underlying private data as std::shared_ptr
+     *
+     * @tparam T
+     * @return std::shared_ptr<T>
+     */
+    template <typename T>
+    inline std::shared_ptr<T> getPrivateSharedPtr() const {
+        assert(_privateObject->isSharedPtr());
+        return static_cast<se::SharedPrivateObject<T> *>(_privateObject)->getData();
+    }
+
+    /**
+     * @brief Get the underlying private data as InstrusivePtr
+     *
+     * @tparam T
+     * @return cc::IntrusivePtr<T>
+     */
+    template <typename T>
+    inline cc::IntrusivePtr<T> getPrivateInstrusivePtr() const {
+        assert(_privateObject->isCCShared());
+        return static_cast<se::CCSharedPtrPrivateObject<T> *>(_privateObject)->getData();
     }
 
     template <typename T>
@@ -332,29 +403,29 @@ public:
     void setClearMappingInFinalizer(bool v) { _clearMappingInFinalizer = v; }
 
     /**
-         *  @brief Roots an object from garbage collection.
-         *  @note Use this method when you want to store an object in a global or on the heap, where the garbage collector will not be able to discover your reference to it.
-         *        An object may be rooted multiple times and must be unrooted an equal number of times before becoming eligible for garbage collection.
-         */
+     *  @brief Roots an object from garbage collection.
+     *  @note Use this method when you want to store an object in a global or on the heap, where the garbage collector will not be able to discover your reference to it.
+     *        An object may be rooted multiple times and must be unrooted an equal number of times before becoming eligible for garbage collection.
+     */
     void root();
 
     /**
-         *  @brief Unroots an object from garbage collection.
-         *  @note An object may be rooted multiple times and must be unrooted an equal number of times before becoming eligible for garbage collection.
-         */
+     *  @brief Unroots an object from garbage collection.
+     *  @note An object may be rooted multiple times and must be unrooted an equal number of times before becoming eligible for garbage collection.
+     */
     void unroot();
 
     /**
-         *  @brief Tests whether an object is rooted.
-         *  @return true if it has been already rooted, otherwise false.
-         */
+     *  @brief Tests whether an object is rooted.
+     *  @return true if it has been already rooted, otherwise false.
+     */
     bool isRooted() const;
 
     /**
-         *  @brief Tests whether two objects are strict equal, as compared by the JS === operator.
-         *  @param[in] o The object to be tested with this object.
-         *  @return true if the two values are strict equal, otherwise false.
-         */
+     *  @brief Tests whether two objects are strict equal, as compared by the JS === operator.
+     *  @param[in] o The object to be tested with this object.
+     *  @return true if the two values are strict equal, otherwise false.
+     */
     bool strictEquals(Object *o) const;
 
     /**
@@ -410,17 +481,17 @@ public:
     bool attachObject(Object *obj);
 
     /**
-         *  @brief Detaches an object from current object.
-         *  @param[in] obj The object to be detached.
-         *  @return true if succeed, otherwise false.
-         *  @note The attached object will not be released if current object is not garbage collected.
-         */
+     *  @brief Detaches an object from current object.
+     *  @param[in] obj The object to be detached.
+     *  @return true if succeed, otherwise false.
+     *  @note The attached object will not be released if current object is not garbage collected.
+     */
     bool detachObject(Object *obj);
 
     /**
-         *  @brief Returns the string for describing current object.
-         *  @return The string for describing current object.
-         */
+     *  @brief Returns the string for describing current object.
+     *  @return The string for describing current object.
+     */
     ccstd::string toString() const;
 
     ccstd::string toStringExt() const;

--- a/native/cocos/bindings/jswrapper/v8/Object.h
+++ b/native/cocos/bindings/jswrapper/v8/Object.h
@@ -331,7 +331,7 @@ public:
      */
     template <typename T>
     inline void setPrivateData(const cc::IntrusivePtr<T> &data) {
-        setPrivateObject(se::ccshared_ptr_private_object(data));
+        setPrivateObject(se::ccintrusive_ptr_private_object(data));
     }
 
     /**

--- a/native/cocos/bindings/manual/jsb_conversions.h
+++ b/native/cocos/bindings/manual/jsb_conversions.h
@@ -323,20 +323,18 @@ bool seval_to_Map_string_key(const se::Value &v, cc::RefMap<ccstd::string, T> *r
     return true;
 }
 
-template <typename T>
-inline typename std::enable_if<std::is_base_of<cc::RefCounted, T>::value, void>::type
-cc_tmp_set_private_data(se::Object *obj, T *v) { // NOLINT(readability-identifier-naming)
-    obj->setPrivateData(v);
+template<typename T>
+void cc_tmp_set_private_data(se::Object *obj, T *v) { // NOLINT(readability-identifier-naming)
+    if constexpr (std::is_base_of_v<cc::RefCounted,T>) {
+        obj->setPrivateData(v);
+    }else{
+        obj->setRawPrivateData(v);
+    }
+
 }
 
-template <typename T>
-inline typename std::enable_if<!std::is_base_of<cc::RefCounted, T>::value, void>::type
-cc_tmp_set_private_data(se::Object *obj, T *v) { // NOLINT(readability-identifier-naming)
-    obj->setPrivateObject(se::rawref_private_object(v));
-}
-
-inline void cc_tmp_set_private_data(se::Object *obj, cc::gfx::Sampler *v) {
-    obj->setPrivateObject(se::rawref_private_object(v));
+inline void cc_tmp_set_private_data(se::Object *obj, cc::gfx::Sampler *v) { // NOLINT(readability-identifier-naming)
+    obj->setRawPrivateData(v);
 }
 
 //handle reference
@@ -392,7 +390,7 @@ bool native_ptr_to_rooted_seval( // NOLINT(readability-identifier-naming)
         CC_ASSERT(cls != nullptr);
         obj = se::Object::createObjectWithClass(cls);
         obj->root();
-        obj->setPrivateObject(se::rawref_private_object(v));
+        obj->setRawPrivateData(v);
         if (isReturnCachedValue != nullptr) {
             *isReturnCachedValue = false;
         }
@@ -1080,9 +1078,7 @@ bool sevalue_to_native(const se::Value &from, std::shared_ptr<T> *out, se::Objec
         out->reset();
         return true;
     }
-    auto *privateObject = from.toObject()->getPrivateObject();
-    CC_ASSERT(privateObject->isSharedPtr());
-    *out = static_cast<se::TypedPrivateObject<T>*>(privateObject)->share();
+    *out = from.toObject()->getPrivateSharedPtr<T>();
     return true;
 }
 
@@ -1100,17 +1096,7 @@ bool sevalue_to_native(const se::Value &from, cc::IntrusivePtr<T> *to, se::Objec
         to = nullptr;
         return true;
     }
-
-    auto *privateObject = from.toObject()->getPrivateObject();
-    if (!privateObject) {
-        T *tmp = nullptr;
-        bool ok = sevalue_to_native(from, &tmp, ctx);
-        *to = tmp;
-        return ok;
-    }
-
-    CC_ASSERT(privateObject->isCCShared());
-    *to = static_cast<se::CCSharedPtrPrivateObject<T> *>(privateObject)->ccShared();
+    *to = from.toObject()->getPrivateInstrusivePtr<T>();
     return true;
 }
 
@@ -1222,12 +1208,12 @@ template <typename T>
 inline bool nativevalue_to_se(const ccstd::vector<T> &from, se::Value &to, se::Object *ctx); // NOLINT
 
 template <typename T>
-inline bool nativevalue_to_se(const ccstd::vector<T> *from, se::Value &to, se::Object *ctx) {
+inline bool nativevalue_to_se(const ccstd::vector<T> *from, se::Value &to, se::Object *ctx) { // NOLINT
     return nativevalue_to_se(*from, to, ctx);
 }
 
 template <typename T>
-inline bool nativevalue_to_se(ccstd::vector<T> *const from, se::Value &to, se::Object *ctx) {
+inline bool nativevalue_to_se(ccstd::vector<T> *const from, se::Value &to, se::Object *ctx) {  // NOLINT
     return nativevalue_to_se(*from, to, ctx);
 }
 
@@ -1564,7 +1550,8 @@ inline bool nativevalue_to_se(const std::shared_ptr<T> &from, se::Value &to, se:
         CC_ASSERT(cls);
         se::Object *obj = se::Object::createObjectWithClass(cls);
         to.setObject(obj, true);
-        obj->setPrivateObject(se::shared_private_object(from));
+        obj->setPrivateData(from);
+
     } else {
         to.setObject(it->second);
     }
@@ -1585,7 +1572,7 @@ inline bool nativevalue_to_se(const cc::IntrusivePtr<T> &from, se::Value &to, se
         CC_ASSERT(cls);
         se::Object *obj = se::Object::createObjectWithClass(cls);
         to.setObject(obj, true);
-        obj->setPrivateObject(se::ccshared_private_object(from));
+        obj->setPrivateData(from);
     } else {
         to.setObject(it->second);
     }

--- a/native/cocos/bindings/manual/jsb_global.h
+++ b/native/cocos/bindings/manual/jsb_global.h
@@ -29,28 +29,24 @@
 #include "jsb_global_init.h"
 
 template <typename T, class... Args>
-T *jsb_override_new(Args &&...args) { //NOLINT(readability-identifier-naming)
-    //create object in the default way
+T *jsb_override_new(Args &&...args) { // NOLINT(readability-identifier-naming)
+    // create object in the default way
     return ccnew T(std::forward<Args>(args)...);
 }
 
 template <typename T>
-void jsb_override_delete(T *arg) { //NOLINT(readability-identifier-naming)
-    //create object in gfx way
+void jsb_override_delete(T *arg) { // NOLINT(readability-identifier-naming)
+    // create object in gfx way
     delete (arg);
 }
 
 template <typename T, typename... ARGS>
-typename std::enable_if<std::is_base_of<cc::RefCounted, T>::value, se::PrivateObjectBase *>::type
-jsb_make_private_object(ARGS &&...args) { //NOLINT(readability-identifier-naming)
-    //return se::raw_private_data(ccnew T(std::forward<ARGS>(args)...));
-    return se::ccshared_private_object(ccnew T(std::forward<ARGS>(args)...));
-}
-
-template <typename T, typename... ARGS>
-typename std::enable_if<!std::is_base_of<cc::RefCounted, T>::value, se::PrivateObjectBase *>::type
-jsb_make_private_object(ARGS &&...args) { //NOLINT(readability-identifier-naming)
-    return se::shared_private_object(std::make_shared<T>(std::forward<ARGS>(args)...));
+se::PrivateObjectBase *jsb_make_private_object(ARGS &&...args) { // NOLINT(readability-identifier-naming)
+    if constexpr (std::is_base_of<cc::RefCounted, T>::value) {
+        return se::ccshared_private_object(ccnew T(std::forward<ARGS>(args)...));
+    } else {
+        return se::shared_private_object(std::make_shared<T>(std::forward<ARGS>(args)...));
+    }
 }
 
 #define JSB_MAKE_PRIVATE_OBJECT(kls, ...) jsb_make_private_object<kls>(__VA_ARGS__)
@@ -61,10 +57,10 @@ class Class;
 class Value;
 } // namespace se
 
-bool jsb_register_global_variables(se::Object *global); //NOLINT(readability-identifier-naming)
+bool jsb_register_global_variables(se::Object *global); // NOLINT(readability-identifier-naming)
 
-bool jsb_set_extend_property(const char *ns, const char *clsName);                    //NOLINT(readability-identifier-naming)
-bool jsb_run_script(const ccstd::string &filePath, se::Value *rval = nullptr);        //NOLINT(readability-identifier-naming)
-bool jsb_run_script_module(const ccstd::string &filePath, se::Value *rval = nullptr); //NOLINT(readability-identifier-naming)
+bool jsb_set_extend_property(const char *ns, const char *clsName);                    // NOLINT(readability-identifier-naming)
+bool jsb_run_script(const ccstd::string &filePath, se::Value *rval = nullptr);        // NOLINT(readability-identifier-naming)
+bool jsb_run_script_module(const ccstd::string &filePath, se::Value *rval = nullptr); // NOLINT(readability-identifier-naming)
 
-bool jsb_global_load_image(const ccstd::string &path, const se::Value &callbackVal); //NOLINT(readability-identifier-naming)
+bool jsb_global_load_image(const ccstd::string &path, const se::Value &callbackVal); // NOLINT(readability-identifier-naming)

--- a/native/cocos/bindings/manual/jsb_global.h
+++ b/native/cocos/bindings/manual/jsb_global.h
@@ -43,9 +43,9 @@ void jsb_override_delete(T *arg) { // NOLINT(readability-identifier-naming)
 template <typename T, typename... ARGS>
 se::PrivateObjectBase *jsb_make_private_object(ARGS &&...args) { // NOLINT(readability-identifier-naming)
     if constexpr (std::is_base_of<cc::RefCounted, T>::value) {
-        return se::ccshared_private_object(ccnew T(std::forward<ARGS>(args)...));
+        return se::ccshared_ptr_private_object(ccnew T(std::forward<ARGS>(args)...));
     } else {
-        return se::shared_private_object(std::make_shared<T>(std::forward<ARGS>(args)...));
+        return se::shared_ptr_private_object(std::make_shared<T>(std::forward<ARGS>(args)...));
     }
 }
 

--- a/native/cocos/bindings/manual/jsb_global.h
+++ b/native/cocos/bindings/manual/jsb_global.h
@@ -43,7 +43,7 @@ void jsb_override_delete(T *arg) { // NOLINT(readability-identifier-naming)
 template <typename T, typename... ARGS>
 se::PrivateObjectBase *jsb_make_private_object(ARGS &&...args) { // NOLINT(readability-identifier-naming)
     if constexpr (std::is_base_of<cc::RefCounted, T>::value) {
-        return se::ccshared_ptr_private_object(ccnew T(std::forward<ARGS>(args)...));
+        return se::ccintrusive_ptr_private_object(ccnew T(std::forward<ARGS>(args)...));
     } else {
         return se::shared_ptr_private_object(std::make_shared<T>(std::forward<ARGS>(args)...));
     }


### PR DESCRIPTION
Re: #

### Changelog

Allow accessing underlying smart pointers without using `PrivateObject` APIs.

New interfaces for `se::Object`:

* `void setPrivateData(const cc::IntrusivePtr<T>&)`
* `void setPrivateData(const std::shared_ptr<T>&)`
* `void setRawPrivateData(T *, bool)`
* `std::shared_ptr<T> getPrivateSharedPtr() const`
* `cc::IntrusivePtr<T> getPrivateInstrusivePtr() const`

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
