### PR TITLE
filled sprite color is incorrect with uiOpacity parent

### DIFF
--- a/cocos/2d/assembler/sprite/bar-filled.ts
+++ b/cocos/2d/assembler/sprite/bar-filled.ts
@@ -70,7 +70,6 @@ export const barFilled: IAssembler = {
             let fillEnd = fillStart + fillRange;
             fillEnd = fillEnd > 1 ? 1 : fillEnd;
 
-            this.updateColor(sprite); // need Dirty
             this.updateUVs(sprite, fillStart, fillEnd); // need Dirty
             this.updateVertexData(sprite, fillStart, fillEnd);
             renderData.updateRenderData(sprite, frame);

--- a/cocos/2d/assembler/sprite/radial-filled.ts
+++ b/cocos/2d/assembler/sprite/radial-filled.ts
@@ -354,7 +354,7 @@ export const radialFilled: IAssembler = {
                 // need dirty
                 this.updateWorldUVData(sprite);
                 //this.updateColorLate(sprite);
-                if (sprite.renderEntity) { sprite.renderEntity.colorDirty = true; }
+                sprite.renderEntity.colorDirty = true;
             }
             renderData.updateRenderData(sprite, frame);
         }

--- a/cocos/2d/assembler/sprite/radial-filled.ts
+++ b/cocos/2d/assembler/sprite/radial-filled.ts
@@ -28,7 +28,7 @@ import { SpriteFrame } from '../../assets';
 import { Mat4, Vec2 } from '../../../core/math';
 import { IRenderData, RenderData } from '../../renderer/render-data';
 import { IBatcher } from '../../renderer/i-batcher';
-import { Sprite } from '../../components';
+import { Sprite, UIOpacity } from '../../components';
 import { IAssembler } from '../../renderer/base';
 import { dynamicAtlasManager } from '../../utils/dynamic-atlas/atlas-manager';
 import { StaticVBChunk } from '../../renderer/static-vb-accessor';
@@ -353,7 +353,8 @@ export const radialFilled: IAssembler = {
                 // may can update color & uv here
                 // need dirty
                 this.updateWorldUVData(sprite);
-                this.updateColorLate(sprite);
+                //this.updateColorLate(sprite);
+                if (sprite.renderEntity) { sprite.renderEntity.colorDirty = true; }
             }
             renderData.updateRenderData(sprite, frame);
         }

--- a/cocos/2d/assembler/sprite/tiled.ts
+++ b/cocos/2d/assembler/sprite/tiled.ts
@@ -102,7 +102,7 @@ export const tiled: IAssembler = {
         this.updateVerts(sprite, sizableWidth, sizableHeight, row, col);
 
         if (renderData.vertexCount !== row * col * 4) {
-            if (sprite.renderEntity) { sprite.renderEntity.colorDirty = true; }
+            sprite.renderEntity.colorDirty = true;
         }
         // update data property
         renderData.resize(row * col * 4, row * col * 6);

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -84,7 +84,7 @@ export class UIOpacity extends Component {
 
     // for UIOpacity
     public static setEntityLocalOpacityDirtyRecursively (node: Node, dirty: boolean, interruptParentOpacity: number) {
-        if (!node) {
+        if (!node.isValid) {
             return;
         }
 

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -84,6 +84,10 @@ export class UIOpacity extends Component {
 
     // for UIOpacity
     public static setEntityLocalOpacityDirtyRecursively (node: Node, dirty: boolean, interruptParentOpacity: number) {
+        if (!node) {
+            return;
+        }
+
         const render = node._uiProps.uiComp as UIRenderer;
         const uiOp = node.getComponent<UIOpacity>(UIOpacity);
         let interruptOpacity = interruptParentOpacity;// if there is no UIOpacity component, it should always equal to 1.

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -85,6 +85,8 @@ export class UIOpacity extends Component {
     // for UIOpacity
     public static setEntityLocalOpacityDirtyRecursively (node: Node, dirty: boolean, interruptParentOpacity: number) {
         if (!node.isValid) {
+            // Since children might be destroyed before the parent,
+            // we should add protecting condition when executing recursion downwards.
             return;
         }
 

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -103,7 +103,8 @@ export class UIOpacity extends Component {
             interruptOpacity = 1;
         } else if (uiOp) {
             // there is a just UIOpacity but no UIRenderer on the node.
-            interruptOpacity = uiOp.opacity / 255;
+            // we should transport the interrupt opacity downward
+            interruptOpacity = interruptOpacity * uiOp.opacity / 255;
         }
 
         for (let i = 0; i < node.children.length; i++) {


### PR DESCRIPTION
Re: #12495

### Changelog

* updateColorLate is rebundant, color and opacity will be applied in native
* UIOpacity add node condition to avoid child nodes are destroied earlier
* consistent interrupt opacities should be multiplied until a renderer appears 


-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
