### PR TITLE
refactor wescocketServer API from ondata to onmessage

### DIFF
--- a/native/cocos/bindings/manual/jsb_websocket.h
+++ b/native/cocos/bindings/manual/jsb_websocket.h
@@ -57,10 +57,4 @@ private:
 
 SE_DECLARE_FINALIZE_FUNC(WebSocket_finalize);
 
-SE_DECLARE_FUNC(WebSocket_constructor);
-
-SE_DECLARE_FUNC(WebSocket_send);
-
-SE_DECLARE_FUNC(WebSocket_close);
-
 bool register_all_websocket(se::Object *obj); // NOLINT (readability-identifier-naming)

--- a/native/cocos/bindings/manual/jsb_websocket_server.cpp
+++ b/native/cocos/bindings/manual/jsb_websocket_server.cpp
@@ -755,6 +755,7 @@ static bool WebSocketServer_Connection_ondata(se::State &s) { // NOLINT(readabil
             se::ScriptEngine::getInstance()->clearException();
         }
     });
+    SE_REPORT_ERROR("Deprecated callback function ondata since v3.7, please use onmessage to instead.");
     return true;
 }
 SE_BIND_PROP_SET(WebSocketServer_Connection_ondata)

--- a/native/cocos/bindings/manual/jsb_websocket_server.cpp
+++ b/native/cocos/bindings/manual/jsb_websocket_server.cpp
@@ -707,6 +707,7 @@ static bool WebSocketServer_Connection_onbinary(se::State &s) { // NOLINT(readab
 }
 SE_BIND_PROP_SET(WebSocketServer_Connection_onbinary)
 
+//deprecated since v3.7, please use WebSocketServer_Connection_onmessage to instead.
 static bool WebSocketServer_Connection_ondata(se::State &s) { // NOLINT(readability-identifier-naming)
     const auto &args = s.args();
     int argc = static_cast<int>(args.size());
@@ -724,7 +725,7 @@ static bool WebSocketServer_Connection_ondata(se::State &s) { // NOLINT(readabil
     s.thisObject()->setProperty("__ondata", args[0]);
     std::weak_ptr<cc::network::WebSocketServerConnection> connWeak = cobj;
 
-    cobj->setOnData([connWeak](const std::shared_ptr<cc::network::DataFrame> &text) {
+    cobj->setOnMessage([connWeak](const std::shared_ptr<cc::network::DataFrame> &text) {
         se::AutoHandleScope hs;
 
         auto connPtr = connWeak.lock();
@@ -757,6 +758,57 @@ static bool WebSocketServer_Connection_ondata(se::State &s) { // NOLINT(readabil
     return true;
 }
 SE_BIND_PROP_SET(WebSocketServer_Connection_ondata)
+
+static bool WebSocketServer_Connection_onmessage(se::State &s) { // NOLINT(readability-identifier-naming)
+    const auto &args = s.args();
+    int argc = static_cast<int>(args.size());
+    if (!(argc == 1 && args[0].isObject() && args[0].toObject()->isFunction())) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting 1 & function", argc);
+        return false;
+    }
+    auto cobj = sharedPtrObj<cc::network::WebSocketServerConnection>(s);
+
+    if (!cobj) {
+        SE_REPORT_ERROR("Connection is not constructed by WebSocketServer, invalidate format!!");
+        return false;
+    }
+
+    s.thisObject()->setProperty("__onmessage", args[0]);
+    std::weak_ptr<cc::network::WebSocketServerConnection> connWeak = cobj;
+
+    cobj->setOnMessage([connWeak](const std::shared_ptr<cc::network::DataFrame> &text) {
+        se::AutoHandleScope hs;
+
+        auto connPtr = connWeak.lock();
+        if (!connPtr) {
+            return;
+        }
+        auto *sobj = static_cast<se::Object *>(connPtr->getData());
+        if (!sobj) {
+            return;
+        }
+
+        se::Value callback;
+        if (!sobj->getProperty("__onmessage", &callback)) {
+            return;
+        }
+
+        se::ValueArray args;
+        if (text->isBinary()) {
+            se::Object *buffer = se::Object::createArrayBufferObject(text->getData(), text->size());
+            args.push_back(se::Value(buffer));
+        } else if (text->isString()) {
+            args.push_back(se::Value(text->toString()));
+        }
+        bool success = callback.toObject()->call(args, sobj, nullptr);
+        ;
+        if (!success) {
+            se::ScriptEngine::getInstance()->clearException();
+        }
+    });
+    return true;
+}
+SE_BIND_PROP_SET(WebSocketServer_Connection_onmessage)
 
 static bool WebSocketServer_Connection_headers(se::State &s) { // NOLINT(readability-identifier-naming)
     const auto &args = s.args();
@@ -855,7 +907,8 @@ bool register_all_websocket_server(se::Object *obj) {
     cls->defineProperty("onconnect", nullptr, _SE(WebSocketServer_Connection_onconnect));
     cls->defineProperty("onerror", nullptr, _SE(WebSocketServer_Connection_onerror));
     cls->defineProperty("onclose", nullptr, _SE(WebSocketServer_Connection_onclose));
-    cls->defineProperty("ondata", nullptr, _SE(WebSocketServer_Connection_ondata));
+    cls->defineProperty("ondata", nullptr, _SE(WebSocketServer_Connection_ondata)); //deprecated since v3.7, please use onmessage to instead.
+    cls->defineProperty("onmessage", nullptr, _SE(WebSocketServer_Connection_onmessage));
 
     cls->defineProperty("headers", _SE(WebSocketServer_Connection_headers), nullptr);
     cls->defineProperty("protocols", _SE(WebSocketServer_Connection_protocols), nullptr);

--- a/native/cocos/bindings/manual/jsb_websocket_server.h
+++ b/native/cocos/bindings/manual/jsb_websocket_server.h
@@ -49,7 +49,8 @@ SE_DECLARE_FUNC(WebSocketServer_Connection_onbinary);
 SE_DECLARE_FUNC(WebSocketServer_Connection_onconnect);
 SE_DECLARE_FUNC(WebSocketServer_Connection_onerror);
 SE_DECLARE_FUNC(WebSocketServer_Connection_onclose);
-SE_DECLARE_FUNC(WebSocketServer_Connection_ondata);
+SE_DECLARE_FUNC(WebSocketServer_Connection_ondata); // deprecated since v3.7, please use onmessage to instead.
+SE_DECLARE_FUNC(WebSocketServer_Connection_onmessage);
 
 SE_DECLARE_FUNC(WebSocketServer_Connection_headers);
 SE_DECLARE_FUNC(WebSocketServer_Connection_protocols);

--- a/native/cocos/bindings/manual/jsb_websocket_server.h
+++ b/native/cocos/bindings/manual/jsb_websocket_server.h
@@ -32,29 +32,5 @@ class Value;
 } // namespace se
 
 SE_DECLARE_FINALIZE_FUNC(WebSocketServer_finalize);
-SE_DECLARE_FUNC(WebSocketServer_constructor);
-SE_DECLARE_FUNC(WebSocketServer_listen);
-SE_DECLARE_FUNC(WebSocketServer_close);
-SE_DECLARE_FUNC(WebSocketServer_onconnection);
-SE_DECLARE_FUNC(WebSocketServer_onclose);
-SE_DECLARE_FUNC(WebSocketServer_connections);
-SE_DECLARE_FUNC(WebSocketServer_Connection_constructor);
-
-SE_DECLARE_FUNC(WebSocketServer_Connection_finalize);
-SE_DECLARE_FUNC(WebSocketServer_Connection_close);
-SE_DECLARE_FUNC(WebSocketServer_Connection_send);
-
-SE_DECLARE_FUNC(WebSocketServer_Connection_ontext);
-SE_DECLARE_FUNC(WebSocketServer_Connection_onbinary);
-SE_DECLARE_FUNC(WebSocketServer_Connection_onconnect);
-SE_DECLARE_FUNC(WebSocketServer_Connection_onerror);
-SE_DECLARE_FUNC(WebSocketServer_Connection_onclose);
-SE_DECLARE_FUNC(WebSocketServer_Connection_ondata); // deprecated since v3.7, please use onmessage to instead.
-SE_DECLARE_FUNC(WebSocketServer_Connection_onmessage);
-
-SE_DECLARE_FUNC(WebSocketServer_Connection_headers);
-SE_DECLARE_FUNC(WebSocketServer_Connection_protocols);
-SE_DECLARE_FUNC(WebSocketServer_Connection_protocol);
-SE_DECLARE_FUNC(WebSocketServer_Connection_readyState);
 
 bool register_all_websocket_server(se::Object *obj);

--- a/native/cocos/network/WebSocketServer.h
+++ b/native/cocos/network/WebSocketServer.h
@@ -152,8 +152,8 @@ public:
         _onbinary = cb;
     }
 
-    inline void setOnData(const std::function<void(std::shared_ptr<DataFrame>)> &cb) {
-        _ondata = cb;
+    inline void setOnMessage(const std::function<void(std::shared_ptr<DataFrame>)> &cb) {
+        _onmessage = cb;
     }
 
     inline void setOnConnect(const std::function<void()> &cb) {
@@ -180,8 +180,8 @@ private:
     }
 
     void onConnected();
-    void onDataReceive(void *in, int len);
-    int onDrainData();
+    void onMessageReceive(void *in, int len);
+    int onDrainMessage();
     void onHTTP();
     void onClientCloseInit(int code, const ccstd::string &msg);
 
@@ -201,7 +201,7 @@ private:
     std::function<void(const ccstd::string &)> _onerror;
     std::function<void(std::shared_ptr<DataFrame>)> _ontext;
     std::function<void(std::shared_ptr<DataFrame>)> _onbinary;
-    std::function<void(std::shared_ptr<DataFrame>)> _ondata;
+    std::function<void(std::shared_ptr<DataFrame>)> _onmessage;
     std::function<void()> _onconnect;
     std::function<void()> _onend;
     uv_async_t _async = {};


### PR DESCRIPTION
Reason:

- Consistent with the `onmessage` interface of WebSocket in Web API
![image](https://user-images.githubusercontent.com/18634782/186389907-3d5e7048-ef3b-422e-9f24-73d93f42043c.png)
- In areas related to websockets, the `message` concept is more acceptable than `data`
![image](https://user-images.githubusercontent.com/18634782/186390267-3e41b4fc-76b3-4e77-8678-fd50e21a711b.png)

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
