### PR TITLE
[waic-gfx] fix potential null context

### DIFF
--- a/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -235,6 +235,8 @@ void GLES2Device::doDestroy() {
 }
 
 void GLES2Device::acquire(Swapchain *const *swapchains, uint32_t count) {
+    _gpuContext->makeCurrent();
+
     if (_onAcquire) _onAcquire->execute();
 
     _swapchains.clear();

--- a/native/cocos/renderer/gfx-gles2/GLES2GPUContext.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2GPUContext.cpp
@@ -289,9 +289,17 @@ void GLES2GPUContext::bindContext(bool bound) {
 void GLES2GPUContext::makeCurrent(const GLES2GPUSwapchain *drawSwapchain, const GLES2GPUSwapchain *readSwapchain) {
     EGLSurface drawSurface = drawSwapchain ? drawSwapchain->eglSurface : _eglCurrentDrawSurface;
     EGLSurface readSurface = readSwapchain ? readSwapchain->eglSurface : _eglCurrentReadSurface;
-    if (_eglCurrentDrawSurface == drawSurface && _eglCurrentReadSurface == readSurface) return;
+    EGLContext prevContext = eglGetCurrentContext();
+
+    if (_eglCurrentDrawSurface == drawSurface && _eglCurrentReadSurface == readSurface && _eglCurrentContext == prevContext) {
+        return;
+    }
 
     makeCurrent(drawSurface, readSurface, _eglCurrentContext);
+    
+    if (prevContext != _eglCurrentContext) {
+        resetStates();
+    }
 }
 
 void GLES2GPUContext::present(const GLES2GPUSwapchain *swapchain) {

--- a/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -243,6 +243,8 @@ void GLES3Device::doDestroy() {
 }
 
 void GLES3Device::acquire(Swapchain *const *swapchains, uint32_t count) {
+    _gpuContext->makeCurrent();
+
     if (_onAcquire) _onAcquire->execute();
 
     _swapchains.clear();

--- a/native/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
@@ -297,9 +297,17 @@ void GLES3GPUContext::bindContext(bool bound) {
 void GLES3GPUContext::makeCurrent(const GLES3GPUSwapchain *drawSwapchain, const GLES3GPUSwapchain *readSwapchain) {
     EGLSurface drawSurface = drawSwapchain ? drawSwapchain->eglSurface : _eglCurrentDrawSurface;
     EGLSurface readSurface = readSwapchain ? readSwapchain->eglSurface : _eglCurrentReadSurface;
-    if (_eglCurrentDrawSurface == drawSurface && _eglCurrentReadSurface == readSurface) return;
+    EGLContext prevContext = eglGetCurrentContext();
+
+    if (_eglCurrentDrawSurface == drawSurface && _eglCurrentReadSurface == readSurface && _eglCurrentContext == prevContext) {
+        return;
+    }
 
     makeCurrent(drawSurface, readSurface, _eglCurrentContext);
+
+    if (prevContext != _eglCurrentContext) {
+        resetStates();
+    }
 }
 
 void GLES3GPUContext::present(const GLES3GPUSwapchain *swapchain) {


### PR DESCRIPTION
Some android activity might change EGLContext.
We need to call eglMakeCurrent as early as possible when EGLContext is changed.
In this pr, we will make context current, when calling device::acquire

### Changelog

* make context current when acquire swapchains.
* add context-change detection in makeCurrent 

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
