### PR TITLE
Android fix `find_pacakge` options

### DIFF
--- a/native/cmake/scripts/plugins_parser.js
+++ b/native/cmake/scripts/plugins_parser.js
@@ -191,10 +191,11 @@ console.log(`Engine version: ${read_engine_version()}`);
 
 /// Generate Pre-AutoLoadPlugins.cmake
 
-let output_lines = ["# plugins found & enabled in search path", "", ""];
+let output_lines = ["# plugins found & enabled in search path",
+    "# To disable automatic update of this file, set SKIP_SCAN_PLUGINS to ON.",
+    ""];
 for (let plugin_dir of cc_config_json_list) {
     let load_plugins = [];
-    let plugin_search_path = {};
     try {
         let maybe_plugin_name = path.basename(plugin_dir);
         console.log(`Parsing plugin directory ${maybe_plugin_name}`);
@@ -215,7 +216,6 @@ for (let plugin_dir of cc_config_json_list) {
             continue;
         }
         const packages = parse_package_dependency(cc_plugin_json);
-        const platform_plugin_dir = path.join(plugin_dir, PLATFORM_NAME_FROM_CMAKE);
         const cc_project_dir = path.dirname(plugin_cmake_output_file);
         let project_to_plugin_dir = path.relative(cc_project_dir, plugin_dir).replace(/\\/g, '/');
         project_to_plugin_dir = `\${CC_PROJECT_DIR}/${project_to_plugin_dir}`;
@@ -237,9 +237,9 @@ for (let plugin_dir of cc_config_json_list) {
             } else {
                 output_lines.push(`find_package(${plg[0]}`);
             }
+            output_lines.push(`  REQUIRED`);
             output_lines.push(`  NAMES "${plg[0]}"`);
-            output_lines.push(`  PATHS\n${plugin_root_path_for_platform.map(x => '    "' + x + '"').join("\n")}`);
-            output_lines.push(`  NO_DEFAULT_PATH`);
+            output_lines.push(`# NO_DEFAULT_PATH`);
             output_lines.push(`)`);
         }
         if (packages.length > 0) {

--- a/templates/cmake/common.cmake
+++ b/templates/cmake/common.cmake
@@ -77,11 +77,11 @@ function(cc_gen_plugin_cmake_hook)
     if("${NODE_EXECUTABLE}" STREQUAL "NODE_EXECUTABLE-NOTFOUND")
         message(STATUS "NodeJS is not found in $PATH, skip searching native plugins.")
     else()
-        message(STATUS " execute plugin_parser.js ${NODE_EXECUTABLE-NOTFOUND}")
-        execute_process(COMMAND ${NODE_EXECUTABLE} ${COCOS_X_PATH}/cmake/scripts/plugins_parser.js
-            ${plugin_args_info}
-            ${load_plugin_cmake}
-            ${PLATFORM_FOLDER}
+        message(STATUS " execute ${NODE_EXECUTABLE} plugin_parser.js")
+        execute_process(COMMAND ${NODE_EXECUTABLE} "${COCOS_X_PATH}/cmake/scripts/plugins_parser.js"
+            "${plugin_args_info}"
+            "${load_plugin_cmake}"
+            "${PLATFORM_FOLDER}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             )
     endif()


### PR DESCRIPTION
Re: #

### Changelog

`find_package` may fail under certain circumstances

* Remove `NO_DEFAULT_PATH` option

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
