### PR TITLE
fix the CHUNK_SIZE related crash by uploading huge buffers by chunk

### DIFF
--- a/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -1250,7 +1250,7 @@ void cmdFuncCCVKUpdateBuffer(CCVKDevice *device, CCVKGPUBuffer *gpuBuffer, const
         CCVKGPUBuffer stagingBuffer;
         stagingBuffer.size = chunkSizeToUpload;
         device->gpuStagingBufferPool()->alloc(&stagingBuffer);
-        memcpy(stagingBuffer.mappedData, (char*)dataToUpload + chunkOffset, chunkSizeToUpload);
+        memcpy(stagingBuffer.mappedData, static_cast<const char *>(dataToUpload) + chunkOffset, chunkSizeToUpload);
 
         VkBufferCopy region{
             stagingBuffer.startOffset,

--- a/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -1170,6 +1170,22 @@ void cmdFuncCCVKCreateGeneralBarrier(CCVKDevice * /*device*/, CCVKGPUGeneralBarr
     thsvsGetVulkanMemoryBarrier(gpuGeneralBarrier->barrier, &gpuGeneralBarrier->srcStageMask, &gpuGeneralBarrier->dstStageMask, &gpuGeneralBarrier->vkBarrier);
 }
 
+void bufferUpload(const CCVKGPUBuffer &stagingBuffer, CCVKGPUBuffer &gpuBuffer, VkBufferCopy region, const CCVKGPUCommandBuffer *gpuCommandBuffer) {
+#if BARRIER_DEDUCTION_LEVEL >= BARRIER_DEDUCTION_LEVEL_BASIC
+    if (gpuBuffer.transferAccess) {
+        // guard against WAW hazard
+        VkMemoryBarrier vkBarrier{VK_STRUCTURE_TYPE_MEMORY_BARRIER};
+        vkBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vkBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vkCmdPipelineBarrier(gpuCommandBuffer->vkCommandBuffer,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0, 1, &vkBarrier, 0, nullptr, 0, nullptr);
+    }
+#endif
+    vkCmdCopyBuffer(gpuCommandBuffer->vkCommandBuffer, stagingBuffer.vkBuffer, gpuBuffer.vkBuffer, 1, &region);
+};
+
 void cmdFuncCCVKUpdateBuffer(CCVKDevice *device, CCVKGPUBuffer *gpuBuffer, const void *buffer, uint32_t size, const CCVKGPUCommandBuffer *cmdBuffer) {
     if (!gpuBuffer) return;
 
@@ -1221,36 +1237,37 @@ void cmdFuncCCVKUpdateBuffer(CCVKDevice *device, CCVKGPUBuffer *gpuBuffer, const
         }
     }
 
-    CCVKGPUBuffer stagingBuffer;
-    stagingBuffer.size = sizeToUpload;
-    device->gpuStagingBufferPool()->alloc(&stagingBuffer);
-    memcpy(stagingBuffer.mappedData, dataToUpload, sizeToUpload);
+    // upload buffer by chunks
+    uint32_t chunkSize = sizeToUpload;
+    while (chunkSize > CCVKGPUStagingBufferPool::CHUNK_SIZE) {
+        chunkSize = utils::alignTo(chunkSize >> 1, 16U);
+    }
 
-    VkBufferCopy region{
-        stagingBuffer.startOffset,
-        gpuBuffer->getStartOffset(backBufferIndex),
-        sizeToUpload,
-    };
-    auto upload = [&stagingBuffer, &gpuBuffer, &region](const CCVKGPUCommandBuffer *gpuCommandBuffer) {
-#if BARRIER_DEDUCTION_LEVEL >= BARRIER_DEDUCTION_LEVEL_BASIC
-        if (gpuBuffer->transferAccess) {
-            // guard against WAW hazard
-            VkMemoryBarrier vkBarrier{VK_STRUCTURE_TYPE_MEMORY_BARRIER};
-            vkBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            vkBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            vkCmdPipelineBarrier(gpuCommandBuffer->vkCommandBuffer,
-                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                 0, 1, &vkBarrier, 0, nullptr, 0, nullptr);
+    uint32_t chunkOffset = 0U;
+    while (sizeToUpload) {
+        uint32_t chunkSizeToUpload = std::min(chunkSize, static_cast<uint32_t>(sizeToUpload));
+        sizeToUpload -= chunkSizeToUpload;
+        CCVKGPUBuffer stagingBuffer;
+        stagingBuffer.size = chunkSizeToUpload;
+        device->gpuStagingBufferPool()->alloc(&stagingBuffer);
+        memcpy(stagingBuffer.mappedData, (char*)dataToUpload + chunkOffset, chunkSizeToUpload);
+
+        VkBufferCopy region{
+            stagingBuffer.startOffset,
+            gpuBuffer->getStartOffset(backBufferIndex) + chunkOffset,
+            chunkSizeToUpload,
+        };
+
+        chunkOffset += chunkSizeToUpload;
+
+        if (cmdBuffer) {
+            bufferUpload(stagingBuffer, *gpuBuffer, region, cmdBuffer);
+        } else {
+            device->gpuTransportHub()->checkIn(
+                [&stagingBuffer, &gpuBuffer, region](CCVKGPUCommandBuffer *gpuCommandBuffer) {
+                    bufferUpload(stagingBuffer, *gpuBuffer, region, gpuCommandBuffer);
+                });
         }
-#endif
-        vkCmdCopyBuffer(gpuCommandBuffer->vkCommandBuffer, stagingBuffer.vkBuffer, gpuBuffer->vkBuffer, 1, &region);
-    };
-
-    if (cmdBuffer) {
-        upload(cmdBuffer);
-    } else {
-        device->gpuTransportHub()->checkIn(upload);
     }
 
     gpuBuffer->transferAccess = THSVS_ACCESS_TRANSFER_WRITE;


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/12501#issue-1345949158

### Changelog

* change the algorithm to upload buffer. Previously, VKbackend will upload the data directly using a single staging buffer, which may cause errors if the buffer's size is greater than the staging buffer's CHUNK_SIZE. This patch will upload huge buffers by chunk.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
