### PR TITLE
修复3D自定义粒子材质在2D上使用恢复回内置粒子问题

### DIFF
--- a/cocos/particle/renderer/particle-system-renderer-base.ts
+++ b/cocos/particle/renderer/particle-system-renderer-base.ts
@@ -44,6 +44,7 @@ export interface IParticleSystemRenderer {
     attachToScene (): void;
     detachFromScene (): void;
     updateMaterialParams (): void;
+    updateVertexAttrib (): void;
     setVertexAttributes (): void;
     updateRenderMode (): void;
     onMaterialModified (index: number, material: Material): void;
@@ -132,6 +133,7 @@ export abstract class ParticleSystemRendererBase implements IParticleSystemRende
 
     public setVertexAttributes () {
         if (this._model) {
+            this.updateVertexAttrib();
             this._model.setVertexAttributes(this._renderInfo!.renderMode === RenderMode.Mesh ? this._renderInfo!.mesh : null, this._vertAttrs);
         }
     }
@@ -158,6 +160,7 @@ export abstract class ParticleSystemRendererBase implements IParticleSystemRende
     public abstract getFreeParticle (): Particle | null;
     public abstract onMaterialModified (index: number, material: Material) : void;
     public abstract onRebuildPSO (index: number, material: Material) : void;
+    public abstract updateVertexAttrib (): void;
     public abstract updateRenderMode () : void;
     public abstract updateMaterialParams () : void;
     public abstract setNewParticle (p: Particle): void;

--- a/cocos/particle/renderer/particle-system-renderer-cpu.ts
+++ b/cocos/particle/renderer/particle-system-renderer-cpu.ts
@@ -26,7 +26,7 @@
 import { EDITOR } from 'internal:constants';
 import { builtinResMgr } from '../../core/builtin';
 import { Material } from '../../core/assets';
-import { AttributeName, Format, Attribute } from '../../core/gfx';
+import { AttributeName, Format, Attribute, FormatInfo, FormatInfos } from '../../core/gfx';
 import { Mat4, Vec2, Vec3, Vec4, pseudoRandom, Quat, random } from '../../core/math';
 import { RecyclePool } from '../../core/memop';
 import { MaterialInstance, IMaterialInstanceInfo } from '../../core/renderer/core/material-instance';
@@ -560,6 +560,51 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
         this._model!.addParticleVertexData(i, this._attrs);
     }
 
+    public updateVertexAttrib () {
+        if (this._renderInfo!.renderMode !== RenderMode.Mesh) {
+            return;
+        }
+        if (!this._useInstance) {
+            if (this._renderInfo!.mesh) {
+                const format = this._renderInfo!.mesh.readAttributeFormat(0, AttributeName.ATTR_COLOR);
+                if (format) {
+                    let type = Format.RGBA8;
+                    for (let i = 0; i < FormatInfos.length; ++i) {
+                        if (FormatInfos[i].name === format.name) {
+                            type = i;
+                            break;
+                        }
+                    }
+                    this._vertAttrs[7] = new Attribute(AttributeName.ATTR_COLOR1, type, true);
+                } else { // mesh without vertex color
+                    const type = Format.RGBA8;
+                    this._vertAttrs[7] = new Attribute(AttributeName.ATTR_COLOR1, type, true);
+                }
+            }
+        } else {
+            this._updateVertexAttribIns();
+        }
+    }
+
+    private _updateVertexAttribIns () {
+        if (this._renderInfo!.mesh) {
+            const format = this._renderInfo!.mesh.readAttributeFormat(0, AttributeName.ATTR_COLOR);
+            if (format) {
+                let type = Format.RGBA8;
+                for (let i = 0; i < FormatInfos.length; ++i) {
+                    if (FormatInfos[i].name === format.name) {
+                        type = i;
+                        break;
+                    }
+                }
+                this._vertAttrs[7] = new Attribute(AttributeName.ATTR_COLOR1, type, true, 1);
+            } else { // mesh without vertex color
+                const type = Format.RGBA8;
+                this._vertAttrs[7] = new Attribute(AttributeName.ATTR_COLOR1, type, true, 1);
+            }
+        }
+    }
+
     private _setVertexAttrib () {
         if (!this._useInstance) {
             switch (this._renderInfo!.renderMode) {
@@ -600,10 +645,6 @@ export default class ParticleSystemRendererCPU extends ParticleSystemRendererBas
         if (shareMaterial != null) {
             const effectName = shareMaterial._effectAsset._name;
             this._renderInfo!.mainTexture = shareMaterial.getProperty('mainTexture', 0);
-            // reset material
-            if (effectName.indexOf('builtin-particle') === -1 || effectName.indexOf('builtin-particle-gpu') !== -1) {
-                ps.setMaterial(null, 0);
-            }
         }
 
         if (ps.sharedMaterial == null && this._defaultMat == null) {

--- a/cocos/particle/renderer/particle-system-renderer-data.ts
+++ b/cocos/particle/renderer/particle-system-renderer-data.ts
@@ -32,7 +32,7 @@ import ParticleSystemRendererGPU from './particle-system-renderer-gpu';
 import { director } from '../../core/director';
 import { Device, Feature, Format, FormatFeatureBit } from '../../core/gfx';
 import { legacyCC } from '../../core/global-exports';
-import { errorID, warnID } from '../../core';
+import { errorID } from '../../core';
 
 function isSupportGPUParticle () {
     const device: Device = director.root!.device;
@@ -170,7 +170,6 @@ export default class ParticleSystemRenderer {
         } else {
             const effectName = val.effectName;
             if (effectName.indexOf('particle') === -1 || effectName.indexOf('particle-gpu') !== -1) {
-                warnID(6035);
                 return;
             }
         }
@@ -199,7 +198,6 @@ export default class ParticleSystemRenderer {
         } else {
             const effectName = val.effectName;
             if (effectName.indexOf('particle-gpu') === -1) {
-                warnID(6035);
                 return;
             }
         }
@@ -310,9 +308,9 @@ export default class ParticleSystemRenderer {
             errorID(6034);
         }
         if (!this._useGPU) {
-            this.cpuMaterial = this.particleMaterial;
+            this.cpuMaterial = this._cpuMaterial;
         } else {
-            this.gpuMaterial = this.particleMaterial;
+            this.gpuMaterial = this._gpuMaterial;
         }
     }
 


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/13759

### Changelog

* Fix the problem of 3D custom particle materials reverting back to built-in particles when used on 2D
