### PR TITLE
Set time before load ended

### DIFF
--- a/native/cocos/audio/apple/AudioEngine-inl.mm
+++ b/native/cocos/audio/apple/AudioEngine-inl.mm
@@ -569,6 +569,8 @@ bool AudioEngineImpl::setCurrentTime(int audioID, float time) {
 
     do {
         if (!player->_ready) {
+            player->_timeDirty = true;
+            player->_currTime = time;
             break;
         }
 

--- a/native/cocos/audio/apple/AudioEngine-inl.mm
+++ b/native/cocos/audio/apple/AudioEngine-inl.mm
@@ -569,6 +569,7 @@ bool AudioEngineImpl::setCurrentTime(int audioID, float time) {
 
     do {
         if (!player->_ready) {
+            std::lock_guard<std::mutex> lck(player->_play2dMutex);// To prevent the race condition
             player->_timeDirty = true;
             player->_currTime = time;
             break;

--- a/native/cocos/audio/apple/AudioPlayer.mm
+++ b/native/cocos/audio/apple/AudioPlayer.mm
@@ -167,6 +167,9 @@ bool AudioPlayer::play2d() {
                 CHECK_AL_ERROR_DEBUG();
             }
         } else {
+            if (_currTime > _audioCache->_duration) {
+                _currTime = 0.F; // Target current start time is invalid, reset to 0.
+            }
             alGenBuffers(QUEUEBUFFER_NUM, _bufferIds);
 
             auto alError = alGetError();

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -443,6 +443,8 @@ bool AudioEngineImpl::setCurrentTime(int audioID, float time) {
 
     do {
         if (!player->_ready) {
+            player->_timeDirty = true;
+            player->_currTime = time;
             break;
         }
 

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 #include "audio/common/decoder/AudioDecoder.h"
 #include "base/Log.h"
 #include "base/Utils.h"
@@ -443,6 +444,7 @@ bool AudioEngineImpl::setCurrentTime(int audioID, float time) {
 
     do {
         if (!player->_ready) {
+            std::lock_guard<std::mutex> lck(player->_play2dMutex);// To prevent the race condition
             player->_timeDirty = true;
             player->_currTime = time;
             break;

--- a/native/cocos/audio/oalsoft/AudioPlayer.cpp
+++ b/native/cocos/audio/oalsoft/AudioPlayer.cpp
@@ -221,7 +221,6 @@ bool AudioPlayer::play2d() {
 void AudioPlayer::rotateBufferThread(int offsetFrame) {
     char *tmpBuffer = nullptr;
     AudioDecoder *decoder = AudioDecoderManager::createDecoder(_audioCache->_fileFullPath.c_str());
-    CC_LOG_DEBUG("rotate buffer thread start, id %d with address %p time is dirty? %d, curtime %f", _id, this, _timeDirty, _currTime);
     do {
         BREAK_IF(decoder == nullptr || !decoder->open(_audioCache->_fileFullPath.c_str()));
 

--- a/native/cocos/audio/oalsoft/AudioPlayer.cpp
+++ b/native/cocos/audio/oalsoft/AudioPlayer.cpp
@@ -154,6 +154,9 @@ bool AudioPlayer::play2d() {
                 CHECK_AL_ERROR_DEBUG();
             }
         } else {
+            if (_currTime > _audioCache->_duration) {
+                _currTime = 0.F; // Target current start time is invalid, reset to 0.
+            }
             alGenBuffers(3, _bufferIds);
 
             auto alError = alGetError();
@@ -218,6 +221,7 @@ bool AudioPlayer::play2d() {
 void AudioPlayer::rotateBufferThread(int offsetFrame) {
     char *tmpBuffer = nullptr;
     AudioDecoder *decoder = AudioDecoderManager::createDecoder(_audioCache->_fileFullPath.c_str());
+    CC_LOG_DEBUG("rotate buffer thread start, id %d with address %p time is dirty? %d, curtime %f", _id, this, _timeDirty, _currTime);
     do {
         BREAK_IF(decoder == nullptr || !decoder->open(_audioCache->_fileFullPath.c_str()));
 


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/12673, https://github.com/cocos/3d-tasks/issues/8760, 

### Changelog

* Now if the player is not ready, the properties will be set but be detected when truly playing.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
