### PR TITLE
fixed #12151: [optimization] Functions in se::State should be inlined

### DIFF
--- a/.github/workflows/native-unit-test.yml
+++ b/.github/workflows/native-unit-test.yml
@@ -1,4 +1,4 @@
-name: <Native> Run Tests
+name: <Native> Run Unit Tests
 
 on:
   pull_request:

--- a/native/cocos/bindings/jswrapper/State.cpp
+++ b/native/cocos/bindings/jswrapper/State.cpp
@@ -25,7 +25,6 @@
 ****************************************************************************/
 
 #include "State.h"
-#include "Object.h"
 
 namespace se {
 
@@ -48,24 +47,4 @@ State::~State() {
     SAFE_DEC_REF(_thisObject);
 }
 
-void *State::nativeThisObject() const {
-    return _thisObject != nullptr ? _thisObject->getPrivateData() : nullptr;
-}
-
-Object *State::thisObject() {
-    // _nativeThisObject in Static method will be nullptr
-    //        assert(_thisObject != nullptr);
-    return _thisObject;
-}
-
-const ValueArray &State::args() const {
-    if (_args != nullptr) {
-        return *(_args);
-    }
-    return EmptyValueArray;
-}
-
-Value &State::rval() {
-    return _retVal;
-}
 } // namespace se

--- a/native/cocos/bindings/jswrapper/State.h
+++ b/native/cocos/bindings/jswrapper/State.h
@@ -52,10 +52,7 @@ public:
          *  @return The arguments of native binding functions or accesstors.
          */
     inline const ValueArray &args() const {
-        if (_args != nullptr) {
-            return *(_args);
-        }
-        return EmptyValueArray;
+        return _args != nullptr ? (*_args) : EmptyValueArray;
     }
 
     /**

--- a/native/cocos/bindings/jswrapper/State.h
+++ b/native/cocos/bindings/jswrapper/State.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
+#include "Object.h"
 #include "PrivateObject.h"
 #include "Value.h"
-#include "Object.h"
 
 namespace se {
 

--- a/native/cocos/bindings/jswrapper/State.h
+++ b/native/cocos/bindings/jswrapper/State.h
@@ -28,6 +28,7 @@
 
 #include "PrivateObject.h"
 #include "Value.h"
+#include "Object.h"
 
 namespace se {
 
@@ -42,25 +43,40 @@ public:
          *  @brief Gets void* pointer of `this` object's private data.
          *  @return A void* pointer of `this` object's private data.
          */
-    void *nativeThisObject() const;
+    inline void *nativeThisObject() const {
+        return _thisObject != nullptr ? _thisObject->getPrivateData() : nullptr;
+    }
 
     /**
          *  @brief Gets the arguments of native binding functions or accesstors.
          *  @return The arguments of native binding functions or accesstors.
          */
-    const ValueArray &args() const;
+    inline const ValueArray &args() const {
+        if (_args != nullptr) {
+            return *(_args);
+        }
+        return EmptyValueArray;
+    }
 
     /**
          *  @brief Gets the JavaScript `this` object wrapped in se::Object.
          *  @return The JavaScript `this` object wrapped in se::Object.
          */
-    Object *thisObject();
+    inline Object *thisObject() const {
+        return _thisObject;
+    }
 
     /**
          *  @brief Gets the return value reference. Used for setting return value for a function.
          *  @return The return value reference.
          */
-    Value &rval();
+    inline const Value &rval() const {
+        return _retVal;
+    }
+
+    inline Value &rval() {
+        return _retVal;
+    }
 
     // Private API used in wrapper
     /**


### PR DESCRIPTION
Re: #12151

### Changelog

* fixed #12151: [optimization] Functions in se::State should be inlined

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
