### PR TITLE
3.6 genbindings abort on error

### DIFF
--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos-creator",
         "name": "engine-native-external",
-        "checkout": "v3.6.1-1"
+        "checkout": "v3.6.1-4"
     }
 }

--- a/native/tools/tojs/genbindings.py
+++ b/native/tools/tojs/genbindings.py
@@ -186,7 +186,11 @@ def main():
             command = '%s -W ignore %s %s -s %s -t %s -o %s -n %s' % (python_bin, generator_py, cfg, section, target, directory, filename)
             print ("command : %s" % (command))
             # tasks.append(_run_cmd(command))
-            _run_cmd(command).communicate()
+            popen = _run_cmd(command)
+            popen.communicate()
+            if popen.returncode != 0:
+                print ("Error: falied to generate bindings for '%s'" % (section))
+                sys.exit(popen.returncode)
 
         if len(sys.argv) > 2 and sys.argv[1] == '--config':
             for path in sys.argv[2:]:

--- a/native/tools/tojs/genbindings.py
+++ b/native/tools/tojs/genbindings.py
@@ -189,7 +189,7 @@ def main():
             popen = _run_cmd(command)
             popen.communicate()
             if popen.returncode != 0:
-                print ("Error: falied to generate bindings for '%s'" % (section))
+                print ("Error: failed to generate bindings for '%s'" % (section))
                 sys.exit(popen.returncode)
 
         if len(sys.argv) > 2 and sys.argv[1] == '--config':


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
