### PR TITLE
Implement Vec3.slerp to support spherical interpolation between directional vectors

### DIFF
--- a/cocos/core/math/vec3.ts
+++ b/cocos/core/math/vec3.ts
@@ -1133,18 +1133,19 @@ export function v3 (x?: number | Vec3, y?: number, z?: number) {
  * Chooses an arbitrary unit vector that is perpendicular to input.
  */
 function chooseAnyPerpendicular (out: Vec3, v: Readonly<Vec3>) {
+    const { x, y, z } = v;
     // 1. Drop the component with minimal magnitude.
     // 2. Negate one of the remain components.
     // 3. Swap the remain components.
-    const absX = Math.abs(v.x);
-    const absY = Math.abs(v.y);
-    const absZ = Math.abs(v.z);
+    const absX = Math.abs(x);
+    const absY = Math.abs(y);
+    const absZ = Math.abs(z);
     if (absX < absY && absX < absZ) {
-        Vec3.set(out, 0.0, absZ, -absY);
+        Vec3.set(out, 0.0, z, -y);
     } else if (absY < absZ) {
-        Vec3.set(out, absZ, 0.0, -absX);
+        Vec3.set(out, z, 0.0, -x);
     } else {
-        Vec3.set(out, absY, -absX, 0.0);
+        Vec3.set(out, y, -x, 0.0);
     }
     return Vec3.normalize(out, out);
 }

--- a/cocos/core/math/vec3.ts
+++ b/cocos/core/math/vec3.ts
@@ -1132,31 +1132,22 @@ export function v3 (x?: number | Vec3, y?: number, z?: number) {
 /**
  * Chooses an arbitrary unit vector that is perpendicular to input.
  */
-const chooseAnyPerpendicular = (() => {
-    const cacheV = new Vec3();
-    return (out: Vec3, v: Readonly<Vec3>) => {
-        // https://math.stackexchange.com/a/413235
-        const EPSILON = 1e-5;
-        if (!approx(v.x, 0.0, EPSILON)) {
-            // Select n = y.
-            cacheV.y = v.x;
-            cacheV.x = -v.y;
-            cacheV.z = 0.0;
-        } else if (!approx(v.y, 0.0, EPSILON)) {
-            // Select n = x.
-            cacheV.x = v.y;
-            cacheV.y = -v.x;
-            cacheV.z = 0.0;
-        } else {
-            // Select n = y.
-            cacheV.y = v.z;
-            cacheV.z = -v.y;
-            cacheV.x = 0.0;
-        }
-        Vec3.normalize(out, cacheV);
-        return out;
-    };
-})();
+function chooseAnyPerpendicular (out: Vec3, v: Readonly<Vec3>) {
+    // 1. Drop the component with minimal magnitude.
+    // 2. Negate one of the remain components.
+    // 3. Swap the remain components.
+    const absX = Math.abs(v.x);
+    const absY = Math.abs(v.y);
+    const absZ = Math.abs(v.z);
+    if (absX < absY && absX < absZ) {
+        Vec3.set(out, 0.0, absZ, -absY);
+    } else if (absY < absZ) {
+        Vec3.set(out, absZ, 0.0, -absX);
+    } else {
+        Vec3.set(out, absY, -absX, 0.0);
+    }
+    return Vec3.normalize(out, out);
+}
 
 /**
  * Rotates `input` around `axis` for `angle` radians.


### PR DESCRIPTION
Re: #

### Changelog

* Implement `Vec3.slerp` to support spherical interpolation between directional vectors.

See:

- Slerp on wiki: https://en.wikipedia.org/wiki/Slerp

- Unity's API: https://docs.unity3d.com/ScriptReference/Vector3.Slerp.html

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [x] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
