### PR TITLE
fix: EventTouch.getAllTouches() not include changedTouches when touch end

### DIFF
--- a/cocos/input/input.ts
+++ b/cocos/input/input.ts
@@ -268,7 +268,7 @@ export class Input {
             return;
         }
         const changedTouches = [touch];
-        const eventTouch = new EventTouch(changedTouches, false, eventType, changedTouches);
+        const eventTouch = new EventTouch(changedTouches, false, eventType, (eventType === InputEventType.TOUCH_END ? [] : changedTouches));
         if (eventType === InputEventType.TOUCH_END) {
             touchManager.releaseTouch(touchID);
         }


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/12387
