### PR TITLE
improve: update engine to support xr development

### DIFF
--- a/cocos/ui/slider.ts
+++ b/cocos/ui/slider.ts
@@ -325,7 +325,7 @@ export class Slider extends Component {
         }
     }
 
-    protected _xrHandleProgress(point: Vec3) {
+    protected _xrHandleProgress (point: Vec3) {
         if (!this._touchHandle) {
             const uiTrans = this.node._uiProps.uiTransformComp!;
             uiTrans.convertToNodeSpaceAR(point, _tempPos);
@@ -337,7 +337,7 @@ export class Slider extends Component {
         }
     }
 
-    protected _xrClick(event: XrUIPressEvent) {
+    protected _xrClick (event: XrUIPressEvent) {
         if (!this._handle) {
             return;
         }
@@ -346,12 +346,12 @@ export class Slider extends Component {
         this._emitSlideEvent();
     }
 
-    protected _xrUnClick() {
+    protected _xrUnClick () {
         this._dragging = false;
         this._touchHandle = false;
     }
 
-    protected _xrHoverStay(event: XrUIPressEvent) {
+    protected _xrHoverStay (event: XrUIPressEvent) {
         if (!this._dragging) {
             return;
         }

--- a/cocos/ui/slider.ts
+++ b/cocos/ui/slider.ts
@@ -328,10 +328,11 @@ export class Slider extends Component {
     protected _xrHandleProgress(point: Vec3) {
         if (!this._touchHandle) {
             const uiTrans = this.node._uiProps.uiTransformComp!;
+            uiTrans.convertToNodeSpaceAR(point, _tempPos);
             if (this.direction === Direction.Horizontal) {
-                this.progress = clamp01(0.5 + (point.x - this.node.worldPosition.x) / (uiTrans.width * this.node.worldScale.x));
+                this.progress = clamp01(0.5 + (_tempPos.x - this.node.position.x) / uiTrans.width);
             } else {
-                this.progress = clamp01(0.5 + (point.y - this.node.worldPosition.y) / (uiTrans.height * this.node.worldScale.y));
+                this.progress = clamp01(0.5 + (_tempPos.y - this.node.position.y) / uiTrans.height);
             }
         }
     }

--- a/native/cocos/platform/interfaces/modules/XRCommon.h
+++ b/native/cocos/platform/interfaces/modules/XRCommon.h
@@ -48,6 +48,7 @@ enum class XRVendor {
     HUAWEIVR,
     PICO,
     ROKID,
+    SEED,
 };
 
 enum class XRConfigKey {

--- a/native/cocos/renderer/GFXDeviceManager.h
+++ b/native/cocos/renderer/GFXDeviceManager.h
@@ -85,7 +85,7 @@ public:
 
 #ifdef CC_USE_VULKAN
     #if XR_OEM_PICO
-        Device::SUPPORT_DETACH_DEVICE_THREAD = false;
+        Device::isSupportDetachDeviceThread = false;
     #endif
         if (tryCreate<CCVKDevice>(info, &device)) return device;
 #endif
@@ -96,7 +96,7 @@ public:
 
 #ifdef CC_USE_GLES3
     #if CC_USE_XR
-        Device::SUPPORT_DETACH_DEVICE_THREAD = false;
+        Device::isSupportDetachDeviceThread = false;
     #endif
         if (tryCreate<GLES3Device>(info, &device)) return device;
 #endif
@@ -111,7 +111,7 @@ public:
     }
 
     static bool isDetachDeviceThread() {
-        return DETACH_DEVICE_THREAD && Device::SUPPORT_DETACH_DEVICE_THREAD;
+        return DETACH_DEVICE_THREAD && Device::isSupportDetachDeviceThread;
     }
 
     static ccstd::string getGFXName() {

--- a/native/cocos/renderer/GFXDeviceManager.h
+++ b/native/cocos/renderer/GFXDeviceManager.h
@@ -64,13 +64,7 @@ namespace cc {
 namespace gfx {
 
 class CC_DLL DeviceManager final {
-#if CC_USE_XR && CC_USE_VULKAN && !XR_OEM_PICO
     static constexpr bool DETACH_DEVICE_THREAD{true};
-#elif CC_USE_XR
-    static constexpr bool DETACH_DEVICE_THREAD{false};
-#else
-    static constexpr bool DETACH_DEVICE_THREAD{true};
-#endif
     static constexpr bool FORCE_DISABLE_VALIDATION{false};
     static constexpr bool FORCE_ENABLE_VALIDATION{false};
 
@@ -90,6 +84,9 @@ public:
 #endif
 
 #ifdef CC_USE_VULKAN
+    #if XR_OEM_PICO
+        Device::SUPPORT_DETACH_DEVICE_THREAD = false;
+    #endif
         if (tryCreate<CCVKDevice>(info, &device)) return device;
 #endif
 
@@ -98,6 +95,9 @@ public:
 #endif
 
 #ifdef CC_USE_GLES3
+    #if CC_USE_XR
+        Device::SUPPORT_DETACH_DEVICE_THREAD = false;
+    #endif
         if (tryCreate<GLES3Device>(info, &device)) return device;
 #endif
 
@@ -110,8 +110,8 @@ public:
         return nullptr;
     }
 
-    static constexpr bool isDetachDeviceThread() {
-        return DETACH_DEVICE_THREAD;
+    static bool isDetachDeviceThread() {
+        return DETACH_DEVICE_THREAD && Device::SUPPORT_DETACH_DEVICE_THREAD;
     }
 
     static ccstd::string getGFXName() {
@@ -149,7 +149,7 @@ private:
     static bool tryCreate(const DeviceInfo &info, Device **pDevice) {
         Device *device = ccnew DeviceCtor;
 
-        if (DETACH_DEVICE_THREAD) {
+        if (isDetachDeviceThread()) {
             device = ccnew gfx::DeviceAgent(device);
         }
 

--- a/native/cocos/renderer/gfx-base/GFXDevice.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDevice.cpp
@@ -31,7 +31,7 @@ namespace cc {
 namespace gfx {
 
 Device *Device::instance = nullptr;
-bool Device::SUPPORT_DETACH_DEVICE_THREAD = true;
+bool Device::isSupportDetachDeviceThread = true;
 
 Device *Device::getInstance() {
     return Device::instance;

--- a/native/cocos/renderer/gfx-base/GFXDevice.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDevice.cpp
@@ -31,6 +31,7 @@ namespace cc {
 namespace gfx {
 
 Device *Device::instance = nullptr;
+bool Device::SUPPORT_DETACH_DEVICE_THREAD = true;
 
 Device *Device::getInstance() {
     return Device::instance;

--- a/native/cocos/renderer/gfx-base/GFXDevice.h
+++ b/native/cocos/renderer/gfx-base/GFXDevice.h
@@ -124,7 +124,7 @@ public:
 
 protected:
     static Device *instance;
-    static bool SUPPORT_DETACH_DEVICE_THREAD;
+    static bool isSupportDetachDeviceThread;
 
     friend class DeviceAgent;
     friend class DeviceValidator;

--- a/native/cocos/renderer/gfx-base/GFXDevice.h
+++ b/native/cocos/renderer/gfx-base/GFXDevice.h
@@ -124,6 +124,7 @@ public:
 
 protected:
     static Device *instance;
+    static bool SUPPORT_DETACH_DEVICE_THREAD;
 
     friend class DeviceAgent;
     friend class DeviceValidator;

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos-creator",
         "name": "engine-native-external",
-        "checkout": "v3.6.1-4"
+        "checkout": "v3.6.1-5"
     }
 }


### PR DESCRIPTION
1.Fixed slider moving in wrong direction
Use local coordinates for determination
2.fix: XR error opening thread detach
The build supports Vulkan and OpenGLES, but when the device does not support Vulkan, the XR platform cannot support thread detach
3.update xr common

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
