### PR TITLE
Fix repeated calls for render-component onEnabled

### DIFF
--- a/cocos2d/core/component-scheduler.js
+++ b/cocos2d/core/component-scheduler.js
@@ -319,7 +319,7 @@ var ComponentScheduler = cc.Class({
             var array = iterator.array;
             for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
                 let comp = array[iterator.i];
-                if (comp._enabled) {
+                if (comp._enabled && !(comp._objFlags & IsOnEnableCalled)) {
                     callOnEnableInTryCatch(comp);
                     var deactivatedDuringOnEnable = !comp.node._activeInHierarchy;
                     if (!deactivatedDuringOnEnable) {
@@ -332,7 +332,7 @@ var ComponentScheduler = cc.Class({
             var array = iterator.array;
             for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
                 let comp = array[iterator.i];
-                if (comp._enabled) {
+                if (comp._enabled && !(comp._objFlags & IsOnEnableCalled)) {
                     comp.onEnable();
                     var deactivatedDuringOnEnable = !comp.node._activeInHierarchy;
                     if (!deactivatedDuringOnEnable) {


### PR DESCRIPTION
修复当用户脚本在 onLoad 触发了某个渲染组件的 enabled 为 true 时，会使该组件重复触发了多次 onEnabled，导致出现组件显示效果错误的问题

测试用例：
[https-::github.com:cocos:cocos-engine:pull:12737 测试用例.zip](https://github.com/cocos/cocos-engine/files/9553162/https-.github.com.cocos.cocos-engine.pull.12737.zip)


正确效果：
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/7564028/189797235-6b26a57b-409a-4eef-9518-6c1bb6bdf912.png">

当前效果：
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/7564028/189797290-84dbe924-774f-44cc-a057-696999078b0e.png">

