### PR TITLE
[v3.6.2-pipeline] add RenderQueue custom ability to classic pipeline

### DIFF
--- a/cocos/core/pipeline/forward/forward-stage.ts
+++ b/cocos/core/pipeline/forward/forward-stage.ts
@@ -92,6 +92,20 @@ export class ForwardStage extends RenderStage {
         this._uiPhase = new UIPhase();
     }
 
+    public addRenderInstancedQueue (queue: RenderInstancedQueue) {
+        if (this.additiveInstanceQueues.includes(queue)) {
+            return;
+        }
+        this.additiveInstanceQueues.push(queue);
+    }
+
+    public removeRenderInstancedQueue (queue: RenderInstancedQueue) {
+        const index = this.additiveInstanceQueues.indexOf(queue);
+        if (index > -1) {
+            this.additiveInstanceQueues.splice(index, 1);
+        }
+    }
+
     public initialize (info: IRenderStageInfo): boolean {
         super.initialize(info);
         if (info.renderQueues) {
@@ -179,7 +193,7 @@ export class ForwardStage extends RenderStage {
             colors, camera.clearDepth, camera.clearStencil);
         cmdBuff.bindDescriptorSet(SetIndex.GLOBAL, pipeline.descriptorSet);
         this._renderQueues[0].recordCommandBuffer(device, renderPass, cmdBuff);
-        
+
         for (let i = 0; i < this.additiveInstanceQueues.length; i++) {
             this.additiveInstanceQueues[i].recordCommandBuffer(device, renderPass, cmdBuff);
         }


### PR DESCRIPTION
Add render queue customization ability to classic pipeline, which is needed for demo.
This ability will be supported in custom pipeline


### Changelog

* added `addRenderInstancedQueue` and `removeRenderInstancedQueue` in forward-stage.ts.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
