### PR TITLE
auto-assign generated PR

### DIFF
--- a/.github/workflows/jsonr.js
+++ b/.github/workflows/jsonr.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+
+// read json from stdin
+
+let buffer = Buffer.alloc(0);
+const args = process.argv.slice(2);
+
+function getAttrByPath(object, pathText) {
+    const parts = pathText.split('.');
+    let curr = object;
+    const REG1 = /\["(\w+)"\]/;
+    const REG2 = /\[(\w+)\]/;
+    const REG3 = /"(\w+)"/;
+    const REG4 = /(\w+)/;
+    const regList = [REG1, REG2, REG3, REG4];
+    for (const p of parts) {
+        let mat;
+        let field = null;
+        for (let r of regList) {
+            mat = p.match(r);
+            if (mat) {
+                field = mat[1];
+                break;
+            }
+        }
+        if (!field) {
+            console.error(`path component "${p}" is invalidate from ${pathText}`);
+            process.exit(1);
+        }
+        curr = curr[field];
+    }
+    return curr;
+}
+
+
+process.stdin.resume();
+
+process.stdin.on('data', data => {
+    buffer = Buffer.concat([buffer, data]);
+}).on('end', () => {
+    const data = JSON.parse(buffer.toString('utf8'))
+    let value = getAttrByPath(data, args[0]);
+    if(args.length >= 2) {
+        const mat = value.match(new RegExp(args[1]));
+        if(mat) {
+            value = mat[args[2]];
+        }
+    }
+    console.log(value);
+});

--- a/.github/workflows/native-generated-pr.yml
+++ b/.github/workflows/native-generated-pr.yml
@@ -1,0 +1,43 @@
+name: <Native> Assign Generated PR
+
+# on:
+  # pull_request_target:
+    # types: [opened]
+    # paths:
+    # - 'native/cocos/bindings/auto/**'
+
+on: pull_request_target
+
+jobs:
+  auto-assign:
+    if: 
+      (contains(github.event.pull_request.body, 'Automated PR to genbindings'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update assignees
+        id: merger
+        env:
+          PR_NUMBER: ${{github.event.number}}
+          # REPO_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # REPO_TOKEN: ${{secrets.PR_TOKEN}}
+          REPO_TOKEN: ${{secrets.LABEL_TOKEN}}
+        run: |
+          SRC_PR=`curl ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits | \
+            sh -c 'node ./.github/workflows/jsonr.js [0].commit.message "\(#(\w+)\)" 1'`
+          echo "Source PR:        ${SRC_PR}"
+          SRC_MERGER=`curl -H "Accept: application/vnd.github+json" ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${SRC_PR} | \
+            sh -c 'node ./.github/workflows/jsonr.js merged_by.login'`
+          echo "Source PR merger: ${SRC_MERGER}"
+          echo "Token Length:     ${#REPO_TOKEN}"
+          echo ::set-output name=SRC_MERGER::${SRC_MERGER}
+          curl -X POST -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token $REPO_TOKEN" \
+            ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/assignees \
+            -d '{"assignees":["${SRC_MERGER}"]}'
+          exit 0
+      # - name: Assignment
+      #   uses: PatriceJiang/auto-assignment@v1
+      #   with:
+      #     token: ${{ secrets.LABEL_TOKEN }}
+      #     users: '["${{steps.merger.outputs.SRC_MERGER}}"]'


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/12292

### Changelog

* Assign generated PR to referenced merger

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
