### PR TITLE
fix: touch issue on retina display

### DIFF
--- a/native/cocos/core/Root.cpp
+++ b/native/cocos/core/Root.cpp
@@ -103,17 +103,14 @@ scene::RenderWindow *Root::createRenderWindowFromSystemWindow(ISystemWindow *win
     if (!window) {
         return nullptr;
     }
-
-    auto *screen = CC_GET_PLATFORM_INTERFACE(IScreen);
-    float pixelRatio = screen->getDevicePixelRatio();
-
+    
     uint32_t windowId = window->getWindowId();
     auto handle = window->getWindowHandle();
     const auto &size = window->getViewSize();
 
     gfx::SwapchainInfo info;
-    info.width = static_cast<uint32_t>(size.x) * pixelRatio;
-    info.height = static_cast<uint32_t>(size.y) * pixelRatio;
+    info.width = static_cast<uint32_t>(size.x);
+    info.height = static_cast<uint32_t>(size.y);
     info.windowHandle = reinterpret_cast<void *>(handle);
     info.windowId = window->getWindowId();
 

--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -25,6 +25,8 @@
 
 #include "platform/ios/modules/SystemWindow.h"
 #import <UIKit/UIKit.h>
+#include "platform/BasePlatform.h"
+#include "platform/interfaces/modules/IScreen.h"
 
 namespace cc {
 
@@ -52,8 +54,9 @@ uintptr_t SystemWindow::getWindowHandle() const {
 }
 
 SystemWindow::Size SystemWindow::getViewSize() const {
+    auto dpr = BasePlatform::getPlatform()->getInterface<IScreen>()->getDevicePixelRatio();
     CGRect bounds = [[UIScreen mainScreen] bounds];
-    return Size{static_cast<float>(bounds.size.width), static_cast<float>(bounds.size.height)};
+    return Size{static_cast<float>(bounds.size.width * dpr), static_cast<float>(bounds.size.height * dpr)};
 }
 
 } // namespace cc

--- a/native/cocos/platform/mac/modules/SystemWindow.mm
+++ b/native/cocos/platform/mac/modules/SystemWindow.mm
@@ -26,6 +26,8 @@
 #include "platform/mac/modules/SystemWindow.h"
 #import <AppKit/AppKit.h>
 #include "platform/mac/AppDelegate.h"
+#include "platform/BasePlatform.h"
+#include "platform/interfaces/modules/IScreen.h"
 
 namespace cc {
 
@@ -40,26 +42,30 @@ SystemWindow::~SystemWindow() = default;
 
 bool SystemWindow::createWindow(const char *title,
                                 int w, int h, int flags) {
-    _width = w;
-    _height = h;
     AppDelegate *delegate = [[NSApplication sharedApplication] delegate];
     NSString *aString = [NSString stringWithUTF8String:title];
     _window = [delegate createLeftBottomWindow:aString width:w height:h];
     NSView *view = [_window contentView];
     _windowHandle = reinterpret_cast<uintptr_t>(view);
+    
+    auto dpr = BasePlatform::getPlatform()->getInterface<IScreen>()->getDevicePixelRatio();
+    _width  = w * dpr;
+    _height = h * dpr;
     return true;
 }
 
 bool SystemWindow::createWindow(const char *title,
                                 int x, int y, int w,
                                 int h, int flags) {
-    _width = w;
-    _height = h;
     AppDelegate *delegate = [[NSApplication sharedApplication] delegate];
     NSString *aString = [NSString stringWithUTF8String:title];
     _window = [delegate createWindow:aString xPos:x yPos:y width:w height:h];
     NSView *view = [_window contentView];
     _windowHandle = reinterpret_cast<uintptr_t>(view);
+    
+    auto dpr = BasePlatform::getPlatform()->getInterface<IScreen>()->getDevicePixelRatio();
+    _width  = w * dpr;
+    _height = h * dpr;
     return true;
 }
 


### PR DESCRIPTION
(cherry picked from commit d5894fdafe122414e2a69dbd242c627c7f7cfd9c)

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
