### PR TITLE
Fix primitive.scale

### DIFF
--- a/cocos/primitive/transform.ts
+++ b/cocos/primitive/transform.ts
@@ -69,9 +69,9 @@ export function translate (geometry: IGeometry, offset: { x?: number; y?: number
  * @param value @zh 缩放量。@en The scaling size
  */
 export function scale (geometry: IGeometry, value: { x?: number; y?: number; z?: number }) {
-    const x = value.x || 0;
-    const y = value.y || 0;
-    const z = value.z || 0;
+    const x = value.x ?? 1.0;
+    const y = value.y ?? 1.0;
+    const z = value.z ?? 1.0;
     const nVertex = Math.floor(geometry.positions.length / 3);
     for (let iVertex = 0; iVertex < nVertex; ++iVertex) {
         const iX = iVertex * 3;
@@ -81,17 +81,35 @@ export function scale (geometry: IGeometry, value: { x?: number; y?: number; z?:
         geometry.positions[iY] *= y;
         geometry.positions[iZ] *= z;
     }
-    if (geometry.minPos) {
-        geometry.minPos.x *= x;
-        geometry.minPos.y *= y;
-        geometry.minPos.z *= z;
+    const {
+        minPos,
+        maxPos,
+    } = geometry;
+    if (minPos) {
+        minPos.x *= x;
+        minPos.y *= y;
+        minPos.z *= z;
     }
-    if (geometry.maxPos) {
-        geometry.maxPos.x *= x;
-        geometry.maxPos.y *= y;
-        geometry.maxPos.z *= z;
+    if (maxPos) {
+        maxPos.x *= x;
+        maxPos.y *= y;
+        maxPos.z *= z;
     }
-    geometry.boundingRadius = Math.max(Math.max(x, y), z);
+    if (minPos && maxPos) {
+        // Negative scaling causes min-max to be flipped.
+        if (x < 0) {
+            const tmp = minPos.x; minPos.x = maxPos.x; maxPos.x = tmp;
+        }
+        if (y < 0) {
+            const tmp = minPos.y; minPos.y = maxPos.y; maxPos.y = tmp;
+        }
+        if (z < 0) {
+            const tmp = minPos.z; minPos.z = maxPos.z; maxPos.z = tmp;
+        }
+    }
+    if (typeof geometry.boundingRadius !== 'undefined') {
+        geometry.boundingRadius *= Math.max(Math.max(Math.abs(x), Math.abs(y)), Math.abs(z));
+    }
     return geometry;
 }
 

--- a/cocos/primitive/transform.ts
+++ b/cocos/primitive/transform.ts
@@ -96,7 +96,7 @@ export function scale (geometry: IGeometry, value: { x?: number; y?: number; z?:
         maxPos.z *= z;
     }
     if (minPos && maxPos) {
-        // Negative scaling causes min-max to be flipped.
+        // Negative scaling causes min-max to be swapped.
         if (x < 0) {
             const tmp = minPos.x; minPos.x = maxPos.x; maxPos.x = tmp;
         }

--- a/tests/primitive/transform.test.ts
+++ b/tests/primitive/transform.test.ts
@@ -1,0 +1,21 @@
+import { IGeometry } from '../../cocos/primitive/define';
+import { scale } from '../../cocos/primitive/transform';
+import '../utils/matcher-deep-close-to';
+
+test('Scaling', () => {
+    expect(scale({ positions: [2.0, 3.0, 4.0] }, { x: 1.2, })).toBeDeepCloseTo({
+        positions: [2.4, 3.0, 4.0],
+    });
+
+    expect(scale({
+        positions: [2.0, 3.0, 4.0],
+        minPos: { x: -1.0, y: -2.0, z: -3.0 },
+        maxPos: { x: 2.0, y: 3.2, z: 4.4 },
+        boundingRadius: 6.6,
+    }, { x: 1.2, y: 1.3, z: -3.0 })).toBeDeepCloseTo({
+        positions: [2.0 * 1.2, 3.0 * 1.3, 4.0 * -3.0],
+        minPos: { x: -1.0 * 1.2, y: -2.0 * 1.3, z: 4.4 * -3.0 },
+        maxPos: { x: 2.0 * 1.2, y: 3.2 * 1.3, z: -3.0 * -3.0 },
+        boundingRadius: 6.6 * 3.0,
+    });
+});


### PR DESCRIPTION
Re: #

### Changelog

* Fix bugs in `primitive.scale`.

Note, this PR introduce a breaking change: components that missed from `value` parameter would be interpreted as `1` instead of `0`. For example, the invocation `scale({ positions: [1.0, 2.0, 3.0] }, { y: 1.2 })` yields:

- `{ positions: [0.0, 2.4, 0.0] }` at before.

- `{ positions: [1.0, 2.4, 3.0] }` after this PR.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [x] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
