### PR TITLE
fix:CC_ASSERT(!_currentApp.expired()); in WebSocketServer

### DIFF
--- a/native/cocos/network/WebSocketServer.cpp
+++ b/native/cocos/network/WebSocketServer.cpp
@@ -93,11 +93,13 @@ void schedule_task_into_server_thread_task_queue(uv_async_t *asyn, std::function
 namespace cc {
 namespace network {
 
-#define RUN_IN_GAMETHREAD(task)                                                   \
-    do {                                                                          \
-        CC_CURRENT_ENGINE()->getScheduler()->performFunctionInCocosThread([=]() { \
-            task;                                                                 \
-        });                                                                       \
+#define RUN_IN_GAMETHREAD(task)                                                       \
+    do {                                                                              \
+        if (CC_CURRENT_APPLICATION()) {                                               \
+            CC_CURRENT_ENGINE()->getScheduler()->performFunctionInCocosThread([=]() { \
+                task;                                                                 \
+            });                                                                       \
+        }                                                                             \
     } while (0)
 
 #define DISPATCH_CALLBACK_IN_GAMETHREAD()                        \


### PR DESCRIPTION
application has destroyed when WebSocketServer process callback in game thread

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
