### PR TITLE
Change windowHandle to windowId when EVENT_DESTROY_WINDOW

### DIFF
--- a/native/cocos/bindings/event/EventDispatcher.cpp
+++ b/native/cocos/bindings/event/EventDispatcher.cpp
@@ -405,8 +405,7 @@ void EventDispatcher::dispatchCloseEvent() {
 
 void EventDispatcher::dispatchDestroyWindowEvent() {
 #if CC_PLATFORM == CC_PLATFORM_WINDOWS
-    EventDispatcher::dispatchCustomEvent(EVENT_DESTROY_WINDOW, 1,
-                                         reinterpret_cast<void *>(CC_GET_MAIN_SYSTEM_WINDOW()->getWindowHandle()));
+    EventDispatcher::dispatchCustomEvent(EVENT_DESTROY_WINDOW, 1, ISystemWindow::mainWindowId);
 #else
     EventDispatcher::dispatchCustomEvent(EVENT_DESTROY_WINDOW, 0);
 #endif
@@ -414,7 +413,7 @@ void EventDispatcher::dispatchDestroyWindowEvent() {
 
 void EventDispatcher::dispatchDestroyWindowEvent(cc::ISystemWindow *window) {
 #if CC_PLATFORM == CC_PLATFORM_WINDOWS
-    EventDispatcher::dispatchCustomEvent(EVENT_DESTROY_WINDOW, 1, reinterpret_cast<void *>(window->getWindowHandle()));
+    EventDispatcher::dispatchCustomEvent(EVENT_DESTROY_WINDOW, 1, window->getWindowId());
 #else
     CC_UNUSED_PARAM(window);
     EventDispatcher::dispatchCustomEvent(EVENT_DESTROY_WINDOW, 0);
@@ -423,8 +422,7 @@ void EventDispatcher::dispatchDestroyWindowEvent(cc::ISystemWindow *window) {
 
 void EventDispatcher::dispatchRecreateWindowEvent() {
 #if CC_PLATFORM == CC_PLATFORM_WINDOWS
-    EventDispatcher::dispatchCustomEvent(EVENT_RECREATE_WINDOW, 1,
-                                         reinterpret_cast<void *>(CC_GET_MAIN_SYSTEM_WINDOW()->getWindowHandle()));
+    EventDispatcher::dispatchCustomEvent(EVENT_RECREATE_WINDOW, 1, ISystemWindow::mainWindowId);
 #else
     EventDispatcher::dispatchCustomEvent(EVENT_RECREATE_WINDOW, 0);
 #endif
@@ -432,8 +430,7 @@ void EventDispatcher::dispatchRecreateWindowEvent() {
 
 void EventDispatcher::dispatchRecreateWindowEvent(cc::ISystemWindow *window) {
 #if CC_PLATFORM == CC_PLATFORM_WINDOWS
-    auto windowId = static_cast<uintptr_t>(window->getWindowId());
-    EventDispatcher::dispatchCustomEvent(EVENT_RECREATE_WINDOW, 1, reinterpret_cast<void *>(windowId));
+    EventDispatcher::dispatchCustomEvent(EVENT_RECREATE_WINDOW, 1, window->getWindowId());
 #else
     CC_UNUSED_PARAM(window);
     EventDispatcher::dispatchCustomEvent(EVENT_RECREATE_WINDOW, 0);

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -60,6 +60,7 @@
 #include "core/assets/FreeTypeFont.h"
 #include "network/HttpClient.h"
 #include "platform/UniversalPlatform.h"
+#include "platform/interfaces/modules/IScreen.h"
 #include "platform/interfaces/modules/ISystemWindow.h"
 #include "platform/interfaces/modules/ISystemWindowManager.h"
 #if CC_USE_DEBUG_RENDERER
@@ -75,11 +76,12 @@ bool setCanvasCallback(se::Object * /*global*/) {
     auto *window = CC_GET_MAIN_SYSTEM_WINDOW();
     auto handler = window->getWindowHandle();
     auto viewSize = window->getViewSize();
-
+    auto dpr = cc::BasePlatform::getPlatform()->getInterface<cc::IScreen>()->getDevicePixelRatio();
+    
     std::stringstream ss;
     {
-        ss << "window.innerWidth = " << static_cast<int>(viewSize.x) << ";";
-        ss << "window.innerHeight = " << static_cast<int>(viewSize.y) << ";";
+        ss << "window.innerWidth = "  << static_cast<int>(viewSize.x / dpr) << ";";
+        ss << "window.innerHeight = " << static_cast<int>(viewSize.y / dpr) << ";";
         ss << "window.windowHandler = ";
         if (sizeof(handler) == 8) { // use bigint
             ss << static_cast<uint64_t>(handler) << "n;";

--- a/native/cocos/platform/android/AndroidPlatform.cpp
+++ b/native/cocos/platform/android/AndroidPlatform.cpp
@@ -343,7 +343,7 @@ public:
 
                     cc::CustomEvent event;
                     event.name = EVENT_RECREATE_WINDOW;
-                    event.args->ptrVal = reinterpret_cast<void *>(ISystemWindow::mainWindowId);
+                    event.args[0].intVal = ISystemWindow::mainWindowId;
                     _androidPlatform->dispatchEvent(event);
                 }
                 break;
@@ -358,7 +358,7 @@ public:
                 }
                 cc::CustomEvent event;
                 event.name = EVENT_DESTROY_WINDOW;
-                event.args->ptrVal = reinterpret_cast<void *>(_androidPlatform->_app->window);
+                event.args[0].intVal = ISystemWindow::mainWindowId;
                 _androidPlatform->dispatchEvent(event);
                 break;
             }

--- a/native/cocos/platform/android/jni/JniCocosSurfaceView.cpp
+++ b/native/cocos/platform/android/jni/JniCocosSurfaceView.cpp
@@ -121,7 +121,7 @@ JNIEXPORT void JNICALL Java_com_cocos_lib_CocosSurfaceView_onSurfaceCreatedNativ
         auto func = [sysWindow]() -> void {
             cc::CustomEvent event;
             event.name = EVENT_RECREATE_WINDOW;
-            event.args->ptrVal = reinterpret_cast<void *>(sysWindow->getWindowId());
+            event.args[0].intVal = sysWindow->getWindowId();
             auto *platform = static_cast<cc::AndroidPlatform *>(cc::BasePlatform::getPlatform());
             platform->dispatchEvent(event);
         };
@@ -159,7 +159,7 @@ JNIEXPORT void JNICALL Java_com_cocos_lib_CocosSurfaceView_onSurfaceChangedNativ
             auto func = [sysWindow]() -> void {
                 cc::CustomEvent event;
                 event.name = EVENT_RECREATE_WINDOW;
-                event.args->ptrVal = reinterpret_cast<void *>(sysWindow->getWindowId());
+                event.args[0].intVal = sysWindow->getWindowId();
                 auto *platform = static_cast<cc::AndroidPlatform *>(cc::BasePlatform::getPlatform());
                 platform->dispatchEvent(event);
             };
@@ -179,9 +179,12 @@ JNIEXPORT void JNICALL Java_com_cocos_lib_CocosSurfaceView_onSurfaceDestroyedNat
     // todo: destroy gfx surface
     auto func = [nativeWindow]() -> void {
         auto *platform = static_cast<cc::AndroidPlatform *>(cc::BasePlatform::getPlatform());
+        auto *windowMgr = platform->getInterface<cc::SystemWindowManager>();
+        cc::ISystemWindow *window = windowMgr->getWindowFromANativeWindow(nativeWindow);
+
         cc::CustomEvent event;
         event.name = EVENT_DESTROY_WINDOW;
-        event.args->ptrVal = reinterpret_cast<void *>(nativeWindow);
+        event.args[0].intVal = window->getWindowId();
         platform->dispatchEvent(event);
     };
     CC_CURRENT_ENGINE()->getScheduler()->performFunctionInCocosThread(func);

--- a/native/cocos/platform/java/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/java/modules/SystemWindowManager.cpp
@@ -42,10 +42,12 @@ void SystemWindowManager::swapWindows() {
 }
 
 ISystemWindow *SystemWindowManager::createWindow(const ISystemWindowInfo &info) {
-    if (!info.externalHandle || !isExternalHandleExist(info.externalHandle)) {
+    if (!isExternalHandleExist(info.externalHandle)) {
         ISystemWindow *window = BasePlatform::getPlatform()->createNativeWindow(_nextWindowId, info.externalHandle);
         if (window) {
-            window->createWindow(info.title.c_str(), info.x, info.y, info.width, info.height, info.flags);
+            if (!info.externalHandle) {
+                window->createWindow(info.title.c_str(), info.x, info.y, info.width, info.height, info.flags);
+            }
             _windows[_nextWindowId] = std::shared_ptr<ISystemWindow>(window);
             _nextWindowId++;
         }

--- a/native/cocos/renderer/GFXDeviceManager.h
+++ b/native/cocos/renderer/GFXDeviceManager.h
@@ -137,11 +137,11 @@ private:
     static void addSurfaceEventListener() {
         Device *device = Device::instance;
         EventDispatcher::addCustomEventListener(EVENT_DESTROY_WINDOW, [device](const CustomEvent &e) -> void {
-            device->destroySurface(e.args->ptrVal);
+            device->destroySurface(e.args[0].intVal);
         });
 
         EventDispatcher::addCustomEventListener(EVENT_RECREATE_WINDOW, [device](const CustomEvent &e) -> void {
-            device->createSurface(e.args->ptrVal);
+            device->createSurface(e.args[0].intVal);
         });
     }
 

--- a/native/cocos/renderer/gfx-base/GFXDevice.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDevice.cpp
@@ -98,17 +98,16 @@ void Device::destroy() {
     CC_SAFE_DELETE(_onAcquire);
 }
 
-void Device::destroySurface(void *windowHandle) {
+void Device::destroySurface(uint32_t windowId) {
     for (const auto &swapchain : _swapchains) {
-        if (swapchain->getWindowHandle() == windowHandle) {
+        if (swapchain->getWindowId() == windowId) {
             swapchain->destroySurface();
             break;
         }
     }
 }
 
-void Device::createSurface(void *windowHandle) {
-    auto windowId = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(windowHandle));
+void Device::createSurface(uint32_t windowId) {
     for (const auto &swapchain : _swapchains) {
         if (swapchain->getWindowId() == windowId) {
             auto *windowMgr = BasePlatform::getPlatform()->getInterface<ISystemWindowManager>();

--- a/native/cocos/renderer/gfx-base/GFXDevice.h
+++ b/native/cocos/renderer/gfx-base/GFXDevice.h
@@ -132,8 +132,8 @@ protected:
 
     Device();
 
-    void destroySurface(void *windowHandle);
-    void createSurface(void *windowHandle);
+    void destroySurface(uint32_t windowId);
+    void createSurface(uint32_t windowId);
 
     virtual bool doInit(const DeviceInfo &info) = 0;
     virtual void doDestroy() = 0;


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
