### PR TITLE
[Bug fix] remove the player of the audio source when its clip is set to null 

### DIFF
--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -75,6 +75,17 @@ export class AudioSource extends Component {
     private _isLoaded = false;
 
     private _lastSetClip: AudioClip | null = null;
+
+    private _resetPlayer () {
+        if (this._player) {
+            audioManager.removePlaying(this._player);
+            this._player.offEnded();
+            this._player.offInterruptionBegin();
+            this._player.offInterruptionEnd();
+            this._player.destroy();
+            this._player = null;
+        }
+    }
     /**
      * @en
      * The default AudioClip to be played for this audio source.
@@ -101,13 +112,7 @@ export class AudioSource extends Component {
         }
         if (!clip) {
             this._lastSetClip = null;
-            if (this._player) {
-                audioManager.removePlaying(this._player);
-                this._player.offEnded();
-                this._player.offInterruptionBegin();
-                this._player.offInterruptionEnd();
-                this._player.destroy();
-            }
+            this._resetPlayer();
             return;
         }
         if (!clip._nativeAsset) {
@@ -128,13 +133,7 @@ export class AudioSource extends Component {
             }
             this._isLoaded = true;
             // clear old player
-            if (this._player) {
-                audioManager.removePlaying(this._player);
-                this._player.offEnded();
-                this._player.offInterruptionBegin();
-                this._player.offInterruptionEnd();
-                this._player.destroy();
-            }
+            this._resetPlayer();
             this._player = player;
             player.onEnded(() => {
                 audioManager.removePlaying(player);

--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -101,6 +101,13 @@ export class AudioSource extends Component {
         }
         if (!clip) {
             this._lastSetClip = null;
+            if (this._player) {
+                audioManager.removePlaying(this._player);
+                this._player.offEnded();
+                this._player.offInterruptionBegin();
+                this._player.offInterruptionEnd();
+                this._player.destroy();
+            }
             return;
         }
         if (!clip._nativeAsset) {


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/14014

### Changelog

* Now when audioSource.clip = null, the player inside will be deleted

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
