### PR TITLE
[feature] adjust the use of bullet.wasm on  runtime based platform

### DIFF
--- a/cocos/physics/bullet/instantiated.ts
+++ b/cocos/physics/bullet/instantiated.ts
@@ -25,7 +25,7 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bulletModule, { bulletType } from '@cocos/bullet';
-import { WECHAT } from 'internal:constants';
+import { WECHAT, RUNTIME_BASED } from 'internal:constants';
 import { physics } from '../../../exports/physics-framework';
 import { game } from '../../core/game';
 import { sys } from '../../core/platform';
@@ -93,7 +93,7 @@ export function waitForAmmoInstantiation () {
                     }, errorReport);
                 }
 
-                if (WECHAT) {
+                if (WECHAT || RUNTIME_BASED) {
                     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                     const wasmFilePath = `cocos-js/${module}` as any;
                     instantiateWasm(wasmFilePath);


### PR DESCRIPTION
Re: #
### Changelog
Adjust the use of bullet.wasm on  Runtime platform. Because on runtime platform,  wasm api design is more similar with weixin than web.
This change is only get effect on our runtime platform, and other RUNTIME-BASED related platform plugin like OPPO VIVO HUAWEI COCOSPLAY,  don't support output bullet.wasm now, because they haven't support wasm.  

