### PR TITLE
remove dependence of render scene caused by core/deprecated.ts

### DIFF
--- a/cocos/core/deprecated.ts
+++ b/cocos/core/deprecated.ts
@@ -27,7 +27,6 @@ import { replaceProperty, removeProperty } from './utils/x-deprecated';
 import * as math from './math';
 import { Scheduler } from './scheduler';
 import { legacyCC } from './global-exports';
-import { SubModel } from '../render-scene/scene/submodel';
 
 import System from './system';
 
@@ -217,25 +216,5 @@ removeProperty(Scheduler, 'Scheduler', [
     {
         name: 'PRIORITY_NON_SYSTEM',
         suggest: 'Use enum` System.Priority` instead',
-    },
-]);
-
-// Render scene
-
-replaceProperty(SubModel.prototype, 'SubModel.prototype', [
-    {
-        name: 'subMeshData',
-        newName: 'subMesh',
-    },
-]);
-
-removeProperty(SubModel.prototype, 'SubModel.prototype', [
-    {
-        name: 'getSubModel',
-        suggest: 'Use `subModels[i]` instead',
-    },
-    {
-        name: 'subModelNum',
-        suggest: 'Use `subModels.length` instead',
     },
 ]);

--- a/cocos/render-scene/deprecated.ts
+++ b/cocos/render-scene/deprecated.ts
@@ -31,6 +31,7 @@ import { Pass } from './core/pass';
 import { Camera } from './scene/camera';
 import { Shadows } from './scene/shadows';
 import { SpotLight } from './scene';
+import { SubModel } from './scene/submodel';
 
 removeProperty(RenderScene.prototype, 'RenderScene.prototype', [
     { name: 'raycastUI2DNode' },
@@ -229,5 +230,23 @@ removeProperty(Shadows.prototype, 'Shadows.prototype', [
 removeProperty(SpotLight.prototype, 'SpotLight.prototype', [
     {
         name: 'aspect',
+    },
+]);
+
+replaceProperty(SubModel.prototype, 'SubModel.prototype', [
+    {
+        name: 'subMeshData',
+        newName: 'subMesh',
+    },
+]);
+
+removeProperty(SubModel.prototype, 'SubModel.prototype', [
+    {
+        name: 'getSubModel',
+        suggest: 'Use `subModels[i]` instead',
+    },
+    {
+        name: 'subModelNum',
+        suggest: 'Use `subModels.length` instead',
     },
 ]);


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/12647

### Changelog

* move SubModel deprecated codes into render scene, then core module will not dependent render scene
