### PR TITLE
Allow override options from cfg.cmake in localCfg.cmake

### DIFF
--- a/templates/common/.gitignore
+++ b/templates/common/.gitignore
@@ -1,0 +1,1 @@
+localCfg.cmake

--- a/templates/common/CMakeLists.txt
+++ b/templates/common/CMakeLists.txt
@@ -35,6 +35,10 @@ endif()
 
 include(${RES_DIR}/proj/cfg.cmake)
 
+if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/localCfg.cmake)
+    include(${CMAKE_CURRENT_LIST_DIR}/localCfg.cmake)
+endif()
+
 if(NOT COCOS_X_PATH)
     message(FATAL_ERROR "COCOS_X_PATH is not set!")
 endif()

--- a/templates/common/localCfg.cmake
+++ b/templates/common/localCfg.cmake
@@ -1,0 +1,3 @@
+## Add or overwrite options from cfg.cmake. 
+## This file is ignored from git.
+# set(NODE_EXECUTABLE /opt/...)


### PR DESCRIPTION
Re: #

### Changelog

*  Add an entrance for developers to override cfg.cmake and the file is ignored in GIT. Different development devices would not share the configuration.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
