### PR TITLE
declare WrapMode in core/geometry/curve.ts

### DIFF
--- a/cocos/animation/animation-clip.ts
+++ b/cocos/animation/animation-clip.ts
@@ -31,7 +31,7 @@ import { errorID, warnID } from '../core/platform/debug';
 import { binarySearchEpsilon } from '../core/algorithm/binary-search';
 import { murmurhash2_32_gc } from '../core/algorithm/murmurhash2_gc';
 import { SkelAnimDataHub } from '../3d/skeletal-animation/skeletal-animation-data-hub';
-import { WrapMode as AnimationWrapMode, WrapMode, WrapModeMask } from './types';
+import { WrapMode as AnimationWrapMode, WrapMode } from './types';
 import { legacyCC } from '../core/global-exports';
 import { approx, clamp, Mat4, Quat, Vec3 } from '../core/math';
 import { Node } from '../scene-graph/node';
@@ -50,6 +50,7 @@ import { array } from '../core/utils/js';
 import type { AnimationMask } from './marionette/animation-mask';
 import { getGlobalAnimationManager } from './global-animation-manager';
 import { EmbeddedPlayableState, EmbeddedPlayer } from './embedded-player/embedded-player';
+import { WrapModeMask } from '../core/geometry/curve';
 
 export declare namespace AnimationClip {
     export interface IEvent {

--- a/cocos/animation/animation-state.ts
+++ b/cocos/animation/animation-state.ts
@@ -27,7 +27,7 @@ import { EDITOR } from 'internal:constants';
 import { Node } from '../scene-graph/node';
 import { AnimationClip } from './animation-clip';
 import { Playable } from './playable';
-import { WrapMode, WrapModeMask, WrappedInfo } from './types';
+import { WrapMode, WrappedInfo } from './types';
 import { legacyCC } from '../core/global-exports';
 import { ccenum } from '../core/value-types/enum';
 import { assertIsTrue } from '../core/data/utils/asserts';
@@ -36,6 +36,7 @@ import { AnimationMask } from './marionette/animation-mask';
 import { PoseOutput } from './pose-output';
 import { BlendStateBuffer } from '../3d/skeletal-animation/skeletal-animation-blending';
 import { getGlobalAnimationManager } from './global-animation-manager';
+import { WrapModeMask } from '../core/geometry/curve';
 
 /**
  * @en The event type supported by Animation

--- a/cocos/animation/types.ts
+++ b/cocos/animation/types.ts
@@ -23,17 +23,8 @@
  THE SOFTWARE.
  */
 
+import { WrapModeMask } from '../core/geometry/curve';
 import { ccenum } from '../core/value-types/enum';
-
-export enum WrapModeMask {
-    Default = 0,
-    Normal = 1 << 0,
-    Loop = 1 << 1,
-    ShouldWrap = 1 << 2,
-    Clamp = 1 << 3,
-    PingPong = 1 << 4 | 1 << 1 | 1 << 2,  // Loop, ShouldWrap
-    Reverse = 1 << 5 | 1 << 2,      // ShouldWrap
-}
 
 /**
  * 动画使用的循环模式。

--- a/cocos/core/geometry/curve.ts
+++ b/cocos/core/geometry/curve.ts
@@ -345,6 +345,9 @@ CCClass.fastDefine('cc.AnimationCurve', AnimationCurve, {
     _curve: null,
 });
 
+/**
+ * @engineInternal
+ */
 export enum WrapModeMask {
     Default = 0,
     Normal = 1 << 0,

--- a/cocos/core/geometry/curve.ts
+++ b/cocos/core/geometry/curve.ts
@@ -25,7 +25,6 @@
 
 import { CCClass } from '../data/class';
 import { clamp, pingPong, repeat } from '../math/utils';
-import { WrapModeMask } from '../../animation/types';
 import { ExtrapolationMode, RealCurve, RealInterpolationMode } from '../curves';
 
 const LOOK_FORWARD = 3;
@@ -345,6 +344,16 @@ export class AnimationCurve {
 CCClass.fastDefine('cc.AnimationCurve', AnimationCurve, {
     _curve: null,
 });
+
+export enum WrapModeMask {
+    Default = 0,
+    Normal = 1 << 0,
+    Loop = 1 << 1,
+    ShouldWrap = 1 << 2,
+    Clamp = 1 << 3,
+    PingPong = 1 << 4 | 1 << 1 | 1 << 2,  // Loop, ShouldWrap
+    Reverse = 1 << 5 | 1 << 2,      // ShouldWrap
+}
 
 function fromLegacyWrapMode (legacyWrapMode: WrapModeMask): ExtrapolationMode {
     switch (legacyWrapMode) {

--- a/cocos/core/geometry/index.ts
+++ b/cocos/core/geometry/index.ts
@@ -39,7 +39,7 @@ export { AABB } from './aabb';
 export { OBB } from './obb';
 export { Capsule } from './capsule';
 export { Frustum } from './frustum';
-export { Keyframe, AnimationCurve } from './curve';
+export { Keyframe, AnimationCurve, WrapModeMask } from './curve';
 export { SplineMode, Spline } from './spline';
 export * from './spec';
 export * from './deprecated-3.0.0';

--- a/tests/core/geometry/geometry-curve.test.ts
+++ b/tests/core/geometry/geometry-curve.test.ts
@@ -1,5 +1,5 @@
-import { WrapModeMask } from '../../../cocos/animation/types';
-import { ExtrapolationMode, RealCurve, RealInterpolationMode, RealKeyframeValue, TangentWeightMode } from '../../../cocos/core/curves';
+import { WrapModeMask } from '../../../cocos/core/geometry';
+import { ExtrapolationMode, RealCurve, RealInterpolationMode, TangentWeightMode } from '../../../cocos/core/curves';
 import { AnimationCurve, Keyframe } from '../../../cocos/core/geometry/curve';
 
 describe('geometry.AnimationCurve', () => {


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/12647

### Changelog

* declare WrapMode in core/geometry/curve.ts, then core will not depend on animation
