### PR TITLE
a compatible way of data copy & default buffer size for uniform buffer

### DIFF
--- a/cocos/core/renderer/scene/submodel.ts
+++ b/cocos/core/renderer/scene/submodel.ts
@@ -399,7 +399,7 @@ export class SubModel {
         // update draw info
         const drawInfo = this._subMesh.drawInfo;
         if (this._inputAssembler && drawInfo) {
-            this._inputAssembler.drawInfo.copy(drawInfo);
+            Object.assign(this._inputAssembler.drawInfo, drawInfo);
         }
     }
 

--- a/native/cocos/renderer/gfx-wgpu/WGPUBuffer.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUBuffer.cpp
@@ -222,7 +222,7 @@ CCWGPUBuffer *CCWGPUBuffer::defaultUniformBuffer() {
         BufferInfo info = {
             .usage = BufferUsageBit::UNIFORM,
             .memUsage = MemoryUsageBit::DEVICE,
-            .size = 4,
+            .size = 256,
             .flags = BufferFlagBit::NONE,
         };
         dftUniformBuffer = ccnew CCWGPUBuffer;
@@ -236,7 +236,7 @@ CCWGPUBuffer *CCWGPUBuffer::defaultStorageBuffer() {
         BufferInfo info = {
             .usage = BufferUsageBit::STORAGE,
             .memUsage = MemoryUsageBit::DEVICE,
-            .size = 4,
+            .size = 256,
             .flags = BufferFlagBit::NONE,
         };
         dftStorageBuffer = ccnew CCWGPUBuffer;

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos-creator",
         "name": "engine-native-external",
-        "checkout": "v3.6.2-2"
+        "checkout": "v3.6.2-3"
     }
 }


### PR DESCRIPTION
Re: # https://github.com/cocos/cocos-engine-external/pull/299

### Changelog

*

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
