### PR TITLE
move prefab-link.ts to cocos/misc

### DIFF
--- a/cocos/core/utils/index.ts
+++ b/cocos/core/utils/index.ts
@@ -38,7 +38,6 @@ import * as misc from './misc';
 import * as path from './path';
 
 export * from './x-deprecated';
-export { PrefabLink } from './prefab-link';
 
 export {
     js,

--- a/cocos/misc/index.ts
+++ b/cocos/misc/index.ts
@@ -27,5 +27,6 @@ export { Camera } from './camera-component';
 export { ModelRenderer } from './model-renderer';
 export { Renderer } from './renderer';
 export { MissingScript } from './missing-script';
+export { PrefabLink } from './prefab-link';
 /** deprecated */
 export * from './deprecated';

--- a/cocos/misc/prefab-link.ts
+++ b/cocos/misc/prefab-link.ts
@@ -1,6 +1,6 @@
-import { ccclass, serializable, type, visible } from '../data/decorators';
-import { Component } from '../../scene-graph/component';
-import { Prefab } from '../../asset/assets/prefab';
+import { ccclass, serializable, type, visible } from '../core/data/decorators';
+import { Component } from '../scene-graph/component';
+import { Prefab } from '../asset/assets/prefab';
 
 /**
  * @en


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/12647

### Changelog

* `prefab-link.ts` is only used in editor to upgrade v2.x projects, so move it to `cocos/misc`. This file may be deleted as currently can not upgrade v2.x projects, this file seems useless.
