### PR TITLE
Adapt ES/WEBGL to support 3d texture/2d array texture.

### DIFF
--- a/cocos/gfx/base/define.ts
+++ b/cocos/gfx/base/define.ts
@@ -736,6 +736,8 @@ export class DeviceCaps {
         public maxUniformBlockSize: number = 0,
         public maxTextureSize: number = 0,
         public maxCubeMapTextureSize: number = 0,
+        public maxArrayTextureLayers: number = 0,
+        public max3DTextureSize: number = 0,
         public uboOffsetAlignment: number = 1,
         public maxComputeSharedMemorySize: number = 0,
         public maxComputeWorkGroupInvocations: number = 0,
@@ -761,6 +763,8 @@ export class DeviceCaps {
         this.maxUniformBlockSize = info.maxUniformBlockSize;
         this.maxTextureSize = info.maxTextureSize;
         this.maxCubeMapTextureSize = info.maxCubeMapTextureSize;
+        this.maxArrayTextureLayers = info.maxArrayTextureLayers;
+        this.max3DTextureSize = info.max3DTextureSize;
         this.uboOffsetAlignment = info.uboOffsetAlignment;
         this.maxComputeSharedMemorySize = info.maxComputeSharedMemorySize;
         this.maxComputeWorkGroupInvocations = info.maxComputeWorkGroupInvocations;

--- a/cocos/gfx/webgl/webgl-device.ts
+++ b/cocos/gfx/webgl/webgl-device.ts
@@ -148,7 +148,8 @@ export class WebGLDevice extends Device {
         this._caps.maxVertexTextureUnits = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
         this._caps.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         this._caps.maxCubeMapTextureSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
-
+        this._caps.maxArrayTextureLayers = 0;
+        this._caps.max3DTextureSize = 0;
         // WebGL doesn't support UBOs at all, so here we return
         // the guaranteed minimum number of available bindings in WebGL2
         this._caps.maxUniformBufferBindings = 16;

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -1034,6 +1034,8 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
 
     let w = gpuTexture.width;
     let h = gpuTexture.height;
+    const d = gpuTexture.depth;
+    const l = gpuTexture.arrayLayer;
 
     switch (gpuTexture.type) {
     case TextureType.TEX2D: {
@@ -1077,6 +1079,71 @@ export function WebGL2CmdFuncCreateTexture (device: WebGL2Device, gpuTexture: IW
 
                 gl.renderbufferStorageMultisample(gl.RENDERBUFFER, gpuTexture.samples,
                     gpuTexture.glInternalFmt, gpuTexture.width, gpuTexture.height);
+            }
+        }
+        break;
+    }
+    case TextureType.TEX2D_ARRAY: {
+        gpuTexture.glTarget = gl.TEXTURE_2D_ARRAY;
+
+        const maxSize = Math.max(w, h);
+        if (maxSize > device.capabilities.maxTextureSize) {
+            errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        }
+        if (l > device.capabilities.maxArrayTextureLayers) {
+            errorID(9100, l, device.capabilities.maxArrayTextureLayers);
+        }
+
+        gpuTexture.glTexture = gl.createTexture();
+        if (gpuTexture.size > 0) {
+            const glTexUnit = device.stateCache.glTexUnits[device.stateCache.texUnit];
+
+            if (glTexUnit.glTexture !== gpuTexture.glTexture) {
+                gl.bindTexture(gl.TEXTURE_2D_ARRAY, gpuTexture.glTexture);
+                glTexUnit.glTexture = gpuTexture.glTexture;
+            }
+
+            if (FormatInfos[gpuTexture.format].isCompressed) {
+                for (let i = 0; i < gpuTexture.mipLevel; ++i) {
+                    const imgSize = FormatSize(gpuTexture.format, w, h, l);
+                    const view: Uint8Array = new Uint8Array(imgSize);
+                    gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, i, gpuTexture.glInternalFmt, w, h, l, 0, view);
+                    w = Math.max(1, w >> 1);
+                    h = Math.max(1, h >> 1);
+                }
+            } else {
+                gl.texStorage3D(gl.TEXTURE_2D_ARRAY, gpuTexture.mipLevel, gpuTexture.glInternalFmt, w, h, l);
+            }
+        }
+        break;
+    }
+    case TextureType.TEX3D: {
+        gpuTexture.glTarget = gl.TEXTURE_3D;
+
+        const maxSize = Math.max(Math.max(w, h), d);
+        if (maxSize > device.capabilities.max3DTextureSize) {
+            errorID(9100, maxSize, device.capabilities.max3DTextureSize);
+        }
+
+        gpuTexture.glTexture = gl.createTexture();
+        if (gpuTexture.size > 0) {
+            const glTexUnit = device.stateCache.glTexUnits[device.stateCache.texUnit];
+
+            if (glTexUnit.glTexture !== gpuTexture.glTexture) {
+                gl.bindTexture(gl.TEXTURE_3D, gpuTexture.glTexture);
+                glTexUnit.glTexture = gpuTexture.glTexture;
+            }
+
+            if (FormatInfos[gpuTexture.format].isCompressed) {
+                for (let i = 0; i < gpuTexture.mipLevel; ++i) {
+                    const imgSize = FormatSize(gpuTexture.format, w, h, d);
+                    const view: Uint8Array = new Uint8Array(imgSize);
+                    gl.compressedTexImage3D(gl.TEXTURE_3D, i, gpuTexture.glInternalFmt, w, h, d, 0, view);
+                    w = Math.max(1, w >> 1);
+                    h = Math.max(1, h >> 1);
+                }
+            } else {
+                gl.texStorage3D(gl.TEXTURE_3D, gpuTexture.mipLevel, gpuTexture.glInternalFmt, w, h, d);
             }
         }
         break;
@@ -1158,6 +1225,8 @@ export function WebGL2CmdFuncResizeTexture (device: WebGL2Device, gpuTexture: IW
 
     let w = gpuTexture.width;
     let h = gpuTexture.height;
+    const d = gpuTexture.depth;
+    const l = gpuTexture.arrayLayer;
 
     switch (gpuTexture.type) {
     case TextureType.TEX2D: {
@@ -1197,6 +1266,71 @@ export function WebGL2CmdFuncResizeTexture (device: WebGL2Device, gpuTexture: IW
 
             gl.renderbufferStorageMultisample(gl.RENDERBUFFER, gpuTexture.samples,
                 gpuTexture.glInternalFmt, gpuTexture.width, gpuTexture.height);
+        }
+        break;
+    }
+    case TextureType.TEX2D_ARRAY: {
+        gpuTexture.glTarget = gl.TEXTURE_2D_ARRAY;
+
+        const maxSize = Math.max(w, h);
+        if (maxSize > device.capabilities.maxTextureSize) {
+            errorID(9100, maxSize, device.capabilities.maxTextureSize);
+        }
+        if (l > device.capabilities.maxArrayTextureLayers) {
+            errorID(9100, l, device.capabilities.maxArrayTextureLayers);
+        }
+
+        gpuTexture.glTexture = gl.createTexture();
+        if (gpuTexture.size > 0) {
+            const glTexUnit = device.stateCache.glTexUnits[device.stateCache.texUnit];
+
+            if (glTexUnit.glTexture !== gpuTexture.glTexture) {
+                gl.bindTexture(gl.TEXTURE_2D_ARRAY, gpuTexture.glTexture);
+                glTexUnit.glTexture = gpuTexture.glTexture;
+            }
+
+            if (FormatInfos[gpuTexture.format].isCompressed) {
+                for (let i = 0; i < gpuTexture.mipLevel; ++i) {
+                    const imgSize = FormatSize(gpuTexture.format, w, h, l);
+                    const view: Uint8Array = new Uint8Array(imgSize);
+                    gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, i, gpuTexture.glInternalFmt, w, h, l, 0, view);
+                    w = Math.max(1, w >> 1);
+                    h = Math.max(1, h >> 1);
+                }
+            } else {
+                gl.texStorage3D(gl.TEXTURE_2D_ARRAY, gpuTexture.mipLevel, gpuTexture.glInternalFmt, w, h, l);
+            }
+        }
+        break;
+    }
+    case TextureType.TEX3D: {
+        gpuTexture.glTarget = gl.TEXTURE_3D;
+
+        const maxSize = Math.max(Math.max(w, h), d);
+        if (maxSize > device.capabilities.max3DTextureSize) {
+            errorID(9100, maxSize, device.capabilities.max3DTextureSize);
+        }
+
+        gpuTexture.glTexture = gl.createTexture();
+        if (gpuTexture.size > 0) {
+            const glTexUnit = device.stateCache.glTexUnits[device.stateCache.texUnit];
+
+            if (glTexUnit.glTexture !== gpuTexture.glTexture) {
+                gl.bindTexture(gl.TEXTURE_3D, gpuTexture.glTexture);
+                glTexUnit.glTexture = gpuTexture.glTexture;
+            }
+
+            if (FormatInfos[gpuTexture.format].isCompressed) {
+                for (let i = 0; i < gpuTexture.mipLevel; ++i) {
+                    const imgSize = FormatSize(gpuTexture.format, w, h, d);
+                    const view: Uint8Array = new Uint8Array(imgSize);
+                    gl.compressedTexImage3D(gl.TEXTURE_3D, i, gpuTexture.glInternalFmt, w, h, d, 0, view);
+                    w = Math.max(1, w >> 1);
+                    h = Math.max(1, h >> 1);
+                }
+            } else {
+                gl.texStorage3D(gl.TEXTURE_3D, gpuTexture.mipLevel, gpuTexture.glInternalFmt, w, h, d);
+            }
         }
         break;
     }

--- a/cocos/gfx/webgl2/webgl2-device.ts
+++ b/cocos/gfx/webgl2/webgl2-device.ts
@@ -150,6 +150,8 @@ export class WebGL2Device extends Device {
         this._caps.maxUniformBlockSize = gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE);
         this._caps.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         this._caps.maxCubeMapTextureSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+        this._caps.maxArrayTextureLayers = gl.getParameter(gl.MAX_ARRAY_TEXTURE_LAYERS);
+        this._caps.max3DTextureSize = gl.getParameter(gl.MAX_3D_TEXTURE_SIZE);
         this._caps.uboOffsetAlignment = gl.getParameter(gl.UNIFORM_BUFFER_OFFSET_ALIGNMENT);
 
         const extensions = gl.getSupportedExtensions();

--- a/native/cocos/renderer/gfx-base/GFXDef-common.h
+++ b/native/cocos/renderer/gfx-base/GFXDef-common.h
@@ -834,6 +834,8 @@ struct DeviceCaps {
     uint32_t maxUniformBlockSize{0};
     uint32_t maxTextureSize{0};
     uint32_t maxCubeMapTextureSize{0};
+    uint32_t maxArrayTextureLayers{0};
+    uint32_t max3DTextureSize{0};
     uint32_t uboOffsetAlignment{1};
 
     uint32_t maxComputeSharedMemorySize{0};

--- a/native/cocos/renderer/gfx-gles2/GLES2Commands.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Commands.cpp
@@ -660,6 +660,86 @@ void cmdFuncGLES2CreateTexture(GLES2Device *device, GLES2GPUTexture *gpuTexture)
                 }
                 break;
             }
+            case TextureType::TEX2D_ARRAY: {
+                gpuTexture->glTarget = GL_TEXTURE_3D;
+                CC_ASSERT((std::max(std::max(gpuTexture->width, gpuTexture->height), gpuTexture->arrayLayer) <= device->getCapabilities().max3DTextureSize)
+                    && "cmdFuncGLES2CreateTexture: texture2DArray's dimension is too large");
+                GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    if (!GFX_FORMAT_INFOS[static_cast<int>(gpuTexture->format)].isCompressed) {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->arrayLayer;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            GL_CHECK(glTexImage3DOES(GL_TEXTURE_3D, i,
+                                                     gpuTexture->glInternalFmt,
+                                                     w, h, d, 0,
+                                                     gpuTexture->glFormat, gpuTexture->glType,
+                                                     nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    } else {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->arrayLayer;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            uint32_t imgSize = formatSize(gpuTexture->format, w, h, d);
+                            GL_CHECK(glCompressedTexImage3DOES(GL_TEXTURE_3D, i,
+                                                               gpuTexture->glInternalFmt,
+                                                               w, h, d, 0, imgSize,
+                                                               nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    }
+                }
+                break;
+            }
+            case TextureType::TEX3D: {
+                gpuTexture->glTarget = GL_TEXTURE_3D;
+                GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    if (!GFX_FORMAT_INFOS[static_cast<int>(gpuTexture->format)].isCompressed) {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->depth;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            GL_CHECK(glTexImage3DOES(GL_TEXTURE_3D, i,
+                                                     gpuTexture->glInternalFmt,
+                                                     w, h, d, 0,
+                                                     gpuTexture->glFormat, gpuTexture->glType,
+                                                     nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    } else {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->depth;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            uint32_t imgSize = formatSize(gpuTexture->format, w, h, d);
+                            GL_CHECK(glCompressedTexImage3DOES(GL_TEXTURE_3D, i,
+                                                               gpuTexture->glInternalFmt,
+                                                               w, h, d, 0, imgSize,
+                                                               nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    }
+                }
+                break;
+            }
             case TextureType::CUBE: {
                 gpuTexture->glTarget = GL_TEXTURE_CUBE_MAP;
                 GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
@@ -756,6 +836,82 @@ void cmdFuncGLES2ResizeTexture(GLES2Device *device, GLES2GPUTexture *gpuTexture)
                         for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
                             uint32_t imgSize = formatSize(gpuTexture->format, w, h, 1);
                             GL_CHECK(glCompressedTexImage2D(GL_TEXTURE_2D, i, gpuTexture->glInternalFmt, w, h, 0, imgSize, nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    }
+                }
+                break;
+            }
+            case TextureType::TEX2D_ARRAY: {
+                gpuTexture->glTarget = GL_TEXTURE_2D_ARRAY;
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    if (!GFX_FORMAT_INFOS[static_cast<int>(gpuTexture->format)].isCompressed) {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->arrayLayer;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            GL_CHECK(glTexImage3DOES(GL_TEXTURE_3D, i,
+                                                     gpuTexture->glInternalFmt,
+                                                     w, h, d, 0,
+                                                     gpuTexture->glFormat, gpuTexture->glType,
+                                                     nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    } else {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->arrayLayer;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            uint32_t imgSize = formatSize(gpuTexture->format, w, h, d);
+                            GL_CHECK(glCompressedTexImage3DOES(GL_TEXTURE_3D, i,
+                                                               gpuTexture->glInternalFmt,
+                                                               w, h, d, 0, imgSize,
+                                                               nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    }
+                }
+                break;
+            }
+            case TextureType::TEX3D: {
+                gpuTexture->glTarget = GL_TEXTURE_3D;
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    if (!GFX_FORMAT_INFOS[static_cast<int>(gpuTexture->format)].isCompressed) {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->depth;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            GL_CHECK(glTexImage3DOES(GL_TEXTURE_3D, i,
+                                                     gpuTexture->glInternalFmt,
+                                                     w, h, d, 0,
+                                                     gpuTexture->glFormat, gpuTexture->glType,
+                                                     nullptr));
+                            w = std::max(1U, w >> 1);
+                            h = std::max(1U, h >> 1);
+                        }
+                    } else {
+                        uint32_t w = gpuTexture->width;
+                        uint32_t h = gpuTexture->height;
+                        uint32_t d = gpuTexture->depth;
+                        for (uint32_t i = 0; i < gpuTexture->mipLevel; ++i) {
+                            uint32_t imgSize = formatSize(gpuTexture->format, w, h, d);
+                            GL_CHECK(glCompressedTexImage3DOES(GL_TEXTURE_3D, i,
+                                                               gpuTexture->glInternalFmt,
+                                                               w, h, d, 0, imgSize,
+                                                               nullptr));
                             w = std::max(1U, w >> 1);
                             h = std::max(1U, h >> 1);
                         }

--- a/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -188,9 +188,14 @@ bool GLES2Device::doInit(const DeviceInfo & /*info*/) {
     glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, reinterpret_cast<GLint *>(&_caps.maxVertexTextureUnits));
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxTextureSize));
     glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxCubeMapTextureSize));
-    glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE_OES, reinterpret_cast<GLint *>(&_caps.max3DTextureSize));
-    // texture2DArray fallback to texture3DOES
-    _caps.maxArrayTextureLayers = _caps.max3DTextureSize;
+    if (checkExtension("GL_OES_texture_3D")) {
+        glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE_OES, reinterpret_cast<GLint *>(&_caps.max3DTextureSize));
+        // texture2DArray fallback to texture3DOES
+        _caps.maxArrayTextureLayers = _caps.max3DTextureSize;
+    } else {
+        _caps.max3DTextureSize = 0;
+        _caps.maxArrayTextureLayers = 0;
+    }
 
     QueueInfo queueInfo;
     queueInfo.type = QueueType::GRAPHICS;

--- a/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -188,6 +188,9 @@ bool GLES2Device::doInit(const DeviceInfo & /*info*/) {
     glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, reinterpret_cast<GLint *>(&_caps.maxVertexTextureUnits));
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxTextureSize));
     glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxCubeMapTextureSize));
+    glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE_OES, reinterpret_cast<GLint *>(&_caps.max3DTextureSize));
+    // texture2DArray fallback to texture3DOES
+    _caps.maxArrayTextureLayers = _caps.max3DTextureSize;
 
     QueueInfo queueInfo;
     queueInfo.type = QueueType::GRAPHICS;

--- a/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
@@ -873,6 +873,38 @@ void cmdFuncGLES3CreateTexture(GLES3Device *device, GLES3GPUTexture *gpuTexture)
                 }
                 break;
             }
+            case TextureType::TEX2D_ARRAY: {
+                gpuTexture->glTarget = GL_TEXTURE_2D_ARRAY;
+                GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_2D_ARRAY, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    uint32_t w = gpuTexture->width;
+                    uint32_t h = gpuTexture->height;
+                    uint32_t d = gpuTexture->arrayLayer;
+                    GL_CHECK(glTexStorage3D(GL_TEXTURE_2D_ARRAY, gpuTexture->mipLevel, gpuTexture->glInternalFmt, w, h, d));
+                }
+                break;
+            }
+            case TextureType::TEX3D: {
+                gpuTexture->glTarget = GL_TEXTURE_3D;
+                GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));
+                if (gpuTexture->size > 0) {
+                    GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
+                    if (gpuTexture->glTexture != glTexture) {
+                        GL_CHECK(glBindTexture(GL_TEXTURE_3D, gpuTexture->glTexture));
+                        glTexture = gpuTexture->glTexture;
+                    }
+                    uint32_t w = gpuTexture->width;
+                    uint32_t h = gpuTexture->height;
+                    uint32_t d = gpuTexture->depth;
+                    GL_CHECK(glTexStorage3D(GL_TEXTURE_3D, gpuTexture->mipLevel, gpuTexture->glInternalFmt, w, h, d));
+                }
+                break;
+            }
             case TextureType::CUBE: {
                 gpuTexture->glTarget = GL_TEXTURE_CUBE_MAP;
                 GL_CHECK(glGenTextures(1, &gpuTexture->glTexture));

--- a/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -188,6 +188,8 @@ bool GLES3Device::doInit(const DeviceInfo & /*info*/) {
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxTextureSize));
     glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.maxCubeMapTextureSize));
     glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, reinterpret_cast<GLint *>(&_caps.uboOffsetAlignment));
+    glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS, reinterpret_cast<GLint *>(&_caps.maxArrayTextureLayers));
+    glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE, reinterpret_cast<GLint *>(&_caps.max3DTextureSize));
 
     if (_gpuConstantRegistry->glMinorVersion) {
         glGetIntegerv(GL_MAX_IMAGE_UNITS, reinterpret_cast<GLint *>(&_caps.maxImageUnits));

--- a/native/cocos/renderer/gfx-validator/TextureValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/TextureValidator.cpp
@@ -67,6 +67,38 @@ void TextureValidator::doInit(const TextureInfo &info) {
         CC_ASSERT(hasAllFlags(DeviceValidator::getInstance()->getFormatFeatures(info.format), ff));
     }
 
+    switch (info.type) {
+        case TextureType::TEX2D: {
+            if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxTextureSize) {
+                CC_ASSERT(false);
+            }
+            break;
+        }
+        case TextureType::TEX2D_ARRAY: {
+            if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxTextureSize
+                || info.layerCount > DeviceValidator::getInstance()->getCapabilities().maxArrayTextureLayers) {
+                CC_ASSERT(false);
+            }
+            break;
+        }
+        case TextureType::CUBE: {
+            if (std::max(info.width, info.height) > DeviceValidator::getInstance()->getCapabilities().maxCubeMapTextureSize || info.layerCount != 6) {
+                CC_ASSERT(false);
+            }
+            break;
+        }
+        case TextureType::TEX3D: {
+            if (std::max(std::max(info.width, info.height), info.depth) > DeviceValidator::getInstance()->getCapabilities().maxCubeMapTextureSize) {
+                CC_ASSERT(false);
+            }
+            break;
+        }
+        default: {
+            CC_ASSERT(false);
+            break;
+        }
+    }
+
     if (hasFlag(info.flags, TextureFlagBit::GEN_MIPMAP)) {
         CC_ASSERT(info.levelCount > 1);
 

--- a/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -313,6 +313,8 @@ bool CCVKDevice::doInit(const DeviceInfo & /*info*/) {
     _caps.maxVertexTextureUnits = limits.maxPerStageDescriptorSampledImages;
     _caps.maxTextureSize = limits.maxImageDimension2D;
     _caps.maxCubeMapTextureSize = limits.maxImageDimensionCube;
+    _caps.maxArrayTextureLayers = limits.maxImageArrayLayers;
+    _caps.max3DTextureSize = limits.maxImageDimension3D;
     _caps.uboOffsetAlignment = utils::toUint(limits.minUniformBufferOffsetAlignment);
     // compute shaders
     _caps.maxComputeSharedMemorySize = limits.maxComputeSharedMemorySize;

--- a/native/cocos/renderer/gfx-vulkan/VKUtils.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKUtils.cpp
@@ -254,7 +254,6 @@ VkImageCreateFlags mapVkImageCreateFlags(TextureType type) {
     uint32_t res = 0U;
     switch (type) {
         case TextureType::CUBE: res |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT; break;
-        case TextureType::TEX2D_ARRAY: res |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT; break;
         default: break;
     }
     return static_cast<VkImageCreateFlags>(res);


### PR DESCRIPTION
Re: #

### Changelog

* Adapt ES/WEBGL to support 3d texture/2d array texture.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
