### PR TITLE
Richtext add child optimization v3.7

### DIFF
--- a/cocos/2d/assembler/label/ttfUtils.ts
+++ b/cocos/2d/assembler/label/ttfUtils.ts
@@ -91,6 +91,7 @@ const Alignment = [
 export const ttfUtils =  {
     getAssemblerData () {
         const sharedLabelData = Label._canvasPool.get();
+        sharedLabelData.canvas.width = sharedLabelData.canvas.height = 1;
         return sharedLabelData;
     },
 

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -483,6 +483,7 @@ export class RichText extends Component {
 
     public onLoad () {
         this.node.on(NodeEventType.LAYER_CHANGED, this._applyLayer, this);
+        this.node.on(NodeEventType.ANCHOR_CHANGED, this._updateRichTextPosition, this);
     }
 
     public onEnable () {
@@ -500,11 +501,6 @@ export class RichText extends Component {
         }
 
         this._activateChildren(false);
-    }
-
-    public start () {
-        this._onTTFLoaded();
-        this.node.on(NodeEventType.ANCHOR_CHANGED, this._updateRichTextPosition, this);
     }
 
     public onRestore () {
@@ -1263,12 +1259,12 @@ export class RichText extends Component {
         label.lineHeight = this._lineHeight;
 
         label.updateRenderData(true);
-        // Todo: need update context size after this function call
-        // @ts-expect-error update assembler renderData for richText
-        const assembler = label._assembler;
-        if (assembler) {
-            assembler.updateRenderData(label);
-        }
+        // // Todo: need update context size after this function call
+        // // @ts-expect-error update assembler renderData for richText
+        // const assembler = label._assembler;
+        // if (assembler) {
+        //     assembler.updateRenderData(label);
+        // }
     }
 
     protected _applyLayer () {

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -568,8 +568,14 @@ export class RichText extends Component {
     * @engineInternal
     */
     protected SplitLongStringApproximatelyIn2048 (text: string, styleIndex: number) {
-        const labelSize = this._calculateSize(styleIndex, text);
+        const approxSize = text.length * this.fontSize;
         const partStringArr: string[] = [];
+        if (approxSize <= 2048 * 0.8) {
+            partStringArr.push(text);
+            return partStringArr;
+        }
+
+        const labelSize = this._calculateSize(styleIndex, text);
         if (labelSize.x < 2048) {
             partStringArr.push(text);
         } else {

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -567,9 +567,11 @@ export class RichText extends Component {
     /**
     * @engineInternal
     */
-    protected SplitLongStringApproximatelyIn2048 (text: string, styleIndex: number) {
+    protected splitLongStringApproximatelyIn2048 (text: string, styleIndex: number) {
         const approxSize = text.length * this.fontSize;
         const partStringArr: string[] = [];
+        // avoid that many short richtext still execute _calculateSize so that performance is low
+        // we set a threshold as 2048 * 0.8, if the estimated size is less than it, we can skip _calculateSize precisely
         if (approxSize <= 2048 * 0.8) {
             partStringArr.push(text);
             return partStringArr;
@@ -1042,7 +1044,7 @@ export class RichText extends Component {
                 }
             }
 
-            const splitArr: string[] = this.SplitLongStringApproximatelyIn2048(text, i);
+            const splitArr: string[] = this.splitLongStringApproximatelyIn2048(text, i);
             text = splitArr.join('\n');
 
             const multilineTexts = text.split('\n');
@@ -1265,12 +1267,6 @@ export class RichText extends Component {
         label.lineHeight = this._lineHeight;
 
         label.updateRenderData(true);
-        // // Todo: need update context size after this function call
-        // // @ts-expect-error update assembler renderData for richText
-        // const assembler = label._assembler;
-        // if (assembler) {
-        //     assembler.updateRenderData(label);
-        // }
     }
 
     protected _applyLayer () {


### PR DESCRIPTION
Re: (https://github.com/cocos/3d-tasks/issues/12592)

### Changelog

* add child optimization #12928

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
