### PR TITLE
[develop] add SamplerInfo to custom pipeline

### DIFF
--- a/cocos/rendering/custom/render-graph.ts
+++ b/cocos/rendering/custom/render-graph.ts
@@ -32,7 +32,7 @@
 import * as impl from './graph';
 import { Material } from '../../asset/assets';
 import { Camera } from '../../render-scene/scene/camera';
-import { AccessFlagBit, Buffer, ClearFlagBit, Color, Format, Framebuffer, SampleCount, Sampler, Swapchain, Texture, TextureFlagBit, Viewport } from '../../gfx';
+import { AccessFlagBit, Buffer, ClearFlagBit, Color, Format, Framebuffer, SampleCount, Sampler, SamplerInfo, Swapchain, Texture, TextureFlagBit, Viewport } from '../../gfx';
 import { ComputeView, CopyPair, LightInfo, MovePair, QueueHint, RasterView, ResourceDimension, ResourceFlags, ResourceResidency, SceneFlags } from './types';
 
 export class ResourceDesc {
@@ -201,6 +201,16 @@ export class ResourceGraphStatesMap implements impl.PropertyMap {
     readonly _states: ResourceStates[];
 }
 
+export class ResourceGraphSamplerMap implements impl.PropertyMap {
+    constructor (readonly samplerInfo: SamplerInfo[]) {
+        this._samplerInfo = samplerInfo;
+    }
+    get (v: number): SamplerInfo {
+        return this._samplerInfo[v];
+    }
+    readonly _samplerInfo: SamplerInfo[];
+}
+
 //-----------------------------------------------------------------
 // ComponentGraph Concept
 export const enum ResourceGraphComponent {
@@ -208,6 +218,7 @@ export const enum ResourceGraphComponent {
     Desc,
     Traits,
     States,
+    Sampler,
 }
 
 interface ResourceGraphComponentType {
@@ -215,6 +226,7 @@ interface ResourceGraphComponentType {
     [ResourceGraphComponent.Desc]: ResourceDesc;
     [ResourceGraphComponent.Traits]: ResourceTraits;
     [ResourceGraphComponent.States]: ResourceStates;
+    [ResourceGraphComponent.Sampler]: SamplerInfo;
 }
 
 interface ResourceGraphComponentPropertyMap {
@@ -222,6 +234,7 @@ interface ResourceGraphComponentPropertyMap {
     [ResourceGraphComponent.Desc]: ResourceGraphDescMap;
     [ResourceGraphComponent.Traits]: ResourceGraphTraitsMap;
     [ResourceGraphComponent.States]: ResourceGraphStatesMap;
+    [ResourceGraphComponent.Sampler]: ResourceGraphSamplerMap;
 }
 
 //-----------------------------------------------------------------
@@ -308,6 +321,7 @@ export class ResourceGraph implements impl.BidirectionalGraph
         this._descs.length = 0;
         this._traits.length = 0;
         this._states.length = 0;
+        this._samplerInfo.length = 0;
         // Graph Vertices
         this._vertices.length = 0;
     }
@@ -318,6 +332,7 @@ export class ResourceGraph implements impl.BidirectionalGraph
         desc: ResourceDesc,
         traits: ResourceTraits,
         states: ResourceStates,
+        sampler: SamplerInfo,
     ): number {
         const vert = new ResourceGraphVertex(id, object);
         const v = this._vertices.length;
@@ -326,6 +341,7 @@ export class ResourceGraph implements impl.BidirectionalGraph
         this._descs.push(desc);
         this._traits.push(traits);
         this._states.push(states);
+        this._samplerInfo.push(sampler);
         // UuidGraph
         this._valueIndex.set(name, v);
         return v;
@@ -371,6 +387,7 @@ export class ResourceGraph implements impl.BidirectionalGraph
         this._descs.splice(u, 1);
         this._traits.splice(u, 1);
         this._states.splice(u, 1);
+        this._samplerInfo.splice(u, 1);
 
         const sz = this._vertices.length;
         if (u === sz) {
@@ -441,7 +458,7 @@ export class ResourceGraph implements impl.BidirectionalGraph
     }
     //-----------------------------------------------------------------
     // PropertyGraph
-    get (tag: string): ResourceGraphNameMap | ResourceGraphDescMap | ResourceGraphTraitsMap | ResourceGraphStatesMap {
+    get (tag: string): ResourceGraphNameMap | ResourceGraphDescMap | ResourceGraphTraitsMap | ResourceGraphStatesMap | ResourceGraphSamplerMap {
         switch (tag) {
         // Components
         case 'Name':
@@ -452,6 +469,8 @@ export class ResourceGraph implements impl.BidirectionalGraph
             return new ResourceGraphTraitsMap(this._traits);
         case 'States':
             return new ResourceGraphStatesMap(this._states);
+        case 'Sampler':
+            return new ResourceGraphSamplerMap(this._samplerInfo);
         default:
             throw Error('property map not found');
         }
@@ -468,6 +487,8 @@ export class ResourceGraph implements impl.BidirectionalGraph
             return this._traits[v] as ResourceGraphComponentType[T];
         case ResourceGraphComponent.States:
             return this._states[v] as ResourceGraphComponentType[T];
+        case ResourceGraphComponent.Sampler:
+            return this._samplerInfo[v] as ResourceGraphComponentType[T];
         default:
             throw Error('component not found');
         }
@@ -482,6 +503,8 @@ export class ResourceGraph implements impl.BidirectionalGraph
             return new ResourceGraphTraitsMap(this._traits) as ResourceGraphComponentPropertyMap[T];
         case ResourceGraphComponent.States:
             return new ResourceGraphStatesMap(this._states) as ResourceGraphComponentPropertyMap[T];
+        case ResourceGraphComponent.Sampler:
+            return new ResourceGraphSamplerMap(this._samplerInfo) as ResourceGraphComponentPropertyMap[T];
         default:
             throw Error('component map not found');
         }
@@ -497,6 +520,9 @@ export class ResourceGraph implements impl.BidirectionalGraph
     }
     getStates (v: number): ResourceStates {
         return this._states[v];
+    }
+    getSampler (v: number): SamplerInfo {
+        return this._samplerInfo[v];
     }
     //-----------------------------------------------------------------
     // PolymorphicGraph
@@ -656,12 +682,13 @@ export class ResourceGraph implements impl.BidirectionalGraph
         return v;
     }
 
-    readonly components: string[] = ['Name', 'Desc', 'Traits', 'States'];
+    readonly components: string[] = ['Name', 'Desc', 'Traits', 'States', 'Sampler'];
     readonly _vertices: ResourceGraphVertex[] = [];
     readonly _names: string[] = [];
     readonly _descs: ResourceDesc[] = [];
     readonly _traits: ResourceTraits[] = [];
     readonly _states: ResourceStates[] = [];
+    readonly _samplerInfo: SamplerInfo[] = [];
     readonly _valueIndex: Map<string, number> = new Map<string, number>();
     nextFenceValue = 1;
 }

--- a/cocos/rendering/custom/web-pipeline.ts
+++ b/cocos/rendering/custom/web-pipeline.ts
@@ -940,6 +940,7 @@ export class WebPipeline implements Pipeline {
                 name, desc,
                 new ResourceTraits(ResourceResidency.EXTERNAL),
                 new ResourceStates(),
+                new SamplerInfo(),
             );
         } else {
             return this._resourceGraph.addVertex<ResourceGraphValue.Swapchain>(
@@ -948,6 +949,7 @@ export class WebPipeline implements Pipeline {
                 name, desc,
                 new ResourceTraits(ResourceResidency.BACKBUFFER),
                 new ResourceStates(),
+                new SamplerInfo(),
             );
         }
     }
@@ -968,6 +970,7 @@ export class WebPipeline implements Pipeline {
             name, desc,
             new ResourceTraits(residency),
             new ResourceStates(),
+            new SamplerInfo(),
         );
     }
     addDepthStencil (name: string, format: Format, width: number, height: number, residency: ResourceResidency) {
@@ -985,6 +988,7 @@ export class WebPipeline implements Pipeline {
             name, desc,
             new ResourceTraits(residency),
             new ResourceStates(),
+            new SamplerInfo(Filter.POINT, Filter.POINT, Filter.NONE),
         );
     }
     beginFrame () {

--- a/native/cocos/renderer/pipeline/custom/NativePipelineImpl.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineImpl.cpp
@@ -124,6 +124,7 @@ uint32_t NativePipeline::addRenderTexture(const ccstd::string &name, gfx::Format
             std::forward_as_tuple(desc),
             std::forward_as_tuple(ResourceTraits{ResourceResidency::EXTERNAL}),
             std::forward_as_tuple(),
+            std::forward_as_tuple(),
             std::forward_as_tuple(IntrusivePtr<gfx::Framebuffer>(renderWindow->getFramebuffer())),
             resourceGraph);
     }
@@ -135,6 +136,7 @@ uint32_t NativePipeline::addRenderTexture(const ccstd::string &name, gfx::Format
         std::forward_as_tuple(name.c_str()),
         std::forward_as_tuple(desc),
         std::forward_as_tuple(ResourceTraits{ResourceResidency::BACKBUFFER}),
+        std::forward_as_tuple(),
         std::forward_as_tuple(),
         std::forward_as_tuple(RenderSwapchain{renderWindow->getSwapchain()}),
         resourceGraph);
@@ -160,6 +162,7 @@ uint32_t NativePipeline::addRenderTarget(const ccstd::string &name, gfx::Format 
         std::forward_as_tuple(ResourceTraits{residency}),
         std::forward_as_tuple(),
         std::forward_as_tuple(),
+        std::forward_as_tuple(),
         resourceGraph);
 }
 
@@ -178,12 +181,17 @@ uint32_t NativePipeline::addDepthStencil(const ccstd::string &name, gfx::Format 
 
     CC_EXPECTS(residency == ResourceResidency::MANAGED && residency == ResourceResidency::MEMORYLESS);
 
+    gfx::SamplerInfo samplerInfo{};
+    samplerInfo.magFilter = gfx::Filter::POINT;
+    samplerInfo.minFilter = gfx::Filter::POINT;
+    samplerInfo.mipFilter = gfx::Filter::NONE;
     return addVertex(
         ManagedTag{},
         std::forward_as_tuple(name.c_str()),
         std::forward_as_tuple(desc),
         std::forward_as_tuple(ResourceTraits{residency}),
         std::forward_as_tuple(),
+        std::forward_as_tuple(samplerInfo),
         std::forward_as_tuple(),
         resourceGraph);
 }

--- a/native/cocos/renderer/pipeline/custom/RenderGraphFwd.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphFwd.h
@@ -53,6 +53,7 @@ struct PersistentBufferTag;
 struct PersistentTextureTag;
 struct FramebufferTag;
 struct SwapchainTag;
+struct SamplerTag;
 struct ResourceGraph;
 struct RasterSubpass;
 struct SubpassGraph;

--- a/native/cocos/renderer/pipeline/custom/RenderGraphGraphs.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphGraphs.h
@@ -283,6 +283,7 @@ inline void remove_vertex(ResourceGraph::vertex_descriptor u, ResourceGraph& g) 
     g.descs.erase(g.descs.begin() + std::ptrdiff_t(u));
     g.traits.erase(g.traits.begin() + std::ptrdiff_t(u));
     g.states.erase(g.states.begin() + std::ptrdiff_t(u));
+    g.samplerInfo.erase(g.samplerInfo.begin() + std::ptrdiff_t(u));
 }
 
 // MutablePropertyGraph(Vertex)
@@ -349,9 +350,9 @@ void addVertexImpl( // NOLINT
     g.swapchains.emplace_back(std::forward<ValueT>(val));
 }
 
-template <class Component0, class Component1, class Component2, class Component3, class ValueT>
+template <class Component0, class Component1, class Component2, class Component3, class Component4, class ValueT>
 inline ResourceGraph::vertex_descriptor
-addVertex(Component0&& c0, Component1&& c1, Component2&& c2, Component3&& c3, ValueT&& val, ResourceGraph& g) {
+addVertex(Component0&& c0, Component1&& c1, Component2&& c2, Component3&& c3, Component4&& c4, ValueT&& val, ResourceGraph& g) {
     auto v = gsl::narrow_cast<ResourceGraph::vertex_descriptor>(g._vertices.size());
 
     g._vertices.emplace_back();
@@ -366,6 +367,7 @@ addVertex(Component0&& c0, Component1&& c1, Component2&& c2, Component3&& c3, Va
     g.descs.emplace_back(std::forward<Component1>(c1));
     g.traits.emplace_back(std::forward<Component2>(c2));
     g.states.emplace_back(std::forward<Component3>(c3));
+    g.samplerInfo.emplace_back(std::forward<Component4>(c4));
 
     // PolymorphicGraph
     // if no matching overloaded function is found, Type is not supported by PolymorphicGraph
@@ -451,9 +453,9 @@ void addVertexImpl(SwapchainTag /*tag*/, Tuple &&val, ResourceGraph &g, Resource
         std::forward<Tuple>(val));
 }
 
-template <class Component0, class Component1, class Component2, class Component3, class Tag, class ValueT>
+template <class Component0, class Component1, class Component2, class Component3, class Component4, class Tag, class ValueT>
 inline ResourceGraph::vertex_descriptor
-addVertex(Tag tag, Component0&& c0, Component1&& c1, Component2&& c2, Component3&& c3, ValueT&& val, ResourceGraph& g) {
+addVertex(Tag tag, Component0&& c0, Component1&& c1, Component2&& c2, Component3&& c3, Component4&& c4, ValueT&& val, ResourceGraph& g) {
     auto v = gsl::narrow_cast<ResourceGraph::vertex_descriptor>(g._vertices.size());
 
     g._vertices.emplace_back();
@@ -491,6 +493,12 @@ addVertex(Tag tag, Component0&& c0, Component1&& c1, Component2&& c2, Component3
             g.states.emplace_back(std::forward<decltype(args)>(args)...);
         },
         std::forward<Component3>(c3));
+
+    std::apply(
+        [&](auto&&... args) {
+            g.samplerInfo.emplace_back(std::forward<decltype(args)>(args)...);
+        },
+        std::forward<Component4>(c4));
 
     // PolymorphicGraph
     // if no matching overloaded function is found, Type is not supported by PolymorphicGraph
@@ -1075,6 +1083,23 @@ struct property_map<cc::render::ResourceGraph, T cc::render::ResourceStates::*> 
         T cc::render::ResourceStates::*>;
 };
 
+// Vertex Component
+template <>
+struct property_map<cc::render::ResourceGraph, cc::render::ResourceGraph::SamplerTag> {
+    using const_type = cc::render::impl::VectorVertexComponentPropertyMap<
+        lvalue_property_map_tag,
+        const cc::render::ResourceGraph,
+        const ccstd::pmr::vector<cc::gfx::SamplerInfo>,
+        cc::gfx::SamplerInfo,
+        const cc::gfx::SamplerInfo&>;
+    using type = cc::render::impl::VectorVertexComponentPropertyMap<
+        lvalue_property_map_tag,
+        cc::render::ResourceGraph,
+        ccstd::pmr::vector<cc::gfx::SamplerInfo>,
+        cc::gfx::SamplerInfo,
+        cc::gfx::SamplerInfo&>;
+};
+
 // Vertex Index
 template <>
 struct property_map<cc::render::SubpassGraph, vertex_index_t> {
@@ -1372,6 +1397,17 @@ template <class T>
 inline typename boost::property_map<ResourceGraph, T ResourceStates::*>::type
 get(T ResourceStates::*memberPointer, ResourceGraph& g) noexcept {
     return {g.states, memberPointer};
+}
+
+// Vertex Component
+inline typename boost::property_map<ResourceGraph, ResourceGraph::SamplerTag>::const_type
+get(ResourceGraph::SamplerTag /*tag*/, const ResourceGraph& g) noexcept {
+    return {g.samplerInfo};
+}
+
+inline typename boost::property_map<ResourceGraph, ResourceGraph::SamplerTag>::type
+get(ResourceGraph::SamplerTag /*tag*/, ResourceGraph& g) noexcept {
+    return {g.samplerInfo};
 }
 
 // PolymorphicGraph
@@ -2177,6 +2213,7 @@ add_vertex(ResourceGraph& g, Tag t, ccstd::pmr::string&& name) { // NOLINT
         std::forward_as_tuple(),                // descs
         std::forward_as_tuple(),                // traits
         std::forward_as_tuple(),                // states
+        std::forward_as_tuple(),                // samplerInfo
         std::forward_as_tuple(),                // PolymorphicType
         g);
 }
@@ -2190,6 +2227,7 @@ add_vertex(ResourceGraph& g, Tag t, const char* name) { // NOLINT
         std::forward_as_tuple(),     // descs
         std::forward_as_tuple(),     // traits
         std::forward_as_tuple(),     // states
+        std::forward_as_tuple(),     // samplerInfo
         std::forward_as_tuple(),     // PolymorphicType
         g);
 }

--- a/native/cocos/renderer/pipeline/custom/RenderGraphNames.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphNames.h
@@ -51,6 +51,7 @@ inline const char* getName(const PersistentBufferTag& /*v*/) noexcept { return "
 inline const char* getName(const PersistentTextureTag& /*v*/) noexcept { return "PersistentTexture"; }
 inline const char* getName(const FramebufferTag& /*v*/) noexcept { return "Framebuffer"; }
 inline const char* getName(const SwapchainTag& /*v*/) noexcept { return "Swapchain"; }
+inline const char* getName(const SamplerTag& /*v*/) noexcept { return "Sampler"; }
 inline const char* getName(const ResourceGraph& /*v*/) noexcept { return "ResourceGraph"; }
 inline const char* getName(const RasterSubpass& /*v*/) noexcept { return "RasterSubpass"; }
 inline const char* getName(const SubpassGraph& /*v*/) noexcept { return "SubpassGraph"; }

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.cpp
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.cpp
@@ -41,6 +41,7 @@ ResourceGraph::ResourceGraph(const allocator_type& alloc) noexcept
   descs(alloc),
   traits(alloc),
   states(alloc),
+  samplerInfo(alloc),
   resources(alloc),
   managedBuffers(alloc),
   managedTextures(alloc),
@@ -56,6 +57,7 @@ ResourceGraph::ResourceGraph(ResourceGraph&& rhs, const allocator_type& alloc)
   descs(std::move(rhs.descs), alloc),
   traits(std::move(rhs.traits), alloc),
   states(std::move(rhs.states), alloc),
+  samplerInfo(std::move(rhs.samplerInfo), alloc),
   resources(std::move(rhs.resources), alloc),
   managedBuffers(std::move(rhs.managedBuffers), alloc),
   managedTextures(std::move(rhs.managedTextures), alloc),
@@ -72,6 +74,7 @@ ResourceGraph::ResourceGraph(ResourceGraph const& rhs, const allocator_type& all
   descs(rhs.descs, alloc),
   traits(rhs.traits, alloc),
   states(rhs.states, alloc),
+  samplerInfo(rhs.samplerInfo, alloc),
   resources(rhs.resources, alloc),
   managedBuffers(rhs.managedBuffers, alloc),
   managedTextures(rhs.managedTextures, alloc),
@@ -89,6 +92,7 @@ void ResourceGraph::reserve(vertices_size_type sz) {
     descs.reserve(sz);
     traits.reserve(sz);
     states.reserve(sz);
+    samplerInfo.reserve(sz);
 }
 
 ResourceGraph::Vertex::Vertex(const allocator_type& alloc) noexcept

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
@@ -126,6 +126,7 @@ struct PersistentBufferTag {};
 struct PersistentTextureTag {};
 struct FramebufferTag {};
 struct SwapchainTag {};
+struct SamplerTag {};
 
 struct ResourceGraph {
     using allocator_type = boost::container::pmr::polymorphic_allocator<char>;
@@ -262,6 +263,8 @@ struct ResourceGraph {
     } static constexpr Traits{}; // NOLINT
     struct StatesTag {
     } static constexpr States{}; // NOLINT
+    struct SamplerTag {
+    } static constexpr Sampler{}; // NOLINT
 
     // Vertices
     ccstd::pmr::vector<Vertex> _vertices;
@@ -270,6 +273,7 @@ struct ResourceGraph {
     ccstd::pmr::vector<ResourceDesc> descs;
     ccstd::pmr::vector<ResourceTraits> traits;
     ccstd::pmr::vector<ResourceStates> states;
+    ccstd::pmr::vector<gfx::SamplerInfo> samplerInfo;
     // PolymorphicGraph
     ccstd::pmr::vector<ManagedResource> resources;
     ccstd::pmr::vector<ManagedBuffer> managedBuffers;


### PR DESCRIPTION
Added default SamplerInfo to resource graph.

### Changelog

* updated web/native pipeline

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
