### PR TITLE
Feat: gpuObjects use smart_ptr [vulkan][buffer, texture]

### DIFF
--- a/native/cocos/renderer/gfx-vulkan/VKBuffer.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKBuffer.cpp
@@ -41,32 +41,33 @@ CCVKBuffer::~CCVKBuffer() {
 }
 
 void CCVKBuffer::doInit(const BufferInfo & /*info*/) {
-    _gpuBuffer = ccnew CCVKGPUBuffer;
-    _gpuBuffer->size = _size;
-    _gpuBuffer->count = _count;
-    createBuffer();
+    createBuffer(_size, _count);
 
-    _gpuBufferView = ccnew CCVKGPUBufferView;
-    _gpuBufferView->range = _size;
-    createBufferView();
+    createBufferView(_size);
 }
 
 void CCVKBuffer::doInit(const BufferViewInfo &info) {
     auto *buffer = static_cast<CCVKBuffer *>(info.buffer);
     _gpuBuffer = buffer->gpuBuffer();
-    _gpuBufferView = ccnew CCVKGPUBufferView;
-    _gpuBufferView->range = _size;
-    createBufferView();
+
+    createBufferView(_size);
 }
 
-void CCVKBuffer::createBuffer() {
+void CCVKBuffer::createBuffer(uint32_t size, uint32_t count) {
+    _gpuBuffer = ccnew CCVKGPUBuffer;
+    _gpuBuffer->size = size;
+    _gpuBuffer->count = count;
+
     _gpuBuffer->usage = _usage;
     _gpuBuffer->memUsage = _memUsage;
     _gpuBuffer->stride = _stride;
     _gpuBuffer->init();
 }
 
-void CCVKBuffer::createBufferView() {
+void CCVKBuffer::createBufferView(uint32_t range) {
+    _gpuBufferView = ccnew CCVKGPUBufferView;
+    _gpuBufferView->range = range;
+
     _gpuBufferView->gpuBuffer = _gpuBuffer;
     _gpuBufferView->offset = _offset;
 }
@@ -77,15 +78,10 @@ void CCVKBuffer::doDestroy() {
 }
 
 void CCVKBuffer::doResize(uint32_t size, uint32_t count) {
-    _gpuBuffer = ccnew CCVKGPUBuffer();
-    _gpuBuffer->size = size;
-    _gpuBuffer->count = count;
-    createBuffer();
+    createBuffer(size, count);
 
-    auto oldBufferView = _gpuBufferView;
-    _gpuBufferView = ccnew CCVKGPUBufferView();
-    _gpuBufferView->range = size;
-    createBufferView();
+    IntrusivePtr<CCVKGPUBufferView> oldBufferView = _gpuBufferView;
+    createBufferView(size);
     CCVKDevice::getInstance()->gpuDescriptorHub()->update(oldBufferView, _gpuBufferView);
     CCVKDevice::getInstance()->gpuIAHub()->update(oldBufferView, _gpuBufferView);
 }

--- a/native/cocos/renderer/gfx-vulkan/VKBuffer.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKBuffer.cpp
@@ -80,6 +80,7 @@ void CCVKBuffer::doDestroy() {
 void CCVKBuffer::doResize(uint32_t size, uint32_t count) {
     createBuffer(size, count);
 
+    // Hold reference to keep the old bufferView alive during DescriptorHub::update and IAHub::update.
     IntrusivePtr<CCVKGPUBufferView> oldBufferView = _gpuBufferView;
     createBufferView(size);
     CCVKDevice::getInstance()->gpuDescriptorHub()->update(oldBufferView, _gpuBufferView);

--- a/native/cocos/renderer/gfx-vulkan/VKBuffer.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKBuffer.cpp
@@ -42,23 +42,12 @@ CCVKBuffer::~CCVKBuffer() {
 
 void CCVKBuffer::doInit(const BufferInfo & /*info*/) {
     _gpuBuffer = ccnew CCVKGPUBuffer;
-    _gpuBuffer->usage = _usage;
-    _gpuBuffer->memUsage = _memUsage;
     _gpuBuffer->size = _size;
-    _gpuBuffer->stride = _stride;
     _gpuBuffer->count = _count;
-
-    if (hasFlag(_usage, BufferUsageBit::INDIRECT)) {
-        const size_t drawInfoCount = _size / sizeof(DrawInfo);
-        _gpuBuffer->indexedIndirectCmds.resize(drawInfoCount);
-        _gpuBuffer->indirectCmds.resize(drawInfoCount);
-    }
-
-    cmdFuncCCVKCreateBuffer(CCVKDevice::getInstance(), _gpuBuffer);
-    CCVKDevice::getInstance()->getMemoryStatus().bufferSize += _size;
-    CC_PROFILE_MEMORY_INC(Buffer, _size);
+    createBuffer();
 
     _gpuBufferView = ccnew CCVKGPUBufferView;
+    _gpuBufferView->range = _size;
     createBufferView();
 }
 
@@ -66,62 +55,70 @@ void CCVKBuffer::doInit(const BufferViewInfo &info) {
     auto *buffer = static_cast<CCVKBuffer *>(info.buffer);
     _gpuBuffer = buffer->gpuBuffer();
     _gpuBufferView = ccnew CCVKGPUBufferView;
+    _gpuBufferView->range = _size;
     createBufferView();
+}
+
+void CCVKBuffer::createBuffer() {
+    _gpuBuffer->usage = _usage;
+    _gpuBuffer->memUsage = _memUsage;
+    _gpuBuffer->stride = _stride;
+    _gpuBuffer->init();
 }
 
 void CCVKBuffer::createBufferView() {
     _gpuBufferView->gpuBuffer = _gpuBuffer;
     _gpuBufferView->offset = _offset;
-    _gpuBufferView->range = _size;
-    if (_gpuBufferView->gpuBuffer->vkBuffer) {
-        CCVKDevice::getInstance()->gpuDescriptorHub()->update(_gpuBufferView);
-    }
 }
 
 void CCVKBuffer::doDestroy() {
-    if (_gpuBufferView) {
-        CCVKDevice::getInstance()->gpuDescriptorHub()->disengage(_gpuBufferView);
-        delete _gpuBufferView;
-        _gpuBufferView = nullptr;
-    }
-
-    if (_gpuBuffer) {
-        if (!_isBufferView) {
-            CCVKDevice::getInstance()->gpuBufferHub()->erase(_gpuBuffer);
-            CCVKDevice::getInstance()->gpuRecycleBin()->collect(_gpuBuffer);
-            CCVKDevice::getInstance()->gpuBarrierManager()->cancel(_gpuBuffer);
-            delete _gpuBuffer;
-            CCVKDevice::getInstance()->getMemoryStatus().bufferSize -= _size;
-            CC_PROFILE_MEMORY_DEC(Buffer, _size);
-        }
-        _gpuBuffer = nullptr;
-    }
+    _gpuBufferView = nullptr;
+    _gpuBuffer = nullptr;
 }
 
 void CCVKBuffer::doResize(uint32_t size, uint32_t count) {
-    CCVKDevice::getInstance()->getMemoryStatus().bufferSize -= _size;
-    CC_PROFILE_MEMORY_DEC(Buffer, _size);
-    CCVKDevice::getInstance()->gpuRecycleBin()->collect(_gpuBuffer);
-
+    _gpuBuffer = ccnew CCVKGPUBuffer();
     _gpuBuffer->size = size;
     _gpuBuffer->count = count;
-    cmdFuncCCVKCreateBuffer(CCVKDevice::getInstance(), _gpuBuffer);
+    createBuffer();
 
+    auto oldBufferView = _gpuBufferView;
+    _gpuBufferView = ccnew CCVKGPUBufferView();
     _gpuBufferView->range = size;
-    CCVKDevice::getInstance()->gpuDescriptorHub()->update(_gpuBuffer);
-
-    if (hasFlag(_usage, BufferUsageBit::INDIRECT)) {
-        const size_t drawInfoCount = _size / sizeof(DrawInfo);
-        _gpuBuffer->indexedIndirectCmds.resize(drawInfoCount);
-        _gpuBuffer->indirectCmds.resize(drawInfoCount);
-    }
-    CCVKDevice::getInstance()->getMemoryStatus().bufferSize += size;
-    CC_PROFILE_MEMORY_INC(Buffer, size);
+    createBufferView();
+    CCVKDevice::getInstance()->gpuDescriptorHub()->update(oldBufferView, _gpuBufferView);
+    CCVKDevice::getInstance()->gpuIAHub()->update(oldBufferView, _gpuBufferView);
 }
 
 void CCVKBuffer::update(const void *buffer, uint32_t size) {
     CC_PROFILE(CCVKBufferUpdate);
     cmdFuncCCVKUpdateBuffer(CCVKDevice::getInstance(), _gpuBuffer, buffer, size, nullptr);
+}
+
+void CCVKGPUBuffer::shutdown() {
+    CCVKDevice::getInstance()->gpuBarrierManager()->cancel(this);
+    CCVKDevice::getInstance()->gpuRecycleBin()->collect(this);
+    CCVKDevice::getInstance()->gpuBufferHub()->erase(this);
+
+    CCVKDevice::getInstance()->getMemoryStatus().bufferSize -= size;
+    CC_PROFILE_MEMORY_DEC(Buffer, size);
+}
+
+void CCVKGPUBuffer::init() {
+    if (hasFlag(usage, BufferUsageBit::INDIRECT)) {
+        const size_t drawInfoCount = size / sizeof(DrawInfo);
+        indexedIndirectCmds.resize(drawInfoCount);
+        indirectCmds.resize(drawInfoCount);
+    }
+
+    cmdFuncCCVKCreateBuffer(CCVKDevice::getInstance(), this);
+    CCVKDevice::getInstance()->getMemoryStatus().bufferSize += size;
+    CC_PROFILE_MEMORY_INC(Buffer, size);
+}
+
+void CCVKGPUBufferView::shutdown() {
+    CCVKDevice::getInstance()->gpuDescriptorHub()->disengage(this);
+    CCVKDevice::getInstance()->gpuIAHub()->disengage(this);
 }
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-vulkan/VKBuffer.h
+++ b/native/cocos/renderer/gfx-vulkan/VKBuffer.h
@@ -27,12 +27,10 @@
 
 #include "VKStd.h"
 #include "gfx-base/GFXBuffer.h"
+#include "gfx-vulkan/VKGPUObjects.h"
 
 namespace cc {
 namespace gfx {
-
-struct CCVKGPUBuffer;
-struct CCVKGPUBufferView;
 
 class CC_VULKAN_API CCVKBuffer final : public Buffer {
 public:
@@ -50,10 +48,11 @@ protected:
     void doDestroy() override;
     void doResize(uint32_t size, uint32_t count) override;
 
+    void createBuffer();
     void createBufferView();
 
-    CCVKGPUBuffer *_gpuBuffer = nullptr;
-    CCVKGPUBufferView *_gpuBufferView = nullptr;
+    IntrusivePtr<CCVKGPUBuffer> _gpuBuffer;
+    IntrusivePtr<CCVKGPUBufferView> _gpuBufferView;
 };
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-vulkan/VKBuffer.h
+++ b/native/cocos/renderer/gfx-vulkan/VKBuffer.h
@@ -48,8 +48,8 @@ protected:
     void doDestroy() override;
     void doResize(uint32_t size, uint32_t count) override;
 
-    void createBuffer();
-    void createBufferView();
+    void createBuffer(uint32_t size, uint32_t count);
+    void createBufferView(uint32_t range);
 
     IntrusivePtr<CCVKGPUBuffer> _gpuBuffer;
     IntrusivePtr<CCVKGPUBufferView> _gpuBufferView;

--- a/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
@@ -382,7 +382,7 @@ void CCVKCommandBuffer::draw(const DrawInfo &info) {
         bindDescriptorSets(VK_PIPELINE_BIND_POINT_GRAPHICS);
     }
 
-    const auto *gpuIndirectBuffer = _curGPUInputAssembler->gpuIndirectBuffer;
+    const auto *gpuIndirectBuffer = _curGPUInputAssembler->gpuIndirectBuffer.get();
 
     if (gpuIndirectBuffer) {
         uint32_t drawInfoCount = gpuIndirectBuffer->range / gpuIndirectBuffer->gpuBuffer->stride;

--- a/native/cocos/renderer/gfx-vulkan/VKCommands.h
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.h
@@ -49,7 +49,7 @@ void cmdFuncCCVKCreateGeneralBarrier(CCVKDevice *device, CCVKGPUGeneralBarrier *
 
 void cmdFuncCCVKUpdateBuffer(CCVKDevice *device, CCVKGPUBuffer *gpuBuffer, const void *buffer, uint32_t size, const CCVKGPUCommandBuffer *cmdBuffer = nullptr);
 void cmdFuncCCVKCopyBuffersToTexture(CCVKDevice *device, const uint8_t *const *buffers, CCVKGPUTexture *gpuTexture, const BufferTextureCopy *regions, uint32_t count, const CCVKGPUCommandBuffer *gpuCommandBuffer);
-void cmdFuncCCVKCopyTextureToBuffers(CCVKDevice *device, CCVKGPUTexture *srcTexture, CCVKGPUBuffer *destBuffer, const BufferTextureCopy *regions, uint32_t count, const CCVKGPUCommandBuffer *gpuCommandBuffer);
+void cmdFuncCCVKCopyTextureToBuffers(CCVKDevice *device, CCVKGPUTexture *srcTexture, CCVKGPUBufferView *destBuffer, const BufferTextureCopy *regions, uint32_t count, const CCVKGPUCommandBuffer *gpuCommandBuffer);
 
 void cmdFuncCCVKDestroyQueryPool(CCVKGPUDevice *device, CCVKGPUQueryPool *gpuQueryPool);
 void cmdFuncCCVKDestroyRenderPass(CCVKGPUDevice *device, CCVKGPURenderPass *gpuRenderPass);

--- a/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -538,7 +538,8 @@ void CCVKDevice::doDestroy() {
     CC_SAFE_DELETE(_gpuIAHub)
 
     if (_gpuDevice) {
-        for (uint32_t i = 0; i < _gpuDevice->backBufferCount; ++i) {
+        uint32_t backBufferCount = _gpuDevice->backBufferCount;
+        for (uint32_t i = 0U; i < backBufferCount; i++) {
             _gpuRecycleBins[i]->clear();
             CC_SAFE_DELETE(_gpuRecycleBins[i])
         }

--- a/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -400,30 +400,33 @@ bool CCVKDevice::doInit(const DeviceInfo & /*info*/) {
     }
 
     _gpuBufferHub = ccnew CCVKGPUBufferHub(_gpuDevice);
+    _gpuIAHub = ccnew CCVKGPUInputAssemblerHub(_gpuDevice);
     _gpuTransportHub = ccnew CCVKGPUTransportHub(_gpuDevice, static_cast<CCVKQueue *>(_queue)->gpuQueue());
     _gpuDescriptorHub = ccnew CCVKGPUDescriptorHub(_gpuDevice);
     _gpuSemaphorePool = ccnew CCVKGPUSemaphorePool(_gpuDevice);
     _gpuBarrierManager = ccnew CCVKGPUBarrierManager(_gpuDevice);
     _gpuDescriptorSetHub = ccnew CCVKGPUDescriptorSetHub(_gpuDevice);
 
-    _gpuDescriptorHub->link(_gpuDescriptorSetHub);
+    _gpuDescriptorSetHub = ccnew CCVKGPUDescriptorSetHub(_gpuDevice);
+    _gpuDevice->defaultSampler = ccnew CCVKGPUSampler();
+    _gpuDevice->defaultSampler->init();
 
-    cmdFuncCCVKCreateSampler(this, &_gpuDevice->defaultSampler);
+    _gpuDevice->defaultTexture = ccnew CCVKGPUTexture();
+    _gpuDevice->defaultTexture->format = Format::RGBA8;
+    _gpuDevice->defaultTexture->usage = TextureUsageBit::SAMPLED | TextureUsage::STORAGE;
+    _gpuDevice->defaultTexture->width = _gpuDevice->defaultTexture->height = 1U;
+    _gpuDevice->defaultTexture->size = formatSize(Format::RGBA8, 1U, 1U, 1U);
+    _gpuDevice->defaultTexture->init();
 
-    _gpuDevice->defaultTexture.format = Format::RGBA8;
-    _gpuDevice->defaultTexture.usage = TextureUsageBit::SAMPLED | TextureUsage::STORAGE;
-    _gpuDevice->defaultTexture.width = _gpuDevice->defaultTexture.height = 1U;
-    _gpuDevice->defaultTexture.size = formatSize(Format::RGBA8, 1U, 1U, 1U);
-    cmdFuncCCVKCreateTexture(this, &_gpuDevice->defaultTexture);
-
-    _gpuDevice->defaultTextureView.gpuTexture = &_gpuDevice->defaultTexture;
-    _gpuDevice->defaultTextureView.format = Format::RGBA8;
-    cmdFuncCCVKCreateTextureView(this, &_gpuDevice->defaultTextureView);
+    _gpuDevice->defaultTextureView = ccnew CCVKGPUTextureView();
+    _gpuDevice->defaultTextureView->gpuTexture = _gpuDevice->defaultTexture;
+    _gpuDevice->defaultTextureView->format = Format::RGBA8;
+    _gpuDevice->defaultTextureView->init();
 
     ThsvsImageBarrier barrier{};
     barrier.nextAccessCount = 1;
     barrier.pNextAccesses = getAccessType(AccessFlagBit::VERTEX_SHADER_READ_TEXTURE);
-    barrier.image = _gpuDevice->defaultTexture.vkImage;
+    barrier.image = _gpuDevice->defaultTexture->vkImage;
     barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -435,11 +438,12 @@ bool CCVKDevice::doInit(const DeviceInfo & /*info*/) {
         },
         true);
 
-    _gpuDevice->defaultBuffer.usage = BufferUsage::UNIFORM | BufferUsage::STORAGE;
-    _gpuDevice->defaultBuffer.memUsage = MemoryUsage::HOST | MemoryUsage::DEVICE;
-    _gpuDevice->defaultBuffer.size = _gpuDevice->defaultBuffer.stride = 16U;
-    _gpuDevice->defaultBuffer.count = 1U;
-    cmdFuncCCVKCreateBuffer(this, &_gpuDevice->defaultBuffer);
+    _gpuDevice->defaultBuffer = ccnew CCVKGPUBuffer();
+    _gpuDevice->defaultBuffer->usage = BufferUsage::UNIFORM | BufferUsage::STORAGE;
+    _gpuDevice->defaultBuffer->memUsage = MemoryUsage::HOST | MemoryUsage::DEVICE;
+    _gpuDevice->defaultBuffer->size = _gpuDevice->defaultBuffer->stride = 16U;
+    _gpuDevice->defaultBuffer->count = 1U;
+    _gpuDevice->defaultBuffer->init();
 
     getAccessTypes(AccessFlagBit::COLOR_ATTACHMENT_WRITE, _gpuDevice->defaultColorBarrier.nextAccesses);
     cmdFuncCCVKCreateGeneralBarrier(this, &_gpuDevice->defaultColorBarrier);
@@ -503,27 +507,42 @@ void CCVKDevice::doDestroy() {
     }
     _depthStencilTextures.clear();
 
+    if (_gpuDevice) {
+        _gpuDevice->defaultBuffer = nullptr;
+        _gpuDevice->defaultTexture = nullptr;
+        _gpuDevice->defaultTextureView = nullptr;
+        _gpuDevice->defaultSampler = nullptr;
+    }
+
     CC_SAFE_DESTROY_AND_DELETE(_queryPool)
     CC_SAFE_DESTROY_AND_DELETE(_queue)
     CC_SAFE_DESTROY_AND_DELETE(_cmdBuff)
+
+    if (_gpuDevice) {
+        uint32_t backBufferCount = _gpuDevice->backBufferCount;
+        for (uint32_t i = 0; i < backBufferCount; i++) {
+            CC_SAFE_DELETE(_gpuStagingBufferPools[i])
+            CC_SAFE_DELETE(_gpuFencePools[i])
+        }
+    }
+    _gpuStagingBufferPools.clear();
+    _gpuFencePools.clear();
+
+
     CC_SAFE_DELETE(_gpuBufferHub)
     CC_SAFE_DELETE(_gpuTransportHub)
     CC_SAFE_DELETE(_gpuSemaphorePool)
     CC_SAFE_DELETE(_gpuDescriptorHub)
     CC_SAFE_DELETE(_gpuBarrierManager)
     CC_SAFE_DELETE(_gpuDescriptorSetHub)
+    CC_SAFE_DELETE(_gpuIAHub)
 
     if (_gpuDevice) {
-        uint32_t backBufferCount = _gpuDevice->backBufferCount;
-        for (uint32_t i = 0U; i < backBufferCount; i++) {
+        for (uint32_t i = 0; i < _gpuDevice->backBufferCount; ++i) {
             _gpuRecycleBins[i]->clear();
-
-            CC_SAFE_DELETE(_gpuStagingBufferPools[i])
             CC_SAFE_DELETE(_gpuRecycleBins[i])
-            CC_SAFE_DELETE(_gpuFencePools[i])
         }
     }
-
     _gpuStagingBufferPools.clear();
     _gpuRecycleBins.clear();
     _gpuFencePools.clear();
@@ -533,22 +552,6 @@ void CCVKDevice::doDestroy() {
             vkDestroyPipelineCache(_gpuDevice->vkDevice, _gpuDevice->vkPipelineCache, nullptr);
             _gpuDevice->vkPipelineCache = VK_NULL_HANDLE;
         }
-
-        if (_gpuDevice->defaultBuffer.vkBuffer) {
-            vmaDestroyBuffer(_gpuDevice->memoryAllocator, _gpuDevice->defaultBuffer.vkBuffer, _gpuDevice->defaultBuffer.vmaAllocation);
-            _gpuDevice->defaultBuffer.vkBuffer = VK_NULL_HANDLE;
-            _gpuDevice->defaultBuffer.vmaAllocation = VK_NULL_HANDLE;
-        }
-        if (_gpuDevice->defaultTextureView.vkImageView) {
-            vkDestroyImageView(_gpuDevice->vkDevice, _gpuDevice->defaultTextureView.vkImageView, nullptr);
-            _gpuDevice->defaultTextureView.vkImageView = VK_NULL_HANDLE;
-        }
-        if (_gpuDevice->defaultTexture.vkImage) {
-            vmaDestroyImage(_gpuDevice->memoryAllocator, _gpuDevice->defaultTexture.vkImage, _gpuDevice->defaultTexture.vmaAllocation);
-            _gpuDevice->defaultTexture.vkImage = VK_NULL_HANDLE;
-            _gpuDevice->defaultTexture.vmaAllocation = VK_NULL_HANDLE;
-        }
-        cmdFuncCCVKDestroySampler(_gpuDevice, &_gpuDevice->defaultSampler);
 
         if (_gpuDevice->memoryAllocator != VK_NULL_HANDLE) {
             VmaStats stats;
@@ -890,17 +893,15 @@ void CCVKDevice::copyTextureToBuffers(Texture *srcTexture, uint8_t *const *buffe
         totalSize += regionSize;
     }
 
-    CCVKGPUBuffer stagingBuffer;
-    stagingBuffer.size = totalSize;
     uint32_t texelSize = GFX_FORMAT_INFOS[toNumber(format)].size;
-    gpuStagingBufferPool()->alloc(&stagingBuffer, texelSize);
+    IntrusivePtr<CCVKGPUBufferView> stagingBuffer = gpuStagingBufferPool()->alloc(totalSize, texelSize);
 
     // make sure the src texture is up-to-date
     waitAllFences();
 
     _gpuTransportHub->checkIn(
         [&](CCVKGPUCommandBuffer *cmdBuffer) {
-            cmdFuncCCVKCopyTextureToBuffers(this, static_cast<CCVKTexture *>(srcTexture)->gpuTexture(), &stagingBuffer, regions, count, cmdBuffer);
+            cmdFuncCCVKCopyTextureToBuffers(this, static_cast<const CCVKTexture *>(srcTexture)->gpuTexture(), stagingBuffer, regions, count, cmdBuffer);
         },
         true);
 
@@ -908,7 +909,7 @@ void CCVKDevice::copyTextureToBuffers(Texture *srcTexture, uint8_t *const *buffe
         uint32_t regionOffset = 0;
         uint32_t regionSize = 0;
         std::tie(regionOffset, regionSize) = regionOffsetSizes[i];
-        memcpy(buffers[i], stagingBuffer.mappedData + regionOffset, regionSize);
+        memcpy(buffers[i], stagingBuffer->mappedData() + regionOffset, regionSize);
     }
 }
 

--- a/native/cocos/renderer/gfx-vulkan/VKDevice.h
+++ b/native/cocos/renderer/gfx-vulkan/VKDevice.h
@@ -87,13 +87,13 @@ public:
     inline CCVKGPUDevice *gpuDevice() const { return _gpuDevice; }
     inline CCVKGPUContext *gpuContext() { return _gpuContext; }
 
-    inline CCVKGPUBufferHub *gpuBufferHub() { return _gpuBufferHub; }
-    inline CCVKGPUTransportHub *gpuTransportHub() { return _gpuTransportHub; }
-    inline CCVKGPUDescriptorHub *gpuDescriptorHub() { return _gpuDescriptorHub; }
-    inline CCVKGPUSemaphorePool *gpuSemaphorePool() { return _gpuSemaphorePool; }
-    inline CCVKGPUBarrierManager *gpuBarrierManager() { return _gpuBarrierManager; }
-    inline CCVKGPUDescriptorSetHub *gpuDescriptorSetHub() { return _gpuDescriptorSetHub; }
-    inline CCVKGPUInputAssemblerHub *gpuIAHub() { return _gpuIAHub; }
+    inline CCVKGPUBufferHub *gpuBufferHub() const { return _gpuBufferHub; }
+    inline CCVKGPUTransportHub *gpuTransportHub() const { return _gpuTransportHub; }
+    inline CCVKGPUDescriptorHub *gpuDescriptorHub() const { return _gpuDescriptorHub; }
+    inline CCVKGPUSemaphorePool *gpuSemaphorePool() const { return _gpuSemaphorePool; }
+    inline CCVKGPUBarrierManager *gpuBarrierManager() const { return _gpuBarrierManager; }
+    inline CCVKGPUDescriptorSetHub *gpuDescriptorSetHub() const { return _gpuDescriptorSetHub; }
+    inline CCVKGPUInputAssemblerHub *gpuIAHub() const { return _gpuIAHub; }
 
     CCVKGPUFencePool *gpuFencePool();
     CCVKGPURecycleBin *gpuRecycleBin();

--- a/native/cocos/renderer/gfx-vulkan/VKDevice.h
+++ b/native/cocos/renderer/gfx-vulkan/VKDevice.h
@@ -43,8 +43,8 @@ class CCVKGPUTransportHub;
 class CCVKGPUDescriptorHub;
 class CCVKGPUSemaphorePool;
 class CCVKGPUBarrierManager;
-class CCVKGPUFramebufferHub;
 class CCVKGPUDescriptorSetHub;
+class CCVKGPUInputAssemblerHub;
 
 class CCVKGPUFencePool;
 class CCVKGPURecycleBin;
@@ -93,6 +93,7 @@ public:
     inline CCVKGPUSemaphorePool *gpuSemaphorePool() { return _gpuSemaphorePool; }
     inline CCVKGPUBarrierManager *gpuBarrierManager() { return _gpuBarrierManager; }
     inline CCVKGPUDescriptorSetHub *gpuDescriptorSetHub() { return _gpuDescriptorSetHub; }
+    inline CCVKGPUInputAssemblerHub *gpuIAHub() { return _gpuIAHub; }
 
     CCVKGPUFencePool *gpuFencePool();
     CCVKGPURecycleBin *gpuRecycleBin();
@@ -149,6 +150,7 @@ protected:
     CCVKGPUSemaphorePool *_gpuSemaphorePool{nullptr};
     CCVKGPUBarrierManager *_gpuBarrierManager{nullptr};
     CCVKGPUDescriptorSetHub *_gpuDescriptorSetHub{nullptr};
+    CCVKGPUInputAssemblerHub *_gpuIAHub{nullptr};
 
     ccstd::vector<const char *> _layers;
     ccstd::vector<const char *> _extensions;

--- a/native/cocos/renderer/gfx-vulkan/VKGPUObjects.h
+++ b/native/cocos/renderer/gfx-vulkan/VKGPUObjects.h
@@ -134,6 +134,9 @@ public:
 struct CCVKGPUSwapchain;
 struct CCVKGPUFramebuffer;
 struct CCVKGPUTexture : public CCVKGPUDeviceObject {
+    void shutdown() override;
+    void init();
+
     TextureType type = TextureType::TEX2D;
     Format format = Format::UNKNOWN;
     TextureUsage usage = TextureUsageBit::NONE;
@@ -163,7 +166,10 @@ struct CCVKGPUTexture : public CCVKGPUDeviceObject {
 };
 
 struct CCVKGPUTextureView : public CCVKGPUDeviceObject {
-    CCVKGPUTexture *gpuTexture = nullptr;
+    void shutdown() override;
+    void init();
+
+    IntrusivePtr<CCVKGPUTexture> gpuTexture;
     TextureType type = TextureType::TEX2D;
     Format format = Format::UNKNOWN;
     uint32_t baseLevel = 0U;
@@ -178,6 +184,9 @@ struct CCVKGPUTextureView : public CCVKGPUDeviceObject {
 };
 
 struct CCVKGPUSampler : public CCVKGPUDeviceObject {
+    void shutdown() override;
+    void init();
+
     Filter minFilter = Filter::LINEAR;
     Filter magFilter = Filter::LINEAR;
     Filter mipFilter = Filter::NONE;
@@ -192,6 +201,9 @@ struct CCVKGPUSampler : public CCVKGPUDeviceObject {
 };
 
 struct CCVKGPUBuffer : public CCVKGPUDeviceObject {
+    void shutdown() override;
+    void init();
+
     BufferUsage usage = BufferUsage::NONE;
     MemoryUsage memUsage = MemoryUsage::NONE;
     uint32_t stride = 0U;
@@ -207,7 +219,6 @@ struct CCVKGPUBuffer : public CCVKGPUDeviceObject {
 
     // descriptor infos
     VkBuffer vkBuffer = VK_NULL_HANDLE;
-    VkDeviceSize startOffset = 0U;
     VkDeviceSize size = 0U;
 
     VkDeviceSize instanceSize = 0U; // per-back-buffer instance
@@ -218,14 +229,19 @@ struct CCVKGPUBuffer : public CCVKGPUDeviceObject {
     ThsvsAccessType transferAccess = THSVS_ACCESS_NONE;
 
     VkDeviceSize getStartOffset(uint32_t curBackBufferIndex) const {
-        return startOffset + instanceSize * curBackBufferIndex;
+        return instanceSize * curBackBufferIndex;
     }
 };
 
 struct CCVKGPUBufferView : public CCVKGPUDeviceObject {
-    CCVKGPUBuffer *gpuBuffer = nullptr;
+    void shutdown() override;
+    ConstPtr<CCVKGPUBuffer> gpuBuffer;
     uint32_t offset = 0U;
     uint32_t range = 0U;
+
+    uint8_t* mappedData() const {
+        return gpuBuffer->mappedData + offset;
+    }
 
     VkDeviceSize getStartOffset(uint32_t curBackBufferIndex) const {
         return gpuBuffer->getStartOffset(curBackBufferIndex) + offset;
@@ -236,8 +252,8 @@ struct CCVKGPUFramebuffer : public CCVKGPUDeviceObject {
     void shutdown() override;
 
     ConstPtr<CCVKGPURenderPass> gpuRenderPass;
-    ccstd::vector<CCVKGPUTextureView *> gpuColorViews;
-    CCVKGPUTextureView *gpuDepthStencilView = nullptr;
+    ccstd::vector<ConstPtr<CCVKGPUTextureView>> gpuColorViews;
+    ConstPtr<CCVKGPUTextureView> gpuDepthStencilView;
     VkFramebuffer vkFramebuffer = VK_NULL_HANDLE;
     std::vector<VkFramebuffer> vkFrameBuffers;
     CCVKGPUSwapchain *swapchain = nullptr;
@@ -306,10 +322,13 @@ struct CCVKGPUShader : public CCVKGPUDeviceObject {
 };
 
 struct CCVKGPUInputAssembler : public CCVKGPUDeviceObject {
+    void shutdown() override;
+    void update(const CCVKGPUBufferView *oldBuffer, const CCVKGPUBufferView *newBuffer);
+
     AttributeList attributes;
-    ccstd::vector<CCVKGPUBufferView *> gpuVertexBuffers;
-    CCVKGPUBufferView *gpuIndexBuffer = nullptr;
-    CCVKGPUBufferView *gpuIndirectBuffer = nullptr;
+    ccstd::vector<ConstPtr<CCVKGPUBufferView>> gpuVertexBuffers;
+    ConstPtr<CCVKGPUBufferView> gpuIndexBuffer;
+    ConstPtr<CCVKGPUBufferView> gpuIndirectBuffer;
     ccstd::vector<VkBuffer> vertexBuffers;
     ccstd::vector<VkDeviceSize> vertexBufferOffsets;
 };
@@ -322,14 +341,17 @@ union CCVKDescriptorInfo {
 struct CCVKGPUDescriptor {
     DescriptorType type = DescriptorType::UNKNOWN;
     ccstd::vector<ThsvsAccessType> accessTypes;
-    CCVKGPUBufferView *gpuBufferView = nullptr;
-    CCVKGPUTextureView *gpuTextureView = nullptr;
-    CCVKGPUSampler *gpuSampler = nullptr;
+    ConstPtr<CCVKGPUBufferView> gpuBufferView;
+    ConstPtr<CCVKGPUTextureView> gpuTextureView;
+    ConstPtr<CCVKGPUSampler> gpuSampler;
 };
 
 struct CCVKGPUDescriptorSetLayout;
 struct CCVKGPUDescriptorSet : public CCVKGPUDeviceObject {
     void shutdown() override;
+
+    void update(const CCVKGPUBufferView *oldView, const CCVKGPUBufferView *newView);
+    void update(const CCVKGPUTextureView *oldView, const CCVKGPUTextureView *newView);
 
     ccstd::vector<CCVKGPUDescriptor> gpuDescriptors;
 
@@ -420,10 +442,10 @@ public:
     PFN_vkCreateRenderPass2 createRenderPass2{nullptr};
 
     // for default backup usages
-    CCVKGPUSampler defaultSampler;
-    CCVKGPUTexture defaultTexture;
-    CCVKGPUTextureView defaultTextureView;
-    CCVKGPUBuffer defaultBuffer;
+    IntrusivePtr<CCVKGPUSampler> defaultSampler;
+    IntrusivePtr<CCVKGPUTexture> defaultTexture;
+    IntrusivePtr<CCVKGPUTextureView> defaultTextureView;
+    IntrusivePtr<CCVKGPUBuffer> defaultBuffer;
 
     CCVKGPUGeneralBarrier defaultColorBarrier;
     CCVKGPUGeneralBarrier defaultDepthStencilBarrier;
@@ -758,15 +780,13 @@ public:
     }
 
     ~CCVKGPUStagingBufferPool() {
-        for (Buffer &buffer : _pool) {
-            vmaDestroyBuffer(_device->memoryAllocator, buffer.vkBuffer, buffer.vmaAllocation);
-        }
         _pool.clear();
     }
 
-    void alloc(CCVKGPUBuffer *gpuBuffer) { alloc(gpuBuffer, 1U); }
-    void alloc(CCVKGPUBuffer *gpuBuffer, uint32_t alignment) {
-        CC_ASSERT(gpuBuffer->size <= CHUNK_SIZE);
+    IntrusivePtr<CCVKGPUBufferView> alloc(uint32_t size) { return alloc(size, 1U); }
+
+    IntrusivePtr<CCVKGPUBufferView> alloc(uint32_t size, uint32_t alignment) {
+        CC_ASSERT(size <= CHUNK_SIZE);
 
         size_t bufferCount = _pool.size();
         Buffer *buffer = nullptr;
@@ -774,7 +794,7 @@ public:
         for (size_t idx = 0U; idx < bufferCount; idx++) {
             Buffer *cur = &_pool[idx];
             offset = roundUp(cur->curOffset, alignment);
-            if (CHUNK_SIZE - offset >= gpuBuffer->size) {
+            if (CHUNK_SIZE - offset >= size) {
                 buffer = cur;
                 break;
             }
@@ -782,21 +802,18 @@ public:
         if (!buffer) {
             _pool.resize(bufferCount + 1);
             buffer = &_pool.back();
-            VkBufferCreateInfo bufferInfo{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-            bufferInfo.size = CHUNK_SIZE;
-            bufferInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-            VmaAllocationCreateInfo allocInfo{};
-            allocInfo.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
-            allocInfo.usage = VMA_MEMORY_USAGE_CPU_ONLY;
-            VmaAllocationInfo res;
-            VK_CHECK(vmaCreateBuffer(_device->memoryAllocator, &bufferInfo, &allocInfo, &buffer->vkBuffer, &buffer->vmaAllocation, &res));
-            buffer->mappedData = reinterpret_cast<uint8_t *>(res.pMappedData);
+            buffer->gpuBuffer = new CCVKGPUBuffer();
+            buffer->gpuBuffer->size = CHUNK_SIZE;
+            buffer->gpuBuffer->usage = BufferUsage::TRANSFER_SRC | BufferUsage::TRANSFER_DST;
+            buffer->gpuBuffer->memUsage = MemoryUsage::HOST;
+            buffer->gpuBuffer->init();
             offset = 0U;
         }
-        gpuBuffer->vkBuffer = buffer->vkBuffer;
-        gpuBuffer->startOffset = offset;
-        gpuBuffer->mappedData = buffer->mappedData + offset;
-        buffer->curOffset = offset + gpuBuffer->size;
+        auto *bufferView = new CCVKGPUBufferView;
+        bufferView->gpuBuffer = buffer->gpuBuffer;
+        bufferView->offset = offset;
+        buffer->curOffset = offset + size;
+        return bufferView;
     }
 
     void reset() {
@@ -807,10 +824,7 @@ public:
 
 private:
     struct Buffer {
-        VkBuffer vkBuffer = VK_NULL_HANDLE;
-        uint8_t *mappedData = nullptr;
-        VmaAllocation vmaAllocation = VK_NULL_HANDLE;
-
+        IntrusivePtr<CCVKGPUBuffer> gpuBuffer;
         VkDeviceSize curOffset = 0U;
     };
 
@@ -892,35 +906,19 @@ public:
     explicit CCVKGPUDescriptorHub(CCVKGPUDevice * /*device*/) {
     }
 
-    void link(CCVKGPUDescriptorSetHub *descriptorSetHub) {
-        _descriptorSetHub = descriptorSetHub;
-    }
-
-    void connect(const CCVKGPUDescriptorSet *set, const CCVKGPUBufferView *buffer, VkDescriptorBufferInfo *descriptor, uint32_t instanceIdx) {
+    void connect(CCVKGPUDescriptorSet *set, const CCVKGPUBufferView *buffer, VkDescriptorBufferInfo *descriptor, uint32_t instanceIdx) {
         _buffers[buffer].sets.insert(set);
         _buffers[buffer].descriptors.push(descriptor);
         _bufferInstanceIndices[descriptor] = instanceIdx;
     }
-    void connect(const CCVKGPUDescriptorSet *set, const CCVKGPUTextureView *texture, VkDescriptorImageInfo *descriptor) {
+    void connect(CCVKGPUDescriptorSet *set, const CCVKGPUTextureView *texture, VkDescriptorImageInfo *descriptor) {
         _textures[texture].sets.insert(set);
         _textures[texture].descriptors.push(descriptor);
     }
-    void connect(const CCVKGPUSampler *sampler, VkDescriptorImageInfo *descriptor) {
+    void connect(CCVKGPUSampler *sampler, VkDescriptorImageInfo *descriptor) {
         _samplers[sampler].push(descriptor);
     }
 
-    void update(const CCVKGPUBufferView *buffer) {
-        for (const auto &it : _buffers) {
-            if (it.first->gpuBuffer != buffer->gpuBuffer) continue;
-            const auto &info = it.second;
-            for (uint32_t i = 0U; i < info.descriptors.size(); i++) {
-                doUpdate(buffer, info.descriptors[i]);
-            }
-            for (const auto *set : info.sets) {
-                _descriptorSetHub->record(set);
-            }
-        }
-    }
     void update(const CCVKGPUBufferView *buffer, VkDescriptorBufferInfo *descriptor) {
         auto it = _buffers.find(buffer);
         if (it == _buffers.end()) return;
@@ -932,18 +930,7 @@ public:
             }
         }
     }
-    void update(const CCVKGPUTextureView *texture) {
-        for (const auto &it : _textures) {
-            if (it.first->gpuTexture != texture->gpuTexture) continue;
-            const auto &info = it.second;
-            for (uint32_t i = 0U; i < info.descriptors.size(); i++) {
-                doUpdate(texture, info.descriptors[i]);
-            }
-            for (const auto *set : info.sets) {
-                _descriptorSetHub->record(set);
-            }
-        }
-    }
+
     void update(const CCVKGPUTextureView *texture, VkDescriptorImageInfo *descriptor) {
         auto it = _textures.find(texture);
         if (it == _textures.end()) return;
@@ -967,28 +954,25 @@ public:
         }
     }
     // for resize events
-    void update(const CCVKGPUBuffer *buffer) {
-        for (const auto &it : _buffers) {
-            if (it.first->gpuBuffer != buffer) continue;
-            const auto &info = it.second;
-            for (uint32_t i = 0U; i < info.descriptors.size(); i++) {
-                doUpdate(it.first, info.descriptors[i]);
+    void update(const CCVKGPUBufferView *oldView, const CCVKGPUBufferView *newView) {
+        auto iter = _buffers.find(oldView);
+        if (iter != _buffers.end()) {
+            auto &sets = iter->second.sets;
+            for (auto *set : sets) {
+                set->update(oldView, newView);
             }
-            for (const auto *set : info.sets) {
-                _descriptorSetHub->record(set);
-            }
+            _buffers.erase(iter);
         }
     }
-    void update(const CCVKGPUTexture *texture) {
-        for (auto &it : _textures) {
-            if (it.first->gpuTexture != texture) continue;
-            const auto &info = it.second;
-            for (uint32_t i = 0U; i < info.descriptors.size(); i++) {
-                doUpdate(it.first, info.descriptors[i]);
+
+    void update(const CCVKGPUTextureView *oldView, const CCVKGPUTextureView *newView) {
+        auto iter = _textures.find(oldView);
+        if (iter != _textures.end()) {
+            auto &sets = iter->second.sets;
+            for (auto *set : sets) {
+                set->update(oldView, newView);
             }
-            for (const auto *set : info.sets) {
-                _descriptorSetHub->record(set);
-            }
+            _textures.erase(iter);
         }
     }
 
@@ -1000,7 +984,7 @@ public:
         }
         _buffers.erase(it);
     }
-    void disengage(const CCVKGPUDescriptorSet *set, const CCVKGPUBufferView *buffer, VkDescriptorBufferInfo *descriptor) {
+    void disengage(CCVKGPUDescriptorSet *set, const CCVKGPUBufferView *buffer, VkDescriptorBufferInfo *descriptor) {
         auto it = _buffers.find(buffer);
         if (it == _buffers.end()) return;
         it->second.sets.erase(set);
@@ -1013,7 +997,7 @@ public:
         if (it == _textures.end()) return;
         _textures.erase(it);
     }
-    void disengage(const CCVKGPUDescriptorSet *set, const CCVKGPUTextureView *texture, VkDescriptorImageInfo *descriptor) {
+    void disengage( CCVKGPUDescriptorSet *set, const CCVKGPUTextureView *texture, VkDescriptorImageInfo *descriptor) {
         auto it = _textures.find(texture);
         if (it == _textures.end()) return;
         it->second.sets.erase(set);
@@ -1058,7 +1042,7 @@ private:
 
     template <typename T>
     struct DescriptorInfo {
-        ccstd::unordered_set<const CCVKGPUDescriptorSet *> sets;
+        ccstd::unordered_set<CCVKGPUDescriptorSet *> sets;
         CachedArray<T *> descriptors;
     };
 
@@ -1066,8 +1050,6 @@ private:
     ccstd::unordered_map<const CCVKGPUBufferView *, DescriptorInfo<VkDescriptorBufferInfo>> _buffers;
     ccstd::unordered_map<const CCVKGPUTextureView *, DescriptorInfo<VkDescriptorImageInfo>> _textures;
     ccstd::unordered_map<const CCVKGPUSampler *, CachedArray<VkDescriptorImageInfo *>> _samplers;
-
-    CCVKGPUDescriptorSetHub *_descriptorSetHub = nullptr;
 };
 
 /**
@@ -1158,6 +1140,47 @@ private:
     CCVKGPUDevice *_device = nullptr;
     ccstd::vector<Resource> _resources;
     size_t _count = 0U;
+};
+
+class CCVKGPUInputAssemblerHub {
+public:
+    explicit CCVKGPUInputAssemblerHub(CCVKGPUDevice *device)
+    : _gpuDevice(device) {
+    }
+
+    ~CCVKGPUInputAssemblerHub() = default;
+
+    void connect(CCVKGPUInputAssembler *ia, const CCVKGPUBufferView *buffer) {
+        _ias[buffer].insert(ia);
+    }
+
+    void update(CCVKGPUBufferView* oldBuffer, CCVKGPUBufferView* newBuffer) {
+        auto iter = _ias.find(oldBuffer);
+        if (iter != _ias.end()) {
+            for (const auto &ia : iter->second) {
+                ia->update(oldBuffer, newBuffer);
+                _ias[newBuffer].insert(ia);
+            }
+            _ias.erase(iter);
+        }
+    }
+
+    void disengage(const CCVKGPUBufferView *buffer) {
+        auto iter = _ias.find(buffer);
+        if (iter != _ias.end()) {
+            _ias.erase(iter);
+        }
+    }
+
+    void disengage(CCVKGPUInputAssembler *set, const CCVKGPUBufferView *buffer) {
+        auto iter = _ias.find(buffer);
+        if (iter == _ias.end()) return;
+        iter->second.erase(set);
+    }
+
+private:
+    CCVKGPUDevice *_gpuDevice;
+    ccstd::unordered_map<const CCVKGPUBufferView *, std::unordered_set<CCVKGPUInputAssembler *>> _ias;
 };
 
 /**

--- a/native/cocos/renderer/gfx-vulkan/VKInputAssembler.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKInputAssembler.cpp
@@ -46,17 +46,21 @@ void CCVKInputAssembler::doInit(const InputAssemblerInfo &info) {
     _gpuInputAssembler->attributes = _attributes;
     _gpuInputAssembler->gpuVertexBuffers.resize(vbCount);
 
+    auto *hub = CCVKDevice::getInstance()->gpuIAHub();
     for (size_t i = 0U; i < vbCount; ++i) {
         auto *vb = static_cast<CCVKBuffer *>(_vertexBuffers[i]);
         _gpuInputAssembler->gpuVertexBuffers[i] = vb->gpuBufferView();
+        hub->connect(_gpuInputAssembler, _gpuInputAssembler->gpuVertexBuffers[i].get());
     }
 
     if (info.indexBuffer) {
         _gpuInputAssembler->gpuIndexBuffer = static_cast<CCVKBuffer *>(info.indexBuffer)->gpuBufferView();
+        hub->connect(_gpuInputAssembler, _gpuInputAssembler->gpuIndexBuffer.get());
     }
 
     if (info.indirectBuffer) {
         _gpuInputAssembler->gpuIndirectBuffer = static_cast<CCVKBuffer *>(info.indirectBuffer)->gpuBufferView();
+        hub->connect(_gpuInputAssembler, _gpuInputAssembler->gpuIndirectBuffer.get());
     }
 
     _gpuInputAssembler->vertexBuffers.resize(vbCount);
@@ -71,6 +75,34 @@ void CCVKInputAssembler::doInit(const InputAssemblerInfo &info) {
 
 void CCVKInputAssembler::doDestroy() {
     _gpuInputAssembler = nullptr;
+}
+
+void CCVKGPUInputAssembler::shutdown() {
+    auto *hub = CCVKDevice::getInstance()->gpuIAHub();
+    for (auto& vb : gpuVertexBuffers) {
+        hub->disengage(this, vb);
+    }
+    if (gpuIndexBuffer) {
+        hub->disengage(this, gpuIndexBuffer);
+    }
+    if (gpuIndirectBuffer) {
+        hub->disengage(this, gpuIndirectBuffer);
+    }
+}
+
+void CCVKGPUInputAssembler::update(const CCVKGPUBufferView *oldBuffer, const CCVKGPUBufferView *newBuffer) {
+    for (uint32_t i = 0; i < gpuVertexBuffers.size(); ++i) {
+        if (gpuVertexBuffers[i].get() == oldBuffer) {
+            gpuVertexBuffers[i] = newBuffer;
+            vertexBuffers[i] = newBuffer->gpuBuffer->vkBuffer;
+        }
+    }
+    if (gpuIndexBuffer.get() == oldBuffer) {
+        gpuIndexBuffer = newBuffer;
+    }
+    if (gpuIndirectBuffer.get() == oldBuffer) {
+        gpuIndirectBuffer = newBuffer;
+    }
 }
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-vulkan/VKTexture.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKTexture.cpp
@@ -102,6 +102,7 @@ void CCVKTexture::doResize(uint32_t width, uint32_t height, uint32_t size) {
     if (!width || !height) return;
     createTexture(width, height, size);
 
+    // Hold reference to keep the old textureView alive during DescriptorHub::update.
     IntrusivePtr<CCVKGPUTextureView> oldTextureView = _gpuTextureView;
     createTextureView();
     CCVKDevice::getInstance()->gpuDescriptorHub()->update(oldTextureView, _gpuTextureView);

--- a/native/cocos/renderer/gfx-vulkan/VKTexture.h
+++ b/native/cocos/renderer/gfx-vulkan/VKTexture.h
@@ -49,8 +49,8 @@ protected:
     void doDestroy() override;
     void doResize(uint32_t width, uint32_t height, uint32_t size) override;
 
-    void createTexture();
-    void createTextureView();
+    void createTexture(uint32_t width, uint32_t height, uint32_t size, bool initGPUTexture = true);
+    void createTextureView(bool initGPUTextureView = true);
 
     IntrusivePtr<CCVKGPUTexture> _gpuTexture;
     IntrusivePtr<CCVKGPUTextureView> _gpuTextureView;

--- a/native/cocos/renderer/gfx-vulkan/VKTexture.h
+++ b/native/cocos/renderer/gfx-vulkan/VKTexture.h
@@ -27,12 +27,10 @@
 
 #include "VKStd.h"
 #include "gfx-base/GFXTexture.h"
+#include "gfx-vulkan/VKGPUObjects.h"
 
 namespace cc {
 namespace gfx {
-
-struct CCVKGPUTexture;
-struct CCVKGPUTextureView;
 
 class CC_VULKAN_API CCVKTexture final : public Texture {
 public:
@@ -51,10 +49,11 @@ protected:
     void doDestroy() override;
     void doResize(uint32_t width, uint32_t height, uint32_t size) override;
 
+    void createTexture();
     void createTextureView();
 
-    CCVKGPUTexture *_gpuTexture = nullptr;
-    CCVKGPUTextureView *_gpuTextureView = nullptr;
+    IntrusivePtr<CCVKGPUTexture> _gpuTexture;
+    IntrusivePtr<CCVKGPUTextureView> _gpuTextureView;
 };
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-vulkan/states/VKSampler.cpp
+++ b/native/cocos/renderer/gfx-vulkan/states/VKSampler.cpp
@@ -45,10 +45,6 @@ CCVKSampler::CCVKSampler(const SamplerInfo &info) : Sampler(info) {
     _gpuSampler->init();
 }
 
-CCVKSampler::~CCVKSampler() {
-    _gpuSampler = nullptr;
-}
-
 void CCVKGPUSampler::init() {
     cmdFuncCCVKCreateSampler(CCVKDevice::getInstance(), this);
 }

--- a/native/cocos/renderer/gfx-vulkan/states/VKSampler.cpp
+++ b/native/cocos/renderer/gfx-vulkan/states/VKSampler.cpp
@@ -42,16 +42,20 @@ CCVKSampler::CCVKSampler(const SamplerInfo &info) : Sampler(info) {
     _gpuSampler->addressW = _info.addressW;
     _gpuSampler->maxAnisotropy = _info.maxAnisotropy;
     _gpuSampler->cmpFunc = _info.cmpFunc;
-
-    cmdFuncCCVKCreateSampler(CCVKDevice::getInstance(), _gpuSampler);
+    _gpuSampler->init();
 }
 
-CCVKSampler::~CCVKSampler() { // NOLINT(bugprone-exception-escape) garbage collect may throw
-    if (_gpuSampler) {
-        CCVKDevice::getInstance()->gpuDescriptorHub()->disengage(_gpuSampler);
-        CCVKDevice::getInstance()->gpuRecycleBin()->collect(_gpuSampler);
-        _gpuSampler = nullptr;
-    }
+CCVKSampler::~CCVKSampler() {
+    _gpuSampler = nullptr;
+}
+
+void CCVKGPUSampler::init() {
+    cmdFuncCCVKCreateSampler(CCVKDevice::getInstance(), this);
+}
+
+void CCVKGPUSampler::shutdown() {
+    CCVKDevice::getInstance()->gpuDescriptorHub()->disengage(this);
+    CCVKDevice::getInstance()->gpuRecycleBin()->collect(this);
 }
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-vulkan/states/VKSampler.h
+++ b/native/cocos/renderer/gfx-vulkan/states/VKSampler.h
@@ -35,7 +35,7 @@ namespace gfx {
 class CC_VULKAN_API CCVKSampler final : public Sampler {
 public:
     explicit CCVKSampler(const SamplerInfo &info);
-    ~CCVKSampler() override;
+    ~CCVKSampler() override = default;
 
     inline CCVKGPUSampler *gpuSampler() const { return _gpuSampler; }
 

--- a/native/cocos/renderer/gfx-vulkan/states/VKSampler.h
+++ b/native/cocos/renderer/gfx-vulkan/states/VKSampler.h
@@ -27,11 +27,10 @@
 
 #include "../VKStd.h"
 #include "gfx-base/states/GFXSampler.h"
+#include "gfx-vulkan/VKGPUObjects.h"
 
 namespace cc {
 namespace gfx {
-
-struct CCVKGPUSampler;
 
 class CC_VULKAN_API CCVKSampler final : public Sampler {
 public:
@@ -41,7 +40,7 @@ public:
     inline CCVKGPUSampler *gpuSampler() const { return _gpuSampler; }
 
 protected:
-    CCVKGPUSampler *_gpuSampler = nullptr;
+    IntrusivePtr<CCVKGPUSampler> _gpuSampler;
 };
 
 } // namespace gfx


### PR DESCRIPTION
Re: #

### Changelog

* gpuObjects use smart_ptr [vulkan][buffer, texture]

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
