### PR TITLE
openharmony support download

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -885,12 +885,14 @@ cocos_source_files(MODULE ccmath
 )
 
 ##### network
-# The network module of OpenHarmony is implemented in the ts layer
-if(NOT OPENHARMONY)
 cocos_source_files(
                  cocos/network/Downloader.cpp
                  cocos/network/Downloader.h
                  cocos/network/DownloaderImpl.h
+)
+# The xmlhttprequest module of OpenHarmony is implemented in the ts layer
+if(NOT OPENHARMONY)
+cocos_source_files(
                  cocos/network/HttpClient.h
                  cocos/network/HttpCookie.cpp
                  cocos/network/HttpCookie.h
@@ -954,7 +956,7 @@ if(NOT APPLE AND USE_SOCKET)
     endif()
 endif()
 
-if(WINDOWS OR LINUX OR QNX)
+if(WINDOWS OR LINUX OR QNX OR OPENHARMONY)
     cocos_source_files(
         NO_WERROR    cocos/network/Downloader-curl.cpp
                      cocos/network/Downloader-curl.h
@@ -2129,13 +2131,9 @@ cocos_source_files(
 )
 
 ######## auto
-if(NOT OPENHARMONY)
 cocos_source_files(
     NO_WERROR   NO_UBUILD   cocos/bindings/auto/jsb_network_auto.cpp
                             cocos/bindings/auto/jsb_network_auto.h
-)
-endif()
-cocos_source_files(
     NO_WERROR   NO_UBUILD   cocos/bindings/auto/jsb_cocos_auto.cpp
                             cocos/bindings/auto/jsb_cocos_auto.h
     NO_WERROR   NO_UBUILD   cocos/bindings/auto/jsb_extension_auto.cpp

--- a/native/cocos/bindings/manual/jsb_module_register.cpp
+++ b/native/cocos/bindings/manual/jsb_module_register.cpp
@@ -124,9 +124,9 @@ bool jsb_register_all_modules() {
     se->addRegisterCallback(register_platform_bindings);
     se->addRegisterCallback(register_all_gfx);
     se->addRegisterCallback(register_all_gfx_manual);
-#if CC_PLATFORM != CC_PLATFORM_OPENHARMONY// TODO(qgh):May be removed later
     se->addRegisterCallback(register_all_network);
     se->addRegisterCallback(register_all_network_manual);
+#if CC_PLATFORM != CC_PLATFORM_OPENHARMONY// TODO(qgh):May be removed later
     se->addRegisterCallback(register_all_xmlhttprequest);
     // extension depend on network
     se->addRegisterCallback(register_all_extension);


### PR DESCRIPTION
Re: #

### Changelog

* download file
* depend curl : https://github.com/cocos/cocos-engine-external/pull/302

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
