### PR TITLE
[develop] added default sampler and deferred layout setup

### DIFF
--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -483,6 +483,8 @@ class RenderPassLayoutInfo {
             if (!gfxTex) {
                 throw Error(`Could not find texture with resource name ${this._inputName}`);
             }
+            const resId = context.resourceGraph.vertex(this._inputName);
+            const samplerInfo = context.resourceGraph.getSampler(resId);
             // bind descriptors
             for (const descriptor of input[1]) {
                 const descriptorName = descriptor.name;
@@ -492,7 +494,7 @@ class RenderPassLayoutInfo {
                     for (let i = 0; i !== block.descriptors.length; ++i) {
                         if (descriptorID === block.descriptors[i].descriptorID) {
                             layoutData.descriptorSet!.bindTexture(block.offset + i, gfxTex);
-                            layoutData.descriptorSet!.bindSampler(block.offset + i, context.device.getSampler(new SamplerInfo()));
+                            layoutData.descriptorSet!.bindSampler(block.offset + i, context.device.getSampler(samplerInfo));
                             if (!this._descriptorSet) this._descriptorSet = layoutData.descriptorSet;
                         }
                     }

--- a/cocos/rendering/custom/index.jsb.ts
+++ b/cocos/rendering/custom/index.jsb.ts
@@ -25,9 +25,9 @@
 
 declare const render: any;
 
-import { legacyCC } from '../../core/global-exports';
 import { Pipeline, PipelineBuilder } from './pipeline';
 import { buildDeferredLayout, buildForwardLayout } from './effect';
+import { macro } from '../../core/platform/macro';
 import { DeferredPipelineBuilder, ForwardPipelineBuilder } from './builtin-pipelines';
 import { CustomPipelineBuilder } from './custom-pipeline';
 
@@ -35,9 +35,9 @@ export * from './types';
 export * from './pipeline';
 
 export function createCustomPipeline (): Pipeline {
-    const root = legacyCC.director.root;
     const ppl = render.Factory.createPipeline();
-    if (root.useDeferredPipeline) {
+    const pplName = macro.CUSTOM_PIPELINE_NAME;
+    if (pplName === 'Deferred') {
         buildDeferredLayout(ppl);
     } else {
         buildForwardLayout(ppl);

--- a/cocos/rendering/custom/index.ts
+++ b/cocos/rendering/custom/index.ts
@@ -39,7 +39,7 @@ export function createCustomPipeline (): Pipeline {
     const ppl = new WebPipeline();
     const pplName = macro.CUSTOM_PIPELINE_NAME;
     ppl.setCustomPipelineName(pplName);
-    if (ppl.usesDeferredPipeline) {
+    if (pplName === 'Deferred') {
         buildDeferredLayout(ppl);
     } else {
         buildForwardLayout(ppl);


### PR DESCRIPTION
enabled default sampler.

### Changelog

* changed layout setup procedure

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
