### PR TITLE
Update auto bindings

### DIFF
--- a/native/cocos/bindings/auto/jsb_2d_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_2d_auto.cpp
@@ -75,10 +75,6 @@
 #define cc_UIMeshBuffer_iData_set(self_, val_) self_->setIData(val_)
   
 
-#define cc_UIMeshBuffer_useLinkData_get(self_) self_->getUseLinkData()
-#define cc_UIMeshBuffer_useLinkData_set(self_, val_) self_->setUseLinkData(val_)
-  
-
 #define cc_RenderDrawInfo_vbBuffer_get(self_) self_->getVbBuffer()
 #define cc_RenderDrawInfo_vbBuffer_set(self_, val_) self_->setVbBuffer(val_)
   
@@ -402,48 +398,78 @@ static bool js_delete_cc_UIMeshBuffer(se::State& s)
 }
 SE_BIND_FINALIZE_FUNC(js_delete_cc_UIMeshBuffer) 
 
-static bool js_cc_UIMeshBuffer_initialize(se::State& s)
+static bool js_cc_UIMeshBuffer_initialize__SWIG_0(se::State& s)
 {
-    // js_function
+    // js_overloaded_function
     
     CC_UNUSED bool ok = true;
     const auto& args = s.args();
-    size_t argc = args.size();
     cc::UIMeshBuffer *arg1 = (cc::UIMeshBuffer *) NULL ;
-    cc::gfx::Device *arg2 = (cc::gfx::Device *) NULL ;
-    ccstd::vector< cc::gfx::Attribute > *arg3 = 0 ;
-    uint32_t arg4 ;
-    uint32_t arg5 ;
-    ccstd::vector< cc::gfx::Attribute > temp3 ;
+    ccstd::vector< cc::gfx::Attribute > *arg2 = 0 ;
+    bool arg3 ;
+    ccstd::vector< cc::gfx::Attribute > temp2 ;
     
-    if(argc != 4) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 4);
-        return false;
-    }
     arg1 = SE_THIS_OBJECT<cc::UIMeshBuffer>(s);
     SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    // %typemap(in) SWIGTYPE*
-    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "UIMeshBuffer_initialize,2,SWIGTYPE_p_cc__gfx__Device"); 
     // %typemap(in) SWIGTYPE&&
-    ok &= sevalue_to_native(args[1], &temp3, s.thisObject());
-    SE_PRECONDITION2(ok, false, "UIMeshBuffer_initialize,3,SWIGTYPE_p_ccstd__vectorT_cc__gfx__Attribute_t");
-    arg3 = &temp3;
+    ok &= sevalue_to_native(args[0], &temp2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "UIMeshBuffer_initialize,2,SWIGTYPE_p_ccstd__vectorT_cc__gfx__Attribute_t");
+    arg2 = &temp2;
     
-    
-    // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[2], &arg4, s.thisObject());
-    SE_PRECONDITION2(ok, false, "UIMeshBuffer_initialize,4,SWIGTYPE_uint32_t"); 
-    
-    
-    // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[3], &arg5, s.thisObject());
-    SE_PRECONDITION2(ok, false, "UIMeshBuffer_initialize,5,SWIGTYPE_uint32_t"); 
-    
-    (arg1)->initialize(arg2,(ccstd::vector< cc::gfx::Attribute > &&)*arg3,arg4,arg5);
+    // %typemap(in) bool
+    ok &= sevalue_to_native(args[1], &arg3);
+    SE_PRECONDITION2(ok, false, "UIMeshBuffer_initialize,3,SWIGTYPE_bool"); 
+    (arg1)->initialize((ccstd::vector< cc::gfx::Attribute > &&)*arg2,arg3);
     
     
     return true;
+}
+
+static bool js_cc_UIMeshBuffer_initialize__SWIG_1(se::State& s)
+{
+    // js_overloaded_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    cc::UIMeshBuffer *arg1 = (cc::UIMeshBuffer *) NULL ;
+    ccstd::vector< cc::gfx::Attribute > *arg2 = 0 ;
+    ccstd::vector< cc::gfx::Attribute > temp2 ;
+    
+    arg1 = SE_THIS_OBJECT<cc::UIMeshBuffer>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE&&
+    ok &= sevalue_to_native(args[0], &temp2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "UIMeshBuffer_initialize,2,SWIGTYPE_p_ccstd__vectorT_cc__gfx__Attribute_t");
+    arg2 = &temp2;
+    
+    (arg1)->initialize((ccstd::vector< cc::gfx::Attribute > &&)*arg2);
+    
+    
+    return true;
+}
+
+static bool js_cc_UIMeshBuffer_initialize(se::State& s)
+{
+    // js_function_dispatcher
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    
+    // js_function_dispatch_case
+    if (argc == 2) {
+        ok = js_cc_UIMeshBuffer_initialize__SWIG_0(s);
+        if (ok) {
+            return true; 
+        }
+    } // js_function_dispatch_case
+    if (argc == 1) {
+        ok = js_cc_UIMeshBuffer_initialize__SWIG_1(s);
+        if (ok) {
+            return true; 
+        }
+    } 
+    SE_REPORT_ERROR("wrong number of arguments: %d", (int)argc);
+    return false;
 }
 SE_BIND_FUNC(js_cc_UIMeshBuffer_initialize) 
 
@@ -617,49 +643,11 @@ static bool js_cc_UIMeshBuffer_iData_get(se::State& s)
 }
 SE_BIND_PROP_GET(js_cc_UIMeshBuffer_iData_get) 
 
-static bool js_cc_UIMeshBuffer_useLinkData_set(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::UIMeshBuffer *arg1 = (cc::UIMeshBuffer *) NULL ;
-    bool arg2 ;
-    
-    arg1 = SE_THIS_OBJECT<cc::UIMeshBuffer>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    // %typemap(in) bool
-    ok &= sevalue_to_native(args[0], &arg2);
-    SE_PRECONDITION2(ok, false, "UIMeshBuffer_useLinkData_set,2,SWIGTYPE_bool"); 
-    cc_UIMeshBuffer_useLinkData_set(arg1,arg2);
-    
-    
-    return true;
-}
-SE_BIND_PROP_SET(js_cc_UIMeshBuffer_useLinkData_set) 
-
-static bool js_cc_UIMeshBuffer_useLinkData_get(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    cc::UIMeshBuffer *arg1 = (cc::UIMeshBuffer *) NULL ;
-    bool result;
-    
-    arg1 = SE_THIS_OBJECT<cc::UIMeshBuffer>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = (bool)cc_UIMeshBuffer_useLinkData_get(arg1);
-    // out 5
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    
-    
-    return true;
-}
-SE_BIND_PROP_GET(js_cc_UIMeshBuffer_useLinkData_get) 
-
 bool js_register_cc_UIMeshBuffer(se::Object* obj) {
     auto* cls = se::Class::create("UIMeshBuffer", obj, nullptr, _SE(js_new_cc_UIMeshBuffer)); 
     
     cls->defineProperty("vData", _SE(js_cc_UIMeshBuffer_vData_get), _SE(js_cc_UIMeshBuffer_vData_set)); 
     cls->defineProperty("iData", _SE(js_cc_UIMeshBuffer_iData_get), _SE(js_cc_UIMeshBuffer_iData_set)); 
-    cls->defineProperty("useLinkData", _SE(js_cc_UIMeshBuffer_useLinkData_get), _SE(js_cc_UIMeshBuffer_useLinkData_set)); 
     
     cls->defineFunction("initialize", _SE(js_cc_UIMeshBuffer_initialize)); 
     cls->defineFunction("reset", _SE(js_cc_UIMeshBuffer_reset)); 
@@ -1640,6 +1628,32 @@ static bool js_cc_RenderDrawInfo_setStride(se::State& s)
 }
 SE_BIND_FUNC(js_cc_RenderDrawInfo_setStride) 
 
+static bool js_cc_RenderDrawInfo_setMeshBuffer(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    cc::RenderDrawInfo *arg1 = (cc::RenderDrawInfo *) NULL ;
+    cc::UIMeshBuffer *arg2 = (cc::UIMeshBuffer *) NULL ;
+    
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<cc::RenderDrawInfo>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "RenderDrawInfo_setMeshBuffer,2,SWIGTYPE_p_cc__UIMeshBuffer"); 
+    (arg1)->setMeshBuffer(arg2);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_cc_RenderDrawInfo_setMeshBuffer) 
+
 static bool js_cc_RenderDrawInfo_getMeshBuffer(se::State& s)
 {
     // js_function
@@ -2281,6 +2295,7 @@ bool js_register_cc_RenderDrawInfo(se::Object* obj) {
     cls->defineFunction("getIsMeshBuffer", _SE(js_cc_RenderDrawInfo_getIsMeshBuffer)); 
     cls->defineFunction("setIsMeshBuffer", _SE(js_cc_RenderDrawInfo_setIsMeshBuffer)); 
     cls->defineFunction("setStride", _SE(js_cc_RenderDrawInfo_setStride)); 
+    cls->defineFunction("setMeshBuffer", _SE(js_cc_RenderDrawInfo_setMeshBuffer)); 
     cls->defineFunction("getMeshBuffer", _SE(js_cc_RenderDrawInfo_getMeshBuffer)); 
     cls->defineFunction("changeMeshBuffer", _SE(js_cc_RenderDrawInfo_changeMeshBuffer)); 
     cls->defineFunction("setRender2dBufferToNative", _SE(js_cc_RenderDrawInfo_setRender2dBufferToNative)); 

--- a/native/cocos/bindings/auto/jsb_2d_auto.h
+++ b/native/cocos/bindings/auto/jsb_2d_auto.h
@@ -62,9 +62,6 @@ JSB_REGISTER_OBJECT_TYPE(cc::UIMeshBuffer);
 extern se::Object *__jsb_cc_UIMeshBuffer_proto; // NOLINT
 extern se::Class * __jsb_cc_UIMeshBuffer_class; // NOLINT
 
-JSB_REGISTER_OBJECT_TYPE(cc::Batcher2d);
-extern se::Object *__jsb_cc_Batcher2d_proto; // NOLINT
-extern se::Class * __jsb_cc_Batcher2d_class; // NOLINT
 
 JSB_REGISTER_OBJECT_TYPE(cc::Render2dLayout);
 extern se::Object *__jsb_cc_Render2dLayout_proto; // NOLINT

--- a/native/cocos/bindings/auto/jsb_dragonbones_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_dragonbones_auto.cpp
@@ -61,6 +61,8 @@
 #include "bindings/manual/jsb_global.h"
 
 
+#include "bindings/auto/jsb_2d_auto.h"
+#include "bindings/auto/jsb_assets_auto.h"
 #include "bindings/auto/jsb_dragonbones_auto.h"
 
 
@@ -12262,34 +12264,6 @@ static bool js_dragonBones_CCArmatureDisplay_getSharedBufferOffset(se::State& s)
 }
 SE_BIND_FUNC(js_dragonBones_CCArmatureDisplay_getSharedBufferOffset) 
 
-static bool js_dragonBones_CCArmatureDisplay_getParamsBuffer(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    dragonBones::CCArmatureDisplay *arg1 = (dragonBones::CCArmatureDisplay *) NULL ;
-    se_object_ptr result;
-    
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<dragonBones::CCArmatureDisplay>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = ((dragonBones::CCArmatureDisplay const *)arg1)->getParamsBuffer();
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "CCArmatureDisplay_getParamsBuffer, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_dragonBones_CCArmatureDisplay_getParamsBuffer) 
-
 static bool js_dragonBones_CCArmatureDisplay_setColor(se::State& s)
 {
     // js_function
@@ -12494,6 +12468,58 @@ static bool js_dragonBones_CCArmatureDisplay_getRootDisplay(se::State& s)
 }
 SE_BIND_FUNC(js_dragonBones_CCArmatureDisplay_getRootDisplay) 
 
+static bool js_dragonBones_CCArmatureDisplay_setMaterial(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    dragonBones::CCArmatureDisplay *arg1 = (dragonBones::CCArmatureDisplay *) NULL ;
+    cc::Material *arg2 = (cc::Material *) NULL ;
+    
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<dragonBones::CCArmatureDisplay>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "CCArmatureDisplay_setMaterial,2,SWIGTYPE_p_cc__Material"); 
+    (arg1)->setMaterial(arg2);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_dragonBones_CCArmatureDisplay_setMaterial) 
+
+static bool js_dragonBones_CCArmatureDisplay_setRenderEntity(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    dragonBones::CCArmatureDisplay *arg1 = (dragonBones::CCArmatureDisplay *) NULL ;
+    cc::RenderEntity *arg2 = (cc::RenderEntity *) NULL ;
+    
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<dragonBones::CCArmatureDisplay>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "CCArmatureDisplay_setRenderEntity,2,SWIGTYPE_p_cc__RenderEntity"); 
+    (arg1)->setRenderEntity(arg2);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_dragonBones_CCArmatureDisplay_setRenderEntity) 
+
 bool js_register_dragonBones_CCArmatureDisplay(se::Object* obj) {
     auto* cls = se::Class::create("CCArmatureDisplay", obj, nullptr, _SE(js_new_dragonBones_CCArmatureDisplay)); 
     
@@ -12512,7 +12538,6 @@ bool js_register_dragonBones_CCArmatureDisplay(se::Object* obj) {
     cls->defineFunction("getAnimation", _SE(js_dragonBones_CCArmatureDisplay_getAnimation)); 
     cls->defineFunction("getDebugData", _SE(js_dragonBones_CCArmatureDisplay_getDebugData)); 
     cls->defineFunction("getSharedBufferOffset", _SE(js_dragonBones_CCArmatureDisplay_getSharedBufferOffset)); 
-    cls->defineFunction("getParamsBuffer", _SE(js_dragonBones_CCArmatureDisplay_getParamsBuffer)); 
     cls->defineFunction("setColor", _SE(js_dragonBones_CCArmatureDisplay_setColor)); 
     cls->defineFunction("setDebugBonesEnabled", _SE(js_dragonBones_CCArmatureDisplay_setDebugBonesEnabled)); 
     cls->defineFunction("setBatchEnabled", _SE(js_dragonBones_CCArmatureDisplay_setBatchEnabled)); 
@@ -12520,6 +12545,8 @@ bool js_register_dragonBones_CCArmatureDisplay(se::Object* obj) {
     cls->defineFunction("setOpacityModifyRGB", _SE(js_dragonBones_CCArmatureDisplay_setOpacityModifyRGB)); 
     cls->defineFunction("convertToRootSpace", _SE(js_dragonBones_CCArmatureDisplay_convertToRootSpace)); 
     cls->defineFunction("getRootDisplay", _SE(js_dragonBones_CCArmatureDisplay_getRootDisplay)); 
+    cls->defineFunction("setMaterial", _SE(js_dragonBones_CCArmatureDisplay_setMaterial)); 
+    cls->defineFunction("setRenderEntity", _SE(js_dragonBones_CCArmatureDisplay_setRenderEntity)); 
     
     
     cls->defineStaticFunction("create", _SE(js_dragonBones_CCArmatureDisplay_create_static)); 
@@ -14124,7 +14151,7 @@ static bool js_dragonBones_CCArmatureCacheDisplay_getSharedBufferOffset(se::Stat
 }
 SE_BIND_FUNC(js_dragonBones_CCArmatureCacheDisplay_getSharedBufferOffset) 
 
-static bool js_dragonBones_CCArmatureCacheDisplay_getParamsBuffer(se::State& s)
+static bool js_dragonBones_CCArmatureCacheDisplay_setMaterial(se::State& s)
 {
     // js_function
     
@@ -14132,25 +14159,49 @@ static bool js_dragonBones_CCArmatureCacheDisplay_getParamsBuffer(se::State& s)
     const auto& args = s.args();
     size_t argc = args.size();
     dragonBones::CCArmatureCacheDisplay *arg1 = (dragonBones::CCArmatureCacheDisplay *) NULL ;
-    se_object_ptr result;
+    cc::Material *arg2 = (cc::Material *) NULL ;
     
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
         return false;
     }
     arg1 = SE_THIS_OBJECT<dragonBones::CCArmatureCacheDisplay>(s);
     SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = ((dragonBones::CCArmatureCacheDisplay const *)arg1)->getParamsBuffer();
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "CCArmatureCacheDisplay_getParamsBuffer, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
-    
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "CCArmatureCacheDisplay_setMaterial,2,SWIGTYPE_p_cc__Material"); 
+    (arg1)->setMaterial(arg2);
     
     
     return true;
 }
-SE_BIND_FUNC(js_dragonBones_CCArmatureCacheDisplay_getParamsBuffer) 
+SE_BIND_FUNC(js_dragonBones_CCArmatureCacheDisplay_setMaterial) 
+
+static bool js_dragonBones_CCArmatureCacheDisplay_setRenderEntity(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    dragonBones::CCArmatureCacheDisplay *arg1 = (dragonBones::CCArmatureCacheDisplay *) NULL ;
+    cc::RenderEntity *arg2 = (cc::RenderEntity *) NULL ;
+    
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<dragonBones::CCArmatureCacheDisplay>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "CCArmatureCacheDisplay_setRenderEntity,2,SWIGTYPE_p_cc__RenderEntity"); 
+    (arg1)->setRenderEntity(arg2);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_dragonBones_CCArmatureCacheDisplay_setRenderEntity) 
 
 bool js_register_dragonBones_CCArmatureCacheDisplay(se::Object* obj) {
     auto* cls = se::Class::create("CCArmatureCacheDisplay", obj, nullptr, _SE(js_new_dragonBones_CCArmatureCacheDisplay)); 
@@ -14179,7 +14230,8 @@ bool js_register_dragonBones_CCArmatureCacheDisplay(se::Object* obj) {
     cls->defineFunction("updateAnimationCache", _SE(js_dragonBones_CCArmatureCacheDisplay_updateAnimationCache)); 
     cls->defineFunction("updateAllAnimationCache", _SE(js_dragonBones_CCArmatureCacheDisplay_updateAllAnimationCache)); 
     cls->defineFunction("getSharedBufferOffset", _SE(js_dragonBones_CCArmatureCacheDisplay_getSharedBufferOffset)); 
-    cls->defineFunction("getParamsBuffer", _SE(js_dragonBones_CCArmatureCacheDisplay_getParamsBuffer)); 
+    cls->defineFunction("setMaterial", _SE(js_dragonBones_CCArmatureCacheDisplay_setMaterial)); 
+    cls->defineFunction("setRenderEntity", _SE(js_dragonBones_CCArmatureCacheDisplay_setRenderEntity)); 
     
     
     

--- a/native/cocos/bindings/auto/jsb_dragonbones_auto.h
+++ b/native/cocos/bindings/auto/jsb_dragonbones_auto.h
@@ -49,9 +49,6 @@ JSB_REGISTER_OBJECT_TYPE(dragonBones::Rectangle);
 extern se::Object *__jsb_dragonBones_Rectangle_proto; // NOLINT
 extern se::Class * __jsb_dragonBones_Rectangle_class; // NOLINT
 
-JSB_REGISTER_OBJECT_TYPE(dragonBones::BlendState);
-extern se::Object *__jsb_dragonBones_BlendState_proto; // NOLINT
-extern se::Class * __jsb_dragonBones_BlendState_class; // NOLINT
 
 JSB_REGISTER_OBJECT_TYPE(dragonBones::Transform);
 extern se::Object *__jsb_dragonBones_Transform_proto; // NOLINT

--- a/native/cocos/bindings/auto/jsb_editor_support_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_editor_support_auto.cpp
@@ -2223,6 +2223,58 @@ static bool js_cc_middleware_Texture2D_setTexParamCallback(se::State& s)
 }
 SE_BIND_FUNC(js_cc_middleware_Texture2D_setTexParamCallback) 
 
+static bool js_cc_middleware_Texture2D_setRealTexture(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    cc::middleware::Texture2D *arg1 = (cc::middleware::Texture2D *) NULL ;
+    void *arg2 = (void *) NULL ;
+    
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<cc::middleware::Texture2D>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    ok &= sevalue_to_native(args[0], &arg2);
+    SE_PRECONDITION2(ok, false, "Texture2D_setRealTexture,2,SWIGTYPE_p_void");
+    (arg1)->setRealTexture(arg2);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_cc_middleware_Texture2D_setRealTexture) 
+
+static bool js_cc_middleware_Texture2D_getRealTexture(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    cc::middleware::Texture2D *arg1 = (cc::middleware::Texture2D *) NULL ;
+    void *result = 0 ;
+    
+    if(argc != 0) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<cc::middleware::Texture2D>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    result = (void *)((cc::middleware::Texture2D const *)arg1)->getRealTexture();
+    // %typemap(out) SWIGTYPE*
+    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
+    SE_PRECONDITION2(ok, false, "Texture2D_getRealTexture, Error processing arguments");
+    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval()); 
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_cc_middleware_Texture2D_getRealTexture) 
+
 bool js_register_cc_middleware_Texture2D(se::Object* obj) {
     auto* cls = se::Class::create("Texture2D", obj, nullptr, _SE(js_new_cc_middleware_Texture2D)); 
     
@@ -2234,6 +2286,8 @@ bool js_register_cc_middleware_Texture2D(se::Object* obj) {
     cls->defineFunction("setPixelsHigh", _SE(js_cc_middleware_Texture2D_setPixelsHigh)); 
     cls->defineFunction("setRealTextureIndex", _SE(js_cc_middleware_Texture2D_setRealTextureIndex)); 
     cls->defineFunction("setTexParamCallback", _SE(js_cc_middleware_Texture2D_setTexParamCallback)); 
+    cls->defineFunction("setRealTexture", _SE(js_cc_middleware_Texture2D_setRealTexture)); 
+    cls->defineFunction("getRealTexture", _SE(js_cc_middleware_Texture2D_getRealTexture)); 
     
     
     
@@ -2742,41 +2796,12 @@ static bool js_cc_middleware_IMiddleware_render(se::State& s)
 }
 SE_BIND_FUNC(js_cc_middleware_IMiddleware_render) 
 
-static bool js_cc_middleware_IMiddleware_getRenderOrder(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::middleware::IMiddleware *arg1 = (cc::middleware::IMiddleware *) NULL ;
-    uint32_t result;
-    
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<cc::middleware::IMiddleware>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = ((cc::middleware::IMiddleware const *)arg1)->getRenderOrder();
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "IMiddleware_getRenderOrder, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_cc_middleware_IMiddleware_getRenderOrder) 
-
 bool js_register_cc_middleware_IMiddleware(se::Object* obj) {
     auto* cls = se::Class::create("IMiddleware", obj, nullptr, nullptr); 
     
     
     cls->defineFunction("update", _SE(js_cc_middleware_IMiddleware_update)); 
     cls->defineFunction("render", _SE(js_cc_middleware_IMiddleware_render)); 
-    cls->defineFunction("getRenderOrder", _SE(js_cc_middleware_IMiddleware_getRenderOrder)); 
     
     
     

--- a/native/cocos/bindings/auto/jsb_editor_support_auto.h
+++ b/native/cocos/bindings/auto/jsb_editor_support_auto.h
@@ -124,9 +124,6 @@ JSB_REGISTER_OBJECT_TYPE(cc::middleware::Texture2D);
 extern se::Object *__jsb_cc_middleware_Texture2D_proto; // NOLINT
 extern se::Class * __jsb_cc_middleware_Texture2D_class; // NOLINT
 
-JSB_REGISTER_OBJECT_TYPE(cc::middleware::V3F_T2F_C4B);
-extern se::Object *__jsb_cc_middleware_V3F_T2F_C4B_proto; // NOLINT
-extern se::Class * __jsb_cc_middleware_V3F_T2F_C4B_class; // NOLINT
 
 JSB_REGISTER_OBJECT_TYPE(cc::middleware::SpriteFrame);
 extern se::Object *__jsb_cc_middleware_SpriteFrame_proto; // NOLINT

--- a/native/cocos/bindings/auto/jsb_pipeline_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_pipeline_auto.cpp
@@ -11872,24 +11872,20 @@ static bool js_cc_pipeline_InstancedBuffer_merge__SWIG_0(se::State& s)
     CC_UNUSED bool ok = true;
     const auto& args = s.args();
     cc::pipeline::InstancedBuffer *arg1 = (cc::pipeline::InstancedBuffer *) NULL ;
-    cc::scene::Model *arg2 = (cc::scene::Model *) NULL ;
-    cc::scene::SubModel *arg3 = (cc::scene::SubModel *) NULL ;
-    uint32_t arg4 ;
+    cc::scene::SubModel *arg2 = (cc::scene::SubModel *) NULL ;
+    uint32_t arg3 ;
     
     arg1 = SE_THIS_OBJECT<cc::pipeline::InstancedBuffer>(s);
     SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
     // %typemap(in) SWIGTYPE*
     ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,2,SWIGTYPE_p_cc__scene__Model"); 
-    // %typemap(in) SWIGTYPE*
-    ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
-    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,3,SWIGTYPE_p_cc__scene__SubModel"); 
+    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,2,SWIGTYPE_p_cc__scene__SubModel"); 
     
     // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[2], &arg4, s.thisObject());
-    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,4,SWIGTYPE_uint32_t"); 
+    ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
+    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,3,SWIGTYPE_uint32_t"); 
     
-    (arg1)->merge((cc::scene::Model const *)arg2,(cc::scene::SubModel const *)arg3,arg4);
+    (arg1)->merge(arg2,arg3);
     
     
     return true;
@@ -11902,28 +11898,24 @@ static bool js_cc_pipeline_InstancedBuffer_merge__SWIG_1(se::State& s)
     CC_UNUSED bool ok = true;
     const auto& args = s.args();
     cc::pipeline::InstancedBuffer *arg1 = (cc::pipeline::InstancedBuffer *) NULL ;
-    cc::scene::Model *arg2 = (cc::scene::Model *) NULL ;
-    cc::scene::SubModel *arg3 = (cc::scene::SubModel *) NULL ;
-    uint32_t arg4 ;
-    cc::gfx::Shader *arg5 = (cc::gfx::Shader *) NULL ;
+    cc::scene::SubModel *arg2 = (cc::scene::SubModel *) NULL ;
+    uint32_t arg3 ;
+    cc::gfx::Shader *arg4 = (cc::gfx::Shader *) NULL ;
     
     arg1 = SE_THIS_OBJECT<cc::pipeline::InstancedBuffer>(s);
     SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
     // %typemap(in) SWIGTYPE*
     ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,2,SWIGTYPE_p_cc__scene__Model"); 
-    // %typemap(in) SWIGTYPE*
-    ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
-    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,3,SWIGTYPE_p_cc__scene__SubModel"); 
+    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,2,SWIGTYPE_p_cc__scene__SubModel"); 
     
     // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[2], &arg4, s.thisObject());
-    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,4,SWIGTYPE_uint32_t"); 
+    ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
+    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,3,SWIGTYPE_uint32_t"); 
     
     // %typemap(in) SWIGTYPE*
-    ok &= sevalue_to_native(args[3], &arg5, s.thisObject());
-    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,5,SWIGTYPE_p_cc__gfx__Shader"); 
-    (arg1)->merge((cc::scene::Model const *)arg2,(cc::scene::SubModel const *)arg3,arg4,arg5);
+    ok &= sevalue_to_native(args[2], &arg4, s.thisObject());
+    SE_PRECONDITION2(ok, false, "InstancedBuffer_merge,4,SWIGTYPE_p_cc__gfx__Shader"); 
+    (arg1)->merge(arg2,arg3,arg4);
     
     
     return true;
@@ -11937,13 +11929,13 @@ static bool js_cc_pipeline_InstancedBuffer_merge(se::State& s)
     size_t argc = args.size();
     
     // js_function_dispatch_case
-    if (argc == 3) {
+    if (argc == 2) {
         ok = js_cc_pipeline_InstancedBuffer_merge__SWIG_0(s);
         if (ok) {
             return true; 
         }
     } // js_function_dispatch_case
-    if (argc == 4) {
+    if (argc == 3) {
         ok = js_cc_pipeline_InstancedBuffer_merge__SWIG_1(s);
         if (ok) {
             return true; 

--- a/native/cocos/bindings/auto/jsb_scene_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_scene_auto.cpp
@@ -723,9 +723,6 @@ using namespace cc;
 #define cc_scene_Model_updateStamp_get(self_) self_->getUpdateStamp()
   
 
-#define cc_scene_Model_isInstancingEnabled_get(self_) self_->isInstancingEnabled()
-  
-
 #define cc_scene_Model_receiveShadow_get(self_) self_->isReceiveShadow()
 #define cc_scene_Model_receiveShadow_set(self_, val_) self_->setReceiveShadow(val_)
   
@@ -760,10 +757,6 @@ using namespace cc;
 
 #define cc_scene_Model_type_get(self_) self_->getType()
 #define cc_scene_Model_type_set(self_, val_) self_->setType(val_)
-  
-
-#define cc_scene_Model_instancedAttributes_get(self_) self_->getInstancedAttributeBlock()
-#define cc_scene_Model_instancedAttributes_set(self_, val_) self_->setInstancedAttributeBlock(val_)
   
 
 #define cc_scene_Model_isDynamicBatching_get(self_) self_->isDynamicBatching()
@@ -12930,207 +12923,6 @@ bool js_register_cc_scene_SphereLight(se::Object* obj) {
 }
 
 
-se::Class* __jsb_cc_scene_InstancedAttributeBlock_class = nullptr;
-se::Object* __jsb_cc_scene_InstancedAttributeBlock_proto = nullptr;
-SE_DECLARE_FINALIZE_FUNC(js_delete_cc_scene_InstancedAttributeBlock) 
-
-static bool js_cc_scene_IInstancedAttributeBlock_buffer_set(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    
-    // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[0], &arg1->buffer, s.thisObject());
-    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_buffer_set,2,SWIGTYPE_cc__TypedArrayTempT_uint8_t_t"); 
-    
-    
-    
-    return true;
-}
-SE_BIND_PROP_SET(js_cc_scene_IInstancedAttributeBlock_buffer_set) 
-
-static bool js_cc_scene_IInstancedAttributeBlock_buffer_get(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(arg1->buffer, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_buffer_get, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(arg1->buffer, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_PROP_GET(js_cc_scene_IInstancedAttributeBlock_buffer_get) 
-
-static bool js_cc_scene_IInstancedAttributeBlock_views_set(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    
-    // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[0], &arg1->views, s.thisObject());
-    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_views_set,2,SWIGTYPE_ccstd__vectorT_cc__TypedArray_t"); 
-    
-    
-    
-    return true;
-}
-SE_BIND_PROP_SET(js_cc_scene_IInstancedAttributeBlock_views_set) 
-
-static bool js_cc_scene_IInstancedAttributeBlock_views_get(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(arg1->views, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_views_get, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(arg1->views, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_PROP_GET(js_cc_scene_IInstancedAttributeBlock_views_get) 
-
-static bool js_cc_scene_IInstancedAttributeBlock_attributes_set(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    
-    // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[0], &arg1->attributes, s.thisObject());
-    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_attributes_set,2,SWIGTYPE_ccstd__vectorT_cc__gfx__Attribute_t"); 
-    
-    
-    
-    return true;
-}
-SE_BIND_PROP_SET(js_cc_scene_IInstancedAttributeBlock_attributes_set) 
-
-static bool js_cc_scene_IInstancedAttributeBlock_attributes_get(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(arg1->attributes, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_attributes_get, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(arg1->attributes, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_PROP_GET(js_cc_scene_IInstancedAttributeBlock_attributes_get) 
-
-// js_ctor
-static bool js_new_cc_scene_InstancedAttributeBlock(se::State& s) // NOLINT(readability-identifier-naming)
-{
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    
-    cc::scene::InstancedAttributeBlock *result;
-    result = (cc::scene::InstancedAttributeBlock *)new cc::scene::InstancedAttributeBlock();
-    
-    
-    auto *ptr = JSB_MAKE_PRIVATE_OBJECT_WITH_INSTANCE(result);
-    s.thisObject()->setPrivateObject(ptr);
-    return true;
-}
-SE_BIND_CTOR(js_new_cc_scene_InstancedAttributeBlock, __jsb_cc_scene_InstancedAttributeBlock_class, js_delete_cc_scene_InstancedAttributeBlock)
-
-static bool js_delete_cc_scene_InstancedAttributeBlock(se::State& s)
-{
-    // js_dtoroverride
-    return true;
-}
-SE_BIND_FINALIZE_FUNC(js_delete_cc_scene_InstancedAttributeBlock) 
-
-template<>
-bool sevalue_to_native(const se::Value &from, cc::scene::InstancedAttributeBlock * to, se::Object *ctx)
-{
-    assert(from.isObject());
-    se::Object *json = from.toObject();
-    auto* data = reinterpret_cast<cc::scene::InstancedAttributeBlock*>(json->getPrivateData());
-    if (data) {
-        *to = *data;
-        return true;
-    }
-    se::Value field;
-    bool ok = true;
-    
-    json->getProperty("buffer", &field, true);
-    if (!field.isNullOrUndefined()) {
-        ok &= sevalue_to_native(field, &(to->buffer), ctx);
-    }
-    
-    
-    json->getProperty("views", &field, true);
-    if (!field.isNullOrUndefined()) {
-        ok &= sevalue_to_native(field, &(to->views), ctx);
-    }
-    
-    
-    json->getProperty("attributes", &field, true);
-    if (!field.isNullOrUndefined()) {
-        ok &= sevalue_to_native(field, &(to->attributes), ctx);
-    }
-    
-    
-    return ok;
-}
-
-
-bool js_register_cc_scene_InstancedAttributeBlock(se::Object* obj) {
-    auto* cls = se::Class::create("IInstancedAttributeBlock", obj, nullptr, _SE(js_new_cc_scene_InstancedAttributeBlock)); 
-    
-    cls->defineProperty("buffer", _SE(js_cc_scene_IInstancedAttributeBlock_buffer_get), _SE(js_cc_scene_IInstancedAttributeBlock_buffer_set)); 
-    cls->defineProperty("views", _SE(js_cc_scene_IInstancedAttributeBlock_views_get), _SE(js_cc_scene_IInstancedAttributeBlock_views_set)); 
-    cls->defineProperty("attributes", _SE(js_cc_scene_IInstancedAttributeBlock_attributes_get), _SE(js_cc_scene_IInstancedAttributeBlock_attributes_set)); 
-    
-    
-    
-    
-    
-    cls->defineFinalizeFunction(_SE(js_delete_cc_scene_InstancedAttributeBlock));
-    
-    
-    cls->install();
-    JSBClassType::registerClass<cc::scene::InstancedAttributeBlock>(cls);
-    
-    __jsb_cc_scene_InstancedAttributeBlock_proto = cls->getProto();
-    __jsb_cc_scene_InstancedAttributeBlock_class = cls;
-    se::ScriptEngine::getInstance()->clearException();
-    return true;
-}
-
-
 se::Class* __jsb_cc_scene_Model_class = nullptr;
 se::Object* __jsb_cc_scene_Model_proto = nullptr;
 SE_DECLARE_FINALIZE_FUNC(js_delete_cc_scene_Model) 
@@ -13283,7 +13075,7 @@ static bool js_cc_scene_Model_setSubModelMaterial(se::State& s)
 }
 SE_BIND_FUNC(js_cc_scene_Model_setSubModelMaterial) 
 
-static bool js_cc_scene_Model__updateInstancedAttributes(se::State& s)
+static bool js_cc_scene_Model_updateInstancedAttributes(se::State& s)
 {
     // js_function
     
@@ -13292,7 +13084,7 @@ static bool js_cc_scene_Model__updateInstancedAttributes(se::State& s)
     size_t argc = args.size();
     cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
     ccstd::vector< cc::gfx::Attribute > *arg2 = 0 ;
-    cc::scene::Pass *arg3 = (cc::scene::Pass *) NULL ;
+    cc::scene::SubModel *arg3 = (cc::scene::SubModel *) NULL ;
     ccstd::vector< cc::gfx::Attribute > temp2 ;
     
     if(argc != 2) {
@@ -13303,18 +13095,18 @@ static bool js_cc_scene_Model__updateInstancedAttributes(se::State& s)
     SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
     // %typemap(in) SWIGTYPE&
     ok &= sevalue_to_native(args[0], &temp2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "Model__updateInstancedAttributes,2,SWIGTYPE_p_ccstd__vectorT_cc__gfx__Attribute_t");
+    SE_PRECONDITION2(ok, false, "Model_updateInstancedAttributes,2,SWIGTYPE_p_ccstd__vectorT_cc__gfx__Attribute_t");
     arg2 = &temp2;
     
     // %typemap(in) SWIGTYPE*
     ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
-    SE_PRECONDITION2(ok, false, "Model__updateInstancedAttributes,3,SWIGTYPE_p_cc__scene__Pass"); 
+    SE_PRECONDITION2(ok, false, "Model_updateInstancedAttributes,3,SWIGTYPE_p_cc__scene__SubModel"); 
     (arg1)->updateInstancedAttributes((ccstd::vector< cc::gfx::Attribute > const &)*arg2,arg3);
     
     
     return true;
 }
-SE_BIND_FUNC(js_cc_scene_Model__updateInstancedAttributes) 
+SE_BIND_FUNC(js_cc_scene_Model_updateInstancedAttributes) 
 
 static bool js_cc_scene_Model_updateTransform(se::State& s)
 {
@@ -13471,41 +13263,6 @@ static bool js_cc_scene_Model_createBoundingShape(se::State& s)
     return true;
 }
 SE_BIND_FUNC(js_cc_scene_Model_createBoundingShape) 
-
-static bool js_cc_scene_Model__getInstancedAttributeIndex(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    ccstd::string *arg2 = 0 ;
-    ccstd::string temp2 ;
-    int32_t result;
-    
-    if(argc != 1) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    // %typemap(in) SWIGTYPE&
-    ok &= sevalue_to_native(args[0], &temp2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "Model__getInstancedAttributeIndex,2,SWIGTYPE_p_ccstd__string");
-    arg2 = &temp2;
-    
-    result = ((cc::scene::Model const *)arg1)->getInstancedAttributeIndex((ccstd::string const &)*arg2);
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "Model__getInstancedAttributeIndex, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_cc_scene_Model__getInstancedAttributeIndex) 
 
 static bool js_cc_scene_Model_initialize(se::State& s)
 {
@@ -13964,34 +13721,6 @@ static bool js_cc_scene_Model_detachFromScene(se::State& s)
 }
 SE_BIND_FUNC(js_cc_scene_Model_detachFromScene) 
 
-static bool js_cc_scene_Model_setInstMatWorldIdx(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    int32_t arg2 ;
-    
-    if(argc != 1) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    
-    // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "Model_setInstMatWorldIdx,2,SWIGTYPE_int32_t"); 
-    
-    (arg1)->setInstMatWorldIdx(arg2);
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_cc_scene_Model_setInstMatWorldIdx) 
-
 static bool js_cc_scene_Model_setBounds(se::State& s)
 {
     // js_function
@@ -14018,116 +13747,6 @@ static bool js_cc_scene_Model_setBounds(se::State& s)
 }
 SE_BIND_FUNC(js_cc_scene_Model_setBounds) 
 
-static bool js_cc_scene_Model_getInstMatWorldIdx(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    int32_t result;
-    
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = ((cc::scene::Model const *)arg1)->getInstMatWorldIdx();
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "Model_getInstMatWorldIdx, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_cc_scene_Model_getInstMatWorldIdx) 
-
-static bool js_cc_scene_Model_getInstanceAttributes(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    ccstd::vector< cc::gfx::Attribute > *result = 0 ;
-    
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = (ccstd::vector< cc::gfx::Attribute > *) &((cc::scene::Model const *)arg1)->getInstanceAttributes();
-    // %typemap(out) SWIGTYPE&
-    ok &= nativevalue_to_se(*result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "Model_getInstanceAttributes, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(*result, s.thisObject(), s.rval()); 
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_cc_scene_Model_getInstanceAttributes) 
-
-static bool js_cc_scene_Model_getInstancedBuffer(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    uint8_t *result = 0 ;
-    
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = (uint8_t *)((cc::scene::Model const *)arg1)->getInstancedBuffer();
-    // %typemap(out) SWIGTYPE*
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "Model_getInstancedBuffer, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval()); 
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_cc_scene_Model_getInstancedBuffer) 
-
-static bool js_cc_scene_Model_getInstancedBufferSize(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    uint32_t result;
-    
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = ((cc::scene::Model const *)arg1)->getInstancedBufferSize();
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "Model_getInstancedBufferSize, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_cc_scene_Model_getInstancedBufferSize) 
-
 static bool js_cc_scene_Model_setCalledFromJS(se::State& s)
 {
     // js_function
@@ -14153,44 +13772,6 @@ static bool js_cc_scene_Model_setCalledFromJS(se::State& s)
     return true;
 }
 SE_BIND_FUNC(js_cc_scene_Model_setCalledFromJS) 
-
-static bool js_cc_scene_Model_setInstancedAttributesViewData(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    index_t arg2 ;
-    index_t arg3 ;
-    float arg4 ;
-    
-    if(argc != 3) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 3);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    
-    // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "Model_setInstancedAttributesViewData,2,SWIGTYPE_int32_t"); 
-    
-    
-    // %typemap(in) SWIGTYPE value in
-    ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
-    SE_PRECONDITION2(ok, false, "Model_setInstancedAttributesViewData,3,SWIGTYPE_int32_t"); 
-    
-    // %typemap(in) int, short, long, signed char, float, double
-    ok &= sevalue_to_native(args[2], &arg4, nullptr);
-    SE_PRECONDITION2(ok, false, "Model_setInstancedAttributesViewData,4,SWIGTYPE_float"); 
-    (arg1)->setInstancedAttributesViewData(arg2,arg3,arg4);
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_cc_scene_Model_setInstancedAttributesViewData) 
 
 static bool js_cc_scene_Model_isModelImplementedInJS(se::State& s)
 {
@@ -14602,23 +14183,6 @@ static bool js_cc_scene_Model_updateStamp_get(se::State& s)
 }
 SE_BIND_PROP_GET(js_cc_scene_Model_updateStamp_get) 
 
-static bool js_cc_scene_Model_isInstancingEnabled_get(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    bool result;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = (bool)cc_scene_Model_isInstancingEnabled_get(arg1);
-    // out 5
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    
-    
-    return true;
-}
-SE_BIND_PROP_GET(js_cc_scene_Model_isInstancingEnabled_get) 
-
 static bool js_cc_scene_Model_receiveShadow_set(se::State& s)
 {
     CC_UNUSED bool ok = true;
@@ -14964,48 +14528,6 @@ static bool js_cc_scene_Model_type_get(se::State& s)
 }
 SE_BIND_PROP_GET(js_cc_scene_Model_type_get) 
 
-static bool js_cc_scene_Model_instancedAttributes_set(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    cc::scene::InstancedAttributeBlock *arg2 = 0 ;
-    cc::scene::InstancedAttributeBlock temp2 ;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    // %typemap(in) SWIGTYPE&
-    ok &= sevalue_to_native(args[0], &temp2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "Model_instancedAttributes_set,2,SWIGTYPE_p_cc__scene__InstancedAttributeBlock");
-    arg2 = &temp2;
-    
-    cc_scene_Model_instancedAttributes_set(arg1,*arg2);
-    
-    
-    return true;
-}
-SE_BIND_PROP_SET(js_cc_scene_Model_instancedAttributes_set) 
-
-static bool js_cc_scene_Model_instancedAttributes_get(se::State& s)
-{
-    CC_UNUSED bool ok = true;
-    cc::scene::Model *arg1 = (cc::scene::Model *) NULL ;
-    cc::scene::InstancedAttributeBlock *result = 0 ;
-    
-    arg1 = SE_THIS_OBJECT<cc::scene::Model>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = (cc::scene::InstancedAttributeBlock *) &cc_scene_Model_instancedAttributes_get(arg1);
-    // %typemap(out) SWIGTYPE&
-    ok &= nativevalue_to_se(*result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "Model_instancedAttributes_get, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(*result, s.thisObject(), s.rval()); 
-    
-    
-    return true;
-}
-SE_BIND_PROP_GET(js_cc_scene_Model_instancedAttributes_get) 
-
 static bool js_cc_scene_Model_isDynamicBatching_set(se::State& s)
 {
     CC_UNUSED bool ok = true;
@@ -15100,7 +14622,6 @@ bool js_register_cc_scene_Model(se::Object* obj) {
     cls->defineProperty("worldBoundBuffer", _SE(js_cc_scene_Model_worldBoundBuffer_get), _SE(js_cc_scene_Model_worldBoundBuffer_set)); 
     cls->defineProperty("localBuffer", _SE(js_cc_scene_Model_localBuffer_get), _SE(js_cc_scene_Model_localBuffer_set)); 
     cls->defineProperty("updateStamp", _SE(js_cc_scene_Model_updateStamp_get), nullptr); 
-    cls->defineProperty("isInstancingEnabled", _SE(js_cc_scene_Model_isInstancingEnabled_get), nullptr); 
     cls->defineProperty("receiveShadow", _SE(js_cc_scene_Model_receiveShadow_get), _SE(js_cc_scene_Model_receiveShadow_set)); 
     cls->defineProperty("castShadow", _SE(js_cc_scene_Model_castShadow_get), _SE(js_cc_scene_Model_castShadow_set)); 
     cls->defineProperty("shadowBias", _SE(js_cc_scene_Model_shadowBias_get), _SE(js_cc_scene_Model_shadowBias_set)); 
@@ -15110,7 +14631,6 @@ bool js_register_cc_scene_Model(se::Object* obj) {
     cls->defineProperty("visFlags", _SE(js_cc_scene_Model_visFlags_get), _SE(js_cc_scene_Model_visFlags_set)); 
     cls->defineProperty("enabled", _SE(js_cc_scene_Model_enabled_get), _SE(js_cc_scene_Model_enabled_set)); 
     cls->defineProperty("type", _SE(js_cc_scene_Model_type_get), _SE(js_cc_scene_Model_type_set)); 
-    cls->defineProperty("instancedAttributes", _SE(js_cc_scene_Model_instancedAttributes_get), _SE(js_cc_scene_Model_instancedAttributes_set)); 
     cls->defineProperty("isDynamicBatching", _SE(js_cc_scene_Model_isDynamicBatching_get), _SE(js_cc_scene_Model_isDynamicBatching_set)); 
     cls->defineProperty("priority", _SE(js_cc_scene_Model_priority_get), _SE(js_cc_scene_Model_priority_set)); 
     
@@ -15118,13 +14638,12 @@ bool js_register_cc_scene_Model(se::Object* obj) {
     cls->defineFunction("initSubModel", _SE(js_cc_scene_Model_initSubModel)); 
     cls->defineFunction("getMacroPatches", _SE(js_cc_scene_Model_getMacroPatches)); 
     cls->defineFunction("setSubModelMaterial", _SE(js_cc_scene_Model_setSubModelMaterial)); 
-    cls->defineFunction("_updateInstancedAttributes", _SE(js_cc_scene_Model__updateInstancedAttributes)); 
+    cls->defineFunction("updateInstancedAttributes", _SE(js_cc_scene_Model_updateInstancedAttributes)); 
     cls->defineFunction("updateTransform", _SE(js_cc_scene_Model_updateTransform)); 
     cls->defineFunction("updateUBOs", _SE(js_cc_scene_Model_updateUBOs)); 
     cls->defineFunction("_updateLocalDescriptors", _SE(js_cc_scene_Model__updateLocalDescriptors)); 
     cls->defineFunction("updateWorldBoundDescriptors", _SE(js_cc_scene_Model_updateWorldBoundDescriptors)); 
     cls->defineFunction("createBoundingShape", _SE(js_cc_scene_Model_createBoundingShape)); 
-    cls->defineFunction("_getInstancedAttributeIndex", _SE(js_cc_scene_Model__getInstancedAttributeIndex)); 
     cls->defineFunction("initialize", _SE(js_cc_scene_Model_initialize)); 
     cls->defineFunction("initLightingmap", _SE(js_cc_scene_Model_initLightingmap)); 
     cls->defineFunction("_initLocalDescriptors", _SE(js_cc_scene_Model__initLocalDescriptors)); 
@@ -15142,14 +14661,8 @@ bool js_register_cc_scene_Model(se::Object* obj) {
     cls->defineFunction("updateLocalShadowBias", _SE(js_cc_scene_Model_updateLocalShadowBias)); 
     cls->defineFunction("attachToScene", _SE(js_cc_scene_Model_attachToScene)); 
     cls->defineFunction("detachFromScene", _SE(js_cc_scene_Model_detachFromScene)); 
-    cls->defineFunction("setInstMatWorldIdx", _SE(js_cc_scene_Model_setInstMatWorldIdx)); 
     cls->defineFunction("setBounds", _SE(js_cc_scene_Model_setBounds)); 
-    cls->defineFunction("getInstMatWorldIdx", _SE(js_cc_scene_Model_getInstMatWorldIdx)); 
-    cls->defineFunction("getInstanceAttributes", _SE(js_cc_scene_Model_getInstanceAttributes)); 
-    cls->defineFunction("getInstancedBuffer", _SE(js_cc_scene_Model_getInstancedBuffer)); 
-    cls->defineFunction("getInstancedBufferSize", _SE(js_cc_scene_Model_getInstancedBufferSize)); 
     cls->defineFunction("setCalledFromJS", _SE(js_cc_scene_Model_setCalledFromJS)); 
-    cls->defineFunction("setInstancedAttributesViewData", _SE(js_cc_scene_Model_setInstancedAttributesViewData)); 
     cls->defineFunction("isModelImplementedInJS", _SE(js_cc_scene_Model_isModelImplementedInJS)); 
     
     
@@ -15163,6 +14676,207 @@ bool js_register_cc_scene_Model(se::Object* obj) {
     
     __jsb_cc_scene_Model_proto = cls->getProto();
     __jsb_cc_scene_Model_class = cls;
+    se::ScriptEngine::getInstance()->clearException();
+    return true;
+}
+
+
+se::Class* __jsb_cc_scene_InstancedAttributeBlock_class = nullptr;
+se::Object* __jsb_cc_scene_InstancedAttributeBlock_proto = nullptr;
+SE_DECLARE_FINALIZE_FUNC(js_delete_cc_scene_InstancedAttributeBlock) 
+
+static bool js_cc_scene_IInstancedAttributeBlock_buffer_set(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
+    
+    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    
+    // %typemap(in) SWIGTYPE value in
+    ok &= sevalue_to_native(args[0], &arg1->buffer, s.thisObject());
+    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_buffer_set,2,SWIGTYPE_cc__TypedArrayTempT_uint8_t_t"); 
+    
+    
+    
+    return true;
+}
+SE_BIND_PROP_SET(js_cc_scene_IInstancedAttributeBlock_buffer_set) 
+
+static bool js_cc_scene_IInstancedAttributeBlock_buffer_get(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
+    
+    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(out) SWIGTYPE
+    ok &= nativevalue_to_se(arg1->buffer, s.rval(), s.thisObject() /*ctx*/);
+    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_buffer_get, Error processing arguments");
+    SE_HOLD_RETURN_VALUE(arg1->buffer, s.thisObject(), s.rval());
+    
+    
+    
+    return true;
+}
+SE_BIND_PROP_GET(js_cc_scene_IInstancedAttributeBlock_buffer_get) 
+
+static bool js_cc_scene_IInstancedAttributeBlock_views_set(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
+    
+    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    
+    // %typemap(in) SWIGTYPE value in
+    ok &= sevalue_to_native(args[0], &arg1->views, s.thisObject());
+    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_views_set,2,SWIGTYPE_ccstd__vectorT_cc__TypedArray_t"); 
+    
+    
+    
+    return true;
+}
+SE_BIND_PROP_SET(js_cc_scene_IInstancedAttributeBlock_views_set) 
+
+static bool js_cc_scene_IInstancedAttributeBlock_views_get(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
+    
+    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(out) SWIGTYPE
+    ok &= nativevalue_to_se(arg1->views, s.rval(), s.thisObject() /*ctx*/);
+    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_views_get, Error processing arguments");
+    SE_HOLD_RETURN_VALUE(arg1->views, s.thisObject(), s.rval());
+    
+    
+    
+    return true;
+}
+SE_BIND_PROP_GET(js_cc_scene_IInstancedAttributeBlock_views_get) 
+
+static bool js_cc_scene_IInstancedAttributeBlock_attributes_set(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
+    
+    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    
+    // %typemap(in) SWIGTYPE value in
+    ok &= sevalue_to_native(args[0], &arg1->attributes, s.thisObject());
+    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_attributes_set,2,SWIGTYPE_ccstd__vectorT_cc__gfx__Attribute_t"); 
+    
+    
+    
+    return true;
+}
+SE_BIND_PROP_SET(js_cc_scene_IInstancedAttributeBlock_attributes_set) 
+
+static bool js_cc_scene_IInstancedAttributeBlock_attributes_get(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    cc::scene::InstancedAttributeBlock *arg1 = (cc::scene::InstancedAttributeBlock *) NULL ;
+    
+    arg1 = SE_THIS_OBJECT<cc::scene::InstancedAttributeBlock>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(out) SWIGTYPE
+    ok &= nativevalue_to_se(arg1->attributes, s.rval(), s.thisObject() /*ctx*/);
+    SE_PRECONDITION2(ok, false, "IInstancedAttributeBlock_attributes_get, Error processing arguments");
+    SE_HOLD_RETURN_VALUE(arg1->attributes, s.thisObject(), s.rval());
+    
+    
+    
+    return true;
+}
+SE_BIND_PROP_GET(js_cc_scene_IInstancedAttributeBlock_attributes_get) 
+
+// js_ctor
+static bool js_new_cc_scene_InstancedAttributeBlock(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    
+    cc::scene::InstancedAttributeBlock *result;
+    result = (cc::scene::InstancedAttributeBlock *)new cc::scene::InstancedAttributeBlock();
+    
+    
+    auto *ptr = JSB_MAKE_PRIVATE_OBJECT_WITH_INSTANCE(result);
+    s.thisObject()->setPrivateObject(ptr);
+    return true;
+}
+SE_BIND_CTOR(js_new_cc_scene_InstancedAttributeBlock, __jsb_cc_scene_InstancedAttributeBlock_class, js_delete_cc_scene_InstancedAttributeBlock)
+
+static bool js_delete_cc_scene_InstancedAttributeBlock(se::State& s)
+{
+    // js_dtoroverride
+    return true;
+}
+SE_BIND_FINALIZE_FUNC(js_delete_cc_scene_InstancedAttributeBlock) 
+
+template<>
+bool sevalue_to_native(const se::Value &from, cc::scene::InstancedAttributeBlock * to, se::Object *ctx)
+{
+    assert(from.isObject());
+    se::Object *json = from.toObject();
+    auto* data = reinterpret_cast<cc::scene::InstancedAttributeBlock*>(json->getPrivateData());
+    if (data) {
+        *to = *data;
+        return true;
+    }
+    se::Value field;
+    bool ok = true;
+    
+    json->getProperty("buffer", &field, true);
+    if (!field.isNullOrUndefined()) {
+        ok &= sevalue_to_native(field, &(to->buffer), ctx);
+    }
+    
+    
+    json->getProperty("views", &field, true);
+    if (!field.isNullOrUndefined()) {
+        ok &= sevalue_to_native(field, &(to->views), ctx);
+    }
+    
+    
+    json->getProperty("attributes", &field, true);
+    if (!field.isNullOrUndefined()) {
+        ok &= sevalue_to_native(field, &(to->attributes), ctx);
+    }
+    
+    
+    return ok;
+}
+
+
+bool js_register_cc_scene_InstancedAttributeBlock(se::Object* obj) {
+    auto* cls = se::Class::create("IInstancedAttributeBlock", obj, nullptr, _SE(js_new_cc_scene_InstancedAttributeBlock)); 
+    
+    cls->defineProperty("buffer", _SE(js_cc_scene_IInstancedAttributeBlock_buffer_get), _SE(js_cc_scene_IInstancedAttributeBlock_buffer_set)); 
+    cls->defineProperty("views", _SE(js_cc_scene_IInstancedAttributeBlock_views_get), _SE(js_cc_scene_IInstancedAttributeBlock_views_set)); 
+    cls->defineProperty("attributes", _SE(js_cc_scene_IInstancedAttributeBlock_attributes_get), _SE(js_cc_scene_IInstancedAttributeBlock_attributes_set)); 
+    
+    
+    
+    
+    
+    cls->defineFinalizeFunction(_SE(js_delete_cc_scene_InstancedAttributeBlock));
+    
+    
+    cls->install();
+    JSBClassType::registerClass<cc::scene::InstancedAttributeBlock>(cls);
+    
+    __jsb_cc_scene_InstancedAttributeBlock_proto = cls->getProto();
+    __jsb_cc_scene_InstancedAttributeBlock_class = cls;
     se::ScriptEngine::getInstance()->clearException();
     return true;
 }
@@ -15335,6 +15049,45 @@ static bool js_cc_scene_SubModel_setOwner(se::State& s)
     return true;
 }
 SE_BIND_FUNC(js_cc_scene_SubModel_setOwner) 
+
+static bool js_cc_scene_SubModel_setInstancedAttribute(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    cc::scene::SubModel *arg1 = (cc::scene::SubModel *) NULL ;
+    ccstd::string *arg2 = 0 ;
+    float *arg3 = (float *) NULL ;
+    uint32_t arg4 ;
+    ccstd::string temp2 ;
+    
+    if(argc != 3) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 3);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<cc::scene::SubModel>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE&
+    ok &= sevalue_to_native(args[0], &temp2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "SubModel_setInstancedAttribute,2,SWIGTYPE_p_ccstd__string");
+    arg2 = &temp2;
+    
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
+    SE_PRECONDITION2(ok, false, "SubModel_setInstancedAttribute,3,SWIGTYPE_p_float"); 
+    
+    // %typemap(in) SWIGTYPE value in
+    ok &= sevalue_to_native(args[2], &arg4, s.thisObject());
+    SE_PRECONDITION2(ok, false, "SubModel_setInstancedAttribute,4,SWIGTYPE_uint32_t"); 
+    
+    (arg1)->setInstancedAttribute((ccstd::string const &)*arg2,(float const *)arg3,arg4);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_cc_scene_SubModel_setInstancedAttribute) 
 
 static bool js_cc_scene_SubModel_getWorldBoundDescriptorSet(se::State& s)
 {
@@ -15955,6 +15708,7 @@ bool js_register_cc_scene_SubModel(se::Object* obj) {
     cls->defineFunction("getPass", _SE(js_cc_scene_SubModel_getPass)); 
     cls->defineFunction("setWorldBoundDescriptorSet", _SE(js_cc_scene_SubModel_setWorldBoundDescriptorSet)); 
     cls->defineFunction("setOwner", _SE(js_cc_scene_SubModel_setOwner)); 
+    cls->defineFunction("setInstancedAttribute", _SE(js_cc_scene_SubModel_setInstancedAttribute)); 
     cls->defineFunction("getWorldBoundDescriptorSet", _SE(js_cc_scene_SubModel_getWorldBoundDescriptorSet)); 
     cls->defineFunction("getOwner", _SE(js_cc_scene_SubModel_getOwner)); 
     cls->defineFunction("getId", _SE(js_cc_scene_SubModel_getId)); 
@@ -26836,8 +26590,8 @@ bool register_all_scene(se::Object* obj) {
     js_register_cc_scene_DirectionalLight(ns); 
     js_register_cc_scene_SpotLight(ns); 
     js_register_cc_scene_SphereLight(ns); 
-    js_register_cc_scene_InstancedAttributeBlock(ns); 
     js_register_cc_scene_Model(ns); 
+    js_register_cc_scene_InstancedAttributeBlock(ns); 
     js_register_cc_scene_SubModel(ns); 
     js_register_cc_scene_PassDynamicsValue(ns); 
     js_register_cc_scene_IBlockRef(ns); 

--- a/native/cocos/bindings/auto/jsb_scene_auto.h
+++ b/native/cocos/bindings/auto/jsb_scene_auto.h
@@ -144,14 +144,6 @@ extern se::Object *__jsb_cc_scene_Shadows_proto; // NOLINT
 extern se::Class * __jsb_cc_scene_Shadows_class; // NOLINT
 
 
-extern se::Object *__jsb_cc_scene_InstancedAttributeBlock_proto;   // NOLINT
-extern se::Class *__jsb_cc_scene_InstancedAttributeBlock_class;    // NOLINT
-
-bool js_register_cc_scene_InstancedAttributeBlock(se::Object *obj); // NOLINT
-
-template <>
-bool sevalue_to_native(const se::Value &, cc::scene::InstancedAttributeBlock *, se::Object *ctx); //NOLINT
-
 JSB_REGISTER_OBJECT_TYPE(cc::scene::SkyboxInfo);
 extern se::Object *__jsb_cc_scene_SkyboxInfo_proto; // NOLINT
 extern se::Class * __jsb_cc_scene_SkyboxInfo_class; // NOLINT
@@ -177,6 +169,11 @@ extern se::Object *__jsb_cc_scene_SphereLight_proto; // NOLINT
 extern se::Class * __jsb_cc_scene_SphereLight_class; // NOLINT
 
 
+JSB_REGISTER_OBJECT_TYPE(cc::scene::Model);
+extern se::Object *__jsb_cc_scene_Model_proto; // NOLINT
+extern se::Class * __jsb_cc_scene_Model_class; // NOLINT
+
+
 JSB_REGISTER_OBJECT_TYPE(cc::scene::InstancedAttributeBlock);
 extern se::Object *__jsb_cc_scene_InstancedAttributeBlock_proto; // NOLINT
 extern se::Class * __jsb_cc_scene_InstancedAttributeBlock_class; // NOLINT
@@ -184,11 +181,6 @@ extern se::Class * __jsb_cc_scene_InstancedAttributeBlock_class; // NOLINT
 
 template<>
 bool sevalue_to_native(const se::Value &from, cc::scene::InstancedAttributeBlock * to, se::Object *ctx);
-
-
-JSB_REGISTER_OBJECT_TYPE(cc::scene::Model);
-extern se::Object *__jsb_cc_scene_Model_proto; // NOLINT
-extern se::Class * __jsb_cc_scene_Model_class; // NOLINT
 
 
 JSB_REGISTER_OBJECT_TYPE(cc::scene::SubModel);

--- a/native/cocos/bindings/auto/jsb_spine_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_spine_auto.cpp
@@ -61,6 +61,8 @@
 #include "bindings/manual/jsb_global.h"
 
 
+#include "bindings/auto/jsb_2d_auto.h"
+#include "bindings/auto/jsb_assets_auto.h"
 #include "bindings/auto/jsb_spine_auto.h"
 using namespace spine;
 
@@ -19499,34 +19501,6 @@ static bool js_spine_SkeletonRenderer_getSharedBufferOffset(se::State& s)
 }
 SE_BIND_FUNC(js_spine_SkeletonRenderer_getSharedBufferOffset) 
 
-static bool js_spine_SkeletonRenderer_getParamsBuffer(se::State& s)
-{
-    // js_function
-    
-    CC_UNUSED bool ok = true;
-    const auto& args = s.args();
-    size_t argc = args.size();
-    spine::SkeletonRenderer *arg1 = (spine::SkeletonRenderer *) NULL ;
-    se_object_ptr result;
-    
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-        return false;
-    }
-    arg1 = SE_THIS_OBJECT<spine::SkeletonRenderer>(s);
-    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = ((spine::SkeletonRenderer const *)arg1)->getParamsBuffer();
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "SkeletonRenderer_getParamsBuffer, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
-    
-    
-    
-    return true;
-}
-SE_BIND_FUNC(js_spine_SkeletonRenderer_getParamsBuffer) 
-
 static bool js_spine_SkeletonRenderer_setColor(se::State& s)
 {
     // js_function
@@ -20339,6 +20313,58 @@ static bool js_spine_SkeletonRenderer_initialize(se::State& s)
 }
 SE_BIND_FUNC(js_spine_SkeletonRenderer_initialize) 
 
+static bool js_spine_SkeletonRenderer_setMaterial(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    spine::SkeletonRenderer *arg1 = (spine::SkeletonRenderer *) NULL ;
+    cc::Material *arg2 = (cc::Material *) NULL ;
+    
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<spine::SkeletonRenderer>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "SkeletonRenderer_setMaterial,2,SWIGTYPE_p_cc__Material"); 
+    (arg1)->setMaterial(arg2);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_spine_SkeletonRenderer_setMaterial) 
+
+static bool js_spine_SkeletonRenderer_setRenderEntity(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    spine::SkeletonRenderer *arg1 = (spine::SkeletonRenderer *) NULL ;
+    cc::RenderEntity *arg2 = (cc::RenderEntity *) NULL ;
+    
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<spine::SkeletonRenderer>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "SkeletonRenderer_setRenderEntity,2,SWIGTYPE_p_cc__RenderEntity"); 
+    (arg1)->setRenderEntity(arg2);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_spine_SkeletonRenderer_setRenderEntity) 
+
 bool js_register_spine_SkeletonRenderer(se::Object* obj) {
     auto* cls = se::Class::create("SkeletonRenderer", obj, nullptr, _SE(js_new_SkeletonRenderer)); 
     
@@ -20364,7 +20390,6 @@ bool js_register_spine_SkeletonRenderer(se::Object* obj) {
     cls->defineFunction("setSlotsRange", _SE(js_spine_SkeletonRenderer_setSlotsRange)); 
     cls->defineFunction("getDebugData", _SE(js_spine_SkeletonRenderer_getDebugData)); 
     cls->defineFunction("getSharedBufferOffset", _SE(js_spine_SkeletonRenderer_getSharedBufferOffset)); 
-    cls->defineFunction("getParamsBuffer", _SE(js_spine_SkeletonRenderer_getParamsBuffer)); 
     cls->defineFunction("setColor", _SE(js_spine_SkeletonRenderer_setColor)); 
     cls->defineFunction("setBatchEnabled", _SE(js_spine_SkeletonRenderer_setBatchEnabled)); 
     cls->defineFunction("setDebugBonesEnabled", _SE(js_spine_SkeletonRenderer_setDebugBonesEnabled)); 
@@ -20380,6 +20405,8 @@ bool js_register_spine_SkeletonRenderer(se::Object* obj) {
     cls->defineFunction("initWithUUID", _SE(js_spine_SkeletonRenderer_initWithUUID)); 
     cls->defineFunction("initWithSkeleton", _SE(js_spine_SkeletonRenderer_initWithSkeleton)); 
     cls->defineFunction("initialize", _SE(js_spine_SkeletonRenderer_initialize)); 
+    cls->defineFunction("setMaterial", _SE(js_spine_SkeletonRenderer_setMaterial)); 
+    cls->defineFunction("setRenderEntity", _SE(js_spine_SkeletonRenderer_setRenderEntity)); 
     
     
     cls->defineStaticFunction("create", _SE(js_spine_SkeletonRenderer_create_static)); 
@@ -22871,7 +22898,7 @@ static bool js_spine_SkeletonCacheAnimation_getSharedBufferOffset(se::State& s)
 }
 SE_BIND_FUNC(js_spine_SkeletonCacheAnimation_getSharedBufferOffset) 
 
-static bool js_spine_SkeletonCacheAnimation_getParamsBuffer(se::State& s)
+static bool js_spine_SkeletonCacheAnimation_setMaterial(se::State& s)
 {
     // js_function
     
@@ -22879,25 +22906,49 @@ static bool js_spine_SkeletonCacheAnimation_getParamsBuffer(se::State& s)
     const auto& args = s.args();
     size_t argc = args.size();
     spine::SkeletonCacheAnimation *arg1 = (spine::SkeletonCacheAnimation *) NULL ;
-    se_object_ptr result;
+    cc::Material *arg2 = (cc::Material *) NULL ;
     
-    if(argc != 0) {
-        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
         return false;
     }
     arg1 = SE_THIS_OBJECT<spine::SkeletonCacheAnimation>(s);
     SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
-    result = ((spine::SkeletonCacheAnimation const *)arg1)->getParamsBuffer();
-    // %typemap(out) SWIGTYPE
-    ok &= nativevalue_to_se(result, s.rval(), s.thisObject() /*ctx*/);
-    SE_PRECONDITION2(ok, false, "SkeletonCacheAnimation_getParamsBuffer, Error processing arguments");
-    SE_HOLD_RETURN_VALUE(result, s.thisObject(), s.rval());
-    
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "SkeletonCacheAnimation_setMaterial,2,SWIGTYPE_p_cc__Material"); 
+    (arg1)->setMaterial(arg2);
     
     
     return true;
 }
-SE_BIND_FUNC(js_spine_SkeletonCacheAnimation_getParamsBuffer) 
+SE_BIND_FUNC(js_spine_SkeletonCacheAnimation_setMaterial) 
+
+static bool js_spine_SkeletonCacheAnimation_setRenderEntity(se::State& s)
+{
+    // js_function
+    
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    spine::SkeletonCacheAnimation *arg1 = (spine::SkeletonCacheAnimation *) NULL ;
+    cc::RenderEntity *arg2 = (cc::RenderEntity *) NULL ;
+    
+    if(argc != 1) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<spine::SkeletonCacheAnimation>(s);
+    SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
+    // %typemap(in) SWIGTYPE*
+    ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
+    SE_PRECONDITION2(ok, false, "SkeletonCacheAnimation_setRenderEntity,2,SWIGTYPE_p_cc__RenderEntity"); 
+    (arg1)->setRenderEntity(arg2);
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_spine_SkeletonCacheAnimation_setRenderEntity) 
 
 bool js_register_spine_SkeletonCacheAnimation(se::Object* obj) {
     auto* cls = se::Class::create("SkeletonCacheAnimation", obj, nullptr, _SE(js_new_spine_SkeletonCacheAnimation)); 
@@ -22935,7 +22986,8 @@ bool js_register_spine_SkeletonCacheAnimation(se::Object* obj) {
     cls->defineFunction("setBonesToSetupPose", _SE(js_spine_SkeletonCacheAnimation_setBonesToSetupPose)); 
     cls->defineFunction("setSlotsToSetupPose", _SE(js_spine_SkeletonCacheAnimation_setSlotsToSetupPose)); 
     cls->defineFunction("getSharedBufferOffset", _SE(js_spine_SkeletonCacheAnimation_getSharedBufferOffset)); 
-    cls->defineFunction("getParamsBuffer", _SE(js_spine_SkeletonCacheAnimation_getParamsBuffer)); 
+    cls->defineFunction("setMaterial", _SE(js_spine_SkeletonCacheAnimation_setMaterial)); 
+    cls->defineFunction("setRenderEntity", _SE(js_spine_SkeletonCacheAnimation_setRenderEntity)); 
     
     
     


### PR DESCRIPTION
* Update bindings with swig
* According to the refactor of SystemWindowManager, the simulator can be compiled but cannot be used..It will be fixed before 3.7 published.