### PR TITLE
features config for simulator

### DIFF
--- a/editor/engine-features/render-config.json
+++ b/editor/engine-features/render-config.json
@@ -6,6 +6,7 @@
             "description": "i18n:ENGINE.features.core.description",
             "required": true,
             "default": ["base"],
+            "simulatorRequired":["base"],
             "wechatPlugin": true
         },
         "graphcis": {

--- a/editor/engine-features/types.ts
+++ b/editor/engine-features/types.ts
@@ -80,6 +80,8 @@ export interface BaseItem {
      */
     description?: string;
 
+    simulatorRequired?: string[];
+
     required?: boolean;
 
     native?: string;


### PR DESCRIPTION
Usage:
If you'd like to make some modules must be chosen as simulator requires, then just add it into `simulatorRequired` list as you wish.
```json
"physics": {
            "label": "i18n:ENGINE.features.physics.label",
            "description": "i18n:ENGINE.features.physics.description",
            "default": ["physics-ammo"],
            "simulatorRequired": ["physics-physx"],
            "category": "3d",
            "options": {
                "physics-ammo": {
                    "label": "i18n:ENGINE.features.physics_ammo.label",
                    "description": "i18n:ENGINE.features.physics_ammo.description"
                },
                "physics-cannon": {
                    "label": "i18n:ENGINE.features.physics_cannon.label",
                    "description": "i18n:ENGINE.features.physics_cannon.description"
                },
                "physics-physx": {
                    "label": "i18n:ENGINE.features.physics_physx.label",
                    "native": "USE_PHYSICS_PHYSX",
                    "description": "i18n:ENGINE.features.physics_physx.description"
                },
                "physics-builtin": {
                    "label": "i18n:ENGINE.features.physics_builtin.label",
                    "description": "i18n:ENGINE.features.physics_builtin.description"
                }
            }
        },
```