### PR TITLE
Fix: XMLHttpRequest failed to get header on TaoBao

### DIFF
--- a/platforms/minigame/platforms/taobao/wrapper/builtin/WebSocket.js
+++ b/platforms/minigame/platforms/taobao/wrapper/builtin/WebSocket.js
@@ -1,7 +1,7 @@
 const _utils = require('../utils');
 
-const MAX_REF_WEBSOCKET = 1  // The maximum number of WEBSOCKET
-let CURR_REF_WEBSOCKET = 0   // The current number of WEBSOCKET
+const MAX_AMOUNT_WEBSOCKET = 1   // The maximum number of WEBSOCKET
+let CURR_AMOUNT_WEBSOCKET = 0    // The current number of WEBSOCKET
 
 export default class WebSocket {
   static CONNECTING = 0 // The connection is not yet open.
@@ -28,8 +28,8 @@ export default class WebSocket {
   readyState = 3
 
   constructor(url, protocols = []) {
-    if(this._isMaxRef()){
-      console.warn(`Failed to construct 'WebSocket': Only ${CURR_REF_WEBSOCKET} WebSocket can be created at the same time on TaoBao.`);
+    if(this._isMaxCount()){
+      console.warn(`Failed to construct 'WebSocket': Only ${CURR_AMOUNT_WEBSOCKET} WebSocket can be created at the same time on TaoBao.`);
       return this;
     }
 
@@ -39,7 +39,7 @@ export default class WebSocket {
 
     this.url = url
     this.readyState = WebSocket.CONNECTING
-    this._addRef();
+    this._addCount();
 
     my.connectSocket({
       url,
@@ -64,7 +64,7 @@ export default class WebSocket {
 
     this._onError = (res) => {
       this._triggerEvent('error', res)
-      this._reduceRef();
+      this._reduceCount();
     }
     my.onSocketError(this._onError)
 
@@ -72,7 +72,7 @@ export default class WebSocket {
       this.readyState = WebSocket.CLOSED
       this._triggerEvent('close')
       this._removeAllSocketListenr()
-      this._reduceRef();
+      this._reduceCount();
     }
     my.onSocketClose(this._onClose)
 
@@ -122,18 +122,18 @@ export default class WebSocket {
     this._onClose = null
   }
 
-  _addRef(){
-    CURR_REF_WEBSOCKET += 1
+  _addCount(){
+    CURR_AMOUNT_WEBSOCKET += 1
   }
 
-  _reduceRef(){
+  _reduceCount(){
     if(!this._isReduced){
-      CURR_REF_WEBSOCKET -= 1
+      CURR_AMOUNT_WEBSOCKET -= 1
       this._isReduced = true
     }
   }
 
-  _isMaxRef(){
-    return CURR_REF_WEBSOCKET >= MAX_REF_WEBSOCKET
+  _isMaxCount(){
+    return CURR_AMOUNT_WEBSOCKET >= MAX_AMOUNT_WEBSOCKET
   }
 }

--- a/platforms/minigame/platforms/taobao/wrapper/builtin/WebSocket.js
+++ b/platforms/minigame/platforms/taobao/wrapper/builtin/WebSocket.js
@@ -39,7 +39,7 @@ export default class WebSocket {
 
     this.url = url
     this.readyState = WebSocket.CONNECTING
-    this._addCount();
+    this._increaseCount();
 
     my.connectSocket({
       url,
@@ -64,7 +64,7 @@ export default class WebSocket {
 
     this._onError = (res) => {
       this._triggerEvent('error', res)
-      this._reduceCount();
+      this._decreaseCount();
     }
     my.onSocketError(this._onError)
 
@@ -72,7 +72,7 @@ export default class WebSocket {
       this.readyState = WebSocket.CLOSED
       this._triggerEvent('close')
       this._removeAllSocketListenr()
-      this._reduceCount();
+      this._decreaseCount();
     }
     my.onSocketClose(this._onClose)
 
@@ -122,11 +122,11 @@ export default class WebSocket {
     this._onClose = null
   }
 
-  _addCount(){
+  _increaseCount(){
     CURR_AMOUNT_WEBSOCKET += 1
   }
 
-  _reduceCount(){
+  _decreaseCount(){
     if(!this._isReduced){
       CURR_AMOUNT_WEBSOCKET -= 1
       this._isReduced = true

--- a/platforms/minigame/platforms/taobao/wrapper/builtin/WebSocket.js
+++ b/platforms/minigame/platforms/taobao/wrapper/builtin/WebSocket.js
@@ -1,7 +1,7 @@
 const _utils = require('../utils');
 
-const MAX_VALUE_WEBSOCkET = 1;
-let CURR_VALUE_WEBSOCKET = 0;
+const MAX_REF_WEBSOCKET = 1  // The maximum number of WEBSOCKET
+let CURR_REF_WEBSOCKET = 0   // The current number of WEBSOCKET
 
 export default class WebSocket {
   static CONNECTING = 0 // The connection is not yet open.
@@ -22,14 +22,14 @@ export default class WebSocket {
   _onOpen = null
   _onError = null
   _onClose = null
-  _isReduced = false;
+  _isReduced = false
 
   protocol = '' // TODO 小程序内目前获取不到，实际上需要根据服务器选择的 sub-protocol 返回
   readyState = 3
 
   constructor(url, protocols = []) {
     if(this._isMaxRef()){
-      console.warn(`Failed to construct 'WebSocket': Only ${CURR_VALUE_WEBSOCKET} WebSocket can be created at the same time on TaoBao.`);
+      console.warn(`Failed to construct 'WebSocket': Only ${CURR_REF_WEBSOCKET} WebSocket can be created at the same time on TaoBao.`);
       return this;
     }
 
@@ -123,17 +123,17 @@ export default class WebSocket {
   }
 
   _addRef(){
-    CURR_VALUE_WEBSOCKET += 1
+    CURR_REF_WEBSOCKET += 1
   }
 
   _reduceRef(){
     if(!this._isReduced){
-      CURR_VALUE_WEBSOCKET -= 1
-      _isReduced = true;
+      CURR_REF_WEBSOCKET -= 1
+      this._isReduced = true
     }
   }
 
   _isMaxRef(){
-    return CURR_VALUE_WEBSOCKET >= MAX_VALUE_WEBSOCkET
+    return CURR_REF_WEBSOCKET >= MAX_REF_WEBSOCKET
   }
 }

--- a/platforms/minigame/platforms/taobao/wrapper/builtin/XMLHttpRequest.js
+++ b/platforms/minigame/platforms/taobao/wrapper/builtin/XMLHttpRequest.js
@@ -94,13 +94,13 @@ export default class XMLHttpRequest extends EventTarget {
         data,
         url: _url.get(this),
         method: _method.get(this),
-        header: _requestHeader.get(this),
+        headers: _requestHeader.get(this),
         dataType: 'other',
         responseType: this.responseType === 'arraybuffer' ? 'arraybuffer' : 'text',
         timeout: this.timeout || undefined,
-        success: ({ data, status, header }) => {
+        success: ({ data, status, headers }) => {
           this.status = status
-          _responseHeader.set(this, header)
+          _responseHeader.set(this, headers)
           _triggerEvent.call(this, 'loadstart')
           _changeReadyState.call(this, XMLHttpRequest.HEADERS_RECEIVED)
           _changeReadyState.call(this, XMLHttpRequest.LOADING)

--- a/platforms/minigame/platforms/taobao/wrapper/builtin/XMLHttpRequest.js
+++ b/platforms/minigame/platforms/taobao/wrapper/builtin/XMLHttpRequest.js
@@ -52,7 +52,7 @@ export default class XMLHttpRequest extends EventTarget {
     super();
 
     _requestHeader.set(this, {
-      'content-type': 'application/x-www-form-urlencoded'
+      'content-type': 'application/json'
     })
     _responseHeader.set(this, {})
   }


### PR DESCRIPTION
Re: #

### Changelog

* Fix: XMLHttpRequest failed to get header
* Fix: Modify the default value of Headers

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
