### PR TITLE
[fix]: inspector property style in material dump

### DIFF
--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -225,8 +225,12 @@ exports.methods = {
                     const $section = $container.$children[i].querySelector('ui-section');
                     $section.appendChild($checkbox);
 
-                    const $label = $section.querySelector('ui-label');
-                    $label.style.width = 'calc(var(--left-width) - 10px)';
+                    // header and switch element appear in `header` slot at the same time, keep the middle distance 12px
+                    const $header = $section.querySelector('div[slot=header]');
+                    $header.style.width = 'auto';
+                    $header.style.flex = '1';
+                    $header.style.minWidth = '0';
+                    $header.style.marginRight = '12px';
                 }
 
                 $container.$children[i].querySelectorAll('ui-prop').forEach(($prop) => {


### PR DESCRIPTION
Re: #

### Changelog

* adjust label style in material dump(when effect type is `builtin-toon`) 
![image](https://user-images.githubusercontent.com/20528478/197702964-8dd928b7-b66f-41f6-abdb-53d520a454e4.png)

### related issue
- https://github.com/cocos/3d-tasks/issues/14221

### related PR
- https://github.com/cocos/creator-ui-kit/pull/286

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
