### PR TITLE
[Bug] Fix material mini preview buffer context.clearRect bug

### DIFF
--- a/editor/inspector/assets/material-header.js
+++ b/editor/inspector/assets/material-header.js
@@ -95,7 +95,7 @@ exports.methods = {
  * @param assetList
  * @param metaList
  */
-exports.update = async function(assetList, metaList) {
+exports.update = async function (assetList, metaList) {
     const panel = this;
 
     panel.assetList = assetList;
@@ -120,7 +120,7 @@ exports.update = async function(assetList, metaList) {
 /**
  * Method of initializing the panel
  */
-exports.ready = async function() {
+exports.ready = async function () {
     const panel = this;
 
     callMaterialPreviewFunction('setLightEnable', true);
@@ -179,12 +179,11 @@ exports.ready = async function() {
     Editor.Message.addBroadcastListener('material-inspector:change-dump', this.updatePreviewDataDirtyBind);
 };
 
-exports.close = function() {
+exports.close = function () {
     const panel = this;
     callMaterialPreviewFunction('hide');
     panel.resizeObserver.unobserve(panel.$.container);
     Editor.Message.removeBroadcastListener('material-inspector:change-dump', this.updatePreviewDataDirtyBind);
     // clear the canvas on close hook
-    const context = panel.$.canvas.getContext('2d');
-    context.clearRect(0, 0, panel.$.canvas.width, panel.$.canvas.height);
+    panel.glPreview.destroyGL()
 };


### PR DESCRIPTION
Re: #

### Changelog

* Fix material mini preview buffer context.clearRect bug

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [x] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [x] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
