### PR TITLE
[develop] improved interface methods code generation

### DIFF
--- a/native/cocos/bindings/auto/jsb_render_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_render_auto.cpp
@@ -1294,7 +1294,7 @@ static bool js_cc_render_RasterQueueBuilder_addFullscreenQuad(se::State& s)
     const auto& args = s.args();
     size_t argc = args.size();
     cc::render::RasterQueueBuilder *arg1 = (cc::render::RasterQueueBuilder *) NULL ;
-    cc::Material *arg2 = (cc::Material *) NULL ;
+    Material *arg2 = (Material *) NULL ;
     uint32_t arg3 ;
     SceneFlags arg4 ;
     
@@ -1306,7 +1306,7 @@ static bool js_cc_render_RasterQueueBuilder_addFullscreenQuad(se::State& s)
     SE_PRECONDITION2(arg1, false, "%s: Invalid Native Object", __FUNCTION__); 
     // %typemap(in) SWIGTYPE*
     ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
-    SE_PRECONDITION2(ok, false, "RasterQueueBuilder_addFullscreenQuad,2,SWIGTYPE_p_cc__Material"); 
+    SE_PRECONDITION2(ok, false, "RasterQueueBuilder_addFullscreenQuad,2,SWIGTYPE_p_Material"); 
     
     // %typemap(in) SWIGTYPE value in
     ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
@@ -1333,7 +1333,7 @@ static bool js_cc_render_RasterQueueBuilder_addCameraQuad(se::State& s)
     size_t argc = args.size();
     cc::render::RasterQueueBuilder *arg1 = (cc::render::RasterQueueBuilder *) NULL ;
     cc::scene::Camera *arg2 = (cc::scene::Camera *) NULL ;
-    cc::Material *arg3 = (cc::Material *) NULL ;
+    Material *arg3 = (Material *) NULL ;
     uint32_t arg4 ;
     SceneFlags arg5 ;
     
@@ -1348,7 +1348,7 @@ static bool js_cc_render_RasterQueueBuilder_addCameraQuad(se::State& s)
     SE_PRECONDITION2(ok, false, "RasterQueueBuilder_addCameraQuad,2,SWIGTYPE_p_cc__scene__Camera"); 
     // %typemap(in) SWIGTYPE*
     ok &= sevalue_to_native(args[1], &arg3, s.thisObject());
-    SE_PRECONDITION2(ok, false, "RasterQueueBuilder_addCameraQuad,3,SWIGTYPE_p_cc__Material"); 
+    SE_PRECONDITION2(ok, false, "RasterQueueBuilder_addCameraQuad,3,SWIGTYPE_p_Material"); 
     
     // %typemap(in) SWIGTYPE value in
     ok &= sevalue_to_native(args[2], &arg4, s.thisObject());

--- a/native/cocos/renderer/pipeline/custom/ArchiveTypes.h
+++ b/native/cocos/renderer/pipeline/custom/ArchiveTypes.h
@@ -50,7 +50,7 @@ public:
     virtual void writeBool(bool value) = 0;
     virtual void writeNumber(double value) = 0;
     virtual void writeString(std::string_view value) = 0;
-    virtual boost::container::pmr::memory_resource* scratch() const noexcept = 0;
+    virtual boost::container::pmr::memory_resource *scratch() const noexcept = 0;
 };
 
 class InputArchive {
@@ -65,7 +65,7 @@ public:
     virtual bool readBool() = 0;
     virtual double readNumber() = 0;
     virtual std::string_view readString() = 0;
-    virtual boost::container::pmr::memory_resource* scratch() const noexcept = 0;
+    virtual boost::container::pmr::memory_resource *scratch() const noexcept = 0;
 };
 
 } // namespace render

--- a/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
@@ -53,14 +53,13 @@ public:
       data(dataIn) {}
 
     void clear() override;
-    uint32_t addRenderStage(const ccstd::string& name) override;
-    uint32_t addRenderPhase(const ccstd::string& name, uint32_t parentID) override;
-    void addShader(const ccstd::string& name, uint32_t parentPhaseID) override;
-    void addDescriptorBlock(uint32_t nodeID, const DescriptorBlockIndex& index, const DescriptorBlockFlattened& block) override;
-    void addUniformBlock(uint32_t nodeID, const DescriptorBlockIndex& index, const ccstd::string& name, const gfx::UniformBlock& uniformBlock) override;
-    void reserveDescriptorBlock(uint32_t nodeID, const DescriptorBlockIndex& index, const DescriptorBlockFlattened& block) override;
+    uint32_t addRenderStage(const ccstd::string &name) override;
+    uint32_t addRenderPhase(const ccstd::string &name, uint32_t parentID) override;
+    void addShader(const ccstd::string &name, uint32_t parentPhaseID) override;
+    void addDescriptorBlock(uint32_t nodeID, const DescriptorBlockIndex &index, const DescriptorBlockFlattened &block) override;
+    void addUniformBlock(uint32_t nodeID, const DescriptorBlockIndex &index, const ccstd::string &name, const gfx::UniformBlock &uniformBlock) override;
+    void reserveDescriptorBlock(uint32_t nodeID, const DescriptorBlockIndex &index, const DescriptorBlockFlattened &block) override;
     int compile() override;
-
     ccstd::string print() const override;
 
     gfx::Device* device{nullptr};
@@ -75,28 +74,27 @@ public:
       layoutGraph(layoutGraphIn),
       queueID(queueIDIn) {}
 
-    void addSceneOfCamera(scene::Camera* camera, LightInfo light, SceneFlags sceneFlags) override;
-    void addScene(const ccstd::string& name, SceneFlags sceneFlags) override;
-    void addFullscreenQuad(cc::Material *material, uint32_t passID, SceneFlags sceneFlags) override;
-    void addCameraQuad(scene::Camera* camera, cc::Material *material, uint32_t passID, SceneFlags sceneFlags) override;
+    ccstd::string getName() const override;
+    void setName(const ccstd::string &name) override;
+
+    void setMat4(const ccstd::string &name, const Mat4 &mat) override;
+    void setQuaternion(const ccstd::string &name, const Quaternion &quat) override;
+    void setColor(const ccstd::string &name, const gfx::Color &color) override;
+    void setVec4(const ccstd::string &name, const Vec4 &vec) override;
+    void setVec2(const ccstd::string &name, const Vec2 &vec) override;
+    void setFloat(const ccstd::string &name, float v) override;
+    void setBuffer(const ccstd::string &name, gfx::Buffer *buffer) override;
+    void setTexture(const ccstd::string &name, gfx::Texture *texture) override;
+    void setReadWriteBuffer(const ccstd::string &name, gfx::Buffer *buffer) override;
+    void setReadWriteTexture(const ccstd::string &name, gfx::Texture *texture) override;
+    void setSampler(const ccstd::string &name, gfx::Sampler *sampler) override;
+
+    void addSceneOfCamera(scene::Camera *camera, LightInfo light, SceneFlags sceneFlags) override;
+    void addScene(const ccstd::string &name, SceneFlags sceneFlags) override;
+    void addFullscreenQuad(Material *material, uint32_t passID, SceneFlags sceneFlags) override;
+    void addCameraQuad(scene::Camera *camera, Material *material, uint32_t passID, SceneFlags sceneFlags) override;
     void clearRenderTarget(const ccstd::string &name, const gfx::Color &color) override;
     void setViewport(const gfx::Viewport &viewport) override;
-
-    void setMat4(const ccstd::string& name, const cc::Mat4& mat) override;
-    void setQuaternion(const ccstd::string& name, const cc::Quaternion& quat) override;
-    void setColor(const ccstd::string& name, const gfx::Color& color) override;
-    void setVec4(const ccstd::string& name, const cc::Vec4& vec) override;
-    void setVec2(const ccstd::string& name, const cc::Vec2& vec) override;
-    void setFloat(const ccstd::string& name, float v) override;
-
-    void setBuffer(const ccstd::string& name, gfx::Buffer* buffer) override;
-    void setTexture(const ccstd::string& name, gfx::Texture* texture) override;
-    void setReadWriteBuffer(const ccstd::string& name, gfx::Buffer* buffer) override;
-    void setReadWriteTexture(const ccstd::string& name, gfx::Texture* texture) override;
-    void setSampler(const ccstd::string& name, gfx::Sampler* sampler) override;
-
-    ccstd::string getName() const override;
-    void setName(const ccstd::string& name) override;
 
     RenderGraph* renderGraph{nullptr};
     const LayoutGraphData* layoutGraph{nullptr};
@@ -112,26 +110,25 @@ public:
       passID(passIDIn),
       layoutID(layoutIDIn) {}
 
-    void addRasterView(const ccstd::string& name, const RasterView& view) override;
-    void addComputeView(const ccstd::string& name, const ComputeView& view) override;
+    ccstd::string getName() const override;
+    void setName(const ccstd::string &name) override;
+
+    void setMat4(const ccstd::string &name, const Mat4 &mat) override;
+    void setQuaternion(const ccstd::string &name, const Quaternion &quat) override;
+    void setColor(const ccstd::string &name, const gfx::Color &color) override;
+    void setVec4(const ccstd::string &name, const Vec4 &vec) override;
+    void setVec2(const ccstd::string &name, const Vec2 &vec) override;
+    void setFloat(const ccstd::string &name, float v) override;
+    void setBuffer(const ccstd::string &name, gfx::Buffer *buffer) override;
+    void setTexture(const ccstd::string &name, gfx::Texture *texture) override;
+    void setReadWriteBuffer(const ccstd::string &name, gfx::Buffer *buffer) override;
+    void setReadWriteTexture(const ccstd::string &name, gfx::Texture *texture) override;
+    void setSampler(const ccstd::string &name, gfx::Sampler *sampler) override;
+
+    void addRasterView(const ccstd::string &name, const RasterView &view) override;
+    void addComputeView(const ccstd::string &name, const ComputeView &view) override;
     RasterQueueBuilder *addQueue(QueueHint hint) override;
     void setViewport(const gfx::Viewport &viewport) override;
-
-    void setMat4(const ccstd::string& name, const cc::Mat4& mat) override;
-    void setQuaternion(const ccstd::string& name, const cc::Quaternion& quat) override;
-    void setColor(const ccstd::string& name, const gfx::Color& color) override;
-    void setVec4(const ccstd::string& name, const cc::Vec4& vec) override;
-    void setVec2(const ccstd::string& name, const cc::Vec2& vec) override;
-    void setFloat(const ccstd::string& name, float v) override;
-
-    void setBuffer(const ccstd::string& name, gfx::Buffer* buffer) override;
-    void setTexture(const ccstd::string& name, gfx::Texture* texture) override;
-    void setReadWriteBuffer(const ccstd::string& name, gfx::Buffer* buffer) override;
-    void setReadWriteTexture(const ccstd::string& name, gfx::Texture* texture) override;
-    void setSampler(const ccstd::string& name, gfx::Sampler* sampler) override;
-
-    ccstd::string getName() const override;
-    void setName(const ccstd::string& name) override;
 
     RenderGraph* renderGraph{nullptr};
     const LayoutGraphData* layoutGraph{nullptr};
@@ -147,23 +144,22 @@ public:
       layoutGraph(layoutGraphIn),
       queueID(queueIDIn) {}
 
-    void addDispatch(const ccstd::string& shader, uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ) override;
-
-    void setMat4(const ccstd::string& name, const cc::Mat4& mat) override;
-    void setQuaternion(const ccstd::string& name, const cc::Quaternion& quat) override;
-    void setColor(const ccstd::string& name, const gfx::Color& color) override;
-    void setVec4(const ccstd::string& name, const cc::Vec4& vec) override;
-    void setVec2(const ccstd::string& name, const cc::Vec2& vec) override;
-    void setFloat(const ccstd::string& name, float v) override;
-
-    void setBuffer(const ccstd::string& name, gfx::Buffer* buffer) override;
-    void setTexture(const ccstd::string& name, gfx::Texture* texture) override;
-    void setReadWriteBuffer(const ccstd::string& name, gfx::Buffer* buffer) override;
-    void setReadWriteTexture(const ccstd::string& name, gfx::Texture* texture) override;
-    void setSampler(const ccstd::string& name, gfx::Sampler* sampler) override;
-
     ccstd::string getName() const override;
-    void setName(const ccstd::string& name) override;
+    void setName(const ccstd::string &name) override;
+
+    void setMat4(const ccstd::string &name, const Mat4 &mat) override;
+    void setQuaternion(const ccstd::string &name, const Quaternion &quat) override;
+    void setColor(const ccstd::string &name, const gfx::Color &color) override;
+    void setVec4(const ccstd::string &name, const Vec4 &vec) override;
+    void setVec2(const ccstd::string &name, const Vec2 &vec) override;
+    void setFloat(const ccstd::string &name, float v) override;
+    void setBuffer(const ccstd::string &name, gfx::Buffer *buffer) override;
+    void setTexture(const ccstd::string &name, gfx::Texture *texture) override;
+    void setReadWriteBuffer(const ccstd::string &name, gfx::Buffer *buffer) override;
+    void setReadWriteTexture(const ccstd::string &name, gfx::Texture *texture) override;
+    void setSampler(const ccstd::string &name, gfx::Sampler *sampler) override;
+
+    void addDispatch(const ccstd::string &shader, uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ) override;
 
     RenderGraph* renderGraph{nullptr};
     const LayoutGraphData* layoutGraph{nullptr};
@@ -179,25 +175,23 @@ public:
       passID(passIDIn),
       layoutID(layoutIDIn) {}
 
-    void addComputeView(const ccstd::string& name, const ComputeView& view) override;
-
-    ComputeQueueBuilder *addQueue() override;
-
-    void setMat4(const ccstd::string& name, const cc::Mat4& mat) override;
-    void setQuaternion(const ccstd::string& name, const cc::Quaternion& quat) override;
-    void setColor(const ccstd::string& name, const gfx::Color& color) override;
-    void setVec4(const ccstd::string& name, const cc::Vec4& vec) override;
-    void setVec2(const ccstd::string& name, const cc::Vec2& vec) override;
-    void setFloat(const ccstd::string& name, float v) override;
-
-    void setBuffer(const ccstd::string& name, gfx::Buffer* buffer) override;
-    void setTexture(const ccstd::string& name, gfx::Texture* texture) override;
-    void setReadWriteBuffer(const ccstd::string& name, gfx::Buffer* buffer) override;
-    void setReadWriteTexture(const ccstd::string& name, gfx::Texture* texture) override;
-    void setSampler(const ccstd::string& name, gfx::Sampler* sampler) override;
-
     ccstd::string getName() const override;
-    void setName(const ccstd::string& name) override;
+    void setName(const ccstd::string &name) override;
+
+    void setMat4(const ccstd::string &name, const Mat4 &mat) override;
+    void setQuaternion(const ccstd::string &name, const Quaternion &quat) override;
+    void setColor(const ccstd::string &name, const gfx::Color &color) override;
+    void setVec4(const ccstd::string &name, const Vec4 &vec) override;
+    void setVec2(const ccstd::string &name, const Vec2 &vec) override;
+    void setFloat(const ccstd::string &name, float v) override;
+    void setBuffer(const ccstd::string &name, gfx::Buffer *buffer) override;
+    void setTexture(const ccstd::string &name, gfx::Texture *texture) override;
+    void setReadWriteBuffer(const ccstd::string &name, gfx::Buffer *buffer) override;
+    void setReadWriteTexture(const ccstd::string &name, gfx::Texture *texture) override;
+    void setSampler(const ccstd::string &name, gfx::Sampler *sampler) override;
+
+    void addComputeView(const ccstd::string &name, const ComputeView &view) override;
+    ComputeQueueBuilder *addQueue() override;
 
     RenderGraph* renderGraph{nullptr};
     const LayoutGraphData* layoutGraph{nullptr};
@@ -212,10 +206,10 @@ public:
     : renderGraph(renderGraphIn),
       passID(passIDIn) {}
 
-    void addPair(const MovePair& pair) override;
-
     ccstd::string getName() const override;
-    void setName(const ccstd::string& name) override;
+    void setName(const ccstd::string &name) override;
+
+    void addPair(const MovePair &pair) override;
 
     RenderGraph* renderGraph{nullptr};
     uint32_t passID{RenderGraph::null_vertex()};
@@ -228,10 +222,10 @@ public:
     : renderGraph(renderGraphIn),
       passID(passIDIn) {}
 
-    void addPair(const CopyPair& pair) override;
-
     ccstd::string getName() const override;
-    void setName(const ccstd::string& name) override;
+    void setName(const ccstd::string &name) override;
+
+    void addPair(const CopyPair &pair) override;
 
     RenderGraph* renderGraph{nullptr};
     uint32_t passID{RenderGraph::null_vertex()};
@@ -244,7 +238,7 @@ public:
     : camera(cameraIn),
       scene(sceneIn) {}
 
-    SceneTask* transverse(SceneVisitor *visitor) const override;
+    SceneTask *transverse(SceneVisitor *visitor) const override;
 
     const scene::Camera* camera{nullptr};
     const scene::RenderScene* scene{nullptr};
@@ -410,11 +404,10 @@ public:
 
     DefaultSceneVisitor(const allocator_type& alloc) noexcept; // NOLINT
 
-    const pipeline::PipelineSceneData* getPipelineSceneData() const override;
-
+    const pipeline::PipelineSceneData *getPipelineSceneData() const override;
     void setViewport(const gfx::Viewport &vp) override;
     void setScissor(const gfx::Rect &rect) override;
-    void bindPipelineState(gfx::PipelineState* pso) override;
+    void bindPipelineState(gfx::PipelineState *pso) override;
     void bindDescriptorSet(uint32_t set, gfx::DescriptorSet *descriptorSet, uint32_t dynamicOffsetCount, const uint32_t *dynamicOffsets) override;
     void bindInputAssembler(gfx::InputAssembler *ia) override;
     void updateBuffer(gfx::Buffer *buff, const void *data, uint32_t size) override;
@@ -432,7 +425,7 @@ public:
 
     DefaultForwardLightingTransversal(const allocator_type& alloc) noexcept; // NOLINT
 
-    SceneTask* transverse(SceneVisitor *visitor) const override;
+    SceneTask *transverse(SceneVisitor *visitor) const override;
 
     ccstd::pmr::string name;
 };
@@ -463,64 +456,52 @@ public:
 
     NativePipeline(const allocator_type& alloc) noexcept; // NOLINT
 
-    void beginSetup() override;
-    void endSetup() override;
-
-    bool containsResource(const ccstd::string& name) const override;
-    uint32_t addRenderTexture(const ccstd::string& name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow* renderWindow) override;
-    uint32_t addRenderTarget(const ccstd::string& name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) override;
-    uint32_t addDepthStencil(const ccstd::string& name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) override;
-
-    void updateRenderWindow(const ccstd::string& name, scene::RenderWindow* renderWindow) override;
-
-    void beginFrame() override;
-    void endFrame() override;
-    RasterPassBuilder *addRasterPass(uint32_t width, uint32_t height, const ccstd::string& layoutName) override;
-    ComputePassBuilder *addComputePass(const ccstd::string& layoutName) override;
-    MovePassBuilder *addMovePass() override;
-    CopyPassBuilder *addCopyPass() override;
-    void presentAll() override;
-
-    SceneTransversal *createSceneTransversal(const scene::Camera *camera, const scene::RenderScene *scene) override;
-    LayoutGraphBuilder *getLayoutGraphBuilder() override;
-    gfx::DescriptorSetLayout *getDescriptorSetLayout(const ccstd::string& shaderName, UpdateFrequency freq) override;
-
-    bool activate(gfx::Swapchain * swapchain) override;
+    bool activate(gfx::Swapchain *swapchain) override;
     bool destroy() noexcept override;
-    void render(const ccstd::vector<scene::Camera*>& cameras) override;
-
-    gfx::Device* getDevice() const override;
+    void render(const ccstd::vector<scene::Camera*> &cameras) override;
+    gfx::Device *getDevice() const override;
     const MacroRecord &getMacros() const override;
     pipeline::GlobalDSManager *getGlobalDSManager() const override;
     gfx::DescriptorSetLayout *getDescriptorSetLayout() const override;
     gfx::DescriptorSet *getDescriptorSet() const override;
-    const ccstd::vector<gfx::CommandBuffer*>& getCommandBuffers() const override;
+    const ccstd::vector<gfx::CommandBuffer*> &getCommandBuffers() const override;
     pipeline::PipelineSceneData *getPipelineSceneData() const override;
     const ccstd::string &getConstantMacros() const override;
     scene::Model *getProfiler() const override;
     void setProfiler(scene::Model *profiler) override;
-    pipeline::GeometryRenderer  *getGeometryRenderer() const override;
-
+    pipeline::GeometryRenderer *getGeometryRenderer() const override;
     float getShadingScale() const override;
     void setShadingScale(float scale) override;
-
-    const ccstd::string& getMacroString(const ccstd::string& name) const override;
-    int32_t getMacroInt(const ccstd::string& name) const override;
-    bool getMacroBool(const ccstd::string& name) const override;
-
-    void setMacroString(const ccstd::string& name, const ccstd::string& value) override;
-    void setMacroInt(const ccstd::string& name, int32_t value) override;
-    void setMacroBool(const ccstd::string& name, bool value) override;
-
+    const ccstd::string &getMacroString(const ccstd::string &name) const override;
+    int32_t getMacroInt(const ccstd::string &name) const override;
+    bool getMacroBool(const ccstd::string &name) const override;
+    void setMacroString(const ccstd::string &name, const ccstd::string &value) override;
+    void setMacroInt(const ccstd::string &name, int32_t value) override;
+    void setMacroBool(const ccstd::string &name, bool value) override;
     void onGlobalPipelineStateChanged() override;
-
-    void setValue(const ccstd::string& name, int32_t value) override;
-    void setValue(const ccstd::string& name, bool value) override;
-
+    void setValue(const ccstd::string &name, int32_t value) override;
+    void setValue(const ccstd::string &name, bool value) override;
     bool isOcclusionQueryEnabled() const override;
-
     void resetRenderQueue(bool reset) override;
     bool isRenderQueueReset() const override;
+
+    void beginSetup() override;
+    void endSetup() override;
+    bool containsResource(const ccstd::string &name) const override;
+    uint32_t addRenderTexture(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow *renderWindow) override;
+    uint32_t addRenderTarget(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) override;
+    uint32_t addDepthStencil(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) override;
+    void updateRenderWindow(const ccstd::string &name, scene::RenderWindow *renderWindow) override;
+    void beginFrame() override;
+    void endFrame() override;
+    RasterPassBuilder *addRasterPass(uint32_t width, uint32_t height, const ccstd::string &layoutName) override;
+    ComputePassBuilder *addComputePass(const ccstd::string &layoutName) override;
+    MovePassBuilder *addMovePass() override;
+    CopyPassBuilder *addCopyPass() override;
+    void presentAll() override;
+    SceneTransversal *createSceneTransversal(const scene::Camera *camera, const scene::RenderScene *scene) override;
+    LayoutGraphBuilder *getLayoutGraphBuilder() override;
+    gfx::DescriptorSetLayout *getDescriptorSetLayout(const ccstd::string &shaderName, UpdateFrequency freq) override;
 
     void executeRenderGraph(const RenderGraph& rg);
 private:

--- a/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
@@ -76,40 +76,32 @@ public:
     PipelineRuntime& operator=(PipelineRuntime const& rhs) = delete;
     virtual ~PipelineRuntime() noexcept = default;
 
-    virtual bool activate(gfx::Swapchain * swapchain) = 0;
+    virtual bool activate(gfx::Swapchain *swapchain) = 0;
     virtual bool destroy() noexcept = 0;
-    virtual void render(const ccstd::vector<scene::Camera*>& cameras) = 0;
-
-    virtual gfx::Device* getDevice() const = 0;
+    virtual void render(const ccstd::vector<scene::Camera*> &cameras) = 0;
+    virtual gfx::Device *getDevice() const = 0;
     virtual const MacroRecord &getMacros() const = 0;
     virtual pipeline::GlobalDSManager *getGlobalDSManager() const = 0;
     virtual gfx::DescriptorSetLayout *getDescriptorSetLayout() const = 0;
     virtual gfx::DescriptorSet *getDescriptorSet() const = 0;
-    virtual const ccstd::vector<gfx::CommandBuffer*>& getCommandBuffers() const = 0;
+    virtual const ccstd::vector<gfx::CommandBuffer*> &getCommandBuffers() const = 0;
     virtual pipeline::PipelineSceneData *getPipelineSceneData() const = 0;
     virtual const ccstd::string &getConstantMacros() const = 0;
     virtual scene::Model *getProfiler() const = 0;
     virtual void setProfiler(scene::Model *profiler) = 0;
-    virtual pipeline::GeometryRenderer  *getGeometryRenderer() const = 0;
-
+    virtual pipeline::GeometryRenderer *getGeometryRenderer() const = 0;
     virtual float getShadingScale() const = 0;
     virtual void setShadingScale(float scale) = 0;
-
-    virtual const ccstd::string& getMacroString(const ccstd::string& name) const = 0;
-    virtual int32_t getMacroInt(const ccstd::string& name) const = 0;
-    virtual bool getMacroBool(const ccstd::string& name) const = 0;
-
-    virtual void setMacroString(const ccstd::string& name, const ccstd::string& value) = 0;
-    virtual void setMacroInt(const ccstd::string& name, int32_t value) = 0;
-    virtual void setMacroBool(const ccstd::string& name, bool value) = 0;
-
+    virtual const ccstd::string &getMacroString(const ccstd::string &name) const = 0;
+    virtual int32_t getMacroInt(const ccstd::string &name) const = 0;
+    virtual bool getMacroBool(const ccstd::string &name) const = 0;
+    virtual void setMacroString(const ccstd::string &name, const ccstd::string &value) = 0;
+    virtual void setMacroInt(const ccstd::string &name, int32_t value) = 0;
+    virtual void setMacroBool(const ccstd::string &name, bool value) = 0;
     virtual void onGlobalPipelineStateChanged() = 0;
-
-    virtual void setValue(const ccstd::string& name, int32_t value) = 0;
-    virtual void setValue(const ccstd::string& name, bool value) = 0;
-
+    virtual void setValue(const ccstd::string &name, int32_t value) = 0;
+    virtual void setValue(const ccstd::string &name, bool value) = 0;
     virtual bool isOcclusionQueryEnabled() const = 0;
-
     virtual void resetRenderQueue(bool reset) = 0;
     virtual bool isRenderQueueReset() const = 0;
 };
@@ -124,35 +116,34 @@ public:
     virtual ~RenderNode() noexcept = default;
 
     virtual ccstd::string getName() const = 0;
-    virtual void setName(const ccstd::string& name) = 0;
+    virtual void setName(const ccstd::string &name) = 0;
 };
 
 class Setter : public RenderNode {
 public:
     Setter() noexcept = default;
 
-    virtual void setMat4(const ccstd::string& name, const cc::Mat4& mat) = 0;
-    virtual void setQuaternion(const ccstd::string& name, const cc::Quaternion& quat) = 0;
-    virtual void setColor(const ccstd::string& name, const gfx::Color& color) = 0;
-    virtual void setVec4(const ccstd::string& name, const cc::Vec4& vec) = 0;
-    virtual void setVec2(const ccstd::string& name, const cc::Vec2& vec) = 0;
-    virtual void setFloat(const ccstd::string& name, float v) = 0;
-
-    virtual void setBuffer(const ccstd::string& name, gfx::Buffer* buffer) = 0;
-    virtual void setTexture(const ccstd::string& name, gfx::Texture* texture) = 0;
-    virtual void setReadWriteBuffer(const ccstd::string& name, gfx::Buffer* buffer) = 0;
-    virtual void setReadWriteTexture(const ccstd::string& name, gfx::Texture* texture) = 0;
-    virtual void setSampler(const ccstd::string& name, gfx::Sampler* sampler) = 0;
+    virtual void setMat4(const ccstd::string &name, const Mat4 &mat) = 0;
+    virtual void setQuaternion(const ccstd::string &name, const Quaternion &quat) = 0;
+    virtual void setColor(const ccstd::string &name, const gfx::Color &color) = 0;
+    virtual void setVec4(const ccstd::string &name, const Vec4 &vec) = 0;
+    virtual void setVec2(const ccstd::string &name, const Vec2 &vec) = 0;
+    virtual void setFloat(const ccstd::string &name, float v) = 0;
+    virtual void setBuffer(const ccstd::string &name, gfx::Buffer *buffer) = 0;
+    virtual void setTexture(const ccstd::string &name, gfx::Texture *texture) = 0;
+    virtual void setReadWriteBuffer(const ccstd::string &name, gfx::Buffer *buffer) = 0;
+    virtual void setReadWriteTexture(const ccstd::string &name, gfx::Texture *texture) = 0;
+    virtual void setSampler(const ccstd::string &name, gfx::Sampler *sampler) = 0;
 };
 
 class RasterQueueBuilder : public Setter {
 public:
     RasterQueueBuilder() noexcept = default;
 
-    virtual void addSceneOfCamera(scene::Camera* camera, LightInfo light, SceneFlags sceneFlags) = 0;
-    virtual void addScene(const ccstd::string& name, SceneFlags sceneFlags) = 0;
-    virtual void addFullscreenQuad(cc::Material *material, uint32_t passID, SceneFlags sceneFlags) = 0;
-    virtual void addCameraQuad(scene::Camera* camera, cc::Material *material, uint32_t passID, SceneFlags sceneFlags) = 0;
+    virtual void addSceneOfCamera(scene::Camera *camera, LightInfo light, SceneFlags sceneFlags) = 0;
+    virtual void addScene(const ccstd::string &name, SceneFlags sceneFlags) = 0;
+    virtual void addFullscreenQuad(Material *material, uint32_t passID, SceneFlags sceneFlags) = 0;
+    virtual void addCameraQuad(scene::Camera *camera, Material *material, uint32_t passID, SceneFlags sceneFlags) = 0;
     virtual void clearRenderTarget(const ccstd::string &name, const gfx::Color &color) = 0;
     virtual void setViewport(const gfx::Viewport &viewport) = 0;
 };
@@ -161,8 +152,8 @@ class RasterPassBuilder : public Setter {
 public:
     RasterPassBuilder() noexcept = default;
 
-    virtual void addRasterView(const ccstd::string& name, const RasterView& view) = 0;
-    virtual void addComputeView(const ccstd::string& name, const ComputeView& view) = 0;
+    virtual void addRasterView(const ccstd::string &name, const RasterView &view) = 0;
+    virtual void addComputeView(const ccstd::string &name, const ComputeView &view) = 0;
     virtual RasterQueueBuilder *addQueue(QueueHint hint) = 0;
     virtual void setViewport(const gfx::Viewport &viewport) = 0;
 };
@@ -171,15 +162,14 @@ class ComputeQueueBuilder : public Setter {
 public:
     ComputeQueueBuilder() noexcept = default;
 
-    virtual void addDispatch(const ccstd::string& shader, uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ) = 0;
+    virtual void addDispatch(const ccstd::string &shader, uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ) = 0;
 };
 
 class ComputePassBuilder : public Setter {
 public:
     ComputePassBuilder() noexcept = default;
 
-    virtual void addComputeView(const ccstd::string& name, const ComputeView& view) = 0;
-
+    virtual void addComputeView(const ccstd::string &name, const ComputeView &view) = 0;
     virtual ComputeQueueBuilder *addQueue() = 0;
 };
 
@@ -187,14 +177,14 @@ class MovePassBuilder : public RenderNode {
 public:
     MovePassBuilder() noexcept = default;
 
-    virtual void addPair(const MovePair& pair) = 0;
+    virtual void addPair(const MovePair &pair) = 0;
 };
 
 class CopyPassBuilder : public RenderNode {
 public:
     CopyPassBuilder() noexcept = default;
 
-    virtual void addPair(const CopyPair& pair) = 0;
+    virtual void addPair(const CopyPair &pair) = 0;
 };
 
 class SceneVisitor {
@@ -206,11 +196,10 @@ public:
     SceneVisitor& operator=(SceneVisitor const& rhs) = delete;
     virtual ~SceneVisitor() noexcept = default;
 
-    virtual const pipeline::PipelineSceneData* getPipelineSceneData() const = 0;
-
+    virtual const pipeline::PipelineSceneData *getPipelineSceneData() const = 0;
     virtual void setViewport(const gfx::Viewport &vp) = 0;
     virtual void setScissor(const gfx::Rect &rect) = 0;
-    virtual void bindPipelineState(gfx::PipelineState* pso) = 0;
+    virtual void bindPipelineState(gfx::PipelineState *pso) = 0;
     virtual void bindDescriptorSet(uint32_t set, gfx::DescriptorSet *descriptorSet, uint32_t dynamicOffsetCount, const uint32_t *dynamicOffsets) = 0;
     virtual void bindInputAssembler(gfx::InputAssembler *ia) = 0;
     virtual void updateBuffer(gfx::Buffer *buff, const void *data, uint32_t size) = 0;
@@ -227,9 +216,9 @@ public:
     virtual ~SceneTask() noexcept = default;
 
     virtual TaskType getTaskType() const noexcept = 0;
-    virtual void     start() = 0;
-    virtual void     join() = 0;
-    virtual void     submit() = 0;
+    virtual void start() = 0;
+    virtual void join() = 0;
+    virtual void submit() = 0;
 };
 
 class SceneTransversal {
@@ -241,7 +230,7 @@ public:
     SceneTransversal& operator=(SceneTransversal const& rhs) = delete;
     virtual ~SceneTransversal() noexcept = default;
 
-    virtual SceneTask* transverse(SceneVisitor *visitor) const = 0;
+    virtual SceneTask *transverse(SceneVisitor *visitor) const = 0;
 };
 
 class LayoutGraphBuilder {
@@ -254,14 +243,13 @@ public:
     virtual ~LayoutGraphBuilder() noexcept = default;
 
     virtual void clear() = 0;
-    virtual uint32_t addRenderStage(const ccstd::string& name) = 0;
-    virtual uint32_t addRenderPhase(const ccstd::string& name, uint32_t parentID) = 0;
-    virtual void addShader(const ccstd::string& name, uint32_t parentPhaseID) = 0;
-    virtual void addDescriptorBlock(uint32_t nodeID, const DescriptorBlockIndex& index, const DescriptorBlockFlattened& block) = 0;
-    virtual void addUniformBlock(uint32_t nodeID, const DescriptorBlockIndex& index, const ccstd::string& name, const gfx::UniformBlock& uniformBlock) = 0;
-    virtual void reserveDescriptorBlock(uint32_t nodeID, const DescriptorBlockIndex& index, const DescriptorBlockFlattened& block) = 0;
+    virtual uint32_t addRenderStage(const ccstd::string &name) = 0;
+    virtual uint32_t addRenderPhase(const ccstd::string &name, uint32_t parentID) = 0;
+    virtual void addShader(const ccstd::string &name, uint32_t parentPhaseID) = 0;
+    virtual void addDescriptorBlock(uint32_t nodeID, const DescriptorBlockIndex &index, const DescriptorBlockFlattened &block) = 0;
+    virtual void addUniformBlock(uint32_t nodeID, const DescriptorBlockIndex &index, const ccstd::string &name, const gfx::UniformBlock &uniformBlock) = 0;
+    virtual void reserveDescriptorBlock(uint32_t nodeID, const DescriptorBlockIndex &index, const DescriptorBlockFlattened &block) = 0;
     virtual int compile() = 0;
-
     virtual ccstd::string print() const = 0;
 };
 
@@ -271,25 +259,21 @@ public:
 
     virtual void beginSetup() = 0;
     virtual void endSetup() = 0;
-
-    virtual bool containsResource(const ccstd::string& name) const = 0;
-    virtual uint32_t addRenderTexture(const ccstd::string& name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow* renderWindow) = 0;
-    virtual uint32_t addRenderTarget(const ccstd::string& name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) = 0;
-    virtual uint32_t addDepthStencil(const ccstd::string& name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) = 0;
-
-    virtual void updateRenderWindow(const ccstd::string& name, scene::RenderWindow* renderWindow) = 0;
-
+    virtual bool containsResource(const ccstd::string &name) const = 0;
+    virtual uint32_t addRenderTexture(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow *renderWindow) = 0;
+    virtual uint32_t addRenderTarget(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) = 0;
+    virtual uint32_t addDepthStencil(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) = 0;
+    virtual void updateRenderWindow(const ccstd::string &name, scene::RenderWindow *renderWindow) = 0;
     virtual void beginFrame() = 0;
     virtual void endFrame() = 0;
-    virtual RasterPassBuilder *addRasterPass(uint32_t width, uint32_t height, const ccstd::string& layoutName) = 0;
-    virtual ComputePassBuilder *addComputePass(const ccstd::string& layoutName) = 0;
+    virtual RasterPassBuilder *addRasterPass(uint32_t width, uint32_t height, const ccstd::string &layoutName) = 0;
+    virtual ComputePassBuilder *addComputePass(const ccstd::string &layoutName) = 0;
     virtual MovePassBuilder *addMovePass() = 0;
     virtual CopyPassBuilder *addCopyPass() = 0;
     virtual void presentAll() = 0;
-
     virtual SceneTransversal *createSceneTransversal(const scene::Camera *camera, const scene::RenderScene *scene) = 0;
     virtual LayoutGraphBuilder *getLayoutGraphBuilder() = 0;
-    virtual gfx::DescriptorSetLayout *getDescriptorSetLayout(const ccstd::string& shaderName, UpdateFrequency freq) = 0;
+    virtual gfx::DescriptorSetLayout *getDescriptorSetLayout(const ccstd::string &shaderName, UpdateFrequency freq) = 0;
 };
 
 class PipelineBuilder {
@@ -301,7 +285,7 @@ public:
     PipelineBuilder& operator=(PipelineBuilder const& rhs) = delete;
     virtual ~PipelineBuilder() noexcept = default;
 
-    virtual void setup(const ccstd::vector<scene::Camera*>& cameras, Pipeline* pipeline) = 0;
+    virtual void setup(const ccstd::vector<scene::Camera*> &cameras, Pipeline *pipeline) = 0;
 };
 
 class Factory {


### PR DESCRIPTION
changed interface code generation.
does not change any logic.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
