### PR TITLE
[Bug fix] Add detections for innerAudioContext.

### DIFF
--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -85,13 +85,17 @@ export class AudioPlayerMinigame implements OperationQueueable {
             eventTarget.emit(AudioEvent.PLAYED);
             if (this._needSeek) {
                 this._needSeek = false;
+                console.log(`try seek`);
                 this.seek(this._cacheTime).catch((e) => {});
             }
         };
         innerAudioContext.onPlay(this._onPlay);
         this._onPause = () => {
             this._state = AudioState.PAUSED;
-            this._cacheTime = this._innerAudioContext.currentTime;
+            // NOTE: On Wechat, the current time of inner audio context might be null as it's not fully initilized.
+            if (this._innerAudioContext && this._innerAudioContext.currentTime !== null) {
+                this._cacheTime = this._innerAudioContext.currentTime;
+            }
             eventTarget.emit(AudioEvent.PAUSED);
         };
         innerAudioContext.onPause(this._onPause);
@@ -125,6 +129,8 @@ export class AudioPlayerMinigame implements OperationQueueable {
             ['Play', 'Pause', 'Stop', 'Seeked', 'Ended'].forEach((event) => {
                 this._offEvent(event);
             });
+            // NOTE: innewAudioContext might not stop the audio playing, have to call it explicitly.
+            this._innerAudioContext.stop();
             this._innerAudioContext.destroy();
             // @ts-expect-error Type 'null' is not assignable to type 'InnerAudioContext'
             this._innerAudioContext = null;
@@ -271,8 +277,12 @@ export class AudioPlayerMinigame implements OperationQueueable {
     @enqueueOperation
     pause (): Promise<void> {
         return new Promise((resolve) => {
-            this._eventTarget.once(AudioEvent.PAUSED, resolve);
-            this._innerAudioContext.pause();
+            if (this.state !== AudioState.PLAYING) {
+                resolve();
+            } else {
+                this._eventTarget.once(AudioEvent.PAUSED, resolve);
+                this._innerAudioContext.pause();
+            }
         });
     }
 

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -91,9 +91,13 @@ export class AudioPlayerMinigame implements OperationQueueable {
         innerAudioContext.onPlay(this._onPlay);
         this._onPause = () => {
             this._state = AudioState.PAUSED;
-            // NOTE: On Wechat, the current time of inner audio context might be null as it's not fully initilized.
-            if (this._innerAudioContext && this._innerAudioContext.currentTime !== null) {
-                this._cacheTime = this._innerAudioContext.currentTime;
+            try {
+                const currentTime = this._innerAudioContext.currentTime;
+                if (currentTime !== null && currentTime !== undefined) {
+                    this._cacheTime = currentTime;
+                }
+            } catch {
+                // Do nothing, cacheTime is not updated.
             }
             eventTarget.emit(AudioEvent.PAUSED);
         };

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -85,7 +85,6 @@ export class AudioPlayerMinigame implements OperationQueueable {
             eventTarget.emit(AudioEvent.PLAYED);
             if (this._needSeek) {
                 this._needSeek = false;
-                console.log(`try seek`);
                 this.seek(this._cacheTime).catch((e) => {});
             }
         };


### PR DESCRIPTION
1. Pausing an innerAudioContext which is not fully initialized, the currentTime might be null.-https://github.com/cocos/3d-tasks/issues/14080
2. Pause means nothing for a stopped audio
3. InnerAudioContext.destroy behavior is insane that it might not stop the audio immediatly,