### PR TITLE
fix toggle err function name

### DIFF
--- a/cocos/ui/toggle.ts
+++ b/cocos/ui/toggle.ts
@@ -185,7 +185,7 @@ export class Toggle extends Button {
         }
     }
 
-    public OnDestroy () {
+    public onDestroy () {
         const group = this._toggleContainer;
         if (group) {
             group.ensureValidState();


### PR DESCRIPTION
fix toggle err function name `OnDestroy`. It will cause problem when destroy toggle component.