### PR TITLE
fix gfx-native-test

### DIFF
--- a/native/cocos/renderer/gfx-metal/MTLRenderPass.mm
+++ b/native/cocos/renderer/gfx-metal/MTLRenderPass.mm
@@ -111,6 +111,10 @@ void CCMTLRenderPass::setDepthStencilAttachment(CCMTLTexture* cctex, int level) 
         _mtlRenderPassDescriptor.stencilAttachment.texture = texture;
         _mtlRenderPassDescriptor.stencilAttachment.level = level;
     }
+
+    if(_renderTargetSizes.empty()) {
+        _renderTargetSizes.emplace_back(static_cast<float>(texture.width), static_cast<float>(texture.height));
+    }
 }
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-metal/MTLUtils.mm
+++ b/native/cocos/renderer/gfx-metal/MTLUtils.mm
@@ -953,6 +953,8 @@ ccstd::string mu::spirv2MSL(const uint32_t *ir, size_t word_count,
 #endif
     options.emulate_subgroups = true;
     options.pad_fragment_output_components = true;
+    // fully support
+    options.set_msl_version(2, 0, 0);
     if (isFramebufferFetchSupported()) {
         options.use_framebuffer_fetch_subpasses = true;
 #if (CC_PLATFORM == CC_PLATFORM_MACOS)


### PR DESCRIPTION
Re: #

### Changelog

* depthstencil index has been changed, so any index greater than fbo color size, ds would take the fbo->depthstencil;
* rendering to depthstencil only support.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
