### PR TITLE
set world orogin as physics-2d joint's connected body (#14328)

### DIFF
--- a/cocos/physics-2d/box2d/physics-world.ts
+++ b/cocos/physics-2d/box2d/physics-world.ts
@@ -34,6 +34,7 @@ export class b2PhysicsWorld implements IPhysicsWorld {
     protected _bodies: b2RigidBody2D[] = [];
     protected _animatedBodies: b2RigidBody2D[] = [];
     protected _rotationAxis: Vec3 = new Vec3();
+    protected _physicsGroundBody: b2.Body;
 
     protected _contactListener: PhysicsContactListener;
     protected _aabbQueryCallback: PhysicsAABBQueryCallback;
@@ -43,9 +44,16 @@ export class b2PhysicsWorld implements IPhysicsWorld {
         return this._world;
     }
 
+    get groundBodyImpl () {
+        return this._physicsGroundBody;
+    }
+
     constructor () {
         this._world = new b2.World(new b2.Vec2(0, -10));
-
+        const tempBodyDef = new b2.BodyDef();
+        //tempBodyDef.position.Set(480 / PHYSICS_2D_PTM_RATIO, 320 / PHYSICS_2D_PTM_RATIO);//temporary
+        this._physicsGroundBody = this._world.CreateBody(tempBodyDef);
+        console.log(this._physicsGroundBody);
         const listener = new PhysicsContactListener();
         listener.setBeginContact(this._onBeginContact);
         listener.setEndContact(this._onEndContact);

--- a/cocos/physics-2d/box2d/physics-world.ts
+++ b/cocos/physics-2d/box2d/physics-world.ts
@@ -53,7 +53,6 @@ export class b2PhysicsWorld implements IPhysicsWorld {
         const tempBodyDef = new b2.BodyDef();
         //tempBodyDef.position.Set(480 / PHYSICS_2D_PTM_RATIO, 320 / PHYSICS_2D_PTM_RATIO);//temporary
         this._physicsGroundBody = this._world.CreateBody(tempBodyDef);
-        console.log(this._physicsGroundBody);
         const listener = new PhysicsContactListener();
         listener.setBeginContact(this._onBeginContact);
         listener.setEndContact(this._onEndContact);

--- a/cocos/physics-2d/framework/components/joints/distance-joint-2d.ts
+++ b/cocos/physics-2d/framework/components/joints/distance-joint-2d.ts
@@ -1,4 +1,3 @@
-
 import { Joint2D } from './joint-2d';
 import { ccclass, property, menu, type } from '../../../../core/data/class-decorator';
 import { IDistanceJoint } from '../../../spec/i-physics-joint';
@@ -18,8 +17,13 @@ export class DistanceJoint2D extends Joint2D {
      */
     @property
     get maxLength () {
-        if (this._autoCalcDistance && this.connectedBody) {
-            return Vec3.distance(this.node.worldPosition, this.connectedBody.node.worldPosition);
+        if (this._autoCalcDistance) {
+            if (this.connectedBody) {
+                return Vec3.distance(this.node.worldPosition, this.connectedBody.node.worldPosition);
+            } else { //if connected body is not set, use scene origin as connected body
+                console.log(this, 'maxLength', Vec3.len(this.node.worldPosition));
+                return Vec3.len(this.node.worldPosition);
+            }
         }
         return this._maxLength;
     }

--- a/cocos/physics-2d/framework/components/joints/distance-joint-2d.ts
+++ b/cocos/physics-2d/framework/components/joints/distance-joint-2d.ts
@@ -21,7 +21,6 @@ export class DistanceJoint2D extends Joint2D {
             if (this.connectedBody) {
                 return Vec3.distance(this.node.worldPosition, this.connectedBody.node.worldPosition);
             } else { //if connected body is not set, use scene origin as connected body
-                console.log(this, 'maxLength', Vec3.len(this.node.worldPosition));
                 return Vec3.len(this.node.worldPosition);
             }
         }

--- a/cocos/physics-2d/framework/components/joints/relative-joint-2d.ts
+++ b/cocos/physics-2d/framework/components/joints/relative-joint-2d.ts
@@ -1,5 +1,3 @@
-
-
 import { Joint2D } from './joint-2d';
 import { ccclass, property, menu, type } from '../../../../core/data/class-decorator';
 import { IRelativeJoint } from '../../../spec/i-physics-joint';
@@ -73,8 +71,14 @@ export class RelativeJoint2D extends Joint2D {
      */
     @property
     get linearOffset (): Vec2 {
-        if (this._autoCalcOffset && this.connectedBody) {
-            return Vec2.subtract(this._linearOffset, this.connectedBody.node.worldPosition as IVec2Like, this.node.worldPosition as IVec2Like) as Vec2;
+        if (this._autoCalcOffset) {
+            if (this.connectedBody) {
+                return Vec2.subtract(this._linearOffset, this.connectedBody.node.worldPosition as IVec2Like,
+                    this.node.worldPosition as IVec2Like) as Vec2;
+            } else { //if connected body is not set, use scene origin as connected body
+                return Vec2.subtract(this._linearOffset, new Vec2(0, 0),
+                    this.node.worldPosition as IVec2Like) as Vec2;
+            }
         }
         return this._linearOffset;
     }
@@ -93,9 +97,13 @@ export class RelativeJoint2D extends Joint2D {
      */
     @property
     get angularOffset (): number {
-        if (this._autoCalcOffset && this.connectedBody) {
+        if (this._autoCalcOffset) {
             Quat.toEuler(tempVec3_1, this.node.worldRotation);
-            Quat.toEuler(tempVec3_2, this.connectedBody.node.worldRotation);
+            if (this.connectedBody) {
+                Quat.toEuler(tempVec3_2, this.connectedBody.node.worldRotation);
+            } else { //if connected body is not set, use scene origin as connected body
+                Quat.toEuler(tempVec3_2, new Quat());//?
+            }
             this._angularOffset = tempVec3_2.z - tempVec3_1.z;
         }
         return this._angularOffset;

--- a/cocos/physics-2d/framework/components/joints/slider-joint-2d.ts
+++ b/cocos/physics-2d/framework/components/joints/slider-joint-2d.ts
@@ -1,5 +1,3 @@
-
-
 import { Joint2D } from './joint-2d';
 import { ccclass, property, menu, type } from '../../../../core/data/class-decorator';
 import { ISliderJoint } from '../../../spec/i-physics-joint';
@@ -19,8 +17,12 @@ export class SliderJoint2D extends Joint2D {
      */
     @property
     get angle (): number {
-        if (this._autoCalcAngle && this.connectedBody) {
-            Vec2.subtract(tempVec2, this.connectedBody.node.worldPosition as IVec2Like, this.node.worldPosition as IVec2Like);
+        if (this._autoCalcAngle) {
+            if (this.connectedBody) {
+                Vec2.subtract(tempVec2, this.connectedBody.node.worldPosition as IVec2Like, this.node.worldPosition as IVec2Like);
+            } else {
+                Vec2.subtract(tempVec2, new Vec2(0, 0), this.node.worldPosition as IVec2Like);
+            }
             this._angle = toDegree(Math.atan2(tempVec2.y, tempVec2.x));
         }
         return this._angle;

--- a/cocos/physics-2d/framework/components/joints/spring-joint-2d.ts
+++ b/cocos/physics-2d/framework/components/joints/spring-joint-2d.ts
@@ -1,5 +1,3 @@
-
-
 import { Joint2D } from './joint-2d';
 import { ccclass, property, menu, type } from '../../../../core/data/class-decorator';
 import { ISpringJoint } from '../../../spec/i-physics-joint';
@@ -53,8 +51,12 @@ export class SpringJoint2D extends Joint2D {
      */
     @property
     get distance () {
-        if (this._autoCalcDistance && this.connectedBody) {
-            return Vec3.distance(this.node.worldPosition, this.connectedBody.node.worldPosition);
+        if (this._autoCalcDistance) {
+            if (this.connectedBody) {
+                return Vec3.distance(this.node.worldPosition, this.connectedBody.node.worldPosition);
+            } else { //if connected body is not set, use scene origin as connected body
+                return Vec3.len(this.node.worldPosition);
+            }
         }
         return this._distance;
     }


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/14328

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
