### PR TITLE
use std array to store event listeners

### DIFF
--- a/native/cocos/core/Root.h
+++ b/native/cocos/core/Root.h
@@ -64,7 +64,7 @@ struct CC_DLL DebugViewConfig {
 struct ISystemWindowInfo;
 class ISystemWindow;
 
-class Root final : public event::EventTarget {
+class Root final {
     IMPL_EVENT_TARGET(Root)
     DECLARE_TARGET_EVENT_BEGIN(Root)
     TARGET_EVENT_ARG0(BeforeCommit)
@@ -73,7 +73,7 @@ class Root final : public event::EventTarget {
 public:
     static Root *getInstance(); // cjh todo: put Root Managerment to Director class.
     explicit Root(gfx::Device *device);
-    ~Root() override;
+    ~Root();
 
     // @minggo IRootInfo seems is not use, and how to return Promise?
     void initialize(gfx::Swapchain *swapchain);

--- a/native/cocos/core/assets/Asset.h
+++ b/native/cocos/core/assets/Asset.h
@@ -38,7 +38,7 @@ namespace cc {
 
 class Node;
 
-class Asset : public CCObject, public event::EventTarget {
+class Asset : public CCObject {
 public:
     using Super = CCObject;
 

--- a/native/cocos/core/assets/SimpleTexture.h
+++ b/native/cocos/core/assets/SimpleTexture.h
@@ -41,7 +41,7 @@ class ImageAsset;
  */
 class SimpleTexture : public TextureBase {
     IMPL_EVENT_TARGET(SimpleTexture)
-    DECLARE_TARGET_EVENT_BEGIN(SimpleTexture)
+    DECLARE_TARGET_EVENT_BEGIN_OFFSET(SimpleTexture, TextureBase::getEventCount())
     TARGET_EVENT_ARG1(TextureUpdated, cc::gfx::Texture *)
     TARGET_EVENT_ARG1(AfterAssignImage, cc::ImageAsset *)
     DECLARE_TARGET_EVENT_END()

--- a/native/cocos/core/event/Event.h
+++ b/native/cocos/core/event/Event.h
@@ -27,6 +27,7 @@
     #define IMPL_EVENT_TARGET_WITH_PARENT(...)
     #define IMPL_EVENT_TARGET(...)
     #define DECLARE_TARGET_EVENT_BEGIN(...)
+    #define DECLARE_TARGET_EVENT_BEGIN_OFFSET(...)
     #define DECLARE_TARGET_EVENT_END(...)
     #define TARGET_EVENT_ARG0(...)
     #define TARGET_EVENT_ARG1(...)

--- a/native/cocos/core/event/EventTarget.h
+++ b/native/cocos/core/event/EventTarget.h
@@ -25,7 +25,9 @@
 #pragma once
 
 #include <array>
+#include <cstring>
 #include <memory>
+#include "base/Log.h"
 #include "base/Macros.h"
 #include "intl/EventIntl.h"
 #include "intl/List.h"
@@ -55,7 +57,7 @@ struct TgtEventInfo {
 };
 
 template <typename TgtEvent>
-struct Event : TgtEventInfo {
+struct Event final : TgtEventInfo {
     using EmitterType = typename TgtEvent::_emitter_type;
     using _argument_tuple_types = typename TgtEvent::_argument_tuple_types;
     using _argument_local_types = typename TgtEvent::_argument_local_types;
@@ -129,7 +131,7 @@ public:
     };
     virtual ~TargetEventListenerBase() = default;
     virtual void *getContext() const = 0;
-    virtual const char *getEventType() const { return nullptr; }
+    virtual const char *getEventName() const { return nullptr; }
 
     bool isEnabled() const { return _enabled; }
     void setOnce() { _state = RunState::PENDING_ONCE; }
@@ -147,13 +149,13 @@ protected:
 };
 
 template <typename TgtEvent>
-class TargetEventListener : public TargetEventListenerBase {
+class TargetEventListener final : public TargetEventListenerBase {
 public:
     using _emitter_type = typename TgtEvent::_emitter_type;
     using EventType = typename TgtEvent::EventType;
     using _persist_function_type = typename TgtEvent::_persist_function_type;
     explicit TargetEventListener(_persist_function_type func) : _func(func) {
-        _eventTypeID = TgtEvent::TypeID();
+        _eventTypeID = TgtEvent::TYPE_ID;
     }
 
     ~TargetEventListener() override {
@@ -171,6 +173,10 @@ public:
     void *getContext() const override {
         if (_fnCmptor) return _fnCmptor->getContext();
         return nullptr;
+    }
+
+    const char *getEventName() const override {
+        return TgtEvent::EVENT_NAME;
     }
 
     void apply(_emitter_type *self, EventType *evobj) {
@@ -216,7 +222,7 @@ private:
 template <size_t N>
 struct TargetListenerContainer final {
     std::array<TargetEventListenerBase *, N> data{nullptr};
-    TargetEventListenerBase *&operator[](size_t index) { return data[index]; }
+    inline TargetEventListenerBase *&operator[](size_t index) { return data[index]; }
     void clear() {
         for (size_t i = 0; i < N; i++) {
             auto &handlers = data[i];
@@ -231,341 +237,405 @@ struct TargetListenerContainer final {
     }
 };
 
-} // namespace event
-} // namespace cc
-// NOLINTNEXTLINE
-#define _IMPL_EVENT_TARGET_(Self)                                                                                                    \
-    using _emitter_type = Self;                                                                                                      \
-                                                                                                                                     \
-protected:                                                                                                                           \
-    template <typename TgtEvent, typename Fn>                                                                                        \
-    cc::event::TargetEventID<TgtEvent> addEventListener(Fn &&func, bool useCapture, bool once) {                                     \
-        /* CC_ASSERT(!_emittingEvent); */                                                                                            \
-        using func_type = std::conditional_t<cc::event::intl::FunctionTrait<Fn>::IS_LAMBDA,                                          \
-                                             typename cc::event::intl::lambda_without_class_t<Fn>, Fn>;                              \
-        using wrap_type = cc::event::intl::TgtEvtFnTrait<func_type>;                                                                 \
-        auto stdfn = wrap_type::template wrap<TgtEvent>(cc::event::intl::convertLambda(std::forward<Fn>(func)));                     \
-        auto *newHandler = new cc::event::TargetEventListener<TgtEvent>(stdfn);                                                      \
-        auto newId = ++_handlerId;                                                                                                   \
-        newHandler->id = newId;                                                                                                      \
-        if (once) {                                                                                                                  \
-            newHandler->setOnce();                                                                                                   \
-        }                                                                                                                            \
-        if constexpr (wrap_type::IS_MEMBER_FUNC) {                                                                                   \
-            newHandler->setMemberFuncAddr(std::forward<Fn>(func), nullptr);                                                          \
-        }                                                                                                                            \
-        if (useCapture) {                                                                                                            \
-            cc::event::intl::listAppend<cc::event::TargetEventListenerBase>(&_capturingHandlersMap[TgtEvent::TypeID()], newHandler); \
-        } else {                                                                                                                     \
-            cc::event::intl::listAppend<cc::event::TargetEventListenerBase>(&_bubblingHandlersMap[TgtEvent::TypeID()], newHandler);  \
-        }                                                                                                                            \
-        return cc::event::TargetEventID<TgtEvent>(newId);                                                                            \
-    }                                                                                                                                \
-                                                                                                                                     \
-    template <typename TgtEvent, typename Fn, typename O>                                                                            \
-    cc::event::TargetEventID<TgtEvent> addEventListener(Fn &&func, O *ctx, bool useCapture, bool once) {                             \
-        /* CC_ASSERT(!_emittingEvent);*/                                                                                             \
-        using wrap_type = cc::event::intl::TgtEvtFnTrait<Fn>;                                                                        \
-        auto stdfn = wrap_type::template wrapWithContext<TgtEvent>(std::forward<Fn>(func), ctx);                                     \
-        auto *newHandler = new cc::event::TargetEventListener<TgtEvent>(stdfn);                                                      \
-        auto newId = ++_handlerId;                                                                                                   \
-        newHandler->id = newId;                                                                                                      \
-        if (once) {                                                                                                                  \
-            newHandler->setOnce();                                                                                                   \
-        }                                                                                                                            \
-        if constexpr (wrap_type::IS_MEMBER_FUNC) {                                                                                   \
-            newHandler->setMemberFuncAddr(std::forward<Fn>(func), ctx);                                                              \
-        }                                                                                                                            \
-        if (useCapture) {                                                                                                            \
-            cc::event::intl::listAppend<cc::event::TargetEventListenerBase>(&_capturingHandlersMap[TgtEvent::TypeID()], newHandler); \
-        } else {                                                                                                                     \
-            cc::event::intl::listAppend<cc::event::TargetEventListenerBase>(&_bubblingHandlersMap[TgtEvent::TypeID()], newHandler);  \
-        }                                                                                                                            \
-        return cc::event::TargetEventID<TgtEvent>(newId);                                                                            \
-    }                                                                                                                                \
-                                                                                                                                     \
-public:                                                                                                                              \
-    template <typename TgtEvent, typename Fn>                                                                                        \
-    cc::event::TargetEventID<TgtEvent> once(Fn &&func, bool useCapture) {                                                            \
-        return this->template addEventListener(std::forward<Fn>(func), useCapture, true);                                            \
-    }                                                                                                                                \
-                                                                                                                                     \
-    template <typename TgtEvent, typename Fn, typename O>                                                                            \
-    cc::event::TargetEventID<TgtEvent> once(Fn &&func, O *ctx) {                                                                     \
-        return this->template addEventListener(std::forward<Fn>(func), ctx, true);                                                   \
-    }                                                                                                                                \
-    template <typename TgtEvent, typename Fn>                                                                                        \
-    cc::event::TargetEventID<TgtEvent> on(Fn &&func, bool useCapture = false) {                                                      \
-        static_assert(std::is_base_of<typename TgtEvent::_emitter_type, Self>::value, "mismatch target type");                       \
-        return this->template addEventListener<TgtEvent, Fn>(std::forward<Fn>(func), useCapture, false);                             \
-    }                                                                                                                                \
-    template <typename TgtEvent, typename Fn, typename O>                                                                            \
-    cc::event::TargetEventID<TgtEvent> on(Fn &&func, O *ctx, bool useCapture = false) {                                              \
-        return this->template addEventListener<TgtEvent, Fn, O>(std::forward<Fn>(func), ctx, useCapture, false);                     \
-    }                                                                                                                                \
-    template <typename TgtEvent>                                                                                                     \
-    bool off(cc::event::TargetEventID<TgtEvent> eventId) {                                                                           \
-        CC_ASSERT(!_emittingEvent[TgtEvent::TypeID()]);                                                                              \
-                                                                                                                                     \
-        cc::event::TargetEventListenerBase *&bubblingHandlers = _bubblingHandlersMap[TgtEvent::TypeID()];                            \
-                                                                                                                                     \
-        EVENT_LIST_LOOP_REV_BEGIN(handle, bubblingHandlers)                                                                          \
-        if (handle && handle->id == eventId.value()) {                                                                               \
-            CC_ASSERT(handle->getEventTypeID() == TgtEvent::TypeID());                                                               \
-            cc::event::intl::detachFromList(&bubblingHandlers, handle);                                                              \
-            delete handle;                                                                                                           \
-            return true;                                                                                                             \
-        }                                                                                                                            \
-        EVENT_LIST_LOOP_REV_END(handle, bubblingHandlers)                                                                            \
-        cc::event::TargetEventListenerBase *&capturingHandlers = _capturingHandlersMap[TgtEvent::TypeID()];                          \
-        EVENT_LIST_LOOP_REV_BEGIN(handle, capturingHandlers)                                                                         \
-        if (handle && handle->id == eventId.value()) {                                                                               \
-            CC_ASSERT(handle->getEventTypeID() == TgtEvent::TypeID());                                                               \
-            cc::event::intl::detachFromList(&capturingHandlers, handle);                                                             \
-            delete handle;                                                                                                           \
-            return true;                                                                                                             \
-        }                                                                                                                            \
-        EVENT_LIST_LOOP_REV_END(handle, capturingHandlers)                                                                           \
-        return false;                                                                                                                \
-    }                                                                                                                                \
-                                                                                                                                     \
-    void offAll() {                                                                                                                  \
-        _bubblingHandlersMap.clear();                                                                                                \
-        _capturingHandlersMap.clear();                                                                                               \
-    }                                                                                                                                \
-                                                                                                                                     \
-    template <typename TgtEvent>                                                                                                     \
-    void off() {                                                                                                                     \
-        static_assert(std::is_base_of_v<cc::event::TgtEventTraitClass, TgtEvent>, "incorrect template argument");                    \
-        CC_ASSERT(!_emittingEvent[TgtEvent::TypeID()]);                                                                              \
-        cc::event::TargetEventListenerBase *&bubblingHandlers = _bubblingHandlersMap[TgtEvent::TypeID()];                            \
-                                                                                                                                     \
-        EVENT_LIST_LOOP_REV_BEGIN(handle, bubblingHandlers)                                                                          \
-        if (handle) {                                                                                                                \
-            cc::event::intl::detachFromList(&bubblingHandlers, handle);                                                              \
-            delete handle;                                                                                                           \
-        }                                                                                                                            \
-        EVENT_LIST_LOOP_REV_END(handle, bubblingHandlers)                                                                            \
-                                                                                                                                     \
-        cc::event::TargetEventListenerBase *&capturingHandlers = _capturingHandlersMap[TgtEvent::TypeID()];                          \
-        EVENT_LIST_LOOP_REV_BEGIN(handle, capturingHandlers)                                                                         \
-        if (handle) {                                                                                                                \
-            cc::event::intl::detachFromList(&capturingHandlers, handle);                                                             \
-            delete handle;                                                                                                           \
-        }                                                                                                                            \
-        EVENT_LIST_LOOP_REV_END(handle, capturingHandlers)                                                                           \
-    }                                                                                                                                \
-                                                                                                                                     \
-    template <typename TgtEvent, typename... ARGS>                                                                                   \
-    void emit(ARGS &&...args) {                                                                                                      \
-        /* TODO() : statistics */                                                                                                    \
-        using _handler_function_type = cc::event::TargetEventListener<TgtEvent>;                                                     \
-        using EventType = typename TgtEvent::EventType;                                                                              \
-        static_assert(sizeof...(ARGS) == TgtEvent::ARG_COUNT, "Parameter count incorrect for function EventTarget::emit");           \
-        cc::event::intl::validateParameters<0, TgtEvent, ARGS...>(std::forward<ARGS>(args)...);                                      \
-        EventType eventObj(std::make_tuple<ARGS...>(std::forward<ARGS>(args)...));                                                   \
-        eventObj.target = this;                                                                                                      \
-        eventObj.currentTarget = this;                                                                                               \
-                                                                                                                                     \
-        emitEvtObj<false, TgtEvent>(&eventObj);                                                                                      \
-    }                                                                                                                                \
-    template <bool useCapture, typename TgtEvent, typename EvtObj>                                                                   \
-    void emitEvtObj(EvtObj *eventObj) {                                                                                              \
-        using EventType = typename TgtEvent::EventType;                                                                              \
-        using _handler_function_type = cc::event::TargetEventListener<TgtEvent>;                                                     \
-        static_assert(std::is_same_v<EventType, EvtObj>, "Event type mismatch");                                                     \
-        _emittingEvent[TgtEvent::TypeID()]++;                                                                                        \
-        if constexpr (useCapture) {                                                                                                  \
-            cc::event::TargetEventListenerBase *&handlers = _capturingHandlersMap[TgtEvent::TypeID()];                               \
-            EVENT_LIST_LOOP_BEGIN(handle, handlers)                                                                                  \
-            if (handle && handle->isEnabled()) {                                                                                     \
-                static_cast<_handler_function_type *>(handle)->apply(this, eventObj);                                                \
-            }                                                                                                                        \
-            EVENT_LIST_LOOP_END(handle, handlers);                                                                                   \
-        } else {                                                                                                                     \
-            cc::event::TargetEventListenerBase *&handlers = _bubblingHandlersMap[TgtEvent::TypeID()];                                \
-            EVENT_LIST_LOOP_BEGIN(handle, handlers)                                                                                  \
-            if (handle && handle->isEnabled()) {                                                                                     \
-                static_cast<_handler_function_type *>(handle)->apply(this, eventObj);                                                \
-            }                                                                                                                        \
-            EVENT_LIST_LOOP_END(handle, handlers);                                                                                   \
-        }                                                                                                                            \
-        _emittingEvent[TgtEvent::TypeID()]--;                                                                                        \
-    }                                                                                                                                \
-    template <typename TgtEvent, typename EvtType>                                                                                   \
-    std::enable_if_t<std::is_same_v<typename TgtEvent::EventType, std::decay_t<EvtType>>, void>                                      \
-    dispatchEvent(EvtType &eventObj) {                                                                                               \
-        if constexpr (HAS_PARENT) {                                                                                                  \
-            std::vector<Self *> parents;                                                                                             \
-            Self *curr = this->evGetParent();                                                                                        \
-            while (curr) {                                                                                                           \
-                if (curr->hasEventHandler<TgtEvent>()) {                                                                             \
-                    parents.emplace_back(curr);                                                                                      \
-                }                                                                                                                    \
-                curr = curr->evGetParent();                                                                                          \
-            }                                                                                                                        \
-            for (auto itr = parents.rbegin(); itr != parents.rend(); itr++) {                                                        \
-                eventObj.currentTarget = *itr;                                                                                       \
-                (*itr)->emitEvtObj<true, TgtEvent>(&eventObj);                                                                       \
-                if (eventObj.propagationStopped) {                                                                                   \
-                    return;                                                                                                          \
-                }                                                                                                                    \
-            }                                                                                                                        \
-        }                                                                                                                            \
-                                                                                                                                     \
-        eventObj.eventPhase = cc::event::EventPhaseType::AT_TARGET;                                                                  \
-        eventObj.currentTarget = static_cast<Self *>(this);                                                                          \
-                                                                                                                                     \
-        emitEvtObj<true, TgtEvent>(&eventObj);                                                                                       \
-        if (!eventObj.propagationStopped) {                                                                                          \
-            emitEvtObj<false, TgtEvent>(&eventObj);                                                                                  \
-        }                                                                                                                            \
-                                                                                                                                     \
-        if constexpr (HAS_PARENT) {                                                                                                  \
-            if (!eventObj.propagationStopped && eventObj.bubbles) {                                                                  \
-                auto *curr = static_cast<Self *>(this)->evGetParent();                                                               \
-                std::vector<Self *> parents;                                                                                         \
-                                                                                                                                     \
-                while (curr) {                                                                                                       \
-                    if (curr->template hasEventHandler<TgtEvent>()) {                                                                \
-                        parents.emplace_back(curr);                                                                                  \
-                    }                                                                                                                \
-                    curr = curr->evGetParent();                                                                                      \
-                }                                                                                                                    \
-                for (auto itr = parents.begin(); itr != parents.end(); itr++) {                                                      \
-                    eventObj.currentTarget = *itr;                                                                                   \
-                    (*itr)->template emitEvtObj<false, TgtEvent>(&eventObj);                                                         \
-                    if (eventObj.propagationStopped) {                                                                               \
-                        return;                                                                                                      \
-                    }                                                                                                                \
-                }                                                                                                                    \
-            }                                                                                                                        \
-        }                                                                                                                            \
-    }                                                                                                                                \
-                                                                                                                                     \
-    template <typename TgtEvent, typename... ARGS>                                                                                   \
-    std::enable_if_t<sizeof...(ARGS) != 1 ||                                                                                         \
-                         (sizeof...(ARGS) == 1 &&                                                                                    \
-                          !std::is_same_v<typename TgtEvent::EventType,                                                              \
-                                          std::remove_pointer_t<typename cc::event::intl::HeadType<ARGS...>::head>>),                \
-                     void>                                                                                                           \
-    dispatchEvent(ARGS &&...args) {                                                                                                  \
-        using _handler_function_type = cc::event::TargetEventListener<TgtEvent>;                                                     \
-        using EventType = typename TgtEvent::EventType;                                                                              \
-        static_assert(sizeof...(ARGS) == TgtEvent::ARG_COUNT, "Parameter count incorrect for function EventTarget::emit");           \
-        cc::event::intl::validateParameters<0, TgtEvent, ARGS...>(std::forward<ARGS>(args)...);                                      \
-        EventType eventObj(std::make_tuple<ARGS...>(std::forward<ARGS>(args)...));                                                   \
-        eventObj.target = this;                                                                                                      \
-        eventObj.currentTarget = this;                                                                                               \
-        eventObj.eventPhase = cc::event::EventPhaseType::CAPTUREING_PHASE;                                                           \
-        dispatchEvent<TgtEvent, EventType>(eventObj);                                                                                \
-    }                                                                                                                                \
-                                                                                                                                     \
-    template <typename TgtEvent>                                                                                                     \
-    void dispatchEvent() {                                                                                                           \
-        using _handler_function_type = cc::event::TargetEventListener<TgtEvent>;                                                     \
-        using EventType = typename TgtEvent::EventType;                                                                              \
-        static_assert(0 == TgtEvent::ARG_COUNT, "Parameter count incorrect for function EventTarget::emit");                         \
-        EventType eventObj;                                                                                                          \
-        eventObj.target = this;                                                                                                      \
-        eventObj.currentTarget = this;                                                                                               \
-        eventObj.eventPhase = cc::event::EventPhaseType::CAPTUREING_PHASE;                                                           \
-        dispatchEvent<TgtEvent, EventType>(eventObj);                                                                          \
-    }                                                                                                                                \
-                                                                                                                                     \
-    template <typename TgtEvent>                                                                                                     \
-    bool hasEventHandler() {                                                                                                         \
-        cc::event::TargetEventListenerBase *&bubblingHandlers = _bubblingHandlersMap[TgtEvent::TypeID()];                            \
-        EVENT_LIST_LOOP_BEGIN(handle, bubblingHandlers)                                                                              \
-        if (handle && handle->isEnabled()) {                                                                                         \
-            return true;                                                                                                             \
-        }                                                                                                                            \
-        EVENT_LIST_LOOP_END(handle, bubblingHandlers);                                                                               \
-        cc::event::TargetEventListenerBase *&capturingHandlers = _capturingHandlersMap[TgtEvent::TypeID()];                          \
-        EVENT_LIST_LOOP_BEGIN(handle, capturingHandlers)                                                                             \
-        if (handle && handle->isEnabled()) {                                                                                         \
-            return true;                                                                                                             \
-        }                                                                                                                            \
-        EVENT_LIST_LOOP_END(handle, capturingHandlers);                                                                              \
-        return false;                                                                                                                \
-    }                                                                                                                                \
-                                                                                                                                     \
-    template <typename TgtEvent, typename Fn, typename C>                                                                            \
-    bool hasEventHandler(Fn func, C *target) {                                                                                       \
-        using wrap_type = cc::event::intl::TgtEvtFnTrait<Fn>;                                                                        \
-        using _handler_function_type = event::TargetEventListener<TgtEvent>;                                                         \
-        static_assert(std::is_same<typename wrap_type::target_type, C>::value, "member function type mismatch");                     \
-                                                                                                                                     \
-        cc::event::TargetEventListenerBase *&bubblingHandlers = _bubblingHandlersMap[TgtEvent::TypeID()];                            \
-        EVENT_LIST_LOOP_BEGIN(handle, bubblingHandlers)                                                                              \
-        if (handle && handle->isEnabled() && handle->getContext() == target) {                                                       \
-            auto *ptr = static_cast<_handler_function_type *>(handle);                                                               \
-            return ptr->getMemberFuncAddr() == func;                                                                                 \
-        }                                                                                                                            \
-        EVENT_LIST_LOOP_END(handle, bubblingHandlers);                                                                               \
-        cc::event::TargetEventListenerBase *&capturingHandlers = _capturingHandlersMap[TgtEvent::TypeID()];                          \
-        EVENT_LIST_LOOP_BEGIN(handle, capturingHandlers)                                                                             \
-        if (handle && handle->isEnabled() && handle->getContext() == target) {                                                       \
-            auto *ptr = static_cast<_handler_function_type *>(handle);                                                               \
-            return ptr->getMemberFuncAddr() == func;                                                                                 \
-        }                                                                                                                            \
-        EVENT_LIST_LOOP_END(handle, capturingHandlers);                                                                              \
-                                                                                                                                     \
-        return false;                                                                                                                \
+template <typename Self, size_t EventCount, bool hasParent>
+class EventTargetImpl final {
+public:
+    constexpr static bool HAS_PARENT = hasParent;
+
+protected:
+    template <typename TgtEvent, typename Fn>
+    TargetEventID<TgtEvent> addEventListener(Fn &&func, bool useCapture, bool once) {
+        /* CC_ASSERT(!_emittingEvent); */
+        using func_type = std::conditional_t<intl::FunctionTrait<Fn>::IS_LAMBDA,
+                                             typename intl::lambda_without_class_t<Fn>, Fn>;
+        using wrap_type = intl::TgtEvtFnTrait<func_type>;
+        auto stdfn = wrap_type::template wrap<TgtEvent>(intl::convertLambda(std::forward<Fn>(func)));
+        auto *newHandler = new TargetEventListener<TgtEvent>(stdfn);
+        auto newId = ++_handlerId;
+        newHandler->id = newId;
+        if (once) {
+            newHandler->setOnce();
+        }
+        if constexpr (wrap_type::IS_MEMBER_FUNC) {
+            newHandler->setMemberFuncAddr(std::forward<Fn>(func), nullptr);
+        }
+        if (useCapture) {
+            intl::listAppend<TargetEventListenerBase>(&_capturingHandlers[TgtEvent::TYPE_ID], newHandler);
+        } else {
+            intl::listAppend<TargetEventListenerBase>(&_bubblingHandlers[TgtEvent::TYPE_ID], newHandler);
+        }
+        return TargetEventID<TgtEvent>(newId);
     }
 
-#define TARGET_EVENT_ARG0(EventTypeClass)                                                 \
-    class EventTypeClass final : public cc::event::TgtEventTrait<_emitter_type> {         \
-    public:                                                                               \
-        using BaseType = cc::event::TgtEventTrait<_emitter_type>;                         \
-        using EventType = cc::event::Event<EventTypeClass>;                               \
-        using EventID = cc::event::TargetEventID<EventTypeClass>;                         \
-        using _persist_function_type = std::function<void(_emitter_type *, EventType *)>; \
-        using _handler_function_type = std::function<void(EventType *)>;                  \
-        constexpr static const char *EVENT_NAME = #EventTypeClass;                        \
-        constexpr static size_t TYPE_ID = __COUNTER__ - __counter_start__ - 1;            \
-        constexpr static size_t TypeID() {                                                \
-            return TYPE_ID;                                                               \
-        }                                                                                 \
-        constexpr static size_t TypeHash() {                                              \
-            return cc::event::intl::hash(#EventTypeClass);                                \
-        }                                                                                 \
+    template <typename TgtEvent, typename Fn, typename O>
+    TargetEventID<TgtEvent> addEventListener(Fn &&func, O *ctx, bool useCapture, bool once) {
+        /* CC_ASSERT(!_emittingEvent);*/
+        using wrap_type = intl::TgtEvtFnTrait<Fn>;
+        auto stdfn = wrap_type::template wrapWithContext<TgtEvent>(std::forward<Fn>(func), ctx);
+        auto *newHandler = new TargetEventListener<TgtEvent>(stdfn);
+        auto newId = ++_handlerId;
+        newHandler->id = newId;
+        if (once) {
+            newHandler->setOnce();
+        }
+        if constexpr (wrap_type::IS_MEMBER_FUNC) {
+            newHandler->setMemberFuncAddr(std::forward<Fn>(func), ctx);
+        }
+        if (useCapture) {
+            intl::listAppend<TargetEventListenerBase>(&_capturingHandlers[TgtEvent::TYPE_ID], newHandler);
+        } else {
+            intl::listAppend<TargetEventListenerBase>(&_bubblingHandlers[TgtEvent::TYPE_ID], newHandler);
+        }
+        return TargetEventID<TgtEvent>(newId);
+    }
+
+public:
+    template <typename TgtEvent, typename Fn>
+    TargetEventID<TgtEvent> once(Fn &&func, bool useCapture) {
+        return this->template addEventListener(std::forward<Fn>(func), useCapture, true);
+    }
+
+    template <typename TgtEvent, typename Fn, typename O>
+    TargetEventID<TgtEvent> once(Fn &&func, O *ctx) {
+        return this->template addEventListener(std::forward<Fn>(func), ctx, true);
+    }
+    template <typename TgtEvent, typename Fn>
+    TargetEventID<TgtEvent> on(Fn &&func, bool useCapture = false) {
+        static_assert(std::is_base_of<typename TgtEvent::_emitter_type, Self>::value, "mismatch target type");
+        return this->template addEventListener<TgtEvent, Fn>(std::forward<Fn>(func), useCapture, false);
+    }
+    template <typename TgtEvent, typename Fn, typename O>
+    TargetEventID<TgtEvent> on(Fn &&func, O *ctx, bool useCapture = false) {
+        return this->template addEventListener<TgtEvent, Fn, O>(std::forward<Fn>(func), ctx, useCapture, false);
+    }
+    template <typename TgtEvent>
+    bool off(TargetEventID<TgtEvent> eventId) {
+        CC_ASSERT(!_emittingEvent[TgtEvent::TYPE_ID]);
+
+        TargetEventListenerBase *&bubblingHandlers = _bubblingHandlers[TgtEvent::TYPE_ID];
+
+        EVENT_LIST_LOOP_REV_BEGIN(handle, bubblingHandlers)
+        if (handle && handle->id == eventId.value()) {
+            CC_ASSERT(handle->getEventTypeID() == TgtEvent::TYPE_ID);
+            intl::detachFromList(&bubblingHandlers, handle);
+            delete handle;
+            return true;
+        }
+        EVENT_LIST_LOOP_REV_END(handle, bubblingHandlers)
+        TargetEventListenerBase *&capturingHandlers = _capturingHandlers[TgtEvent::TYPE_ID];
+        EVENT_LIST_LOOP_REV_BEGIN(handle, capturingHandlers)
+        if (handle && handle->id == eventId.value()) {
+            CC_ASSERT(handle->getEventTypeID() == TgtEvent::TYPE_ID);
+            intl::detachFromList(&capturingHandlers, handle);
+            delete handle;
+            return true;
+        }
+        EVENT_LIST_LOOP_REV_END(handle, capturingHandlers)
+        return false;
+    }
+
+    void offAll() {
+#if CC_DEBUG
+        for (auto &itr : _emittingEvent) {
+            CC_ASSERT(!itr);
+        }
+#endif
+        _bubblingHandlers.clear();
+        _capturingHandlers.clear();
+    }
+
+    template <typename TgtEvent>
+    void off() {
+        static_assert(std::is_base_of_v<TgtEventTraitClass, TgtEvent>, "incorrect template argument");
+        CC_ASSERT(!_emittingEvent[TgtEvent::TYPE_ID]);
+        TargetEventListenerBase *&bubblingHandlers = _bubblingHandlers[TgtEvent::TYPE_ID];
+
+        EVENT_LIST_LOOP_REV_BEGIN(handle, bubblingHandlers)
+        if (handle) {
+            intl::detachFromList(&bubblingHandlers, handle);
+            delete handle;
+        }
+        EVENT_LIST_LOOP_REV_END(handle, bubblingHandlers)
+
+        TargetEventListenerBase *&capturingHandlers = _capturingHandlers[TgtEvent::TYPE_ID];
+        EVENT_LIST_LOOP_REV_BEGIN(handle, capturingHandlers)
+        if (handle) {
+            intl::detachFromList(&capturingHandlers, handle);
+            delete handle;
+        }
+        EVENT_LIST_LOOP_REV_END(handle, capturingHandlers)
+    }
+
+    template <typename TgtEvent, typename... ARGS>
+    void emit(Self *self, ARGS &&...args) { /* TODO() : statistics */
+        using _handler_function_type = TargetEventListener<TgtEvent>;
+        using EventType = typename TgtEvent::EventType;
+        static_assert(sizeof...(ARGS) == TgtEvent::ARG_COUNT, "Parameter count incorrect for function EventTarget::emit");
+        if (_bubblingHandlers[TgtEvent::TYPE_ID] == nullptr) return;
+        intl::validateParameters<0, TgtEvent, ARGS...>(std::forward<ARGS>(args)...);
+        EventType eventObj(std::make_tuple<ARGS...>(std::forward<ARGS>(args)...));
+        eventObj.target = self;
+        eventObj.currentTarget = self;
+
+        emitEvtObj<false, TgtEvent>(self, &eventObj);
+    }
+    template <bool useCapture, typename TgtEvent, typename EvtObj>
+    void emitEvtObj(Self *self, EvtObj *eventObj) {
+        using EventType = typename TgtEvent::EventType;
+        using _handler_function_type = TargetEventListener<TgtEvent>;
+        static_assert(std::is_same_v<EventType, EvtObj>, "Event type mismatch");
+        _emittingEvent[TgtEvent::TYPE_ID]++;
+        if constexpr (useCapture) {
+            TargetEventListenerBase *&handlers = _capturingHandlers[TgtEvent::TYPE_ID];
+            EVENT_LIST_LOOP_BEGIN(handle, handlers)
+            if (handle->isEnabled()) {
+#if CC_DEBUG
+                bool sameAddr = handle->getEventName() == TgtEvent::EVENT_NAME;
+                if (!sameAddr && strcmp(handle->getEventName(), TgtEvent::EVENT_NAME)) {
+                    // different event should not shared a same typeid.
+                    CC_LOG_ERROR("Event '%s' and '%s' shared the same TypeID(), for event declaration of subclasses, please use DECLARE_TARGET_EVENT_BEGIN_OFFSET()", TgtEvent::EVENT_NAME, handle->getEventName());
+                    CC_ASSERT(false);
+                }
+#endif
+                static_cast<_handler_function_type *>(handle)->apply(self, eventObj);
+            }
+            EVENT_LIST_LOOP_END(handle, handlers);
+        } else {
+            TargetEventListenerBase *&handlers = _bubblingHandlers[TgtEvent::TYPE_ID];
+            EVENT_LIST_LOOP_BEGIN(handle, handlers)
+            if (handle->isEnabled()) {
+#if CC_DEBUG
+                bool sameAddr = handle->getEventName() == TgtEvent::EVENT_NAME;
+                if (!sameAddr && strcmp(handle->getEventName(), TgtEvent::EVENT_NAME)) {
+                    // different event should not shared a same typeid.
+                    CC_LOG_ERROR("Event '%s' and '%s' shared the same TypeID(), for event declaration of subclasses, please use DECLARE_TARGET_EVENT_BEGIN_OFFSET()", TgtEvent::EVENT_NAME, handle->getEventName());
+                    CC_ASSERT(false);
+                }
+#endif
+                static_cast<_handler_function_type *>(handle)->apply(self, eventObj);
+            }
+            EVENT_LIST_LOOP_END(handle, handlers);
+        }
+        _emittingEvent[TgtEvent::TYPE_ID]--;
+    }
+    template <typename TgtEvent, typename EvtType>
+    std::enable_if_t<std::is_same_v<typename TgtEvent::EventType, std::decay_t<EvtType>>, void>
+    dispatchEvent(Self *self, EvtType &eventObj) {
+        if constexpr (HAS_PARENT) {
+            std::vector<Self *> parents;
+            Self *curr = self->evGetParent();
+            while (curr) {
+                if (curr->getEventTarget().template hasEventHandler<TgtEvent>()) {
+                    parents.emplace_back(curr);
+                }
+                curr = curr->evGetParent();
+            }
+            for (auto itr = parents.rbegin(); itr != parents.rend(); itr++) {
+                eventObj.currentTarget = *itr;
+                (*itr)->getEventTarget().template emitEvtObj<true, TgtEvent>(*itr, &eventObj);
+                if (eventObj.propagationStopped) {
+                    return;
+                }
+            }
+        }
+
+        eventObj.eventPhase = EventPhaseType::AT_TARGET;
+        eventObj.currentTarget = self;
+
+        emitEvtObj<true, TgtEvent>(self, &eventObj);
+        if (!eventObj.propagationStopped) {
+            emitEvtObj<false, TgtEvent>(self, &eventObj);
+        }
+
+        if constexpr (HAS_PARENT) {
+            if (!eventObj.propagationStopped && eventObj.bubbles) {
+                auto *curr = self->evGetParent();
+                std::vector<Self *> parents;
+
+                while (curr) {
+                    if (curr->getEventTarget().template hasEventHandler<TgtEvent>()) {
+                        parents.emplace_back(curr);
+                    }
+                    curr = curr->evGetParent();
+                }
+                for (auto itr = parents.begin(); itr != parents.end(); itr++) {
+                    eventObj.currentTarget = *itr;
+                    (*itr)->getEventTarget().template emitEvtObj<false, TgtEvent>(*itr, &eventObj);
+                    if (eventObj.propagationStopped) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    template <typename TgtEvent, typename... ARGS>
+    std::enable_if_t<sizeof...(ARGS) != 1 ||
+                         (sizeof...(ARGS) == 1 &&
+                          !std::is_same_v<typename TgtEvent::EventType,
+                                          std::remove_pointer_t<typename intl::HeadType<ARGS...>::head>>),
+                     void>
+    dispatchEvent(Self *self, ARGS &&...args) {
+        using _handler_function_type = TargetEventListener<TgtEvent>;
+        using EventType = typename TgtEvent::EventType;
+        static_assert(sizeof...(ARGS) == TgtEvent::ARG_COUNT, "Parameter count incorrect for function EventTarget::emit");
+        intl::validateParameters<0, TgtEvent, ARGS...>(std::forward<ARGS>(args)...);
+        EventType eventObj(std::make_tuple<ARGS...>(std::forward<ARGS>(args)...));
+        eventObj.target = self;
+        eventObj.currentTarget = self;
+        eventObj.eventPhase = EventPhaseType::CAPTUREING_PHASE;
+        dispatchEvent<TgtEvent, EventType>(self, eventObj);
+    }
+
+    template <typename TgtEvent>
+    void dispatchEvent(Self *self) {
+        using _handler_function_type = TargetEventListener<TgtEvent>;
+        using EventType = typename TgtEvent::EventType;
+        static_assert(0 == TgtEvent::ARG_COUNT, "Parameter count incorrect for function EventTarget::emit");
+        EventType eventObj;
+        eventObj.target = self;
+        eventObj.currentTarget = self;
+        eventObj.eventPhase = EventPhaseType::CAPTUREING_PHASE;
+        dispatchEvent<TgtEvent, EventType>(self, eventObj);
+    }
+
+    template <typename TgtEvent>
+    bool hasEventHandler() {
+        TargetEventListenerBase *&bubblingHandlers = _bubblingHandlers[TgtEvent::TYPE_ID];
+        EVENT_LIST_LOOP_BEGIN(handle, bubblingHandlers)
+        if (handle->isEnabled()) {
+            return true;
+        }
+        EVENT_LIST_LOOP_END(handle, bubblingHandlers);
+        TargetEventListenerBase *&capturingHandlers = _capturingHandlers[TgtEvent::TYPE_ID];
+        EVENT_LIST_LOOP_BEGIN(handle, capturingHandlers)
+        if (handle->isEnabled()) {
+            return true;
+        }
+        EVENT_LIST_LOOP_END(handle, capturingHandlers);
+        return false;
+    }
+
+    template <typename TgtEvent, typename Fn, typename C>
+    bool hasEventHandler(Fn func, C *target) {
+        using wrap_type = intl::TgtEvtFnTrait<Fn>;
+        using _handler_function_type = event::TargetEventListener<TgtEvent>;
+        static_assert(std::is_same<typename wrap_type::target_type, C>::value, "member function type mismatch");
+
+        TargetEventListenerBase *&bubblingHandlers = _bubblingHandlers[TgtEvent::TYPE_ID];
+        EVENT_LIST_LOOP_BEGIN(handle, bubblingHandlers)
+        if (handle->isEnabled() && handle->getContext() == target) {
+            auto *ptr = static_cast<_handler_function_type *>(handle);
+            return ptr->getMemberFuncAddr() == func;
+        }
+        EVENT_LIST_LOOP_END(handle, bubblingHandlers);
+        TargetEventListenerBase *&capturingHandlers = _capturingHandlers[TgtEvent::TYPE_ID];
+        EVENT_LIST_LOOP_BEGIN(handle, capturingHandlers)
+        if (handle->isEnabled() && handle->getContext() == target) {
+            auto *ptr = static_cast<_handler_function_type *>(handle);
+            return ptr->getMemberFuncAddr() == func;
+        }
+        EVENT_LIST_LOOP_END(handle, capturingHandlers);
+
+        return false;
+    }
+
+protected:
+    TargetListenerContainer<EventCount> _bubblingHandlers;
+    TargetListenerContainer<EventCount> _capturingHandlers;
+    TargetEventIdType _handlerId{1};
+    std::array<int, EventCount> _emittingEvent{0};
+};
+} // namespace event
+} // namespace cc
+
+#define TARGET_EVENT_ARG0(EventTypeClass)                                                           \
+    class EventTypeClass final : public cc::event::TgtEventTrait<Self> {                            \
+    public:                                                                                         \
+        using BaseType = cc::event::TgtEventTrait<Self>;                                            \
+        using EventType = cc::event::Event<EventTypeClass>;                                         \
+        using EventID = cc::event::TargetEventID<EventTypeClass>;                                   \
+        using _persist_function_type = std::function<void(Self *, EventType *)>;                    \
+        using _handler_function_type = std::function<void(EventType *)>;                            \
+        constexpr static const char *EVENT_NAME = #EventTypeClass;                                  \
+        constexpr static size_t TYPE_ID = __COUNTER__ - __counter_start__ - 1 + __counter_offset__; \
+        constexpr static size_t TypeHash() {                                                        \
+            return cc::event::intl::hash(#EventTypeClass);                                          \
+        }                                                                                           \
     };
 
 // NOLINTNEXTLINE
-#define _DECLARE_TARGET_EVENT_INTER(EventTypeClass, ...)                                       \
-    class EventTypeClass final : public cc::event::TgtEventTrait<_emitter_type, __VA_ARGS__> { \
-    public:                                                                                    \
-        using BaseType = cc::event::TgtEventTrait<_emitter_type, __VA_ARGS__>;                 \
-        using EventType = cc::event::Event<EventTypeClass>;                                    \
-        using EventID = cc::event::TargetEventID<EventTypeClass>;                              \
-        using _persist_function_type = std::function<void(_emitter_type *, EventType *)>;      \
-        using _handler_function_type = std::function<void(EventType *)>;                       \
-        constexpr static const char *EVENT_NAME = #EventTypeClass;                             \
-        constexpr static size_t TYPE_ID = __COUNTER__ - __counter_start__ - 1;                 \
-        constexpr static size_t TypeID() {                                                     \
-            return TYPE_ID;                                                                    \
-        }                                                                                      \
-        constexpr static size_t TypeHash() {                                                   \
-            return cc::event::intl::hash(#EventTypeClass);                                     \
-        }                                                                                      \
+#define _DECLARE_TARGET_EVENT_INTER(EventTypeClass, ...)                                            \
+    class EventTypeClass final : public cc::event::TgtEventTrait<Self, __VA_ARGS__> {               \
+    public:                                                                                         \
+        using BaseType = cc::event::TgtEventTrait<Self, __VA_ARGS__>;                               \
+        using EventType = cc::event::Event<EventTypeClass>;                                         \
+        using EventID = cc::event::TargetEventID<EventTypeClass>;                                   \
+        using _persist_function_type = std::function<void(Self *, EventType *)>;                    \
+        using _handler_function_type = std::function<void(EventType *)>;                            \
+        constexpr static const char *EVENT_NAME = #EventTypeClass;                                  \
+        constexpr static size_t TYPE_ID = __COUNTER__ - __counter_start__ - 1 + __counter_offset__; \
+        constexpr static size_t TypeHash() {                                                        \
+            return cc::event::intl::hash(#EventTypeClass);                                          \
+        }                                                                                           \
     };
 
-#define IMPL_EVENT_TARGET(TargetClass)             \
-public:                                            \
-    static constexpr bool HAS_PARENT = false;      \
-    TargetClass *evGetParent() { return nullptr; } \
+// NOLINTNEXTLINE
+#define _IMPL_EVENT_TARGET_(Self)                                                                              \
+public:                                                                                                        \
+    template <typename TgtEvent, typename Fn>                                                                  \
+    cc::event::TargetEventID<TgtEvent> once(Fn &&func, bool useCapture) {                                      \
+        return _eventTargetImpl.once<TgtEvent>(std::forward<Fn>(func), useCapture);                            \
+    }                                                                                                          \
+                                                                                                               \
+    template <typename TgtEvent, typename Fn, typename O>                                                      \
+    cc::event::TargetEventID<TgtEvent> once(Fn &&func, O *ctx) {                                               \
+        return _eventTargetImpl.once<TgtEvent>(std::forward<Fn>(func), ctx);                                   \
+    }                                                                                                          \
+    template <typename TgtEvent, typename Fn>                                                                  \
+    cc::event::TargetEventID<TgtEvent> on(Fn &&func, bool useCapture = false) {                                \
+        static_assert(std::is_base_of<typename TgtEvent::_emitter_type, Self>::value, "mismatch target type"); \
+        return _eventTargetImpl.on<TgtEvent, Fn>(std::forward<Fn>(func), useCapture);                          \
+    }                                                                                                          \
+    template <typename TgtEvent, typename Fn, typename O>                                                      \
+    cc::event::TargetEventID<TgtEvent> on(Fn &&func, O *ctx, bool useCapture = false) {                        \
+        return _eventTargetImpl.on<TgtEvent, Fn, O>(std::forward<Fn>(func), ctx, useCapture);                  \
+    }                                                                                                          \
+    template <typename TgtEvent>                                                                               \
+    bool off(cc::event::TargetEventID<TgtEvent> eventId) {                                                     \
+        return _eventTargetImpl.off(eventId);                                                                  \
+    }                                                                                                          \
+    void offAll() {                                                                                            \
+        _eventTargetImpl.offAll();                                                                             \
+    }                                                                                                          \
+    template <typename TgtEvent>                                                                               \
+    void off() {                                                                                               \
+        _eventTargetImpl.off<TgtEvent>();                                                                      \
+    }                                                                                                          \
+    template <typename TgtEvent, typename... ARGS>                                                             \
+    void emit(ARGS &&...args) {                                                                                \
+        _eventTargetImpl.emit<TgtEvent>(this, std::forward<ARGS>(args)...);                                    \
+    }                                                                                                          \
+    template <typename TgtEvent, typename... ARGS>                                                             \
+    void dispatchEvent(ARGS &&...args) {                                                                       \
+        _eventTargetImpl.dispatchEvent<TgtEvent, ARGS...>(this, std::forward<ARGS>(args)...);                  \
+    }
+
+#define IMPL_EVENT_TARGET(TargetClass)                    \
+public:                                                   \
+    static constexpr bool HAS_PARENT = false;             \
+    inline TargetClass *evGetParent() { return nullptr; } \
     _IMPL_EVENT_TARGET_(TargetClass)
 
 #define IMPL_EVENT_TARGET_WITH_PARENT(TargetClass, getParentMethod) \
 public:                                                             \
     static constexpr bool HAS_PARENT = true;                        \
-    auto evGetParent() {                                            \
+    inline auto evGetParent() {                                     \
         return getParentMethod();                                   \
     }                                                               \
     _IMPL_EVENT_TARGET_(TargetClass)
 
-#define DECLARE_TARGET_EVENT_BEGIN(TargetClass)           \
+#define _DECLARE_TARGET_EVENT_BEGIN(TargetClass)          \
     using Self = TargetClass;                             \
                                                           \
 private:                                                  \
@@ -573,17 +643,22 @@ private:                                                  \
                                                           \
 public:
 
-#define DECLARE_TARGET_EVENT_END()                                             \
-private:                                                                       \
-    constexpr static int __counter_stop__ = __COUNTER__;                       \
-    constexpr static int __event_count = __counter_stop__ - __counter_start__; \
-                                                                               \
-protected:                                                                     \
-    cc::event::TargetListenerContainer<__event_count> _bubblingHandlersMap;    \
-    cc::event::TargetListenerContainer<__event_count> _capturingHandlersMap;   \
-    cc::event::TargetEventIdType _handlerId{1};                                \
-    std::array<int, __event_count> _emittingEvent{0};                          \
-                                                                               \
-public:
+#define DECLARE_TARGET_EVENT_BEGIN(TargetClass)  \
+    constexpr static int __counter_offset__ = 0; \
+    _DECLARE_TARGET_EVENT_BEGIN(TargetClass)
+
+#define DECLARE_TARGET_EVENT_BEGIN_OFFSET(TargetClass, offset) \
+    constexpr static int __counter_offset__ = offset;          \
+    _DECLARE_TARGET_EVENT_BEGIN(TargetClass)
+
+#define DECLARE_TARGET_EVENT_END()                                                                    \
+private:                                                                                              \
+    constexpr static int __counter_stop__ = __COUNTER__;                                              \
+    constexpr static int __event_count__ = __counter_stop__ - __counter_start__ + __counter_offset__; \
+    cc::event::EventTargetImpl<Self, __event_count__, HAS_PARENT> _eventTargetImpl;                   \
+                                                                                                      \
+public:                                                                                               \
+    constexpr static int getEventCount() { return __event_count__; }                                  \
+    auto &getEventTarget() { return _eventTargetImpl; }
 
 #include "intl/EventTargetMacros.h"

--- a/native/cocos/core/event/EventTarget.h
+++ b/native/cocos/core/event/EventTarget.h
@@ -26,7 +26,6 @@
 
 #include <array>
 #include <memory>
-#include <unordered_map>
 #include "base/Macros.h"
 #include "intl/EventIntl.h"
 #include "intl/List.h"
@@ -224,6 +223,7 @@ struct TargetListenerContainer final {
             EVENT_LIST_LOOP_REV_BEGIN(handle, handlers)
             delete handle;
             EVENT_LIST_LOOP_REV_END(handle, handlers)
+            data[i] = nullptr;
         }
     }
     ~TargetListenerContainer() {
@@ -470,7 +470,7 @@ public:                                                                         
         eventObj.target = this;                                                                                                      \
         eventObj.currentTarget = this;                                                                                               \
         eventObj.eventPhase = cc::event::EventPhaseType::CAPTUREING_PHASE;                                                           \
-        dispatchEvent<TgtEvent, Self, EventType>(eventObj);                                                                          \
+        dispatchEvent<TgtEvent, EventType>(eventObj);                                                                          \
     }                                                                                                                                \
                                                                                                                                      \
     template <typename TgtEvent>                                                                                                     \

--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -32,7 +32,6 @@
 #include "core/scene-graph/Scene.h"
 #include "core/utils/IDGenerator.h"
 #include "math/Utils.h"
-#include "base/std/container/string.h"
 
 namespace cc {
 

--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -32,6 +32,7 @@
 #include "core/scene-graph/Scene.h"
 #include "core/utils/IDGenerator.h"
 #include "math/Utils.h"
+#include "base/std/container/string.h"
 
 namespace cc {
 

--- a/native/cocos/core/scene-graph/Node.h
+++ b/native/cocos/core/scene-graph/Node.h
@@ -51,7 +51,7 @@ class Scene;
  */
 using TransformDirtyBit = TransformBit;
 
-class Node : public CCObject, public event::EventTarget {
+class Node : public CCObject {
     IMPL_EVENT_TARGET_WITH_PARENT(Node, getParent)
     DECLARE_TARGET_EVENT_BEGIN(Node)
     TARGET_EVENT_ARG0(TouchStart)

--- a/native/cocos/engine/BaseEngine.cpp
+++ b/native/cocos/engine/BaseEngine.cpp
@@ -30,8 +30,6 @@
 
 namespace cc {
 
-BaseEngine::~BaseEngine() = default;
-
 // static
 BaseEngine::Ptr BaseEngine::createEngine() {
     return std::make_shared<Engine>();

--- a/native/cocos/engine/BaseEngine.h
+++ b/native/cocos/engine/BaseEngine.h
@@ -34,7 +34,7 @@
 
 namespace cc {
 
-class CC_DLL BaseEngine : public std::enable_shared_from_this<BaseEngine>, public event::EventTarget {
+class CC_DLL BaseEngine : public std::enable_shared_from_this<BaseEngine> {
 public:
     enum EngineStatus {
         ON_START,
@@ -43,7 +43,7 @@ public:
         ON_CLOSE,
         UNKNOWN,
     };
-    ~BaseEngine() override;
+    ~BaseEngine();
     using Ptr = std::shared_ptr<BaseEngine>;
 
     IMPL_EVENT_TARGET(BaseEngine)

--- a/native/cocos/engine/BaseEngine.h
+++ b/native/cocos/engine/BaseEngine.h
@@ -43,7 +43,7 @@ public:
         ON_CLOSE,
         UNKNOWN,
     };
-    ~BaseEngine();
+    ~BaseEngine() = default;
     using Ptr = std::shared_ptr<BaseEngine>;
 
     IMPL_EVENT_TARGET(BaseEngine)

--- a/native/cocos/engine/Engine.h
+++ b/native/cocos/engine/Engine.h
@@ -62,7 +62,7 @@ public:
     /**
      @brief Constructor of Engine.
      */
-    ~Engine() override;
+    ~Engine();
     /**
      @brief Implement initialization engine.
      */

--- a/native/cocos/scene/Model.h
+++ b/native/cocos/scene/Model.h
@@ -58,7 +58,7 @@ class Octree;
 class Pass;
 struct IMacroPatch;
 
-class Model : public RefCounted, public event::EventTarget {
+class Model : public RefCounted {
     IMPL_EVENT_TARGET(Model)
 
     DECLARE_TARGET_EVENT_BEGIN(Model)

--- a/native/tests/unit-test/src/core_event_target.cpp
+++ b/native/tests/unit-test/src/core_event_target.cpp
@@ -2,7 +2,7 @@
 #include "core/event/EventTarget.h"
 #include "utils.h"
 namespace {
-class TestNode : public cc::event::EventTarget {
+class TestNode {
     IMPL_EVENT_TARGET(TestNode)
     DECLARE_TARGET_EVENT_BEGIN(TestNode)
     TARGET_EVENT_ARG0(Init)
@@ -37,7 +37,7 @@ struct LinkNode {
     LinkNode *prev{nullptr};
 };
 
-class TestNodeWithParent : public cc::event::EventTarget {
+class TestNodeWithParent {
     IMPL_EVENT_TARGET_WITH_PARENT(TestNodeWithParent, getParent)
     DECLARE_TARGET_EVENT_BEGIN(TestNodeWithParent)
     TARGET_EVENT_ARG0(Init)


### PR DESCRIPTION
Re: #

### Changelog

* remove `cc::event::EventTarget`
* use std::array to replace std::unordered_map

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
