### PR TITLE
FIx: lifecycle hook `update` should not been called after panel is closed or not ready yet

### DIFF
--- a/editor/inspector/components/class.js
+++ b/editor/inspector/components/class.js
@@ -94,6 +94,11 @@ exports.methods = {
  */
 async function update(dump) {
     const $panel = this;
+
+    if (!$panel.$this.isConnected) {
+        return;
+    }
+
     const $section = $panel.$.section;
     const oldPropList = Object.keys($panel.$propList);
     const newPropList = [];

--- a/editor/inspector/contributions/asset.js
+++ b/editor/inspector/contributions/asset.js
@@ -56,12 +56,12 @@ const Elements = {
     panel: {
         ready() {
             const panel = this;
-            let animationId;
+            panel.__assetChangedHandle__ = undefined;
 
             panel.__assetChanged__ = (uuid) => {
                 if (Array.isArray(panel.uuidList) && panel.uuidList.includes(uuid)) {
-                    window.cancelAnimationFrame(animationId);
-                    animationId = window.requestAnimationFrame(async () => {
+                    window.cancelAnimationFrame(panel.__assetChangedHandle__);
+                    panel.__assetChangedHandle__ = window.requestAnimationFrame(async () => {
                         await panel.reset();
                     });
                 }
@@ -149,6 +149,11 @@ const Elements = {
         },
         close() {
             const panel = this;
+
+            if (panel.__assetChangedHandle__) {
+                window.cancelAnimationFrame(panel.__assetChangedHandle__);
+                panel.__assetChangedHandle__ = undefined;
+            }
 
             Editor.Message.removeBroadcastListener('asset-db:asset-change', panel.__assetChanged__);
 
@@ -543,6 +548,10 @@ exports.methods = {
             }
         }
 
+        if (panel.ready !== true) {
+            return;
+        }
+
         panel.$this.update(panel.uuidList, panel.renderMap);
     },
     getHelpUrl(url) {
@@ -584,6 +593,7 @@ exports.update = async function update(uuidList, renderMap, dropConfig) {
 
 exports.ready = function ready() {
     const panel = this;
+    panel.ready = true;
 
     for (const prop in Elements) {
         const element = Elements[prop];
@@ -652,6 +662,7 @@ exports.beforeClose = async function beforeClose() {
 
 exports.close = async function close() {
     const panel = this;
+    panel.ready = false;
 
     for (const prop in Elements) {
         const element = Elements[prop];

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -390,13 +390,16 @@ const Elements = {
     panel: {
         ready() {
             const panel = this;
-            let animationId;
+            panel.__nodeChangedHandle__ = undefined;
 
             panel.__nodeChanged__ = (uuid) => {
                 if (Array.isArray(panel.uuidList) && panel.uuidList.includes(uuid)) {
-                    window.cancelAnimationFrame(animationId);
-                    animationId = window.requestAnimationFrame(async () => {
+                    window.cancelAnimationFrame(panel.__nodeChangedHandle__);
+                    panel.__nodeChangedHandle__ = window.requestAnimationFrame(async () => {
                         for (const prop in Elements) {
+                            if (!panel.ready) {
+                                return;
+                            }
                             const element = Elements[prop];
                             if (element.update) {
                                 await element.update.call(panel);
@@ -505,6 +508,11 @@ const Elements = {
         },
         close() {
             const panel = this;
+
+            if (panel.__nodeChangedHandle__) {
+                window.cancelAnimationFrame(panel.__nodeChangedHandle__);
+                panel.__nodeChangedHandle__ = undefined;
+            }
 
             Editor.Message.removeBroadcastListener('scene:change-node', panel.__nodeChanged__);
             Editor.Message.removeBroadcastListener('project:setting-change', panel.__projectSettingChanged__);
@@ -903,7 +911,7 @@ const Elements = {
                 event.stopPropagation();
             });
         },
-        update() {
+        async update() {
             const panel = this;
 
             if (!panel.dump || panel.dump.isScene) {
@@ -946,7 +954,9 @@ const Elements = {
 
             // 如果元素长度、类型一致，则直接更新现有的界面
             if (isAllSameType) {
-                sectionBody.__sections__.forEach(($section, index) => {
+                for (let index = 0; index < sectionBody.__sections__.length; index++) {
+                    const $section = sectionBody.__sections__[index];
+
                     const dump = componentList[index];
                     $section.dump = dump;
 
@@ -968,10 +978,10 @@ const Elements = {
                         $link.removeAttribute('value');
                     }
 
-                    Array.prototype.forEach.call($section.__panels__, ($panel) => {
-                        $panel.update(dump);
-                    });
-                });
+                    await Promise.all($section.__panels__.map(($panel) => {
+                        return $panel.update(dump);
+                    }));
+                }
             } else {
                 // 如果元素不一致，说明切换了选中元素，那么需要更新整个界面
                 sectionBody.innerText = '';
@@ -1299,7 +1309,6 @@ const Elements = {
                     materialPanel.panelObject.$.container.removeAttribute('whole');
                     materialPanel.panelObject.$.container.setAttribute('cache-expand', materialUuid);
                     const { section = {} } = panel.renderManager[materialPanelType];
-                    materialPanel.update([materialUuid], { section });
 
                     // 按数组顺序放置
                     if (materialPrevPanel) {
@@ -1307,6 +1316,9 @@ const Elements = {
                     } else {
                         panel.$.sectionAsset.prepend(materialPanel);
                     }
+
+                    // call update after panel is connected(ensure lifecycle hook `ready` has been called)
+                    materialPanel.update([materialUuid], { section });
 
                     materialPanel.focusEventInNode = () => {
                         const children = Array.from(materialPanel.parentElement.children);
@@ -1847,6 +1859,7 @@ exports.ready = async function ready() {
 
     // 为了避免把 ui-num-input, ui-color 的连续 change 进行 snapshot
     panel.snapshotLock = false;
+    panel.ready = true;
 
     for (const prop in Elements) {
         const element = Elements[prop];
@@ -1863,6 +1876,7 @@ exports.ready = async function ready() {
 
 exports.close = async function close() {
     const panel = this;
+    panel.ready = false;
 
     for (const prop in Elements) {
         const element = Elements[prop];


### PR DESCRIPTION
@arsen2010 @VisualSJ 

Re: #

### Changelog

* lifecycle hook `update` should not been called after panel is closed or not ready yet

### Dependent PR

* https://github.com/cocos/creator-ui-kit/pull/291

### Related issue

- https://github.com/cocos/3d-tasks/issues/14251
- https://github.com/cocos/3d-tasks/issues/14230

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
