### PR TITLE
add custom 'rootURL' config to settings

### DIFF
--- a/platforms/minigame/common/engine/AssetManager.js
+++ b/platforms/minigame/common/engine/AssetManager.js
@@ -12,6 +12,9 @@ downloader.maxRequestsPerFrame = 64;
 presets.scene.maxConcurrency = 36;
 presets.scene.maxRequestsPerFrame = 64;
 
+// 根目录路径
+let customRootURL = '';
+
 const subpackages = {};
 
 const sys = cc.sys;
@@ -229,7 +232,7 @@ function downloadBundle (nameOrUrl, options, onComplete) {
                 js = `src/bundle-scripts/${bundleName}/index.${suffix}js`;
                 cacheManager.makeBundleFolder(bundleName);
             } else {
-                url = `assets/${bundleName}`;
+                url = customRootURL + `assets/${bundleName}`;
                 js = `assets/${bundleName}/index.${suffix}js`;
             }
         require(`./${js}`);
@@ -466,6 +469,7 @@ cc.assetManager.transformPipeline.append((task) => {
 
 const originInit = cc.assetManager.init;
 cc.assetManager.init = function (options) {
+    customRootURL = cc.settings.querySettings('custom', 'rootURL') || '';
     originInit.call(cc.assetManager, options);
     const subpacks = cc.settings.querySettings('assets', 'subpackages');
     subpacks && subpacks.forEach((x) => subpackages[x] = `subpackages/${x}`);


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/14373

### Changelog

* add custom 'rootURL' config to settings

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
