### PR TITLE
[fix] [physx-backend] Dynamically setting the convex property of the …

### DIFF
--- a/cocos/physics/framework/components/colliders/mesh-collider.ts
+++ b/cocos/physics/framework/components/colliders/mesh-collider.ts
@@ -84,6 +84,8 @@ export class MeshCollider extends Collider {
     set convex (value) {
         if (this._convex === value) return;
         this._convex = value;
+
+        if (this._shape && this._mesh) this.shape.setMesh(this._mesh);
     }
 
     /**

--- a/cocos/physics/physx/shapes/physx-trimesh-shape.ts
+++ b/cocos/physics/physx/shapes/physx-trimesh-shape.ts
@@ -28,7 +28,7 @@ import { IVec3Like, Quat, Vec3 } from '../../../core';
 import { Mesh } from '../../../3d/assets';
 import { MeshCollider, PhysicsMaterial } from '../../framework';
 import { ITrimeshShape } from '../../spec/i-physics-shape';
-import { createConvexMesh, createMeshGeometryFlags, createTriangleMesh, PX, _trans } from '../physx-adapter';
+import { createConvexMesh, createMeshGeometryFlags, createTriangleMesh, PX, _trans, removeReference } from '../physx-adapter';
 import { EPhysXShapeType, PhysXShape } from './physx-shape';
 import { AttributeName } from '../../../gfx';
 import { PhysXInstance } from '../physx-instance';
@@ -41,7 +41,13 @@ export class PhysXTrimeshShape extends PhysXShape implements ITrimeshShape {
     }
 
     setMesh (v: Mesh | null): void {
-        if (v && v.renderingSubMeshes.length > 0 && this._impl == null) {
+        if (v && v.renderingSubMeshes.length > 0) {
+            if (this._impl != null) {
+                removeReference(this, this._impl);
+                this._impl.release();
+                this._impl = null;
+            }
+
             const physics = PhysXInstance.physics;
             const collider = this.collider;
             const pxmat = this.getSharedMaterial(collider.sharedMaterial!);

--- a/native/cocos/physics/physx/shapes/PhysXTrimesh.cpp
+++ b/native/cocos/physics/physx/shapes/PhysXTrimesh.cpp
@@ -38,7 +38,11 @@ PhysXTrimesh::PhysXTrimesh() : _mMeshHandle(0),
 void PhysXTrimesh::setMesh(uint32_t objectID) {
     uintptr_t handle = PhysXWorld::getInstance().getPXPtrWithPXObjectID(objectID);
     if (handle == 0) return;
-    if (_mShape) return;
+    if (_mShape) {
+        eraseFromShapeMap();
+        _mShape->release();
+        _mShape = nullptr;
+    }
     if (_mMeshHandle == handle) return;
     _mMeshHandle = handle;
     if (_mSharedBody && _mMeshHandle) {


### PR DESCRIPTION
…MeshCollider after rigid body generation has no effect #12048

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
