### PR TITLE
Remove unused swapWindow methods.

### DIFF
--- a/native/cocos/platform/SDLHelper.cpp
+++ b/native/cocos/platform/SDLHelper.cpp
@@ -358,10 +358,6 @@ void SDLHelper::setCursorEnabled(bool value) {
     SDL_SetRelativeMouseMode(value ? SDL_FALSE : SDL_TRUE);
 }
 
-void SDLHelper::swapWindow(SDL_Window *window) {
-    SDL_GL_SwapWindow(window);
-}
-
 #if (CC_PLATFORM == CC_PLATFORM_LINUX)
 uintptr_t SDLHelper::getDisplay(SDL_Window *window) {
     SDL_SysWMinfo wmInfo;

--- a/native/cocos/platform/SDLHelper.h
+++ b/native/cocos/platform/SDLHelper.h
@@ -41,7 +41,6 @@ public:
     ~SDLHelper();
 
     static int init();
-    static void swapWindow(SDL_Window* window);
 
     static SDL_Window* createWindow(const char* title,
                                     int w, int h, int flags);

--- a/native/cocos/platform/empty/modules/SystemWindow.cpp
+++ b/native/cocos/platform/empty/modules/SystemWindow.cpp
@@ -67,10 +67,6 @@ void SystemWindow::pollEvent(bool* quit) {
     return;
 }
 
-void SystemWindow::swapWindow() {
-    return;
-}
-
 SystemWindow::Size SystemWindow::getViewSize() const {
     return Size{static_cast<float>(_width), static_cast<float>(_height)};
 }

--- a/native/cocos/platform/empty/modules/SystemWindow.h
+++ b/native/cocos/platform/empty/modules/SystemWindow.h
@@ -48,7 +48,6 @@ public:
 
     int init();
     void pollEvent(bool* quit);
-    void swapWindow();
 
 private:
     int _width{0};

--- a/native/cocos/platform/empty/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/empty/modules/SystemWindowManager.cpp
@@ -38,10 +38,6 @@ void SystemWindowManager::processEvent(bool* quit) {
 
 }
 
-void SystemWindowManager::swapWindows() {
-
-}
-
 ISystemWindow *SystemWindowManager::getWindow(uint32_t windowId) const {
     if (windowId == 0) {
         return nullptr;

--- a/native/cocos/platform/empty/modules/SystemWindowManager.h
+++ b/native/cocos/platform/empty/modules/SystemWindowManager.h
@@ -39,7 +39,6 @@ public:
 
     int init() override;
     void processEvent(bool* quit) override;
-    void swapWindows() override;
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/interfaces/modules/ISystemWindowManager.h
+++ b/native/cocos/platform/interfaces/modules/ISystemWindowManager.h
@@ -59,11 +59,6 @@ public:
     virtual void processEvent(bool *quit) = 0;
 
     /**
-     * Swap window back buffer
-     */
-    virtual void swapWindows() = 0;
-
-    /**
      * Create an ISystemWindow object
      * @param info window description
      * @return The created ISystemWindow object，if failed then return nullptr

--- a/native/cocos/platform/ios/modules/SystemWindowManager.h
+++ b/native/cocos/platform/ios/modules/SystemWindowManager.h
@@ -40,7 +40,6 @@ public:
 
     int init() override { return 0; }
     void processEvent(bool *quit) override {}
-    void swapWindows() override {}
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/java/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/java/modules/SystemWindowManager.cpp
@@ -37,9 +37,6 @@ int SystemWindowManager::init() {
 void SystemWindowManager::processEvent(bool *quit) {
 }
 
-void SystemWindowManager::swapWindows() {
-}
-
 ISystemWindow *SystemWindowManager::createWindow(const ISystemWindowInfo &info) {
     if (!isExternalHandleExist(info.externalHandle)) {
         ISystemWindow *window = BasePlatform::getPlatform()->createNativeWindow(_nextWindowId, info.externalHandle);

--- a/native/cocos/platform/java/modules/SystemWindowManager.h
+++ b/native/cocos/platform/java/modules/SystemWindowManager.h
@@ -39,7 +39,6 @@ public:
 
     int init() override;
     void processEvent(bool *quit) override;
-    void swapWindows() override;
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;
     const SystemWindowMap &getWindows() const override { return _windows; }

--- a/native/cocos/platform/linux/LinuxPlatform.cpp
+++ b/native/cocos/platform/linux/LinuxPlatform.cpp
@@ -98,7 +98,6 @@ int32_t LinuxPlatform::loop() {
         if (actualInterval >= desiredInterval) {
             lastTime = getCurrentMillSecond();
             runTask();
-            _windowManager->swapWindows();
         } else {
             usleep((desiredInterval - curTime + lastTime) * 1000);
         }

--- a/native/cocos/platform/linux/modules/SystemWindow.cpp
+++ b/native/cocos/platform/linux/modules/SystemWindow.cpp
@@ -49,10 +49,6 @@ SystemWindow::~SystemWindow() {
     _windowId = 0;
 }
 
-void SystemWindow::swapWindow() {
-    SDLHelper::swapWindow(_window);
-}
-
 bool SystemWindow::createWindow(const char *title,
                                 int w, int h, int flags) {
     _window = SDLHelper::createWindow(title, w, h, flags);

--- a/native/cocos/platform/linux/modules/SystemWindow.h
+++ b/native/cocos/platform/linux/modules/SystemWindow.h
@@ -39,8 +39,6 @@ public:
     explicit SystemWindow(uint32_t windowId, void* externalHandle);
     ~SystemWindow() override;
 
-    void swapWindow();
-
     bool createWindow(const char* title,
                       int w, int h, int flags) override;
     bool createWindow(const char* title,

--- a/native/cocos/platform/linux/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/linux/modules/SystemWindowManager.cpp
@@ -55,15 +55,6 @@ void SystemWindowManager::processEvent(bool *quit) {
     }
 }
 
-void SystemWindowManager::swapWindows() {
-    for (const auto &pair : _windows) {
-        SystemWindow *window = static_cast<SystemWindow *>(pair.second.get());
-        if (window) {
-            window->swapWindow();
-        }
-    }
-}
-
 ISystemWindow *SystemWindowManager::createWindow(const ISystemWindowInfo &info) {
     ISystemWindow *window = BasePlatform::getPlatform()->createNativeWindow(_nextWindowId, info.externalHandle);
     if (window) {

--- a/native/cocos/platform/linux/modules/SystemWindowManager.h
+++ b/native/cocos/platform/linux/modules/SystemWindowManager.h
@@ -40,7 +40,6 @@ public:
 
     int init() override;
     void processEvent(bool *quit) override;
-    void swapWindows() override;
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/mac/modules/SystemWindowManager.h
+++ b/native/cocos/platform/mac/modules/SystemWindowManager.h
@@ -41,7 +41,6 @@ public:
 
     int init() override { return 0; }
     void processEvent(bool *quit) override {}
-    void swapWindows() override {}
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/win32/WindowsPlatform.cpp
+++ b/native/cocos/platform/win32/WindowsPlatform.cpp
@@ -151,7 +151,6 @@ int32_t WindowsPlatform::loop() {
         if (actualInterval >= desiredInterval) {
             nLast.QuadPart = nNow.QuadPart;
             runTask();
-            _windowManager->swapWindows();
         } else {
             // The precision of timer on Windows is set to highest (1ms) by 'timeBeginPeriod' from above code,
             // but it's still not precise enough. For example, if the precision of timer is 1ms,

--- a/native/cocos/platform/win32/modules/SystemWindow.cpp
+++ b/native/cocos/platform/win32/modules/SystemWindow.cpp
@@ -45,10 +45,6 @@ SystemWindow::~SystemWindow() {
     _windowId = 0;
 }
 
-void SystemWindow::swapWindow() {
-    SDLHelper::swapWindow(_window);
-}
-
 bool SystemWindow::createWindow(const char *title,
                                 int w, int h, int flags) {
     _window = SDLHelper::createWindow(title, w, h, flags);

--- a/native/cocos/platform/win32/modules/SystemWindow.h
+++ b/native/cocos/platform/win32/modules/SystemWindow.h
@@ -40,8 +40,6 @@ public:
     explicit SystemWindow(uint32_t windowId, void* externalHandle);
     ~SystemWindow() override;
 
-    void swapWindow();
-
     bool createWindow(const char* title,
                       int w, int h, int flags) override;
     bool createWindow(const char* title,

--- a/native/cocos/platform/win32/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/win32/modules/SystemWindowManager.cpp
@@ -55,15 +55,6 @@ void SystemWindowManager::processEvent(bool *quit) {
     }
 }
 
-void SystemWindowManager::swapWindows() {
-    for (const auto &pair : _windows) {
-        SystemWindow *window = static_cast<SystemWindow *>(pair.second.get());
-        if (window) {
-            window->swapWindow();
-        }
-    }
-}
-
 ISystemWindow *SystemWindowManager::createWindow(const ISystemWindowInfo &info) {
     ISystemWindow *window = BasePlatform::getPlatform()->createNativeWindow(_nextWindowId, info.externalHandle);
     if (window) {

--- a/native/cocos/platform/win32/modules/SystemWindowManager.h
+++ b/native/cocos/platform/win32/modules/SystemWindowManager.h
@@ -40,7 +40,6 @@ public:
 
     int init() override;
     void processEvent(bool *quit) override;
-    void swapWindows() override;
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;


### PR DESCRIPTION
The operation of swapping (presenting) buffers is done in gfx::Device::present. To swap multi-systemwindows, multiple gfx swapchains need be created, and relevant gfx backend will iterate each swapchain and present them. Therefore, `swap buffers` operation doesn't need to be in SystemWindow or SystemWindowManager.

```c++
void GLES3Device::present() {
    CC_PROFILE(GLES3DevicePresent);
    auto *queue = static_cast<GLES3Queue *>(_queue);
    _numDrawCalls = queue->_numDrawCalls;
    _numInstances = queue->_numInstances;
    _numTriangles = queue->_numTriangles;

    bool isGFXDeviceNeedsPresent = _xr ? _xr->isGFXDeviceNeedsPresent(_api) : true;
    for (auto *swapchain : _swapchains) { // We iterate each swapchain and do the present thing here.
        if (isGFXDeviceNeedsPresent) _gpuContext->present(swapchain);
    }
    if (_xr) _xr->postGFXDevicePresent(_api);

    // Clear queue stats
    queue->_numDrawCalls = 0;
    queue->_numInstances = 0;
    queue->_numTriangles = 0;
}
```

Besides, `SDL_GL_SwapWindow` invocation is doing nothing on Windows & Linux platforms, it will generate an SDL an error that `The specified window isn't an OpenGL window` because GL context is not created by SDL_GL_CreateContext. We create contexts in our gfx code.

https://github.com/libsdl-org/SDL/blob/main/src/video/SDL_video.c#L4192

```c++

#define NOT_AN_OPENGL_WINDOW "The specified window isn't an OpenGL window"
int
SDL_GL_SwapWindowWithResult(SDL_Window * window)
{
    CHECK_WINDOW_MAGIC(window, -1);

    if (!(window->flags & SDL_WINDOW_OPENGL)) {
        return SDL_SetError(NOT_AN_OPENGL_WINDOW);
    }

    if (SDL_GL_GetCurrentWindow() != window) {
        return SDL_SetError("The specified window has not been made current");
    }

    return _this->GL_SwapWindow(_this, window);
}

void
SDL_GL_SwapWindow(SDL_Window * window)
{
    SDL_GL_SwapWindowWithResult(window);
}
```

Also, SDL_GL_SwapWindow could not take any effect if running on gfx Vulkan backend.

```c++
void SDLHelper::swapWindow(SDL_Window *window) {
    SDL_GL_SwapWindow(window);
}
```

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
