### PR TITLE
Animation graph: fix empty to empty transition

### DIFF
--- a/cocos/animation/marionette/graph-eval.ts
+++ b/cocos/animation/marionette/graph-eval.ts
@@ -715,8 +715,16 @@ class LayerEval {
             _toWeight: toWeight,
         } = this;
         if (currentNode.kind === NodeKind.empty) {
-            this.passthroughWeight = toWeight;
+            // If current state is empty:
+            // - if there is no transition, the passthrough weight is 0.0, means this layer has no effect.
+            // - otherwise,
+            //   - if the destination is also empty state, it's as if no transition.
+            //   - otherwise, asserts the destination to be motion state;
+            //     the passthrough weight is set to the transition rate,
+            //     the motion state is sampled with full weight.
+            this.passthroughWeight = 0.0;
             if (currentTransitionToNode && currentTransitionToNode.kind === NodeKind.animation) {
+                this.passthroughWeight = toWeight;
                 currentTransitionToNode.sampleToPort(1.0);
             }
         } else if (currentTransitionToNode && currentTransitionToNode.kind === NodeKind.empty) {

--- a/tests/animation/__snapshots__/newgenanim.test.ts.snap
+++ b/tests/animation/__snapshots__/newgenanim.test.ts.snap
@@ -44,3 +44,5 @@ Object {
   "1_2": 0.7200000000000001,
 }
 `;
+
+exports[`NewGen Anim Transitions Empty->Empty transition: Expected result 1`] = `0.7`;


### PR DESCRIPTION
Re: #

### Changelog

* Fixes the behavior of empty->empty transition in an animation graph layer.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
