### PR TITLE
Do not support blob in native

### DIFF
--- a/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
+++ b/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
@@ -866,8 +866,7 @@ static bool XMLHttpRequest_getResponse(se::State &s) { //NOLINT(readability-iden
                 }
             } else if (xhr->getResponseType() == XMLHttpRequest::ResponseType::BLOB) {
                 SE_PRECONDITION2(false, false, "Don't support blob response type");
-            } 
-            else {
+            } else {
                 SE_PRECONDITION2(false, false, "Invalid response type");
             }
         }

--- a/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
+++ b/native/cocos/bindings/manual/jsb_xmlhttprequest.cpp
@@ -864,7 +864,10 @@ static bool XMLHttpRequest_getResponse(se::State &s) { //NOLINT(readability-iden
                 } else {
                     s.rval().setNull();
                 }
-            } else {
+            } else if (xhr->getResponseType() == XMLHttpRequest::ResponseType::BLOB) {
+                SE_PRECONDITION2(false, false, "Don't support blob response type");
+            } 
+            else {
                 SE_PRECONDITION2(false, false, "Invalid response type");
             }
         }

--- a/platforms/native/builtin/jsb-adapter/fetch.js
+++ b/platforms/native/builtin/jsb-adapter/fetch.js
@@ -2,17 +2,7 @@ var self = window;
 var support = {
   searchParams: 'URLSearchParams' in self,
   iterable: 'Symbol' in self && 'iterator' in Symbol,
-  blob:
-    'FileReader' in self &&
-    'Blob' in self &&
-    (function() {
-      try {
-        new Blob()
-        return true
-      } catch (e) {
-        return false
-      }
-    })(),
+  blob: false, // do not support blob in native
   formData: 'FormData' in self,
   arrayBuffer: 'ArrayBuffer' in self
 }


### PR DESCRIPTION
https://github.com/cocos/cocos-engine/pull/12884
https://github.com/cocos/3d-tasks/issues/14384
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
