### PR TITLE
Optimize Node.invalidateChildren function

### DIFF
--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -603,18 +603,16 @@ export class Node extends BaseNode implements CustomSerializable {
 
         while (i >= 0) {
             cur = dirtyNodes[i--];
-            if (cur._flagChangeVersion !== globalFlagChangeVersion || (cur._dirtyFlags & cur._hasChangedFlags & dirtyBit) !== dirtyBit) {
-                if (cur.isValid) {
-                    cur._dirtyFlags |= dirtyBit;
+            if ((cur._flagChangeVersion !== globalFlagChangeVersion || (cur._dirtyFlags & cur._hasChangedFlags & dirtyBit) !== dirtyBit) && cur.isValid) {
+                cur._dirtyFlags |= dirtyBit;
 
-                    cur._flagChangeVersion = globalFlagChangeVersion;
-                    cur._hasChangedFlags |= dirtyBit;
+                cur._flagChangeVersion = globalFlagChangeVersion;
+                cur._hasChangedFlags |= dirtyBit;
 
-                    children = cur._children;
-                    l = children.length;
-                    for (j = 0; j < l; ++j) {
-                        dirtyNodes[++i] = children[j];
-                    }
+                children = cur._children;
+                l = children.length;
+                for (j = 0; j < l; ++j) {
+                    dirtyNodes[++i] = children[j];
                 }
             }
             dirtyBit = childDirtyBit;

--- a/cocos/core/scene-graph/node.ts
+++ b/cocos/core/scene-graph/node.ts
@@ -596,24 +596,25 @@ export class Node extends BaseNode implements CustomSerializable {
         let j = 0;
         let l = 0;
         let cur: this;
-        let children:this[];
-        let hasChangedFlags = 0;
+        let children: this[];
         const childDirtyBit = dirtyBit | TransformBit.POSITION;
 
         dirtyNodes[0] = this;
 
         while (i >= 0) {
             cur = dirtyNodes[i--];
-            hasChangedFlags = cur.hasChangedFlags;
-            if (cur.isValid && (cur._dirtyFlags & hasChangedFlags & dirtyBit) !== dirtyBit) {
-                cur._dirtyFlags |= dirtyBit;
+            if (cur._flagChangeVersion !== globalFlagChangeVersion || (cur._dirtyFlags & cur._hasChangedFlags & dirtyBit) !== dirtyBit) {
+                if (cur.isValid) {
+                    cur._dirtyFlags |= dirtyBit;
 
-                cur.hasChangedFlags = hasChangedFlags | dirtyBit;
+                    cur._flagChangeVersion = globalFlagChangeVersion;
+                    cur._hasChangedFlags |= dirtyBit;
 
-                children = cur._children;
-                l = children.length;
-                for (j = 0; j < l; j++) {
-                    dirtyNodes[++i] = children[j];
+                    children = cur._children;
+                    l = children.length;
+                    for (j = 0; j < l; ++j) {
+                        dirtyNodes[++i] = children[j];
+                    }
                 }
             }
             dirtyBit = childDirtyBit;


### PR DESCRIPTION
Remove the getter & setter from Node.invalidateChildren function. And optimize the conditions checking.

1. Remove the getter & setter to avoid function calls.
2. The cur.hasChangedFlags (cur._flagChangeVersion !== globalFlagChangeVersion returns 0) is zero in most of the time. Zero AND other flags always is zero, it !== dirtyBit. So this condition passes in most of the time. It can check cur._flagChangeVersion !== globalFlagChangeVersion (= 0) first, if fail, recheck the flags.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
