### PR TITLE
feat: add function to clear measureCache.

### DIFF
--- a/cocos2d/core/utils/text-utils.js
+++ b/cocos2d/core/utils/text-utils.js
@@ -160,6 +160,10 @@ var textUtils = {
         return ((ch >= 9 && ch <= 13) || ch === 32 || ch === 133 || ch === 160 || ch === 5760 || (ch >= 8192 && ch <= 8202) || ch === 8232 || ch === 8233 || ch === 8239 || ch === 8287 || ch === 12288);
     },
 
+    clearMeasureCache: function() {
+        measureCache.clear();
+    },
+
     safeMeasureText: function (ctx, string, desc) {
         let font = desc || ctx.font;
         let key = font + "\uD83C\uDFAE" + string;


### PR DESCRIPTION
when custom ttf font download timeout, but on web platform this custom font still downloading, then it download finished,  we want use it replace system font, before richtext._updateRichTextStatus should clear measureCache.