### PR TITLE
[Optimize] Some of the data in the build template does not need to be…

### DIFF
--- a/editor/assets/default_prefab/3d/Capsule.prefab
+++ b/editor/assets/default_prefab/3d/Capsule.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@801ec"
     },
-    "_shadowCastingMode": 0,
     "_receiveShadows": false,
     "_id": "",
     "__prefab": {

--- a/editor/assets/default_prefab/3d/Capsule.prefab
+++ b/editor/assets/default_prefab/3d/Capsule.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@801ec"
     },
-    "_receiveShadows": false,
     "_id": "",
     "__prefab": {
       "__id__": 3

--- a/editor/assets/default_prefab/3d/Cone.prefab
+++ b/editor/assets/default_prefab/3d/Cone.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@38fd2"
     },
-    "_shadowCastingMode": 0,
     "_receiveShadows": false,
     "_id": "",
     "__prefab": {

--- a/editor/assets/default_prefab/3d/Cone.prefab
+++ b/editor/assets/default_prefab/3d/Cone.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@38fd2"
     },
-    "_receiveShadows": false,
     "_id": "",
     "__prefab": {
       "__id__": 3

--- a/editor/assets/default_prefab/3d/Cube.prefab
+++ b/editor/assets/default_prefab/3d/Cube.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a"
     },
-    "_receiveShadows": false,
     "_id": "",
     "__prefab": {
       "__id__": 3

--- a/editor/assets/default_prefab/3d/Cube.prefab
+++ b/editor/assets/default_prefab/3d/Cube.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a"
     },
-    "_shadowCastingMode": 0,
     "_receiveShadows": false,
     "_id": "",
     "__prefab": {

--- a/editor/assets/default_prefab/3d/Cylinder.prefab
+++ b/editor/assets/default_prefab/3d/Cylinder.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@8abdc"
     },
-    "_shadowCastingMode": 0,
     "_receiveShadows": false,
     "_id": "",
     "__prefab": {

--- a/editor/assets/default_prefab/3d/Cylinder.prefab
+++ b/editor/assets/default_prefab/3d/Cylinder.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@8abdc"
     },
-    "_receiveShadows": false,
     "_id": "",
     "__prefab": {
       "__id__": 3

--- a/editor/assets/default_prefab/3d/Plane.prefab
+++ b/editor/assets/default_prefab/3d/Plane.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@2e76e"
     },
-    "_receiveShadows": false,
     "_id": "",
     "__prefab": {
       "__id__": 3

--- a/editor/assets/default_prefab/3d/Plane.prefab
+++ b/editor/assets/default_prefab/3d/Plane.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@2e76e"
     },
-    "_shadowCastingMode": 0,
     "_receiveShadows": false,
     "_id": "",
     "__prefab": {

--- a/editor/assets/default_prefab/3d/Quad.prefab
+++ b/editor/assets/default_prefab/3d/Quad.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@fc873"
     },
-    "_shadowCastingMode": 0,
     "_receiveShadows": false,
     "_id": "",
     "__prefab": {

--- a/editor/assets/default_prefab/3d/Quad.prefab
+++ b/editor/assets/default_prefab/3d/Quad.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@fc873"
     },
-    "_receiveShadows": false,
     "_id": "",
     "__prefab": {
       "__id__": 3

--- a/editor/assets/default_prefab/3d/Sphere.prefab
+++ b/editor/assets/default_prefab/3d/Sphere.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@17020"
     },
-    "_shadowCastingMode": 0,
     "_receiveShadows": false,
     "_id": "",
     "__prefab": {

--- a/editor/assets/default_prefab/3d/Sphere.prefab
+++ b/editor/assets/default_prefab/3d/Sphere.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@17020"
     },
-    "_receiveShadows": false,
     "_id": "",
     "__prefab": {
       "__id__": 3

--- a/editor/assets/default_prefab/3d/Torus.prefab
+++ b/editor/assets/default_prefab/3d/Torus.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@40ece"
     },
-    "_shadowCastingMode": 0,
     "_receiveShadows": false,
     "_id": "",
     "__prefab": {

--- a/editor/assets/default_prefab/3d/Torus.prefab
+++ b/editor/assets/default_prefab/3d/Torus.prefab
@@ -71,7 +71,6 @@
     "_mesh": {
       "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@40ece"
     },
-    "_receiveShadows": false,
     "_id": "",
     "__prefab": {
       "__id__": 3


### PR DESCRIPTION
… saved

Re: #

### Changelog

* Because some of the data in the template needs to be dynamically modified at run time, if serialized data is recorded, each class cannot control the default value of the data itself
* https://github.com/cocos/3d-tasks/issues/14043

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
