### PR TITLE
V3.7 children all hidden in a group, the group also hidden

### DIFF
--- a/editor/inspector/components/class.js
+++ b/editor/inspector/components/class.js
@@ -51,6 +51,17 @@ exports.methods = {
         });
         return $group;
     },
+    toggleGroups($groups) {
+        for (const key in $groups) {
+            const $props = Array.from($groups[key].querySelectorAll('.tab-content > ui-prop'));
+            const show = $props.some($prop => getComputedStyle($prop).display !== 'none');
+            if (show) {
+                $groups[key].removeAttribute('hidden');
+            } else {
+                $groups[key].setAttribute('hidden', '');
+            }
+        }
+    },
     appendToTabGroup($group, tabName) {
         if ($group.tabs[tabName]) {
             return;
@@ -163,6 +174,8 @@ async function update(dump) {
             }
         }
     }
+
+    $panel.toggleGroups($panel.$groups);
 }
 exports.update = update;
 async function ready() {

--- a/editor/inspector/utils/prop.js
+++ b/editor/inspector/utils/prop.js
@@ -289,6 +289,8 @@ exports.updatePropByDump = function(panel, dump) {
             element.update.call(panel, panel.$[key], dump.value);
         }
     }
+
+    exports.toggleGroups(panel.$groups);
 };
 
 /**
@@ -388,7 +390,17 @@ exports.createTabGroup = function(dump, panel) {
 
     return $group;
 };
-
+exports.toggleGroups = function($groups) {
+    for (const key in $groups) {
+        const $props = Array.from($groups[key].querySelectorAll('.tab-content > ui-prop'));
+        const show = $props.some($prop => getComputedStyle($prop).display !== 'none');
+        if (show) {
+            $groups[key].removeAttribute('hidden');
+        } else {
+            $groups[key].setAttribute('hidden', '');
+        }
+    }
+},
 exports.appendToTabGroup = function($group, tabName) {
     if ($group.tabs[tabName]) {
         return;


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/14040

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
