### PR TITLE
Fix the problem that when music is played with AudioSource and suddenly quit, it is still playing

### DIFF
--- a/cocos/audio/audio-source.ts
+++ b/cocos/audio/audio-source.ts
@@ -106,7 +106,6 @@ export class AudioSource extends Component {
     }
     private _syncPlayer () {
         const clip = this._clip;
-        this._isLoaded = false;
         if (this._lastSetClip === clip) {
             return;
         }
@@ -119,6 +118,10 @@ export class AudioSource extends Component {
             console.error('Invalid audio clip');
             return;
         }
+        // The state of _isloaded cannot be modified if clip is the wrong argument.
+        // Because load is an asynchronous function, if it is called multiple times with the same arguments.
+        // It may cause an illegal state change
+        this._isLoaded = false;
         this._lastSetClip = clip;
         this._operationsBeforeLoading.length = 0;
         AudioPlayer.load(clip._nativeAsset.url, {


### PR DESCRIPTION
* Fix the problem that when music is played with AudioSource and suddenly quit, it is still playing.

* Fix eslint error

Re: #

https://github.com/cocos/cocos-engine/pull/13408
https://github.com/cocos/cocos-engine/issues/12492

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
