### PR TITLE
fix lod's objectSize can not be auto calculated

### DIFF
--- a/cocos/misc/lodgroup-component.ts
+++ b/cocos/misc/lodgroup-component.ts
@@ -33,6 +33,8 @@ import { NodeEventType } from '../scene-graph/node-event';
 
 // Ratio of objects occupying the screen
 const DEFAULT_SCREEN_OCCUPATION: number[] = [0.25, 0.125, 0.0625];
+
+export type ModelAddedCallback = () => void;
 @ccclass('cc.LOD')
 export class LOD {
     // Minimum percentage of screen usage for the current lod in effect, range in [0, 1]
@@ -48,8 +50,14 @@ export class LOD {
      */
     private _LODData: scene.LODData = new scene.LODData();
 
+    /**
+     * @engineInternal
+     */
+    private _modelAddedCallback: ModelAddedCallback | null;
+
     constructor () {
         this._LODData.screenUsagePercentage = this._screenUsagePercentage;
+        this._modelAddedCallback = null;
     }
 
     /**
@@ -78,14 +86,19 @@ export class LOD {
      */
     set renderers (meshList: readonly MeshRenderer[]) {
         if (meshList === this._renderers) return;
+        let modelAdded = false;
         this._renderers.length = 0;
         this._LODData.clearModels();
         for (let i = 0; i < meshList.length; i++) {
             this._renderers[i] = meshList[i];
             const model = meshList[i]?.model;
             if (model) {
+                modelAdded = true;
                 this._LODData.addModel(model);
             }
+        }
+        if (this._modelAddedCallback && modelAdded) {
+            this._modelAddedCallback();
         }
     }
 
@@ -126,6 +139,13 @@ export class LOD {
     get lodData () { return this._LODData; }
 
     /**
+      * @engineInternal
+      */
+    setModelAddedCallback (modelAddedCallback: (() => void)) {
+        this._modelAddedCallback = modelAddedCallback;
+    }
+
+    /**
      * @en Insert a [[MeshRenderer]] before specific index position.
      * @zh 在指定的数组索引处插入一个[[MeshRenderer]]
      * @param index @en The rendering array is indexed from 0. If - 1 is passed, it will be added to the end of the list.
@@ -133,14 +153,19 @@ export class LOD {
      * @param renderer @en The mesh-renderer object. @zh [[MeshRenderer]] 对象
      * @returns @en The inserted [[MeshRenderer]] @zh 返回被插入的 [[MeshRenderer]] 对象
      */
-    insertRenderer (index: number, renderer: MeshRenderer): MeshRenderer {
+    public insertRenderer (index: number, renderer: MeshRenderer): MeshRenderer {
         // make sure insert at the tail of the list.
         if (index < 0 || index > this._renderers.length) {
             index = this._renderers.length;
         }
         this._renderers.splice(index, 0, renderer);
+        let modelAdded = false;
         if (renderer.model) {
+            modelAdded = true;
             this._LODData.addModel(renderer.model);
+        }
+        if (this._modelAddedCallback && modelAdded) {
+            this._modelAddedCallback();
         }
         return renderer;
     }
@@ -276,6 +301,7 @@ export class LODGroup extends Component {
         valArray.forEach((lod: LOD, index: number) => {
             this.lodGroup.insertLOD(index, lod.lodData);
             this._LODs[index] = lod;
+            lod.setModelAddedCallback(this.onLodModelAddedCallback.bind(this));
         });
     }
 
@@ -283,6 +309,12 @@ export class LODGroup extends Component {
      * @engineInternal
      */
     get lodGroup () { return this._lodGroup; }
+
+    private onLodModelAddedCallback () {
+        if (this.objectSize === 0) {
+            this.recalculateBounds();
+        }
+    }
 
     /**
      * @en Insert the [[LOD]] at specific index position, [[LOD]] will be inserted to the last position if index less than 0 or greater than lodCount.
@@ -301,6 +333,7 @@ export class LODGroup extends Component {
         if (!lod) {
             lod = new LOD();
         }
+        lod.setModelAddedCallback(this.onLodModelAddedCallback.bind(this));
         if (!screenUsagePercentage) {
             const preLod = this.getLOD(index - 1);
             const nextLod = this.getLOD(index);
@@ -372,6 +405,7 @@ export class LODGroup extends Component {
             return;
         }
         this._LODs[index] = lod;
+        lod.setModelAddedCallback(this.onLodModelAddedCallback.bind(this));
         this.lodGroup.updateLOD(index, lod.lodData);
     }
 
@@ -455,6 +489,10 @@ export class LODGroup extends Component {
             // Save the result
             this.localBoundaryCenter = c;
             this.objectSize = Math.max(e.x, e.y, e.z) * 2.0;
+        } else {
+            // No model exists, reset to default value
+            this.localBoundaryCenter = new Vec3(0, 0, 0);
+            this.objectSize = 0;
         }
         this._emitChangeNode(this.node);
     }

--- a/cocos/misc/lodgroup-component.ts
+++ b/cocos/misc/lodgroup-component.ts
@@ -141,8 +141,8 @@ export class LOD {
     /**
       * @engineInternal
       */
-    setModelAddedCallback (modelAddedCallback: (() => void)) {
-        this._modelAddedCallback = modelAddedCallback;
+    set modelAddedCallback (callback: ModelAddedCallback) {
+        this._modelAddedCallback = callback;
     }
 
     /**
@@ -301,7 +301,7 @@ export class LODGroup extends Component {
         valArray.forEach((lod: LOD, index: number) => {
             this.lodGroup.insertLOD(index, lod.lodData);
             this._LODs[index] = lod;
-            lod.setModelAddedCallback(this.onLodModelAddedCallback.bind(this));
+            lod.modelAddedCallback = this.onLodModelAddedCallback;
         });
     }
 
@@ -333,7 +333,7 @@ export class LODGroup extends Component {
         if (!lod) {
             lod = new LOD();
         }
-        lod.setModelAddedCallback(this.onLodModelAddedCallback.bind(this));
+        lod.modelAddedCallback = this.onLodModelAddedCallback;
         if (!screenUsagePercentage) {
             const preLod = this.getLOD(index - 1);
             const nextLod = this.getLOD(index);
@@ -405,7 +405,7 @@ export class LODGroup extends Component {
             return;
         }
         this._LODs[index] = lod;
-        lod.setModelAddedCallback(this.onLodModelAddedCallback.bind(this));
+        lod.modelAddedCallback = this.onLodModelAddedCallback;
         this.lodGroup.updateLOD(index, lod.lodData);
     }
 

--- a/cocos/misc/lodgroup-component.ts
+++ b/cocos/misc/lodgroup-component.ts
@@ -301,7 +301,7 @@ export class LODGroup extends Component {
         valArray.forEach((lod: LOD, index: number) => {
             this.lodGroup.insertLOD(index, lod.lodData);
             this._LODs[index] = lod;
-            lod.modelAddedCallback = this.onLodModelAddedCallback;
+            lod.modelAddedCallback = this.onLodModelAddedCallback.bind(this);
         });
     }
 
@@ -333,7 +333,7 @@ export class LODGroup extends Component {
         if (!lod) {
             lod = new LOD();
         }
-        lod.modelAddedCallback = this.onLodModelAddedCallback;
+        lod.modelAddedCallback = this.onLodModelAddedCallback.bind(this);
         if (!screenUsagePercentage) {
             const preLod = this.getLOD(index - 1);
             const nextLod = this.getLOD(index);
@@ -405,7 +405,7 @@ export class LODGroup extends Component {
             return;
         }
         this._LODs[index] = lod;
-        lod.modelAddedCallback = this.onLodModelAddedCallback;
+        lod.modelAddedCallback = this.onLodModelAddedCallback.bind(this);
         this.lodGroup.updateLOD(index, lod.lodData);
     }
 


### PR DESCRIPTION
(cherry picked from commit 319da00ffd58e6a0847904d70cb2661a0b31ec22)

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
