### PR TITLE
generate cocos-version.h

### DIFF
--- a/.github/workflows/native-bindings.yml
+++ b/.github/workflows/native-bindings.yml
@@ -6,6 +6,7 @@ on:
     paths:
     - 'templates/**'
     - 'native/**'
+    - 'package.json'
 
 jobs:
   generate-jsb:
@@ -18,24 +19,20 @@ jobs:
           EXT_VERSION=`node ./.github/workflows/get-native-external-version.js`
           git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos/cocos-engine-external native/external
           rm -rf native/external/.git
-      - uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        with:
-          ndk-version: r21e
-          add-to-path: false
       - name: Generate Bindings
         run: |
           cd ./native/tools/swig-config
           node genbindings.js
           git status
-      - name: Update builtin-res 
-        env:
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+      - name: Update auto-gen source files 
         run: |
           cd native
           npm install -g typescript
           sh utils/generate_compile_commands_android.sh
+          echo "Generating DebugInfos ... "
           cmake --build ./build --target builtin-res
+          echo "Generating cocos-version.h ... "
+          node ./cmake/scripts/engine-version.js
 
       - name: Create Pull Request 
         uses: fish9167/create-pull-request@v3

--- a/native/cmake/scripts/engine-version.js
+++ b/native/cmake/scripts/engine-version.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const path = require('path');
+
+
+const pkgCfg = path.join(__dirname, '../../../package.json');
+
+if (!fs.existsSync(pkgCfg)) {
+    console.error(`Can not find package.json: ${pkgCfg}`);
+    process.exit(1);
+}
+
+let pkgJson = {};
+try {
+    pkgJson = JSON.parse(fs.readFileSync(pkgCfg, 'utf8'));
+} catch (err) {
+    console.error(`Error parsing ${pkgCfg}`);
+    console.error(err);
+    process.exit(1);
+}
+
+if (!pkgJson.version) {
+    console.error(`Can not find field 'version' in file ${pkgCfg}`);
+    process.exit(1);
+}
+
+const version_regex = /(\d+)\.(\d+)(\.(\d+))?(-(\w+))?/;
+const version_str = pkgJson.version;
+const version_result = version_str.match(version_regex);
+
+if (!version_result) {
+    console.error(`Failed to parse version string: '${version_str}'`);
+    process.exit(1);
+}
+const majorVersion = parseInt(version_result[1]);
+const minorVersion = parseInt(version_result[2]);
+const patchVersion = version_result[4] ? parseInt(version_result[4]) : 0;
+const preRelease = version_result[6] ? version_result[6] : 'release';
+const versionIntValue = majorVersion * 10000 + minorVersion * 100 + patchVersion;
+const version_header = `/****************************************************************************
+ Copyright (c) 2022 Xiamen Yaji Software Co., Ltd.
+
+ http://www.cocos.com
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated engine source code (the "Software"), a limited,
+ worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+ to use Cocos Creator solely to develop games on your target platforms. You shall
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
+
+ The software or tools in this License Agreement are licensed, not sold.
+ Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+****************************************************************************/
+#pragma once
+
+#define COCOS_MAJOR_VERSION     ${majorVersion}
+#define COCOS_MINJOR_VERSION    ${minorVersion}
+#define COCOS_PATCH_VERSION     ${patchVersion}
+#define COCOS_VERSION_STRING    "${majorVersion}.${minorVersion}.${patchVersion}"
+#define COCOS_VERSION_DEFINED   1
+#define COCOS_VERSION           ${versionIntValue}
+
+// #define COCOS_PRE_RELEASE       "${preRelease}"
+`;
+
+const outputVersionFile = path.join(__dirname, '../../cocos/cocos-version.h');
+
+if(!fs.existsSync(outputVersionFile) || !compareFileContent(outputVersionFile, version_header)) {
+    console.log(`Update cocos-version.h to ${version_str}`);
+    fs.writeFileSync(outputVersionFile, version_header);   
+} else {
+    console.log(`cocos-version.h is up to date`);
+}
+
+function compareFileContent(file, content) {
+    const srcLines = fs.readFileSync(file, 'utf8').split('\n').map(x=>x.trim());
+    const dstLines = content.split('\n').map(x => x.trim());
+    if(srcLines.length !== dstLines.length) {
+        return false;
+    }
+    for(let i = 0, l = srcLines.length; i < l; i++) {
+        if(srcLines[i] != dstLines[i]) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/native/cocos/cocos-version.h
+++ b/native/cocos/cocos-version.h
@@ -22,17 +22,13 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
 ****************************************************************************/
-
 #pragma once
 
-// public headers for user application
+#define COCOS_MAJOR_VERSION     3
+#define COCOS_MINJOR_VERSION    7
+#define COCOS_PATCH_VERSION     0
+#define COCOS_VERSION_STRING    "3.7.0"
+#define COCOS_VERSION_DEFINED   1
+#define COCOS_VERSION           30700
 
-#include "cocos-version.h"
-#include "application/ApplicationManager.h"
-#include "application/BaseGame.h"
-#include "bindings/event/EventDispatcher.h"
-#include "bindings/jswrapper/SeApi.h"
-#include "bindings/manual/jsb_classtype.h"
-#include "bindings/manual/jsb_global.h"
-#include "bindings/manual/jsb_module_register.h"
-#include "core/event/Event.h"
+// #define COCOS_PRE_RELEASE       "release"


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/12851

### Changelog

* generate cocos-version.h in CI

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
