### PR TITLE
[lod]fix select multi lod to update multi screen size error

### DIFF
--- a/editor/inspector/components/lod-group/multi-lod-group.js
+++ b/editor/inspector/components/lod-group/multi-lod-group.js
@@ -62,14 +62,17 @@ exports.methods = {
         if (that.dump.value) {
             that.multiObjectSizeInvalid = that.dump.value.objectSize.values.some((val) => val !== that.dump.value.objectSize.values[0]);
             const multiLodGroups = that.dump.value.LODs.values;
-            that.multiLen = multiLodGroups.reduce((pre, next) => {
-                return pre.length < next.length ? pre.length : next.length;
-            });
+            that.multiLen = multiLodGroups.reduce((pre, current) => {
+                return pre < current.length ? pre : current.length;
+            }, multiLodGroups[0].length);
             const multiLods = [];
             for (let i = 0; i < that.multiLen; i++) {
                 let multiScreenSizeInvalid = false;
                 for (let j = 1; j < multiLodGroups.length; j++) {
-                    if (multiLodGroups[j][i].value.screenUsagePercentage.value !== multiLodGroups[0][i].value.screenUsagePercentage.value) {
+                    if (
+                        !multiLodGroups[0][i] || !multiLodGroups[j][i] ||
+                        multiLodGroups[j][i].value.screenUsagePercentage.value !== multiLodGroups[0][i].value.screenUsagePercentage.value
+                    ) {
                         multiScreenSizeInvalid = true;
                         break;
                     }
@@ -88,7 +91,7 @@ exports.methods = {
     onMultiScreenSizeConfirm(event, index) {
         const that = this;
         that.dump.value.LODs.values.forEach((lod) => {
-            lod[index].value.screenUsagePercentage.value = event.target.value / 100;
+            lod[index] && (lod[index].value.screenUsagePercentage.value = event.target.value / 100);
         });
         that.updateDump(that.dump.value.LODs);
     },


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/14531

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
