### PR TITLE
fix ar add image parameter's name errror

### DIFF
--- a/native/cocos/xr/ar/ARLib.h
+++ b/native/cocos/xr/ar/ARLib.h
@@ -94,7 +94,7 @@ public:
     // image recognition & tracking
     void enableImageTracking(bool enable) override;
     void addImageToLib(const std::string& imageName) override;
-    void addImageToLibWithSize(const std::string& name, float withInMeters) override;
+    void addImageToLibWithSize(const std::string& name, float widthInMeters) override;
     void setImageMaxTrackingNumber(int number) override;
     float* getAddedImagesInfo() override;
     float* getUpdatedImagesInfo() override;

--- a/native/cocos/xr/ar/ARModule.cpp
+++ b/native/cocos/xr/ar/ARModule.cpp
@@ -236,8 +236,8 @@ void ARModule::addImageToLib(const std::string& imageName) const {
     _impl->addImageToLib(imageName);
 }
 
-void ARModule::addImageToLibWithSize(const std::string& imageName, float withInMeters) const {
-    _impl->addImageToLibWithSize(imageName, withInMeters);
+void ARModule::addImageToLibWithSize(const std::string& imageName, float widthInMeters) const {
+    _impl->addImageToLibWithSize(imageName, widthInMeters);
 }
 
 void ARModule::setImageMaxTrackingNumber(int number) const {

--- a/native/cocos/xr/ar/ARModule.h
+++ b/native/cocos/xr/ar/ARModule.h
@@ -97,7 +97,7 @@ public:
     // image recognition & tracking
     void enableImageTracking(bool enable) const;
     void addImageToLib(const std::string& name) const;
-    void addImageToLibWithSize(const std::string& name, float withInMeters) const;
+    void addImageToLibWithSize(const std::string& name, float widthInMeters) const;
     void setImageMaxTrackingNumber(int number) const;
     float* getAddedImagesInfo() const;
     float* getUpdatedImagesInfo() const;

--- a/native/cocos/xr/ar/IARAPI.h
+++ b/native/cocos/xr/ar/IARAPI.h
@@ -95,7 +95,7 @@ public:
     // image recognition & tracking
     virtual void enableImageTracking(bool enable) = 0;
     virtual void addImageToLib(const std::string& name) = 0;
-    virtual void addImageToLibWithSize(const std::string& name, float withInMeters) = 0;
+    virtual void addImageToLibWithSize(const std::string& name, float widthInMeters) = 0;
     virtual void setImageMaxTrackingNumber(int number) = 0;
     virtual float* getAddedImagesInfo() = 0;
     virtual float* getUpdatedImagesInfo() = 0;


### PR DESCRIPTION
Re: #

### Changelog

* fix addImageToLibWithSize parameter's name
withInMeters -> widthInMeters

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
