### PR TITLE
fix videoPlayer display incorrectly in specific devices

### DIFF
--- a/native/cocos/ui/videoplayer/VideoPlayer-ios.mm
+++ b/native/cocos/ui/videoplayer/VideoPlayer-ios.mm
@@ -25,10 +25,8 @@
 ****************************************************************************/
 
 #include "VideoPlayer.h"
-
 using namespace cc;
 
-// No Available on tvOS
 #if CC_PLATFORM == CC_PLATFORM_IOS
 
 //-------------------------------------------------------------------------------------
@@ -279,8 +277,8 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 }
 
 - (void)addPlayerControllerSubView {
-    auto eaglview = UIApplication.sharedApplication.delegate.window.rootViewController.view;
-    [eaglview addSubview:self.playerController.view];
+    auto rootView = UIApplication.sharedApplication.delegate.window.rootViewController.view;
+    [rootView addSubview:self.playerController.view];
 }
 
 @end
@@ -408,8 +406,7 @@ void VideoPlayer::onPlayEvent(int event) {
 }
 
 void VideoPlayer::setFrame(float x, float y, float width, float height) {
-    auto eaglview = UIApplication.sharedApplication.delegate.window.rootViewController.view;
-    auto scaleFactor = [eaglview contentScaleFactor];
+    auto scaleFactor = [[UIScreen mainScreen] nativeScale];
     [((UIVideoViewWrapperIos *)_videoView) setFrame:x / scaleFactor:y / scaleFactor:width / scaleFactor:height / scaleFactor];
 }
 


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/13470

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
