### PR TITLE
apply sequence id for log-remote

### DIFF
--- a/native/cocos/base/LogRemote.cpp
+++ b/native/cocos/base/LogRemote.cpp
@@ -74,13 +74,16 @@ enum class UdpLogClientState {
     OK,
     DONE, // FAILED
 };
+
+uint64_t logId = 0;
+
 /**
 * Parse auto-test-config.json to get ServerConfig.IP & ServerConfig.PORT
 * Logs will be formated with 5 fields
 * 1. testId
 * 2. clientId
 * 3. bootId,  the boot timestamp
-* 4. milliseconds since boot
+* 4. sequence number of the message
 * 5. log content
 *
 * These parts are joined with '\n'.
@@ -103,14 +106,11 @@ public:
         if (_status == UdpLogClientState::DONE) {
             return;
         }
-        auto timeNow = std::chrono::duration_cast<std::chrono::milliseconds>(
-                           std::chrono::system_clock::now().time_since_epoch())
-                           .count();
         std::stringstream ss;
         ss << _testID << std::endl
            << _clientID << std::endl
            << _bootID << std::endl
-           << (timeNow - _bootID) << std::endl
+           << ++logId << std::endl
            << msg;
         sendLog(ss.str());
     }


### PR DESCRIPTION
Re: #

### Changelog

* Remote log: Change timestamp to sequence id

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
