### PR TITLE
Fix the problem that the simulator initializes Fileutils twice and causes leakage.

### DIFF
--- a/native/cocos/platform/apple/FileUtils-apple.mm
+++ b/native/cocos/platform/apple/FileUtils-apple.mm
@@ -179,7 +179,13 @@ static void addCCValueToNSDictionary(const ccstd::string &key, const Value &valu
 }
 
 FileUtils *createFileUtils() {
-    return ccnew FileUtilsApple();
+    // TODO(qgh):In the simulator, it will be called twice. So the judgment here is to prevent memory leaks.
+    // But this is equivalent to using a singleton pattern,
+    // which is not consistent with the current design and will be optimized later.
+    if (!FileUtils::getInstance()) {
+        return ccnew FileUtilsApple();
+    }
+    return FileUtils::getInstance();
 }
 
 FileUtilsApple::FileUtilsApple() : pimpl_(ccnew IMPL([NSBundle mainBundle])) {

--- a/native/cocos/platform/win32/FileUtils-win32.cpp
+++ b/native/cocos/platform/win32/FileUtils-win32.cpp
@@ -73,7 +73,13 @@ static void _checkPath() {
 }
 
 FileUtils *createFileUtils() {
-    return ccnew FileUtilsWin32();
+    // TODO(qgh):In the simulator, it will be called twice. So the judgment here is to prevent memory leaks.
+    // But this is equivalent to using a singleton pattern,
+    // which is not consistent with the current design and will be optimized later.
+    if (!FileUtils::getInstance()) {
+        return ccnew FileUtilsWin32();
+    }
+    return FileUtils::getInstance();
 }
 
 FileUtilsWin32::FileUtilsWin32() {


### PR DESCRIPTION


Re: #

### Changelog

Fix the problem that the simulator initializes Fileutils twice and causes leakage.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
