### PR TITLE
Update particle-system.ts and improve particle-system's performance

### DIFF
--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -1388,11 +1388,14 @@ export class ParticleSystem extends ModelRenderer {
                 this.emit(emitNum, dt);
             }
 
-            // emit by rateOverDistance
-            this.node.getWorldPosition(this._curWPos);
-            const distance = Vec3.distance(this._curWPos, this._oldWPos);
-            Vec3.copy(this._oldWPos, this._curWPos);
-            this._emitRateDistanceCounter += distance * this.rateOverDistance.evaluate(this._time / this.duration, 1)!;
+             // emit by rateOverDistance
+             const rateOverDistance = this.rateOverDistance.evaluate(this._time / this.duration, 1)!;
+             if (rateOverDistance > 0) {
+                 Vec3.copy(this._oldWPos, this._curWPos);
+                 this.node.getWorldPosition(this._curWPos);
+                 const distance = Vec3.distance(this._curWPos, this._oldWPos);
+                 this._emitRateDistanceCounter += distance * rateOverDistance;
+             }
 
             if (this._emitRateDistanceCounter > 1) {
                 const emitNum = Math.floor(this._emitRateDistanceCounter);


### PR DESCRIPTION
Even if the rateOverDistance is 0, it will still get the world position and calculate the distance, which is waste. To improve the performance, only if the rateOverDistance is above 0, it would get the world position and calculate the distance

Re: #

### Changelog

* optimize particle-system's performance by reducing distance calculation

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
