### PR TITLE
Bugfix: call debug::errorID with uint data type

### DIFF
--- a/native/cocos/core/builtin/DebugInfos.cpp
+++ b/native/cocos/core/builtin/DebugInfos.cpp
@@ -28,7 +28,7 @@
 
 namespace cc {
 
-ccstd::unordered_map<int, ccstd::string> debugInfos = {
+ccstd::unordered_map<uint32_t, ccstd::string> debugInfos = {
 { 0100, "%s not yet implemented." },
 { 0200, "You should specify a valid DOM canvas element." },
 { 1006, "[Action step]. override me" },

--- a/native/cocos/core/builtin/DebugInfos.cpp.in
+++ b/native/cocos/core/builtin/DebugInfos.cpp.in
@@ -28,7 +28,7 @@
 
 namespace cc {
 
-ccstd::unordered_map<int, ccstd::string> debugInfos = {
+ccstd::unordered_map<uint32_t, ccstd::string> debugInfos = {
 ${PLACE_HOLDER}
 };
 }//namespace cc

--- a/native/cocos/core/builtin/DebugInfos.h
+++ b/native/cocos/core/builtin/DebugInfos.h
@@ -30,6 +30,6 @@
 
 namespace cc {
 
-extern ccstd::unordered_map<int, ccstd::string> debugInfos;
+extern ccstd::unordered_map<uint32_t, ccstd::string> debugInfos;
 
 }

--- a/native/cocos/core/platform/Debug.cpp
+++ b/native/cocos/core/platform/Debug.cpp
@@ -88,36 +88,44 @@ void printLog(DebugMode mode, const ccstd::string &fmt, ccstd::any *arr, int par
         if (pos != ccstd::string::npos && pos != (msg.length() - 1) && (msg[pos + 1] == 'd' || msg[pos + 1] == 's' || msg[pos + 1] == 'f')) {
             needToReplace = true;
         }
-
-        if (arr[i].type() == typeid(const ccstd::string)) {
+        auto &elemTypeId = arr[i].type();
+        if (elemTypeId == typeid(const ccstd::string)) {
             const ccstd::string s = ccstd::any_cast<const ccstd::string>(arr[i]);
             if (needToReplace) {
                 msg.replace(pos, 2, s);
             } else {
                 msg += " " + s;
             }
-        } else if (arr[i].type() == typeid(ccstd::string)) {
+        } else if (elemTypeId == typeid(ccstd::string)) {
             ccstd::string s = ccstd::any_cast<ccstd::string>(arr[i]);
             if (needToReplace) {
                 msg.replace(pos, 2, s);
             } else {
                 msg += " " + s;
             }
-        } else if (arr[i].type() == typeid(int)) {
+        } else if (elemTypeId == typeid(int)) {
             int value = ccstd::any_cast<int>(arr[i]);
             if (needToReplace) {
                 msg.replace(pos, 2, std::to_string(value));
             } else {
                 msg += " " + std::to_string(value);
             }
-        } else if (arr[i].type() == typeid(float)) {
+        } else if (elemTypeId == typeid(unsigned int)) {
+            auto value = ccstd::any_cast<unsigned int>(arr[i]);
+            if (needToReplace) {
+                msg.replace(pos, 2, std::to_string(value));
+            } else {
+                msg += " " + std::to_string(value);
+            }
+
+        } else if (elemTypeId == typeid(float)) {
             auto value = ccstd::any_cast<float>(arr[i]);
             if (needToReplace) {
                 msg.replace(pos, 2, std::to_string(value));
             } else {
                 msg += " " + std::to_string(value);
             }
-        } else if (arr[i].type() == typeid(const char *)) {
+        } else if (elemTypeId == typeid(const char *)) {
             ccstd::string s = ccstd::any_cast<const char *>(arr[i]);
             if (needToReplace) {
                 msg.replace(pos, 2, s);
@@ -125,7 +133,7 @@ void printLog(DebugMode mode, const ccstd::string &fmt, ccstd::any *arr, int par
                 msg += " " + s;
             }
         } else {
-            CC_LOG_ERROR("unsupport params data type");
+            CC_LOG_ERROR("Debug: unsupport params data type: '%s'", elemTypeId.name());
             return;
         }
     }

--- a/native/cocos/core/platform/Debug.cpp
+++ b/native/cocos/core/platform/Debug.cpp
@@ -88,16 +88,16 @@ void printLog(DebugMode mode, const ccstd::string &fmt, ccstd::any *arr, int par
         if (pos != ccstd::string::npos && pos != (msg.length() - 1) && (msg[pos + 1] == 'd' || msg[pos + 1] == 's' || msg[pos + 1] == 'f')) {
             needToReplace = true;
         }
-        auto &elemTypeId = arr[i].type();
+        const auto &elemTypeId = arr[i].type();
         if (elemTypeId == typeid(const ccstd::string)) {
-            const ccstd::string s = ccstd::any_cast<const ccstd::string>(arr[i]);
+            const auto s = ccstd::any_cast<const ccstd::string>(arr[i]);
             if (needToReplace) {
                 msg.replace(pos, 2, s);
             } else {
                 msg += " " + s;
             }
         } else if (elemTypeId == typeid(ccstd::string)) {
-            ccstd::string s = ccstd::any_cast<ccstd::string>(arr[i]);
+            auto s = ccstd::any_cast<ccstd::string>(arr[i]);
             if (needToReplace) {
                 msg.replace(pos, 2, s);
             } else {
@@ -133,7 +133,8 @@ void printLog(DebugMode mode, const ccstd::string &fmt, ccstd::any *arr, int par
                 msg += " " + s;
             }
         } else {
-            CC_LOG_ERROR("Debug: unsupport params data type: '%s'", elemTypeId.name());
+            CC_LOG_ERROR("DebugInfos: unsupport params data type: '%s'", elemTypeId.name());
+            CC_LOG_ERROR(" fmt: \"%s\", parameter index: %d", fmt.c_str(), i);
             return;
         }
     }
@@ -142,4 +143,4 @@ void printLog(DebugMode mode, const ccstd::string &fmt, ccstd::any *arr, int par
 }
 
 } // namespace debug
-} //namespace cc
+} // namespace cc


### PR DESCRIPTION
Re: #

### Changelog

* debug::errorID should accept uint as format argument

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
