### PR TITLE
[fix] builtin-2d-physics removeShape() slow #12843

### DIFF
--- a/cocos/physics-2d/builtin/builtin-world.ts
+++ b/cocos/physics-2d/builtin/builtin-world.ts
@@ -47,8 +47,6 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
                 if (this.shouldCollide(shape, other)) {
                     const contact = new BuiltinContact(shape, other);
                     this._contacts.push(contact);
-                    if (shape._contacts.indexOf(contact) === -1) { shape._contacts.push(contact); }
-                    if (other._contacts.indexOf(contact) === -1) { other._contacts.push(contact); }
                 }
             }
 
@@ -61,27 +59,15 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
         const index = shapes.indexOf(shape);
         if (index >= 0) {
             fastRemoveAt(shapes, index);
-
-            for (let i = 0; i < shape._contacts.length; i++) {
-                const contact = shape._contacts[i];
-                const cIndex = this._contacts.indexOf(contact);
-                if (cIndex >= 0) {
-                    //remove corresponding contact from another shape
-                    let otherShape;
-                    if (contact.shape1 === shape) {
-                        otherShape = contact.shape2;
-                    } else {
-                        otherShape = contact.shape1;
-                    }
-                    const cIndex1 = otherShape._contacts.indexOf(contact);
-                    if (cIndex1  > 0) {
-                        fastRemoveAt(otherShape._contacts, cIndex1);
-                    }
-
+            const contacts = this._contacts;
+            for (let i = contacts.length - 1; i >= 0; i--) {
+                const contact = contacts[i];
+                if (contact.shape1 === shape || contact.shape2 === shape) {
                     if (contact.touching) {
                         this._emitCollide(contact, Contact2DType.END_CONTACT);
                     }
-                    fastRemoveAt(this._contacts, cIndex);
+
+                    fastRemoveAt(contacts, i);
                 }
             }
         }

--- a/cocos/physics-2d/builtin/builtin-world.ts
+++ b/cocos/physics-2d/builtin/builtin-world.ts
@@ -11,6 +11,7 @@ import { EPhysics2DDrawFlags, Contact2DType, ERaycast2DType, RaycastResult2D } f
 import { PhysicsSystem2D, Collider2D } from '../framework';
 import { BuiltinContact } from './builtin-contact';
 import { legacyCC } from '../../core/global-exports';
+import { fastRemoveAt } from '../../core/utils/array';
 
 const contactResults: BuiltinContact[] = [];
 const testIntersectResults: Collider2D[] = [];
@@ -57,8 +58,7 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
         const shapes = this._shapes;
         const index = shapes.indexOf(shape);
         if (index >= 0) {
-            shapes.splice(index, 1);
-
+            fastRemoveAt(shapes, index);
             const contacts = this._contacts;
             for (let i = contacts.length - 1; i >= 0; i--) {
                 const contact = contacts[i];
@@ -67,7 +67,7 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
                         this._emitCollide(contact, Contact2DType.END_CONTACT);
                     }
 
-                    contacts.splice(i, 1);
+                    fastRemoveAt(contacts, i);
                 }
             }
         }

--- a/cocos/physics-2d/builtin/builtin-world.ts
+++ b/cocos/physics-2d/builtin/builtin-world.ts
@@ -47,6 +47,8 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
                 if (this.shouldCollide(shape, other)) {
                     const contact = new BuiltinContact(shape, other);
                     this._contacts.push(contact);
+                    if (shape._contacts.indexOf(contact) === -1) { shape._contacts.push(contact); }
+                    if (other._contacts.indexOf(contact) === -1) { other._contacts.push(contact); }
                 }
             }
 
@@ -59,15 +61,27 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
         const index = shapes.indexOf(shape);
         if (index >= 0) {
             fastRemoveAt(shapes, index);
-            const contacts = this._contacts;
-            for (let i = contacts.length - 1; i >= 0; i--) {
-                const contact = contacts[i];
-                if (contact.shape1 === shape || contact.shape2 === shape) {
+
+            for (let i = 0; i < shape._contacts.length; i++) {
+                const contact = shape._contacts[i];
+                const cIndex = this._contacts.indexOf(contact);
+                if (cIndex >= 0) {
+                    //remove corresponding contact from another shape
+                    let otherShape;
+                    if (contact.shape1 === shape) {
+                        otherShape = contact.shape2;
+                    } else {
+                        otherShape = contact.shape1;
+                    }
+                    const cIndex1 = otherShape._contacts.indexOf(contact);
+                    if (cIndex1  > 0) {
+                        fastRemoveAt(otherShape._contacts, cIndex1);
+                    }
+
                     if (contact.touching) {
                         this._emitCollide(contact, Contact2DType.END_CONTACT);
                     }
-
-                    fastRemoveAt(contacts, i);
+                    fastRemoveAt(this._contacts, cIndex);
                 }
             }
         }

--- a/cocos/physics-2d/builtin/shapes/shape-2d.ts
+++ b/cocos/physics-2d/builtin/shapes/shape-2d.ts
@@ -2,11 +2,14 @@ import { IBaseShape } from '../../spec/i-physics-shape';
 import { Collider2D, PhysicsSystem2D } from '../../../../exports/physics-2d-framework';
 import { Rect, Vec2 } from '../../../core';
 import { BuiltinPhysicsWorld } from '../builtin-world';
+import { BuiltinContact } from '../builtin-contact';
 
 export class BuiltinShape2D implements IBaseShape {
     protected _collider: Collider2D | null = null;
 
     protected _worldAabb = new Rect();
+    //contacts contain this Shape
+    public _contacts: BuiltinContact[] = [];
 
     get impl () {
         return null;

--- a/cocos/physics-2d/builtin/shapes/shape-2d.ts
+++ b/cocos/physics-2d/builtin/shapes/shape-2d.ts
@@ -2,14 +2,11 @@ import { IBaseShape } from '../../spec/i-physics-shape';
 import { Collider2D, PhysicsSystem2D } from '../../../../exports/physics-2d-framework';
 import { Rect, Vec2 } from '../../../core';
 import { BuiltinPhysicsWorld } from '../builtin-world';
-import { BuiltinContact } from '../builtin-contact';
 
 export class BuiltinShape2D implements IBaseShape {
     protected _collider: Collider2D | null = null;
 
     protected _worldAabb = new Rect();
-    //contacts contain this Shape
-    public _contacts: BuiltinContact[] = [];
 
     get impl () {
         return null;


### PR DESCRIPTION
Re: #12843 
 [#13757](https://github.com/cocos/3d-tasks/issues/13757)
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
