### PR TITLE
fix win32 editbox cannot getCurrentWindow handler

### DIFF
--- a/native/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/native/cocos/ui/edit-box/EditBox-win32.cpp
@@ -28,6 +28,7 @@
 #include "cocos/bindings/jswrapper/SeApi.h"
 #include "cocos/bindings/manual/jsb_global.h"
 #include "cocos/platform/interfaces/modules/ISystemWindow.h"
+#include "cocos/platform/interfaces/modules/ISystemWindowManager.h"
 
 #include <stdlib.h>
 #include <windows.h>
@@ -54,7 +55,7 @@ HWND getCurrentWindowHwnd() {
     if (!CC_CURRENT_APPLICATION()) {
         return nullptr;
     }
-    ISystemWindow *systemWindowIntf = CC_GET_PLATFORM_INTERFACE(ISystemWindow);
+    ISystemWindow *systemWindowIntf = CC_GET_MAIN_SYSTEM_WINDOW();
     if (!systemWindowIntf) {
         return nullptr;
     }
@@ -238,17 +239,17 @@ void EditBox::show(const EditBox::ShowInfo &showInfo) {
     SetFocus(g_hwndEditBox);
 
     SendMessage(g_hwndEditBox, EM_SETSEL, (WPARAM)0, (LPARAM)index);
-    // int height = CC_GET_PLATFORM_INTERFACE(ISystemWindow)->kheight;
+    // int height = CC_GET_MAIN_SYSTEM_WINDOW()->kheight;
     CHARFORMAT2 cf;
     RECT rect;
 
     GetWindowRect(getCurrentWindowHwnd(), &rect);
-    float WindowRatio = (float)(rect.bottom - rect.top) / (float)CC_GET_PLATFORM_INTERFACE(ISystemWindow)->getViewSize().height;
+    float WindowRatio = (float)(rect.bottom - rect.top) / (float)CC_GET_MAIN_SYSTEM_WINDOW()->getViewSize().height;
     float JsFontRatio = float(showInfo.fontSize) / 5;
     /** A probale way to calculate the increase of font size
      * OriginalSize + Increase = OriginalSize * Ratio_of_js_fontSize * Ratio_of_window
      * Default value : OriginalSize = 8, Ratio_of_js_fontSize = showInfo.fontSize /5,
-     * Ratio_of_window = (float)height / (float)CC_GET_PLATFORM_INTERFACE(ISystemWindow)->getViewSize().height
+     * Ratio_of_window = (float)height / (float)CC_GET_MAIN_SYSTEM_WINDOW()->getViewSize().height
      * thus Increase was calculated.
      */
     int fsize = (float)(JsFontRatio + 8) * WindowRatio - 8;


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/14620

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
