### PR TITLE
Separate present time from renderer time in profiler

### DIFF
--- a/cocos/animation/animation-manager.ts
+++ b/cocos/animation/animation-manager.ts
@@ -92,7 +92,7 @@ export class AnimationManager extends System {
         }
         this._blendStateBuffer.apply();
 
-        const stamp = cclegacy.director.getTotalFrames();
+        const stamp = director.getTotalFrames();
         for (let i = 0, l = _sockets.length; i < l; i++) {
             const { target, transform } = _sockets[i];
             target.matrix = getWorldMatrix(transform, stamp);

--- a/cocos/asset/asset-manager/deprecated.ts
+++ b/cocos/asset/asset-manager/deprecated.ts
@@ -25,8 +25,6 @@
 
 import { BUILD } from 'internal:constants';
 import { Asset } from '../assets/asset';
-import { director } from '../../game/director';
-import { game } from '../../game';
 import { getError, macro, path, removeProperty, replaceProperty, cclegacy } from '../../core';
 import Cache from './cache';
 import assetManager, { AssetManager } from './asset-manager';
@@ -38,7 +36,6 @@ import parser from './parser';
 import releaseManager from './release-manager';
 import { assets, BuiltinBundleName, bundles, ProgressCallback, CompleteCallback } from './shared';
 import { parseLoadResArgs, setDefaultProgressCallback } from './utilities';
-import { ISceneInfo } from './config';
 import factory from './factory';
 
 const ImageFmts = ['.png', '.jpg', '.bmp', '.jpeg', '.gif', '.ico', '.tiff', '.webp', '.image', '.pvr', '.pkm', '.astc'];
@@ -985,37 +982,6 @@ replaceProperty(macro, 'macro', [
         target: downloader,
         targetName: 'assetManager.downloader',
         newName: 'maxConcurrency',
-    },
-]);
-
-replaceProperty(director, 'director', [
-    {
-        name: '_getSceneUuid',
-        targetName: 'assetManager.main',
-        newName: 'getSceneInfo',
-        customFunction: (sceneName) => {
-            if (assetManager.main) {
-                return assetManager.main.getSceneInfo(sceneName)?.uuid;
-            }
-            return '';
-        },
-    },
-]);
-
-replaceProperty(game, 'game', [
-    {
-        name: '_sceneInfos',
-        targetName: 'assetManager.main',
-        newName: 'getSceneInfo',
-        customGetter: () => {
-            const scenes: ISceneInfo[] = [];
-            if (assetManager.main) {
-                assetManager.main.config.scenes.forEach((val) => {
-                    scenes.push(val);
-                });
-            }
-            return scenes;
-        },
     },
 ]);
 

--- a/cocos/game/deprecated.ts
+++ b/cocos/game/deprecated.ts
@@ -23,8 +23,10 @@
  THE SOFTWARE.
  */
 
-import { removeProperty, markAsWarning } from '../core';
-import { Director } from './director';
+import { assetManager } from '../asset/asset-manager';
+import { ISceneInfo } from '../asset/asset-manager/config';
+import { removeProperty, markAsWarning, replaceProperty } from '../core/utils/x-deprecated';
+import { Director, director } from './director';
 import { game } from './game';
 
 // Director
@@ -87,6 +89,20 @@ removeProperty(Director.prototype, 'director', [
     },
 ]);
 
+replaceProperty(director, 'director', [
+    {
+        name: '_getSceneUuid',
+        targetName: 'assetManager.main',
+        newName: 'getSceneInfo',
+        customFunction: (sceneName) => {
+            if (assetManager.main) {
+                return assetManager.main.getSceneInfo(sceneName)?.uuid;
+            }
+            return '';
+        },
+    },
+]);
+
 // game
 
 markAsWarning(game, 'game', [
@@ -95,5 +111,22 @@ markAsWarning(game, 'game', [
     },
     {
         name: 'groupList',
+    },
+]);
+
+replaceProperty(game, 'game', [
+    {
+        name: '_sceneInfos',
+        targetName: 'assetManager.main',
+        newName: 'getSceneInfo',
+        customGetter: () => {
+            const scenes: ISceneInfo[] = [];
+            if (assetManager.main) {
+                assetManager.main.config.scenes.forEach((val) => {
+                    scenes.push(val);
+                });
+            }
+            return scenes;
+        },
     },
 ]);

--- a/cocos/game/director.ts
+++ b/cocos/game/director.ts
@@ -162,15 +162,15 @@ export class Director extends EventTarget {
     public static readonly EVENT_BEFORE_COMMIT = 'director_before_commit';
 
     /**
-     * @en The event which will be triggered before the render pipeline process the render scene.
-     * @zh 当前渲染帧渲染前所触发的事件。
+     * @en The event which will be triggered before the render pipeline processes the render scene.
+     * @zh 当前帧将渲染场景提交到渲染管线之前所触发的事件。
      * @event Director.EVENT_BEFORE_RENDER
      */
     public static readonly EVENT_BEFORE_RENDER = 'director_before_render';
 
     /**
-     * @en The event which will be triggered after the render pipeline process the render scene.
-     * @zh 当前渲染帧渲染前所触发的事件。
+     * @en The event which will be triggered after the render pipeline finishes the rendering process on CPU.
+     * @zh 当前帧渲染管线渲染流程完成后所触发的事件。
      * @event Director.EVENT_AFTER_RENDER
      */
     public static readonly EVENT_AFTER_RENDER = 'director_after_render';

--- a/cocos/game/director.ts
+++ b/cocos/game/director.ts
@@ -161,11 +161,18 @@ export class Director extends EventTarget {
     public static readonly EVENT_BEFORE_COMMIT = 'director_before_commit';
 
     /**
-     * @en The event which will be triggered before the pipeline render.
+     * @en The event which will be triggered before the render pipeline process the render scene.
      * @zh 当前渲染帧渲染前所触发的事件。
      * @event Director.EVENT_BEFORE_RENDER
      */
     public static readonly EVENT_BEFORE_RENDER = 'director_before_render';
+
+    /**
+     * @en The event which will be triggered after the render pipeline process the render scene.
+     * @zh 当前渲染帧渲染前所触发的事件。
+     * @event Director.EVENT_AFTER_RENDER
+     */
+    public static readonly EVENT_AFTER_RENDER = 'director_after_render';
 
     /**
      * @en The event which will be triggered before the physics process.<br/>

--- a/cocos/rendering/custom/index.ts
+++ b/cocos/rendering/custom/index.ts
@@ -26,7 +26,7 @@
 import { Pipeline, PipelineBuilder } from './pipeline';
 import { WebPipeline } from './web-pipeline';
 import { buildDeferredLayout, buildForwardLayout, replacePerBatchOrInstanceShaderInfo } from './effect';
-import { macro } from '../../core';
+import { macro } from '../../core/platform/macro';
 import { DeferredPipelineBuilder, ForwardPipelineBuilder } from './builtin-pipelines';
 import { CustomPipelineBuilder, NativePipelineBuilder } from './custom-pipeline';
 import { LayoutGraphData, loadLayoutGraphData } from './layout-graph';

--- a/cocos/root.jsb.ts
+++ b/cocos/root.jsb.ts
@@ -1,4 +1,4 @@
-import legacyCC from '../predefine';
+import { legacyCC } from './core/global-exports';
 import { DataPoolManager } from './3d/skeletal-animation/data-pool-manager';
 import { Device, deviceManager } from './gfx';
 import { DebugView } from './rendering/debug-view';
@@ -183,6 +183,10 @@ rootProto._onDirectorBeforeCommit = function () {
 
 rootProto._onDirectorBeforeRender = function () {
     legacyCC.director.emit(legacyCC.Director.EVENT_BEFORE_RENDER);
+};
+
+rootProto._onDirectorAfterRender = function () {
+    legacyCC.director.emit(legacyCC.Director.EVENT_AFTER_RENDER);
 };
 
 const oldFrameMove = rootProto.frameMove;

--- a/cocos/root.ts
+++ b/cocos/root.ts
@@ -359,6 +359,7 @@ export class Root {
      * @returns The setup is successful or not
      */
     public setRenderPipeline (rppl?: RenderPipeline): boolean {
+        const { internal, director, rendering } = cclegacy;
         //-----------------------------------------------
         // prepare classic pipeline
         //-----------------------------------------------
@@ -382,8 +383,8 @@ export class Root {
         //-----------------------------------------------
         // choose pipeline
         //-----------------------------------------------
-        if (macro.CUSTOM_PIPELINE_NAME !== '' && cclegacy.rendering && this.usesCustomPipeline) {
-            this._customPipeline = cclegacy.rendering.createCustomPipeline();
+        if (macro.CUSTOM_PIPELINE_NAME !== '' && rendering && this.usesCustomPipeline) {
+            this._customPipeline = rendering.createCustomPipeline();
             isCreateDefaultPipeline = true;
             this._pipeline = this._customPipeline!;
         } else {
@@ -408,14 +409,14 @@ export class Root {
         //-----------------------------------------------
         // pipeline initialization completed
         //-----------------------------------------------
-        const scene = cclegacy.director.getScene();
+        const scene = director.getScene();
         if (scene) {
             scene.globals.activate();
         }
 
         this.onGlobalPipelineStateChanged();
-        if (!this._batcher && cclegacy.internal.Batcher2D) {
-            this._batcher = new cclegacy.internal.Batcher2D(this);
+        if (!this._batcher && internal.Batcher2D) {
+            this._batcher = new internal.Batcher2D(this);
             if (!this._batcher!.initialize()) {
                 this.destroy();
                 return false;

--- a/cocos/root.ts
+++ b/cocos/root.ts
@@ -226,7 +226,7 @@ export class Root {
      * @en Whether the built-in deferred pipeline is used.
      * @zh 是否启用内置延迟渲染管线
      */
-    public get useDeferredPipeline () : boolean {
+    public get useDeferredPipeline (): boolean {
         return this._useDeferredPipeline;
     }
 
@@ -460,6 +460,7 @@ export class Root {
      * @param deltaTime @en The delta time since last update. @zh 距离上一帧间隔时间
      */
     public frameMove (deltaTime: number) {
+        const { director, Director } = cclegacy;
         this._frameTime = deltaTime;
 
         /*
@@ -497,7 +498,8 @@ export class Root {
         if (this._pipeline && cameraList.length > 0) {
             this._device.acquire([deviceManager.swapchain]);
             const scenes = this._scenes;
-            const stamp = cclegacy.director.getTotalFrames();
+            const stamp = director.getTotalFrames();
+
             if (this._batcher) {
                 this._batcher.update();
                 this._batcher.uploadBuffers();
@@ -507,14 +509,15 @@ export class Root {
                 scenes[i].update(stamp);
             }
 
-            cclegacy.director.emit(cclegacy.Director.EVENT_BEFORE_COMMIT);
+            director.emit(Director.EVENT_BEFORE_COMMIT);
             cameraList.sort((a: Camera, b: Camera) => a.priority - b.priority);
 
             for (let i = 0; i < cameraList.length; ++i) {
                 cameraList[i].geometryRenderer?.update();
             }
-            cclegacy.director.emit(cclegacy.Director.EVENT_BEFORE_RENDER);
+            director.emit(Director.EVENT_BEFORE_RENDER);
             this._pipeline.render(cameraList);
+            director.emit(Director.EVENT_AFTER_RENDER);
             this._device.present();
         }
 

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -122,6 +122,7 @@ static bool js_root_registerListeners(se::State &s) // NOLINT(readability-identi
 
     DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::BeforeCommit, _onDirectorBeforeCommit);
     DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::BeforeRender, _onDirectorBeforeRender);
+    DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::AfterRender, _onDirectorAfterRender);
 
     return true;
 }

--- a/native/cocos/core/Root.cpp
+++ b/native/cocos/core/Root.cpp
@@ -420,6 +420,7 @@ void Root::frameMoveEnd() {
 
         emit<BeforeRender>();
         _pipelineRuntime->render(_cameraList);
+        emit<AfterRender>();
 #endif
         _device->present();
     }

--- a/native/cocos/core/Root.h
+++ b/native/cocos/core/Root.h
@@ -69,6 +69,7 @@ class Root final {
     DECLARE_TARGET_EVENT_BEGIN(Root)
     TARGET_EVENT_ARG0(BeforeCommit)
     TARGET_EVENT_ARG0(BeforeRender)
+    TARGET_EVENT_ARG0(AfterRender)
     DECLARE_TARGET_EVENT_END()
 public:
     static Root *getInstance(); // cjh todo: put Root Managerment to Director class.


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/11043

### Changelog

* Separate present time from renderer time in profiler

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
