### PR TITLE
synchronize spine anchor to UITransform

### DIFF
--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -694,6 +694,12 @@ export class Skeleton extends UIRenderer {
         const uiTrans = this.node._uiProps.uiTransformComp!;
         if (skeletonData.width != null && skeletonData.height != null) {
             uiTrans.setContentSize(skeletonData.width, skeletonData.height);
+            if (skeletonData.x !== null && skeletonData.width !== 0) {
+                uiTrans.anchorX = Math.abs(skeletonData.x) / skeletonData.width;
+            } 
+            if (skeletonData.y !== null && skeletonData.width !== 0) {
+                uiTrans.anchorY = Math.abs(skeletonData.y) / skeletonData.height;
+            }
         }
 
         if (!EDITOR || legacyCC.GAME_VIEW) {


### PR DESCRIPTION
### Changelog

* [spine] calculate anchor point of UITransform by skeleton offset in the bounding box.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------