### PR TITLE
fix: hack texture float support query for Taobao HUAWEI devices

### DIFF
--- a/cocos/core/gfx/webgl/webgl-swapchain.ts
+++ b/cocos/core/gfx/webgl/webgl-swapchain.ts
@@ -23,7 +23,7 @@
  THE SOFTWARE.
  */
 
-import { ALIPAY, RUNTIME_BASED, BYTEDANCE, WECHAT, LINKSURE, QTT, COCOSPLAY, HUAWEI, EDITOR, VIVO } from 'internal:constants';
+import { ALIPAY, RUNTIME_BASED, BYTEDANCE, WECHAT, LINKSURE, QTT, COCOSPLAY, HUAWEI, EDITOR, VIVO, TAOBAO } from 'internal:constants';
 import { systemInfo } from 'pal/system-info';
 import { macro } from '../../platform/macro';
 import { warnID, warn, debug } from '../../platform/debug';
@@ -174,6 +174,14 @@ export function getExtensions (gl: WebGLRenderingContext) {
         // compressedTexSubImage2D too
         if (WECHAT) {
             res.noCompressedTexSubImage2D = true;
+        }
+
+        // HACK: for HUAWEI devices
+        if (TAOBAO && systemInfo.os === OS.ANDROID) {
+            res.OES_texture_half_float = { HALF_FLOAT_OES: 36193 };
+            res.OES_texture_half_float_linear = {};
+            res.OES_texture_float = {};
+            res.OES_texture_float_linear = {};
         }
     }
 

--- a/cocos/core/gfx/webgl/webgl-swapchain.ts
+++ b/cocos/core/gfx/webgl/webgl-swapchain.ts
@@ -176,7 +176,8 @@ export function getExtensions (gl: WebGLRenderingContext) {
             res.noCompressedTexSubImage2D = true;
         }
 
-        // HACK: on Taobao Android, some devices can't query texture float extension correctly, especially Huawei devices.
+        // HACK: on Taobao Android, some devices can't query texture float extension correctly, especially Huawei devices
+        // the query interface returns null.
         if (TAOBAO && systemInfo.os === OS.ANDROID) {
             res.OES_texture_half_float = { HALF_FLOAT_OES: 36193 };
             res.OES_texture_half_float_linear = {};

--- a/cocos/core/gfx/webgl/webgl-swapchain.ts
+++ b/cocos/core/gfx/webgl/webgl-swapchain.ts
@@ -176,7 +176,7 @@ export function getExtensions (gl: WebGLRenderingContext) {
             res.noCompressedTexSubImage2D = true;
         }
 
-        // HACK: for HUAWEI devices
+        // HACK: on Taobao Android, some devices can't query texture float extension correctly, especially Huawei devices.
         if (TAOBAO && systemInfo.os === OS.ANDROID) {
             res.OES_texture_half_float = { HALF_FLOAT_OES: 36193 };
             res.OES_texture_half_float_linear = {};


### PR DESCRIPTION
Re: 
https://github.com/cocos/3d-tasks/issues/14413
https://github.com/cocos/3d-tasks/issues/14392
https://github.com/cocos/3d-tasks/issues/14394
https://github.com/cocos/3d-tasks/issues/14396
https://github.com/cocos/3d-tasks/issues/14407

### Changelog

* hack texture float support query for Taobao HUAWEI devices

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
