### PR TITLE
fix: the orthogonal camera does not apply the xr fov parameters correctly

### DIFF
--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -410,6 +410,21 @@ export class SplashScreen {
             for (let xrEye = 0; xrEye < renderSize; xrEye++) {
                 if (sys.isXR) {
                     xr.entry.renderLoopStart(xrEye);
+                    const xrFov = xr.entry.getEyeFov(xrEye);
+                    const left = Math.tan(xrFov[0]);
+                    const right = Math.tan(xrFov[1]);
+                    const bottom = Math.tan(xrFov[2]);
+                    const top = Math.tan(xrFov[3]);
+                    Mat4.ortho(this.projection, left, right, bottom, top, -1, 1, device.capabilities.clipSpaceMinZ,
+                        device.capabilities.clipSpaceSignY, swapchain.surfaceTransform);
+                    this.bgMat.setProperty('u_projection', this.projection);
+                    this.bgMat.passes[0].update();
+                    this.logoMat.setProperty('u_projection', this.projection);
+                    this.logoMat.passes[0].update();
+                    if (this.watermarkMat) {
+                        this.watermarkMat.setProperty('u_projection', this.projection);
+                        this.watermarkMat.passes[0].update();
+                    }
                 }
 
                 device.acquire([swapchain]);

--- a/native/cocos/scene/Camera.cpp
+++ b/native/cocos/scene/Camera.cpp
@@ -214,9 +214,9 @@ void Camera::update(bool forceUpdate /*false*/) {
             } else {
                 const auto &xrFov = _xr->getXREyeFov(static_cast<uint32_t>(wndXREye));
                 const float left = _orthoHeight * tanf(xrFov[0]);
-                const float right = _orthoHeight* tanf(xrFov[1]);
-                const float bottom = _orthoHeight* tanf(xrFov[2]);
-                const float top = _orthoHeight* tanf(xrFov[3]);
+                const float right = _orthoHeight * tanf(xrFov[1]);
+                const float bottom = _orthoHeight * tanf(xrFov[2]);
+                const float top = _orthoHeight * tanf(xrFov[3]);
                 const float projectionSignY = _device->getCapabilities().clipSpaceSignY;
                 Mat4::createOrthographicOffCenter(left, right, bottom, top, _nearClip, _farClip,
                                                   _device->getCapabilities().clipSpaceMinZ, projectionSignY,


### PR DESCRIPTION
…ctly, resulting in the inability to focus under different IPDs.

Re: #

### Changelog

the orthogonal camera does not apply the xr fov parameters correctly, resulting in the inability to focus under different IPDs.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
