### PR TITLE
fixed #12670: [doc] Swig documentation about %arg(...) and not need to add const prefix for attribute

### DIFF
--- a/native/tools/swig-config/tutorial/index.md
+++ b/native/tools/swig-config/tutorial/index.md
@@ -748,13 +748,13 @@ Object.defineProperty(MyNewClass.prototype, 'width', {
 
 #### Reference type
 
-If C++ `get` and `set` function return reference type, don't forget to add `&` suffix in %attribute or %attribute_writeonly directives. The following `ccstd::string&` is an example.
+If C++ `get` function returns a reference data type or `set` function accesses a reference data type , don't forget to add `&` suffix in %attribute or %attribute_writeonly directives. The following `ccstd::string&` is an example.
 
 ```c++
 %attribute_writeonly(cc::ICanvasRenderingContext2D, ccstd::string&, fillStyle, setFillStyle);
 ```
 
-If `&` is missing, temporary `ccstd::string` objects will be created while binding functions are invoked.
+If `&` is missing, a temporary `ccstd::string` instance will be created while the binding function is invoked.
 
 #### %arg() directive
 

--- a/native/tools/swig-config/tutorial/index.md
+++ b/native/tools/swig-config/tutorial/index.md
@@ -1,16 +1,16 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents** 
+**Table of Contents**
 
 - [The Tutorial of Swig Workflow in Cocos Creator](#the-tutorial-of-swig-workflow-in-cocos-creator)
-  - [How to Bind a New Module in Engine](#how-to-bind-a-new-module-in-engine)
-    - [Add a new module interface file](#add-a-new-module-interface-file)
-    - [Modify swig-config.js](#modify-swig-configjs)
-    - [Generate bindings](#generate-bindings)
-    - [Modify `engine/native/cocos/CMakeLists.txt`](#modify-enginenativecocoscmakeliststxt)
-    - [Register the new module to Script Engine](#register-the-new-module-to-script-engine)
-  - [How to Bind a New Module in Developer's Project](#how-to-bind-a-new-module-in-developers-project)
-    - [Bind a simple class](#bind-a-simple-class)
+  * [How to Bind a New Module in Engine](#how-to-bind-a-new-module-in-engine)
+    + [Add a new module interface file](#add-a-new-module-interface-file)
+    + [Modify swig-config.js](#modify-swig-configjs)
+    + [Generate bindings](#generate-bindings)
+    + [Modify `engine/native/cocos/CMakeLists.txt`](#modify-enginenativecocoscmakeliststxt)
+    + [Register the new module to Script Engine](#register-the-new-module-to-script-engine)
+  * [How to Bind a New Module in Developer's Project](#how-to-bind-a-new-module-in-developers-project)
+    + [Bind a simple class](#bind-a-simple-class)
       - [Create a simple class](#create-a-simple-class)
       - [Write an interface file](#write-an-interface-file)
       - [Write a swig config file](#write-a-swig-config-file)
@@ -20,14 +20,20 @@
       - [Register the new module to Script Engine](#register-the-new-module-to-script-engine-1)
       - [Test binding](#test-binding)
       - [Section Conclusion](#section-conclusion)
-    - [Import depended header files](#import-depended-header-files)
-    - [Ignore classes, methods, properties](#ignore-classes-methods-properties)
+    + [Import depended header files](#import-depended-header-files)
+    + [Ignore classes, methods, properties](#ignore-classes-methods-properties)
       - [Ignore classes](#ignore-classes)
       - [Ignore methods and properties](#ignore-methods-and-properties)
-    - [Rename classes, methods, properties](#rename-classes-methods-properties)
-    - [Define attributes which bind C++ getter and setter as a JS property](#define-attributes-which-bind-c-getter-and-setter-as-a-js-property)
-    - [Configure C++ modules in .i file](#configure-c-modules-in-i-file)
-    - [Multiple swig modules configuration](#multiple-swig-modules-configuration)
+    + [Rename classes, methods, properties](#rename-classes-methods-properties)
+    + [Define an attribute](#define-an-attribute)
+      - [Usage](#usage)
+      - [Demo](#demo)
+      - [%attribute_writeonly directive](#%25attribute_writeonly--directive)
+      - [Reference type](#reference-type)
+      - [%arg() directive](#%25arg-directive)
+      - [Don't add `const`](#dont-add-const)
+    + [Configure C++ modules in .i file](#configure-c-modules-in-i-file)
+    + [Multiple swig modules configuration](#multiple-swig-modules-configuration)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -610,26 +616,28 @@ Build and run project, get log:
 17:53:28 [DEBUG]: ==> hello MyObject::methodToBeRenamed
 ```
 
-### Define attributes which bind C++ getter and setter as a JS property
+### Define an attribute
 
-### Usage
+`%attribute` directive is used for bind C++ getter and setter functions as a JS property.
+
+#### Usage
 
 1. Define an attribute (JS property) without setter
 
    ```c++
-   %attribute(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_getter_name)
+   %attribute(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_getter_function_name)
    ```
 
 2. Define an attribute (JS property) with getter and setter
 
    ```c++
-   %attribute(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_getter_name, cpp_setter_name)
+   %attribute(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_getter_function_name, cpp_setter_function_name)
    ```
 
 3. Define an attribute (JS property) without getter
 
    ```c++
-   %attribute_writeonly(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_setter_name)
+   %attribute_writeonly(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_setter_function_name)
    ```
 
 #### Demo
@@ -725,7 +733,7 @@ In `native/tools/swig-config/cocos.i`, there are:
 %attribute_writeonly(cc::ICanvasRenderingContext2D, ccstd::string&, font, setFont);
 ```
 
-This is the similar functionality like which in JS:
+This is the similar functionality in JS:
 
 ```javascript
 Object.defineProperty(MyNewClass.prototype, 'width', {

--- a/native/tools/swig-config/tutorial/index.md
+++ b/native/tools/swig-config/tutorial/index.md
@@ -799,7 +799,7 @@ Re-run `node genbindings.js`, the error should have gone.
 
 #### Don't add `const` 
 
-In the above sample, `%arg(std::map<std::string, std::string>&)` is used as a C++ type in %attribue directive. You may consider to add a `const` prefix before `std::map` like `%arg(const std::map<std::string, std::string>&)`. If you do that, you will make a readyonly `config` property which only binds `MyNewClass::getConfig`. That's obviously not what we expect. If we need a readonly property, just don't assign a `set` function. 
+In the above sample, `%arg(std::map<std::string, std::string>&)` is used as a C++ data type in %attribue directive. You may consider to add a `const` prefix before `std::map` like `%arg(const std::map<std::string, std::string>&)`. If you do that, you will make a readyonly `config` property which only binds `MyNewClass::getConfig`. That's obviously not what we expect. If we need a readonly property, just don't assign a `set` function. 
 
 ```c++
 // Don't assign setConfig means the property doesn't need a setter.

--- a/native/tools/swig-config/tutorial/index.md
+++ b/native/tools/swig-config/tutorial/index.md
@@ -612,6 +612,28 @@ Build and run project, get log:
 
 ### Define attributes which bind C++ getter and setter as a JS property
 
+### Usage
+
+1. Define an attribute (JS property) without setter
+
+   ```c++
+   %attribute(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_getter_name)
+   ```
+
+2. Define an attribute (JS property) with getter and setter
+
+   ```c++
+   %attribute(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_getter_name, cpp_setter_name)
+   ```
+
+3. Define an attribute (JS property) without getter
+
+   ```c++
+   %attribute_writeonly(your_namespace::your_class_name, cpp_member_variable_type, js_property_name, cpp_setter_name)
+   ```
+
+#### Demo
+
 To demonstrate, we add two new methods for MyObject class.
 
 ```c++
@@ -688,6 +710,95 @@ Build and run project
 18:09:53 [DEBUG]: ==> setType: v: 888 // Cool, C++ setType is invoked
 18:09:53 [DEBUG]: D/ JS: ==> new: myObj.type: 888 // Cool, C++ getType is invoked, 888 is return from C++
 ```
+
+#### %attribute_writeonly  directive
+
+`%attribute_writeonly` directive is an extension we added in swig  `Cocos` backend, it's used for the purpose that C++ class only has a `set` function and there isn't a `get` function.
+
+In `native/tools/swig-config/cocos.i`, there are:
+
+```c++
+%attribute_writeonly(cc::ICanvasRenderingContext2D, float, width, setWidth);
+%attribute_writeonly(cc::ICanvasRenderingContext2D, float, height, setHeight);
+%attribute_writeonly(cc::ICanvasRenderingContext2D, float, lineWidth, setLineWidth);
+%attribute_writeonly(cc::ICanvasRenderingContext2D, ccstd::string&, fillStyle, setFillStyle);
+%attribute_writeonly(cc::ICanvasRenderingContext2D, ccstd::string&, font, setFont);
+```
+
+This is the similar functionality like which in JS:
+
+```javascript
+Object.defineProperty(MyNewClass.prototype, 'width', {
+  configurable: true,
+  enumerable: true,
+  set(v) {
+    this._width = v;
+  },
+	// No get() for property
+});
+```
+
+#### Reference type
+
+If C++ `get` and `set` function return reference type, don't forget to add `&` suffix in %attribute or %attribute_writeonly directives. The following `ccstd::string&` is an example.
+
+```c++
+%attribute_writeonly(cc::ICanvasRenderingContext2D, ccstd::string&, fillStyle, setFillStyle);
+```
+
+If `&` is missing, temporary `ccstd::string` objects will be created while binding functions are invoked.
+
+#### %arg() directive
+
+Sometimes, the type of C++ variable is a describled by C++ template, for instance:
+
+```c++
+class MyNewClass {
+  public:
+		const std::map<std::string, std::string>& getConfig() const { return _config; }
+  	void setConfig(const std::map<std::string, std::string> &config) { _config = config; }
+  private:
+  	std::map<std::string, std::string> _config;
+};
+```
+
+We may write an `%attribute` in `.i` file like:
+
+```c++
+%attribute(MyNewClass, std::map<std::string, std::string>&, config, getConfig, setConfig);
+```
+
+You will get an error while invoking `node genbindings.js`.
+
+```
+Error: Macro '%attribute_custom' expects 7 arguments
+```
+
+This is because `swig` doesn't know how to deal with comma (`,`) in `std::map<std::string, std::string>&`, it will split it to two parts:
+
+1. std::map<std::string
+2. std::string>&
+
+Therefore, this line of %attribute directive will be parsed with 6 arguments instead of 5.
+
+To avoid making `swig` confused, we need to use `%arg` directive to tell `swig` that `std::map<std::string, std::string>&` is a whole thing.
+
+```c++
+%attribute(MyNewClass, %arg(std::map<std::string, std::string>&), config, getConfig, setConfig);
+```
+
+Re-run `node genbindings.js`, the error should have gone.
+
+#### Don't add `const` 
+
+In the previous sample, `%arg(std::map<std::string, std::string>&)` is used as C++ type in %attribue directive. You may consider to add a const prefix before `std::map` like `%arg(const std::map<std::string, std::string>&)`. If you do that, you will make a readyonly `config` property which only bind `MyNewClass::getConfig`. That's obviously not what we expect. If we need a readonly property, just don't assign a `set` function. 
+
+```c++
+// Don't assign setConfig means the property doesn't need a setter.
+%attribute(MyNewClass, %arg(std::map<std::string, std::string>&), config, getConfig); 
+```
+
+So to keep things simple, never add `const` prefix while writing a `%attribute` directive.
 
 ### Configure C++ modules in .i file
 

--- a/native/tools/swig-config/tutorial/index.md
+++ b/native/tools/swig-config/tutorial/index.md
@@ -799,7 +799,7 @@ Re-run `node genbindings.js`, the error should have gone.
 
 #### Don't add `const` 
 
-In the previous sample, `%arg(std::map<std::string, std::string>&)` is used as C++ type in %attribue directive. You may consider to add a const prefix before `std::map` like `%arg(const std::map<std::string, std::string>&)`. If you do that, you will make a readyonly `config` property which only bind `MyNewClass::getConfig`. That's obviously not what we expect. If we need a readonly property, just don't assign a `set` function. 
+In the above sample, `%arg(std::map<std::string, std::string>&)` is used as C++ type in %attribue directive. You may consider to add a const prefix before `std::map` like `%arg(const std::map<std::string, std::string>&)`. If you do that, you will make a readyonly `config` property which only bind `MyNewClass::getConfig`. That's obviously not what we expect. If we need a readonly property, just don't assign a `set` function. 
 
 ```c++
 // Don't assign setConfig means the property doesn't need a setter.

--- a/native/tools/swig-config/tutorial/index.md
+++ b/native/tools/swig-config/tutorial/index.md
@@ -799,7 +799,7 @@ Re-run `node genbindings.js`, the error should have gone.
 
 #### Don't add `const` 
 
-In the above sample, `%arg(std::map<std::string, std::string>&)` is used as C++ type in %attribue directive. You may consider to add a const prefix before `std::map` like `%arg(const std::map<std::string, std::string>&)`. If you do that, you will make a readyonly `config` property which only bind `MyNewClass::getConfig`. That's obviously not what we expect. If we need a readonly property, just don't assign a `set` function. 
+In the above sample, `%arg(std::map<std::string, std::string>&)` is used as a C++ type in %attribue directive. You may consider to add a `const` prefix before `std::map` like `%arg(const std::map<std::string, std::string>&)`. If you do that, you will make a readyonly `config` property which only binds `MyNewClass::getConfig`. That's obviously not what we expect. If we need a readonly property, just don't assign a `set` function. 
 
 ```c++
 // Don't assign setConfig means the property doesn't need a setter.


### PR DESCRIPTION
Re: #12670

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
