### PR TITLE
V3.7.0 fix unable change multiple nodes name in inspector

### DIFF
--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -623,7 +623,7 @@ const Elements = {
     header: {
         ready() {
             const panel = this;
-            panel.$.active.addEventListener('change', (event) => {
+            panel.$.active.addEventListener('confirm', (event) => {
                 const value = event.target.value;
                 const dump = event.target.dump;
 
@@ -635,6 +635,7 @@ const Elements = {
                     });
                 }
                 panel.$.active.dispatch('change-dump');
+                panel.$.active.dispatch('confirm-dump');
             });
 
             panel.$.name.addEventListener('change', (event) => {
@@ -649,6 +650,9 @@ const Elements = {
                     });
                 }
                 panel.$.name.dispatch('change-dump');
+            });
+            panel.$.name.addEventListener('confirm', () => {
+                panel.$.name.dispatch('confirm-dump');
             });
         },
         update() {
@@ -667,13 +671,17 @@ const Elements = {
                 activeDisabled = true;
                 nameDisabled = true;
             } else {
+
                 if (panel.dumps && panel.dumps.length > 1) {
                     if (panel.dumps.some((dump) => dump.active.value !== panel.dump.active.value)) {
                         activeInvalid = true;
                     }
 
-                    if (panel.dumps.some((dump) => dump.name.value !== panel.dump.name.value)) {
-                        nameInvalid = true;
+                    // 在输入中的时候不做数据校验
+                    if (!panel.$.name.$input.matches(':focus')) {
+                        if (panel.dumps.some((dump) => dump.name.value !== panel.dump.name.value)) {
+                            nameInvalid = true;
+                        }
                     }
                 }
             }

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -623,7 +623,7 @@ const Elements = {
     header: {
         ready() {
             const panel = this;
-            panel.$.active.addEventListener('confirm', (event) => {
+            panel.$.active.addEventListener('change', (event) => {
                 const value = event.target.value;
                 const dump = event.target.dump;
 
@@ -635,7 +635,9 @@ const Elements = {
                     });
                 }
                 panel.$.active.dispatch('change-dump');
-                panel.$.active.dispatch('confirm-dump');
+            });
+            panel.$.active.addEventListener('confirm', () => {
+                panel.snapshotLock = false;
             });
 
             panel.$.name.addEventListener('change', (event) => {
@@ -652,7 +654,7 @@ const Elements = {
                 panel.$.name.dispatch('change-dump');
             });
             panel.$.name.addEventListener('confirm', () => {
-                panel.$.name.dispatch('confirm-dump');
+                panel.snapshotLock = false;
             });
         },
         update() {
@@ -673,12 +675,15 @@ const Elements = {
             } else {
 
                 if (panel.dumps && panel.dumps.length > 1) {
-                    if (panel.dumps.some((dump) => dump.active.value !== panel.dump.active.value)) {
-                        activeInvalid = true;
+                    // when changing, stop validating
+                    if (!panel.$.active.hasAttribute('focused')) {
+                        if (panel.dumps.some((dump) => dump.active.value !== panel.dump.active.value)) {
+                            activeInvalid = true;
+                        }
                     }
 
-                    // 在输入中的时候不做数据校验
-                    if (!panel.$.name.$input.matches(':focus')) {
+                    // when changing, stop validating
+                    if (!panel.$.name.hasAttribute('focused')) {
                         if (panel.dumps.some((dump) => dump.name.value !== panel.dump.name.value)) {
                             nameInvalid = true;
                         }


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/13022

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
