### PR TITLE
v3.7 fix bug: ui group element can not use displayOrder

### DIFF
--- a/editor/inspector/components/class.js
+++ b/editor/inspector/components/class.js
@@ -26,6 +26,8 @@ exports.methods = {
         $group.setAttribute('class', 'tab-group');
         $group.dump = dump;
         $group.tabs = {};
+        $group.displayOrder = dump.displayOrder;
+
         $group.$header = document.createElement('ui-tab');
         $group.$header.setAttribute('class', 'tab-header');
         $group.appendChild($group.$header);
@@ -80,7 +82,8 @@ exports.methods = {
         $button.appendChild($label);
         $group.$header.appendChild($button);
     },
-    appendChildByDisplayOrder(parent, newChild, displayOrder = 0) {
+    appendChildByDisplayOrder(parent, newChild) {
+        const displayOrder = newChild.displayOrder || 0;
         const children = Array.from(parent.children);
         const child = children.find(child => child.dump && child.displayOrder > displayOrder);
         if (child) {
@@ -145,22 +148,22 @@ async function update(dump) {
                 }
                 if ($panel.$groups[id]) {
                     if (!$panel.$groups[id].isConnected) {
-                        $panel.appendChildByDisplayOrder($section, $panel.$groups[id], dump.groups[id].displayOrder);
+                        $panel.appendChildByDisplayOrder($section, $panel.$groups[id]);
                     }
                     if (dump.groups[id].style === 'tab') {
                         $panel.appendToTabGroup($panel.$groups[id], name);
                     }
                 }
-                $panel.appendChildByDisplayOrder($panel.$groups[id].tabs[name], $prop, $prop.displayOrder);
+                $panel.appendChildByDisplayOrder($panel.$groups[id].tabs[name], $prop);
             } else {
-                $panel.appendChildByDisplayOrder($section, $prop, $prop.displayOrder);
+                $panel.appendChildByDisplayOrder($section, $prop);
             }
         } else if (!$prop.isConnected || !$prop.parentElement) {
             if (info.group && dump.groups) {
                 const { id = 'default', name } = info.group;
-                $panel.appendChildByDisplayOrder($panel.$groups[id].tabs[name], $prop, $prop.displayOrder);
+                $panel.appendChildByDisplayOrder($panel.$groups[id].tabs[name], $prop);
             } else {
-                $panel.appendChildByDisplayOrder($section, $prop, $prop.displayOrder);
+                $panel.appendChildByDisplayOrder($section, $prop);
             }
         }
         $prop.render(info);

--- a/editor/inspector/utils/prop.js
+++ b/editor/inspector/utils/prop.js
@@ -240,7 +240,7 @@ exports.updatePropByDump = function(panel, dump) {
 
                     if (panel.$groups[id]) {
                         if (!panel.$groups[id].isConnected) {
-                            exports.appendChildByDisplayOrder(panel.$.componentContainer, panel.$groups[id], dump.groups[id].displayOrder);
+                            exports.appendChildByDisplayOrder(panel.$.componentContainer, panel.$groups[id]);
                         }
 
                         if (dump.groups[id].style === 'tab') {
@@ -248,18 +248,18 @@ exports.updatePropByDump = function(panel, dump) {
                         }
                     }
 
-                    exports.appendChildByDisplayOrder(panel.$groups[id].tabs[name], $prop, $prop.displayOrder);
+                    exports.appendChildByDisplayOrder(panel.$groups[id].tabs[name], $prop);
                 } else {
-                    exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop, $prop.displayOrder);
+                    exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop);
                 }
             }
         } else if (!$prop.isConnected || !$prop.parentElement) {
             if (!element || !element.isAppendToParent || element.isAppendToParent.call(panel)) {
                 if (info.group && dump.groups) {
                     const { id = 'default', name } = info.group;
-                    exports.appendChildByDisplayOrder(panel.$groups[id].tabs[name], $prop, $prop.displayOrder);
+                    exports.appendChildByDisplayOrder(panel.$groups[id].tabs[name], $prop);
                 } else {
-                    exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop, $prop.displayOrder);
+                    exports.appendChildByDisplayOrder(panel.$.componentContainer, $prop);
                 }
             }
         }
@@ -339,6 +339,7 @@ exports.createTabGroup = function(dump, panel) {
 
     $group.dump = dump;
     $group.tabs = {};
+    $group.displayOrder = dump.displayOrder;
 
     $group.$header = document.createElement('ui-tab');
     $group.$header.setAttribute('class', 'tab-header');
@@ -423,7 +424,8 @@ exports.appendToTabGroup = function($group, tabName) {
     $group.$header.appendChild($button);
 };
 
-exports.appendChildByDisplayOrder = function(parent, newChild, displayOrder = 0) {
+exports.appendChildByDisplayOrder = function(parent, newChild) {
+    const displayOrder = newChild.displayOrder || 0;
     const children = Array.from(parent.children);
 
     const child = children.find((child) => {


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
