### PR TITLE
fix error caused by create terrain model and not use 3d base modules

### DIFF
--- a/cocos/3d/reflection-probe/reflection-probe-component.ts
+++ b/cocos/3d/reflection-probe/reflection-probe-component.ts
@@ -333,7 +333,7 @@ export class ReflectionProbe extends Component {
                 ReflectionProbeManager.probeManager.onUpdateProbes(true);
             }
         }
-        if (this.sourceCamera && (this.sourceCamera.node.hasChangedFlags & TransformBit.TRS)) {
+        if (this.probeType === ProbeType.PLANAR && this.sourceCamera && (this.sourceCamera.node.hasChangedFlags & TransformBit.TRS)) {
             this.probe.renderPlanarReflection(this.sourceCamera.camera);
         }
     }

--- a/cocos/3d/reflection-probe/reflection-probe-component.ts
+++ b/cocos/3d/reflection-probe/reflection-probe-component.ts
@@ -333,6 +333,9 @@ export class ReflectionProbe extends Component {
                 ReflectionProbeManager.probeManager.onUpdateProbes(true);
             }
         }
+        if (this.sourceCamera && this.sourceCamera.node.hasChangedFlags & TransformBit.TRS) {
+            this.probe.renderPlanarReflection(this.sourceCamera.camera);
+        }
     }
 
     /**

--- a/cocos/3d/reflection-probe/reflection-probe-component.ts
+++ b/cocos/3d/reflection-probe/reflection-probe-component.ts
@@ -333,7 +333,7 @@ export class ReflectionProbe extends Component {
                 ReflectionProbeManager.probeManager.onUpdateProbes(true);
             }
         }
-        if (this.sourceCamera && this.sourceCamera.node.hasChangedFlags & TransformBit.TRS) {
+        if (this.sourceCamera && (this.sourceCamera.node.hasChangedFlags & TransformBit.TRS)) {
             this.probe.renderPlanarReflection(this.sourceCamera.camera);
         }
     }

--- a/cocos/render-scene/scene/model.ts
+++ b/cocos/render-scene/scene/model.ts
@@ -531,6 +531,8 @@ export class Model {
         this.enabled = true;
         this.visFlags = Layers.Enum.NONE;
         this._inited = true;
+        this._bakeToReflectionProbe = true;
+        this._reflectionProbeType = 0;
     }
 
     /**

--- a/cocos/rendering/reflection-probe/reflection-probe-flow.ts
+++ b/cocos/rendering/reflection-probe/reflection-probe-flow.ts
@@ -59,6 +59,9 @@ export class ReflectionProbeFlow extends RenderFlow {
     }
 
     public render (camera: Camera) {
+        if (!cclegacy.internal.reflectionProbeManager) {
+            return;
+        }
         const probes = cclegacy.internal.reflectionProbeManager.getProbes();
         for (let i = 0; i < probes.length; i++) {
             if (probes[i].needRender) {

--- a/native/cocos/scene/Model.cpp
+++ b/native/cocos/scene/Model.cpp
@@ -84,6 +84,8 @@ void Model::initialize() {
     _enabled = true;
     _visFlags = Layers::Enum::NONE;
     _inited = true;
+    _bakeToReflectionProbe = true;
+    _reflectionProbeType = 0;
 }
 
 void Model::destroy() {


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/15066

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
