### PR TITLE
[fix] rich-text incorrected switching line

### DIFF
--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -560,7 +560,7 @@ export class RichText extends Component {
         }
     }
 
-    /**
+   /**
     * @engineInternal
     */
     protected splitLongStringApproximatelyIn2048 (text: string, styleIndex: number) {
@@ -583,7 +583,7 @@ export class RichText extends Component {
                 if (thisPartSize.x < 2048) {
                     partStringArr.push(multilineTexts[i]);
                 } else {
-                    const thisPartSplitResultArr =  this.splitLongStringOver2048(multilineTexts[i], styleIndex);
+                    const thisPartSplitResultArr = this.splitLongStringOver2048(multilineTexts[i], styleIndex);
                     partStringArr.push(...thisPartSplitResultArr);
                 }
             }
@@ -594,7 +594,7 @@ export class RichText extends Component {
     /**
     * @engineInternal
     */
-    protected splitLongStringOver2048 (text: string, styleIndex: number) {
+    protected splitLongStringOver2048(text: string, styleIndex: number) {
         const partStringArr: string[] = [];
         const longStr = text;
 
@@ -665,28 +665,24 @@ export class RichText extends Component {
                 }
             }
 
-            // curStart and curEnd can be float since they are like positions of pointer,
-            // but step must be integer because we split the complete characters of which the unit is integer.
-            // it is reasonable that using the length of this result to estimate the next result.
             partStringArr.push(curString);
-            const partStep = curString.length;
-            curStart = curEnd;
-            curEnd += partStep;
 
-            curString = longStr.substring(curStart, curEnd);
+            // update the left part string & size
             leftString = longStr.substring(curEnd);
             leftStringSize = this._calculateSize(styleIndex, leftString);
-
             leftTryTimes--;
 
             // Exit: If the left part string size is less than 2048, the method will finish.
             if (leftStringSize.x < 2048) {
-                curStart = text.length;
-                curEnd = text.length;
-                curString = leftString;
-                partStringArr.push(curString);
+                partStringArr.push(leftString);
                 break;
             } else {
+                // curStart and curEnd can be float since they are like positions of pointer,
+                // but step must be integer because we split the complete characters of which the unit is integer.
+                // it is reasonable that using the length of this result to estimate the next result.
+                const partStep = curString.length;
+                curStart = curEnd;
+                curEnd += partStep;
                 curStringSize = this._calculateSize(styleIndex, curString);
             }
         }


### PR DESCRIPTION
Re: #

### Changelog

* fix rich-text incorrected switching line (#13820)

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
