### PR TITLE
[fix] collider does not use physics default material directly #12931

### DIFF
--- a/cocos/physics/bullet/shapes/bullet-shape.ts
+++ b/cocos/physics/bullet/shapes/bullet-shape.ts
@@ -42,14 +42,15 @@ export abstract class BulletShape implements IBaseShape {
     }
 
     setMaterial (v: PhysicsMaterial | null) {
-        if (!this._isTrigger && this._isEnabled && v) {
+        const v1 = (v == null) ? PhysicsSystem.instance.defaultMaterial : v;
+        if (!this._isTrigger && this._isEnabled) {
             if (this._compound) {
-                if (!ccMaterialBooks[v._uuid]) ccMaterialBooks[v._uuid] = bt.ccMaterial_new();
-                const mat = ccMaterialBooks[v._uuid];
-                bt.ccMaterial_set(mat, v.restitution, v.friction, v.rollingFriction, v.spinningFriction);
+                if (!ccMaterialBooks[v1._uuid]) ccMaterialBooks[v1._uuid] = bt.ccMaterial_new();
+                const mat = ccMaterialBooks[v1._uuid];
+                bt.ccMaterial_set(mat, v1.restitution, v1.friction, v1.rollingFriction, v1.spinningFriction);
                 bt.CollisionShape_setMaterial(this._impl, mat);
             } else {
-                bt.CollisionObject_setMaterial(this._sharedBody.body, v.restitution, v.friction, v.rollingFriction, v.spinningFriction);
+                bt.CollisionObject_setMaterial(this._sharedBody.body, v1.restitution, v1.friction, v1.rollingFriction, v1.spinningFriction);
             }
         }
     }

--- a/cocos/physics/cannon/shapes/cannon-shape.ts
+++ b/cocos/physics/cannon/shapes/cannon-shape.ts
@@ -61,20 +61,18 @@ export class CannonShape implements IBaseShape {
     get sharedBody (): CannonSharedBody { return this._sharedBody; }
 
     setMaterial (mat: PhysicsMaterial | null) {
-        if (mat == null) {
-            (this._shape.material as unknown) = null;
-        } else {
-            if (CannonShape.idToMaterial[mat.id] == null) {
-                CannonShape.idToMaterial[mat.id] = new CANNON.Material(mat.id as any);
-            }
+        const mat1 = (mat == null) ? PhysicsSystem.instance.defaultMaterial : mat;
 
-            this._shape.material = CannonShape.idToMaterial[mat.id];
-            const smat = this._shape.material;
-            smat.friction = mat.friction;
-            smat.restitution = mat.restitution;
-            const coef = (CANNON as any).CC_CONFIG.correctInelastic;
-            (smat as any).correctInelastic = smat.restitution === 0 ? coef : 0;
+        if (CannonShape.idToMaterial[mat1.id] == null) {
+            CannonShape.idToMaterial[mat1.id] = new CANNON.Material(mat1.id as any);
         }
+
+        this._shape.material = CannonShape.idToMaterial[mat1.id];
+        const smat = this._shape.material;
+        smat.friction = mat1.friction;
+        smat.restitution = mat1.restitution;
+        const coef = (CANNON as any).CC_CONFIG.correctInelastic;
+        (smat as any).correctInelastic = smat.restitution === 0 ? coef : 0;
     }
 
     setAsTrigger (v: boolean) {

--- a/cocos/physics/framework/components/colliders/collider.ts
+++ b/cocos/physics/framework/components/colliders/collider.ts
@@ -410,7 +410,8 @@ export class Collider extends Eventify(Component) {
 
     protected onLoad () {
         if (!selector.runInEditor) return;
-        this.sharedMaterial = this._material == null ? PhysicsSystem.instance.defaultMaterial : this._material;
+
+        this.sharedMaterial = this._material;
         this._shape = createShape(this.type);
         this._shape.initialize(this);
         this._shape.onLoad!();

--- a/cocos/physics/physx/shapes/physx-cylinder-shape.ts
+++ b/cocos/physics/physx/shapes/physx-cylinder-shape.ts
@@ -67,7 +67,7 @@ export class PhysXCylinderShape extends PhysXShape implements ICylinderShape {
         meshScale.setScale(Vec3.ONE);
         meshScale.setRotation(Quat.IDENTITY);
         const convexMesh = PhysXCylinderShape.CONVEX_MESH;
-        const pxmat = this.getSharedMaterial(collider.sharedMaterial!);
+        const pxmat = this.getSharedMaterial(collider.sharedMaterial);
         this.geometry = new PX.ConvexMeshGeometry(convexMesh, meshScale, createMeshGeometryFlags(0, true));
         this.updateGeometry();
         this._impl = physics.createShape(this.geometry, pxmat, true, this._flags);

--- a/cocos/physics/physx/shapes/physx-plane-shape.ts
+++ b/cocos/physics/physx/shapes/physx-plane-shape.ts
@@ -64,7 +64,7 @@ export class PhysXPlaneShape extends PhysXShape implements IPlaneShape {
 
     onComponentSet (): void {
         const co = this.collider;
-        const pxmat = this.getSharedMaterial(co.sharedMaterial!);
+        const pxmat = this.getSharedMaterial(co.sharedMaterial);
         this._impl = PhysXInstance.physics.createShape(PhysXPlaneShape.PLANE_GEOMETRY, pxmat, true, this._flags);
         this.setCenter();
     }

--- a/cocos/physics/physx/shapes/physx-shape.ts
+++ b/cocos/physics/physx/shapes/physx-shape.ts
@@ -125,24 +125,24 @@ export class PhysXShape implements IBaseShape {
     }
 
     setMaterial (v: PhysicsMaterial | null): void {
-        if (v == null) v = PhysicsSystem.instance.defaultMaterial;
         const mat = this.getSharedMaterial(v);
         this._impl.setMaterials(getShapeMaterials(mat));
     }
 
-    protected getSharedMaterial (v: PhysicsMaterial): any {
-        if (!PX.CACHE_MAT[v.id]) {
+    protected getSharedMaterial (v: PhysicsMaterial | null): any {
+        const v1 = (v == null) ? PhysicsSystem.instance.defaultMaterial : v;
+        if (!PX.CACHE_MAT[v1.id]) {
             const physics = PhysXInstance.physics;
-            const mat = physics.createMaterial(v.friction, v.friction, v.restitution);
+            const mat = physics.createMaterial(v1.friction, v1.friction, v1.restitution);
             mat.setFrictionCombineMode(PX.CombineMode.eMULTIPLY);
             mat.setRestitutionCombineMode(PX.CombineMode.eMULTIPLY);
-            PX.CACHE_MAT[v.id] = mat;
+            PX.CACHE_MAT[v1.id] = mat;
             return mat;
         }
-        const mat = PX.CACHE_MAT[v.id];
-        mat.setStaticFriction(v.friction);
-        mat.setDynamicFriction(v.friction);
-        mat.setRestitution(v.restitution);
+        const mat = PX.CACHE_MAT[v1.id];
+        mat.setStaticFriction(v1.friction);
+        mat.setDynamicFriction(v1.friction);
+        mat.setRestitution(v1.restitution);
         return mat;
     }
 

--- a/cocos/physics/physx/shapes/physx-sphere-shape.ts
+++ b/cocos/physics/physx/shapes/physx-sphere-shape.ts
@@ -50,7 +50,7 @@ export class PhysXSphereShape extends PhysXShape implements ISphereShape {
 
     onComponentSet () {
         this.updateGeometry();
-        const pxmat = this.getSharedMaterial(this.collider.sharedMaterial!);
+        const pxmat = this.getSharedMaterial(this.collider.sharedMaterial);
         this._impl = PhysXInstance.physics.createShape(PhysXSphereShape.SPHERE_GEOMETRY, pxmat, true, this._flags);
     }
 


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/12931

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
