### PR TITLE
[fix] physics3d BulletTrimeshShape should not delete refBtTriangleMesh of triangle mesh #12949

### DIFF
--- a/cocos/physics/bullet/shapes/bullet-trimesh-shape.ts
+++ b/cocos/physics/bullet/shapes/bullet-trimesh-shape.ts
@@ -31,10 +31,10 @@ import { cocos2BulletVec3, cocos2BulletTriMesh } from '../bullet-utils';
 import { ITrimeshShape } from '../../spec/i-physics-shape';
 import { BulletCache } from '../bullet-cache';
 import { bt, EBulletType } from '../instantiated';
+import { BulletBvhTriangleMeshShape } from '../bullet-bvh-triangle-mesh-shape';
 
 export class BulletTrimeshShape extends BulletShape implements ITrimeshShape {
-    private static _mapTrimesh2btBVHMeshShape = {};
-
+    private btBVHMeshShape;
     public get collider () {
         return this._collider as MeshCollider;
     }
@@ -51,14 +51,9 @@ export class BulletTrimeshShape extends BulletShape implements ITrimeshShape {
                 if (this.collider.convex) {
                     const btTriangleMesh = this._getBtTriangleMesh(mesh);
                     this._impl = bt.ConvexTriangleMeshShape_new(btTriangleMesh);
-                } else if (BulletTrimeshShape._mapTrimesh2btBVHMeshShape[mesh.hash] == null) { // triangle mesh and bvh is not built
-                    const btTriangleMesh = this._getBtTriangleMesh(mesh);
-                    const bvhTrimesh = bt.BvhTriangleMeshShape_new(btTriangleMesh, true, true);
-                    BulletTrimeshShape._mapTrimesh2btBVHMeshShape[mesh.hash] = bvhTrimesh;
-                    this._impl = bt.ScaledBvhTriangleMeshShape_new(bvhTrimesh, 1, 1, 1);
-                } else if (BulletTrimeshShape._mapTrimesh2btBVHMeshShape[mesh.hash]) { // triangle mesh and bvh is already built
-                    const bvhMeshShapePtr = BulletTrimeshShape._mapTrimesh2btBVHMeshShape[mesh.hash];
-                    this._impl = bt.ScaledBvhTriangleMeshShape_new(bvhMeshShapePtr, 1, 1, 1);
+                } else {
+                    this.btBVHMeshShape = BulletBvhTriangleMeshShape.getBulletBvhTriangleMeshShape(mesh.hash, mesh);
+                    this._impl = bt.ScaledBvhTriangleMeshShape_new(this.btBVHMeshShape.bulletBvhTriangleMeshShapePtr, 1, 1, 1);
                 }
                 const bt_v3 = BulletCache.instance.BT_V3_0;
                 cocos2BulletVec3(bt_v3, this._collider.node.worldScale);
@@ -80,11 +75,12 @@ export class BulletTrimeshShape extends BulletShape implements ITrimeshShape {
     }
 
     onDestroy () {
-        //do not delete refBtTriangleMesh of triangle mesh, it might be shared by multiple (Scaled)BvhTriangleMeshShape
         if (this.collider.convex) {
             if (this.refBtTriangleMesh) {
                 bt._safe_delete(this.refBtTriangleMesh, EBulletType.EBulletTypeTriangleMesh);
             }
+        } else if (this.btBVHMeshShape) {
+            this.btBVHMeshShape.reference = false;
         }
         super.onDestroy();
     }

--- a/cocos/physics/bullet/shapes/bullet-trimesh-shape.ts
+++ b/cocos/physics/bullet/shapes/bullet-trimesh-shape.ts
@@ -48,10 +48,11 @@ export class BulletTrimeshShape extends BulletShape implements ITrimeshShape {
         } else {
             const mesh = v;
             if (mesh && mesh.renderingSubMeshes.length > 0) {
-                const btTriangleMesh = this._getBtTriangleMesh(mesh);
                 if (this.collider.convex) {
+                    const btTriangleMesh = this._getBtTriangleMesh(mesh);
                     this._impl = bt.ConvexTriangleMeshShape_new(btTriangleMesh);
                 } else if (BulletTrimeshShape._mapTrimesh2btBVHMeshShape[mesh.hash] == null) { // triangle mesh and bvh is not built
+                    const btTriangleMesh = this._getBtTriangleMesh(mesh);
                     const bvhTrimesh = bt.BvhTriangleMeshShape_new(btTriangleMesh, true, true);
                     BulletTrimeshShape._mapTrimesh2btBVHMeshShape[mesh.hash] = bvhTrimesh;
                     this._impl = bt.ScaledBvhTriangleMeshShape_new(bvhTrimesh, 1, 1, 1);
@@ -79,7 +80,12 @@ export class BulletTrimeshShape extends BulletShape implements ITrimeshShape {
     }
 
     onDestroy () {
-        if (this.refBtTriangleMesh) {  bt._safe_delete(this.refBtTriangleMesh, EBulletType.EBulletTypeTriangleMesh); }
+        //do not delete refBtTriangleMesh of triangle mesh, it might be shared by multiple (Scaled)BvhTriangleMeshShape
+        if (this.collider.convex) {
+            if (this.refBtTriangleMesh) {
+                bt._safe_delete(this.refBtTriangleMesh, EBulletType.EBulletTypeTriangleMesh);
+            }
+        }
         super.onDestroy();
     }
 


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/12949
https://github.com/cocos/3d-tasks/issues/15013

通过BulletBvhTriangleMeshShape类管理bt.TriangleMesh和bt.BvhTriangleMeshShape。bt.TriangleMesh和bt.BvhTriangleMeshShape一一对应。bt.BvhTriangleMeshShape可以被多个bt.ScaledBvhTriangleMeshShape共享。bt.ScaledBvhTriangleMeshShape是BulletTrimeshShape实际使用的bullet类。

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
