### PR TITLE
allow modify edit-box TEXT_LABEL&PLACEHOLDER_LABEL attributes

### DIFF
--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -590,10 +590,6 @@ export class EditBox extends Component {
             this._textLabel = textLabel;
         }
 
-        // update
-        const transformComp = this._textLabel!.node._uiProps.uiTransformComp;
-        transformComp!.setAnchorPoint(0, 1);
-        textLabel.overflow = Label.Overflow.CLAMP;
         if (this._inputMode === InputMode.ANY) {
             textLabel.verticalAlign = VerticalTextAlignment.TOP;
             textLabel.enableWrapText = true;
@@ -621,9 +617,6 @@ export class EditBox extends Component {
             this._placeholderLabel = placeholderLabel;
         }
 
-        // update
-        const transform = this._placeholderLabel!.node._uiProps.uiTransformComp;
-        transform!.setAnchorPoint(0, 1);
         if (this._inputMode === InputMode.ANY) {
             placeholderLabel.enableWrapText = true;
         } else {


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/13845

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
