### PR TITLE
Use double precision instead of float for terrain asset

### DIFF
--- a/cocos/terrain/terrain-asset.ts
+++ b/cocos/terrain/terrain-asset.ts
@@ -47,6 +47,7 @@ export const TERRAIN_DATA_VERSION3 = 0x01010003;
 export const TERRAIN_DATA_VERSION4 = 0x01010004;
 export const TERRAIN_DATA_VERSION5 = 0x01010005;
 export const TERRAIN_DATA_VERSION6 = 0x01010006;
+export const TERRAIN_DATA_VERSION7 = 0x01010007;
 export const TERRAIN_DATA_VERSION_DEFAULT = 0x01010111;
 
 class TerrainBuffer {
@@ -127,6 +128,22 @@ class TerrainBuffer {
         this.length += 4 * value.length;
     }
 
+    public writeDouble (value: number) {
+        this.reserve(this.length + 8);
+
+        this._buffView.setFloat64(this.length, value, true);
+        this.length += 8;
+    }
+
+    public writeDoubleArray (value: number[]) {
+        this.reserve(this.length + 8 * value.length);
+
+        for (let i = 0; i < value.length; ++i) {
+            this._buffView.setFloat64(this.length + i * 8, value[i], true);
+        }
+        this.length += 8 * value.length;
+    }
+
     public writeString (value: string) {
         this.reserve(this.length + value.length + 4);
 
@@ -174,6 +191,20 @@ class TerrainBuffer {
             value[i] = this._buffView.getFloat32(this._seekPos + i * 4, true);
         }
         this._seekPos += 4 * value.length;
+        return value;
+    }
+
+    public readDouble () {
+        const value = this._buffView.getFloat64(this._seekPos, true);
+        this._seekPos += 8;
+        return value;
+    }
+
+    public readDoubleArray (value: number[]) {
+        for (let i = 0; i < value.length; ++i) {
+            value[i] = this._buffView.getFloat64(this._seekPos + i * 4, true);
+        }
+        this._seekPos += 8 * value.length;
         return value;
     }
 
@@ -444,12 +475,18 @@ export class TerrainAsset extends Asset {
             && this._version !== TERRAIN_DATA_VERSION3
             && this._version !== TERRAIN_DATA_VERSION4
             && this._version !== TERRAIN_DATA_VERSION5
-            && this._version !== TERRAIN_DATA_VERSION6) {
+            && this._version !== TERRAIN_DATA_VERSION6
+            && this._version !== TERRAIN_DATA_VERSION7) {
             return false;
         }
 
         // geometry info
-        this.tileSize = stream.readFloat();
+        if (this._version >= TERRAIN_DATA_VERSION7) {
+            this.tileSize = stream.readDouble();
+        }
+        else {
+            this.tileSize = stream.readFloat();
+        }
         this.tileSize = Math.floor(this.tileSize * 100) / 100.0;
 
         stream.readIntArray(this._blockCount);
@@ -495,13 +532,24 @@ export class TerrainAsset extends Asset {
             for (let i = 0; i < this._layerBinaryInfos.length; ++i) {
                 this._layerBinaryInfos[i] = new TerrainLayerBinaryInfo();
                 this._layerBinaryInfos[i].slot = stream.readInt();
-                this._layerBinaryInfos[i].tileSize = stream.readFloat();
+                if (this._version >= TERRAIN_DATA_VERSION7) {
+                    this._layerBinaryInfos[i].tileSize = stream.readDouble();
+                }
+                else {
+                    this._layerBinaryInfos[i].tileSize = stream.readFloat();
+                }
 
                 this._layerBinaryInfos[i].detailMapId = stream.readString();
                 if (this._version >= TERRAIN_DATA_VERSION4) {
                     this._layerBinaryInfos[i].normalMapId = stream.readString();
-                    this._layerBinaryInfos[i].roughness = stream.readFloat();
-                    this._layerBinaryInfos[i].metallic = stream.readFloat();
+                    if (this._version >= TERRAIN_DATA_VERSION7) {
+                        this._layerBinaryInfos[i].roughness = stream.readDouble();
+                        this._layerBinaryInfos[i].metallic = stream.readDouble();
+                    }
+                    else {
+                        this._layerBinaryInfos[i].roughness = stream.readFloat();
+                        this._layerBinaryInfos[i].metallic = stream.readFloat();
+                    }
                 }
             }
         }
@@ -516,10 +564,10 @@ export class TerrainAsset extends Asset {
         const stream = new TerrainBuffer();
 
         // version
-        stream.writeInt32(TERRAIN_DATA_VERSION6);
+        stream.writeInt32(TERRAIN_DATA_VERSION7);
 
         // geometry info
-        stream.writeFloat(this.tileSize);
+        stream.writeDouble(this.tileSize);
         stream.writeIntArray(this._blockCount);
         stream.writeInt16(this.weightMapSize);
         stream.writeInt16(this.lightMapSize);
@@ -567,11 +615,11 @@ export class TerrainAsset extends Asset {
         stream.writeInt32(layerBinaryInfos.length);
         for (let i = 0; i < layerBinaryInfos.length; ++i) {
             stream.writeInt32(layerBinaryInfos[i].slot);
-            stream.writeFloat(layerBinaryInfos[i].tileSize);
+            stream.writeDouble(layerBinaryInfos[i].tileSize);
             stream.writeString(layerBinaryInfos[i].detailMapId);
             stream.writeString(layerBinaryInfos[i].normalMapId);
-            stream.writeFloat(layerBinaryInfos[i].roughness);
-            stream.writeFloat(layerBinaryInfos[i].metallic);
+            stream.writeDouble(layerBinaryInfos[i].roughness);
+            stream.writeDouble(layerBinaryInfos[i].metallic);
         }
 
         return stream.buffer;

--- a/cocos/terrain/terrain-asset.ts
+++ b/cocos/terrain/terrain-asset.ts
@@ -483,8 +483,7 @@ export class TerrainAsset extends Asset {
         // geometry info
         if (this._version >= TERRAIN_DATA_VERSION7) {
             this.tileSize = stream.readDouble();
-        }
-        else {
+        } else {
             this.tileSize = stream.readFloat();
         }
         this.tileSize = Math.floor(this.tileSize * 100) / 100.0;
@@ -534,8 +533,7 @@ export class TerrainAsset extends Asset {
                 this._layerBinaryInfos[i].slot = stream.readInt();
                 if (this._version >= TERRAIN_DATA_VERSION7) {
                     this._layerBinaryInfos[i].tileSize = stream.readDouble();
-                }
-                else {
+                } else {
                     this._layerBinaryInfos[i].tileSize = stream.readFloat();
                 }
 
@@ -545,8 +543,7 @@ export class TerrainAsset extends Asset {
                     if (this._version >= TERRAIN_DATA_VERSION7) {
                         this._layerBinaryInfos[i].roughness = stream.readDouble();
                         this._layerBinaryInfos[i].metallic = stream.readDouble();
-                    }
-                    else {
+                    } else {
                         this._layerBinaryInfos[i].roughness = stream.readFloat();
                         this._layerBinaryInfos[i].metallic = stream.readFloat();
                     }


### PR DESCRIPTION
Re: #

### Changelog

* Use double precision instead of float for terrain asset

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
