### PR TITLE
fix wrong logic of murmurhash2_32_gc

### DIFF
--- a/cocos/core/algorithm/murmurhash2_gc.ts
+++ b/cocos/core/algorithm/murmurhash2_gc.ts
@@ -69,8 +69,11 @@ export function murmurhash2_32_gc (input: string | Uint8Array, seed: number) {
     }
 
     switch (l) {
-    case 3: h ^= (getUint8.call(input, i + 2) & 0xff) << 16; break;
-    case 2: h ^= (getUint8.call(input, i + 1) & 0xff) << 8; break;
+    // Don't break in case 3 and case 2.
+    case 3: h ^= (getUint8.call(input, i + 2) & 0xff) << 16;
+    // eslint-disable-next-line no-fallthrough
+    case 2: h ^= (getUint8.call(input, i + 1) & 0xff) << 8;
+    // eslint-disable-next-line no-fallthrough
     case 1:
         h ^= (getUint8.call(input, i) & 0xff);
         h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));

--- a/tests/core/algorithm/murmurhash2.test.ts
+++ b/tests/core/algorithm/murmurhash2.test.ts
@@ -1,0 +1,12 @@
+import { murmurhash2_32_gc } from '../../../cocos/core/algorithm/murmurhash2_gc'
+
+const SEED = 3339675911;
+
+// The test case refers to https://github.com/jtpio/murmurhash2/blob/main/test/murmur2_spec.ts
+describe('murmurhash2_32_gc', () => {
+    test('should encode ASCII strings', () => {
+        const str = 'abcde';
+        const h = murmurhash2_32_gc(str, SEED);
+        expect(h).toEqual(730143326);
+    });
+})


### PR DESCRIPTION
Re: #

### Changelog

* Fix the wrong logic brought by https://github.com/cocos/cocos-engine/pull/13883

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
