### PR TITLE
3.7 fix node polyfill

### DIFF
--- a/cocos/core/global-exports.ts
+++ b/cocos/core/global-exports.ts
@@ -65,7 +65,7 @@ _global.cc = legacyCC;
 export { engineVersion as VERSION };
 
 if (EDITOR && legacyCC.GAME_VIEW === undefined) {
-    // Whether in native-scene/preview mode
+    // Used to indicate whether it is currently in preview mode
     // 'isPreviewProcess' is defined only in the editor's process
     legacyCC.GAME_VIEW = typeof globalThis.isPreviewProcess !== 'undefined' ? globalThis.isPreviewProcess : false;
 }

--- a/cocos/core/global-exports.ts
+++ b/cocos/core/global-exports.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { DEV } from 'internal:constants';
+import { DEV, EDITOR } from 'internal:constants';
 
 const _global = typeof window === 'undefined' ? global : window;
 
@@ -63,6 +63,12 @@ _global.CocosEngine = legacyCC.ENGINE_VERSION = engineVersion;
 _global.cc = legacyCC;
 
 export { engineVersion as VERSION };
+
+if (EDITOR && legacyCC.GAME_VIEW === undefined) {
+    // Whether in native-scene/preview mode
+    // 'isPreviewProcess' is defined only in the editor's process
+    legacyCC.GAME_VIEW = typeof globalThis.isPreviewProcess !== 'undefined' ? globalThis.isPreviewProcess : false;
+}
 
 const ccwindow: typeof window = typeof globalThis.jsb !== 'undefined' ? (typeof jsb.window !== 'undefined' ? jsb.window : globalThis) : globalThis;
 _global.ccwindow = ccwindow;

--- a/cocos/core/global-exports.ts
+++ b/cocos/core/global-exports.ts
@@ -65,8 +65,8 @@ _global.cc = legacyCC;
 export { engineVersion as VERSION };
 
 if (EDITOR && legacyCC.GAME_VIEW === undefined) {
-    // Used to indicate whether it is currently in preview mode
-    // 'isPreviewProcess' is defined only in the editor's process
+    // Used to indicate whether it is currently in preview mode.
+    // 'isPreviewProcess' is defined only in the editor's process.
     legacyCC.GAME_VIEW = typeof globalThis.isPreviewProcess !== 'undefined' ? globalThis.isPreviewProcess : false;
 }
 

--- a/cocos/scene-graph/node-dev.ts
+++ b/cocos/scene-graph/node-dev.ts
@@ -32,7 +32,7 @@ import { Component } from './component';
 const Destroying = CCObject.Flags.Destroying;
 
 export function nodePolyfill (Node) {
-    if (EDITOR || TEST) {
+    if ((EDITOR && !legacyCC.GAME_VIEW) || TEST) {
         Node.prototype._checkMultipleComp = function (ctor) {
             const existing = this.getComponent(ctor._disallowMultiple);
             if (existing) {
@@ -86,7 +86,7 @@ export function nodePolyfill (Node) {
 
             comp.node = this;
             this._components.splice(index, 0, comp);
-            if (EDITOR && EditorExtends.Node && EditorExtends.Component) {
+            if (EDITOR && !legacyCC.GAME_VIEW && EditorExtends.Node && EditorExtends.Component) {
                 const node = EditorExtends.Node.getNode(this._id);
                 if (node) {
                     EditorExtends.Component.add(comp._id, comp);
@@ -146,7 +146,7 @@ export function nodePolyfill (Node) {
         Node.prototype._onRestoreBase = Node.prototype.onRestore;
     }
 
-    if (EDITOR || TEST) {
+    if ((EDITOR && !legacyCC.GAME_VIEW) || TEST) {
         Node.prototype._registerIfAttached = function (register) {
             if (!this._id) {
                 console.warn(`Node(${this && this.name}}) is invalid or its data is corrupted.`);

--- a/cocos/scene-graph/node-dev.ts
+++ b/cocos/scene-graph/node-dev.ts
@@ -30,9 +30,10 @@ import { error, errorID, getError } from '../core/platform/debug';
 import { Component } from './component';
 
 const Destroying = CCObject.Flags.Destroying;
+const IS_PREVIEW = !!legacyCC.GAME_VIEW;
 
 export function nodePolyfill (Node) {
-    if ((EDITOR && !legacyCC.GAME_VIEW) || TEST) {
+    if ((EDITOR && !IS_PREVIEW) || TEST) {
         Node.prototype._checkMultipleComp = function (ctor) {
             const existing = this.getComponent(ctor._disallowMultiple);
             if (existing) {
@@ -86,7 +87,7 @@ export function nodePolyfill (Node) {
 
             comp.node = this;
             this._components.splice(index, 0, comp);
-            if (EDITOR && !legacyCC.GAME_VIEW && EditorExtends.Node && EditorExtends.Component) {
+            if (EDITOR && !IS_PREVIEW && EditorExtends.Node && EditorExtends.Component) {
                 const node = EditorExtends.Node.getNode(this._id);
                 if (node) {
                     EditorExtends.Component.add(comp._id, comp);
@@ -146,7 +147,7 @@ export function nodePolyfill (Node) {
         Node.prototype._onRestoreBase = Node.prototype.onRestore;
     }
 
-    if ((EDITOR && !legacyCC.GAME_VIEW) || TEST) {
+    if ((EDITOR && !IS_PREVIEW) || TEST) {
         Node.prototype._registerIfAttached = function (register) {
             if (!this._id) {
                 console.warn(`Node(${this && this.name}}) is invalid or its data is corrupted.`);
@@ -190,8 +191,9 @@ export function nodePolyfill (Node) {
         // promote debug info
         js.get(Node.prototype, ' INFO ', function () {
             let path = '';
-            // @ts-expect-error
-            let node = this;
+            // @ts-expect-error: type of this
+            // eslint-disable-next-line @typescript-eslint/no-this-alias
+            let node: any = this;
             while (node && !(node instanceof legacyCC.Scene)) {
                 if (path) {
                     path = `${node.name}/${path}`;
@@ -200,7 +202,7 @@ export function nodePolyfill (Node) {
                 }
                 node = node._parent;
             }
-            // @ts-expect-error
+            // @ts-expect-error: type of this
             return `${this.name}, path: ${path}`;
         });
     }


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/15223

### Changelog

* define cc.GAME_VIEW in global-exports.ts

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
