### PR TITLE
fix: decorated property without default value

### DIFF
--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -478,7 +478,9 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
     if ('default' in attributes) {
         (attrs || initAttrs())[`${propertyNamePrefix}default`] = attributes.default;
     } else if (((EDITOR && !window.Build) || TEST) && warnOnNoDefault && !(attributes.get || attributes.set)) {
-        warnID(3654, className, propertyName);
+        // TODO: we close this warning for now:
+        // issue: https://github.com/cocos/3d-tasks/issues/14887
+        // warnID(3654, className, propertyName);
     }
 
     const parseSimpleAttribute = (attributeName: keyof IAcceptableAttributes, expectType: string) => {

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -248,9 +248,12 @@ function setDefaultValue<T> (
     propertyKey: PropertyKey,
     descriptorOrInitializer: BabelPropertyDecoratorDescriptor | Initializer | undefined,
 ) {
-    if (descriptorOrInitializer) {
+    if (descriptorOrInitializer !== undefined) {
         if (typeof descriptorOrInitializer === 'function') {
             propertyStash.default = getDefaultFromInitializer(descriptorOrInitializer);
+        } else if (descriptorOrInitializer === null) {
+            // some decorated properties we haven't specified default value, then the initializer should be null.
+            propertyStash.default = null;
         } else if (descriptorOrInitializer.initializer) {
             // In case of Babel, if an initializer is given for class field.
             // That initializer is passed to `descriptor.initializer`.
@@ -259,6 +262,7 @@ function setDefaultValue<T> (
     } else {
         // In case of TypeScript, we can not directly capture the initializer.
         // We have to be hacking to extract the value.
+        // We should fallback to TypeScript case only when `descriptorOrInitializer` is undefined.
         const actualDefaultValues = classStash.default || (classStash.default = extractActualDefaultValues(classConstructor));
         // eslint-disable-next-line no-prototype-builtins
         if ((actualDefaultValues as any).hasOwnProperty(propertyKey)) {

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -253,7 +253,8 @@ function setDefaultValue<T> (
             propertyStash.default = getDefaultFromInitializer(descriptorOrInitializer);
         } else if (descriptorOrInitializer === null) {
             // some decorated properties we haven't specified default value, then the initializer should be null.
-            propertyStash.default = undefined;
+            // We fallback to the behavior of v3.6.3, where we don't specify default value automatically.
+            // propertyStash.default = undefined;
         } else if (descriptorOrInitializer.initializer) {
             // In case of Babel, if an initializer is given for class field.
             // That initializer is passed to `descriptor.initializer`.

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -246,14 +246,14 @@ function setDefaultValue<T> (
     propertyStash: PropertyStash,
     classConstructor: new () => T,
     propertyKey: PropertyKey,
-    descriptorOrInitializer: BabelPropertyDecoratorDescriptor | Initializer | undefined,
+    descriptorOrInitializer: BabelPropertyDecoratorDescriptor | Initializer | undefined | null,
 ) {
     if (descriptorOrInitializer !== undefined) {
         if (typeof descriptorOrInitializer === 'function') {
             propertyStash.default = getDefaultFromInitializer(descriptorOrInitializer);
         } else if (descriptorOrInitializer === null) {
             // some decorated properties we haven't specified default value, then the initializer should be null.
-            propertyStash.default = null;
+            propertyStash.default = undefined;
         } else if (descriptorOrInitializer.initializer) {
             // In case of Babel, if an initializer is given for class field.
             // That initializer is passed to `descriptor.initializer`.

--- a/cocos/core/data/decorators/utils.ts
+++ b/cocos/core/data/decorators/utils.ts
@@ -40,7 +40,9 @@ export type BabelPropertyDecoratorDescriptor = PropertyDescriptor & { initialize
  * 该签名同时兼容 TypeScript legacy 装饰器以及 Babel legacy 装饰器。
  * 第三个参数在 Babel 情况下，会传入 descriptor。对于一些被优化的引擎内部装饰器，会传入 initializer。
  */
-export type LegacyPropertyDecorator = (target: Record<string, any>, propertyKey: string | symbol, descriptorOrInitializer?: BabelPropertyDecoratorDescriptor | Initializer) => void;
+export type LegacyPropertyDecorator = (
+    target: Record<string, any>, propertyKey: string | symbol, descriptorOrInitializer?: BabelPropertyDecoratorDescriptor | Initializer | null,
+) => void;
 
 /**
  * @en

--- a/cocos/scene-graph/prefab/prefab-info.ts
+++ b/cocos/scene-graph/prefab/prefab-info.ts
@@ -222,7 +222,7 @@ export class PrefabInfo {
 
     @serializable
     @type([TargetOverrideInfo])
-    public targetOverrides?: TargetOverrideInfo[];
+    public targetOverrides?: TargetOverrideInfo[] = [];
 
     // record outMost prefabInstance nodes in descendants
     // collected when saving sceneAsset or prefabAsset

--- a/cocos/scene-graph/prefab/prefab-info.ts
+++ b/cocos/scene-graph/prefab/prefab-info.ts
@@ -222,7 +222,7 @@ export class PrefabInfo {
 
     @serializable
     @type([TargetOverrideInfo])
-    public targetOverrides?: TargetOverrideInfo[] = [];
+    public targetOverrides?: TargetOverrideInfo[];
 
     // record outMost prefabInstance nodes in descendants
     // collected when saving sceneAsset or prefabAsset

--- a/tests/core/ccclass.test.ts
+++ b/tests/core/ccclass.test.ts
@@ -43,7 +43,8 @@ describe('ccclass warnings', () => {
         warnID.mockClear();
     };
 
-    test('Warn on no default value specified', () => {
+    // TODO
+    test.skip('Warn on no default value specified', () => {
         clearWarnID();
         { @ccclass class _ { @float p; } }
         expect(warnID).toHaveBeenCalledTimes(1);

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -283,9 +283,7 @@ describe('Decorated property test', () => {
     };
 
     test('property without default value', () => {
-        expect(t(null)).toMatchObject({
-            default: undefined,
-        });
+        expect(t(null)).toMatchObject({});
     });
 
     test('property with default value null', () => {

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -283,6 +283,7 @@ describe('Decorated property test', () => {
     };
 
     test('property without default value', () => {
+        // Simulate `class A { @property test; }`(in babel case)
         expect(t(null)).toMatchObject({});
     });
 

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -307,6 +307,7 @@ describe('Decorated property test', () => {
     });
 
     test('property in TSC compiler', () => {
+        // Simulate `class A { @property test; }`(in tsc case)
         expect(t()).toMatchObject({
             default: undefined,
         });

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -295,6 +295,7 @@ describe('Decorated property test', () => {
     });
 
     test('property with property descriptor', () => {
+        // Simulate `class A { @property test = null; }`(in babel case)
         expect(t({
             configurable: true,
             enumerable: true,

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -287,6 +287,7 @@ describe('Decorated property test', () => {
     });
 
     test('property with default value null', () => {
+        // Simulate `class A { @property test = null; }`(in babel case)
         expect(t(() => null)).toMatchObject({
             default: null,
         });

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -11,44 +11,38 @@ import {
 } from '../../cocos/core/data/decorators';
 import { CCClass } from '../../cocos/core/data/class';
 import { property } from '../../cocos/core/data/decorators/property';
+import { getClassByName, unregisterClass } from '../../cocos/core/utils/js-typed';
+import { LegacyPropertyDecorator } from '../../cocos/core/data/decorators/utils';
 
-describe('Decorators signature', () => {
+test('Decorators signature', () => {
     class Foo {}
 
-    property(Foo, 'field1', function initializer () {
+    property(Foo.prototype, 'field1', function initializer () {
         return 1;
     });
-    property(Foo, 'field2', {
+    property(Foo.prototype, 'field2', {
         initializer() {
             return 2;
         },
     });
-    property(Foo, 'property', { value: 1 });
-    property(Foo, 'getset', {
+    property(Foo.prototype, 'property', { value: 1 });
+    property(Foo.prototype, 'getset', {
         get() {
             return 3;
         },
         set(v) {},
     });
-    expect(Foo.constructor['__ccclassCache__']).toMatchInlineSnapshot(`
-        Object {
-          "proto": Object {
-            "properties": Object {
-              "field1": Object {
-                "default": 1,
-              },
-              "field2": Object {
-                "default": 2,
-              },
-              "getset": Object {
-                "get": [Function],
-                "set": [Function],
-              },
-              "property": Object {},
-            },
-          },
-        }
-    `);
+    ccclass('Foo')(Foo);
+    expect(Foo['__attrs__']).toMatchObject({
+        field1$_$default: 1,
+        field2$_$default: 2,
+        getset$_$hasGetter: true,
+        getset$_$hasSetter: true,
+        getset$_$serializable: false,
+    });
+    expect(Foo['__props__']).toMatchObject(['field1', 'field2', 'property', 'getset']);
+
+    unregisterClass(Foo);
 });
 
 describe(`Decorators`, () => {
@@ -270,5 +264,51 @@ describe(`Decorators`, () => {
         }
 
         expect(CCClass.Attr.attr(Tooltip, 'boo').tooltip).toBe('i18n:ENGINE.model.shadow_normal_bias');
+    });
+});
+
+describe('Decorated property test', () => {
+    afterEach(() => {
+        const cls = getClassByName('A');
+        unregisterClass(cls);
+    });
+
+    const t = (descriptorOrInitializer?: Parameters<LegacyPropertyDecorator>[2]) => {
+        class A {
+            test: number;
+        }
+        property(A.prototype, 'test', descriptorOrInitializer);
+        ccclass('A')(A);
+        return CCClass.Attr.attr(A, 'test');
+    };
+
+    test('property without default value', () => {
+        expect(t(null)).toMatchObject({
+            default: undefined,
+        });
+    });
+
+    test('property with default value null', () => {
+        expect(t(() => null)).toMatchObject({
+            default: null,
+        });
+    });
+
+    test('property with property descriptor', () => {
+        expect(t({
+            configurable: true,
+            enumerable: true,
+            value: 1,
+            writable: true,
+            initializer () { return null; }
+        })).toMatchObject({
+            default: null,
+        });
+    });
+
+    test('property in TSC compiler', () => {
+        expect(t()).toMatchObject({
+            default: undefined,
+        });
     });
 });


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/15388

![企业微信截图_20230106161843](https://user-images.githubusercontent.com/17872773/210959872-54d07985-7210-42ca-a396-9fcaa53fe000.png)


this PR will fallback to the state of v3.6.3, which will report many warning that we don't specify default value to decorated property
![企业微信截图_16729994129106](https://user-images.githubusercontent.com/17872773/210978979-c975f3d7-d6e7-41f8-8ed9-4b7160bc244e.png)
