### PR TITLE
Native platform modifies exit process

### DIFF
--- a/@types/pal/system-info.d.ts
+++ b/@types/pal/system-info.d.ts
@@ -50,6 +50,7 @@ declare module 'pal/system-info' {
         public restartJSVM (): void;
 
         public close (): void;
+        public exit(): void;
 
         on (event: PalSystemEvent, cb: (...args: any)=>void, target?: any): void;
         off (event: PalSystemEvent, cb?: (...args: any)=>void, target?: any): void;

--- a/@types/pal/system-info.d.ts
+++ b/@types/pal/system-info.d.ts
@@ -48,8 +48,13 @@ declare module 'pal/system-info' {
         public openURL (url: string): void;
         public now (): number;
         public restartJSVM (): void;
-
+        /*
+         * Trigger to exit the game
+         */
         public close (): void;
+        /*
+         * Free the native's resources
+         */
         public exit(): void;
 
         on (event: PalSystemEvent, cb: (...args: any)=>void, target?: any): void;

--- a/cocos/game/game.ts
+++ b/cocos/game/game.ts
@@ -307,6 +307,12 @@ export class Game extends EventTarget {
     public static readonly EVENT_RESUME = 'game_on_resume';
 
     /**
+     * @en Events triggered when the game pauses to resume running. <br>
+     * @zh 游戏关闭时触发的事件。<br>
+     */
+    public static readonly EVENT_CLOSE = 'game_on_close';
+
+    /**
      * @en Web Canvas 2d API as renderer backend.
      * @zh 使用 Web Canvas 2d API 作为渲染器后端。
      */
@@ -542,6 +548,7 @@ export class Game extends EventTarget {
         if (this._paused) { return; }
         this._pausedByEngine = true;
         this.pause();
+        this.emit(Game.EVENT_PAUSE);
     }
 
     /**
@@ -551,6 +558,7 @@ export class Game extends EventTarget {
     private resumeByEngine () {
         if (this._pausedByEngine) {
             this.resume();
+            this.emit(Game.EVENT_RESUME);
             this._pausedByEngine = false;
         }
     }
@@ -1027,6 +1035,7 @@ export class Game extends EventTarget {
     private _initEvents () {
         systemInfo.on('show', this._onShow, this);
         systemInfo.on('hide', this._onHide, this);
+        systemInfo.on('close', this._onClose, this);
     }
 
     private _onHide () {
@@ -1037,6 +1046,11 @@ export class Game extends EventTarget {
     private _onShow () {
         this.emit(Game.EVENT_SHOW);
         this.resumeByEngine();
+    }
+
+    private _onClose() {
+        this.emit(Game.EVENT_CLOSE);
+        systemInfo.exit();
     }
 
     //  @ Persist root node section

--- a/cocos/game/game.ts
+++ b/cocos/game/game.ts
@@ -548,7 +548,6 @@ export class Game extends EventTarget {
         if (this._paused) { return; }
         this._pausedByEngine = true;
         this.pause();
-        this.emit(Game.EVENT_PAUSE);
     }
 
     /**
@@ -558,7 +557,6 @@ export class Game extends EventTarget {
     private resumeByEngine () {
         if (this._pausedByEngine) {
             this.resume();
-            this.emit(Game.EVENT_RESUME);
             this._pausedByEngine = false;
         }
     }
@@ -1050,6 +1048,7 @@ export class Game extends EventTarget {
 
     private _onClose() {
         this.emit(Game.EVENT_CLOSE);
+        // TODO : Release Resources.
         systemInfo.exit();
     }
 

--- a/cocos/game/game.ts
+++ b/cocos/game/game.ts
@@ -307,8 +307,8 @@ export class Game extends EventTarget {
     public static readonly EVENT_RESUME = 'game_on_resume';
 
     /**
-     * @en Events triggered when the game pauses to resume running. <br>
-     * @zh 游戏关闭时触发的事件。<br>
+     * @en Triggered when the game will be closed. <br>
+     * @zh 游戏将要关闭时触发的事件。<br>
      */
     public static readonly EVENT_CLOSE = 'game_on_close';
 

--- a/cocos/game/game.ts
+++ b/cocos/game/game.ts
@@ -1046,7 +1046,7 @@ export class Game extends EventTarget {
         this.resumeByEngine();
     }
 
-    private _onClose() {
+    private _onClose () {
         this.emit(Game.EVENT_CLOSE);
         // TODO : Release Resources.
         systemInfo.exit();

--- a/native/cocos/bindings/auto/jsb_cocos_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_cocos_auto.cpp
@@ -4616,7 +4616,7 @@ static bool js_cc_ISystemWindowManager_processEvent(se::State& s)
     
     ok &= sevalue_to_native(args[0], &arg2, s.thisObject());
     SE_PRECONDITION2(ok, false, "Error processing arguments"); 
-    (arg1)->processEvent(arg2);
+    (arg1)->processEvent();
     
     
     return true;

--- a/native/cocos/bindings/manual/jsb_global.cpp
+++ b/native/cocos/bindings/manual/jsb_global.cpp
@@ -387,7 +387,7 @@ static bool JSB_closeWindow(se::State &s) {
 SE_BIND_FUNC(JSB_closeWindow)
 
 static bool JSB_exit(se::State &s) {
-    BasePlatform::getPlatform()->exitLoop();
+    BasePlatform::getPlatform()->exit();
     return true;
 }
 SE_BIND_FUNC(JSB_exit);

--- a/native/cocos/bindings/manual/jsb_global.cpp
+++ b/native/cocos/bindings/manual/jsb_global.cpp
@@ -386,6 +386,12 @@ static bool JSB_closeWindow(se::State &s) {
 }
 SE_BIND_FUNC(JSB_closeWindow)
 
+static bool JSB_exit(se::State &s) {
+    BasePlatform::getPlatform()->exitLoop();
+    return true;
+}
+SE_BIND_FUNC(JSB_exit);
+
 static bool JSB_isObjectValid(se::State &s) { // NOLINT
     const auto &args = s.args();
     int argc = static_cast<int>(args.size());
@@ -1431,6 +1437,7 @@ bool jsb_register_global_variables(se::Object *global) { // NOLINT
     global->defineFunction("__restartVM", _SE(JSB_core_restartVM));
     global->defineFunction("__close", _SE(JSB_closeWindow));
     global->defineFunction("__isObjectValid", _SE(JSB_isObjectValid));
+    global->defineFunction("__exit", _SE(JSB_exit));
 
     se::HandleObject performanceObj(se::Object::createPlainObject());
     performanceObj->defineFunction("now", _SE(js_performance_now));

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -338,6 +338,8 @@ bool Engine::redirectWindowEvent(const WindowEvent &ev) {
     } else if (ev.type == WindowEvent::Type::CLOSE) {
         emit<EngineStatusChange>(ON_CLOSE);
         events::Close::broadcast();
+        // Increase the frame rate and get the program to exit as quickly as possible
+        setPreferredFramesPerSecond(1000);
         isHandled = true;
     } else if (ev.type == WindowEvent::Type::QUIT) {
         // There is no need to process the quit message,

--- a/native/cocos/platform/BasePlatform.h
+++ b/native/cocos/platform/BasePlatform.h
@@ -69,6 +69,11 @@ public:
     virtual void pollEvent() = 0;
 
     /**
+     * @brief Exit loop.
+     */
+    virtual void exitLoop() = 0;
+
+    /**
      * @brief Get target system type.
      */
     using OSType = ISystem::OSType;

--- a/native/cocos/platform/BasePlatform.h
+++ b/native/cocos/platform/BasePlatform.h
@@ -69,7 +69,7 @@ public:
     virtual void pollEvent() = 0;
 
     /**
-     * @brief Exit loop.
+     * @brief Exit platform.
      */
     virtual void exit() = 0;
 

--- a/native/cocos/platform/BasePlatform.h
+++ b/native/cocos/platform/BasePlatform.h
@@ -71,7 +71,7 @@ public:
     /**
      * @brief Exit loop.
      */
-    virtual void exitLoop() = 0;
+    virtual void exit() = 0;
 
     /**
      * @brief Get target system type.

--- a/native/cocos/platform/SDLHelper.cpp
+++ b/native/cocos/platform/SDLHelper.cpp
@@ -210,7 +210,7 @@ void SDLHelper::dispatchWindowEvent(uint32_t windowId, const SDL_WindowEvent &we
     }
 }
 
-void SDLHelper::dispatchSDLEvent(uint32_t windowId, const SDL_Event &sdlEvent, bool *quit) {
+void SDLHelper::dispatchSDLEvent(uint32_t windowId, const SDL_Event &sdlEvent) {
     cc::TouchEvent touch;
     cc::MouseEvent mouse;
     cc::KeyboardEvent keyboard;
@@ -223,9 +223,6 @@ void SDLHelper::dispatchSDLEvent(uint32_t windowId, const SDL_Event &sdlEvent, b
 
     switch (sdlEvent.type) {
         case SDL_QUIT: {
-            if (quit) {
-                *quit = true;
-            }
             WindowEvent ev;
             ev.type = WindowEvent::Type::QUIT;
             events::WindowEvent::broadcast(ev);

--- a/native/cocos/platform/SDLHelper.h
+++ b/native/cocos/platform/SDLHelper.h
@@ -54,7 +54,7 @@ public:
     static void setCursorEnabled(bool value);
 
 private:
-    static void dispatchSDLEvent( uint32_t windowId, const SDL_Event& sdlEvent);
+    static void dispatchSDLEvent(uint32_t windowId, const SDL_Event& sdlEvent);
     static void dispatchWindowEvent(uint32_t windowId, const SDL_WindowEvent& wevent);
 };
 } // namespace cc

--- a/native/cocos/platform/SDLHelper.h
+++ b/native/cocos/platform/SDLHelper.h
@@ -54,7 +54,7 @@ public:
     static void setCursorEnabled(bool value);
 
 private:
-    static void dispatchSDLEvent(uint32_t windowId, const SDL_Event& sdlEvent, bool* quit);
+    static void dispatchSDLEvent( uint32_t windowId, const SDL_Event& sdlEvent);
     static void dispatchWindowEvent(uint32_t windowId, const SDL_WindowEvent& wevent);
 };
 } // namespace cc

--- a/native/cocos/platform/UniversalPlatform.cpp
+++ b/native/cocos/platform/UniversalPlatform.cpp
@@ -79,4 +79,8 @@ void UniversalPlatform::onDestroy() {
     cocos_destory();
 }
 
+void UniversalPlatform::exitLoop() {
+
+}
+
 } // namespace cc

--- a/native/cocos/platform/UniversalPlatform.cpp
+++ b/native/cocos/platform/UniversalPlatform.cpp
@@ -79,7 +79,7 @@ void UniversalPlatform::onDestroy() {
     cocos_destory();
 }
 
-void UniversalPlatform::exitLoop() {
+void UniversalPlatform::exit() {
 
 }
 

--- a/native/cocos/platform/UniversalPlatform.h
+++ b/native/cocos/platform/UniversalPlatform.h
@@ -81,7 +81,7 @@ public:
     virtual void onDestroy();
 
     /**
-     * @brief Exit loop.
+     * @brief Exit platform.
      */
     void exit() override;
 

--- a/native/cocos/platform/UniversalPlatform.h
+++ b/native/cocos/platform/UniversalPlatform.h
@@ -83,7 +83,7 @@ public:
     /**
      * @brief Exit loop.
      */
-    void exitLoop() override;
+    void exit() override;
 
 private:
     ThreadCallback _mainTask{nullptr};

--- a/native/cocos/platform/UniversalPlatform.h
+++ b/native/cocos/platform/UniversalPlatform.h
@@ -80,6 +80,11 @@ public:
      */
     virtual void onDestroy();
 
+    /**
+     * @brief Exit loop.
+     */
+    virtual void exitLoop();
+
 private:
     ThreadCallback _mainTask{nullptr};
 

--- a/native/cocos/platform/UniversalPlatform.h
+++ b/native/cocos/platform/UniversalPlatform.h
@@ -83,7 +83,7 @@ public:
     /**
      * @brief Exit loop.
      */
-    virtual void exitLoop();
+    void exitLoop() override;
 
 private:
     ThreadCallback _mainTask{nullptr};

--- a/native/cocos/platform/android/AndroidPlatform.cpp
+++ b/native/cocos/platform/android/AndroidPlatform.cpp
@@ -255,7 +255,6 @@ public:
                     addTouchEvent(i, motionEvent);
                 }
             }
-            finishActivity();
             events::Touch::broadcast(touchEvent);
             touchEvent.touches.clear();
             return true;
@@ -604,13 +603,11 @@ int32_t AndroidPlatform::loop() {
 
             // Exit the game loop when the Activity is destroyed
             if (_app->destroyRequested) {
-                CC_LOG_DEBUG("AndroidPlatform destroyRequested");
                 break;
             }
         }
         // Exit the game loop when the Activity is destroyed
         if (_app->destroyRequested) {
-            CC_LOG_DEBUG("AndroidPlatform destroyRequested");
             break;
         }
         if (xr && !xr->platformLoopStart()) continue;
@@ -636,9 +633,7 @@ int32_t AndroidPlatform::loop() {
 #endif
         if (xr) xr->platformLoopEnd();
     }
-    CC_LOG_DEBUG("AndroidPlatform onDestroy1");
     onDestroy();
-    CC_LOG_DEBUG("AndroidPlatform onDestroy2");
     return 0;
 }
 

--- a/native/cocos/platform/android/AndroidPlatform.cpp
+++ b/native/cocos/platform/android/AndroidPlatform.cpp
@@ -583,8 +583,6 @@ int32_t AndroidPlatform::run(int /*argc*/, const char ** /*argv*/) {
 
 void AndroidPlatform::exitLoop() {
     _app->destroyRequested = 1;
-    CC_LOG_DEBUG("AndroidPlatform exit loop");
-    //_quit = true;
 }
 
 int32_t AndroidPlatform::loop() {

--- a/native/cocos/platform/android/AndroidPlatform.cpp
+++ b/native/cocos/platform/android/AndroidPlatform.cpp
@@ -581,7 +581,7 @@ int32_t AndroidPlatform::run(int /*argc*/, const char ** /*argv*/) {
     return 0;
 }
 
-void AndroidPlatform::exitLoop() {
+void AndroidPlatform::exit() {
     _app->destroyRequested = 1;
 }
 

--- a/native/cocos/platform/android/AndroidPlatform.h
+++ b/native/cocos/platform/android/AndroidPlatform.h
@@ -47,7 +47,8 @@ public:
     int getSdkVersion() const override;
 
     int32_t loop() override;
-
+    void exitLoop() override;
+    
     void *getActivity();
 
     static void *getEnv();
@@ -66,7 +67,6 @@ private:
     int _loopTimeOut{-1};
     GameInputProxy *_inputProxy{nullptr};
     android_app *_app{nullptr};
-
     friend class GameInputProxy;
 };
 } // namespace cc

--- a/native/cocos/platform/android/AndroidPlatform.h
+++ b/native/cocos/platform/android/AndroidPlatform.h
@@ -47,7 +47,7 @@ public:
     int getSdkVersion() const override;
 
     int32_t loop() override;
-    void exitLoop() override;
+    void exit() override;
     
     void *getActivity();
 

--- a/native/cocos/platform/empty/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/empty/modules/SystemWindowManager.cpp
@@ -33,7 +33,7 @@ int SystemWindowManager::init() {
     return 0;
 }
 
-void SystemWindowManager::processEvent(bool *quit) {
+void SystemWindowManager::processEvent() {
 }
 
 ISystemWindow *SystemWindowManager::getWindow(uint32_t windowId) const {

--- a/native/cocos/platform/empty/modules/SystemWindowManager.h
+++ b/native/cocos/platform/empty/modules/SystemWindowManager.h
@@ -36,7 +36,7 @@ public:
     explicit SystemWindowManager() = default;
 
     int init() override;
-    void processEvent(bool *quit) override;
+    void processEvent() override;
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/interfaces/modules/ISystemWindowManager.h
+++ b/native/cocos/platform/interfaces/modules/ISystemWindowManager.h
@@ -55,7 +55,7 @@ public:
     /**
      * Process messages at the PAL layer
      */
-    virtual void processEvent(void) = 0;
+    virtual void processEvent() = 0;
 
     /**
      * Create an ISystemWindow object

--- a/native/cocos/platform/interfaces/modules/ISystemWindowManager.h
+++ b/native/cocos/platform/interfaces/modules/ISystemWindowManager.h
@@ -55,7 +55,7 @@ public:
     /**
      * Process messages at the PAL layer
      */
-    virtual void processEvent(bool *quit) = 0;
+    virtual void processEvent(void) = 0;
 
     /**
      * Create an ISystemWindow object

--- a/native/cocos/platform/ios/IOSPlatform.h
+++ b/native/cocos/platform/ios/IOSPlatform.h
@@ -45,7 +45,7 @@ public:
      */
     int32_t run(int argc, const char **argv) override;
     
-    void manualExit();
+    void requestQuit();
     
     void exitLoop() override;
     /**
@@ -63,7 +63,7 @@ public:
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 
 private:
-    bool _manualQuit{false};
+    bool _requestQuit{false};
     bool _quitLoop{false};
     ThreadCallback _cb;
 };

--- a/native/cocos/platform/ios/IOSPlatform.h
+++ b/native/cocos/platform/ios/IOSPlatform.h
@@ -44,6 +44,10 @@ public:
      * @brief Start base platform initialization.
      */
     int32_t run(int argc, const char **argv) override;
+    
+    void manualExit();
+    
+    void exitLoop() override;
     /**
      * @brief Implement the main logic of the base platform.
      */
@@ -55,10 +59,12 @@ public:
     void onPause() override;
     void onResume() override;
     void onClose() override;
-
+    void onDestroy() override;
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 
 private:
+    bool _manualQuit{false};
+    bool _quitLoop{false};
     ThreadCallback _cb;
 };
 

--- a/native/cocos/platform/ios/IOSPlatform.h
+++ b/native/cocos/platform/ios/IOSPlatform.h
@@ -45,9 +45,9 @@ public:
      */
     int32_t run(int argc, const char **argv) override;
     
-    void requestQuit();
+    void requestExit();
     
-    void exitLoop() override;
+    void exit() override;
     /**
      * @brief Implement the main logic of the base platform.
      */
@@ -63,7 +63,7 @@ public:
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 
 private:
-    bool _requestQuit{false};
+    bool _requestExit{false};
     bool _quitLoop{false};
     ThreadCallback _cb;
 };

--- a/native/cocos/platform/ios/IOSPlatform.mm
+++ b/native/cocos/platform/ios/IOSPlatform.mm
@@ -111,8 +111,8 @@ int32_t IOSPlatform::init() {
 }
 
 void IOSPlatform::exitLoop() {
-    if(_manualQuit) {
-        // Manual exit requires an active call to onDestory.
+    if(_requestQuit) {
+        // Manual quit requires a call to onDestory.
         onDestroy();
         exit(0);
     } else {
@@ -160,13 +160,13 @@ void IOSPlatform::onClose() {
     cc::events::WindowEvent::broadcast(ev);
 }
 
-void IOSPlatform::manualExit() {
-    _manualQuit = true;
+void IOSPlatform::requestQuit() {
+    _requestQuit = true;
     onClose();
 }
 
 void IOSPlatform::onDestroy() {
-    if(!_manualQuit) {
+    if(!_requestQuit) {
         // ios exit process is special because it needs to wait for ts layer to destroy resources
         int32_t fps = getFps();
         float sleepTime = 1000.0 / fps;

--- a/native/cocos/platform/ios/IOSPlatform.mm
+++ b/native/cocos/platform/ios/IOSPlatform.mm
@@ -110,8 +110,8 @@ int32_t IOSPlatform::init() {
     return 0;
 }
 
-void IOSPlatform::exitLoop() {
-    if(_requestQuit) {
+void IOSPlatform::exit() {
+    if(_requestExit) {
         // Manual quit requires a call to onDestory.
         onDestroy();
         exit(0);
@@ -160,13 +160,13 @@ void IOSPlatform::onClose() {
     cc::events::WindowEvent::broadcast(ev);
 }
 
-void IOSPlatform::requestQuit() {
-    _requestQuit = true;
+void IOSPlatform::requestExit() {
+    _requestExit = true;
     onClose();
 }
 
 void IOSPlatform::onDestroy() {
-    if(!_requestQuit) {
+    if(!_requestExit) {
         // ios exit process is special because it needs to wait for ts layer to destroy resources.
         // The timer cannot be used here.
         int32_t fps = getFps();

--- a/native/cocos/platform/ios/IOSPlatform.mm
+++ b/native/cocos/platform/ios/IOSPlatform.mm
@@ -167,7 +167,8 @@ void IOSPlatform::requestQuit() {
 
 void IOSPlatform::onDestroy() {
     if(!_requestQuit) {
-        // ios exit process is special because it needs to wait for ts layer to destroy resources
+        // ios exit process is special because it needs to wait for ts layer to destroy resources.
+        // The timer cannot be used here.
         int32_t fps = getFps();
         float sleepTime = 1000.0 / fps;
         while (!_quitLoop) {

--- a/native/cocos/platform/ios/IOSPlatform.mm
+++ b/native/cocos/platform/ios/IOSPlatform.mm
@@ -114,7 +114,7 @@ void IOSPlatform::exit() {
     if(_requestExit) {
         // Manual quit requires a call to onDestory.
         onDestroy();
-        exit(0);
+        ::exit(0);
     } else {
         _quitLoop = true;
     }

--- a/native/cocos/platform/ios/IOSPlatform.mm
+++ b/native/cocos/platform/ios/IOSPlatform.mm
@@ -169,11 +169,8 @@ void IOSPlatform::onDestroy() {
     if(!_requestExit) {
         // ios exit process is special because it needs to wait for ts layer to destroy resources.
         // The timer cannot be used here.
-        int32_t fps = getFps();
-        float sleepTime = 1000.0 / fps;
         while (!_quitLoop) {
             runTask();
-            usleep(sleepTime);
         }
     }
     UniversalPlatform::onDestroy();

--- a/native/cocos/platform/ios/IOSPlatform.mm
+++ b/native/cocos/platform/ios/IOSPlatform.mm
@@ -110,6 +110,11 @@ int32_t IOSPlatform::init() {
     return 0;
 }
 
+void IOSPlatform::exitLoop() {
+    onDestroy();
+    exit(0);
+}
+
 int32_t IOSPlatform::loop() {
     cocos_main(0, nullptr);
     [_timer start];

--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -47,10 +47,8 @@ void SystemWindow::copyTextToClipboard(const std::string& text) {
 }
 void SystemWindow::closeWindow() {
     // Force quit as there's no API to exit UIApplication
-    //cc::events::Close::broadcast();
     IOSPlatform* platform = dynamic_cast<IOSPlatform*>(BasePlatform::getPlatform());
     platform->requestQuit();
-    //platform->onClose();
 }
 
 uintptr_t SystemWindow::getWindowHandle() const {

--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -26,6 +26,7 @@
 #include "platform/ios/modules/SystemWindow.h"
 #import <UIKit/UIKit.h>
 #include "platform/BasePlatform.h"
+#include "platform/ios/IOSPlatform.h"
 #include "platform/interfaces/modules/IScreen.h"
 
 namespace cc {
@@ -47,7 +48,10 @@ void SystemWindow::copyTextToClipboard(const std::string& text) {
 void SystemWindow::closeWindow() {
     // Force quit as there's no API to exit UIApplication
     cc::events::Close::broadcast();
-    exit(0);
+    IOSPlatform* platform = dynamic_cast<IOSPlatform*>(BasePlatform::getPlatform());
+    platform->onClose();
+    //platform->onDestroy();
+    //exit(0);
 }
 uintptr_t SystemWindow::getWindowHandle() const {
     return reinterpret_cast<uintptr_t>(UIApplication.sharedApplication.delegate.window.rootViewController.view);

--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -47,9 +47,10 @@ void SystemWindow::copyTextToClipboard(const std::string& text) {
 }
 void SystemWindow::closeWindow() {
     // Force quit as there's no API to exit UIApplication
-    cc::events::Close::broadcast();
+    //cc::events::Close::broadcast();
     IOSPlatform* platform = dynamic_cast<IOSPlatform*>(BasePlatform::getPlatform());
-    platform->onClose();
+    platform->manualExit();
+    //platform->onClose();
     //platform->onDestroy();
     //exit(0);
 }

--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -49,7 +49,7 @@ void SystemWindow::closeWindow() {
     // Force quit as there's no API to exit UIApplication
     //cc::events::Close::broadcast();
     IOSPlatform* platform = dynamic_cast<IOSPlatform*>(BasePlatform::getPlatform());
-    platform->manualExit();
+    platform->requestQuit();
     //platform->onClose();
 }
 

--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -48,7 +48,7 @@ void SystemWindow::copyTextToClipboard(const std::string& text) {
 void SystemWindow::closeWindow() {
     // Force quit as there's no API to exit UIApplication
     IOSPlatform* platform = dynamic_cast<IOSPlatform*>(BasePlatform::getPlatform());
-    platform->requestQuit();
+    platform->requestExit();
 }
 
 uintptr_t SystemWindow::getWindowHandle() const {

--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -51,9 +51,8 @@ void SystemWindow::closeWindow() {
     IOSPlatform* platform = dynamic_cast<IOSPlatform*>(BasePlatform::getPlatform());
     platform->manualExit();
     //platform->onClose();
-    //platform->onDestroy();
-    //exit(0);
 }
+
 uintptr_t SystemWindow::getWindowHandle() const {
     return reinterpret_cast<uintptr_t>(UIApplication.sharedApplication.delegate.window.rootViewController.view);
 }

--- a/native/cocos/platform/ios/modules/SystemWindowManager.h
+++ b/native/cocos/platform/ios/modules/SystemWindowManager.h
@@ -38,7 +38,7 @@ public:
     explicit SystemWindowManager() = default;
 
     int init() override { return 0; }
-    void processEvent(bool *quit) override {}
+    void processEvent() override {}
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/java/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/java/modules/SystemWindowManager.cpp
@@ -32,7 +32,7 @@ int SystemWindowManager::init() {
     return 0;
 }
 
-void SystemWindowManager::processEvent(bool *quit) {
+void SystemWindowManager::processEvent() {
 }
 
 ISystemWindow *SystemWindowManager::createWindow(const ISystemWindowInfo &info) {

--- a/native/cocos/platform/java/modules/SystemWindowManager.h
+++ b/native/cocos/platform/java/modules/SystemWindowManager.h
@@ -37,7 +37,7 @@ public:
     SystemWindowManager() = default;
 
     int init() override;
-    void processEvent(bool *quit) override;
+    void processEvent() override;
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;
     const SystemWindowMap &getWindows() const override { return _windows; }

--- a/native/cocos/platform/linux/LinuxPlatform.cpp
+++ b/native/cocos/platform/linux/LinuxPlatform.cpp
@@ -83,6 +83,10 @@ static long getCurrentMillSecond() {
     return lLastTime;
 }
 
+void LinuxPlatform::exitLoop() {
+    _quit = true;
+}
+
 int32_t LinuxPlatform::loop() {
     long lastTime = 0L;
     long curTime = 0L;
@@ -92,7 +96,7 @@ int32_t LinuxPlatform::loop() {
     while (!_quit) {
         curTime = getCurrentMillSecond();
         desiredInterval = static_cast<long>(1000.0 / getFps());
-        _windowManager->processEvent(&_quit);
+        _windowManager->processEvent();
         actualInterval = curTime - lastTime;
         if (actualInterval >= desiredInterval) {
             lastTime = getCurrentMillSecond();

--- a/native/cocos/platform/linux/LinuxPlatform.cpp
+++ b/native/cocos/platform/linux/LinuxPlatform.cpp
@@ -83,7 +83,7 @@ static long getCurrentMillSecond() {
     return lLastTime;
 }
 
-void LinuxPlatform::exitLoop() {
+void LinuxPlatform::exit() {
     _quit = true;
 }
 

--- a/native/cocos/platform/linux/LinuxPlatform.h
+++ b/native/cocos/platform/linux/LinuxPlatform.h
@@ -42,6 +42,7 @@ public:
      */
     int32_t init() override;
 
+    void exitLoop() override;
     int32_t loop() override;
 
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;

--- a/native/cocos/platform/linux/LinuxPlatform.h
+++ b/native/cocos/platform/linux/LinuxPlatform.h
@@ -42,7 +42,7 @@ public:
      */
     int32_t init() override;
 
-    void exitLoop() override;
+    void exit() override;
     int32_t loop() override;
 
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;

--- a/native/cocos/platform/linux/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/linux/modules/SystemWindowManager.cpp
@@ -35,21 +35,18 @@ int SystemWindowManager::init() {
     return SDLHelper::init();
 }
 
-void SystemWindowManager::processEvent(bool *quit) {
+void SystemWindowManager::processEvent() {
     SDL_Event sdlEvent;
     while (SDL_PollEvent(&sdlEvent) != 0) {
         SDL_Window *sdlWindow = SDL_GetWindowFromID(sdlEvent.window.windowID);
         // SDL_Event like SDL_QUIT does not associate a window
         if (!sdlWindow) {
-            SDLHelper::dispatchSDLEvent(0, sdlEvent, quit);
+            SDLHelper::dispatchSDLEvent(0, sdlEvent);
         } else {
             ISystemWindow *window = getWindowFromSDLWindow(sdlWindow);
             CC_ASSERT(window);
             uint32_t windowId = window->getWindowId();
-            SDLHelper::dispatchSDLEvent(windowId, sdlEvent, quit);
-        }
-        if (*quit) {
-            break;
+            SDLHelper::dispatchSDLEvent(windowId, sdlEvent);
         }
     }
 }

--- a/native/cocos/platform/linux/modules/SystemWindowManager.h
+++ b/native/cocos/platform/linux/modules/SystemWindowManager.h
@@ -38,7 +38,7 @@ public:
     SystemWindowManager() = default;
 
     int init() override;
-    void processEvent(bool *quit) override;
+    void processEvent() override;
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/mac/AppDelegate.mm
+++ b/native/cocos/platform/mac/AppDelegate.mm
@@ -104,6 +104,12 @@
     return _window;
 }
 
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
+{
+    //return NSTerminateCancel;
+    return _platform->readyToExit() ? NSTerminateNow : NSTerminateLater;
+}
+
 - (void)applicationWillTerminate:(NSNotification*)aNotification {
     //    delete _game;
     //FIXME: will crash if relase it here.

--- a/native/cocos/platform/mac/AppDelegate.mm
+++ b/native/cocos/platform/mac/AppDelegate.mm
@@ -106,7 +106,6 @@
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
 {
-    //return NSTerminateCancel;
     return _platform->readyToExit() ? NSTerminateNow : NSTerminateLater;
 }
 

--- a/native/cocos/platform/mac/MacPlatform.h
+++ b/native/cocos/platform/mac/MacPlatform.h
@@ -47,6 +47,7 @@ public:
 
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 
+    bool readyToExit();
     /**
      * @brief Implement the main logic of the base platform.
      */
@@ -56,6 +57,8 @@ public:
     void onPause() override;
     void onResume() override;
     void onClose() override;
+private:
+    bool _readyToExit{false};
 };
 
 } // namespace cc

--- a/native/cocos/platform/mac/MacPlatform.h
+++ b/native/cocos/platform/mac/MacPlatform.h
@@ -48,6 +48,7 @@ public:
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 
     bool readyToExit();
+    void exitLoop() override;
     /**
      * @brief Implement the main logic of the base platform.
      */

--- a/native/cocos/platform/mac/MacPlatform.h
+++ b/native/cocos/platform/mac/MacPlatform.h
@@ -48,7 +48,7 @@ public:
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 
     bool readyToExit();
-    void exitLoop() override;
+    void exit() override;
     /**
      * @brief Implement the main logic of the base platform.
      */

--- a/native/cocos/platform/mac/MacPlatform.mm
+++ b/native/cocos/platform/mac/MacPlatform.mm
@@ -132,7 +132,6 @@ bool MacPlatform::readyToExit() {
 }
 
 void MacPlatform::exitLoop() {
-    //[_timer release];
     if(!_readyToExit) {
         [[NSApplication sharedApplication] replyToApplicationShouldTerminate:true];
         _readyToExit = true;

--- a/native/cocos/platform/mac/MacPlatform.mm
+++ b/native/cocos/platform/mac/MacPlatform.mm
@@ -131,7 +131,7 @@ bool MacPlatform::readyToExit() {
     return _readyToExit;
 }
 
-void MacPlatform::exitLoop() {
+void MacPlatform::exit() {
     if(!_readyToExit) {
         [[NSApplication sharedApplication] replyToApplicationShouldTerminate:true];
         _readyToExit = true;

--- a/native/cocos/platform/mac/MacPlatform.mm
+++ b/native/cocos/platform/mac/MacPlatform.mm
@@ -98,6 +98,10 @@ extern int cocos_main(int argc, const char **argv);
 - (void)renderScene {
     _platform->runTask();
 }
+
+- (bool) isValid {
+    return [_timer valid];
+}
 #endif
 @end
 
@@ -121,6 +125,18 @@ int32_t MacPlatform::init() {
     registerInterface(std::make_shared<SystemWindowManager>());
     registerInterface(std::make_shared<Vibrator>());
     return 0;
+}
+
+bool MacPlatform::readyToExit() {
+    return _readyToExit;
+}
+
+void MacPlatform::exitLoop() {
+    //[_timer release];
+    if(!_readyToExit) {
+        [[NSApplication sharedApplication] replyToApplicationShouldTerminate:true];
+        _readyToExit = true;
+    }
 }
 
 int32_t MacPlatform::loop(void) {

--- a/native/cocos/platform/mac/modules/SystemWindowManager.h
+++ b/native/cocos/platform/mac/modules/SystemWindowManager.h
@@ -39,7 +39,7 @@ public:
     explicit SystemWindowManager() = default;
 
     int init() override { return 0; }
-    void processEvent(bool *quit) override {}
+    void processEvent() override {}
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/ohos/OhosPlatform.cpp
+++ b/native/cocos/platform/ohos/OhosPlatform.cpp
@@ -78,6 +78,10 @@ void OhosPlatform::waitWindowInitialized() {
     }
 }
 
+void OhosPlatform::exit() {
+
+}
+
 int32_t OhosPlatform::loop() {
     while (_jniNativeGlue->isRunning()) {
         pollEvent();

--- a/native/cocos/platform/ohos/OhosPlatform.h
+++ b/native/cocos/platform/ohos/OhosPlatform.h
@@ -36,6 +36,7 @@ public:
     int32_t run(int argc, const char **argv) override;
     int getSdkVersion() const override;
     int32_t loop() override;
+    void exit() override;
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 
 private:

--- a/native/cocos/platform/win32/WindowsPlatform.cpp
+++ b/native/cocos/platform/win32/WindowsPlatform.cpp
@@ -113,7 +113,7 @@ int32_t WindowsPlatform::init() {
     return _windowManager->init();
 }
 
-void WindowsPlatform::exitLoop() {
+void WindowsPlatform::exit() {
     _quit = true;
 }
 

--- a/native/cocos/platform/win32/WindowsPlatform.cpp
+++ b/native/cocos/platform/win32/WindowsPlatform.cpp
@@ -119,7 +119,7 @@ void WindowsPlatform::exitLoop() {
 
 int32_t WindowsPlatform::loop() {
 #if CC_EDITOR
-    _windowManager->processEvent(&_quit);
+    _windowManager->processEvent();
     runTask();
 #else
     ///////////////////////////////////////////////////////////////////////////

--- a/native/cocos/platform/win32/WindowsPlatform.cpp
+++ b/native/cocos/platform/win32/WindowsPlatform.cpp
@@ -113,6 +113,10 @@ int32_t WindowsPlatform::init() {
     return _windowManager->init();
 }
 
+void WindowsPlatform::exitLoop() {
+    _quit = true;
+}
+
 int32_t WindowsPlatform::loop() {
 #if CC_EDITOR
     _windowManager->processEvent(&_quit);
@@ -147,7 +151,7 @@ int32_t WindowsPlatform::loop() {
     onResume();
     while (!_quit) {
         desiredInterval = (LONGLONG)(1.0 / getFps() * nFreq.QuadPart);
-        _windowManager->processEvent(&_quit);
+        _windowManager->processEvent();
 
         QueryPerformanceCounter(&nNow);
         actualInterval = nNow.QuadPart - nLast.QuadPart;

--- a/native/cocos/platform/win32/WindowsPlatform.h
+++ b/native/cocos/platform/win32/WindowsPlatform.h
@@ -45,6 +45,8 @@ public:
 
     int32_t loop() override;
 
+    void exitLoop() override;
+
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 
 private:

--- a/native/cocos/platform/win32/WindowsPlatform.h
+++ b/native/cocos/platform/win32/WindowsPlatform.h
@@ -45,7 +45,7 @@ public:
 
     int32_t loop() override;
 
-    void exitLoop() override;
+    void exit() override;
 
     ISystemWindow *createNativeWindow(uint32_t windowId, void *externalHandle) override;
 

--- a/native/cocos/platform/win32/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/win32/modules/SystemWindowManager.cpp
@@ -35,7 +35,7 @@ int SystemWindowManager::init() {
     return SDLHelper::init();
 }
 
-void SystemWindowManager::processEvent(void) {
+void SystemWindowManager::processEvent() {
     SDL_Event sdlEvent;
     while (SDL_PollEvent(&sdlEvent) != 0) {
         SDL_Window *sdlWindow = SDL_GetWindowFromID(sdlEvent.window.windowID);

--- a/native/cocos/platform/win32/modules/SystemWindowManager.cpp
+++ b/native/cocos/platform/win32/modules/SystemWindowManager.cpp
@@ -35,21 +35,18 @@ int SystemWindowManager::init() {
     return SDLHelper::init();
 }
 
-void SystemWindowManager::processEvent(bool *quit) {
+void SystemWindowManager::processEvent(void) {
     SDL_Event sdlEvent;
     while (SDL_PollEvent(&sdlEvent) != 0) {
         SDL_Window *sdlWindow = SDL_GetWindowFromID(sdlEvent.window.windowID);
         // SDL_Event like SDL_QUIT does not associate a window
         if (!sdlWindow) {
-            SDLHelper::dispatchSDLEvent(0, sdlEvent, quit);
+            SDLHelper::dispatchSDLEvent(0, sdlEvent);
         } else {
             ISystemWindow *window = getWindowFromSDLWindow(sdlWindow);
             CC_ASSERT(window);
             uint32_t windowId = window->getWindowId();
-            SDLHelper::dispatchSDLEvent(windowId, sdlEvent, quit);
-        }
-        if (*quit) {
-            break;
+            SDLHelper::dispatchSDLEvent(windowId, sdlEvent);
         }
     }
 }

--- a/native/cocos/platform/win32/modules/SystemWindowManager.h
+++ b/native/cocos/platform/win32/modules/SystemWindowManager.h
@@ -38,7 +38,7 @@ public:
     SystemWindowManager() = default;
 
     int init() override;
-    void processEvent(bool *quit) override;
+    void processEvent(void) override;
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/platform/win32/modules/SystemWindowManager.h
+++ b/native/cocos/platform/win32/modules/SystemWindowManager.h
@@ -38,7 +38,7 @@ public:
     SystemWindowManager() = default;
 
     int init() override;
-    void processEvent(void) override;
+    void processEvent() override;
 
     ISystemWindow *createWindow(const ISystemWindowInfo &info) override;
     ISystemWindow *getWindow(uint32_t windowId) const override;

--- a/native/cocos/renderer/pipeline/custom/NativeFactory.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeFactory.cpp
@@ -91,18 +91,6 @@ RenderingModule* getRenderingModule() {
     return sRenderingModule;
 }
 
-ProgramLibrary* getProgramLibrary() {
-    if (!sRenderingModule) {
-        return nullptr;
-    }
-    return sRenderingModule->programLibrary.get();
-}
-
-RenderingModule* getRenderingModule() {
-    //CC_EXPECTS(sRenderingModule);
-    return sRenderingModule;
-}
-
 } // namespace render
 
 } // namespace cc

--- a/native/cocos/renderer/pipeline/custom/NativeFactory.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeFactory.cpp
@@ -91,6 +91,18 @@ RenderingModule* getRenderingModule() {
     return sRenderingModule;
 }
 
+ProgramLibrary* getProgramLibrary() {
+    if (!sRenderingModule) {
+        return nullptr;
+    }
+    return sRenderingModule->programLibrary.get();
+}
+
+RenderingModule* getRenderingModule() {
+    //CC_EXPECTS(sRenderingModule);
+    return sRenderingModule;
+}
+
 } // namespace render
 
 } // namespace cc

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos-creator",
         "name": "engine-native-external",
-        "checkout": "v3.7.1-2"
+        "checkout": "develop-13"
     }
 }

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -173,6 +173,11 @@ class SystemInfo extends EventTarget {
         // @ts-expect-error __close() is defined in JSB
         __close();
     }
+
+    public exit () {
+        // @ts-expect-error __exit() is defined in JSB
+        __exit();
+    }
 }
 
 export const systemInfo = new SystemInfo();


### PR DESCRIPTION
Re: #

### Changelog

*  https://github.com/cocos/cocos-engine/issues/13834
https://github.com/cocos/cocos-engine/issues/12505
https://github.com/cocos/cocos-engine/issues/12545
https://github.com/cocos/cocos-engine/issues/13889
https://github.com/cocos/3d-tasks/issues/8696

![1675749494841](https://user-images.githubusercontent.com/5205637/217160848-1e56fd25-4be3-4356-aad8-ed4c428602f5.jpg)

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
