### PR TITLE
Support cmake 3.25 for new xcode scheme options

### DIFF
--- a/scripts/native-pack-tool/source/base/default.ts
+++ b/scripts/native-pack-tool/source/base/default.ts
@@ -129,6 +129,13 @@ export abstract class NativePackTool {
     }
 
     /**
+     * Debug / Release
+     */
+    protected get buildType(): string {
+        return this.params.debug ? "Debug" : "Release";
+    }
+
+    /**
      * Read version number from cocos-version.json
      */
     protected tryReadProjectTemplateVersion(): { version: string, skipCheck: boolean | undefined } | null {
@@ -429,9 +436,12 @@ export abstract class NativePackTool {
         await fs.outputFile(file, content);
     }
 
-    protected appendCmakeResDirArgs(args: string[]) {
-        args.push(`-DRES_DIR="${cchelper.fixPath(this.paths.buildDir)}" -DAPP_NAME="${this.params.projectName}" `);
+    protected appendCmakeCommonArgs(args: string[]) {
+        args.push(`-DRES_DIR="${cchelper.fixPath(this.paths.buildDir)}"`);
+        args.push(`-DAPP_NAME="${this.params.projectName}"`);
+        args.push(`-DLAUNCH_TYPE="${this.buildType}"`);
     }
+
 
     /**
      * 加密脚本，加密后，会修改 cmake 参数，因而需要再次执行 cmake 配置文件的生成

--- a/scripts/native-pack-tool/source/platforms/ios.ts
+++ b/scripts/native-pack-tool/source/platforms/ios.ts
@@ -93,7 +93,7 @@ export class IOSPackTool extends MacOSPackTool {
 
         const ext: string[] = ['-DCMAKE_CXX_COMPILER=clang++', '-DCMAKE_C_COMPILER=clang'];
 
-        this.appendCmakeResDirArgs(ext);
+        this.appendCmakeCommonArgs(ext);
 
         const ver = toolHelper.getXcodeMajorVerion() >= 12 ? "12" : "1";
         await toolHelper.runCmake(['-S', `"${this.paths.platformTemplateDirInPrj}"`, '-GXcode', `-B"${nativePrjDir}"`, '-T', `buildsystem=${ver}`,

--- a/scripts/native-pack-tool/source/platforms/mac.ts
+++ b/scripts/native-pack-tool/source/platforms/mac.ts
@@ -33,7 +33,7 @@ export class MacPackTool extends MacOSPackTool {
         const ver = toolHelper.getXcodeMajorVerion() >= 12 ? "12" : "1";
         const cmakeArgs = ['-S', `"${this.paths.platformTemplateDirInPrj}"`, '-GXcode', '-T', `buildsystem=${ver}`,
                            `-B"${nativePrjDir}"`, '-DCMAKE_SYSTEM_NAME=Darwin'];
-        this.appendCmakeResDirArgs(cmakeArgs);
+        this.appendCmakeCommonArgs(cmakeArgs);
 
         await toolHelper.runCmake(cmakeArgs);
 

--- a/scripts/native-pack-tool/source/platforms/windows.ts
+++ b/scripts/native-pack-tool/source/platforms/windows.ts
@@ -51,7 +51,7 @@ export class WindowsPackTool extends NativePackTool {
             }
 
         }
-        this.appendCmakeResDirArgs(generateArgs);
+        this.appendCmakeCommonArgs(generateArgs);
         await toolHelper.runCmake([`-S"${cchelper.fixPath(this.paths.platformTemplateDirInPrj)}"`, `-B"${cchelper.fixPath(this.paths.nativePrjDir)}"`].concat(generateArgs));
         return true;
     }


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/12651

### Changelog

* Support new cmake xcode scheme options  `XCODE_SCHEME_LAUNCH_CONFIGURATION/XCODE_SCHEME_ENABLE_GPU_API_VALIDATION/XCODE_SCHEME_ENABLE_GPU_SHADER_VALIDATION`. Allow lauch app in release mode when Debug is not checked on build panel.
-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
