### PR TITLE
Mac platform adds pointerlock function

### DIFF
--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -38,7 +38,6 @@ SystemWindow::SystemWindow(uint32_t windowId, void *externalHandle)
 SystemWindow::~SystemWindow() = default;
 
 void SystemWindow::setCursorEnabled(bool value) {
-
 }
 
 void SystemWindow::copyTextToClipboard(const std::string& text) {

--- a/native/cocos/platform/ios/modules/SystemWindow.mm
+++ b/native/cocos/platform/ios/modules/SystemWindow.mm
@@ -38,6 +38,7 @@ SystemWindow::SystemWindow(uint32_t windowId, void *externalHandle)
 SystemWindow::~SystemWindow() = default;
 
 void SystemWindow::setCursorEnabled(bool value) {
+
 }
 
 void SystemWindow::copyTextToClipboard(const std::string& text) {

--- a/native/cocos/platform/mac/View.mm
+++ b/native/cocos/platform/mac/View.mm
@@ -276,9 +276,8 @@
     auto *windowMgr = CC_GET_PLATFORM_INTERFACE(cc::SystemWindowManager);
     auto *window = dynamic_cast<cc::SystemWindow*>( windowMgr->getWindowFromNSWindow([self window]));
     const NSRect contentRect = [self frame];
-    const NSPoint pos = [event locationInWindow];
     if(!window->isPointerLock()) {
-        
+        const NSPoint pos = [event locationInWindow];
         _mouseEvent.x = pos.x;
         _mouseEvent.y = contentRect.size.height - pos.y;
     } else {
@@ -287,11 +286,8 @@
             _mouseEvent.y = _mouseEvent.y + [event deltaY];
             float x_min = 0, x_max = 0;
             float y_min = 0, y_max = 0;
-            cc::Size sz = window->getViewSize();
-            auto dpr = cc::BasePlatform::getPlatform()->getInterface<cc::IScreen>()->getDevicePixelRatio();
-            x_max = sz.width / dpr;
-            y_max = sz.height / dpr;
-            //SDL_GetWindowSize(window, &x_max, &y_max);
+            x_max = contentRect.size.width;
+            y_max = contentRect.size.height;
             --x_max;
             --y_max;
             if (_mouseEvent.x > x_max) {
@@ -307,12 +303,11 @@
             }
         }
         auto mainDisplayId = CGMainDisplayID();
-        float windowX = [[self.window contentView] frame].origin.x;
+        float windowX = contentRect.origin.x;
         float windowY =
            CGDisplayPixelsHigh(mainDisplayId) - contentRect.origin.y - contentRect.size.height;
         window->setLastMousePos(windowX + _mouseEvent.x, windowY + _mouseEvent.y);
     }
-
     cc::events::Mouse::broadcast(_mouseEvent);
 }
 - (int)getWindowId {

--- a/native/cocos/platform/mac/View.mm
+++ b/native/cocos/platform/mac/View.mm
@@ -32,7 +32,6 @@
 #import "application/ApplicationManager.h"
 #import "cocos/bindings/event/EventDispatcher.h"
 #import "platform/mac/AppDelegate.h"
-#import "platform/interfaces/modules/IScreen.h"
 #import "platform/mac/modules/SystemWindow.h"
 #import "platform/mac/modules/SystemWindowManager.h"
 

--- a/native/cocos/platform/mac/View.mm
+++ b/native/cocos/platform/mac/View.mm
@@ -273,7 +273,7 @@
     _mouseEvent.button = button;
     
     auto *windowMgr = CC_GET_PLATFORM_INTERFACE(cc::SystemWindowManager);
-    auto *window = dynamic_cast<cc::SystemWindow*>( windowMgr->getWindowFromNSWindow([self window]));
+    auto *window = static_cast<cc::SystemWindow*>( windowMgr->getWindowFromNSWindow([self window]));
     const NSRect contentRect = [self frame];
     if(!window->isPointerLock()) {
         const NSPoint pos = [event locationInWindow];
@@ -281,24 +281,25 @@
         _mouseEvent.y = contentRect.size.height - pos.y;
     } else {
         if(type == cc::MouseEvent::Type::MOVE) {
+            // Out of window only happens when mouse is moved.
             _mouseEvent.x = _mouseEvent.x + [event deltaX];
             _mouseEvent.y = _mouseEvent.y + [event deltaY];
-            float x_min = 0, x_max = 0;
-            float y_min = 0, y_max = 0;
-            x_max = contentRect.size.width;
-            y_max = contentRect.size.height;
-            --x_max;
-            --y_max;
-            if (_mouseEvent.x > x_max) {
-                _mouseEvent.x = x_max;
-            } else if (_mouseEvent.x < x_min) {
-                _mouseEvent.x = x_min;
+            float xMin = 0, xMax = 0;
+            float yMin = 0, yMax = 0;
+            xMax = contentRect.size.width;
+            yMax = contentRect.size.height;
+            --xMax;
+            --yMax;
+            if (_mouseEvent.x > xMax) {
+                _mouseEvent.x = xMax;
+            } else if (_mouseEvent.x < xMin) {
+                _mouseEvent.x = xMin;
             }
             
-            if (_mouseEvent.y > y_max) {
-                _mouseEvent.y = y_max;
-            } else if (_mouseEvent.y < y_min) {
-                _mouseEvent.y = y_min;
+            if (_mouseEvent.y > yMax) {
+                _mouseEvent.y = yMax;
+            } else if (_mouseEvent.y < yMin) {
+                _mouseEvent.y = yMin;
             }
         }
         auto mainDisplayId = CGMainDisplayID();

--- a/native/cocos/platform/mac/modules/SystemWindow.h
+++ b/native/cocos/platform/mac/modules/SystemWindow.h
@@ -57,8 +57,13 @@ public:
      */
     void setCursorEnabled(bool value) override;
     void copyTextToClipboard(const std::string& text) override;
-
+    
+    bool isPointerLock() const;
+    void setLastMousePos(float x, float y);
 private:
+    bool _pointerLock{false};
+    float _lastMousePosX{0.0F};
+    float _lastMousePosY{0.0F};
     int32_t _width{0};
     int32_t _height{0};
 

--- a/native/cocos/platform/mac/modules/SystemWindow.mm
+++ b/native/cocos/platform/mac/modules/SystemWindow.mm
@@ -43,7 +43,9 @@ SystemWindow::SystemWindow(uint32_t windowId, void *externalHandle)
     }
 }
 
-SystemWindow::~SystemWindow() = default;
+SystemWindow::~SystemWindow() {
+    setCursorEnabled(true);
+}
 
 bool SystemWindow::createWindow(const char *title,
                                 int w, int h, int flags) {
@@ -98,6 +100,22 @@ void SystemWindow::closeWindow() {
 }
 
 void SystemWindow::setCursorEnabled(bool value) {
+    CGError result;
+    if(value) {
+        result = CGAssociateMouseAndMouseCursorPosition(YES);
+        [NSCursor unhide];
+        if(_pointerLock) {
+            CGPoint point =
+                CGPointMake((float)_lastMousePosX, _lastMousePosY);
+            CGWarpMouseCursorPosition(point);
+        }
+        _pointerLock = false;
+    } else {
+        result = CGAssociateMouseAndMouseCursorPosition(NO);
+        [NSCursor hide];
+        _pointerLock = true;
+    }
+    
 }
 
 void SystemWindow::copyTextToClipboard(const std::string &text) {
@@ -118,6 +136,15 @@ SystemWindow::Size SystemWindow::getViewSize() const {
 
 uint32_t SystemWindow::getWindowId() const { 
     return _windowId;
+}
+
+bool SystemWindow::isPointerLock() const {
+    return _pointerLock;
+}
+
+void SystemWindow::setLastMousePos(float x, float y) {
+    _lastMousePosX = x;
+    _lastMousePosY = y;
 }
 
 } // namespace cc

--- a/native/cocos/platform/mac/modules/SystemWindow.mm
+++ b/native/cocos/platform/mac/modules/SystemWindow.mm
@@ -115,7 +115,7 @@ void SystemWindow::setCursorEnabled(bool value) {
         [NSCursor hide];
         _pointerLock = true;
     }
-    
+    CC_ASSERT(result == kCGErrorSuccess);
 }
 
 void SystemWindow::copyTextToClipboard(const std::string &text) {


### PR DESCRIPTION

### Changelog

Implement setCursorEnabled interface on mac platform

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
