### PR TITLE
set default build variant for android

### DIFF
--- a/scripts/native-pack-tool/source/cocosConfig.ts
+++ b/scripts/native-pack-tool/source/cocosConfig.ts
@@ -6,6 +6,9 @@ export const cocosConfig = {
         windows: {
             generators: [
                 {
+                    G: 'Visual Studio 17 2022',
+                },
+                {
                     G: 'Visual Studio 16 2019',
                 },
                 {

--- a/scripts/native-pack-tool/source/platforms/android.ts
+++ b/scripts/native-pack-tool/source/platforms/android.ts
@@ -198,6 +198,7 @@ export class AndroidPackTool extends NativePackTool {
             content = content.replace(/PROP_MIN_SDK_VERSION=.*/, `PROP_MIN_SDK_VERSION=${Math.min(apiLevel, minimalSDKVersion)}`);
             content = content.replace(/PROP_APP_NAME=.*/, `PROP_APP_NAME=${this.params.projectName}`);
             content = content.replace(/PROP_ENABLE_INSTANT_APP=.*/, `PROP_ENABLE_INSTANT_APP=${options.androidInstant ? "true" : "false"}`);
+            content = content.replace(/PROP_IS_DEBUG=.*/, `PROP_IS_DEBUG=${this.params.debug ? "true" : "false"}`);
 
             content = content.replace(/RES_PATH=.*/, `RES_PATH=${cchelper.fixPath(this.paths.buildDir)}`);
             content = content.replace(/COCOS_ENGINE_PATH=.*/, `COCOS_ENGINE_PATH=${cchelper.fixPath(Paths.nativeRoot)}`);

--- a/templates/android/build/gradle.properties
+++ b/templates/android/build/gradle.properties
@@ -41,6 +41,9 @@ PROP_ENABLE_INSTANT_APP=true
 
 PROP_NDK_PATH=
 
+# Build variant
+PROP_IS_DEBUG=true
+
 # Cocos Engine Path
 COCOS_ENGINE_PATH=
 

--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -81,7 +81,11 @@ android {
                     arguments "-DHIDE_SYMBOLS=ON"
                 }
             }
-            
+
+            if (PROP_IS_DEBUG == "false") {
+                getIsDefault().set(true)
+            }
+
             // resValue  "string", "app_name", PROP_APP_NAME
         }
 


### PR DESCRIPTION
Similar issue https://github.com/cocos/cocos-engine/issues/12101

### Changelog

* Android: set default build variant

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
