### PR TITLE
export hasCoefficients to js

### DIFF
--- a/native/cocos/bindings/auto/jsb_gi_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_gi_auto.cpp
@@ -1413,6 +1413,29 @@ static bool js_cc_gi_LightProbesData_updateTetrahedrons(se::State& s)
 }
 SE_BIND_FUNC(js_cc_gi_LightProbesData_updateTetrahedrons) 
 
+static bool js_cc_gi_LightProbesData_hasCoefficients(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    cc::gi::LightProbesData *arg1 = (cc::gi::LightProbesData *) NULL ;
+    bool result;
+    
+    if(argc != 0) {
+        SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+        return false;
+    }
+    arg1 = SE_THIS_OBJECT<cc::gi::LightProbesData>(s);
+    if (nullptr == arg1) return true;
+    result = (bool)((cc::gi::LightProbesData const *)arg1)->hasCoefficients();
+    
+    ok &= nativevalue_to_se(result, s.rval(), s.thisObject());
+    
+    
+    return true;
+}
+SE_BIND_FUNC(js_cc_gi_LightProbesData_hasCoefficients) 
+
 static bool js_cc_gi_LightProbesData_getInterpolationSHCoefficients(se::State& s)
 {
     CC_UNUSED bool ok = true;
@@ -1672,6 +1695,7 @@ bool js_register_cc_gi_LightProbesData(se::Object* obj) {
     cls->defineFunction("reset", _SE(js_cc_gi_LightProbesData_reset)); 
     cls->defineFunction("updateProbes", _SE(js_cc_gi_LightProbesData_updateProbes)); 
     cls->defineFunction("updateTetrahedrons", _SE(js_cc_gi_LightProbesData_updateTetrahedrons)); 
+    cls->defineFunction("hasCoefficients", _SE(js_cc_gi_LightProbesData_hasCoefficients)); 
     cls->defineFunction("getInterpolationSHCoefficients", _SE(js_cc_gi_LightProbesData_getInterpolationSHCoefficients)); 
     cls->defineFunction("getInterpolationWeights", _SE(js_cc_gi_LightProbesData_getInterpolationWeights)); 
     

--- a/native/cocos/gi/light-probe/LightProbe.h
+++ b/native/cocos/gi/light-probe/LightProbe.h
@@ -59,11 +59,11 @@ public:
     void updateProbes(ccstd::vector<Vec3> &points);
     void updateTetrahedrons();
 
+    inline bool hasCoefficients() const { return !empty() && !_probes[0].coefficients.empty(); }
     bool getInterpolationSHCoefficients(int32_t tetIndex, const Vec4 &weights, ccstd::vector<Vec3> &coefficients) const;
     int32_t getInterpolationWeights(const Vec3 &position, int32_t tetIndex, Vec4 &weights) const;
 
 private:
-    inline bool hasCoefficients() const { return !empty() && !_probes[0].coefficients.empty(); }
     static Vec3 getTriangleBarycentricCoord(const Vec3 &p0, const Vec3 &p1, const Vec3 &p2, const Vec3 &position);
     void getBarycentricCoord(const Vec3 &position, const Tetrahedron &tetrahedron, Vec4 &weights) const;
     void getTetrahedronBarycentricCoord(const Vec3 &position, const Tetrahedron &tetrahedron, Vec4 &weights) const;


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/15580

### Changelog

* export hasCoefficients to js

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
