### PR TITLE
export 'boneData.length' of dragonbones to js

### DIFF
--- a/native/cocos/bindings/auto/jsb_dragonbones_auto.cpp
+++ b/native/cocos/bindings/auto/jsb_dragonbones_auto.cpp
@@ -3887,6 +3887,39 @@ se::Class* __jsb_dragonBones_BoneData_class = nullptr;
 se::Object* __jsb_dragonBones_BoneData_proto = nullptr;
 SE_DECLARE_FINALIZE_FUNC(js_delete_dragonBones_BoneData) 
 
+static bool js_dragonBones_BoneData_length_set(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    const auto& args = s.args();
+    size_t argc = args.size();
+    dragonBones::BoneData *arg1 = (dragonBones::BoneData *) NULL ;
+    
+    arg1 = SE_THIS_OBJECT<dragonBones::BoneData>(s);
+    if (nullptr == arg1) return true;
+    
+    ok &= sevalue_to_native(args[0], &arg1->length, s.thisObject());
+    SE_PRECONDITION2(ok, false, "Error processing arguments"); 
+    
+    
+    return true;
+}
+SE_BIND_PROP_SET(js_dragonBones_BoneData_length_set) 
+
+static bool js_dragonBones_BoneData_length_get(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    dragonBones::BoneData *arg1 = (dragonBones::BoneData *) NULL ;
+    
+    arg1 = SE_THIS_OBJECT<dragonBones::BoneData>(s);
+    if (nullptr == arg1) return true;
+    
+    ok &= nativevalue_to_se(arg1->length, s.rval(), s.thisObject()); 
+    
+    
+    return true;
+}
+SE_BIND_PROP_GET(js_dragonBones_BoneData_length_get) 
+
 static bool js_dragonBones_BoneData_name_set(se::State& s)
 {
     CC_UNUSED bool ok = true;
@@ -4043,6 +4076,7 @@ bool js_register_dragonBones_BoneData(se::Object* obj) {
     auto* cls = se::Class::create("BoneData", obj, __jsb_dragonBones_BaseObject_proto, nullptr); 
     
     cls->defineStaticProperty("__isJSB", se::Value(true), se::PropertyAttribute::READ_ONLY | se::PropertyAttribute::DONT_ENUM | se::PropertyAttribute::DONT_DELETE);
+    cls->defineProperty("length", _SE(js_dragonBones_BoneData_length_get), _SE(js_dragonBones_BoneData_length_set)); 
     cls->defineProperty("name", _SE(js_dragonBones_BoneData_name_get), _SE(js_dragonBones_BoneData_name_set)); 
     cls->defineProperty("parent", _SE(js_dragonBones_BoneData_parent_get), _SE(js_dragonBones_BoneData_parent_set)); 
     

--- a/native/tools/swig-config/dragonbones.i
+++ b/native/tools/swig-config/dragonbones.i
@@ -203,7 +203,6 @@
 %ignore dragonBones::BoneData::inheritRotation;
 %ignore dragonBones::BoneData::inheritScale;
 %ignore dragonBones::BoneData::inheritReflection;
-%ignore dragonBones::BoneData::length;
 %ignore dragonBones::BoneData::transform;
 %ignore dragonBones::BoneData::userData;
 


### PR DESCRIPTION
Re: # This pr fixes #14181, which allows access to 'boneData.length' of DragonBones on native platforms.

### Changelog

* Export 'boneData.length' of dragonbones to js

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [x] Your pull request title is using English, it's precise and appropriate.
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [x] Document new code with comments in source code based on API docs
- [x] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [x] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
