### PR TITLE
fixed vulkan staging buffer alignment allocate issue.  (#14192)

### DIFF
--- a/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -1222,7 +1222,7 @@ void cmdFuncCCVKUpdateBuffer(CCVKDevice *device, CCVKGPUBuffer *gpuBuffer, const
     }
 
     // upload buffer by chunks
-    uint32_t chunkSize = std::min(sizeToUpload, CCVKGPUStagingBufferPool::CHUNK_SIZE);
+    uint32_t chunkSize = std::min(static_cast<VkDeviceSize>(sizeToUpload), CCVKGPUStagingBufferPool::CHUNK_SIZE);
 
     uint32_t chunkOffset = 0U;
     while (sizeToUpload) {

--- a/native/cocos/renderer/gfx-vulkan/VKGPUObjects.h
+++ b/native/cocos/renderer/gfx-vulkan/VKGPUObjects.h
@@ -772,9 +772,10 @@ private:
  */
 class CCVKGPUStagingBufferPool final {
 public:
-    static constexpr size_t CHUNK_SIZE = 16 * 1024 * 1024; // 16M per block by default
+    static constexpr VkDeviceSize CHUNK_SIZE = 16 * 1024 * 1024; // 16M per block by default
 
     explicit CCVKGPUStagingBufferPool(CCVKGPUDevice *device)
+
     : _device(device) {
     }
 
@@ -793,7 +794,7 @@ public:
         for (size_t idx = 0U; idx < bufferCount; idx++) {
             Buffer *cur = &_pool[idx];
             offset = roundUp(cur->curOffset, alignment);
-            if (CHUNK_SIZE - offset >= size) {
+            if (size + offset <= CHUNK_SIZE) {
                 buffer = cur;
                 break;
             }


### PR DESCRIPTION
Re: #

### Changelog

* [fixed vulkan staging buffer alignment allocate issue.](https://github.com/cocos/cocos-engine/commit/f5afaac068b444a000cf1c4b31adaf57a3c29ebc)

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
