### PR TITLE
fix effect compile error and plane reflection incorrect effect 

### DIFF
--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -549,6 +549,7 @@ export class MeshRenderer extends ModelRenderer {
         this._onUpdateLocalShadowBiasAndProbeId();
         this._updateUseLightProbe();
         this._updateReceiveDirLight();
+        this._onUpdateReflectionProbeDataMap();
         this._attachToScene();
     }
 

--- a/cocos/render-scene/scene/reflection-probe.ts
+++ b/cocos/render-scene/scene/reflection-probe.ts
@@ -484,7 +484,6 @@ export class ReflectionProbe {
         this.camera.update(true);
 
         // Transform the plane from world space to reflection camera space use the inverse transpose matrix
-        //const viewSpaceProbe = new Vec4(Vec3.UP.x, Vec3.UP.y, Vec3.UP.z, -Vec3.dot(Vec3.UP, this.node.worldPosition));
         const viewSpaceProbe = new Vec4(this.node.up.x, this.node.up.y, this.node.up.z, -Vec3.dot(this.node.up, this.node.worldPosition));
         viewSpaceProbe.transformMat4(this.camera.matView.clone().invert().transpose());
         this.camera.calculateObliqueMat(viewSpaceProbe);

--- a/cocos/render-scene/scene/reflection-probe.ts
+++ b/cocos/render-scene/scene/reflection-probe.ts
@@ -464,17 +464,17 @@ export class ReflectionProbe {
     }
 
     private _transformReflectionCamera (sourceCamera: Camera) {
-        const offset = Vec3.dot(this.node.worldPosition, Vec3.UP);
-        this._reflect(this._cameraWorldPos, sourceCamera.node.worldPosition, Vec3.UP, offset);
+        const offset = Vec3.dot(this.node.worldPosition, this.node.up);
+        this._reflect(this._cameraWorldPos, sourceCamera.node.worldPosition, this.node.up, offset);
         this.cameraNode.worldPosition = this._cameraWorldPos;
 
         Vec3.transformQuat(this._forward, Vec3.FORWARD, sourceCamera.node.worldRotation);
-        this._reflect(this._forward, this._forward, Vec3.UP, 0);
+        this._reflect(this._forward, this._forward, this.node.up, 0);
         this._forward.normalize();
         this._forward.negative();
 
-        Vec3.transformQuat(this._up, Vec3.UP, sourceCamera.node.worldRotation);
-        this._reflect(this._up, this._up, Vec3.UP, 0);
+        Vec3.transformQuat(this._up, this.node.up, sourceCamera.node.worldRotation);
+        this._reflect(this._up, this._up, this.node.up, 0);
         this._up.normalize();
 
         Quat.fromViewUp(this._cameraWorldRotation, this._forward, this._up);
@@ -484,7 +484,8 @@ export class ReflectionProbe {
         this.camera.update(true);
 
         // Transform the plane from world space to reflection camera space use the inverse transpose matrix
-        const viewSpaceProbe = new Vec4(Vec3.UP.x, Vec3.UP.y, Vec3.UP.z, -Vec3.dot(Vec3.UP, this.node.worldPosition));
+        //const viewSpaceProbe = new Vec4(Vec3.UP.x, Vec3.UP.y, Vec3.UP.z, -Vec3.dot(Vec3.UP, this.node.worldPosition));
+        const viewSpaceProbe = new Vec4(this.node.up.x, this.node.up.y, this.node.up.z, -Vec3.dot(this.node.up, this.node.worldPosition));
         viewSpaceProbe.transformMat4(this.camera.matView.clone().invert().transpose());
         this.camera.calculateObliqueMat(viewSpaceProbe);
     }

--- a/cocos/rendering/pipeline-ubo.ts
+++ b/cocos/rendering/pipeline-ubo.ts
@@ -70,8 +70,10 @@ export class PipelineUBO {
         fv[UBOGlobal.NATIVE_SIZE_OFFSET + 2] = 1.0 / fv[UBOGlobal.NATIVE_SIZE_OFFSET];
         fv[UBOGlobal.NATIVE_SIZE_OFFSET + 3] = 1.0 / fv[UBOGlobal.NATIVE_SIZE_OFFSET + 1];
 
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        fv[UBOGlobal.PROBE_INFO_OFFSET] = cclegacy.internal.reflectionProbeManager.getMaxProbeId() + 1;
+        if (cclegacy.internal.reflectionProbeManager) {
+            // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+            fv[UBOGlobal.PROBE_INFO_OFFSET] = cclegacy.internal.reflectionProbeManager.getMaxProbeId() + 1;
+        }
 
         const debugView = root.debugView;
         fv[UBOGlobal.DEBUG_VIEW_MODE_OFFSET] = debugView.singleMode as number;

--- a/cocos/rendering/reflection-probe-manager.ts
+++ b/cocos/rendering/reflection-probe-manager.ts
@@ -275,8 +275,8 @@ export class ReflectionProbeManager {
                 // if used other probe,reset texture
                 if (old !== nearest) {
                     this._useCubeModels.set(model, nearest);
+                    nearest.needRefresh = true;
                 }
-                nearest.needRefresh = true;
             } else {
                 this._useCubeModels.set(model, nearest);
                 nearest.needRefresh = true;

--- a/cocos/rendering/reflection-probe-manager.ts
+++ b/cocos/rendering/reflection-probe-manager.ts
@@ -275,8 +275,8 @@ export class ReflectionProbeManager {
                 // if used other probe,reset texture
                 if (old !== nearest) {
                     this._useCubeModels.set(model, nearest);
-                    nearest.needRefresh = true;
                 }
+                nearest.needRefresh = true;
             } else {
                 this._useCubeModels.set(model, nearest);
                 nearest.needRefresh = true;

--- a/editor/assets/chunks/legacy/decode-base.chunk
+++ b/editor/assets/chunks/legacy/decode-base.chunk
@@ -39,7 +39,7 @@ layout(location = 3) in vec4 a_tangent;
   #if CC_USE_LIGHTMAP
     in vec4 a_lightingMapUVParam;
   #endif
-  #if CC_RECEIVE_SHADOW || CC_USE_REFLECTION_PROBE
+  #if CC_USE_REFLECTION_PROBE || CC_RECEIVE_SHADOW
     in vec4 a_localShadowBiasAndProbeId; // x:shadow bias, y:shadow normal bias, z: reflection probe id, w: reserved for blend reflection probe id
   #endif
   #if CC_USE_LIGHT_PROBE

--- a/native/cocos/scene/ReflectionProbe.cpp
+++ b/native/cocos/scene/ReflectionProbe.cpp
@@ -124,19 +124,19 @@ void ReflectionProbe::switchProbeType(int32_t type, const Camera* sourceCamera) 
 }
 
 void ReflectionProbe::transformReflectionCamera(const Camera* sourceCamera) {
-    float offset = Vec3::dot(_node->getWorldPosition(), Vec3::UNIT_Y);
-    _cameraWorldPos = reflect(sourceCamera->getNode()->getWorldPosition(), Vec3::UNIT_Y, offset);
+    float offset = Vec3::dot(_node->getWorldPosition(), _node->getUp());
+    _cameraWorldPos = reflect(sourceCamera->getNode()->getWorldPosition(), _node->getUp(), offset);
     _cameraNode->setWorldPosition(_cameraWorldPos);
 
     _forward = Vec3::FORWARD;
     _forward.transformQuat(sourceCamera->getNode()->getWorldRotation());
-    _forward = reflect(_forward, Vec3::UNIT_Y, 0);
+    _forward = reflect(_forward, _node->getUp(), 0);
     _forward.normalize();
     _forward *= -1;
 
     _up = Vec3::UNIT_Y;
     _up.transformQuat(sourceCamera->getNode()->getWorldRotation());
-    _up = reflect(_up, Vec3::UNIT_Y, 0);
+    _up = reflect(_up, _node->getUp(), 0);
     _up.normalize();
 
     Quaternion::fromViewUp(_forward, _up, &_cameraWorldRotation);
@@ -144,7 +144,7 @@ void ReflectionProbe::transformReflectionCamera(const Camera* sourceCamera) {
     _camera->update(true);
 
     // Transform the plane from world space to reflection camera space use the inverse transpose matrix
-    Vec4 viewSpaceProbe{Vec3::UNIT_Y.x, Vec3::UNIT_Y.y, Vec3::UNIT_Y.z, -Vec3::dot(Vec3::UNIT_Y, _node->getWorldPosition())};
+    Vec4 viewSpaceProbe{ _node->getUp().x, _node->getUp().y, _node->getUp().z, -Vec3::dot(_node->getUp(), _node->getWorldPosition())};
     Mat4 matView = _camera->getMatView();
     matView.inverse();
     matView.transpose();


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/15483
### Changelog

*

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
