### PR TITLE
fixed metal scissor exceed framebuffer extent issue.

### DIFF
--- a/native/cocos/renderer/gfx-metal/MTLCommandBuffer.h
+++ b/native/cocos/renderer/gfx-metal/MTLCommandBuffer.h
@@ -116,6 +116,9 @@ protected:
     CCMTLSemaphore *_texCopySemaphore = nullptr;
 
     std::bitset<MAX_COLORATTACHMENTS> _colorAppearedBefore;
+
+    uint32_t _currentFbWidth = 1;
+    uint32_t _currentFbHeight = 1;
 };
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-metal/MTLCommandBuffer.h
+++ b/native/cocos/renderer/gfx-metal/MTLCommandBuffer.h
@@ -117,8 +117,8 @@ protected:
 
     std::bitset<MAX_COLORATTACHMENTS> _colorAppearedBefore;
 
-    uint32_t _currentFbWidth = 1;
-    uint32_t _currentFbHeight = 1;
+    int32_t _currentFbWidth = 0;
+    int32_t _currentFbHeight = 0;
 };
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
+++ b/native/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
@@ -216,7 +216,7 @@ void CCMTLCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *fb
                 }
                 if (visited[input])
                     continue;
-                
+
                 auto *ccMtlTexture = static_cast<CCMTLTexture *>(colorTextures[input]);
                 ccMtlRenderPass->setColorAttachment(input, ccMtlTexture, 0);
                 mtlRenderPassDescriptor.colorAttachments[input].clearColor = mu::toMTLClearColor(colors[input]);
@@ -295,11 +295,13 @@ void CCMTLCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *fb
     }
 
     Rect scissorArea = renderArea;
-#if defined(CC_DEBUG) && (CC_DEBUG > 0)
     const Vec2 renderTargetSize = ccMtlRenderPass->getRenderTargetSizes()[0];
-    scissorArea.width = MIN(scissorArea.width, renderTargetSize.x - scissorArea.x);
-    scissorArea.height = MIN(scissorArea.height, renderTargetSize.y - scissorArea.y);
-#endif
+    _currentFbWidth = MIN(scissorArea.width, renderTargetSize.x - scissorArea.x);
+    _currentFbHeight = MIN(scissorArea.height, renderTargetSize.y - scissorArea.y);
+
+    scissorArea.width = _currentFbWidth;
+    scissorArea.height = _currentFbHeight;
+
     _renderEncoder.setViewport(scissorArea);
     _renderEncoder.setScissor(scissorArea);
 
@@ -338,7 +340,7 @@ void CCMTLCommandBuffer::updateDepthStencilState(uint32_t index, MTLRenderPassDe
     const DepthStencilAttachment &dsAttachment = curRenderPass->getDepthStencilAttachment();
     const SubpassInfo &subpass = subpasses[index];
     uint32_t ds = subpass.depthStencil;
-    
+
     if (ds != INVALID_BINDING) {
         auto *ccMTLTexture = static_cast<CCMTLTexture *>(curFBO->getDepthStencilTexture());
         // if ds is provided explicitly in fbo->depthStencil, use it.
@@ -484,7 +486,14 @@ void CCMTLCommandBuffer::setViewport(const Viewport &vp) {
 }
 
 void CCMTLCommandBuffer::setScissor(const Rect &rect) {
-    _renderEncoder.setScissor(rect);
+    Rect validate = rect;
+    int32_t w = MIN(static_cast<int32_t>(rect.width) - rect.x, static_cast<int32_t>(_currentFbWidth));
+    int32_t h = MIN(static_cast<int32_t>(rect.height) - rect.y, static_cast<int32_t>(_currentFbHeight));
+
+    validate.width = static_cast<uint32_t>(MAX(w, 0));
+    validate.height = static_cast<uint32_t>(MAX(h, 0));
+
+    _renderEncoder.setScissor(validate);
 }
 
 void CCMTLCommandBuffer::setLineWidth(float /*width*/) {
@@ -698,27 +707,27 @@ void CCMTLCommandBuffer::copyBuffersToTexture(const uint8_t *const *buffers, Tex
     auto *mtlTexture = static_cast<CCMTLTexture *>(texture);
     const bool isArrayTexture = mtlTexture->isArray();
     auto textureType = mtlTexture->textureInfo().type;
-    
+
     auto format = texture->getFormat();
     // no rg8b/rgb32f support
     auto convertedFormat = mtlTexture->getConvertedFormat();
     auto blockSize = formatAlignment(convertedFormat);
-    
+
     id<MTLBlitCommandEncoder> encoder = [getMTLCommandBuffer() blitCommandEncoder];
     id<MTLTexture> dstTexture = mtlTexture->getMTLTexture();
-    
+
     // Macro Pixel: minimum block to descirbe pixels.
     // when a picture has a 4*4 size:
     // ASTC_4x4: MacroPixelWidth:1 MacroPixelHeight:1
     // RGBA_4x4: MacroPixelWidth:4 MacroPixelHeight:4
-    
+
     for (size_t i = 0; i < count; i++) {
         const auto &region = regions[i];
         auto bufferPixelWidth = region.buffStride > 0 ? region.buffStride : region.texExtent.width;
         auto bufferPixelHeight = region.buffTexHeight > 0 ? region.buffTexHeight : region.texExtent.height;
         auto targetWidth = region.texExtent.width;
         auto targetHeight = region.texExtent.height;
-        
+
         const MTLSize targetSize = {
             bufferPixelWidth == 0 ? 0 : utils::alignTo(bufferPixelWidth, blockSize.first),
             bufferPixelHeight == 0 ? 0 : utils::alignTo(bufferPixelHeight, blockSize.second),
@@ -727,24 +736,24 @@ void CCMTLCommandBuffer::copyBuffersToTexture(const uint8_t *const *buffers, Tex
             region.texOffset.x == 0 ? 0 : utils::alignTo(static_cast<uint>(region.texOffset.x), blockSize.first),
             region.texOffset.y == 0 ? 0 : utils::alignTo(static_cast<uint>(region.texOffset.y), blockSize.second),
             static_cast<uint>(region.texOffset.z)};
-        
+
         auto bytesPerRowForTarget = formatSize(convertedFormat, targetWidth, 1, 1);
         auto bytesPerImageForTarget = formatSize(convertedFormat, static_cast<uint32_t>(targetSize.width), static_cast<uint32_t>(targetSize.height), static_cast<uint32_t>(targetSize.depth));
-        
+
         if(textureType == TextureType::TEX1D || textureType == TextureType::TEX1D_ARRAY || mtlTexture->isPVRTC()) {
             bytesPerRowForTarget = 0;
         }
-        
+
         if(textureType != TextureType::TEX3D || mtlTexture->isPVRTC()) {
             bytesPerImageForTarget = 0;
         }
-    
+
         auto bufferSliceSize = formatSize(convertedFormat, bufferPixelWidth, bufferPixelHeight, 1);
         auto bufferBytesPerRow = formatSize(convertedFormat, bufferPixelWidth, 1, 1);
         auto bufferBytesPerImage = region.texExtent.depth * bufferBytesPerRow;
-        
+
         auto macroPixelHeight = targetHeight / blockSize.second;
-        
+
         bool compactMemory = bufferPixelWidth == region.texExtent.width;
         for(size_t l = region.texSubres.baseArrayLayer; l < region.texSubres.layerCount + region.texSubres.baseArrayLayer; ++l) {
             for(size_t d = targetOffset.z; d < targetSize.depth + targetOffset.z; ++d) {
@@ -752,22 +761,22 @@ void CCMTLCommandBuffer::copyBuffersToTexture(const uint8_t *const *buffers, Tex
                     const auto *convertedData = mu::convertData(buffers[i] + region.buffOffset + (l - region.texSubres.baseArrayLayer) * bufferBytesPerImage
                                                                 + (d - targetOffset.z) * bufferSliceSize,
                                                                 bufferPixelWidth * blockSize.second, format);
-                    
+
                     ccstd::vector<uint8_t> data(bufferSliceSize);
                     memcpy(data.data(), convertedData, bufferSliceSize);
-                    
+
                     MTLRegion mtlRegion = {
                         {targetOffset.x, targetOffset.y, d},
                         {targetSize.width, targetSize.height, 1}
                     };
-                    
+
                     [dstTexture replaceRegion:mtlRegion
                                   mipmapLevel:region.texSubres.mipLevel
                                         slice:l
                                     withBytes:data.data()
                                   bytesPerRow:bytesPerRowForTarget
                                 bytesPerImage:bytesPerImageForTarget];
-                    
+
                     if (format == Format::RGB8 || format == Format::RGB32F) {
                         CC_FREE(convertedData);
                     }
@@ -776,22 +785,22 @@ void CCMTLCommandBuffer::copyBuffersToTexture(const uint8_t *const *buffers, Tex
                         const auto *convertedData = mu::convertData(buffers[i] + region.buffOffset + (l - region.texSubres.baseArrayLayer) * bufferBytesPerImage
                                                                     + (d - targetOffset.z) * bufferSliceSize + h / blockSize.second * bufferBytesPerRow,
                                                                     bufferPixelWidth * blockSize.second, format);
-                        
+
                         ccstd::vector<uint8_t> data(bytesPerRowForTarget);
                         memcpy(data.data(), convertedData, bytesPerRowForTarget );
-                        
+
                         MTLRegion mtlRegion = {
                             {targetOffset.x, targetOffset.y + h, d},
                             {targetSize.width, blockSize.second, 1}
                         };
-                        
+
                         [dstTexture replaceRegion:mtlRegion
                                       mipmapLevel:region.texSubres.mipLevel
                                             slice:l
                                         withBytes:data.data()
                                       bytesPerRow:bytesPerRowForTarget
                                     bytesPerImage:bytesPerImageForTarget];
-                        
+
                         if (format == Format::RGB8 || format == Format::RGB32F) {
                             CC_FREE(convertedData);
                         }
@@ -799,8 +808,8 @@ void CCMTLCommandBuffer::copyBuffersToTexture(const uint8_t *const *buffers, Tex
                 }
             }
         }
-        
-        
+
+
     }
 
     if (hasFlag(static_cast<CCMTLTexture *>(texture)->textureInfo().flags, TextureFlags::GEN_MIPMAP) && mu::pixelFormatIsColorRenderable(convertedFormat)) {

--- a/native/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
+++ b/native/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
@@ -294,7 +294,7 @@ void CCMTLCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *fb
         mu::clearRenderArea(_mtlDevice, _renderEncoder.getMTLEncoder(), renderPass, renderArea, colors, depth, stencil);
     }
 
-    const auto &targetSize = ccMtlRenderPass->getRenderTargetSizes()[0];
+    const auto &targetSize = ccMtlRenderPass->getRenderTargetSizes().at(0);
     _currentFbWidth = static_cast<int32_t>(targetSize.x);
     _currentFbHeight = static_cast<int32_t>(targetSize.y);
     Rect scissorArea = renderArea;


### PR DESCRIPTION
Re: #

### Changelog

* fixed metal scissor exceed framebuffer extent issue.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
