### PR TITLE
v3.7.2 Hide material edit  in hidden props of node components

### DIFF
--- a/editor/inspector/contributions/utils.js
+++ b/editor/inspector/contributions/utils.js
@@ -1,5 +1,5 @@
 'use strict';
-function translate(dump, path, dumps, assets) {
+function translate(dump, path, dumps, assets, ignoreCollectAssets) {
     const type = typeof dump;
     if (!dump || type !== 'object') {
         return;
@@ -23,14 +23,15 @@ function translate(dump, path, dumps, assets) {
                     // 仅当存在 value 数据时才添加 values
                     item.values = values;
                 }
-                collectAssets(item, assets);
-                translate(item.value, item.path, values, assets);
+                collectAssets(item, assets, ignoreCollectAssets);
+                translate(item.value, item.path, values, assets, ignoreCollectAssets);
                 // 如果是数组，内部元素不需要显示 displayName
                 delete item.displayName;
             }
         });
         return;
     }
+
     for (const name of Object.keys(dump)) {
         const item = dump[name];
         if (item === null || item === undefined) {
@@ -40,7 +41,16 @@ function translate(dump, path, dumps, assets) {
         if (typeof item === 'object') {
             item.name = name;
             item.path = `${path}.${name}`;
-            collectAssets(item, assets);
+
+            // Once parent data has visible = false，itself and children do not collect Assets any more.
+            let ignoreCollect = false;
+            if (ignoreCollectAssets) {
+                ignoreCollect = ignoreCollectAssets;
+            } else {
+                ignoreCollect = !item.visible;
+            }
+
+            collectAssets(item, assets, ignoreCollect);
             collectGroups(item);
             let values;
             if (dumps) {
@@ -56,7 +66,8 @@ function translate(dump, path, dumps, assets) {
                     values = undefined;
                 }
             }
-            translate(item.value, item.path, values, assets);
+
+            translate(item.value, item.path, values, assets, ignoreCollect);
         }
     }
 }
@@ -65,8 +76,8 @@ function translate(dump, path, dumps, assets) {
  * @param item
  * @param assets
  */
-function collectAssets(dump, assets) {
-    if (dump.visible && Array.isArray(dump.extends) && dump.value && dump.value.uuid) {
+function collectAssets(dump, assets, ignore) {
+    if (!ignore && Array.isArray(dump.extends) && dump.value && dump.value.uuid) {
         if (dump.extends.includes('cc.Asset')) {
             if (!assets[dump.type]) {
                 assets[dump.type] = {};


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/15516

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
