### PR TITLE
[native] Fix that JSB conversion for std::function doesn't support passing 'null' from JS.

### DIFF
--- a/native/cocos/bindings/manual/jsb_conversions.h
+++ b/native/cocos/bindings/manual/jsb_conversions.h
@@ -754,6 +754,11 @@ bool nativevalue_to_se_args_v(se::ValueArray &array, Args &&...args); // NOLINT(
 
 template <typename R>
 inline bool sevalue_to_native(const se::Value &from, std::function<R()> *func, se::Object *self) { // NOLINT(readability-identifier-naming)
+    if (from.isNullOrUndefined()) {
+        *func = nullptr;
+        return true;
+    }
+
     if (from.isObject() && from.toObject()->isFunction()) {
         CC_ASSERT(from.toObject()->isRooted());
         *func = [from, self]() {
@@ -778,6 +783,11 @@ inline bool sevalue_to_native(const se::Value &from, std::function<R()> *func, s
 
 template <typename R, typename... Args>
 inline bool sevalue_to_native(const se::Value &from, std::function<R(Args...)> *func, se::Object *self) { // NOLINT(readability-identifier-naming)
+    if (from.isNullOrUndefined()) {
+        *func = nullptr;
+        return true;
+    }
+
     if (from.isObject() && from.toObject()->isFunction()) {
         CC_ASSERT(from.toObject()->isRooted());
         *func = [from, self](Args... inargs) {
@@ -805,6 +815,11 @@ inline bool sevalue_to_native(const se::Value &from, std::function<R(Args...)> *
 }
 
 inline bool sevalue_to_native(const se::Value &from, std::function<void()> *func, se::Object *self) { // NOLINT(readability-identifier-naming)
+    if (from.isNullOrUndefined()) {
+        *func = nullptr;
+        return true;
+    }
+
     if (from.isObject() && from.toObject()->isFunction()) {
         CC_ASSERT(from.toObject()->isRooted());
         *func = [from, self]() {
@@ -825,6 +840,11 @@ inline bool sevalue_to_native(const se::Value &from, std::function<void()> *func
 
 template <typename... Args>
 inline bool sevalue_to_native(const se::Value &from, std::function<void(Args...)> *func, se::Object *self) { // NOLINT(readability-identifier-naming)
+    if (from.isNullOrUndefined()) {
+        *func = nullptr;
+        return true;
+    }
+
     if (from.isObject() && from.toObject()->isFunction()) {
         CC_ASSERT(from.toObject()->isRooted());
         *func = [from, self](Args... inargs) {


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/15140

In v3.6 or earlier version, we used [binding-generator](https://github.com/cocos/cocos-engine/tree/3.6.3/native/tools/bindings-generator) to generate auto-binding code. std::function<...> conversion code was generated at [lambda.c](https://github.com/cocos/cocos-engine/blob/3.6.3/native/tools/bindings-generator/targets/spidermonkey/templates/lambda.c#L64) template. In that template, passing `null` value from JS was considered as a valid conversion.

There are also some `sevalue_to_native` conversion functions in [jsb_conversions.h](https://github.com/cocos/cocos-engine/blob/3.6.3/native/cocos/bindings/manual/jsb_conversions.h#L862) :  which didn't consider `null` value. 

We refactored binding logic in v3.7, started to use `swig` to generate auto-binding code. Read [this issue](https://github.com/cocos/cocos-engine/issues/10792) for more details about why we switched the tool to `swig`.

Since we have already defined `sevalue_to_native` conversions functions for `std::function`, we just invoke them rather than expand the code which make binding code cleaner.

What we didn't notice is that `sevalue_to_native`s doesn't handle `null` or `undefined` value, they treat `null` or `undefined` as an invalid value and return `false` to indicate the conversion fails. An error will be triggered like the following:

<img width="594" alt="Screenshot 2023-02-17 at 11 16 53" src="https://user-images.githubusercontent.com/493372/219541064-4725c898-5bad-4955-917f-2327c4cc0498.png">

This Pull Request fixes the issue.

### Changelog

* [native] Fix that JSB conversion for std::function doesn't support passing 'null' from JS.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
