### PR TITLE
fix:xr skip shadowCulling when camera culling enable is false

### DIFF
--- a/native/cocos/renderer/pipeline/ShadowMapBatchedQueue.cpp
+++ b/native/cocos/renderer/pipeline/ShadowMapBatchedQueue.cpp
@@ -70,7 +70,10 @@ void ShadowMapBatchedQueue::gatherLightPasses(const scene::Camera *camera, const
                         } else {
                             layer = csmLayers->getLayers()[level];
                         }
-                        shadowCulling(_pipeline, camera, layer);
+                        bool isCullingEnable = camera->isCullingEnabled();
+                        if (isCullingEnable) {
+                            shadowCulling(_pipeline, camera, layer);
+                        }
                         const RenderObjectList &dirShadowObjects = layer->getShadowObjects();
                         for (const auto &ro : dirShadowObjects) {
                             add(ro.model);


### PR DESCRIPTION
if not right eye will not show shadow
For performance, xr right eye will use left eye culling data on some condition
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
