### PR TITLE
AOT-5: optimize engien constant && update OH template

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -142,14 +142,14 @@
             }
         },
         {
-            "test": "context.platform !== 'NATIVE'",
+            "test": "!context.buildTimeConstants.NATIVE",
             "isVirtualModule": false,
             "overrides": {
                 "cocos/2d/renderer/native-2d.ts": "cocos/2d/renderer/native-2d-empty.ts"
             }
         },
         {
-            "test": "context.platform === 'NATIVE'",
+            "test": "context.buildTimeConstants.NATIVE",
             "isVirtualModule": false,
             "overrides": {
                 "cocos/core/pipeline/index.ts": "cocos/core/pipeline/index.jsb.ts",
@@ -287,9 +287,58 @@
         "NATIVE": {
             "comment": "Running in native platform (mobile app, desktop app, or simulator).",
             "type": "boolean",
-            "value": false,
+            "value": "$ANDROID || $IOS || $MAC || $WINDOWS || $LINUX || $OHOS || $OPEN_HARMONY",
             "internal": false,
             "dynamic": true
+        },
+        "ANDROID": {
+            "comment": "Running in ANDROID platform",
+            "type": "boolean",
+            "value": false,
+            "internal": false,
+            "dynamic": false
+        },
+        "IOS": {
+            "comment": "Running in IOS platform",
+            "type": "boolean",
+            "value": false,
+            "internal": false,
+            "dynamic": false
+        },
+        "MAC": {
+            "comment": "Running in MAC platform",
+            "type": "boolean",
+            "value": false,
+            "internal": false,
+            "dynamic": false
+        },
+        "WINDOWS": {
+            "comment": "Running in WINDOWS platform",
+            "type": "boolean",
+            "value": false,
+            "internal": false,
+            "dynamic": false
+        },
+        "LINUX": {
+            "comment": "Running in LINUX platform",
+            "type": "boolean",
+            "value": false,
+            "internal": false,
+            "dynamic": false
+        },        
+        "OHOS": {
+            "comment": "Running in OHOS platform",
+            "type": "boolean",
+            "value": false,
+            "internal": false,
+            "dynamic": false
+        },
+        "OPEN_HARMONY": {
+            "comment": "Running in OPEN_HARMONY platform",
+            "type": "boolean",
+            "value": false,
+            "internal": false,
+            "dynamic": false
         },
         "WECHAT": {
             "comment": "Running in the Wechat's mini game.",
@@ -442,7 +491,7 @@
         "SUPPORT_JIT": {
             "comment": "Support JIT.",
             "type": "boolean",
-            "value": "!(($PREVIEW && !$NATIVE) || $MINIGAME || $RUNTIME_BASED)",
+            "value": "!(($PREVIEW && !$NATIVE) || $MINIGAME || $RUNTIME_BASED || $OPEN_HARMONY)",
             "ccGlobal": true,
             "internal": false
         },

--- a/templates/openharmony/entry/src/main/ets/cocos/game.ts
+++ b/templates/openharmony/entry/src/main/ets/cocos/game.ts
@@ -28,16 +28,15 @@ const commonJSModuleMap: Record<string, Function> = {
 <% if (chunkBundleUrl) { %>
     '/src/chunks/<%= chunkBundleUrl%>'() { require('./src/chunks/<%= chunkBundleUrl%>') },
 <% }  %> 
-<% for (var i = 0; i < ccUrls.length; i++) {%>
-    '/src/cocos-js/<%=ccUrls[i]%>' () { require('./src/cocos-js/<%=ccUrls[i]%>'); },
-<% } %> 
 <% for (var j = 0; j < bundleJsList.length; j++) {%> 
     'assets/<%=bundleJsList[j]%>' () { require('./assets/<%=bundleJsList[j]%>'); },
 <% } %>
+    '/src/<%= systemCCUrl%>' () { return import('./src/<%= systemCCUrl%>'); },
+    '/src/settings.js' () { return import('./src/settings.js'); },
 }
 export function loadModule (name: string) {
     const moduleExecutor = commonJSModuleMap[name];
-    moduleExecutor?.();
+    return moduleExecutor?.();
 }
 declare const require: any;
 declare const System: any;
@@ -67,42 +66,40 @@ const onTouch = () => new Promise<void>(resolve => resolve())
 export function launchEngine (): Promise<void> {
     return new Promise((resolve, reject) => {
         // @ts-ignore
-        window.global = window;
-        const systemReady = require('./jsb-adapter/sys-ability-polyfill.js');
+        window.global = window;            
+        const { systemReady } = require('./jsb-adapter/sys-ability-polyfill.js');  // TODO: strangely can't use import statement
         systemReady().then(() => {
             // @ts-ignore
             window.oh.loadModule = loadModule;
-            try {
-                require("./jsb-adapter/web-adapter.js");
-            } catch (e) {
-                console.error('error in builtin ', e.stack, e.message);
-            }
-
-            require("./src/<%= systemBundleUrl%>");
-            System.warmup({
-                importMap,
-                importMapUrl: './src/<%= importMapUrl%>',
-                defaultHandler: (urlNoSchema: string) => {
-                    console.info('urlNoSchema ', urlNoSchema);
-                    loadModule(urlNoSchema);
-                },
-            });
-            System.import('./src/<%= applicationUrl%>').then(({ Application }) => {
-                return new Application();
-            }).then((application) => {
-                System.import('cc').then((cc) => {
-                    require('./jsb-adapter/engine-adapter.js');
-                    cc.macro.CLEANUP_IMAGE_CACHE = false;
-                    return application.init(cc);
-                }).then(() => {
-                    return application.start();
-                }).catch(e => {
-                    console.log('error in importing cc ' + e.stack)
+            import('./jsb-adapter/web-adapter.js').then(() => {
+                return import('./src/<%= systemBundleUrl%>').then(() => {
+                    System.warmup({
+                        importMap,
+                        importMapUrl: './src/<%= importMapUrl%>',
+                        defaultHandler: (urlNoSchema: string) => {
+                            console.info('urlNoSchema ', urlNoSchema);
+                            return loadModule(urlNoSchema);
+                        },
+                    });
+                    return System.import('./src/<%= applicationUrl%>').then(({ Application }) => {
+                        return new Application();
+                    }).then((application) => {
+                        return import('./src/cocos-js/cc').then(() => {
+                            return System.import('cc').then((cc) => {
+                                return import('./jsb-adapter/engine-adapter.js').then(() => {
+                                    cc.macro.CLEANUP_IMAGE_CACHE = false;
+                                    return application.init(cc);
+                                });
+                            }).then(() => {
+                                return application.start();
+                            });
+                        });
+                    });
                 });
-            }).catch((e: any) => {
-                console.error('imported failed', e.message, e.stack)
-                reject(e);
-            })
+            });             
+        }).catch((e: any) => {
+            console.error('imported failed', e.message, e.stack)
+            reject(e);
         });
     })
 }

--- a/templates/openharmony/entry/src/main/ets/cocos/game.ts
+++ b/templates/openharmony/entry/src/main/ets/cocos/game.ts
@@ -24,12 +24,12 @@
 ****************************************************************************/
 import importMap from './src/<%= importMapUrl%>'
 const commonJSModuleMap: Record<string, Function> = {
-    '/src/<%= applicationUrl%>'() { require('./src/<%= applicationUrl%>'); },
+    '/src/<%= applicationUrl%>'() { return import('./src/<%= applicationUrl%>'); },
 <% if (chunkBundleUrl) { %>
-    '/src/chunks/<%= chunkBundleUrl%>'() { require('./src/chunks/<%= chunkBundleUrl%>') },
+    '/src/chunks/<%= chunkBundleUrl%>'() { return import('./src/chunks/<%= chunkBundleUrl%>') },
 <% }  %> 
 <% for (var j = 0; j < bundleJsList.length; j++) {%> 
-    'assets/<%=bundleJsList[j]%>' () { require('./assets/<%=bundleJsList[j]%>'); },
+    'assets/<%=bundleJsList[j]%>' () { return import('./assets/<%=bundleJsList[j]%>'); },
 <% } %>
     '/src/<%= systemCCUrl%>' () { return import('./src/<%= systemCCUrl%>'); },
     '/src/settings.js' () { return import('./src/settings.js'); },

--- a/templates/openharmony/entry/src/main/ets/cocos/jsb-adapter/sys-ability-polyfill.js
+++ b/templates/openharmony/entry/src/main/ets/cocos/jsb-adapter/sys-ability-polyfill.js
@@ -30,7 +30,7 @@ import sensor from '@ohos.sensor';
 
 window.oh = {};
 
-module.exports = function systemReady () {
+export function systemReady () {
     return new Promise(resolve => {
         if (typeof XMLHttpRequest === 'undefined') {
             window.XMLHttpRequest = function () {}


### PR DESCRIPTION
Re: 
https://github.com/cocos/3d-tasks/issues/15665
https://github.com/cocos/3d-tasks/issues/15666

### Changelog

* optimize engien constant, now we have specific native paltform constant 
* update OH template

### dependence PR
https://github.com/cocos/creator-runtime-extensions/pull/343
https://github.com/cocos/cocos-editor/pull/1659

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
