### PR TITLE
fix: touch event not working in wechat miniprogram webview

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -1009,6 +1009,7 @@ function initSys () {
             }).catch(err => {});
         }
         // NOTE: '__wxjs_environment' is defined in wechat miniprogram webview environment
+        // We need to open touch capability on wechat miniprogram webview environment so that touch event listener is registered on canvas element.
         if (docEle['ontouchstart'] !== undefined || doc['ontouchstart'] !== undefined || nav.msPointerEnabled || (typeof __wxjs_environment === 'string' && __wxjs_environment === 'miniprogram'))
             capabilities["touches"] = true;
         if (docEle['onmouseup'] !== undefined)

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -1009,7 +1009,7 @@ function initSys () {
             }).catch(err => {});
         }
         // NOTE: '__wxjs_environment' is defined in wechat miniprogram webview environment
-        // We need to open touch capability on wechat miniprogram webview environment so that touch event listener is registered on canvas element.
+        // developpers would embed builded web project in a WebView component on wechat miniprogram, so that we need to handle this situation.
         if (docEle['ontouchstart'] !== undefined || doc['ontouchstart'] !== undefined || nav.msPointerEnabled || (typeof __wxjs_environment === 'string' && __wxjs_environment === 'miniprogram'))
             capabilities["touches"] = true;
         if (docEle['onmouseup'] !== undefined)

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -1008,7 +1008,8 @@ function initSys () {
                 imageBitmap.close && imageBitmap.close();
             }).catch(err => {});
         }
-        if (docEle['ontouchstart'] !== undefined || doc['ontouchstart'] !== undefined || nav.msPointerEnabled)
+        // NOTE: '__wxjs_environment' is defined in wechat miniprogram webview environment
+        if (docEle['ontouchstart'] !== undefined || doc['ontouchstart'] !== undefined || nav.msPointerEnabled || (typeof __wxjs_environment === 'string' && __wxjs_environment === 'miniprogram'))
             capabilities["touches"] = true;
         if (docEle['onmouseup'] !== undefined)
             capabilities["mouse"] = true;

--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -1009,7 +1009,7 @@ function initSys () {
             }).catch(err => {});
         }
         // NOTE: '__wxjs_environment' is defined in wechat miniprogram webview environment
-        // developpers would embed builded web project in a WebView component on wechat miniprogram, so that we need to handle this situation.
+        // developpers would embed builded web project in a webview component on wechat miniprogram, so that we need to handle this situation.
         if (docEle['ontouchstart'] !== undefined || doc['ontouchstart'] !== undefined || nav.msPointerEnabled || (typeof __wxjs_environment === 'string' && __wxjs_environment === 'miniprogram'))
             capabilities["touches"] = true;
         if (docEle['onmouseup'] !== undefined)


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/11330

### Changelog

* fix touch event not working in wechat miniprogram webview

### Note
- touch event need to be registered on canvas element, this issue only exists on 2.x, not on 3.x

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
