### PR TITLE
v3.7.2 Fix the rendering issue with MotionStreak + RigidBody2D on native platforms

### DIFF
--- a/cocos/particle-2d/motion-streak-2d-assembler.ts
+++ b/cocos/particle-2d/motion-streak-2d-assembler.ts
@@ -187,8 +187,7 @@ export const MotionStreakAssembler: IAssembler = {
             renderData.updateRenderData(comp, comp.texture!);
             // No need update WorldMatrix, so change dirty flag
             // A dirty hack
-            renderData.renderDrawInfo.setVertDirty(false);
-            comp.node.hasChangedFlags = 0;
+            comp.markForUpdateRenderData();
         }
     },
 
@@ -244,6 +243,10 @@ export const MotionStreakAssembler: IAssembler = {
     },
 
     updateRenderData (comp: MotionStreak) {
+        if (JSB) {
+            comp.renderData!.renderDrawInfo.setVertDirty(false);
+            comp.node.hasChangedFlags = 0;
+        }
     },
 
     updateColor (comp: MotionStreak) {

--- a/cocos/particle-2d/motion-streak-2d-assembler.ts
+++ b/cocos/particle-2d/motion-streak-2d-assembler.ts
@@ -243,10 +243,6 @@ export const MotionStreakAssembler: IAssembler = {
     },
 
     updateRenderData (comp: MotionStreak) {
-        if (JSB) {
-            comp.renderData!.renderDrawInfo.setVertDirty(false);
-            comp.node.hasChangedFlags = 0;
-        }
     },
 
     updateColor (comp: MotionStreak) {

--- a/cocos/particle-2d/motion-streak-2d-assembler.ts
+++ b/cocos/particle-2d/motion-streak-2d-assembler.ts
@@ -185,8 +185,6 @@ export const MotionStreakAssembler: IAssembler = {
             this.updateWorldVertexAllData(comp);
 
             renderData.updateRenderData(comp, comp.texture!);
-            // No need update WorldMatrix, so change dirty flag
-            // A dirty hack
             comp.markForUpdateRenderData();
         }
     },
@@ -244,6 +242,9 @@ export const MotionStreakAssembler: IAssembler = {
 
     updateRenderData (comp: MotionStreak) {
         if (JSB) {
+            // A dirty hack
+            // The world matrix was updated in advance and needs to be avoided at the cpp level
+            // Need a flag to explicitly not update the world transform to solve this problem
             comp.renderData!.renderDrawInfo.setVertDirty(false);
             comp.node.hasChangedFlags = 0;
         }

--- a/cocos/particle-2d/motion-streak-2d-assembler.ts
+++ b/cocos/particle-2d/motion-streak-2d-assembler.ts
@@ -243,6 +243,10 @@ export const MotionStreakAssembler: IAssembler = {
     },
 
     updateRenderData (comp: MotionStreak) {
+        if (JSB) {
+            comp.renderData!.renderDrawInfo.setVertDirty(false);
+            comp.node.hasChangedFlags = 0;
+        }
     },
 
     updateColor (comp: MotionStreak) {


### PR DESCRIPTION
Re: # This pr fixes #14300 and #12992. 

### Changelog

* Fix the issue with MotionStreak plus RigidBody2D not rendering correctly on native platforms

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
