### PR TITLE
Fixing a potential crash when releasing an Asset object passed to JS

### DIFF
--- a/native/cocos/bindings/jswrapper/PrivateObject.h
+++ b/native/cocos/bindings/jswrapper/PrivateObject.h
@@ -30,6 +30,7 @@
 #include "base/Ptr.h"
 #include "base/RefCounted.h"
 #include "base/memory/Memory.h"
+#include "base/HasMemberFunction.h"
 
 namespace se {
 
@@ -114,7 +115,11 @@ public:
     CCIntrusivePtrPrivateObject() = default;
     explicit CCIntrusivePtrPrivateObject(const cc::IntrusivePtr<T> &p) : _ptr(p) {}
     explicit CCIntrusivePtrPrivateObject(cc::IntrusivePtr<T> &&p) : _ptr(std::move(p)) {}
-    ~CCIntrusivePtrPrivateObject() override = default;
+    ~CCIntrusivePtrPrivateObject() override {
+        if constexpr (cc::has_setScriptObject<T,void(se::Object *)>::value) {
+            _ptr->setScriptObject(nullptr);
+        }
+    }
 
     inline const cc::IntrusivePtr<T> &getData() const { return _ptr; }
     inline cc::IntrusivePtr<T> &getData() { return _ptr; }


### PR DESCRIPTION
In the current implementation of our C++-based Asset object, when passing it to JavaScript, a weak reference to the associated `se::Object` object is created. However, this weak reference must be disconnected when the `se::Object/PrivateObject` is destructed, or else it may cause a crash.

This pull request includes changes to properly release the weak reference when the `PrivateObject` is destructed.

### Changelog

* Deref script object when se::Object destructed

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
