### PR TITLE
 Merge _flagChangeVersion and _hasChangedFlags, Use Single uint32_t to Save Memory and Avoid Inconsistencies

### DIFF
--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -215,7 +215,7 @@ nodeProto.addComponent = function (typeOrClassName) {
         legacyCC.director._nodeActivator.activateComp(component);
     }
     if (EDITOR && !legacyCC.GAME_VIEW) {
-        component.resetInEditor?.()
+        component.resetInEditor?.();
     }
 
     return component;

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -1000,7 +1000,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
             legacyCC.director._nodeActivator.activateComp(component);
         }
         if (EDITOR && !legacyCC.GAME_VIEW) {
-            component.resetInEditor?.()
+            component.resetInEditor?.();
         }
 
         return component;

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -1483,7 +1483,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      *
      * | 31 - 29 reserved | 28 - 3 version number | 2  - 0 : Scale Rotation Translation|
      */
-    protected _hasChangedFlagsWithVersion = 0;
+    protected _changedVersionAndRTS = 0;
 
     constructor (name?: string) {
         super(name);
@@ -1714,11 +1714,11 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * @zh 这个节点的空间变换信息在当前帧内是否有变过？
      */
     get hasChangedFlags () {
-        return (this._hasChangedFlagsWithVersion >>> 3) === globalFlagChangeVersion ? (this._hasChangedFlagsWithVersion & 7) : 0;
+        return (this._changedVersionAndRTS >>> 3) === globalFlagChangeVersion ? (this._changedVersionAndRTS & 7) : 0;
     }
 
     set hasChangedFlags (val: number) {
-        this._hasChangedFlagsWithVersion = (globalFlagChangeVersion << 3) | val;
+        this._changedVersionAndRTS = (globalFlagChangeVersion << 3) | val;
     }
 
     /**

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -1478,8 +1478,12 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
     protected _dirtyFlags = TransformBit.NONE; // does the world transform need to update?
     protected _eulerDirty = false;
 
-    // The high bits are used to store the version number of the changedFlag, and the low 3 bits represent its specific value
-    protected _versionedChangedFlags = 0;
+    /**
+     * The high bits are used to store the version number of the changedFlag, and the low 3 bits represent its specific value
+     *
+     * | 31 - 29 reserved | 28 - 3 version number | 2  - 0 : Scale Rotation Translation|
+     */
+    protected _hasChangedFlagsWithVersion = 0;
 
     constructor (name?: string) {
         super(name);
@@ -1710,11 +1714,11 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * @zh 这个节点的空间变换信息在当前帧内是否有变过？
      */
     get hasChangedFlags () {
-        return (this._versionedChangedFlags >>> 3) === globalFlagChangeVersion ? (this._versionedChangedFlags & 7) : 0;
+        return (this._hasChangedFlagsWithVersion >>> 3) === globalFlagChangeVersion ? (this._hasChangedFlagsWithVersion & 7) : 0;
     }
 
     set hasChangedFlags (val: number) {
-        this._versionedChangedFlags = (globalFlagChangeVersion << 3) | val;
+        this._hasChangedFlagsWithVersion = (globalFlagChangeVersion << 3) | val;
     }
 
     /**
@@ -2508,10 +2512,6 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * 清除所有节点的脏标记。
      */
     public static resetHasChangedFlags () {
-        // This code uses 32 bits for bit operations:
-        //   1 bit for sign,
-        //   28 bits for global flag version,
-        //   3 bits for transform flags.
         // Using 26 bits for the flags is sufficient.
         globalFlagChangeVersion = (globalFlagChangeVersion + 1) & 0x3FFFFFF;
     }

--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -39,7 +39,7 @@ namespace cc {
 uint32_t Node::clearFrame{0};
 uint32_t Node::clearRound{1000};
 const uint32_t Node::TRANSFORM_ON{1 << 0};
-uint32_t Node::globalFlagChangeVersion{0};
+uint32_t Node::globalFlagChangeVersion{1};
 
 namespace {
 const ccstd::string EMPTY_NODE_NAME;
@@ -773,10 +773,6 @@ void Node::setRTSInternal(Quaternion *rot, Vec3 *pos, Vec3 *scale, bool calledFr
             emit<TransformChanged>(static_cast<TransformBit>(dirtyBit));
         }
     }
-}
-
-void Node::resetChangedFlags() {
-    globalFlagChangeVersion++;
 }
 
 void Node::clearNodeArray() {

--- a/native/cocos/core/scene-graph/Node.h
+++ b/native/cocos/core/scene-graph/Node.h
@@ -128,10 +128,6 @@ public:
     static bool isNode(T *obj);
 
     inline static void resetChangedFlags() {
-        // This code uses 32 bits for bit operations:
-        //   1 bit for sign,
-        //   28 bits for global flag version,
-        //   3 bits for transform flags.
         // Using 26 bits for the flags is sufficient.
         globalFlagChangeVersion = (globalFlagChangeVersion + 1) & 0x3FFFFFF;
     }
@@ -471,10 +467,10 @@ public:
      * @zh 这个节点的空间变换信息在当前帧内是否有变过？
      */
     inline uint32_t getChangedFlags() const {
-        return (_versionedChangedFlags >> 3) == globalFlagChangeVersion ? (_versionedChangedFlags & 0x7) : 0;
+        return (_hasChangedFlagWithVersion >> 3) == globalFlagChangeVersion ? (_hasChangedFlagWithVersion & 0x7) : 0;
     }
     inline void setChangedFlags(uint32_t value) {
-        _versionedChangedFlags = (globalFlagChangeVersion << 3) | value;
+        _hasChangedFlagWithVersion = (globalFlagChangeVersion << 3) | value;
     }
 
     inline void setDirtyFlag(uint32_t value) { _dirtyFlag = value; }
@@ -664,8 +660,12 @@ private:
     uint8_t _isStatic{0};                                               // Uint8: 2
     uint8_t _padding{0};                                                // Uint8: 3
 
-    // The high bits are used to store the version number of the changeflag, and the low 3 bits represent its specific value
-    uint32_t _versionedChangedFlags{0};
+    /**
+     * The high bits are used to store the version number of the changeflag, and the low 3 bits represent its specific value
+     *
+     * | 31 - 29 reserved | 28 - 3 version number | 2  - 0 : Scale Rotation Translation|
+    */
+    uint32_t _hasChangedFlagWithVersion{0};
 
     bool _eulerDirty{false};
 

--- a/native/cocos/core/scene-graph/Node.h
+++ b/native/cocos/core/scene-graph/Node.h
@@ -467,10 +467,10 @@ public:
      * @zh 这个节点的空间变换信息在当前帧内是否有变过？
      */
     inline uint32_t getChangedFlags() const {
-        return (_hasChangedFlagWithVersion >> 3) == globalFlagChangeVersion ? (_hasChangedFlagWithVersion & 0x7) : 0;
+        return (_changedVersionAndRTS >> 3) == globalFlagChangeVersion ? (_changedVersionAndRTS & 0x7) : 0;
     }
     inline void setChangedFlags(uint32_t value) {
-        _hasChangedFlagWithVersion = (globalFlagChangeVersion << 3) | value;
+        _changedVersionAndRTS = (globalFlagChangeVersion << 3) | value;
     }
 
     inline void setDirtyFlag(uint32_t value) { _dirtyFlag = value; }
@@ -665,7 +665,7 @@ private:
      *
      * | 31 - 29 reserved | 28 - 3 version number | 2  - 0 : Scale Rotation Translation|
     */
-    uint32_t _hasChangedFlagWithVersion{0};
+    uint32_t _changedVersionAndRTS{0};
 
     bool _eulerDirty{false};
 


### PR DESCRIPTION
This pull request merges the _flagChangeVersion and _hasChangedFlags fields and uses a single `uint32` to store them. The high bits store the version, while the low bits store the flags. This change saves memory and avoids inconsistencies between the two automatically modified fields.

### Changelog

* Merged `_flagChangeVersion` and `_hasChangedFlags` fields.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
