### PR TITLE
Fix console.log output for objects by calling toString() method

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -1101,16 +1101,23 @@ bool Object::detachObject(Object *obj) {
 }
 
 ccstd::string Object::toString() const {
-    ccstd::string ret;
+    v8::Local<v8::Object> v8Obj = const_cast<Object *>(this)->_obj.handle(__isolate);
     if (isFunction() || isArray() || isTypedArray()) {
-        v8::String::Utf8Value utf8(__isolate, const_cast<Object *>(this)->_obj.handle(__isolate));
-        ret = *utf8;
+        v8::String::Utf8Value utf8(__isolate, v8Obj);
+        return  *utf8;
     } else if (isArrayBuffer()) {
-        ret = "[object ArrayBuffer]";
+        return "[object ArrayBuffer]";
     } else {
-        ret = "[object Object]";
+        v8::Local<v8::String> strObj;
+        v8::Local<v8::Value> v8Val{v8Obj};
+        if (!v8Val->ToString(__isolate->GetCurrentContext()).ToLocal(&strObj)) {
+            return "[object Object]";
+        }
+
+        v8::String::Utf8Value str(__isolate, strObj);
+        return *str;
     }
-    return ret;
+    return "[unknown]";
 }
 
 ccstd::string Object::toStringExt() const {

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -1102,22 +1102,8 @@ bool Object::detachObject(Object *obj) {
 
 ccstd::string Object::toString() const {
     v8::Local<v8::Object> v8Obj = const_cast<Object *>(this)->_obj.handle(__isolate);
-    if (isFunction() || isArray() || isTypedArray()) {
-        v8::String::Utf8Value utf8(__isolate, v8Obj);
-        return  *utf8;
-    } else if (isArrayBuffer()) {
-        return "[object ArrayBuffer]";
-    } else {
-        v8::Local<v8::String> strObj;
-        v8::Local<v8::Value> v8Val{v8Obj};
-        if (!v8Val->ToString(__isolate->GetCurrentContext()).ToLocal(&strObj)) {
-            return "[object Object]";
-        }
-
-        v8::String::Utf8Value str(__isolate, strObj);
-        return *str;
-    }
-    return "[unknown]";
+    v8::String::Utf8Value utf8(__isolate, v8Obj);
+    return *utf8;
 }
 
 ccstd::string Object::toStringExt() const {


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/7908

Fixed console.log output for Object parameters. Previously, the output for Objects was [object Object]. With this fix, the toString method of the Object will be called instead, resulting in more consistent output with devtools

- web
![image](https://user-images.githubusercontent.com/40414978/222658808-aa8e66fb-d226-4e5b-8da2-6d00db3f09a7.png)
- visual studio
![image](https://user-images.githubusercontent.com/40414978/222658909-aa934c67-9ae5-4f83-a3e7-d5999d5b14cd.png)


### Changelog

* Modified the implementation of console.log to call the toString method on objects, arrays, and other non-scalar types when printing them to the console.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
