### PR TITLE
Fix pass properties order in native editor

### DIFF
--- a/native/cocos/bindings/manual/jsb_conversions.h
+++ b/native/cocos/bindings/manual/jsb_conversions.h
@@ -46,6 +46,7 @@
     #include "cocos/editor-support/spine-creator-support/spine-cocos2dx.h"
 #endif
 
+#include "core/assets/EffectAsset.h"
 #include "core/geometry/Geometry.h"
 #include "math/Color.h"
 #include "math/Math.h"
@@ -790,8 +791,8 @@ bool sevalue_to_native(const se::Value &from, ccstd::vector<T> *to, se::Object *
     return false;
 }
 
-template<typename K, typename V>
-bool sevalue_to_native(const se::Value& from, ccstd::vector<std::pair<K, V>>* to, se::Object* ctx) {
+template <typename K, typename V>
+bool sevalue_to_native(const se::Value &from, cc::StablePropertyMap<K, V> *to, se::Object *ctx) { // NOLINT
     // convert object to attribute/value list: [{"prop1", v1}, {"prop2", v2}... {"propN", vn}]
     CC_ASSERT_NOT_NULL(to);
     CC_ASSERT(from.isObject());
@@ -808,8 +809,8 @@ bool sevalue_to_native(const se::Value& from, ccstd::vector<std::pair<K, V>>* to
         }
         if (!sevalue_to_native(valueJS, &value, ctx)) {
             continue;
-        } 
-        to->emplace_back(std::make_pair(std::move(attr), std::move(value))); 
+        }
+        to->emplace_back(std::make_pair(std::move(attr), std::move(value)));
     }
     return true;
 }
@@ -1323,9 +1324,8 @@ inline bool nativevalue_to_se(const std::function<R(Args...)> & /*from*/, se::Va
     return false;
 }
 
-
 template <typename K, typename V>
-bool nativevalue_to_se(const ccstd::vector<std::pair<K, V>> &from, se::Value &to, se::Object *ctx) {
+bool nativevalue_to_se(const cc::StablePropertyMap<K, V> &from, se::Value &to, se::Object *ctx) { // NOLINT(readability-identifier-naming
     // convert to object from  attribute/value list: [{"prop1", v1}, {"prop2", v2}... {"propN", vn}]
     se::HandleObject ret(se::Object::createPlainObject());
     for (const auto &ele : from) {
@@ -1342,7 +1342,6 @@ bool nativevalue_to_se(const ccstd::vector<std::pair<K, V>> &from, se::Value &to
     to.setObject(ret);
     return true;
 }
-
 
 ///////////////////////// function ///////////////////////
 

--- a/native/cocos/core/assets/EffectAsset.h
+++ b/native/cocos/core/assets/EffectAsset.h
@@ -39,35 +39,26 @@
 #include "renderer/pipeline/Define.h"
 namespace cc {
 
+
 #if !SWIGCOCOS
-
-template <typename T>
-struct IsVectorContainer : std::false_type {};
-
-template <typename E, typename A>
-struct IsVectorContainer<ccstd::vector<E, A>> : std::true_type {};
-
-/**
- * This function retrieves the value of a specific property from an attribute container. 
- * The type of container used for storing the properties depends on whether the CC_EDITOR macro is enabled or not.
- * If the macro is enabled, the container is a list, otherwise it is an unordered map.
- */
-template <typename T, typename K>
-inline auto retrieveProperty(T &collection, K &key) {
-    if constexpr (IsVectorContainer<std::remove_cv_t<T>>::value) {
-        return std::find_if(collection.begin(), collection.end(), [&](auto &e) { return e.first == key; });
-    } else {
-        return collection.find(key);
+template <typename K, typename V>
+class StablePropertyMap : public ccstd::vector<std::pair<K, V>> { // NOLINT
+    using Super = ccstd::vector<std::pair<K, V>>;
+public:
+    auto find(const K &key) const {
+        auto *self = static_cast<const Super*>(this);
+        return std::find_if(self->begin(), self->end(), [&](auto &ele) {
+            return ele.first == key;
+        });
     }
-}
-
+};
 #endif
 
 template <typename K, typename V>
 using UnstablePropertyContainer = ccstd::unordered_map<K, V>;
 
 template <typename K, typename V>
-using StablePropertyContainer = ccstd::vector<std::pair<K, V>>;
+using StablePropertyContainer = StablePropertyMap<K, V>;
 
 #if CC_EDITOR
 template <typename K, typename V>

--- a/native/cocos/core/assets/EffectAsset.h
+++ b/native/cocos/core/assets/EffectAsset.h
@@ -39,14 +39,20 @@
 #include "renderer/pipeline/Define.h"
 namespace cc {
 
-
+// To avoid errors when generating code using SWIG.
 #if !SWIGCOCOS
+
+// The properties in Pass are obtained from an asset file. If they are directly stored in an unordered_map,
+// the order of these properties may become scrambled. To maintain their order, a vector<pair> is used
+// instead. Since there is no scenario where these data objects are randomly inserted,
+// only a find interface is provided.
 template <typename K, typename V>
 class StablePropertyMap : public ccstd::vector<std::pair<K, V>> { // NOLINT
     using Super = ccstd::vector<std::pair<K, V>>;
+
 public:
     auto find(const K &key) const {
-        auto *self = static_cast<const Super*>(this);
+        auto *self = static_cast<const Super *>(this);
         return std::find_if(self->begin(), self->end(), [&](auto &ele) {
             return ele.first == key;
         });

--- a/native/cocos/core/assets/EffectAsset.h
+++ b/native/cocos/core/assets/EffectAsset.h
@@ -39,6 +39,8 @@
 #include "renderer/pipeline/Define.h"
 namespace cc {
 
+#if !SWIGCOCOS
+
 template <typename T>
 struct IsVectorContainer : std::false_type {};
 
@@ -58,6 +60,8 @@ inline auto retrieveProperty(T &collection, K &key) {
         return collection.find(key);
     }
 }
+
+#endif
 
 template <typename K, typename V>
 using UnstablePropertyContainer = ccstd::unordered_map<K, V>;

--- a/native/cocos/core/assets/Material.cpp
+++ b/native/cocos/core/assets/Material.cpp
@@ -365,7 +365,7 @@ bool Material::uploadProperty(scene::Pass *pass, const ccstd::string &name, cons
             pass->setUniformArray(handle, ccstd::get<MaterialPropertyList>(val));
         } else if (val.index() == MATERIAL_PROPERTY_INDEX_SINGLE) {
             const auto &passProps = pass->getProperties();
-            auto iter = passProps.find(name);
+            auto iter = retrieveProperty(passProps, name);
             if (iter != passProps.end() && iter->second.linear.has_value()) {
                 CC_ASSERT(ccstd::holds_alternative<MaterialProperty>(val));
                 const auto &prop = ccstd::get<MaterialProperty>(val);

--- a/native/cocos/core/assets/Material.cpp
+++ b/native/cocos/core/assets/Material.cpp
@@ -365,7 +365,7 @@ bool Material::uploadProperty(scene::Pass *pass, const ccstd::string &name, cons
             pass->setUniformArray(handle, ccstd::get<MaterialPropertyList>(val));
         } else if (val.index() == MATERIAL_PROPERTY_INDEX_SINGLE) {
             const auto &passProps = pass->getProperties();
-            auto iter = retrieveProperty(passProps, name);
+            auto iter = passProps.find(name);
             if (iter != passProps.end() && iter->second.linear.has_value()) {
                 CC_ASSERT(ccstd::holds_alternative<MaterialProperty>(val));
                 const auto &prop = ccstd::get<MaterialProperty>(val);

--- a/native/cocos/scene/Pass.cpp
+++ b/native/cocos/scene/Pass.cpp
@@ -27,6 +27,7 @@
 #include "cocos/bindings/jswrapper/SeApi.h"
 #include "cocos/renderer/pipeline/custom/RenderingModule.h"
 #include "core/Root.h"
+#include "core/assets/EffectAsset.h"
 #include "core/assets/TextureBase.h"
 #include "core/builtin/BuiltinResMgr.h"
 #include "core/platform/Debug.h"
@@ -347,7 +348,7 @@ void Pass::resetUniform(const ccstd::string &name) {
     const uint32_t count = Pass::getCountFromHandle(handle);
     auto &block = _blocks[binding];
     ccstd::optional<IPropertyValue> givenDefaultOpt;
-    auto iter = _properties.find(name);
+    auto iter = retrieveProperty(_properties, name);
     if (iter != _properties.end()) {
         givenDefaultOpt = iter->second.value;
     }
@@ -380,7 +381,7 @@ void Pass::resetTexture(const ccstd::string &name, uint32_t index) {
     const uint32_t binding = Pass::getBindingFromHandle(handle);
     ccstd::string texName;
     IPropertyInfo *info = nullptr;
-    auto iter = _properties.find(name);
+    auto iter = retrieveProperty(_properties, name);
     if (iter != _properties.end()) {
         if (iter->second.value.has_value()) {
             info = &iter->second;
@@ -418,11 +419,10 @@ void Pass::resetUBOs() {
         uint32_t ofs = 0;
         for (const auto &cur : u.members) {
             const auto &block = _blocks[u.binding];
-            const auto &info = _properties[cur.name];
-            const auto &givenDefault = info.value;
+            auto iter = retrieveProperty(_properties, cur.name);
             const auto &value =
-                (givenDefault.has_value()
-                     ? ccstd::get<ccstd::vector<float>>(givenDefault.value())
+                (iter != _properties.end() && iter->second.value.has_value()
+                     ? ccstd::get<ccstd::vector<float>>(iter->second.value.value())
                      : getDefaultFloatArrayFromType(cur.type));
             const uint32_t size = (gfx::getTypeSize(cur.type) >> 2) * cur.count;
             for (size_t k = 0; (k + value.size()) <= size; k += value.size()) {

--- a/native/cocos/scene/Pass.cpp
+++ b/native/cocos/scene/Pass.cpp
@@ -348,7 +348,7 @@ void Pass::resetUniform(const ccstd::string &name) {
     const uint32_t count = Pass::getCountFromHandle(handle);
     auto &block = _blocks[binding];
     ccstd::optional<IPropertyValue> givenDefaultOpt;
-    auto iter = retrieveProperty(_properties, name);
+    auto iter = _properties.find(name);
     if (iter != _properties.end()) {
         givenDefaultOpt = iter->second.value;
     }
@@ -380,12 +380,12 @@ void Pass::resetTexture(const ccstd::string &name, uint32_t index) {
     const gfx::Type type = Pass::getTypeFromHandle(handle);
     const uint32_t binding = Pass::getBindingFromHandle(handle);
     ccstd::string texName;
-    IPropertyInfo *info = nullptr;
-    auto iter = retrieveProperty(_properties, name);
+    const IPropertyInfo *info = nullptr;
+    auto iter = _properties.find(name);
     if (iter != _properties.end()) {
         if (iter->second.value.has_value()) {
             info = &iter->second;
-            ccstd::string *pStrVal = ccstd::get_if<ccstd::string>(&iter->second.value.value());
+            const ccstd::string *pStrVal = ccstd::get_if<ccstd::string>(&iter->second.value.value());
             if (pStrVal != nullptr) {
                 texName = (*pStrVal) + getStringFromType(type);
             }
@@ -419,7 +419,7 @@ void Pass::resetUBOs() {
         uint32_t ofs = 0;
         for (const auto &cur : u.members) {
             const auto &block = _blocks[u.binding];
-            auto iter = retrieveProperty(_properties, cur.name);
+            auto iter = _properties.find(cur.name);
             const auto &value =
                 (iter != _properties.end() && iter->second.value.has_value()
                      ? ccstd::get<ccstd::vector<float>>(iter->second.value.value())

--- a/native/cocos/scene/Pass.h
+++ b/native/cocos/scene/Pass.h
@@ -266,7 +266,7 @@ public:
     inline const IProgramInfo *getShaderInfo() const { return _shaderInfo; }
     const gfx::DescriptorSetLayout *getLocalSetLayout() const;
     inline const ccstd::string &getProgram() const { return _programName; }
-    inline const Record<ccstd::string, IPropertyInfo> &getProperties() const { return _properties; }
+    inline const PassPropertyInfoMap &getProperties() const { return _properties; }
     inline const MacroRecord &getDefines() const { return _defines; }
     inline MacroRecord &getDefines() { return _defines; }
     inline index_t getPassIndex() const { return _passIndex; }
@@ -342,7 +342,7 @@ protected:
 
     const IProgramInfo *_shaderInfo; // weakref to template of ProgramLib
     MacroRecord _defines;
-    Record<ccstd::string, IPropertyInfo> _properties;
+    PassPropertyInfoMap _properties;
     IntrusivePtr<gfx::Shader> _shader;
     gfx::BlendState _blendState{};
     gfx::DepthStencilState _depthStencilState{};


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/15277

Add a new function to retrieve the value of a specific property from a container, where the type of the container depends on whether the CC_EDITOR macro is enabled or not. If the macro is enabled, the container is a list, otherwise it is an unordered map.

The associated issue states that due to the use of an `unordered_map` to store effects data in C++, the traversal order cannot be guaranteed. To maintain order, a `vector<pair>` is being used instead. However, to ensure performance, the `unordered_map` will still be used in non-Editor mode.

### Changelog

* [bugfix] Fix the property order of Material/Pass in native editor

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
