### PR TITLE
V3.7.3 clear skybox reflectionMap value and remove its asset 

### DIFF
--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -904,6 +904,7 @@ const Elements = {
         async skyboxReflectionConvolution() {
             const panel = this;
 
+            panel.$.sceneSkyboxReflection.style.display = 'inline-block';
             panel.$.sceneSkyboxReflectionLoading.style.display = 'none';
 
             const reflectionMap = panel.dump._globals.skybox.value['reflectionMap'];
@@ -914,12 +915,10 @@ const Elements = {
                 panel.$.sceneSkyboxReflectionBake.style.display = 'inline-block';
                 panel.$.sceneSkyboxReflectionRemove.style.display = 'none';
 
-                // 在 bake 按钮显示的状态下，如果 envmap 都没有配置，那 bake 也不需要显示
+                // if envmap value unexist, the column of bake button hidden;
                 const envMapData = panel.dump._globals.skybox.value['envmap'];
-                if (envMapData.value && envMapData.value.uuid) {
-                    panel.$.sceneSkyboxReflection.removeAttribute('hidden');
-                } else {
-                    panel.$.sceneSkyboxReflection.setAttribute('hidden', '');
+                if (!envMapData.value || !envMapData.value.uuid) {
+                    panel.$.sceneSkyboxReflection.style.display = 'none';
                 }
             }
         },
@@ -940,18 +939,35 @@ const Elements = {
                 args: [envMapData.value.uuid],
             });
         },
-        skyboxReflectionConvolutionRemove() {
+        async skyboxReflectionConvolutionRemove() {
             const panel = this;
 
             const reflectionMap = panel.dump._globals.skybox.value['reflectionMap'];
             if (reflectionMap.value && reflectionMap.value.uuid) {
                 const $skyProps = panel.$.sceneSkybox.querySelectorAll('ui-prop[type="dump"]');
-                $skyProps.forEach(($prop) => {
-                    if ($prop.dump.name === 'reflectionMap') {
-                        $prop.dump.value.uuid = '';
-                        $prop.dispatch('change-dump');
+                for (const $skyProp of $skyProps) {
+                    if ($skyProp.dump.name === 'reflectionMap') {
+                        const textCubeAssetUuid = $skyProp.dump.value.uuid;
+                        if (textCubeAssetUuid) {
+                            // remove asset
+                            try {
+                                const imageAssetUuid = textCubeAssetUuid.split('@')[0];
+                                const imageAssetUrl = await Editor.Message.request('asset-db', 'query-url', imageAssetUuid);
+                                if (imageAssetUrl) {
+                                    await Editor.Message.request('asset-db', 'delete-asset', imageAssetUrl);
+                                }
+                            } catch (error) {
+                                console.error(error);
+                            }
+
+                            $skyProp.dump.value.uuid = '';
+                            $skyProp.dispatch('change-dump');
+                            $skyProp.dispatch('confirm-dump'); // for scene snapshot
+                        }
+                        break;
                     }
-                });
+                }
+
             }
         },
         skyboxUseHDRChange(event) {
@@ -962,6 +978,7 @@ const Elements = {
 
             $radioGraph.dump.value = useHDR;
             $radioGraph.dispatch('change-dump');
+            $radioGraph.dispatch('confirm-dump'); // for scene snapshot
 
             const $prop = useHDR ? panel.$.sceneSkyboxEnvmapHDR : panel.$.sceneSkyboxEnvmapLDR;
             const uuid = $prop.dump.value.uuid;


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/14472

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
