### PR TITLE
Use CMAKE_SUPPRESS_REGENERATION to skip Xcode updates and support versions prior to Xcode 12.

### DIFF
--- a/scripts/native-pack-tool/source/base/default.ts
+++ b/scripts/native-pack-tool/source/base/default.ts
@@ -213,14 +213,14 @@ export abstract class NativePackTool {
                 return false;
             }
 
-            if(!fs.existsSync(srcFile)) {
+            if (!fs.existsSync(srcFile)) {
                 console.warn(`${f} not exists in ${commonSrc}`);
                 return false;
             }
 
-            if(!compFile(srcFile, dstFile)) {
+            if (!compFile(srcFile, dstFile)) {
                 console.log(`File ${dstFile} differs from ${srcFile}`);
-                return false;   
+                return false;
             }
         }
         return true;
@@ -440,6 +440,9 @@ export abstract class NativePackTool {
         args.push(`-DRES_DIR="${cchelper.fixPath(this.paths.buildDir)}"`);
         args.push(`-DAPP_NAME="${this.params.projectName}"`);
         args.push(`-DLAUNCH_TYPE="${this.buildType}"`);
+        if (this.params.platformParams?.skipUpdateXcodeProject) {
+            args.push(`-DCMAKE_SUPPRESS_REGENERATION=ON`);
+        }
     }
 
 

--- a/scripts/native-pack-tool/source/platforms/ios.ts
+++ b/scripts/native-pack-tool/source/platforms/ios.ts
@@ -99,7 +99,7 @@ export class IOSPackTool extends MacOSPackTool {
         await toolHelper.runCmake(['-S', `"${this.paths.platformTemplateDirInPrj}"`, '-GXcode', `-B"${nativePrjDir}"`, '-T', `buildsystem=${ver}`,
                                     '-DCMAKE_SYSTEM_NAME=iOS'].concat(ext));
 
-        await this.skipUpdateXcodeProject();
+        await this.modifyXcodeProject();
 
         return true;
     }

--- a/scripts/native-pack-tool/source/platforms/mac.ts
+++ b/scripts/native-pack-tool/source/platforms/mac.ts
@@ -37,7 +37,7 @@ export class MacPackTool extends MacOSPackTool {
 
         await toolHelper.runCmake(cmakeArgs);
 
-        await this.skipUpdateXcodeProject();
+        await this.modifyXcodeProject();
         return true;
     }
 


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/13190

Skipping Xcode project updates is not fully supported in versions prior to Xcode 12, but partial support is provided here. Please note that adding or removing resource files may still result in errors on older versions of Xcode.

### Changelog

* Apply `CMAKE_SUPPRESS_REGENERATION` to support older version of Xcode

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
