### PR TITLE
adapt decode-base so that the shader parser can collect the right mac…

### DIFF
--- a/editor/assets/chunks/legacy/decode-base.chunk
+++ b/editor/assets/chunks/legacy/decode-base.chunk
@@ -39,9 +39,14 @@ layout(location = 3) in vec4 a_tangent;
   #if CC_USE_LIGHTMAP
     in vec4 a_lightingMapUVParam;
   #endif
-  #if CC_USE_REFLECTION_PROBE || CC_RECEIVE_SHADOW
+
+  // TODO (jk20012001)
+  #if CC_USE_REFLECTION_PROBE
     in vec4 a_localShadowBiasAndProbeId; // x:shadow bias, y:shadow normal bias, z: reflection probe id, w: reserved for blend reflection probe id
+  #elif CC_RECEIVE_SHADOW
+    in vec4 a_localShadowBiasAndProbeId;
   #endif
+
   #if CC_USE_LIGHT_PROBE
     in vec4 a_sh_linear_const_r;
     in vec4 a_sh_linear_const_g;


### PR DESCRIPTION
…ro list

Re: #https://github.com/cocos/3d-tasks/issues/15873?from_wecom=1#issue-1615004626

### Changelog

* adapt decode-base so that the shader parser can collect the right macro list

Note that, the shader parser doesn't support "or" ("||") in pre-processor.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
