### PR TITLE
Fix interruption matching on state exit condition

### DIFF
--- a/cocos/animation/marionette/graph-eval.ts
+++ b/cocos/animation/marionette/graph-eval.ts
@@ -994,10 +994,10 @@ class LayerEval {
      *
      * @param isCurrentState True if `node` is current state or "interruption source state"(see `getInterruptionSourceMotion`) of current state.
      * In detail:
-     * | State machine                          | This method is used for            | `isCurrentState` should |
-     * | -------------------------------------- | ---------------------------------- | ----------------------- |
-     * | No transition <br/> Current state is A | detecting transition from A        | true                    |
-     * | In transition <br/> A --> B            | detecting interruption from A or B | A: true <br/> B: false  |
+     * | State machine                          | This method is used for            | `isCurrentState` should be    |
+     * | -------------------------------------- | ---------------------------------- | ----------------------------- |
+     * | No transition <br/> Current state is A | detecting transition from A        | true                          |
+     * | In transition <br/> A --> B            | detecting interruption from A or B | true for A <br/> false for B  |
      *
      * @returns True if a transition match is updated into the `result`.
      */

--- a/cocos/animation/marionette/graph-eval.ts
+++ b/cocos/animation/marionette/graph-eval.ts
@@ -931,6 +931,7 @@ class LayerEval {
 
         this._matchTransition(
             currentNode,
+            true,
             currentNode,
             deltaTime,
             transitionMatch,
@@ -942,6 +943,7 @@ class LayerEval {
         if (currentNode.kind === NodeKind.animation) {
             this._matchAnyScoped(
                 currentNode,
+                true,
                 deltaTime,
                 transitionMatch,
             );
@@ -961,14 +963,16 @@ class LayerEval {
      * Notes the real node is used:
      * - to determinate the starting state machine from where the any states are matched;
      * - so we can solve transitions' relative durations.
+     * @param isHeadState See `_matchTransition`.
      */
-    private _matchAnyScoped (realNode: MotionStateEval, deltaTime: number, result: TransitionMatchCache) {
+    private _matchAnyScoped (realNode: MotionStateEval, isHeadState: boolean, deltaTime: number, result: TransitionMatchCache) {
         let transitionMatchUpdated = false;
         for (let ancestor: StateMachineInfo | null = realNode.stateMachine;
             ancestor !== null;
             ancestor = ancestor.parent) {
             const updated = this._matchTransition(
                 ancestor.any,
+                isHeadState,
                 realNode,
                 deltaTime,
                 result,
@@ -990,7 +994,7 @@ class LayerEval {
      * @returns True if a transition match is updated into the `result`.
      */
     private _matchTransition (
-        node: NodeEval, realNode: NodeEval, deltaTime: Readonly<number>, result: TransitionMatchCache,
+        node: NodeEval, isHeadState: boolean, realNode: NodeEval, deltaTime: Readonly<number>, result: TransitionMatchCache,
     ) {
         assertIsTrue(node === realNode || node.kind === NodeKind.any);
         const { outgoingTransitions } = node;
@@ -1023,7 +1027,8 @@ class LayerEval {
 
             if (realNode.kind === NodeKind.animation && transition.exitConditionEnabled) {
                 const exitTime = realNode.duration * transition.exitCondition;
-                deltaTimeRequired = Math.max(exitTime - realNode.fromPortTime, 0.0);
+                const currentStateTime = isHeadState ? realNode.fromPortTime : realNode.toPortTime;
+                deltaTimeRequired = Math.max(exitTime - currentStateTime, 0.0);
                 // Note: the >= is reasonable in compare to >: we select the first-minimal requires.
                 if (deltaTimeRequired > deltaTime || deltaTimeRequired >= result.requires) {
                     continue;
@@ -1120,6 +1125,7 @@ class LayerEval {
             const transitionMatch = transitionMatchCache.reset();
             this._matchTransition(
                 tailNode,
+                false,
                 tailNode,
                 0.0,
                 transitionMatch,
@@ -1344,6 +1350,7 @@ class LayerEval {
             : currentNode.first;
         let transitionMatchUpdated = this._matchAnyScoped(
             anyTransitionMeasureBaseState,
+            true,
             remainTimePiece,
             transitionMatch,
         );
@@ -1354,12 +1361,19 @@ class LayerEval {
             // TODO
         }
 
-        const motion0: MotionStateEval                = interruption === TransitionInterruptionSource.CURRENT_STATE
-                || interruption === TransitionInterruptionSource.CURRENT_STATE_THEN_NEXT_STATE
-            ? getInterruptionSourceMotion(currentNode)
-            : currentTransitionToNode;
+        let motion0: MotionStateEval;
+        let motion0IsHeadState = false;
+        if (interruption === TransitionInterruptionSource.CURRENT_STATE
+            || interruption === TransitionInterruptionSource.CURRENT_STATE_THEN_NEXT_STATE) {
+            motion0 = getInterruptionSourceMotion(currentNode);
+            motion0IsHeadState = true;
+        } else {
+            motion0 = currentTransitionToNode;
+            motion0IsHeadState = false;
+        }
         transitionMatchUpdated = this._matchTransition(
             motion0,
+            motion0IsHeadState,
             motion0,
             remainTimePiece,
             transitionMatch,
@@ -1371,12 +1385,19 @@ class LayerEval {
             // TODO
         }
 
-        const motion1 = interruption === TransitionInterruptionSource.NEXT_STATE_THEN_CURRENT_STATE ? getInterruptionSourceMotion(currentNode)
-            : interruption === TransitionInterruptionSource.CURRENT_STATE_THEN_NEXT_STATE ? currentTransitionToNode
-                : null;
+        let motion1: MotionStateEval | null = null;
+        let motion1IsHeadState = false;
+        if (interruption === TransitionInterruptionSource.NEXT_STATE_THEN_CURRENT_STATE) {
+            motion1 = getInterruptionSourceMotion(currentNode);
+            motion1IsHeadState = true;
+        } else if (interruption === TransitionInterruptionSource.CURRENT_STATE_THEN_NEXT_STATE) {
+            motion1 = currentTransitionToNode;
+            motion1IsHeadState = false;
+        }
         if (motion1) {
             transitionMatchUpdated = this._matchTransition(
                 motion1,
+                motion1IsHeadState,
                 motion1,
                 remainTimePiece,
                 transitionMatch,
@@ -1777,6 +1798,14 @@ export class MotionStateEval extends StateEval {
 
     get fromPortTime () {
         return this._fromPort.progress * this.duration;
+    }
+
+    get toPortTime () {
+        if (DEBUG) {
+            // See `this.finishTransition()`
+            assertIsTrue(!Number.isNaN(this._toPort.progress));
+        }
+        return this._toPort.progress * this.duration;
     }
 
     public updateFromPort (deltaTime: number) {

--- a/tests/animation/new-gen-anim/interruption.test.ts
+++ b/tests/animation/new-gen-anim/interruption.test.ts
@@ -1,0 +1,78 @@
+import { lerp } from '../../../exports/base';
+import { AnimationGraphEvalMock } from './utils/eval-mock';
+import { createAnimationGraph } from './utils/factory';
+import { LinearRealValueAnimationFixture } from './utils/fixtures';
+import { SingleRealValueObserver } from './utils/single-real-value-observer';
+
+describe(`Interruption matching`, () => {
+    test(`Exit condition should consider "to" port when matching interruption from non-head state`, () => {
+        const fixture = {
+            motion_1: new LinearRealValueAnimationFixture(1., 2., 6.),
+            motion_2: new LinearRealValueAnimationFixture(4., 5., 3.),
+            motion_3: new LinearRealValueAnimationFixture(7., 8., 9.),
+        };
+        // To ensure motion_1 won't exit util motion_2 exit.
+        expect(fixture.motion_1.duration).toBeGreaterThan(fixture.motion_2.duration);
+        expect(fixture.motion_3.duration).toBeGreaterThan(fixture.motion_2.duration);
+    
+        const valueObserver = new SingleRealValueObserver();
+    
+        const exitTime = 0.5;
+        const exitTimeUnit = fixture.motion_2.duration;
+        const exitTimeAbsolute = exitTimeUnit * exitTime;
+    
+        const originalTransitionDuration = exitTimeAbsolute * 1.5;
+        const interruptingTransitionDuration = Math.max(fixture.motion_1.duration, fixture.motion_2.duration, fixture.motion_3.duration);
+    
+        const animationGraph = createAnimationGraph({
+            variableDeclarations: {
+                'original_transition_activated': { type: 'boolean', value: true },
+                'interruption_enabled': { type: 'boolean', value: false },
+            },
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'motion_1': { type: 'motion', motion: fixture.motion_1.createMotion(valueObserver.getCreateMotionContext()) },
+                        'motion_2': { type: 'motion', motion: fixture.motion_2.createMotion(valueObserver.getCreateMotionContext()) },
+                        'motion_3': { type: 'motion', motion: fixture.motion_3.createMotion(valueObserver.getCreateMotionContext()) },
+                    },
+                    entryTransitions: [{ to: 'motion_1' }],
+                    transitions: [{
+                        from: 'motion_1', to: 'motion_2', exitTimeEnabled: false, duration: originalTransitionDuration,
+                        interruptible: true,
+                        conditions: [{ type: 'unary', operator: 'to-be-true', operand: { type: 'variable', name: 'original_transition_activated' } }],
+                    }, {
+                        from: 'motion_2', to: 'motion_3',
+                        exitTimeEnabled: true,
+                        exitTime: exitTime,
+                        duration: interruptingTransitionDuration,
+                        conditions: [{ type: 'unary', operator: 'to-be-true', operand: { type: 'variable', name: 'interruption_enabled' } }],
+                    }],
+                },
+            }],
+        });
+    
+        const evalMock = new AnimationGraphEvalMock(valueObserver.root, animationGraph);
+    
+        // Satisfies interruption's exit time condition.
+        evalMock.step(exitTimeAbsolute * 1.01);
+    
+        // Satisfies interruption's condition.
+        const timeBeforeInterruptionEnabled = evalMock.current;
+        evalMock.controller.setValue('interruption_enabled', true);
+        evalMock.step(0.1);
+        // The interruption should have taken place.
+        expect(valueObserver.value).toBeCloseTo(
+            lerp(
+                lerp(
+                    fixture.motion_1.getExpected(timeBeforeInterruptionEnabled),
+                    fixture.motion_2.getExpected(timeBeforeInterruptionEnabled),
+                    timeBeforeInterruptionEnabled / originalTransitionDuration,
+                ),
+                fixture.motion_3.getExpected(evalMock.lastDeltaTime),
+                evalMock.lastDeltaTime / interruptingTransitionDuration,
+            ),
+            5,
+        );
+    });
+});


### PR DESCRIPTION
Re: #

### Changelog

* Fix interruption matching on state exit condition. 

  When matching interruption on interruptible transition A --> B, there's transition B --> C which enabled state exit condition. Then the play time, used to be compared with state exit condition, should be play time of B's "to port" instead of "from port".

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
