### PR TITLE
Revert "Fix vertex count undefined error."

### DIFF
--- a/cocos/3d/assets/mesh.ts
+++ b/cocos/3d/assets/mesh.ts
@@ -1104,7 +1104,7 @@ export class Mesh extends Asset {
             const vertexCount = vertexBundle.view.count;
             const { format } = vertexBundle.attributes[iAttribute];
             const StorageConstructor = getTypedArrayConstructor(FormatInfos[format]);
-            if (vertexCount === 0 || vertexCount === undefined) {
+            if (vertexCount === 0) {
                 return;
             }
 


### PR DESCRIPTION
Reverts cocos/cocos-engine#14531
gltf的view count不允许是undefined， 必须是一个有值的number。 后续修复该问题。