### PR TITLE
improve: effect select option label naming and grouping

### DIFF
--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -4,6 +4,58 @@ const { materialTechniquePolyfill } = require('../utils/material');
 const { setDisabled, setReadonly, setHidden, loopSetAssetDumpDataReadonly } = require('../utils/prop');
 const { join, sep, normalize } = require('path');
 
+const effectGroupNameRE = /^db:\/\/(\w+)\//i; // match root DB name
+const effectDirRE = /^effects\//i;
+
+/**
+ * 
+ * @param {{name: string; uuid: string; assetPath: string}[]} sortedEffects 
+ * @returns html template
+ */
+function renderGroupEffectOptions(sortedEffects) {
+    const groupNames = new Set();
+
+    let htmlTemplate = '';
+    let currGroup = '';
+
+    for (const effect of sortedEffects) {
+        const groupName = effectGroupNameRE.exec(effect.assetPath)?.[1] ?? '';
+        let optionLabel = effect.assetPath;
+
+        if (groupName !== '') {
+            // complete prev group
+            if (currGroup !== '' && currGroup !== groupName) {
+                htmlTemplate += '</optgroup>';
+            }
+
+            if (!groupNames.has(groupName)) {
+                groupNames.add(groupName);
+
+                currGroup = groupName;
+
+                htmlTemplate += `<optgroup label="${groupName}">`;
+            }
+
+            // for option label, remove group name if matched
+            optionLabel = optionLabel.replace(effectGroupNameRE, '');
+        }
+
+        // remove prefix 'effects'(after 'db://' prefix removed)
+        if (effectDirRE.test(optionLabel)) {
+            optionLabel = optionLabel.replace(effectDirRE, '');
+        }
+
+        // use full name as option value
+        htmlTemplate += `<option value="${effect.name}" data-uuid="${effect.uuid}">${optionLabel}</option>`;
+    }
+
+    if (currGroup !== '') {
+        htmlTemplate += '</optgroup>';
+    }
+
+    return htmlTemplate;
+}
+
 exports.style = `
 .invalid { display: none; }
 .invalid[active] { display: block; }
@@ -105,22 +157,18 @@ exports.methods = {
 
     async updateEffect() {
         const effectMap = await Editor.Message.request('scene', 'query-all-effects');
-        this.effects = Object.keys(effectMap).sort().filter((name) => {
-            const effect = effectMap[name];
-            return !effect.hideInEditor;
-        }).map((name) => {
-            const effect = effectMap[name];
-            return {
-                name,
-                uuid: effect.uuid,
-            };
-        });
 
-        let effectOption = '';
-        for (let effect of this.effects) {
-            effectOption += `<option>${effect.name}</option>`;
-        }
-        this.$.effect.innerHTML = effectOption;
+        this.effects = Object.keys(effectMap).sort().reduce((arr, name) => {
+            const effect = effectMap[name];
+            if (!effect.hideInEditor) {
+                arr.push(effect);
+            }
+            return arr;
+        }, []);
+
+        const effectOptionsHTML = renderGroupEffectOptions(this.effects);
+
+        this.$.effect.innerHTML = effectOptionsHTML;
 
         this.$.effect.value = this.material.effect;
         setDisabled(this.asset.readonly, this.$.effect);


### PR DESCRIPTION
Re: #

### Changelog

* improve effect select option label naming and grouping
![image](https://user-images.githubusercontent.com/20528478/224268278-a6aab59a-f24c-4da7-b824-835b65fa6b9a.png)


### Dependent PR
- https://github.com/cocos/cocos-editor/pull/1713

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
