### PR TITLE
remove and ban @ts-expect-error

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -98,6 +98,12 @@ rules:
 
     ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####
 
+    '@typescript-eslint/ban-ts-comment': [error, {
+        'ts-expect-error': true,
+        'ts-ignore': true,
+        'ts-nocheck': true,
+        'ts-check': false,
+    }]
     '@typescript-eslint/indent': [warn, 4, {
         SwitchCase: 0
     }]

--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -105,3 +105,13 @@ declare const Buffer: any;
 declare type EnumAlias<EnumT> = EnumT[keyof EnumT];
 
 declare module 'internal:native' {}
+
+/**
+ * Only declare on minigame platforms.
+ */
+declare const GameGlobal: any;
+
+/**
+ * only implemented on Editor.
+ */
+declare const Editor: any;

--- a/@types/jsb.d.ts
+++ b/@types/jsb.d.ts
@@ -363,3 +363,8 @@ declare namespace ns {
     export class Frustum extends jsb.NativePOD {
     }
 }
+
+/**
+ * Only defined on native platforms.
+ */
+declare const scriptEngineType: 'JavaScriptCore' | 'SpiderMonkey' | 'V8';

--- a/@types/jsb.d.ts
+++ b/@types/jsb.d.ts
@@ -366,5 +366,6 @@ declare namespace ns {
 
 /**
  * Only defined on native platforms.
+ * Now we only support 'V8'
  */
-declare const scriptEngineType: 'JavaScriptCore' | 'SpiderMonkey' | 'V8';
+declare const scriptEngineType: 'V8';

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -367,6 +367,10 @@ cc.Scheduler: updateFunc parameter is deprecated in scheduleUpdate function, and
 
 cc.Scheduler: scheduler stopped using `__instanceId` as id since v2.0, you should do Scheduler.enableForTarget(target) before all scheduler API usage on target
 
+### 1514
+
+since v3.8.0, `Scheduler.schedule(target, callback, interval)` is deprecated, please use `Scheduler.schedule(callback, target, interval)` instead.
+
 ### 1600
 
 <!-- DEPRECATED -->

--- a/cocos/2d/assembler/graphics/webgl/impl.ts
+++ b/cocos/2d/assembler/graphics/webgl/impl.ts
@@ -197,7 +197,7 @@ export class Impl {
         this._renderDataList.push(renderData);
         if (JSB) {
             renderData.initRenderDrawInfo(this._comp, RenderDrawInfoType.MODEL);
-            // TODO: MeshRenderData and RenderData a both sub class of BaseRenderData, here we weirdly use MeshRenderData as RenderData
+            // TODO: MeshRenderData and RenderData are both sub class of BaseRenderData, here we weirdly use MeshRenderData as RenderData
             // please fix the type @holycanvas
             this._comp._renderData = renderData as unknown as RenderData;
             this._comp._renderData.material = this._comp.getMaterialInstance(0)!;// hack

--- a/cocos/2d/assembler/graphics/webgl/impl.ts
+++ b/cocos/2d/assembler/graphics/webgl/impl.ts
@@ -197,10 +197,8 @@ export class Impl {
         this._renderDataList.push(renderData);
         if (JSB) {
             renderData.initRenderDrawInfo(this._comp, RenderDrawInfoType.MODEL);
-            // @ts-expect-error temporary no care
             this._comp._renderData = renderData;
-            // @ts-expect-error temporary no care
-            this._comp._renderData!.material = this._comp.getMaterialInstance(0)!;// hack
+            this._comp._renderData.material = this._comp.getMaterialInstance(0)!;// hack
         }
 
         return renderData;

--- a/cocos/2d/assembler/graphics/webgl/impl.ts
+++ b/cocos/2d/assembler/graphics/webgl/impl.ts
@@ -25,7 +25,7 @@
 import { JSB } from 'internal:constants';
 import { Color, Vec2 } from '../../../../core';
 import { Graphics } from '../../../components';
-import { MeshRenderData } from '../../../renderer/render-data';
+import { RenderData, MeshRenderData } from '../../../renderer/render-data';
 import { RenderDrawInfoType } from '../../../renderer/render-draw-info';
 import { arc, ellipse, roundRect, tesselateBezier } from '../helper';
 import { LineCap, LineJoin, PointFlags } from '../types';
@@ -197,7 +197,9 @@ export class Impl {
         this._renderDataList.push(renderData);
         if (JSB) {
             renderData.initRenderDrawInfo(this._comp, RenderDrawInfoType.MODEL);
-            this._comp._renderData = renderData;
+            // TODO: MeshRenderData and RenderData a both sub class of BaseRenderData, here we weirdly use MeshRenderData as RenderData
+            // please fix the type @holycanvas
+            this._comp._renderData = renderData as unknown as RenderData;
             this._comp._renderData.material = this._comp.getMaterialInstance(0)!;// hack
         }
 

--- a/cocos/2d/assembler/label/ttfUtils.ts
+++ b/cocos/2d/assembler/label/ttfUtils.ts
@@ -279,7 +279,6 @@ export const ttfUtils =  {
             _context.fillRect(0, 0, _canvas.width, _canvas.height);
             // to keep the one model same as before
             // Todo: remove this protect when component remove blend function
-            // @ts-expect-error remove when component remove blend function
         } else if (comp._srcBlendFactor === BlendFactor.SRC_ALPHA) {
             _context.fillStyle = `rgba(${_color.r}, ${_color.g}, ${_color.b}, ${_invisibleAlpha})`;
             _context.fillRect(0, 0, _canvas.width, _canvas.height);

--- a/cocos/2d/components/mask.ts
+++ b/cocos/2d/components/mask.ts
@@ -379,7 +379,6 @@ export class Mask extends Component {
             sprite.sizeMode = 0;
         }
         this._sprite!.stencilStage = this.inverted ? Stage.ENTER_LEVEL_INVERTED : Stage.ENTER_LEVEL;
-        // @ts-expect-error Mask hack
         this._sprite!.updateMaterial();
     }
 
@@ -442,7 +441,6 @@ export class Mask extends Component {
     protected _disableRender () {
         if (this.subComp) {
             this.subComp.stencilStage = Stage.DISABLED;
-            // @ts-expect-error Mask hack
             this.subComp.updateMaterial();
             if (this.node.activeInHierarchy) {
                 this.subComp.enabled = false;

--- a/cocos/2d/components/ui-mesh-renderer.ts
+++ b/cocos/2d/components/ui-mesh-renderer.ts
@@ -223,7 +223,7 @@ export class UIMeshRenderer extends Component {
             const passNum = passes.length;
             for (let j = 0; j < passNum; j++) {
                 const pass = passes[j];
-                pass.setPriority(RenderPriority.MAX - 11);
+                pass._priority = RenderPriority.MAX - 11;
                 // Because the deferred pipeline cannot perform lighting processing on the uimodel,
                 // it may even cause the uimodel to crash in the metal backend,
                 // so force rendering uimodel in forward pipeline

--- a/cocos/2d/components/ui-mesh-renderer.ts
+++ b/cocos/2d/components/ui-mesh-renderer.ts
@@ -33,7 +33,7 @@ import { Component } from '../../scene-graph/component';
 import { NativeUIModelProxy } from '../renderer/native-2d';
 import { uiRendererManager } from '../framework/ui-renderer-manager';
 import { RenderEntity, RenderEntityType } from '../renderer/render-entity';
-import { BaseRenderData, MeshRenderData, RenderData } from '../renderer/render-data';
+import { MeshRenderData, RenderData } from '../renderer/render-data';
 import { assert, cclegacy } from '../../core';
 import { RenderDrawInfoType } from '../renderer/render-draw-info';
 
@@ -179,7 +179,9 @@ export class UIMeshRenderer extends Component {
         if (JSB) {
             const renderData = MeshRenderData.add();
             renderData.initRenderDrawInfo(this, RenderDrawInfoType.MODEL);
-            this._renderData = renderData;
+            // TODO: MeshRenderData and RenderData a both sub class of BaseRenderData, here we weirdly use MeshRenderData as RenderData
+            // please fix the type @holycanvas
+            this._renderData = renderData as unknown as RenderData;
             this._renderData.material = this._modelComponent!.getMaterialInstance(index);
         }
     }
@@ -218,7 +220,7 @@ export class UIMeshRenderer extends Component {
             const passNum = passes.length;
             for (let j = 0; j < passNum; j++) {
                 const pass = passes[j];
-                pass._priority = RenderPriority.MAX - 11;
+                pass.setPriority(RenderPriority.MAX - 11);
                 // Because the deferred pipeline cannot perform lighting processing on the uimodel,
                 // it may even cause the uimodel to crash in the metal backend,
                 // so force rendering uimodel in forward pipeline
@@ -266,7 +268,7 @@ export class UIMeshRenderer extends Component {
         return this._renderEntity;
     }
 
-    protected _renderData: BaseRenderData | null = null;
+    protected _renderData: RenderData | null = null;
     /**
      * @deprecated Since v3.7.0, this is an engine private interface that will be removed in the future.
      */

--- a/cocos/2d/components/ui-mesh-renderer.ts
+++ b/cocos/2d/components/ui-mesh-renderer.ts
@@ -36,6 +36,7 @@ import { RenderEntity, RenderEntityType } from '../renderer/render-entity';
 import { MeshRenderData, RenderData } from '../renderer/render-data';
 import { assert, cclegacy } from '../../core';
 import { RenderDrawInfoType } from '../renderer/render-draw-info';
+import type { UIRenderer } from '../framework/ui-renderer';
 
 /**
  * @en
@@ -178,7 +179,9 @@ export class UIMeshRenderer extends Component {
     private _uploadRenderData (index) {
         if (JSB) {
             const renderData = MeshRenderData.add();
-            renderData.initRenderDrawInfo(this, RenderDrawInfoType.MODEL);
+            // TODO: here we weirdly use UIMeshRenderer as UIRenderer
+            // please fix the type @holycanvas
+            renderData.initRenderDrawInfo(this as unknown as UIRenderer, RenderDrawInfoType.MODEL);
             // TODO: MeshRenderData and RenderData are both sub class of BaseRenderData, here we weirdly use MeshRenderData as RenderData
             // please fix the type @holycanvas
             this._renderData = renderData as unknown as RenderData;

--- a/cocos/2d/components/ui-mesh-renderer.ts
+++ b/cocos/2d/components/ui-mesh-renderer.ts
@@ -33,7 +33,7 @@ import { Component } from '../../scene-graph/component';
 import { NativeUIModelProxy } from '../renderer/native-2d';
 import { uiRendererManager } from '../framework/ui-renderer-manager';
 import { RenderEntity, RenderEntityType } from '../renderer/render-entity';
-import { MeshRenderData, RenderData } from '../renderer/render-data';
+import { BaseRenderData, MeshRenderData, RenderData } from '../renderer/render-data';
 import { assert, cclegacy } from '../../core';
 import { RenderDrawInfoType } from '../renderer/render-draw-info';
 
@@ -132,7 +132,6 @@ export class UIMeshRenderer extends Component {
     public _render (render: IBatcher) {
         if (this._modelComponent) {
             const models = this._modelComponent._collectModels();
-            // @ts-expect-error: UIMeshRenderer do not attachToScene
             this._modelComponent._detachFromScene();
             for (let i = 0; i < models.length; i++) {
                 if (models[i].enabled) {
@@ -163,7 +162,6 @@ export class UIMeshRenderer extends Component {
             this.renderEntity.enabled = this._canRender();
             if (this._modelComponent) {
                 const models = this._modelComponent._collectModels();
-                // @ts-expect-error: UIMeshRenderer do not attachToScene
                 this._modelComponent._detachFromScene(); // JSB
                 // clear models
                 this._UIModelNativeProxy.clearModels();
@@ -180,11 +178,9 @@ export class UIMeshRenderer extends Component {
     private _uploadRenderData (index) {
         if (JSB) {
             const renderData = MeshRenderData.add();
-            // @ts-expect-error temporary no care
             renderData.initRenderDrawInfo(this, RenderDrawInfoType.MODEL);
-            // @ts-expect-error temporary no care
             this._renderData = renderData;
-            this._renderData!.material = this._modelComponent!.getMaterialInstance(index);
+            this._renderData.material = this._modelComponent!.getMaterialInstance(index);
         }
     }
 
@@ -222,7 +218,6 @@ export class UIMeshRenderer extends Component {
             const passNum = passes.length;
             for (let j = 0; j < passNum; j++) {
                 const pass = passes[j];
-                // @ts-expect-error private property access
                 pass._priority = RenderPriority.MAX - 11;
                 // Because the deferred pipeline cannot perform lighting processing on the uimodel,
                 // it may even cause the uimodel to crash in the metal backend,
@@ -271,7 +266,7 @@ export class UIMeshRenderer extends Component {
         return this._renderEntity;
     }
 
-    protected _renderData: RenderData | null = null;
+    protected _renderData: BaseRenderData | null = null;
     /**
      * @deprecated Since v3.7.0, this is an engine private interface that will be removed in the future.
      */

--- a/cocos/2d/components/ui-mesh-renderer.ts
+++ b/cocos/2d/components/ui-mesh-renderer.ts
@@ -179,7 +179,7 @@ export class UIMeshRenderer extends Component {
         if (JSB) {
             const renderData = MeshRenderData.add();
             renderData.initRenderDrawInfo(this, RenderDrawInfoType.MODEL);
-            // TODO: MeshRenderData and RenderData a both sub class of BaseRenderData, here we weirdly use MeshRenderData as RenderData
+            // TODO: MeshRenderData and RenderData are both sub class of BaseRenderData, here we weirdly use MeshRenderData as RenderData
             // please fix the type @holycanvas
             this._renderData = renderData as unknown as RenderData;
             this._renderData.material = this._modelComponent!.getMaterialInstance(index);

--- a/cocos/2d/event/pointer-event-dispatcher.ts
+++ b/cocos/2d/event/pointer-event-dispatcher.ts
@@ -53,7 +53,6 @@ class PointerEventDispatcher implements IEventDispatcher {
     private _processorListToRemove: NodeEventProcessor[] = [];
 
     constructor () {
-        // @ts-expect-error Property '_registerEventDispatcher' is private and only accessible within class 'Input'.
         input._registerEventDispatcher(this);
 
         NodeEventProcessor.callbacksInvoker.on(DispatcherEventType.ADD_POINTER_EVENT_PROCESSOR, this.addPointerEventProcessor, this);
@@ -102,7 +101,6 @@ class PointerEventDispatcher implements IEventDispatcher {
         for (let i = 0; i < length; ++i) {
             const pointerEventProcessor = pointerEventProcessorList[i];
             if (pointerEventProcessor.isEnabled && pointerEventProcessor.shouldHandleEventMouse
-                // @ts-expect-error access private method
                 && pointerEventProcessor._handleEventMouse(eventMouse)) {
                 dispatchToNextEventDispatcher = false;
                 if (!eventMouse.preventSwallow) {
@@ -129,7 +127,6 @@ class PointerEventDispatcher implements IEventDispatcher {
             const pointerEventProcessor = pointerEventProcessorList[i];
             if (pointerEventProcessor.isEnabled && pointerEventProcessor.shouldHandleEventTouch) {
                 if (eventTouch.type === InputEventType.TOUCH_START) {
-                    // @ts-expect-error access private method
                     if (pointerEventProcessor._handleEventTouch(eventTouch)) {
                         pointerEventProcessor.claimedTouchIdList.push(touch.getID());
                         dispatchToNextEventDispatcher = false;
@@ -142,7 +139,6 @@ class PointerEventDispatcher implements IEventDispatcher {
                 } else if (pointerEventProcessor.claimedTouchIdList.length > 0) {
                     const index = pointerEventProcessor.claimedTouchIdList.indexOf(touch.getID());
                     if (index !== -1) {
-                        // @ts-expect-error access private method
                         pointerEventProcessor._handleEventTouch(eventTouch);
                         if (eventTouch.type === InputEventType.TOUCH_END || eventTouch.type === InputEventType.TOUCH_CANCEL) {
                             js.array.removeAt(pointerEventProcessor.claimedTouchIdList, index);
@@ -210,20 +206,16 @@ class PointerEventDispatcher implements IEventDispatcher {
             return p2.cachedCameraPriority - p1.cachedCameraPriority;
         }
         let n1: Node | null = node1; let n2: Node | null = node2; let ex = false;
-        // @ts-expect-error _id is a protected property
-        while (n1.parent?._id !== n2.parent?._id) {
+        while (n1!.parent?.uuid !== n2!.parent?.uuid) {
             n1 = n1?.parent?.parent === null ? (ex = true) && node2 : n1 && n1.parent;
             n2 = n2?.parent?.parent === null ? (ex = true) && node1 : n2 && n2.parent;
         }
 
-        // @ts-expect-error protected property _id
-        if (n1._id === n2._id) {
-            // @ts-expect-error protected property _id
-            if (n1._id === node2._id) {
+        if (n1!.uuid === n2!.uuid) {
+            if (n1!.uuid === node2.uuid) {
                 return -1;
             }
-            // @ts-expect-error protected property _id
-            if (n1._id === node1._id) {
+            if (n1!.uuid === node1.uuid) {
                 return 1;
             }
         }

--- a/cocos/2d/framework/sprite-renderer.ts
+++ b/cocos/2d/framework/sprite-renderer.ts
@@ -205,7 +205,10 @@ export class SpriteRenderer extends ModelRenderer {
         this._onRebuildPSO(idx, material || this._getBuiltinMaterial());
     }
 
-    protected _onRebuildPSO (idx: number, material: Material) {
+    /**
+     * @engineInternal
+     */
+    public _onRebuildPSO (idx: number, material: Material) {
         if (!this._model || !this._model.inited) { return; }
         this._model.setSubModelMaterial(idx, material);
         this._onUpdateLocalDescriptorSet();
@@ -240,7 +243,10 @@ export class SpriteRenderer extends ModelRenderer {
         renderScene.addModel(this._model);
     }
 
-    protected _detachFromScene () {
+    /**
+     * @engineInternal
+     */
+    public _detachFromScene () {
         if (this._model && this._model.scene) {
             this._model.scene.removeModel(this._model);
         }

--- a/cocos/2d/framework/ui-component.ts
+++ b/cocos/2d/framework/ui-component.ts
@@ -45,7 +45,7 @@ export class UIComponent extends Component {
     protected _lastParent: Node | null = null;
 
     public __preload () {
-        // TODO: UIComponent should not be assigned to UIMeshRenderer | UIRenderer
+        // TODO: UIComponent should not be assigned to UIMeshRenderer | UIRenderer @holycanvas
         // workaround: mark this as any
         (this as any).node._uiProps.uiComp = this;
     }
@@ -58,7 +58,7 @@ export class UIComponent extends Component {
     }
 
     public onDestroy () {
-        // TODO: UIComponent should not be assigned to UIMeshRenderer | UIRenderer
+        // TODO: UIComponent should not be assigned to UIMeshRenderer | UIRenderer @holycanvas
         // workaround: mark this as any
         if ((this as any).node._uiProps.uiComp === this) {
             (this as any).node._uiProps.uiComp = null;

--- a/cocos/2d/framework/ui-component.ts
+++ b/cocos/2d/framework/ui-component.ts
@@ -45,8 +45,9 @@ export class UIComponent extends Component {
     protected _lastParent: Node | null = null;
 
     public __preload () {
-        // @ts-expect-error temporary, UIComponent should be removed
-        this.node._uiProps.uiComp = this;
+        // TODO: UIComponent should not be assigned to UIMeshRenderer | UIRenderer
+        // workaround: mark this as any
+        (this as any).node._uiProps.uiComp = this;
     }
 
     public onEnable () {
@@ -57,10 +58,10 @@ export class UIComponent extends Component {
     }
 
     public onDestroy () {
-        // @ts-expect-error temporary, UIComponent should be removed
-        if (this.node._uiProps.uiComp === this) {
-            // @ts-expect-error temporary, UIComponent should be removed
-            this.node._uiProps.uiComp = null;
+        // TODO: UIComponent should not be assigned to UIMeshRenderer | UIRenderer
+        // workaround: mark this as any
+        if ((this as any).node._uiProps.uiComp === this) {
+            (this as any).node._uiProps.uiComp = null;
         }
     }
 

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -32,7 +32,7 @@ import { builtinResMgr } from '../../asset/asset-manager';
 import { Material } from '../../asset/assets';
 import { BlendFactor } from '../../gfx';
 import { IAssembler, IAssemblerManager } from '../renderer/base';
-import { BaseRenderData, RenderData } from '../renderer/render-data';
+import { RenderData } from '../renderer/render-data';
 import { IBatcher } from '../renderer/i-batcher';
 import { Node } from '../../scene-graph';
 import { TransformBit } from '../../scene-graph/node-enum';
@@ -199,9 +199,9 @@ export class UIRenderer extends Renderer {
     }
 
     /**
-     * @engineInternal
+     * @engineInternal NOTE: this is engine internal only, we need to access `_renderData` for we don't wan't to see the deprecated warning.
      */
-    public _renderData: BaseRenderData | null = null;
+    public _renderData: RenderData | null = null;
     /**
      * @deprecated Since v3.7.0, this is an engine private interface that will be removed in the future.
      */

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -199,7 +199,7 @@ export class UIRenderer extends Renderer {
     }
 
     /**
-     * @engineInternal NOTE: this is engine internal only, we need to access `_renderData` for we don't wan't to see the deprecated warning.
+     * @engineInternal NOTE: this is engine internal only, we need to access `_renderData` for we don't want to see the deprecated warning.
      */
     public _renderData: RenderData | null = null;
     /**

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -32,7 +32,7 @@ import { builtinResMgr } from '../../asset/asset-manager';
 import { Material } from '../../asset/assets';
 import { BlendFactor } from '../../gfx';
 import { IAssembler, IAssemblerManager } from '../renderer/base';
-import { RenderData } from '../renderer/render-data';
+import { BaseRenderData, RenderData } from '../renderer/render-data';
 import { IBatcher } from '../renderer/i-batcher';
 import { Node } from '../../scene-graph';
 import { TransformBit } from '../../scene-graph/node-enum';
@@ -198,7 +198,10 @@ export class UIRenderer extends Renderer {
         }
     }
 
-    protected _renderData: RenderData | null = null;
+    /**
+     * @engineInternal
+     */
+    public _renderData: BaseRenderData | null = null;
     /**
      * @deprecated Since v3.7.0, this is an engine private interface that will be removed in the future.
      */
@@ -231,8 +234,11 @@ export class UIRenderer extends Renderer {
     @type(Material)
     protected _customMaterial: Material | null = null;
 
+    /**
+     * @engineInternal
+     */
     @serializable
-    protected _srcBlendFactor = BlendFactor.SRC_ALPHA;
+    public _srcBlendFactor = BlendFactor.SRC_ALPHA;
     @serializable
     protected _dstBlendFactor = BlendFactor.ONE_MINUS_SRC_ALPHA;
     @serializable
@@ -428,7 +434,10 @@ export class UIRenderer extends Renderer {
 
     protected _postCanRender () { }
 
-    protected updateMaterial () {
+    /**
+     * @engineInternal
+     */
+    public updateMaterial () {
         if (this._customMaterial) {
             if (this.getMaterial(0) !== this._customMaterial) {
                 this.setMaterial(this._customMaterial, 0);
@@ -527,7 +536,6 @@ export class UIRenderer extends Renderer {
             target.blendSrc = this._srcBlendFactor;
             const targetPass = this.getMaterialInstance(0)!.passes[0];
             targetPass.blendState.setTarget(0, target);
-            // @ts-expect-error hack for UI use pass object
             targetPass._updatePassHash();
             this._dstBlendFactorCache = this._dstBlendFactor;
             this._srcBlendFactorCache = this._srcBlendFactor;

--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -792,7 +792,7 @@ export class Batcher2D implements IBatcher {
         const selfOpacity = render && render.color ? render.color.a / 255 : 1;
         this._pOpacity = opacity *= selfOpacity * uiProps.localOpacity;
         // TODO Set opacity to ui property's opacity before remove it
-        uiProps._opacity = opacity;
+        uiProps.setOpacity(opacity);
         if (!approx(opacity, 0, EPSILON)) {
             if (uiProps.colorDirty) {
             // Cascade color dirty state

--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -792,7 +792,6 @@ export class Batcher2D implements IBatcher {
         const selfOpacity = render && render.color ? render.color.a / 255 : 1;
         this._pOpacity = opacity *= selfOpacity * uiProps.localOpacity;
         // TODO Set opacity to ui property's opacity before remove it
-        // @ts-expect-error temporary force set, will be removed with ui property's opacity
         uiProps._opacity = opacity;
         if (!approx(opacity, 0, EPSILON)) {
             if (uiProps.colorDirty) {

--- a/cocos/2d/renderer/draw-batch.ts
+++ b/cocos/2d/renderer/draw-batch.ts
@@ -124,7 +124,6 @@ export class DrawBatch2D {
                 // Hack: Cause pass.hash can not check all pass value
                 if (!dss) { dss = mtlPass.depthStencilState; dssHash = 0; }
 
-                // @ts-expect-error hack for UI use pass object
                 passInUse._initPassFromTarget(mtlPass, dss, dssHash);
 
                 this._shaders[i] = passInUse.getShaderVariant(patches)!;

--- a/cocos/2d/renderer/mesh-buffer.ts
+++ b/cocos/2d/renderer/mesh-buffer.ts
@@ -369,7 +369,6 @@ export class MeshBuffer {
         }
 
         // On iOS14, different IAs can not share same GPU buffer, so must submit the same date to different buffers
-        // @ts-expect-error Property '__isWebIOS14OrIPadOS14Env' does not exist on 'sys'
         const iOS14 = sys.__isWebIOS14OrIPadOS14Env;
         const submitCount = iOS14 ? this._nextFreeIAHandle : 1;
         if (iOS14 && (submitCount / this._iaPool.length < IA_POOL_USED_SCALE)) {
@@ -416,7 +415,6 @@ export class MeshBuffer {
         let indexBuffer;
         // HACK: After sharing buffer between drawcalls, the performance degradation a lots on iOS 14 or iPad OS 14 device
         // TODO: Maybe it can be removed after Apple fixes it?
-        // @ts-expect-error Property '__isWebIOS14OrIPadOS14Env' does not exist on 'sys'
         if (sys.__isWebIOS14OrIPadOS14Env || !this._iaPool[0]) {
             const vbStride = this._vertexFormatBytes = this._floatsPerVertex * Float32Array.BYTES_PER_ELEMENT;
             const ibStride = Uint16Array.BYTES_PER_ELEMENT;

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -35,6 +35,7 @@ import { Buffer, BufferInfo, BufferUsageBit, Device, Attribute, InputAssembler, 
 import { RenderDrawInfo, RenderDrawInfoType } from './render-draw-info';
 import { Batcher2D } from './batcher-2d';
 import { RenderEntity, RenderEntityType } from './render-entity';
+import { UIMeshRenderer } from '../components';
 
 /**
  * @deprecated since v3.5.0, this is an engine private interface that will be removed in the future.
@@ -152,7 +153,7 @@ export class BaseRenderData {
     }
 
     // it should be invoked at where a render data is allocated.
-    public initRenderDrawInfo (comp: UIRenderer, drawInfoType: RenderDrawInfoType = RenderDrawInfoType.COMP) {
+    public initRenderDrawInfo (comp: UIRenderer | UIMeshRenderer, drawInfoType: RenderDrawInfoType = RenderDrawInfoType.COMP) {
         if (JSB) {
             const renderEntity: RenderEntity = comp.renderEntity;
 

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -153,7 +153,7 @@ export class BaseRenderData {
     }
 
     // it should be invoked at where a render data is allocated.
-    public initRenderDrawInfo (comp: UIRenderer | UIMeshRenderer, drawInfoType: RenderDrawInfoType = RenderDrawInfoType.COMP) {
+    public initRenderDrawInfo (comp: UIRenderer, drawInfoType: RenderDrawInfoType = RenderDrawInfoType.COMP) {
         if (JSB) {
             const renderEntity: RenderEntity = comp.renderEntity;
 

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -35,7 +35,6 @@ import { Buffer, BufferInfo, BufferUsageBit, Device, Attribute, InputAssembler, 
 import { RenderDrawInfo, RenderDrawInfoType } from './render-draw-info';
 import { Batcher2D } from './batcher-2d';
 import { RenderEntity, RenderEntityType } from './render-entity';
-import { UIMeshRenderer } from '../components';
 
 /**
  * @deprecated since v3.5.0, this is an engine private interface that will be removed in the future.

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -820,7 +820,10 @@ export class MeshRenderer extends ModelRenderer {
         renderScene.addModel(this._model);
     }
 
-    protected _detachFromScene () {
+    /**
+     * @engineInternal
+     */
+    public _detachFromScene () {
         if (this._model && this._model.scene) {
             this._model.scene.removeModel(this._model);
         }
@@ -886,7 +889,10 @@ export class MeshRenderer extends ModelRenderer {
         this._onRebuildPSO(idx, material || this._getBuiltinMaterial());
     }
 
-    protected _onRebuildPSO (idx: number, material: Material) {
+    /**
+     * @engineInternal
+     */
+    public _onRebuildPSO (idx: number, material: Material) {
         if (!this._model || !this._model.inited) { return; }
         this._model.isDynamicBatching = this._isBatchingEnabled();
         this._model.setSubModelMaterial(idx, material);

--- a/cocos/3d/lod/lodgroup-component.ts
+++ b/cocos/3d/lod/lodgroup-component.ts
@@ -629,8 +629,9 @@ export class LODGroup extends Component {
      */
     private _emitChangeNode (node: Node) {
         if (EDITOR) {
-            // @ts-expect-error Because EditorExtends is Editor only
-            EditorExtends.Node.emit('change', node.uuid, node);
+            // TODO: Property 'emit' does not exist on type 'EditorExtendsNode'.
+            // workaround: mark Node as any
+            (EditorExtends.Node as any).emit('change', node.uuid, node);
         }
     }
 

--- a/cocos/3d/models/baked-skinning-model.ts
+++ b/cocos/3d/models/baked-skinning-model.ts
@@ -118,7 +118,7 @@ export class BakedSkinningModel extends MorphModel {
         const worldBounds = this._worldBounds;
         if (worldBounds && skelBound) {
             const node = this.transform;
-            skelBound.transform(node.w_mat, node.w_pos, node.w_rot, node.w_scale, worldBounds);
+            skelBound.transform(node.worldMatrix, node.worldPosition, node.worldRotation, node.worldScale, worldBounds);
         }
     }
 

--- a/cocos/3d/models/baked-skinning-model.ts
+++ b/cocos/3d/models/baked-skinning-model.ts
@@ -117,8 +117,9 @@ export class BakedSkinningModel extends MorphModel {
         const skelBound = boundsInfo![animInfo.data[0]];
         const worldBounds = this._worldBounds;
         if (worldBounds && skelBound) {
-            const node = this.transform;
-            // @ts-expect-error TS2339
+            // TODO: should not access private property
+            // workaround: mark node as any
+            const node: any = this.transform;
             skelBound.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
         }
     }

--- a/cocos/3d/models/baked-skinning-model.ts
+++ b/cocos/3d/models/baked-skinning-model.ts
@@ -118,7 +118,7 @@ export class BakedSkinningModel extends MorphModel {
         const worldBounds = this._worldBounds;
         if (worldBounds && skelBound) {
             const node = this.transform;
-            skelBound.transform(node.worldMatrix, node.worldPosition, node.worldRotation, node.worldScale, worldBounds);
+            skelBound.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
         }
     }
 

--- a/cocos/3d/models/baked-skinning-model.ts
+++ b/cocos/3d/models/baked-skinning-model.ts
@@ -117,10 +117,8 @@ export class BakedSkinningModel extends MorphModel {
         const skelBound = boundsInfo![animInfo.data[0]];
         const worldBounds = this._worldBounds;
         if (worldBounds && skelBound) {
-            // TODO: should not access private property
-            // workaround: mark node as any
-            const node: any = this.transform;
-            skelBound.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
+            const node = this.transform;
+            skelBound.transform(node.w_mat, node.w_pos, node.w_rot, node.w_scale, worldBounds);
         }
     }
 

--- a/cocos/3d/models/skinning-model.ts
+++ b/cocos/3d/models/skinning-model.ts
@@ -189,8 +189,7 @@ export class SkinningModel extends MorphModel {
         const worldBounds = this._worldBounds;
         if (this._modelBounds && worldBounds) {
             geometry.AABB.fromPoints(this._modelBounds, v3_min, v3_max);
-            // @ts-expect-error TS2445
-            this._modelBounds.transform(root._mat, root._pos, root._rot, root._scale, this._worldBounds);
+            this._modelBounds.transform(root._mat, root._pos, root._rot, root._scale, this._worldBounds!);
         }
     }
 

--- a/cocos/3d/models/skinning-model.ts
+++ b/cocos/3d/models/skinning-model.ts
@@ -189,7 +189,7 @@ export class SkinningModel extends MorphModel {
         const worldBounds = this._worldBounds;
         if (this._modelBounds && worldBounds) {
             geometry.AABB.fromPoints(this._modelBounds, v3_min, v3_max);
-            this._modelBounds.transform(root.w_mat, root.w_pos, root.w_rot, root.w_scale, this._worldBounds!);
+            this._modelBounds.transform(root.worldMatrix, root.worldPosition, root.worldRotation, root.worldScale, this._worldBounds!);
         }
     }
 

--- a/cocos/3d/models/skinning-model.ts
+++ b/cocos/3d/models/skinning-model.ts
@@ -189,7 +189,7 @@ export class SkinningModel extends MorphModel {
         const worldBounds = this._worldBounds;
         if (this._modelBounds && worldBounds) {
             geometry.AABB.fromPoints(this._modelBounds, v3_min, v3_max);
-            this._modelBounds.transform(root.worldMatrix, root.worldPosition, root.worldRotation, root.worldScale, this._worldBounds!);
+            this._modelBounds.transform(root._mat, root._pos, root._rot, root._scale, this._worldBounds!);
         }
     }
 

--- a/cocos/3d/models/skinning-model.ts
+++ b/cocos/3d/models/skinning-model.ts
@@ -189,7 +189,7 @@ export class SkinningModel extends MorphModel {
         const worldBounds = this._worldBounds;
         if (this._modelBounds && worldBounds) {
             geometry.AABB.fromPoints(this._modelBounds, v3_min, v3_max);
-            this._modelBounds.transform(root._mat, root._pos, root._rot, root._scale, this._worldBounds!);
+            this._modelBounds.transform(root.w_mat, root.w_pos, root.w_rot, root.w_scale, this._worldBounds!);
         }
     }
 

--- a/cocos/3d/skeletal-animation/skeletal-animation-blending.ts
+++ b/cocos/3d/skeletal-animation/skeletal-animation-blending.ts
@@ -124,8 +124,8 @@ class BlendStateWriterInternal<P extends BlendingPropertyName> implements Runtim
             _host: host,
         } = this;
         const weight = host.weight;
-        // @ts-expect-error Complex typing
-        propertyBlendState.blend(value, weight);
+        // TODO: please fix type here @Leslie Leigh
+        propertyBlendState.blend(value as Readonly<Vec3> & Readonly<Quat>, weight);
     }
 }
 

--- a/cocos/animation/animation-curve.ts
+++ b/cocos/animation/animation-curve.ts
@@ -316,8 +316,9 @@ const selectLerpFx = (() => {
     function makeValueTypeLerpFx<T extends ValueType> (constructor: Constructor<T>) {
         const tempValue = new constructor();
         return (from: T, to: T, ratio: number) => {
-            // @ts-expect-error Hard to typing
-            constructor.lerp(tempValue, from, to, ratio);
+            // TODO: `ValueType` class doesn't define lerp method
+            // please fix the type @Leslie Leigh
+            (constructor as any).lerp(tempValue, from, to, ratio);
             return tempValue;
         };
     }

--- a/cocos/animation/cubic-spline-value.ts
+++ b/cocos/animation/cubic-spline-value.ts
@@ -40,29 +40,29 @@ type ScaleFx<T> = (out: T, v: T, s: number) => T;
 type ScaleAndAddFx<T> = (out: T, v1: T, v2: T, s: number) => T;
 function makeCubicSplineValueConstructor<T> (
     name: string,
-    constructorX: new () => T,
+    ConstructorX: new () => T,
     scaleFx: ScaleFx<T>,
     scaleAndAdd: ScaleAndAddFx<T>,
 ): CubicSplineValueConstructor<T> {
-    let tempValue = new constructorX();
-    let m0 = new constructorX();
-    let m1 = new constructorX();
+    let tempValue = new ConstructorX();
+    let m0 = new ConstructorX();
+    let m1 = new ConstructorX();
 
     @ccclass(name)
     class CubicSplineValueClass implements ICubicSplineValue<T> {
         @serializable
-        public dataPoint: T = new constructorX();
+        public dataPoint: T = new ConstructorX();
 
         @serializable
-        public inTangent: T = new constructorX();
+        public inTangent: T = new ConstructorX();
 
         @serializable
-        public outTangent: T = new constructorX();
+        public outTangent: T = new ConstructorX();
 
         constructor (dataPoint?: T, inTangent?: T, outTangent?: T) {
-            this.dataPoint = dataPoint || new constructorX();
-            this.inTangent = inTangent || new constructorX();
-            this.outTangent = outTangent || new constructorX();
+            this.dataPoint = dataPoint || new ConstructorX();
+            this.inTangent = inTangent || new ConstructorX();
+            this.outTangent = outTangent || new ConstructorX();
         }
 
         public lerp (to: CubicSplineValueClass, t: number, dt: number) {
@@ -89,8 +89,8 @@ function makeCubicSplineValueConstructor<T> (
         }
     }
 
-    // @ts-expect-error TS2367
-    if (constructorX === Quat) {
+    // TODO: This comparison appears to be unintentional because the types 'new () => T' and 'typeof Quat' have no overlap.
+    if (ConstructorX as any === Quat) {
         const lerp = CubicSplineValueClass.prototype.lerp;
         CubicSplineValueClass.prototype.lerp = function (this: CubicSplineValueClass, to: CubicSplineValueClass, t: number, dt: number) {
             const result = lerp.call(this, to, t, dt) as Quat;

--- a/cocos/animation/exotic-animation/exotic-animation.ts
+++ b/cocos/animation/exotic-animation/exotic-animation.ts
@@ -181,13 +181,13 @@ class ExoticNodeAnimation {
     private _scale: ExoticVec3Track | null = null;
 }
 
-function floatToHashString (value: number): number {
+function floatToHashString (value: number): string {
     // Note: referenced to `Skeleton.prototype.hash`
-    return Number.parseFloat(value.toPrecision(2));
+    return value.toPrecision(2);
 }
 
 function floatArrayToHashString (values: FloatArray) {
-    return (values).map(floatToHashString).join(' ');
+    return (values).map((v: number) => Number.parseFloat(floatToHashString(v))).join(' ');
 }
 
 interface ExoticTrackValues<TValue> {

--- a/cocos/animation/exotic-animation/exotic-animation.ts
+++ b/cocos/animation/exotic-animation/exotic-animation.ts
@@ -181,13 +181,12 @@ class ExoticNodeAnimation {
     private _scale: ExoticVec3Track | null = null;
 }
 
-function floatToHashString (value: number) {
+function floatToHashString (value: number): number {
     // Note: referenced to `Skeleton.prototype.hash`
-    return value.toPrecision(2);
+    return Number.parseFloat(value.toPrecision(2));
 }
 
 function floatArrayToHashString (values: FloatArray) {
-    // @ts-expect-error Complex typing
     return (values).map(floatToHashString).join(' ');
 }
 

--- a/cocos/animation/marionette/state.ts
+++ b/cocos/animation/marionette/state.ts
@@ -77,8 +77,7 @@ export class InteractiveState extends State {
 
     public instantiateComponents (): StateMachineComponent[] {
         const instantiatedComponents = this._components.map((component) => {
-            // @ts-expect-error Typing
-            const instantiated = instantiate(component, true) as unknown as StateMachineComponent;
+            const instantiated = instantiate(component) as unknown as StateMachineComponent;
             return instantiated;
         });
         return instantiatedComponents;

--- a/cocos/asset/asset-manager/asset-manager.ts
+++ b/cocos/asset/asset-manager/asset-manager.ts
@@ -39,7 +39,7 @@ import packManager from './pack-manager';
 import parser, { Parser } from './parser';
 import { Pipeline } from './pipeline';
 import preprocess from './preprocess';
-import releaseManager from './release-manager';
+import { releaseManager } from './release-manager';
 import RequestItem from './request-item';
 import {
     presets,
@@ -298,12 +298,6 @@ export class AssetManager {
      */
     public references = references;
 
-    /**
-     * @engineInternal
-     */
-    public get releaseManager () {
-        return this._releaseManager;
-    }
     private _releaseManager = releaseManager;
     private _files = files;
     private _parsed = parsed;

--- a/cocos/asset/asset-manager/asset-manager.ts
+++ b/cocos/asset/asset-manager/asset-manager.ts
@@ -301,7 +301,10 @@ export class AssetManager {
     /**
      * @engineInternal
      */
-    public _releaseManager = releaseManager;
+    public get releaseManager () {
+        return this._releaseManager;
+    }
+    private _releaseManager = releaseManager;
     private _files = files;
     private _parsed = parsed;
     private _parsePipeline = BUILD ? null : new Pipeline('parse existing json', [this.loadPipe]);

--- a/cocos/asset/asset-manager/asset-manager.ts
+++ b/cocos/asset/asset-manager/asset-manager.ts
@@ -298,7 +298,10 @@ export class AssetManager {
      */
     public references = references;
 
-    private _releaseManager = releaseManager;
+    /**
+     * @engineInternal
+     */
+    public _releaseManager = releaseManager;
     private _files = files;
     private _parsed = parsed;
     private _parsePipeline = BUILD ? null : new Pipeline('parse existing json', [this.loadPipe]);

--- a/cocos/asset/asset-manager/builtin-res-mgr.jsb.ts
+++ b/cocos/asset/asset-manager/builtin-res-mgr.jsb.ts
@@ -29,7 +29,7 @@ import assetManager from '../asset-manager/asset-manager';
 import { BuiltinBundleName } from '../asset-manager/shared';
 import Bundle from '../asset-manager/bundle';
 import { Settings, settings, cclegacy } from '../../core';
-import releaseManager from '../asset-manager/release-manager';
+import { releaseManager } from '../asset-manager/release-manager';
 import type { BuiltinResMgr as JsbBuiltinResMgr } from './builtin-res-mgr';
 
 declare const jsb: any;

--- a/cocos/asset/asset-manager/builtin-res-mgr.ts
+++ b/cocos/asset/asset-manager/builtin-res-mgr.ts
@@ -32,7 +32,7 @@ import assetManager from './asset-manager';
 import { BuiltinBundleName } from './shared';
 import Bundle from './bundle';
 import { Settings, settings, cclegacy } from '../../core';
-import releaseManager from './release-manager';
+import { releaseManager } from './release-manager';
 import { Material } from '../assets';
 
 export class BuiltinResMgr {

--- a/cocos/asset/asset-manager/bundle.ts
+++ b/cocos/asset/asset-manager/bundle.ts
@@ -27,7 +27,7 @@ import { Asset } from '../assets/asset';
 import { SceneAsset } from '../assets/scene-asset';
 import { error, errorID, cclegacy } from '../../core';
 import Config, { IAddressableInfo, IAssetInfo, IConfigOption, ISceneInfo } from './config';
-import releaseManager from './release-manager';
+import { releaseManager } from './release-manager';
 import RequestItem from './request-item';
 import { assets, bundles, RequestType } from './shared';
 import { parseLoadResArgs, parseParameters } from './utilities';

--- a/cocos/asset/asset-manager/cache.ts
+++ b/cocos/asset/asset-manager/cache.ts
@@ -136,7 +136,10 @@ export interface ICache<T> {
  *
  */
 export default class Cache<T = any> implements ICache<T> {
-    protected _map: Record<string, T> | null = null;
+    /**
+     * @engineInternal
+     */
+    public _map: Record<string, T> | null = null;
     protected _count = 0;
 
     /**

--- a/cocos/asset/asset-manager/cache.ts
+++ b/cocos/asset/asset-manager/cache.ts
@@ -139,7 +139,10 @@ export default class Cache<T = any> implements ICache<T> {
     /**
      * @engineInternal
      */
-    public _map: Record<string, T> | null = null;
+    public get map () {
+        return this._map;
+    }
+    protected _map: Record<string, T> | null = null;
     protected _count = 0;
 
     /**

--- a/cocos/asset/asset-manager/depend-util.ts
+++ b/cocos/asset/asset-manager/depend-util.ts
@@ -179,8 +179,9 @@ export class DependUtil {
                 return this._depends.get(uuid)!;
             }
 
-            // @ts-expect-error unknown json
-            if (Array.isArray(json) && (!(BUILD || isCompiledJson(json)) || !hasNativeDep(json))) {
+            // TODO: json: any[] is not assigned to IFileData
+            // workaround: mark json as any
+            if (Array.isArray(json) && (!(BUILD || isCompiledJson(json)) || !hasNativeDep(json as any))) {
                 out = {
                     deps: this._parseDepsFromJson(json),
                 };

--- a/cocos/asset/asset-manager/deprecated.ts
+++ b/cocos/asset/asset-manager/deprecated.ts
@@ -108,7 +108,7 @@ export class CCLoader {
      */
     public get _cache (): Record<string, Asset> {
         if (assets instanceof Cache) {
-            return assets._map!;
+            return assets.map!;
         } else {
             const map = {};
             assets.forEach((val, key) => {

--- a/cocos/asset/asset-manager/deprecated.ts
+++ b/cocos/asset/asset-manager/deprecated.ts
@@ -32,7 +32,7 @@ import dependUtil from './depend-util';
 import downloader from './downloader';
 import { getUuidFromURL, transform } from './helper';
 import parser from './parser';
-import releaseManager from './release-manager';
+import { releaseManager } from './release-manager';
 import { assets, BuiltinBundleName, bundles } from './shared';
 import { parseLoadResArgs, setDefaultProgressCallback } from './utilities';
 import factory from './factory';

--- a/cocos/asset/asset-manager/deprecated.ts
+++ b/cocos/asset/asset-manager/deprecated.ts
@@ -108,8 +108,7 @@ export class CCLoader {
      */
     public get _cache (): Record<string, Asset> {
         if (assets instanceof Cache) {
-            // @ts-expect-error return private property
-            return assets._map;
+            return assets._map!;
         } else {
             const map = {};
             assets.forEach((val, key) => {

--- a/cocos/asset/asset-manager/release-manager.ts
+++ b/cocos/asset/asset-manager/release-manager.ts
@@ -277,4 +277,4 @@ class ReleaseManager {
     }
 }
 
-export default new ReleaseManager();
+export const releaseManager =  new ReleaseManager();

--- a/cocos/asset/assets/deprecation.ts
+++ b/cocos/asset/assets/deprecation.ts
@@ -41,9 +41,8 @@ removeProperty(TextureBase.prototype, 'TextureBase.prototype', [
 replaceProperty(RenderTexture.prototype, 'RenderTexture.prototype', [
     {
         name: 'getGFXWindow',
-        customFunction () {
-            // @ts-expect-error
-            return this._window;
+        customFunction (this: RenderTexture) {
+            return this.window;
         },
     },
 ]);

--- a/cocos/asset/assets/image-asset.jsb.ts
+++ b/cocos/asset/assets/image-asset.jsb.ts
@@ -67,7 +67,6 @@ function isNativeImage (imageSource: ImageSource): imageSource is (HTMLImageElem
 
 const imageAssetProto = ImageAsset.prototype;
 
-// @ts-expect-error TODO: Property '_ctor' does not exist on type 'ImageAsset'.
 imageAssetProto._ctor = function (nativeAsset?: ImageSource) {
     jsb.Asset.prototype._ctor.apply(this, arguments);
     this._width = 0;
@@ -92,9 +91,10 @@ Object.defineProperty(imageAssetProto, '_nativeAsset', {
     get () {
         return this._nativeData;
     },
-    set (value: ImageSource) {
+    // TODO: Property 'format' does not exist on type 'HTMLCanvasElement'
+    // set (value: ImageSource) {
+    set (value: any) {
         if (!(value instanceof jsbWindow.HTMLElement) && !isImageBitmap(value)) {
-            // @ts-expect-error internal API usage
             value.format = value.format || this.format;
         }
         this.reset(value);
@@ -121,12 +121,12 @@ imageAssetProto._setRawAsset = function (filename: string, inLibrary = true) {
     }
 };
 
-
-imageAssetProto.reset = function (data: ImageSource) {
+// TODO: Property 'format' does not exist on type 'HTMLCanvasElement'.
+// imageAssetProto.reset = function (data: ImageSource) {
+imageAssetProto.reset = function (data: any) {
     this._nativeData = data;
 
     if (!(data instanceof jsbWindow.HTMLElement)) {
-        // @ts-expect-error internal api usage
         if(data.format !== undefined) {
             this.format = (data as any).format;
         }
@@ -162,7 +162,6 @@ Object.defineProperty(imageAssetProto, 'height', {
     }
 });
 
-// @ts-expect-error TODO: Property '_syncDataToNative' does not exist on type 'ImageAsset'.
 imageAssetProto._syncDataToNative = function () {
     const data: any = this._nativeData;
     this._width = data.width;

--- a/cocos/asset/assets/image-asset.ts
+++ b/cocos/asset/assets/image-asset.ts
@@ -464,9 +464,10 @@ export class ImageAsset extends Asset {
         // Maybe returned to pool in webgl.
         return this._nativeData;
     }
-    set _nativeAsset (value: ImageSource) {
+    // TODO: Property 'format' does not exist on type 'ImageBitmap'
+    // set _nativeAsset (value: ImageSource) {
+    set _nativeAsset (value: any) {
         if (!(value instanceof HTMLElement) && !isImageBitmap(value)) {
-            // @ts-expect-error internal API usage
             value.format = value.format || this._format;
         }
         this.reset(value);
@@ -579,8 +580,8 @@ export class ImageAsset extends Asset {
         } else if (!(data instanceof HTMLElement)) {
             // this._nativeData = Object.create(data);
             this._nativeData = data;
-            // @ts-expect-error internal api usage
-            this._format = data.format;
+            // TODO: Property 'format' does not exist on type 'ImageBitmap'
+            this._format = (data as any).format;
         } else {
             this._nativeData = data;
         }
@@ -590,11 +591,12 @@ export class ImageAsset extends Asset {
         if (this.data && this.data instanceof HTMLImageElement) {
             this.data.src = '';
             this._setRawAsset('');
-            // @ts-expect-error JSB element should destroy native data.
-            if (JSB) this.data.destroy();
+            // JSB element should destroy native data.
+            // TODO: Property 'destroy' does not exist on type 'HTMLImageElement'.
+            if (JSB) (this.data as any).destroy();
         } else if (isImageBitmap(this.data)) {
-            // @ts-expect-error internal api usage
-            this.data.close && this.data.close();
+            // TODO: Property 'close' does not exist on type 'HTMLCanvasElement'
+            (this.data as any)?.close();
         }
         return super.destroy();
     }

--- a/cocos/asset/assets/rendering-sub-mesh.jsb.ts
+++ b/cocos/asset/assets/rendering-sub-mesh.jsb.ts
@@ -79,7 +79,6 @@ export const RenderingSubMesh: typeof JsbRenderingSubMesh = jsb.RenderingSubMesh
 
 const renderingSubMeshProto = RenderingSubMesh.prototype;
 
-// @ts-expect-error TODO: Property '_ctor' does not exist on type 'RenderingSubMesh'.
 renderingSubMeshProto._ctor = function (vertexBuffers: Buffer[], attributes: Attribute[], primitiveMode: PrimitiveMode,
     indexBuffer: Buffer | null = null, indirectBuffer: Buffer | null = null) {
     jsb.Asset.prototype._ctor.apply(this, arguments);

--- a/cocos/asset/assets/texture-2d.jsb.ts
+++ b/cocos/asset/assets/texture-2d.jsb.ts
@@ -50,8 +50,8 @@ export interface ITexture2DSerializeData {
 }
 
 texture2DProto._ctor = function () {
-    // @ts-expect-error TODO: Property '_ctor' does not exist on type 'SimpleTexture'.
-    SimpleTexture.prototype._ctor.apply(this, arguments);
+    // TODO TODO: Property '_ctor' does not exist on type 'SimpleTexture'.
+    (SimpleTexture.prototype as any)._ctor.apply(this, arguments);
     this._mipmaps = [];
 };
 

--- a/cocos/audio/audio-clip.ts
+++ b/cocos/audio/audio-clip.ts
@@ -48,8 +48,11 @@ export class AudioClip extends Asset {
     /**
      * @engineInternal
      */
+    public set duration (v: number) {
+        this._duration = v;
+    }
     @serializable
-    public _duration = 0; // we serialize this because it's unavailable at runtime on some platforms
+    protected _duration = 0; // we serialize this because it's unavailable at runtime on some platforms
 
     protected _loadMode = AudioType.UNKNOWN_AUDIO;
 

--- a/cocos/audio/audio-clip.ts
+++ b/cocos/audio/audio-clip.ts
@@ -45,8 +45,11 @@ export interface AudioMeta {
 export class AudioClip extends Asset {
     public static AudioType = AudioType;
 
+    /**
+     * @engineInternal
+     */
     @serializable
-    protected _duration = 0; // we serialize this because it's unavailable at runtime on some platforms
+    public _duration = 0; // we serialize this because it's unavailable at runtime on some platforms
 
     protected _loadMode = AudioType.UNKNOWN_AUDIO;
 

--- a/cocos/audio/audio-downloader.ts
+++ b/cocos/audio/audio-downloader.ts
@@ -51,7 +51,6 @@ function createAudioClip (id: string,
     const out = new AudioClip();
     out._nativeUrl = id;
     out._nativeAsset = data;
-    // @ts-expect-error assignment to private field
     out._duration = data.duration;
     onComplete(null, out);
 }

--- a/cocos/audio/audio-downloader.ts
+++ b/cocos/audio/audio-downloader.ts
@@ -51,7 +51,7 @@ function createAudioClip (id: string,
     const out = new AudioClip();
     out._nativeUrl = id;
     out._nativeAsset = data;
-    out._duration = data.duration;
+    out.duration = data.duration;
     onComplete(null, out);
 }
 

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -199,8 +199,7 @@ function mergePropertyOptions (
     if (options) {
         fullOptions = getFullFormOfProperty(options, isGetset);
     }
-    // @ts-expect-error enum PropertyStashInternalFlag is used as number
-    const propertyRecord: PropertyStash = mixin(propertyStash, fullOptions || options || {});
+    const propertyRecord: PropertyStash = mixin(propertyStash, fullOptions || options || {}) as PropertyStash;
 
     if (isGetset) {
         // typescript or babel

--- a/cocos/core/data/decorators/utils.ts
+++ b/cocos/core/data/decorators/utils.ts
@@ -157,6 +157,5 @@ export function getClassCache (ctor, decoratorName?) {
 }
 
 export function getSubDict<T, TKey extends keyof T> (obj: T, key: TKey): NonNullable<T[TKey]> {
-    // @ts-expect-error I don't know how to fix it.
-    return obj[key] || (obj[key] = {});
+    return obj[key] || ((obj[key]) = {} as NonNullable<T[TKey]>);
 }

--- a/cocos/core/data/decorators/utils.ts
+++ b/cocos/core/data/decorators/utils.ts
@@ -157,5 +157,5 @@ export function getClassCache (ctor, decoratorName?) {
 }
 
 export function getSubDict<T, TKey extends keyof T> (obj: T, key: TKey): NonNullable<T[TKey]> {
-    return obj[key] || ((obj[key]) = {} as NonNullable<T[TKey]>);
+    return obj[key] as NonNullable<T[TKey]> || ((obj[key]) = {} as NonNullable<T[TKey]>);
 }

--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -195,13 +195,6 @@ class CCObject implements EditorExtendableObject {
     public declare [editorExtrasTag]: unknown;
 
     /**
-     * Called before the object being destroyed.
-     * @method _onPreDestroy
-     * @private
-     */
-    private _onPreDestroy: (() => void) | null = null;
-
-    /**
      * @internal
      */
     public _objFlags: number;
@@ -379,11 +372,8 @@ class CCObject implements EditorExtendableObject {
             errorID(5000);
             return;
         }
-        // engine internal callback
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        if (this._onPreDestroy) {
-            this._onPreDestroy();
-        }
+        // TODO: '_onPreDestroy' should be define in CCObject class.
+        ((this as any)._onPreDestroy)?.();
 
         if (!EDITOR || legacyCC.GAME_VIEW) {
             /*Native properties cannot be reset by _destruct, because the native properties are hung on the prototype and

--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -168,23 +168,6 @@ function compileDestruct (obj, ctor) {
  * @private
  */
 class CCObject implements EditorExtendableObject {
-    /**
-     * The customized serialization for this object. (Editor Only)
-     * @method _serialize
-     * @param {Boolean} exporting
-     * @return {object} the serialized json data object
-     * @engineInternal
-     */
-    public _serialize: ((exporting: boolean) => Record<string, any>) | null = null;
-
-    /**
-     * Init this object from the custom serialized data.
-     * @method _deserialize
-     * @param {Object} data - the serialized json data
-     * @param {_Deserializer} ctx
-     * @engineInternal
-     */
-    public _deserialize: ((data: Record<string, any>, ctx: any) => void) | null = null;
     public static _deferredDestroy () {
         const deleteCount = objectsToDestroy.length;
         for (let i = 0; i < deleteCount; ++i) {
@@ -217,11 +200,6 @@ class CCObject implements EditorExtendableObject {
      * @private
      */
     private _onPreDestroy: (() => void) | null = null;
-
-    /**
-     * @engineInternal
-     */
-    public realDestroyInEditor: (() => void) | null = null;
 
     /**
      * @internal
@@ -450,8 +428,9 @@ if (EDITOR || TEST) {
     * 析构操作将在 Undo 系统中**延后**执行。
     * @method realDestroyInEditor
     * @private
+    * TODO: this is a dynamic inject method, should be define in class
     */
-    prototype.realDestroyInEditor = function () {
+    (prototype as any).realDestroyInEditor = function () {
         if (!(this._objFlags & Destroyed)) {
             warnID(5001);
             return;
@@ -474,11 +453,24 @@ if (EDITOR) {
             deferredDestroyTimer = null;
         }
     });
-
-    prototype._serialize = null;
+    /**
+     * The customized serialization for this object. (Editor Only)
+     * @method _serialize
+     * @param {Boolean} exporting
+     * @return {object} the serialized json data object
+     * TODO: this is a dynamic inject method, should be define in class
+     */
+    (prototype as any)._serialize = null;
 }
 
-prototype._deserialize = null;
+/**
+ * Init this object from the custom serialized data.
+ * @method _deserialize
+ * @param {Object} data - the serialized json data
+ * @param {_Deserializer} ctx
+ * TODO: this is a dynamic inject method, should be define in class
+ */
+(prototype as any)._deserialize = null;
 
 CCClass.fastDefine('cc.Object', CCObject, { _name: '', _objFlags: 0, [editorExtrasTag]: {} });
 CCClass.Attr.setClassAttr(CCObject, editorExtrasTag, 'editorOnly', true);

--- a/cocos/core/event/callbacks-invoker.ts
+++ b/cocos/core/event/callbacks-invoker.ts
@@ -371,7 +371,10 @@ export class CallbacksInvoker<EventTypeClass extends EventType = EventType> {
         }
     }
 
-    private _registerOffCallback (cb: () => void) {
+    /**
+     * @engineInternal
+     */
+    public _registerOffCallback (cb: () => void) {
         this._offCallback = cb;
     }
 }

--- a/cocos/core/platform/debug.ts
+++ b/cocos/core/platform/debug.ts
@@ -238,7 +238,6 @@ export function _resetDebugSetting (mode: DebugMode) {
         ccLog = console.log.bind(console);
     } else if (mode <= DebugMode.INFO) {
         if (JSB) {
-            // @ts-expect-error We have no typing for this
             if (scriptEngineType === 'JavaScriptCore') {
                 // console.log has to use `console` as its context for iOS 8~9. Therefore, apply it.
                 ccLog = (message?: any, ...optionalParams: any[]) => console.log.apply(console, [message, ...optionalParams]);

--- a/cocos/core/platform/debug.ts
+++ b/cocos/core/platform/debug.ts
@@ -238,12 +238,7 @@ export function _resetDebugSetting (mode: DebugMode) {
         ccLog = console.log.bind(console);
     } else if (mode <= DebugMode.INFO) {
         if (JSB) {
-            if (scriptEngineType === 'JavaScriptCore') {
-                // console.log has to use `console` as its context for iOS 8~9. Therefore, apply it.
-                ccLog = (message?: any, ...optionalParams: any[]) => console.log.apply(console, [message, ...optionalParams]);
-            } else {
-                ccLog = console.log;
-            }
+            ccLog = console.log;
         } else if (console.log.bind) {
             // use bind to avoid pollute call stacks
             ccLog = console.log.bind(console);

--- a/cocos/core/platform/screen.ts
+++ b/cocos/core/platform/screen.ts
@@ -150,17 +150,15 @@ class Screen {
      * @return {Promise}
      */
     public requestFullScreen (): Promise<void>;
-    public requestFullScreen (element?: HTMLElement, onFullScreenChange?: (this: Document, ev: any) => any, onFullScreenError?: (this: Document, ev: any) => any): Promise<any> {
+    public requestFullScreen (element?: HTMLElement, onFullScreenChange?: (this: Document, ev?: any) => any, onFullScreenError?: (this: Document, ev?: any) => any): Promise<any> {
         if (arguments.length > 0) {
             warnID(1400, 'screen.requestFullScreen(element, onFullScreenChange?, onFullScreenError?)', 'screen.requestFullScreen(): Promise');
         }
         return screenAdapter.requestFullScreen().then(() => {
-            // @ts-expect-error no parameter passed
-            onFullScreenChange?.();
+            onFullScreenChange?.call(document);  // this case is only used on Web platforms, which is deprecated since v3.3.0
         }).catch((err) => {
             console.error(err);
-            // @ts-expect-error no parameter passed
-            onFullScreenError?.();
+            onFullScreenError?.call(document);  // this case is only used on Web platforms, which is deprecated since v3.3.0
         });
     }
 

--- a/cocos/core/platform/sys.ts
+++ b/cocos/core/platform/sys.ts
@@ -260,6 +260,11 @@ export const sys = {
     },
 
     /**
+     * @engineInternal
+     */
+    __isWebIOS14OrIPadOS14Env: false,
+
+    /**
      * @en Dump systemInfo informations.
      * @zh 在控制台打印当前的主要系统信息。
      */
@@ -304,24 +309,23 @@ export const sys = {
                     localStorage.removeItem('storage');
                     localStorage = null;
                 } catch (e) {
-                    const warn = function () {
+                    const warn = function (...args: any): any {
                         warnID(5200);
                     };
                     this.localStorage = {
-                        // @ts-expect-error Type '() => void' is not assignable to type '(key: string) => string | null'
                         getItem: warn,
                         setItem: warn,
                         clear: warn,
                         removeItem: warn,
+                        key: warn,
+                        length: 0,
                     };
                 }
 
                 if (WECHAT) {
-                    // @ts-expect-error HACK: this private property only needed on web & wechat JIT
                     this.__isWebIOS14OrIPadOS14Env = (sys.os === OS.IOS || sys.os === OS.OSX) && GameGlobal?.isIOSHighPerformanceMode
             && /(OS 1((4\.[0-9])|(5\.[0-3])))|(Version\/1((4\.[0-9])|(5\.[0-3])))/.test(window.navigator.userAgent);
                 } else {
-                    // @ts-expect-error HACK: this private property only needed on web & wechat JIT
                     this.__isWebIOS14OrIPadOS14Env = (sys.os === OS.IOS || sys.os === OS.OSX) && systemInfo.isBrowser
             && /(OS 14)|(Version\/14)/.test(window.navigator.userAgent);
                 }

--- a/cocos/core/scheduler.ts
+++ b/cocos/core/scheduler.ts
@@ -373,12 +373,7 @@ export class Scheduler extends System {
             found = true;
         }
         if (!found) {
-            // @ts-expect-error Notes written for over eslint
-            if (target.__instanceId) {
-                warnID(1513);
-            } else {
-                target.id = idGenerator.getNewId();
-            }
+            target.id = idGenerator.getNewId();
         }
     }
 
@@ -526,36 +521,34 @@ export class Scheduler extends System {
     }
 
     /**
-     * @en Specify the callback, target and other information to schedule a new timer.
-     * @zh 指定回调函数，调用对象等信息来规划一个新的定时器。
-     * @param callback
-     * @en The specified callback function.
+     * @en Specify the callback to schedule a new timer.
      * If the callback function is already scheduled, then only the interval parameter will be updated without re-scheduling it again.
-     * @zh 所指定的回调函数。
+     * @zh 指定回调函数来规划一个新的定时器。
      * 如果回调函数已经被定时器使用，那么只会更新之前定时器的时间间隔参数，不会设置新的定时器。
-     * @param target
+     * @param callback
      * @en The specified target.
      * @zh 所指定的调用对象。
-     * @param interval
+     * @param target
      * @en The scheduled method will be called every 'interval' seconds.
      * If 'interval' is 0, it will be called every frame, but if so, it recommended to use 'scheduleUpdateForTarget:' instead.
      * @zh 当时间间隔达到指定值时，设置的回调函数将会被调用。
      * 如果 interval 值为 0，那么回调函数每一帧都会被调用，但如果是这样，建议使用 scheduleUpdateForTarget 代替。
-     * @param [repeat]
+     * @param interval
      * @en repeat let the action be repeated repeat + 1 times, use `macro.REPEAT_FOREVER` to let the action run continuously.
      * @zh repeat 值可以让定时器触发 repeat + 1 次，使用 `macro.REPEAT_FOREVER` 可以让定时器一直循环触发。
-     * @param [delay=0]
+     * @param repeat
      * @en delay is the amount of time the action will wait before it'll start. Unit: s.
      * @zh delay 值指定延迟时间，定时器会在延迟指定的时间之后开始计时，单位: 秒。
-     * @param [paused=false]
+     * @param delay
      * @en If paused is YES, then it won't be called until it is resumed.
      * @zh 如果 paused 值为 true，那么直到 resume 被调用才开始计时。
+     * @param paused
      */
     public schedule (callback: (dt?: number) => void, target: ISchedulable, interval: number, repeat?: number, delay?: number, paused?: boolean) {
         if (typeof callback !== 'function') {
+            warnID(1514);
             const tmp = callback;
-            // @ts-expect-error Notes written for over eslint
-            callback = target;
+            callback = target as any;
             target = tmp;
         }
         // selector, target, interval, repeat, delay, paused

--- a/cocos/core/utils/jsb-utils.ts
+++ b/cocos/core/utils/jsb-utils.ts
@@ -139,7 +139,7 @@ export function updateChildrenForDeserialize (node: Node) {
         return;
     }
 
-    // TODO: `_setChildren` is only implemented on native platforms. @dumganhar
+    // NOTE: `_setChildren` is only implemented on native platforms. @dumganhar
     (node as any)._setChildren(children);
 
     for (let i = 0; i < len; ++i) {

--- a/cocos/core/utils/jsb-utils.ts
+++ b/cocos/core/utils/jsb-utils.ts
@@ -108,25 +108,19 @@ import type { Node } from '../../scene-graph';
 //     });
 // }
 
-export function syncNodeValues (node: Node) {
-    // @ts-expect-error: jsb related codes.
+// TODO: we mark node as type of any, because we access much of protected properties here.
+// export function syncNodeValues (node: Node) {
+export function syncNodeValues (node: any) {
     const lpos = node._lpos;
-    // @ts-expect-error: jsb related codes.
     node.setPositionForJS(lpos.x, lpos.y, lpos.z);
 
-    // @ts-expect-error: jsb related codes.
     const lscale = node._lscale;
-    // @ts-expect-error: jsb related codes.
     node.setScaleForJS(lscale.x, lscale.y, lscale.z);
 
-    // @ts-expect-error: jsb related codes.
     const lrot = node._lrot;
-    // @ts-expect-error: jsb related codes.
     node.setRotationForJS(lrot.x, lrot.y, lrot.z, lrot.w);
 
-    // @ts-expect-error: jsb related codes.
     const euler = node._euler;
-    // @ts-expect-error: jsb related codes.
     node.setRotationFromEulerForJS(euler.x, euler.y, euler.z);
 }
 
@@ -135,8 +129,7 @@ export function updateChildrenForDeserialize (node: Node) {
         return;
     }
 
-    // @ts-expect-error: jsb related codes.
-    const children = node._children;
+    const children = node.children;
     if (!children) {
         return;
     }
@@ -146,8 +139,8 @@ export function updateChildrenForDeserialize (node: Node) {
         return;
     }
 
-    // @ts-expect-error: jsb related codes.
-    node._setChildren(children);
+    // TODO: `_setChildren` is only implemented on native platforms. @dumganhar
+    (node as any)._setChildren(children);
 
     for (let i = 0; i < len; ++i) {
         const child = children[i];

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -308,7 +308,7 @@ interface IDeprecateInfo {
  * @engineInternal
  */
 interface TopLevelDeprecateList {
-    [name: string]: IDeprecateInfo | undefined;
+    [name: string | symbol]: IDeprecateInfo | undefined;
 }
 
 const topLevelDeprecateList: TopLevelDeprecateList = {
@@ -337,7 +337,7 @@ export function deprecateModuleExportedName (deprecateList: TopLevelDeprecateLis
     }
 }
 
-function _checkObsoleteByName (checkName: string) {
+function _checkObsoleteByName (checkName: string | symbol) {
     const deprecateInfo = topLevelDeprecateList[checkName];
     if (!deprecateInfo) {
         return;
@@ -392,7 +392,6 @@ export function __checkObsoleteInNamespace__ (ccNamespace: object) {
         } else {
             _cachedProxy = new Proxy(ccNamespace, {
                 get (target, name, receiver) {
-                    // @ts-expect-error name could be a symbol
                     _checkObsoleteByName(name);
                     return Reflect.get(target, name, receiver);
                 },

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -392,6 +392,7 @@ export function __checkObsoleteInNamespace__ (ccNamespace: object) {
         } else {
             _cachedProxy = new Proxy(ccNamespace, {
                 get (target, name, receiver) {
+                    // NOTE: for now we use tsc version 4.3.5, which has not supported symbol as index.
                     _checkObsoleteByName(name as string);
                     return Reflect.get(target, name, receiver);
                 },

--- a/cocos/core/utils/x-deprecated.ts
+++ b/cocos/core/utils/x-deprecated.ts
@@ -308,7 +308,7 @@ interface IDeprecateInfo {
  * @engineInternal
  */
 interface TopLevelDeprecateList {
-    [name: string | symbol]: IDeprecateInfo | undefined;
+    [name: string]: IDeprecateInfo | undefined;
 }
 
 const topLevelDeprecateList: TopLevelDeprecateList = {
@@ -337,7 +337,7 @@ export function deprecateModuleExportedName (deprecateList: TopLevelDeprecateLis
     }
 }
 
-function _checkObsoleteByName (checkName: string | symbol) {
+function _checkObsoleteByName (checkName: string) {
     const deprecateInfo = topLevelDeprecateList[checkName];
     if (!deprecateInfo) {
         return;
@@ -392,7 +392,7 @@ export function __checkObsoleteInNamespace__ (ccNamespace: object) {
         } else {
             _cachedProxy = new Proxy(ccNamespace, {
                 get (target, name, receiver) {
-                    _checkObsoleteByName(name);
+                    _checkObsoleteByName(name as string);
                     return Reflect.get(target, name, receiver);
                 },
             });

--- a/cocos/core/value-types/enum.ts
+++ b/cocos/core/value-types/enum.ts
@@ -84,8 +84,8 @@ Enum.update = <T> (obj: T): T => {
         }
     }
     // auto update list if __enums__ is array
-    // @ts-expect-error Injected properties
-    if (Array.isArray(obj.__enums__)) {
+    // NOTE: `__enums__` is injected properties
+    if (Array.isArray((obj as any).__enums__)) {
         updateList(obj);
     }
     return obj;

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -712,7 +712,10 @@ export class ArmatureDisplay extends UIRenderer {
         this.markForUpdateRenderData();
     }
 
-    protected updateMaterial () {
+    /**
+     * @engineInternal
+     */
+    public updateMaterial () {
         let mat;
         if (this._customMaterial) mat = this._customMaterial;
         else mat = this._updateBuiltinMaterial();

--- a/cocos/game/director.ts
+++ b/cocos/game/director.ts
@@ -343,7 +343,6 @@ export class Director extends EventTarget {
         if (BUILD && DEBUG) {
             console.time('InitScene');
         }
-        // @ts-expect-error run private method
         scene._load();  // ensure scene initialized
         if (BUILD && DEBUG) {
             console.timeEnd('InitScene');
@@ -387,7 +386,6 @@ export class Director extends EventTarget {
             if (BUILD && DEBUG) {
                 console.time('AutoRelease');
             }
-            // @ts-expect-error Using private API in editor
             assetManager._releaseManager._autoRelease(oldScene!, scene, this._persistRootNodes);
             if (BUILD && DEBUG) {
                 console.timeEnd('AutoRelease');
@@ -411,7 +409,6 @@ export class Director extends EventTarget {
         if (BUILD && DEBUG) {
             console.time('Activate');
         }
-        // @ts-expect-error run private method
         scene._activate();
         if (BUILD && DEBUG) {
             console.timeEnd('Activate');
@@ -521,8 +518,9 @@ export class Director extends EventTarget {
     ) {
         const bundle = assetManager.bundles.find((bundle) => !!bundle.getSceneInfo(sceneName));
         if (bundle) {
-            // @ts-expect-error Manual checked parameter mapping
-            bundle.preloadScene(sceneName, null, onProgress, onLoaded);
+            // NOTE: the similar function signatures but defined as deferent function types.
+            bundle.preloadScene(sceneName, null, onProgress as (finished: number, total: number, item: any) => void,
+                onLoaded as ((err?: Error | null) => void) | null);
         } else {
             const err = `Can not preload the scene "${sceneName}" because it is not in the build settings.`;
             if (onLoaded) {
@@ -698,7 +696,6 @@ export class Director extends EventTarget {
         if (!this._invalid) {
             this.emit(Director.EVENT_BEGIN_FRAME);
             if (!EDITOR || cclegacy.GAME_VIEW) {
-                // @ts-expect-error _frameDispatchEvents is a private method.
                 input._frameDispatchEvents();
             }
 
@@ -809,7 +806,6 @@ export class Director extends EventTarget {
             }
             this._persistRootNodes[id] = node;
             node._persistNode = true;
-            // @ts-expect-error Using private API
             assetManager._releaseManager._addPersistNodeRef(node);
         }
     }
@@ -825,7 +821,6 @@ export class Director extends EventTarget {
             delete this._persistRootNodes[id];
             node._persistNode = false;
             node._originalSceneId = '';
-            // @ts-expect-error Using private API
             assetManager._releaseManager._removePersistNodeRef(node);
         }
     }

--- a/cocos/game/director.ts
+++ b/cocos/game/director.ts
@@ -39,6 +39,7 @@ import { scalableContainerManager } from '../core/memop/scalable-container';
 import { uiRendererManager } from '../2d/framework/ui-renderer-manager';
 import { assetManager } from '../asset/asset-manager';
 import { deviceManager } from '../gfx';
+import { releaseManager } from '../asset/asset-manager/release-manager';
 
 // ----------------------------------------------------------------------------------------------------------------------
 
@@ -386,7 +387,7 @@ export class Director extends EventTarget {
             if (BUILD && DEBUG) {
                 console.time('AutoRelease');
             }
-            assetManager.releaseManager._autoRelease(oldScene!, scene, this._persistRootNodes);
+            releaseManager._autoRelease(oldScene!, scene, this._persistRootNodes);
             if (BUILD && DEBUG) {
                 console.timeEnd('AutoRelease');
             }
@@ -806,7 +807,7 @@ export class Director extends EventTarget {
             }
             this._persistRootNodes[id] = node;
             node._persistNode = true;
-            assetManager.releaseManager._addPersistNodeRef(node);
+            releaseManager._addPersistNodeRef(node);
         }
     }
 
@@ -821,7 +822,7 @@ export class Director extends EventTarget {
             delete this._persistRootNodes[id];
             node._persistNode = false;
             node._originalSceneId = '';
-            assetManager.releaseManager._removePersistNodeRef(node);
+            releaseManager._removePersistNodeRef(node);
         }
     }
 

--- a/cocos/game/director.ts
+++ b/cocos/game/director.ts
@@ -386,7 +386,7 @@ export class Director extends EventTarget {
             if (BUILD && DEBUG) {
                 console.time('AutoRelease');
             }
-            assetManager._releaseManager._autoRelease(oldScene!, scene, this._persistRootNodes);
+            assetManager.releaseManager._autoRelease(oldScene!, scene, this._persistRootNodes);
             if (BUILD && DEBUG) {
                 console.timeEnd('AutoRelease');
             }
@@ -806,7 +806,7 @@ export class Director extends EventTarget {
             }
             this._persistRootNodes[id] = node;
             node._persistNode = true;
-            assetManager._releaseManager._addPersistNodeRef(node);
+            assetManager.releaseManager._addPersistNodeRef(node);
         }
     }
 
@@ -821,7 +821,7 @@ export class Director extends EventTarget {
             delete this._persistRootNodes[id];
             node._persistNode = false;
             node._originalSceneId = '';
-            assetManager._releaseManager._removePersistNodeRef(node);
+            assetManager.releaseManager._removePersistNodeRef(node);
         }
     }
 

--- a/cocos/game/game.ts
+++ b/cocos/game/game.ts
@@ -590,7 +590,6 @@ export class Game extends EventTarget {
      */
     public resume () {
         if (!this._paused) { return; }
-        // @ts-expect-error _clearEvents is a private method.
         input._clearEvents();
         this._paused = false;
         this._pacer?.start();

--- a/cocos/gfx/base/texture.ts
+++ b/cocos/gfx/base/texture.ts
@@ -177,7 +177,10 @@ export abstract class Texture extends GFXObject {
      */
     public abstract resize (width: number, height: number): void;
 
-    protected abstract initAsSwapchainTexture (info: Readonly<ISwapchainTextureInfo>): void;
+    /**
+     * @engineInternal
+     */
+    public abstract initAsSwapchainTexture (info: Readonly<ISwapchainTextureInfo>): void;
 
     public static getLevelCount (width: number, height: number): number {
         return Math.floor(Math.log2(Math.max(width, height)));

--- a/cocos/gfx/empty/empty-swapchain.ts
+++ b/cocos/gfx/empty/empty-swapchain.ts
@@ -29,7 +29,6 @@ import { EmptyTexture } from './empty-texture';
 export class EmptySwapchain extends Swapchain {
     public initialize (info: Readonly<SwapchainInfo>) {
         this._colorTexture = new EmptyTexture();
-        // @ts-expect-error(2445) private initializer
         this._colorTexture.initAsSwapchainTexture({
             swapchain: this,
             format: Format.RGBA8,
@@ -38,7 +37,6 @@ export class EmptySwapchain extends Swapchain {
         });
 
         this._depthStencilTexture = new EmptyTexture();
-        // @ts-expect-error(2445) private initializer
         this._depthStencilTexture.initAsSwapchainTexture({
             swapchain: this,
             format: Format.DEPTH_STENCIL,

--- a/cocos/gfx/empty/empty-texture.ts
+++ b/cocos/gfx/empty/empty-texture.ts
@@ -59,5 +59,8 @@ export class EmptyTexture extends Texture {
         this._info.width = width;
         this._info.height = height;
     }
-    protected initAsSwapchainTexture (info: ISwapchainTextureInfo) {}
+    /**
+     * @engineInternal
+     */
+    public initAsSwapchainTexture (info: ISwapchainTextureInfo) {}
 }

--- a/cocos/gfx/webgl/webgl-swapchain.ts
+++ b/cocos/gfx/webgl/webgl-swapchain.ts
@@ -265,7 +265,6 @@ export class WebGLSwapchain extends Swapchain {
         else if (depthBits) depthStencilFmt = Format.DEPTH;
 
         this._colorTexture = new WebGLTexture();
-        // @ts-expect-error(2445) private initializer
         this._colorTexture.initAsSwapchainTexture({
             swapchain: this,
             format: colorFmt,
@@ -274,7 +273,6 @@ export class WebGLSwapchain extends Swapchain {
         });
 
         this._depthStencilTexture = new WebGLTexture();
-        // @ts-expect-error(2445) private initializer
         this._depthStencilTexture.initAsSwapchainTexture({
             swapchain: this,
             format: depthStencilFmt,

--- a/cocos/gfx/webgl/webgl-texture.ts
+++ b/cocos/gfx/webgl/webgl-texture.ts
@@ -159,7 +159,10 @@ export class WebGLTexture extends Texture {
 
     // ======================= Swapchain Specific ======================= //
 
-    protected initAsSwapchainTexture (info: Readonly<ISwapchainTextureInfo>) {
+    /**
+     * @engineInternal
+     */
+    public initAsSwapchainTexture (info: Readonly<ISwapchainTextureInfo>) {
         const texInfo = new TextureInfo();
         texInfo.format = info.format;
         texInfo.usage = FormatInfos[info.format].hasDepth ? TextureUsageBit.DEPTH_STENCIL_ATTACHMENT : TextureUsageBit.COLOR_ATTACHMENT;

--- a/cocos/gfx/webgl2/webgl2-swapchain.ts
+++ b/cocos/gfx/webgl2/webgl2-swapchain.ts
@@ -202,7 +202,6 @@ export class WebGL2Swapchain extends Swapchain {
         else if (depthBits) depthStencilFmt = Format.DEPTH;
 
         this._colorTexture = new WebGL2Texture();
-        // @ts-expect-error(2445) private initializer
         this._colorTexture.initAsSwapchainTexture({
             swapchain: this,
             format: colorFmt,
@@ -211,7 +210,6 @@ export class WebGL2Swapchain extends Swapchain {
         });
 
         this._depthStencilTexture = new WebGL2Texture();
-        // @ts-expect-error(2445) private initializer
         this._depthStencilTexture.initAsSwapchainTexture({
             swapchain: this,
             format: depthStencilFmt,

--- a/cocos/gfx/webgl2/webgl2-texture.ts
+++ b/cocos/gfx/webgl2/webgl2-texture.ts
@@ -181,7 +181,10 @@ export class WebGL2Texture extends Texture {
 
     // ======================= Swapchain Specific ======================= //
 
-    protected initAsSwapchainTexture (info: Readonly<ISwapchainTextureInfo>) {
+    /**
+     * @engineInternal
+     */
+    public initAsSwapchainTexture (info: Readonly<ISwapchainTextureInfo>) {
         const texInfo = new TextureInfo();
         texInfo.format = info.format;
         texInfo.usage = FormatInfos[info.format].hasDepth ? TextureUsageBit.DEPTH_STENCIL_ATTACHMENT : TextureUsageBit.COLOR_ATTACHMENT;

--- a/cocos/input/input.ts
+++ b/cocos/input/input.ts
@@ -278,8 +278,10 @@ export class Input {
         this._dispatchOrPushEventTouch(eventTouch, this._eventTouchList);
     }
 
-    // TODO: public in engine
-    private _registerEventDispatcher (eventDispatcher: IEventDispatcher) {
+    /**
+     * @engineInternal
+     */
+    public _registerEventDispatcher (eventDispatcher: IEventDispatcher) {
         this._eventDispatcherList.push(eventDispatcher);
         this._eventDispatcherList.sort((a, b) => b.priority - a.priority);
     }
@@ -364,7 +366,10 @@ export class Input {
         }
     }
 
-    private _clearEvents () {
+    /**
+     * @engineInternal
+     */
+    public _clearEvents () {
         this._eventMouseList.length = 0;
         this._eventTouchList.length = 0;
         this._eventKeyboardList.length = 0;
@@ -396,7 +401,10 @@ export class Input {
         }
     }
 
-    private _frameDispatchEvents () {
+    /**
+     * @engineInternal
+     */
+    public _frameDispatchEvents () {
         const eventHMDList = this._eventHMDList;
         // TODO: culling event queue
         for (let i = 0, length = eventHMDList.length; i < length; ++i) {

--- a/cocos/input/system-event.ts
+++ b/cocos/input/system-event.ts
@@ -123,10 +123,7 @@ export class SystemEvent extends EventTarget {
      * @param target - The event listener's target and callee
      * @param once - Register the event listener once
      */
-    // TODO: don't know how to fix this typing
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error Property 'on' in type 'SystemEvent' is not assignable to the same property in base type
-    public on<K extends keyof SystemEventMap> (type: K, callback: SystemEventMap[K], target?: any, once?: boolean) {
+    public on<TFunction extends (...any) => void>(type: string, callback: TFunction, target?: unknown, once?: boolean) {
         super.on(type, callback, target, once);
         return callback;
     }

--- a/cocos/input/system-event.ts
+++ b/cocos/input/system-event.ts
@@ -123,6 +123,8 @@ export class SystemEvent extends EventTarget {
      * @param target - The event listener's target and callee
      * @param once - Register the event listener once
      */
+    // TODO: don't know how to fix this typing
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error Property 'on' in type 'SystemEvent' is not assignable to the same property in base type
     public on<K extends keyof SystemEventMap> (type: K, callback: SystemEventMap[K], target?: any, once?: boolean) {
         super.on(type, callback, target, once);

--- a/cocos/input/types/event/event-acceleration.ts
+++ b/cocos/input/types/event/event-acceleration.ts
@@ -50,5 +50,5 @@ export class EventAcceleration extends Event {
     }
 }
 
-// @ts-expect-error TODO
-Event.EventAcceleration = EventAcceleration;
+// TODO: this is an injected property, should be deprecated
+(Event as any).EventAcceleration = EventAcceleration;

--- a/cocos/input/types/event/event-keyboard.ts
+++ b/cocos/input/types/event/event-keyboard.ts
@@ -93,5 +93,5 @@ export class EventKeyboard extends Event {
     }
 }
 
-// @ts-expect-error TODO
-Event.EventKeyboard = EventKeyboard;
+// TODO: this is an injected property, should be deprecated
+(Event as any).EventKeyboard = EventKeyboard;

--- a/cocos/input/types/event/event-mouse.ts
+++ b/cocos/input/types/event/event-mouse.ts
@@ -378,5 +378,5 @@ export class EventMouse extends Event {
     }
 }
 
-// @ts-expect-error TODO
-Event.EventMouse = EventMouse;
+// TODO: this is an injected property, should be deprecated
+(Event as any).EventMouse = EventMouse;

--- a/cocos/input/types/event/event-touch.ts
+++ b/cocos/input/types/event/event-touch.ts
@@ -246,5 +246,5 @@ export class EventTouch extends Event {
     }
 }
 
-// @ts-expect-error TODO
-Event.EventTouch = EventTouch;
+// TODO: this is an injected property, should be deprecated
+(Event as any).EventTouch = EventTouch;

--- a/cocos/misc/model-renderer.ts
+++ b/cocos/misc/model-renderer.ts
@@ -83,7 +83,10 @@ export class ModelRenderer extends Renderer {
     protected _attachToScene () {
     }
 
-    protected _detachFromScene () {
+    /**
+     * @engineInternal
+     */
+    public _detachFromScene () {
     }
 
     protected _onVisibilityChange (val) {

--- a/cocos/misc/renderer.ts
+++ b/cocos/misc/renderer.ts
@@ -232,7 +232,10 @@ export class Renderer extends Component {
     protected _onMaterialModified (index: number, material: Material | null) {
     }
 
-    protected _onRebuildPSO (index: number, material: Material | null) {
+    /**
+     * @engineInternal
+     */
+    public _onRebuildPSO (index: number, material: Material | null) {
     }
 
     protected _clearMaterials () {

--- a/cocos/particle/line.ts
+++ b/cocos/particle/line.ts
@@ -282,7 +282,10 @@ export class Line extends ModelRenderer {
         }
     }
 
-    protected _detachFromScene () {
+    /**
+     * @engineInternal
+     */
+    public _detachFromScene () {
         super._detachFromScene();
         if (this._models.length > 0 && this._models[0]) {
             const lineModel = this._models[0];

--- a/cocos/particle/particle-culler.ts
+++ b/cocos/particle/particle-culler.ts
@@ -28,7 +28,7 @@ import { TransformBit } from '../scene-graph/node-enum';
 import { RenderMode, Space } from './enum';
 import { approx, EPSILON, Mat4, pseudoRandom, Quat, randomRangeInt, Vec3, Vec4, geometry, bits } from '../core';
 import { isCurveTwoValues, particleEmitZAxis } from './particle-general-function';
-import { IParticleSystemRenderer } from './renderer/particle-system-renderer-base';
+import { ParticleSystemRendererBase } from './renderer/particle-system-renderer-base';
 import { Mesh } from '../3d';
 import type { ParticleSystem } from './particle-system';
 import { Mode } from './animator/curve-range';
@@ -50,7 +50,7 @@ const _anim_module = [
 
 export class ParticleCuller {
     private _particleSystem: ParticleSystem;
-    private _processor: IParticleSystemRenderer;
+    private _processor: ParticleSystemRendererBase;
     private _node: Node;
     private _particlesAll: Particle[];
     private _updateList: Map<string, IParticleModule> = new Map<string, IParticleModule>();

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -45,7 +45,7 @@ import { CullingMode, Space } from './enum';
 import { particleEmitZAxis } from './particle-general-function';
 import ParticleSystemRenderer from './renderer/particle-system-renderer-data';
 import TrailModule from './renderer/trail';
-import { IParticleSystemRenderer } from './renderer/particle-system-renderer-base';
+import { ParticleSystemRendererBase } from './renderer/particle-system-renderer-base';
 import { PARTICLE_MODULE_PROPERTY } from './particle';
 import { TransformBit } from '../scene-graph/node-enum';
 import { Camera } from '../render-scene/scene';
@@ -86,9 +86,7 @@ export class ParticleSystem extends ModelRenderer {
 
     public set capacity (val) {
         this._capacity = Math.floor(val > 0 ? val : 0);
-        // @ts-expect-error private property access
         if (this.processor && this.processor._model) {
-            // @ts-expect-error private property access
             this.processor._model.setCapacity(this._capacity);
         }
     }
@@ -812,7 +810,7 @@ export class ParticleSystem extends ModelRenderer {
      * @en Particle update processor (update every particle).
      * @zh 粒子更新器（负责更新每个粒子）。
      */
-    public processor: IParticleSystemRenderer = null!;
+    public processor: ParticleSystemRendererBase = null!;
 
     constructor () {
         super();
@@ -1267,7 +1265,6 @@ export class ParticleSystem extends ModelRenderer {
         }
 
         if (!this.renderer.useGPU && this._trailModule && this._trailModule.enable) {
-            // @ts-expect-error private property access
             if (!this._trailModule._inited) {
                 this._trailModule.clear();
                 this._trailModule.destroy();
@@ -1301,9 +1298,7 @@ export class ParticleSystem extends ModelRenderer {
     }
 
     protected _onVisibilityChange (val) {
-        // @ts-expect-error private property access
         if (this.processor._model) {
-            // @ts-expect-error private property access
             this.processor._model.visFlags = val;
         }
     }

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -86,8 +86,8 @@ export class ParticleSystem extends ModelRenderer {
 
     public set capacity (val) {
         this._capacity = Math.floor(val > 0 ? val : 0);
-        if (this.processor && this.processor._model) {
-            this.processor._model.setCapacity(this._capacity);
+        if (this.processor && this.processor.model) {
+            this.processor.model.setCapacity(this._capacity);
         }
     }
 
@@ -1265,7 +1265,7 @@ export class ParticleSystem extends ModelRenderer {
         }
 
         if (!this.renderer.useGPU && this._trailModule && this._trailModule.enable) {
-            if (!this._trailModule._inited) {
+            if (!this._trailModule.inited) {
                 this._trailModule.clear();
                 this._trailModule.destroy();
                 this._trailModule.onInit(this);
@@ -1298,8 +1298,8 @@ export class ParticleSystem extends ModelRenderer {
     }
 
     protected _onVisibilityChange (val) {
-        if (this.processor._model) {
-            this.processor._model.visFlags = val;
+        if (this.processor.model) {
+            this.processor.model.visFlags = val;
         }
     }
 

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -899,7 +899,10 @@ export class ParticleSystem extends ModelRenderer {
         }
     }
 
-    protected _detachFromScene () {
+    /**
+     * @engineInternal
+     */
+    public _detachFromScene () {
         this.processor.detachFromScene();
         if (this._trailModule && this._trailModule.enable) {
             this._trailModule._detachFromScene();

--- a/cocos/particle/particle.ts
+++ b/cocos/particle/particle.ts
@@ -24,7 +24,7 @@
 
 import { Color, Vec3, Mat4, Quat } from '../core';
 import { ParticleSystem } from './particle-system';
-import { IParticleSystemRenderer } from './renderer/particle-system-renderer-base';
+import { ParticleSystemRendererBase } from './renderer/particle-system-renderer-base';
 
 export class Particle {
     public static INDENTIFY_NEG_QUAT = 10;
@@ -137,7 +137,7 @@ export const PARTICLE_MODULE_PROPERTY = [
 ];
 
 export interface IParticleModule {
-    target: IParticleSystemRenderer | null;
+    target: ParticleSystemRendererBase | null;
     needUpdate: boolean;
     needAnimate: boolean;
     name: string;
@@ -147,11 +147,11 @@ export interface IParticleModule {
 }
 
 export abstract class ParticleModuleBase implements IParticleModule {
-    public target:IParticleSystemRenderer | null = null;
+    public target: ParticleSystemRendererBase | null = null;
     public needUpdate = false;
     public needAnimate = true;
 
-    public bindTarget (target: IParticleSystemRenderer) {
+    public bindTarget (target: ParticleSystemRendererBase) {
         this.target = target;
     }
 

--- a/cocos/particle/renderer/particle-system-renderer-base.ts
+++ b/cocos/particle/renderer/particle-system-renderer-base.ts
@@ -32,42 +32,12 @@ import { RenderMode } from '../enum';
 import { cclegacy } from '../../core';
 import { Pass } from '../../render-scene';
 
-export interface IParticleSystemRenderer {
-    onInit (ps: Component): void;
-    getInfo (): ParticleSystemRenderer;
-    onEnable (): void;
-    onDisable (): void;
-    onDestroy (): void;
-    clear (): void;
-    getModel (): ParticleBatchModel | null;
-    attachToScene (): void;
-    detachFromScene (): void;
-    updateMaterialParams (): void;
-    updateVertexAttrib (): void;
-    setVertexAttributes (): void;
-    updateRenderMode (): void;
-    onMaterialModified (index: number, material: Material): void;
-    onRebuildPSO (index: number, material: Material) : void;
-    getParticleCount (): number;
-    getFreeParticle (): Particle | null;
-    setNewParticle (p: Particle): void;
-    getDefaultMaterial(): Material | null;
-    updateRotation (pass: Pass | null): void;
-    updateScale (pass: Pass | null): void;
-    updateParticles (dt: number): number;
-    updateRenderData (): void;
-    enableModule (name: string, val: boolean, pm: IParticleModule): void;
-    updateTrailMaterial (): void;
-    getDefaultTrailMaterial (): any;
-    beforeRender (): void;
-    setUseInstance (value: boolean): void;
-    getUseInstance (): boolean;
-    getNoisePreview (out: number[], width: number, height: number): void;
-}
-
-export abstract class ParticleSystemRendererBase implements IParticleSystemRenderer {
+export abstract class ParticleSystemRendererBase {
     protected _particleSystem: any = null;
-    protected _model: ParticleBatchModel | null = null;
+    /**
+     * @engineInternal
+     */
+    public _model: ParticleBatchModel | null = null;
     protected _renderInfo: ParticleSystemRenderer | null = null;
     protected _vertAttrs: Attribute[] = [];
     protected _useInstance: boolean;

--- a/cocos/particle/renderer/particle-system-renderer-base.ts
+++ b/cocos/particle/renderer/particle-system-renderer-base.ts
@@ -37,7 +37,10 @@ export abstract class ParticleSystemRendererBase {
     /**
      * @engineInternal
      */
-    public _model: ParticleBatchModel | null = null;
+    public get model () {
+        return this._model;
+    }
+    protected _model: ParticleBatchModel | null = null;
     protected _renderInfo: ParticleSystemRenderer | null = null;
     protected _vertAttrs: Attribute[] = [];
     protected _useInstance: boolean;

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -335,7 +335,10 @@ export default class TrailModule {
     private _iBuffer: Uint16Array | null = null;
     private _needTransform = false;
     private _material: Material | null = null;
-    private _inited: boolean;
+    /**\
+     * @engineInternal
+     */
+    public _inited: boolean;
 
     constructor () {
         this._iaInfo = new IndirectBuffer([new DrawInfo()]);

--- a/cocos/particle/renderer/trail.ts
+++ b/cocos/particle/renderer/trail.ts
@@ -335,10 +335,13 @@ export default class TrailModule {
     private _iBuffer: Uint16Array | null = null;
     private _needTransform = false;
     private _material: Material | null = null;
-    /**\
+    /**
      * @engineInternal
      */
-    public _inited: boolean;
+    public get inited () {
+        return this._inited;
+    }
+    private _inited: boolean;
 
     constructor () {
         this._iaInfo = new IndirectBuffer([new DrawInfo()]);

--- a/cocos/profiler/profiler.ts
+++ b/cocos/profiler/profiler.ts
@@ -400,7 +400,6 @@ export class Profiler extends System {
             this.offsetData[3] = surfaceTransform;
         }
 
-        // @ts-expect-error using private members for efficiency.
         this.pass._rootBufferDirty = true;
 
         if (this._meshRenderer.model) {

--- a/cocos/profiler/profiler.ts
+++ b/cocos/profiler/profiler.ts
@@ -400,7 +400,8 @@ export class Profiler extends System {
             this.offsetData[3] = surfaceTransform;
         }
 
-        this.pass.setRootBufferDirty(true);
+        // TODO: on native, we only binding the `_rootBufferDirty` setter. @dumganhar
+        this.pass._rootBufferDirty = true;
 
         if (this._meshRenderer.model) {
             director.root!.pipeline.profiler = this._meshRenderer.model;

--- a/cocos/profiler/profiler.ts
+++ b/cocos/profiler/profiler.ts
@@ -400,7 +400,7 @@ export class Profiler extends System {
             this.offsetData[3] = surfaceTransform;
         }
 
-        this.pass._rootBufferDirty = true;
+        this.pass.setRootBufferDirty(true);
 
         if (this._meshRenderer.model) {
             director.root!.pipeline.profiler = this._meshRenderer.model;

--- a/cocos/render-scene/core/material-instance.ts
+++ b/cocos/render-scene/core/material-instance.ts
@@ -97,7 +97,6 @@ export class MaterialInstance extends Material {
     public onPassStateChange (dontNotify: boolean) {
         this._hash = Material.getHash(this);
         if (!dontNotify && this._owner) {
-            // @ts-expect-error calling protected method here
             this._owner._onRebuildPSO(this._subModelIdx, this);
         }
     }

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -188,7 +188,10 @@ export class Pass {
     protected _bs: BlendState = new BlendState();
     protected _dss: DepthStencilState = new DepthStencilState();
     protected _rs: RasterizerState = new RasterizerState();
-    protected _priority: RenderPriority = RenderPriority.DEFAULT;
+    /**
+     * @engineInternal
+     */
+    public _priority: RenderPriority = RenderPriority.DEFAULT;
     protected _stage: RenderPassStage = RenderPassStage.DEFAULT;
     protected _phase = getPhaseID('default');
     protected _passID = 0xFFFFFFFF;
@@ -203,7 +206,10 @@ export class Pass {
     protected _root: Root;
     protected _device: Device;
 
-    protected  _rootBufferDirty = false;
+    /**
+     * @engineInternal
+     */
+    public  _rootBufferDirty = false;
 
     constructor (root: Root) {
         this._root = root;
@@ -770,8 +776,11 @@ export class Pass {
         return type < Type.FLOAT ? this._blocksInt[binding] : this._blocks[binding];
     }
 
-    // Only for UI
-    private _initPassFromTarget (target: Pass, dss: DepthStencilState, hashFactor: number) {
+    /**
+     * @engineInternal
+     * Only for UI
+     */
+    public _initPassFromTarget (target: Pass, dss: DepthStencilState, hashFactor: number) {
         this._priority = target.priority;
         this._stage = target.stage;
         this._phase = target.phase;
@@ -807,7 +816,10 @@ export class Pass {
     }
 
     // Only for UI
-    private _updatePassHash () {
+    /**
+     * @engineInternal
+     */
+    public _updatePassHash () {
         this._hash = Pass.getPassHash(this);
     }
 

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -188,7 +188,10 @@ export class Pass {
     protected _bs: BlendState = new BlendState();
     protected _dss: DepthStencilState = new DepthStencilState();
     protected _rs: RasterizerState = new RasterizerState();
-    protected _priority: RenderPriority = RenderPriority.DEFAULT;
+    /**
+     * @engineInternal TODO: we haven't bind 'setPriority' setter on native, this is engineInternal only
+     */
+    public _priority: RenderPriority = RenderPriority.DEFAULT;
     protected _stage: RenderPassStage = RenderPassStage.DEFAULT;
     protected _phase = getPhaseID('default');
     protected _passID = 0xFFFFFFFF;
@@ -204,7 +207,7 @@ export class Pass {
     protected _device: Device;
 
     /**
-     * @engineInternal TODO: on native, we only binding the `_rootBufferDirty` setter.
+     * @engineInternal TODO: on native, we only bind the `_rootBufferDirty` setter.
      */
     public _rootBufferDirty = false;
 
@@ -844,11 +847,6 @@ export class Pass {
     get rootBufferDirty (): boolean { return this._rootBufferDirty; }
     // states
     get priority (): RenderPriority { return this._priority; }
-    /**
-     * NOTE: engineInternal tag cannot set only for priority setter
-     * @engineInternal
-     */
-    public setPriority (p: RenderPriority) { this._priority = p; }
     get primitive (): PrimitiveMode { return this._primitive; }
     get stage (): RenderPassStage { return this._stage; }
     get phase (): number { return this._phase; }

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -203,7 +203,10 @@ export class Pass {
     protected _root: Root;
     protected _device: Device;
 
-    protected _rootBufferDirty = false;
+    /**
+     * @engineInternal TODO: on native, we only binding the `_rootBufferDirty` setter.
+     */
+    public _rootBufferDirty = false;
 
     constructor (root: Root) {
         this._root = root;
@@ -839,11 +842,6 @@ export class Pass {
     get blocks (): Float32Array[] { return this._blocks; }
     get blocksInt (): Int32Array[] { return this._blocksInt; }
     get rootBufferDirty (): boolean { return this._rootBufferDirty; }
-    /**
-     * NOTE: engineInternal tag cannot only mark rootBufferDirty setter as internal
-     * @engineInternal
-     */
-    public setRootBufferDirty (v: boolean) { this._rootBufferDirty = v; }
     // states
     get priority (): RenderPriority { return this._priority; }
     /**

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -188,10 +188,7 @@ export class Pass {
     protected _bs: BlendState = new BlendState();
     protected _dss: DepthStencilState = new DepthStencilState();
     protected _rs: RasterizerState = new RasterizerState();
-    /**
-     * @engineInternal
-     */
-    public _priority: RenderPriority = RenderPriority.DEFAULT;
+    protected _priority: RenderPriority = RenderPriority.DEFAULT;
     protected _stage: RenderPassStage = RenderPassStage.DEFAULT;
     protected _phase = getPhaseID('default');
     protected _passID = 0xFFFFFFFF;
@@ -206,10 +203,7 @@ export class Pass {
     protected _root: Root;
     protected _device: Device;
 
-    /**
-     * @engineInternal
-     */
-    public  _rootBufferDirty = false;
+    protected _rootBufferDirty = false;
 
     constructor (root: Root) {
         this._root = root;
@@ -845,8 +839,18 @@ export class Pass {
     get blocks (): Float32Array[] { return this._blocks; }
     get blocksInt (): Int32Array[] { return this._blocksInt; }
     get rootBufferDirty (): boolean { return this._rootBufferDirty; }
+    /**
+     * NOTE: engineInternal tag cannot only mark rootBufferDirty setter as internal
+     * @engineInternal
+     */
+    public setRootBufferDirty (v: boolean) { this._rootBufferDirty = v; }
     // states
     get priority (): RenderPriority { return this._priority; }
+    /**
+     * NOTE: engineInternal tag cannot set only for priority setter
+     * @engineInternal
+     */
+    public setPriority (p: RenderPriority) { this._priority = p; }
     get primitive (): PrimitiveMode { return this._primitive; }
     get stage (): RenderPassStage { return this._stage; }
     get phase (): number { return this._phase; }

--- a/cocos/render-scene/scene/camera.jsb.ts
+++ b/cocos/render-scene/scene/camera.jsb.ts
@@ -132,7 +132,7 @@ const cameraProto: any = jsb.Camera.prototype;
 Object.defineProperty(Camera, "standardExposureValue", {
     configurable: true,
     enumerable: true,
-    get() {
+    get () {
         // TODO: `getStandardExposureValue` only implemented on native platforms. @dumganhar
         return (Camera as any).getStandardExposureValue();
     },
@@ -141,7 +141,7 @@ Object.defineProperty(Camera, "standardExposureValue", {
 Object.defineProperty(Camera, "standardLightMeterScale", {
     configurable: true,
     enumerable: true,
-    get() {
+    get () {
         // TODO: `getStandardLightMeterScale` only implemented on native platforms. @dumganhar
         return (Camera as any).getStandardLightMeterScale();
     },
@@ -150,7 +150,7 @@ Object.defineProperty(Camera, "standardLightMeterScale", {
 Object.defineProperty(cameraProto, 'matView', {
     configurable: true,
     enumerable: true,
-    get() {
+    get () {
         this.getMatView();
         fillMat4WithTempFloatArray(this._matView);
         return this._matView;
@@ -160,7 +160,7 @@ Object.defineProperty(cameraProto, 'matView', {
 Object.defineProperty(cameraProto, 'matProj', {
     configurable: true,
     enumerable: true,
-    get() {
+    get () {
         this.getMatProj();
         fillMat4WithTempFloatArray(this._matProj);
         return this._matProj;
@@ -170,7 +170,7 @@ Object.defineProperty(cameraProto, 'matProj', {
 Object.defineProperty(cameraProto, 'matProjInv', {
     configurable: true,
     enumerable: true,
-    get() {
+    get () {
         this.getMatProjInv();
         fillMat4WithTempFloatArray(this._matProjInv);
         return this._matProjInv;
@@ -180,7 +180,7 @@ Object.defineProperty(cameraProto, 'matProjInv', {
 Object.defineProperty(cameraProto, 'matViewProj', {
     configurable: true,
     enumerable: true,
-    get() {
+    get () {
         this.getMatViewProj();
         fillMat4WithTempFloatArray(this._matViewProj);
         return this._matViewProj;
@@ -190,7 +190,7 @@ Object.defineProperty(cameraProto, 'matViewProj', {
 Object.defineProperty(cameraProto, 'matViewProjInv', {
     configurable: true,
     enumerable: true,
-    get() {
+    get () {
         this.getMatViewProjInv();
         fillMat4WithTempFloatArray(this._matViewProjInv);
         return this._matViewProjInv;
@@ -216,7 +216,7 @@ const oldWorldMatrixToScreen = cameraProto.worldMatrixToScreen;
 /**
  * transform a screen position (in oriented space) to a world space ray
  */
-cameraProto.screenPointToRay = function screenPointToRay(out: geometry.Ray, x: number, y: number): geometry.Ray {
+cameraProto.screenPointToRay = function screenPointToRay (out: geometry.Ray, x: number, y: number): geometry.Ray {
     _tempFloatArray[0] = x;
     _tempFloatArray[1] = y;
     oldScreenPointToRay.call(this);
@@ -231,7 +231,7 @@ cameraProto.screenPointToRay = function screenPointToRay(out: geometry.Ray, x: n
     return out;
 };
 
-cameraProto.screenToWorld = function screenToWorld(out: Vec3, screenPos: Vec3): Vec3 {
+cameraProto.screenToWorld = function screenToWorld (out: Vec3, screenPos: Vec3): Vec3 {
     _tempFloatArray[0] = screenPos.x;
     _tempFloatArray[1] = screenPos.y;
     _tempFloatArray[2] = screenPos.z;
@@ -240,7 +240,7 @@ cameraProto.screenToWorld = function screenToWorld(out: Vec3, screenPos: Vec3): 
     return out;
 };
 
-cameraProto.worldToScreen = function worldToScreen(out: Vec3, worldPos: Vec3 | Readonly<Vec3>): Vec3 {
+cameraProto.worldToScreen = function worldToScreen (out: Vec3, worldPos: Vec3 | Readonly<Vec3>): Vec3 {
     _tempFloatArray[0] = worldPos.x;
     _tempFloatArray[1] = worldPos.y;
     _tempFloatArray[2] = worldPos.z;
@@ -249,7 +249,7 @@ cameraProto.worldToScreen = function worldToScreen(out: Vec3, worldPos: Vec3 | R
     return out;
 };
 
-cameraProto.worldMatrixToScreen = function worldMatrixToScreen(out: Mat4, worldMatrix: Mat4, width: number, height: number) {
+cameraProto.worldMatrixToScreen = function worldMatrixToScreen (out: Mat4, worldMatrix: Mat4, width: number, height: number) {
     _tempFloatArray[0] = worldMatrix.m00;
     _tempFloatArray[1] = worldMatrix.m01;
     _tempFloatArray[2] = worldMatrix.m02;

--- a/cocos/render-scene/scene/camera.jsb.ts
+++ b/cocos/render-scene/scene/camera.jsb.ts
@@ -132,25 +132,25 @@ const cameraProto: any = jsb.Camera.prototype;
 Object.defineProperty(Camera, "standardExposureValue", {
     configurable: true,
     enumerable: true,
-    get () {
-        // @ts-expect-error Property 'getStandardExposureValue' does not exist on type 'typeof Camera'.
-        return Camera.getStandardExposureValue();
+    get() {
+        // TODO: `getStandardExposureValue` only implemented on native platforms. @dumganhar
+        return (Camera as any).getStandardExposureValue();
     },
 });
 
 Object.defineProperty(Camera, "standardLightMeterScale", {
     configurable: true,
     enumerable: true,
-    get () {
-        // @ts-expect-error Property 'getStandardLightMeterScale' does not exist on type 'typeof Camera'.
-        return Camera.getStandardLightMeterScale();
+    get() {
+        // TODO: `getStandardLightMeterScale` only implemented on native platforms. @dumganhar
+        return (Camera as any).getStandardLightMeterScale();
     },
 });
 
 Object.defineProperty(cameraProto, 'matView', {
     configurable: true,
     enumerable: true,
-    get () {
+    get() {
         this.getMatView();
         fillMat4WithTempFloatArray(this._matView);
         return this._matView;
@@ -160,7 +160,7 @@ Object.defineProperty(cameraProto, 'matView', {
 Object.defineProperty(cameraProto, 'matProj', {
     configurable: true,
     enumerable: true,
-    get () {
+    get() {
         this.getMatProj();
         fillMat4WithTempFloatArray(this._matProj);
         return this._matProj;
@@ -170,7 +170,7 @@ Object.defineProperty(cameraProto, 'matProj', {
 Object.defineProperty(cameraProto, 'matProjInv', {
     configurable: true,
     enumerable: true,
-    get () {
+    get() {
         this.getMatProjInv();
         fillMat4WithTempFloatArray(this._matProjInv);
         return this._matProjInv;
@@ -180,7 +180,7 @@ Object.defineProperty(cameraProto, 'matProjInv', {
 Object.defineProperty(cameraProto, 'matViewProj', {
     configurable: true,
     enumerable: true,
-    get () {
+    get() {
         this.getMatViewProj();
         fillMat4WithTempFloatArray(this._matViewProj);
         return this._matViewProj;
@@ -190,7 +190,7 @@ Object.defineProperty(cameraProto, 'matViewProj', {
 Object.defineProperty(cameraProto, 'matViewProjInv', {
     configurable: true,
     enumerable: true,
-    get () {
+    get() {
         this.getMatViewProjInv();
         fillMat4WithTempFloatArray(this._matViewProjInv);
         return this._matViewProjInv;
@@ -199,7 +199,7 @@ Object.defineProperty(cameraProto, 'matViewProjInv', {
 
 const oldInitialize = cameraProto.initialize;
 
-cameraProto.initialize = function initialize () {
+cameraProto.initialize = function initialize() {
     oldInitialize.apply(this, arguments);
     this._matView = new Mat4();
     this._matProj = new Mat4();
@@ -216,7 +216,7 @@ const oldWorldMatrixToScreen = cameraProto.worldMatrixToScreen;
 /**
  * transform a screen position (in oriented space) to a world space ray
  */
-cameraProto.screenPointToRay = function screenPointToRay (out: geometry.Ray, x: number, y: number): geometry.Ray {
+cameraProto.screenPointToRay = function screenPointToRay(out: geometry.Ray, x: number, y: number): geometry.Ray {
     _tempFloatArray[0] = x;
     _tempFloatArray[1] = y;
     oldScreenPointToRay.call(this);
@@ -231,7 +231,7 @@ cameraProto.screenPointToRay = function screenPointToRay (out: geometry.Ray, x: 
     return out;
 };
 
-cameraProto.screenToWorld = function screenToWorld (out: Vec3, screenPos: Vec3): Vec3 {
+cameraProto.screenToWorld = function screenToWorld(out: Vec3, screenPos: Vec3): Vec3 {
     _tempFloatArray[0] = screenPos.x;
     _tempFloatArray[1] = screenPos.y;
     _tempFloatArray[2] = screenPos.z;
@@ -240,7 +240,7 @@ cameraProto.screenToWorld = function screenToWorld (out: Vec3, screenPos: Vec3):
     return out;
 };
 
-cameraProto.worldToScreen = function worldToScreen (out: Vec3, worldPos: Vec3 | Readonly<Vec3>): Vec3 {
+cameraProto.worldToScreen = function worldToScreen(out: Vec3, worldPos: Vec3 | Readonly<Vec3>): Vec3 {
     _tempFloatArray[0] = worldPos.x;
     _tempFloatArray[1] = worldPos.y;
     _tempFloatArray[2] = worldPos.z;
@@ -249,7 +249,7 @@ cameraProto.worldToScreen = function worldToScreen (out: Vec3, worldPos: Vec3 | 
     return out;
 };
 
-cameraProto.worldMatrixToScreen = function worldMatrixToScreen (out: Mat4, worldMatrix: Mat4, width: number, height: number) {
+cameraProto.worldMatrixToScreen = function worldMatrixToScreen(out: Mat4, worldMatrix: Mat4, width: number, height: number) {
     _tempFloatArray[0] = worldMatrix.m00;
     _tempFloatArray[1] = worldMatrix.m01;
     _tempFloatArray[2] = worldMatrix.m02;

--- a/cocos/render-scene/scene/model.ts
+++ b/cocos/render-scene/scene/model.ts
@@ -637,7 +637,6 @@ export class Model {
             this._localDataUpdated = true;
             const worldBounds = this._worldBounds;
             if (this._modelBounds && worldBounds) {
-                // @ts-expect-error TS2445
                 this._modelBounds.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
             }
         }
@@ -654,7 +653,6 @@ export class Model {
             this._localDataUpdated = true;
             const worldBounds = this._worldBounds;
             if (this._modelBounds && worldBounds) {
-                // @ts-expect-error TS2445
                 this._modelBounds.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
             }
         }
@@ -678,7 +676,6 @@ export class Model {
         if (!this._localDataUpdated) { return; }
         this._localDataUpdated = false;
 
-        // @ts-expect-error using private members here for efficiency
         const worldMatrix = this.transform._mat;
         let hasNonInstancingPass = false;
         for (let i = 0; i < subModels.length; i++) {

--- a/cocos/render-scene/scene/model.ts
+++ b/cocos/render-scene/scene/model.ts
@@ -637,7 +637,7 @@ export class Model {
             this._localDataUpdated = true;
             const worldBounds = this._worldBounds;
             if (this._modelBounds && worldBounds) {
-                this._modelBounds.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
+                this._modelBounds.transform(node.w_mat, node.w_pos, node.w_rot, node.w_scale, worldBounds);
             }
         }
     }
@@ -653,7 +653,7 @@ export class Model {
             this._localDataUpdated = true;
             const worldBounds = this._worldBounds;
             if (this._modelBounds && worldBounds) {
-                this._modelBounds.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
+                this._modelBounds.transform(node.w_mat, node.w_pos, node.w_rot, node.w_scale, worldBounds);
             }
         }
     }
@@ -676,7 +676,7 @@ export class Model {
         if (!this._localDataUpdated) { return; }
         this._localDataUpdated = false;
 
-        const worldMatrix = this.transform._mat;
+        const worldMatrix = this.transform.w_mat;
         let hasNonInstancingPass = false;
         for (let i = 0; i < subModels.length; i++) {
             const subModel = subModels[i];

--- a/cocos/render-scene/scene/model.ts
+++ b/cocos/render-scene/scene/model.ts
@@ -637,7 +637,7 @@ export class Model {
             this._localDataUpdated = true;
             const worldBounds = this._worldBounds;
             if (this._modelBounds && worldBounds) {
-                this._modelBounds.transform(node.w_mat, node.w_pos, node.w_rot, node.w_scale, worldBounds);
+                this._modelBounds.transform(node.worldMatrix, node.worldPosition, node.worldRotation, node.worldScale, worldBounds);
             }
         }
     }
@@ -653,7 +653,7 @@ export class Model {
             this._localDataUpdated = true;
             const worldBounds = this._worldBounds;
             if (this._modelBounds && worldBounds) {
-                this._modelBounds.transform(node.w_mat, node.w_pos, node.w_rot, node.w_scale, worldBounds);
+                this._modelBounds.transform(node.worldMatrix, node.worldPosition, node.worldRotation, node.worldScale, worldBounds);
             }
         }
     }

--- a/cocos/render-scene/scene/model.ts
+++ b/cocos/render-scene/scene/model.ts
@@ -676,7 +676,7 @@ export class Model {
         if (!this._localDataUpdated) { return; }
         this._localDataUpdated = false;
 
-        const worldMatrix = this.transform.worldMatrix;
+        const worldMatrix = this.transform._mat;
         let hasNonInstancingPass = false;
         for (let i = 0; i < subModels.length; i++) {
             const subModel = subModels[i];

--- a/cocos/render-scene/scene/model.ts
+++ b/cocos/render-scene/scene/model.ts
@@ -637,7 +637,7 @@ export class Model {
             this._localDataUpdated = true;
             const worldBounds = this._worldBounds;
             if (this._modelBounds && worldBounds) {
-                this._modelBounds.transform(node.worldMatrix, node.worldPosition, node.worldRotation, node.worldScale, worldBounds);
+                this._modelBounds.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
             }
         }
     }
@@ -653,7 +653,7 @@ export class Model {
             this._localDataUpdated = true;
             const worldBounds = this._worldBounds;
             if (this._modelBounds && worldBounds) {
-                this._modelBounds.transform(node.worldMatrix, node.worldPosition, node.worldRotation, node.worldScale, worldBounds);
+                this._modelBounds.transform(node._mat, node._pos, node._rot, node._scale, worldBounds);
             }
         }
     }

--- a/cocos/render-scene/scene/model.ts
+++ b/cocos/render-scene/scene/model.ts
@@ -676,7 +676,7 @@ export class Model {
         if (!this._localDataUpdated) { return; }
         this._localDataUpdated = false;
 
-        const worldMatrix = this.transform.w_mat;
+        const worldMatrix = this.transform.worldMatrix;
         let hasNonInstancingPass = false;
         for (let i = 0; i < subModels.length; i++) {
             const subModel = subModels[i];

--- a/cocos/scene-graph/component.ts
+++ b/cocos/scene-graph/component.ts
@@ -359,8 +359,8 @@ class Component extends CCObject {
 
     public destroy () {
         if (EDITOR) {
-            // @ts-expect-error private function access
-            const depend = this.node._getDependComponent(this);
+            // TODO: `_getDependComponent` is an injected method.
+            const depend = (this.node as any)._getDependComponent(this);
             if (depend.length > 0) {
                 errorID(3626,
                     getClassName(this), getClassName(depend[0]));
@@ -647,45 +647,31 @@ class Component extends CCObject {
     protected onRestore? (): void;
 }
 
-const proto = Component.prototype;
-// @ts-expect-error modify prototype
+// NOTE: here we access the protected properties in Component, so we need to mark it as type of any.
+const proto = Component.prototype as any;
 proto.update = undefined;
-// @ts-expect-error modify prototype
 proto.lateUpdate = undefined;
-// @ts-expect-error modify prototype
 proto.__preload = undefined;
-// @ts-expect-error modify prototype
 proto.onLoad = undefined;
-// @ts-expect-error modify prototype
 proto.start = undefined;
-// @ts-expect-error modify prototype
 proto.onEnable = undefined;
-// @ts-expect-error modify prototype
 proto.onDisable = undefined;
-// @ts-expect-error modify prototype
 proto.onDestroy = undefined;
 proto.onFocusInEditor = undefined;
 proto.onLostFocusInEditor = undefined;
 proto.resetInEditor = undefined;
-// @ts-expect-error modify prototype
 proto._getLocalBounds = undefined;
-// @ts-expect-error modify prototype
 proto.onRestore = undefined;
-// @ts-expect-error modify class
-Component._requireComponent = null;
-// @ts-expect-error modify class
-Component._executionOrder = 0;
+// NOTE: these are all injected properties
+(Component as any)._requireComponent = null;
+(Component as any)._executionOrder = 0;
 
 if (EDITOR || TEST) {
     // INHERITABLE STATIC MEMBERS
-    // @ts-expect-error modify static member
-    Component._executeInEditMode = false;
-    // @ts-expect-error modify static member
-    Component._playOnFocus = false;
-    // @ts-expect-error modify static member
-    Component._disallowMultiple = null;
-    // @ts-expect-error modify static member
-    Component._help = '';
+    (Component as any)._executeInEditMode = false;
+    (Component as any)._playOnFocus = false;
+    (Component as any)._disallowMultiple = null;
+    (Component as any)._help = '';
 
     // NON-INHERITED STATIC MEMBERS
     // (TypeScript 2.3 will still inherit them, so always check hasOwnProperty before using)

--- a/cocos/scene-graph/node-activator.ts
+++ b/cocos/scene-graph/node-activator.ts
@@ -131,7 +131,6 @@ function _componentCorrupted (node, comp, index) {
 
 function _onLoadInEditor (comp) {
     if (comp.onLoad && !legacyCC.GAME_VIEW) {
-        // @ts-expect-error Editor API usage
         const focused = Editor.Selection.getLastSelected('node') === comp.node.uuid;
         if (focused) {
             if (comp.onFocusInEditor && callOnFocusInTryCatch) {

--- a/cocos/scene-graph/node-event-processor.ts
+++ b/cocos/scene-graph/node-event-processor.ts
@@ -158,7 +158,6 @@ export class NodeEventProcessor {
         if (recursive && children.length > 0) {
             for (let i = 0; i < children.length; ++i) {
                 const child = children[i];
-                // @ts-expect-error child._eventProcessor is a protected property.
                 child._eventProcessor.setEnabled(value, true);
             }
         }
@@ -463,7 +462,6 @@ export class NodeEventProcessor {
      */
     private _newCallbacksInvoker (): CallbacksInvoker<SystemEventTypeUnion> {
         const callbacksInvoker = new CallbacksInvoker<SystemEventTypeUnion>();
-        // @ts-expect-error Property '_registerOffCallback' is private
         callbacksInvoker._registerOffCallback(() => {
             if (this.shouldHandleEventTouch && !this._hasTouchListeners()) {
                 this.shouldHandleEventTouch = false;
@@ -480,7 +478,10 @@ export class NodeEventProcessor {
 
     // #region handle mouse event
 
-    private _handleEventMouse (eventMouse: EventMouse): boolean {
+    /**
+     * @engineInternal
+     */
+    public _handleEventMouse (eventMouse: EventMouse): boolean {
         switch (eventMouse.type) {
         case InputEventType.MOUSE_DOWN:
             return this._handleMouseDown(eventMouse);
@@ -589,7 +590,10 @@ export class NodeEventProcessor {
 
     // #region handle touch event
 
-    private _handleEventTouch (eventTouch: EventTouch) {
+    /**
+     * @engineInternal
+     */
+    public _handleEventTouch (eventTouch: EventTouch) {
         switch (eventTouch.type) {
         case InputEventType.TOUCH_START:
             return this._handleTouchStart(eventTouch);

--- a/cocos/scene-graph/node-event-processor.ts
+++ b/cocos/scene-graph/node-event-processor.ts
@@ -158,7 +158,8 @@ export class NodeEventProcessor {
         if (recursive && children.length > 0) {
             for (let i = 0; i < children.length; ++i) {
                 const child = children[i];
-                child._eventProcessor.setEnabled(value, true);
+                // NOTE: for circular reference reason, eventProcessor is typeof any, so it's OK to mark child as any
+                (child as any)._eventProcessor.setEnabled(value, true);
             }
         }
         // When a node is dispatching touch events and the node is set to disabled,

--- a/cocos/scene-graph/node-ui-properties.ts
+++ b/cocos/scene-graph/node-ui-properties.ts
@@ -67,8 +67,9 @@ export class NodeUIProperties {
     /**
      * @en The opacity of the UI node for final rendering
      * @zh 最终显示的 UI 透明度，受父节点透明度影响
+     * @engineInternal
      */
-    private _opacity = 1;
+    public _opacity = 1;
     public get opacity () { return this._opacity; }
 
     /**

--- a/cocos/scene-graph/node-ui-properties.ts
+++ b/cocos/scene-graph/node-ui-properties.ts
@@ -67,9 +67,13 @@ export class NodeUIProperties {
     /**
      * @en The opacity of the UI node for final rendering
      * @zh 最终显示的 UI 透明度，受父节点透明度影响
+     */
+    private _opacity = 1;
+    /**
+     * NOTE: engineInternal tag cannot only mark opacity setter as internal.
      * @engineInternal
      */
-    public _opacity = 1;
+    public setOpacity (v: number) { this._opacity = v; }
     public get opacity () { return this._opacity; }
 
     /**

--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -83,8 +83,8 @@ const nodeProto: any = jsb.Node.prototype;
 export const TRANSFORM_ON = 1 << 0;
 const Destroying = CCObject.Flags.Destroying;
 
-// @ts-expect-error TODO: Property '_setTempFloatArray' does not exist on type 'typeof Node'.
-Node._setTempFloatArray(_tempFloatArray.buffer);
+// TODO: `_setTempFloatArray` is only implemented on Native platforms. @dumganhar
+(Node as any)._setTempFloatArray(_tempFloatArray.buffer);
 
 function getConstructor<T>(typeOrClassName) {
     if (!typeOrClassName) {
@@ -379,8 +379,8 @@ nodeProto._registerIfAttached = !EDITOR ? undefined : function (this: Node, atta
     const children = this._children;
     for (let i = 0, len = children.length; i < len; ++i) {
         const child = children[i];
-        // @ts-expect-error TODO: Property '_registerIfAttached' does not exist on type 'Node'.
-        child._registerIfAttached(attached);
+        // TODO: `_registerIfAttached` is an injected property.
+        (child as any)._registerIfAttached(attached);
     }
 };
 
@@ -1271,7 +1271,6 @@ nodeProto._instantiate = function (cloned: Node, isSyncedNode: boolean) {
         cloned = legacyCC.instantiate._clone(this, this);
     }
 
-    // @ts-expect-error TODO: access protected property
     const newPrefabInfo = cloned._prefab;
     if (EDITOR && newPrefabInfo) {
         if (cloned === newPrefabInfo.root) {
@@ -1282,17 +1281,16 @@ nodeProto._instantiate = function (cloned: Node, isSyncedNode: boolean) {
         }
     }
     if (EDITOR && legacyCC.GAME_VIEW) {
-        // @ts-expect-error TODO: Property 'sync' does not exist on type 'PrefabInfo'.
-        const syncing = newPrefabInfo && cloned === newPrefabInfo.root && newPrefabInfo.sync;
+        // TODO: Property 'sync' does not exist on type 'PrefabInfo'.
+        const syncing = newPrefabInfo && cloned === newPrefabInfo.root && (newPrefabInfo as any).sync;
         if (!syncing) {
-            // @ts-expect-error TODO: access protected property
-            cloned._name += ' (Clone)';
+            cloned.name += ' (Clone)';
         }
     }
 
     // reset and init
-    // @ts-expect-error access protected property
-    cloned._parent = null;
+    // NOTE: access protected property
+    (cloned as any)._parent = null;
     cloned._onBatchCreated(isSyncedNode);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -336,8 +336,11 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
         }
     }
 
+    /**
+     * @engineInternal this is engineInternal for it doesn't have side effect of setting parent.
+     */
     @serializable
-    protected _parent: this | null = null;
+    public _parent: this | null = null;
 
     @serializable
     protected _children: this[] = [];
@@ -356,9 +359,8 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
     /**
      * @engineInternal The PrefabInfo object
      */
-    public get prefab () { return this._prefab; }
     @serializable
-    protected _prefab: PrefabInfo | null = null;
+    public _prefab: PrefabInfo | null = null;
 
     protected _scene: Scene = null!;
 
@@ -375,7 +377,10 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
     protected _eventProcessor: any = new legacyCC.NodeEventProcessor(this);
     protected _eventMask = 0;
 
-    protected _siblingIndex = 0;
+    /**
+     * @engineInternal this is engineInternal for it doesn't have side effect of setting sibling index
+     */
+    public _siblingIndex = 0;
 
     /**
      * @en
@@ -1458,14 +1463,22 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * @deprecated since v3.5.0, this is an engine private interface that will be removed in the future.
      */
     public _static = false;
-
-    protected declare _pos: Vec3;
-
-    protected declare _rot: Quat;
-
-    protected declare _scale: Vec3;
-
-    protected declare _mat: Mat4;
+    /**
+     * @engineInternal NOTE: this is engineInternal interface that doesn't have a side effect of updating the transforms
+     */
+    public declare _pos: Vec3;
+    /**
+     * @engineInternal NOTE: this is engineInternal interface that doesn't have a side effect of updating the transforms
+     */
+    public declare _rot: Quat;
+    /**
+     * @engineInternal NOTE: this is engineInternal interface that doesn't have a side effect of updating the transforms
+     */
+    public declare _scale: Vec3;
+    /**
+     * @engineInternal NOTE: this is engineInternal interface that doesn't have a side effect of updating the transforms
+     */
+    public declare _mat: Mat4;
 
     // local transform
     @serializable

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -336,32 +336,29 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
         }
     }
 
-    /**
-     * @engineInternal
-     */
     @serializable
-    public _parent: this | null = null;
+    protected _parent: this | null = null;
 
-    /**
-     * @engineInternal
-     */
     @serializable
-    public _children: this[] = [];
+    protected _children: this[] = [];
 
     @serializable
     protected _active = true;
 
     /**
+     * NOTE: components getter is typeof ReadonlyArray
      * @engineInternal
      */
+    public getWritableComponents () { return this._components; }
     @serializable
-    public _components: Component[] = [];
+    protected _components: Component[] = [];
 
     /**
      * @engineInternal The PrefabInfo object
      */
+    public get prefab () { return this._prefab; }
     @serializable
-    public _prefab: PrefabInfo | null = null;
+    protected _prefab: PrefabInfo | null = null;
 
     protected _scene: Scene = null!;
 
@@ -370,20 +367,15 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
     /**
      * @engineInternal
      */
-    public _id: string = idGenerator.getNewId();
+    public set id (v: string) { this._id = v; }
+    protected _id: string = idGenerator.getNewId();
 
     protected _name: string;
 
-    /**
-     * @engineInternal
-     */
-    public _eventProcessor: any = new legacyCC.NodeEventProcessor(this);
+    protected _eventProcessor: any = new legacyCC.NodeEventProcessor(this);
     protected _eventMask = 0;
 
-    /**
-     * @engineInternal
-     */
-    public _siblingIndex = 0;
+    protected _siblingIndex = 0;
 
     /**
      * @en
@@ -1470,22 +1462,34 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
     /**
      * @engineInternal world transform, don't access this directly
      */
-    public declare _pos: Vec3;
+    public get w_pos () {
+        return this._pos;
+    }
+    protected declare _pos: Vec3;
 
     /**
-     * @engineInternal
+     * @engineInternal world transform, don't access this directly
      */
-    public declare _rot: Quat;
+    public get w_rot () {
+        return this._rot;
+    }
+    protected declare _rot: Quat;
 
     /**
-     * @engineInternal
+     * @engineInternal world transform, don't access this directly
      */
-    public declare _scale: Vec3;
+    public get w_scale () {
+        return this._scale;
+    }
+    protected declare _scale: Vec3;
 
     /**
-     * @engineInternal
+     * @engineInternal world transform, don't access this directly
      */
-    public declare _mat: Mat4;
+    public get w_mat () {
+        return this._mat;
+    }
+    protected declare _mat: Mat4;
 
     // local transform
     @serializable

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -268,8 +268,8 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
     protected static _findComponent<T extends Component> (node: Node, constructor: Constructor<T> | AbstractedConstructor<T>): T | null {
         const cls = constructor;
         const comps = node._components;
-        // @ts-expect-error internal rtti property
-        if (cls._sealed) {
+        // NOTE: internal rtti property
+        if ((cls as any)._sealed) {
             for (let i = 0; i < comps.length; ++i) {
                 const comp = comps[i];
                 if (comp.constructor === constructor) {
@@ -290,8 +290,8 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
     protected static _findComponents<T extends Component> (node: Node, constructor: Constructor<T> | AbstractedConstructor<T>, components: Component[]) {
         const cls = constructor;
         const comps = node._components;
-        // @ts-expect-error internal rtti property
-        if (cls._sealed) {
+        // NOTE: internal rtti property
+        if ((cls as any)._sealed) {
             for (let i = 0; i < comps.length; ++i) {
                 const comp = comps[i];
                 if (comp.constructor === constructor) {
@@ -336,34 +336,54 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
         }
     }
 
+    /**
+     * @engineInternal
+     */
     @serializable
-    protected _parent: this | null = null;
+    public _parent: this | null = null;
 
+    /**
+     * @engineInternal
+     */
     @serializable
-    protected _children: this[] = [];
+    public _children: this[] = [];
 
     @serializable
     protected _active = true;
 
+    /**
+     * @engineInternal
+     */
     @serializable
-    protected _components: Component[] = [];
+    public _components: Component[] = [];
 
-    // The PrefabInfo object
+    /**
+     * @engineInternal The PrefabInfo object
+     */
     @serializable
-    protected _prefab: PrefabInfo | null = null;
+    public _prefab: PrefabInfo | null = null;
 
     protected _scene: Scene = null!;
 
     protected _activeInHierarchy = false;
 
-    protected _id: string = idGenerator.getNewId();
+    /**
+     * @engineInternal
+     */
+    public _id: string = idGenerator.getNewId();
 
     protected _name: string;
 
-    protected _eventProcessor: any = new legacyCC.NodeEventProcessor(this);
+    /**
+     * @engineInternal
+     */
+    public _eventProcessor: any = new legacyCC.NodeEventProcessor(this);
     protected _eventMask = 0;
 
-    protected _siblingIndex = 0;
+    /**
+     * @engineInternal
+     */
+    public _siblingIndex = 0;
 
     /**
      * @en
@@ -1313,12 +1333,12 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
             const inCurrentSceneNow = newParent && newParent.isChildOf(scene);
             if (!inCurrentSceneBefore && inCurrentSceneNow) {
                 // attached
-                // @ts-expect-error Polyfilled functions in node-dev.ts
-                this._registerIfAttached!(true);
+                // TODO: `_registerIfAttached` is injected property
+                (this as any)._registerIfAttached!(true);
             } else if (inCurrentSceneBefore && !inCurrentSceneNow) {
                 // detached
-                // @ts-expect-error Polyfilled functions in node-dev.ts
-                this._registerIfAttached!(false);
+                // TODO: `_registerIfAttached` is injected property
+                (this as any)._registerIfAttached!(false);
             }
 
             // conflict detection
@@ -1339,8 +1359,8 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
         const parent = this._parent;
         const destroyByParent: boolean = (!!parent) && ((parent._objFlags & Destroying) !== 0);
         if (!destroyByParent && EDITOR) {
-            // @ts-expect-error Polyfilled functions in node-dev.ts
-            this._registerIfAttached!(false);
+            // TODO: `_registerIfAttached` is injected property
+            (this as any)._registerIfAttached!(false);
         }
 
         // remove from persist
@@ -1447,14 +1467,25 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      */
     public _static = false;
 
-    // world transform, don't access this directly
-    protected declare _pos: Vec3;
+    /**
+     * @engineInternal world transform, don't access this directly
+     */
+    public declare _pos: Vec3;
 
-    protected declare _rot: Quat;
+    /**
+     * @engineInternal
+     */
+    public declare _rot: Quat;
 
-    protected declare _scale: Vec3;
+    /**
+     * @engineInternal
+     */
+    public declare _scale: Vec3;
 
-    protected declare _mat: Mat4;
+    /**
+     * @engineInternal
+     */
+    public declare _mat: Mat4;
 
     // local transform
     @serializable

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -1459,36 +1459,12 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      */
     public _static = false;
 
-    /**
-     * @engineInternal world transform, don't access this directly
-     */
-    public get w_pos () {
-        return this._pos;
-    }
     protected declare _pos: Vec3;
 
-    /**
-     * @engineInternal world transform, don't access this directly
-     */
-    public get w_rot () {
-        return this._rot;
-    }
     protected declare _rot: Quat;
 
-    /**
-     * @engineInternal world transform, don't access this directly
-     */
-    public get w_scale () {
-        return this._scale;
-    }
     protected declare _scale: Vec3;
 
-    /**
-     * @engineInternal world transform, don't access this directly
-     */
-    public get w_mat () {
-        return this._mat;
-    }
     protected declare _mat: Mat4;
 
     // local transform

--- a/cocos/scene-graph/prefab/prefab.ts
+++ b/cocos/scene-graph/prefab/prefab.ts
@@ -144,7 +144,10 @@ export class Prefab extends Asset {
     // just instantiate, will not initialize the Node, this will be called during Node's initialization.
     // @param {Node} [rootToRedirect] - specify an instantiated prefabRoot that all references to prefabRoot in prefab
     //                                  will redirect to
-    private _doInstantiate (rootToRedirect?: any) {
+    /**
+     * @engineInternal
+     */
+    public _doInstantiate (rootToRedirect?: any) {
         if (!this.data._prefab) {
             // temp guard code
             warnID(3700);

--- a/cocos/scene-graph/prefab/utils.ts
+++ b/cocos/scene-graph/prefab/utils.ts
@@ -81,7 +81,7 @@ export function createNodeWithPrefab (node: Node) {
     // restore preserved props
     node._objFlags = _objFlags;
     node.setParent(_parent);
-    node._id = _id;
+    node.id = _id;
     if (EDITOR) {
         node[editorExtrasTag] = editorExtras;
     }

--- a/cocos/scene-graph/prefab/utils.ts
+++ b/cocos/scene-graph/prefab/utils.ts
@@ -33,7 +33,7 @@ import { ValueType } from '../../core/value-types';
 export * from './prefab-info';
 
 export function createNodeWithPrefab (node: Node) {
-    const prefabInfo = node.prefab;
+    const prefabInfo = node._prefab;
     if (!prefabInfo) {
         return;
     }
@@ -59,7 +59,7 @@ export function createNodeWithPrefab (node: Node) {
     const _objFlags = node._objFlags;
     const _parent = node.getParent();
     const _id = node.uuid;
-    const _prefab = node.prefab;
+    const _prefab = node._prefab;
     const editorExtras = node[editorExtrasTag];
 
     // instantiate prefab
@@ -80,15 +80,15 @@ export function createNodeWithPrefab (node: Node) {
 
     // restore preserved props
     node._objFlags = _objFlags;
-    node.setParent(_parent);
+    node._parent = _parent;
     node.id = _id;
     if (EDITOR) {
         node[editorExtrasTag] = editorExtras;
     }
 
-    if (node.prefab) {
+    if (node._prefab) {
         // just keep the instance
-        node.prefab.instance = _prefab?.instance;
+        node._prefab.instance = _prefab?.instance;
     }
 }
 
@@ -104,13 +104,13 @@ export function generateTargetMap (node: Node, targetMap: any, isRoot: boolean) 
 
     let curTargetMap = targetMap;
 
-    const prefabInstance = node.prefab?.instance;
+    const prefabInstance = node._prefab?.instance;
     if (!isRoot && prefabInstance) {
         targetMap[prefabInstance.fileId] = {};
         curTargetMap = targetMap[prefabInstance.fileId];
     }
 
-    const prefabInfo = node.prefab;
+    const prefabInfo = node._prefab;
     if (prefabInfo) {
         curTargetMap[prefabInfo.fileId] = node;
     }
@@ -177,7 +177,7 @@ export function applyMountedChildren (node: Node, mountedChildren: MountedChildr
                     }
 
                     target.children.push(childNode);
-                    childNode.setParent(target);
+                    childNode._parent = target;
                     if (EDITOR) {
                         if (!childNode[editorExtrasTag]) {
                             childNode[editorExtrasTag] = {};
@@ -187,7 +187,7 @@ export function applyMountedChildren (node: Node, mountedChildren: MountedChildr
                     }
                     // mounted node need to add to the target map
                     generateTargetMap(childNode, curTargetMap, false);
-                    childNode.setSiblingIndex(target.children.length - 1);
+                    childNode._siblingIndex = target.children.length - 1;
                     expandPrefabInstanceNode(childNode, true);
                 }
             }
@@ -310,7 +310,7 @@ export function applyPropertyOverrides (node: Node, propertyOverrides: PropertyO
 }
 
 export function applyTargetOverrides (node: Node) {
-    const targetOverrides = node.prefab?.targetOverrides;
+    const targetOverrides = node._prefab?.targetOverrides;
     if (targetOverrides) {
         for (let i = 0; i < targetOverrides.length; i++) {
             const targetOverride = targetOverrides[i];
@@ -319,7 +319,7 @@ export function applyTargetOverrides (node: Node) {
             const sourceInfo = targetOverride.sourceInfo;
             if (sourceInfo) {
                 // TODO: targetOverride.source is type of `Node | Component`, while `_prefab` does not exist on type 'Component'.
-                const sourceInstance = (targetOverride.source as Node)?.prefab?.instance;
+                const sourceInstance = (targetOverride.source as Node)?._prefab?.instance;
                 if (sourceInstance && sourceInstance.targetMap) {
                     source = getTarget(sourceInfo.localID, sourceInstance.targetMap);
                 }
@@ -336,7 +336,7 @@ export function applyTargetOverrides (node: Node) {
                 continue;
             }
 
-            const targetInstance = targetOverride.target?.prefab?.instance;
+            const targetInstance = targetOverride.target?._prefab?.instance;
             if (!targetInstance || !targetInstance.targetMap) {
                 continue;
             }
@@ -373,7 +373,7 @@ export function applyTargetOverrides (node: Node) {
 }
 
 export function expandPrefabInstanceNode (node: Node, recursively = false) {
-    const prefabInfo = node.prefab;
+    const prefabInfo = node._prefab;
     const prefabInstance = prefabInfo?.instance;
     if (prefabInstance && !prefabInstance.expanded) {
         createNodeWithPrefab(node);
@@ -404,14 +404,14 @@ export function expandPrefabInstanceNode (node: Node, recursively = false) {
 }
 
 export function expandNestedPrefabInstanceNode (node: Node) {
-    const prefabInfo = node.prefab;
+    const prefabInfo = node._prefab;
 
     if (prefabInfo && prefabInfo.nestedPrefabInstanceRoots) {
         prefabInfo.nestedPrefabInstanceRoots.forEach((instanceNode: Node) => {
             expandPrefabInstanceNode(instanceNode);
             // when expanding the prefab,it's children will be change,so need to apply after expanded
             if (!EDITOR) {
-                applyNodeAndComponentId(instanceNode, instanceNode.prefab?.instance?.fileId ?? '');
+                applyNodeAndComponentId(instanceNode, instanceNode._prefab?.instance?.fileId ?? '');
             }
         });
     }
@@ -427,7 +427,7 @@ export function applyNodeAndComponentId (prefabInstanceNode: Node, rootId: strin
     }
     for (let i = 0; i < children.length; i++) {
         const child = children[i];
-        const prefabInfo = child.prefab!;
+        const prefabInfo = child._prefab!;
         const fileId = prefabInfo?.instance ? prefabInfo.instance.fileId : prefabInfo?.fileId;
         if (!fileId) continue;
         child.id = `${rootId}${fileId}`;

--- a/cocos/scene-graph/prefab/utils.ts
+++ b/cocos/scene-graph/prefab/utils.ts
@@ -33,7 +33,6 @@ import { ValueType } from '../../core/value-types';
 export * from './prefab-info';
 
 export function createNodeWithPrefab (node: Node) {
-    // @ts-expect-error: private member access
     const prefabInfo = node._prefab;
     if (!prefabInfo) {
         return;
@@ -58,18 +57,14 @@ export function createNodeWithPrefab (node: Node) {
 
     // save root's preserved props to avoid overwritten by prefab
     const _objFlags = node._objFlags;
-    // @ts-expect-error: private member access
     const _parent = node._parent;
-    // @ts-expect-error: private member access
     const _id = node._id;
-    // @ts-expect-error: private member access
     const _prefab = node._prefab;
     const editorExtras = node[editorExtrasTag];
 
     // instantiate prefab
     cclegacy.game._isCloning = true;
     if (SUPPORT_JIT) {
-        // @ts-expect-error: private member access
         prefabInfo.asset._doInstantiate(node);
     } else {
         // root in prefab asset is always synced
@@ -85,18 +80,14 @@ export function createNodeWithPrefab (node: Node) {
 
     // restore preserved props
     node._objFlags = _objFlags;
-    // @ts-expect-error: private member access
     node._parent = _parent;
-    // @ts-expect-error: private member access
     node._id = _id;
     if (EDITOR) {
         node[editorExtrasTag] = editorExtras;
     }
 
-    // @ts-expect-error: private member access
     if (node._prefab) {
         // just keep the instance
-        // @ts-expect-error: private member access
         node._prefab.instance = _prefab?.instance;
     }
 }
@@ -113,14 +104,12 @@ export function generateTargetMap (node: Node, targetMap: any, isRoot: boolean) 
 
     let curTargetMap = targetMap;
 
-    // @ts-expect-error: private member access
     const prefabInstance = node._prefab?.instance;
     if (!isRoot && prefabInstance) {
         targetMap[prefabInstance.fileId] = {};
         curTargetMap = targetMap[prefabInstance.fileId];
     }
 
-    // @ts-expect-error: private member access
     const prefabInfo = node._prefab;
     if (prefabInfo) {
         curTargetMap[prefabInfo.fileId] = node;
@@ -183,26 +172,23 @@ export function applyMountedChildren (node: Node, mountedChildren: MountedChildr
                 for (let i = 0; i < childInfo.nodes.length; i++) {
                     const childNode = childInfo.nodes[i];
 
-                    // @ts-expect-error private member access
                     if (!childNode || target._children.includes(childNode)) {
                         continue;
                     }
 
-                    // @ts-expect-error private member access
                     target._children.push(childNode);
-                    // @ts-expect-error: private member access
                     childNode._parent = target;
                     if (EDITOR) {
                         if (!childNode[editorExtrasTag]) {
                             childNode[editorExtrasTag] = {};
                         }
-                        // @ts-expect-error editor polyfill
-                        childNode[editorExtrasTag].mountedRoot = node;
+                        // NOTE: editor polyfill
+                        (childNode[editorExtrasTag] as any).mountedRoot = node;
                     }
                     // mounted node need to add to the target map
                     generateTargetMap(childNode, curTargetMap, false);
                     // siblingIndex update is in _onBatchCreated function, and it p needs a parent.
-                    // @ts-expect-error private member access
+                    // TODO: access private property
                     childNode._siblingIndex = target._children.length - 1;
                     expandPrefabInstanceNode(childNode, true);
                 }
@@ -236,10 +222,9 @@ export function applyMountedComponents (node: Node, mountedComponents: MountedCo
                         if (!comp[editorExtrasTag]) {
                             comp[editorExtrasTag] = {};
                         }
-                        // @ts-expect-error editor polyfill
-                        comp[editorExtrasTag].mountedRoot = node;
+                        // TODO: editor polyfill
+                        (comp[editorExtrasTag] as any).mountedRoot = node;
                     }
-                    // @ts-expect-error private member access
                     target._components.push(comp);
                 }
             }
@@ -262,7 +247,6 @@ export function applyRemovedComponents (node: Node, removedComponents: TargetInf
 
             const index = target.node.components.indexOf(target);
             if (index >= 0) {
-                // @ts-expect-error private member access
                 target.node._components.splice(index, 1);
             }
         }
@@ -328,7 +312,6 @@ export function applyPropertyOverrides (node: Node, propertyOverrides: PropertyO
 }
 
 export function applyTargetOverrides (node: Node) {
-    // @ts-expect-error private member access
     const targetOverrides = node._prefab?.targetOverrides;
     if (targetOverrides) {
         for (let i = 0; i < targetOverrides.length; i++) {
@@ -337,8 +320,8 @@ export function applyTargetOverrides (node: Node) {
             let source: Node | Component | null = targetOverride.source;
             const sourceInfo = targetOverride.sourceInfo;
             if (sourceInfo) {
-                // @ts-expect-error private member access
-                const sourceInstance = targetOverride.source?._prefab?.instance;
+                // TODO: targetOverride.source is type of `Node | Component`, while `_prefab` does not exist on type 'Component'.
+                const sourceInstance = (targetOverride.source as Node)?._prefab?.instance;
                 if (sourceInstance && sourceInstance.targetMap) {
                     source = getTarget(sourceInfo.localID, sourceInstance.targetMap);
                 }
@@ -355,7 +338,6 @@ export function applyTargetOverrides (node: Node) {
                 continue;
             }
 
-            // @ts-expect-error private member access
             const targetInstance = targetOverride.target?._prefab?.instance;
             if (!targetInstance || !targetInstance.targetMap) {
                 continue;
@@ -393,7 +375,6 @@ export function applyTargetOverrides (node: Node) {
 }
 
 export function expandPrefabInstanceNode (node: Node, recursively = false) {
-    // @ts-expect-error private member access
     const prefabInfo = node._prefab;
     const prefabInstance = prefabInfo?.instance;
     if (prefabInstance && !prefabInstance.expanded) {
@@ -425,7 +406,6 @@ export function expandPrefabInstanceNode (node: Node, recursively = false) {
 }
 
 export function expandNestedPrefabInstanceNode (node: Node) {
-    // @ts-expect-error private member access
     const prefabInfo = node._prefab;
 
     if (prefabInfo && prefabInfo.nestedPrefabInstanceRoots) {
@@ -433,7 +413,6 @@ export function expandNestedPrefabInstanceNode (node: Node) {
             expandPrefabInstanceNode(instanceNode);
             // when expanding the prefab,it's children will be change,so need to apply after expanded
             if (!EDITOR) {
-                // @ts-expect-error private member access
                 applyNodeAndComponentId(instanceNode, instanceNode._prefab?.instance?.fileId);
             }
         });
@@ -450,11 +429,9 @@ export function applyNodeAndComponentId (prefabInstanceNode: Node, rootId: strin
     }
     for (let i = 0; i < children.length; i++) {
         const child = children[i];
-        // @ts-expect-error private member access
         const prefabInfo = child._prefab!;
         const fileId = prefabInfo?.instance ? prefabInfo.instance.fileId : prefabInfo?.fileId;
         if (!fileId) continue;
-        // @ts-expect-error private member access
         child._id = `${rootId}${fileId}`;
 
         // ignore prefab instance,because it will be apply in 'nestedPrefabInstanceRoots' for loop;

--- a/cocos/scene-graph/scene.jsb.ts
+++ b/cocos/scene-graph/scene.jsb.ts
@@ -81,8 +81,8 @@ Object.defineProperty(sceneProto, 'renderScene', {
 });
 
 sceneProto._ctor = function () {
-    // @ts-expect-error TODO: Property '_ctor' does not exist on type 'Node'.
-    Node.prototype._ctor.apply(this, arguments);
+    // TODO: Property '_ctor' does not exist on type 'Node'.
+    (Node.prototype as any)._ctor.apply(this, arguments);
     this._inited = false;
     this._renderSceneInternal = null;
     this._globalRef = null;

--- a/cocos/scene-graph/scene.ts
+++ b/cocos/scene-graph/scene.ts
@@ -161,7 +161,10 @@ export class Scene extends Node {
 
     protected _instantiate () { }
 
-    protected _load () {
+    /**
+     * @engineInternal
+     */
+    public _load () {
         if (!this._inited) {
             if (TEST) {
                 assert(!this._activeInHierarchy, 'Should deactivate ActionManager by default');
@@ -176,12 +179,14 @@ export class Scene extends Node {
         this.walk(Node._setScene);
     }
 
-    protected _activate (active: boolean) {
-        active = (active !== false);
+    /**
+     * @engineInternal
+     */
+    public _activate (active = true) {
         if (EDITOR) {
             // register all nodes to editor
-            // @ts-expect-error Polyfilled functions in node-dev.ts
-            this._registerIfAttached!(active);
+            // TODO: `_registerIfAttached` is injected property
+            (this as any)._registerIfAttached!(active);
         }
         legacyCC.director._nodeActivator.activateNode(this, active);
         // The test environment does not currently support the renderer

--- a/cocos/serialization/deserialize-dynamic.ts
+++ b/cocos/serialization/deserialize-dynamic.ts
@@ -351,26 +351,25 @@ class DeserializerPool extends js.Pool<_Deserializer> {
             deserializer.clear();
         }, 1);
     }
-
-    // TODO: don't know how to fix this typing
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error We only use this signature.
-    public get (
-        details: Details,
-        classFinder: ClassFinder,
-        reportMissingClass: ReportMissingClass,
-        customEnv: unknown,
-        ignoreEditorOnly: boolean | undefined,
-    ) {
-        const cache = this._get();
-        if (cache) {
-            cache.reset(details, classFinder, reportMissingClass, customEnv, ignoreEditorOnly);
-            return cache;
-        } else {
-            return new _Deserializer(details, classFinder, reportMissingClass, customEnv, ignoreEditorOnly);
-        }
-    }
 }
+
+// HACK: we've changed the method signature
+(DeserializerPool.prototype as any).get = function (
+    this: DeserializerPool,
+    details: Details,
+    classFinder: ClassFinder,
+    reportMissingClass: ReportMissingClass,
+    customEnv: unknown,
+    ignoreEditorOnly: boolean | undefined,
+) {
+    const cache = this._get();
+    if (cache) {
+        cache.reset(details, classFinder, reportMissingClass, customEnv, ignoreEditorOnly);
+        return cache;
+    } else {
+        return new _Deserializer(details, classFinder, reportMissingClass, customEnv, ignoreEditorOnly);
+    }
+};
 
 class _Deserializer {
     public static pool: DeserializerPool = new DeserializerPool();

--- a/cocos/serialization/deserialize-dynamic.ts
+++ b/cocos/serialization/deserialize-dynamic.ts
@@ -353,7 +353,7 @@ class DeserializerPool extends js.Pool<_Deserializer> {
     }
 }
 
-// HACK: we've changed the method signature
+// TODO: this is should be a HACK, we've changed the method signature
 (DeserializerPool.prototype as any).get = function (
     this: DeserializerPool,
     details: Details,
@@ -839,7 +839,9 @@ export function deserializeDynamic (data: SerializedData | CCON, details: Detail
 
     details.init();
 
-    const deserializer = _Deserializer.pool.get(details, classFinder, reportMissingClass, customEnv, ignoreEditorOnly);
+    // TODO: this should be a HACK, we've changed the method signature
+    // workaround: mark pool as type of any.
+    const deserializer = (_Deserializer.pool as any).get(details, classFinder, reportMissingClass, customEnv, ignoreEditorOnly);
 
     cclegacy.game._isCloning = true;
     const res = deserializer.deserialize(data);

--- a/cocos/serialization/deserialize-dynamic.ts
+++ b/cocos/serialization/deserialize-dynamic.ts
@@ -105,7 +105,7 @@ function compileDeserializeJIT (self: _Deserializer, klass: CCClassConstructor<u
 
     for (let p = 0; p < props.length; p++) {
         const propName = props[p];
-        if ((PREVIEW || (EDITOR && self._ignoreEditorOnly)) && attrs[propName + POSTFIX_EDITOR_ONLY]) {
+        if ((PREVIEW || (EDITOR && self.ignoreEditorOnly)) && attrs[propName + POSTFIX_EDITOR_ONLY]) {
             continue;   // skip editor only if in preview
         }
 
@@ -161,7 +161,7 @@ function compileDeserializeJIT (self: _Deserializer, klass: CCClassConstructor<u
         sources.push('}');
     }
     if (js.isChildClassOf(klass, cclegacy.Node) || js.isChildClassOf(klass, cclegacy.Component)) {
-        if (PREVIEW || (EDITOR && self._ignoreEditorOnly)) {
+        if (PREVIEW || (EDITOR && self.ignoreEditorOnly)) {
             const mayUsedInPersistRoot = js.isChildClassOf(klass, cclegacy.Node);
             if (mayUsedInPersistRoot) {
                 sources.push('d._id&&(o._id=d._id);');
@@ -384,7 +384,8 @@ class _Deserializer {
     /**
      * @engineInternal
      */
-    public _ignoreEditorOnly: any;
+    public get ignoreEditorOnly () { return this._ignoreEditorOnly; }
+    private _ignoreEditorOnly: unknown;
     private declare _mainBinChunk: Uint8Array;
     private declare _serializedData: SerializedObject | SerializedObject[];
     private declare _context: DeserializationContext;

--- a/cocos/serialization/deserialize.ts
+++ b/cocos/serialization/deserialize.ts
@@ -97,27 +97,20 @@ function serializeBuiltinValueTypes (obj: ValueType): IValueTypeData | null {
     const typeId = BuiltinValueTypes.indexOf(ctor);
     switch (ctor) {
     case Vec2:
-        // @ts-expect-error Complex typing
-        return [typeId, obj.x, obj.y];
+        return [typeId, (obj as Vec2).x, (obj as Vec2).y];
     case Vec3:
-        // @ts-expect-error Complex typing
-        return [typeId, obj.x, obj.y, obj.z];
+        return [typeId, (obj as Vec3).x, (obj as Vec3).y, (obj as Vec3).z];
     case Vec4:
     case Quat:
-        // @ts-expect-error Complex typing
-        return [typeId, obj.x, obj.y, obj.z, obj.w];
+        return [typeId, (obj as Vec4).x, (obj as Vec4).y, (obj as Vec4).z, (obj as Vec4).w];
     case Color:
-        // @ts-expect-error Complex typing
-        return [typeId, obj._val];
+        return [typeId, (obj as Color)._val];
     case Size:
-        // @ts-expect-error Complex typing
-        return [typeId, obj.width, obj.height];
+        return [typeId, (obj as Size).width, (obj as Size).height];
     case Rect:
-        // @ts-expect-error Complex typing
-        return [typeId, obj.x, obj.y, obj.width, obj.height];
+        return [typeId, (obj as Rect).x, (obj as Rect).y, (obj as Rect).width, (obj as Rect).height];
     case Mat4: {
-        // @ts-expect-error Complex typing
-        const res: IValueTypeData = new Array<number>(1 + 16);
+        const res: IValueTypeData = new Array<number>(1 + 16) as IValueTypeData;
         res[VALUETYPE_SETTER] = typeId;
         Mat4.toArray(res, obj as Mat4, 1);
         return res;
@@ -961,8 +954,7 @@ function cacheMasks (data: IPackedFileData) {
         const classes = data[File.SharedClasses];
         for (let i = 0; i < masks.length; ++i) {
             const mask = masks[i];
-            // @ts-expect-error Complex typing.
-            mask[MASK_CLASS] = classes[mask[MASK_CLASS]];
+            mask[MASK_CLASS] = classes[mask[MASK_CLASS]] as unknown as number;
         }
     }
 }

--- a/cocos/serialization/instantiate-jit.ts
+++ b/cocos/serialization/instantiate-jit.ts
@@ -134,11 +134,11 @@ Assignments.pool = new js.Pool((obj: any) => {
     obj._exps.length = 0;
     obj._targetExp = null;
 }, 1);
-// @ts-expect-error
-Assignments.pool.get = function (targetExpression) {
+// HACK: here we've changed the signature of get method
+(Assignments.pool.get as any) = function (this: any, targetExpression) {
     const cache: any = this._get() || new Assignments();
     cache._targetExp = targetExpression;
-    return cache;
+    return cache as Assignments;
 };
 
 // HELPER FUNCTIONS
@@ -277,8 +277,8 @@ class Parser {
     }
 
     public setValueType (codeArray, defaultValue, srcValue, targetExpression) {
-        // @ts-expect-error
-        const assignments: any = Assignments.pool.get(targetExpression);
+        // HACK: here we've changed the signature of get method.
+        const assignments: any = (Assignments.pool.get as any)(targetExpression);
         let fastDefinedProps = defaultValue.constructor.__props__;
         if (!fastDefinedProps) {
             fastDefinedProps = Object.keys(defaultValue);

--- a/cocos/serialization/instantiate.ts
+++ b/cocos/serialization/instantiate.ts
@@ -239,8 +239,8 @@ function instantiateObj (obj, parent) {
     if (ArrayBuffer.isView(obj)) {
         const len = (obj as any).length;
         clone = new ((obj as any).constructor)(len);
-        // @ts-expect-error: unknown
-        obj._iN$t = clone;
+        // NOTE: unknown  injected property `_iN$t`
+        (obj as any)._iN$t = clone;
         objsToClearTmpVar.push(obj);
         for (let i = 0; i < len; ++i) {
             clone[i] = obj[i];
@@ -251,8 +251,8 @@ function instantiateObj (obj, parent) {
     if (Array.isArray(obj)) {
         const len = obj.length;
         clone = new Array(len);
-        // @ts-expect-error: unknown
-        obj._iN$t = clone;
+        // NOTE: unknown  injected property `_iN$t`
+        (obj as any)._iN$t = clone;
         objsToClearTmpVar.push(obj);
         for (let i = 0; i < len; ++i) {
             const value = obj[i];

--- a/cocos/sorting/sorting-layers.ts
+++ b/cocos/sorting/sorting-layers.ts
@@ -167,8 +167,9 @@ export class SortingLayers {
             scene.walk((node) => {
                 const sort = node.getComponent('cc.Sorting');
                 if (sort) {
-                    // @ts-expect-error private method
-                    sort._updateSortingPriority();
+                    // HACK: Property '_updateSortingPriority' does not exist on type 'Component'.
+                    // we can't import Sorting class in this module.
+                    (sort as any)._updateSortingPriority();
                 }
             });
         }

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -207,7 +207,10 @@ export class Skeleton extends UIRenderer {
         this.markForUpdateRenderData();
     }
 
-    protected updateMaterial () {
+    /**
+     * @engineInternal
+     */
+    public updateMaterial () {
         let mat;
         if (this._customMaterial) mat = this._customMaterial;
         else mat = this._updateBuiltinMaterial();

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -316,7 +316,10 @@ class TerrainRenderable extends ModelRenderer {
         this._onRebuildPSO(idx, mtl || this._getBuiltinMaterial());
     }
 
-    protected _onRebuildPSO (idx: number, material: Material) {
+    /**
+     * @engineInternal
+     */
+    public _onRebuildPSO (idx: number, material: Material) {
         if (this._model) {
             this._model.setSubModelMaterial(idx, material);
         }

--- a/cocos/tiledmap/tiled-object-group.ts
+++ b/cocos/tiledmap/tiled-object-group.ts
@@ -344,9 +344,7 @@ export class TiledObjectGroup extends Component {
 
                 // HACK: we should support _premultiplyAlpha when group had material
                 const srcBlendFactor = this._premultiplyAlpha ? BlendFactor.ONE : BlendFactor.SRC_ALPHA;
-                // @ts-expect-error remove when ui-render remove blend
                 if (sprite._srcBlendFactor !== srcBlendFactor) {
-                    // @ts-expect-error remove when ui-render remove blend
                     sprite._srcBlendFactor = srcBlendFactor;
                     if (sprite.material) {
                         sprite._updateBlendFunc();

--- a/cocos/video/video-player-impl-web.ts
+++ b/cocos/video/video-player-impl-web.ts
@@ -169,24 +169,21 @@ export class VideoPlayerImplWeb extends VideoPlayerImpl {
     }
 
     canFullScreen (enabled: boolean) {
-        const video = this._video;
+        // NOTE: below we visited some non-standard web interfaces to complement browser compatibility
+        // we need to mark video as any type.
+        const video = this._video as any;
         if (!video || video.readyState !== READY_STATE.HAVE_ENOUGH_DATA) {
             return;
         }
 
         if (sys.os === OS.IOS && sys.isBrowser) {
             if (enabled) {
-                // @ts-expect-error only ios support
                 if (video.webkitEnterFullscreen) {
-                    // @ts-expect-error only ios support
                     video.webkitEnterFullscreen();
                 }
-                // @ts-expect-error only ios support
             } else if (video.webkitExitFullscreen) {
-                // @ts-expect-error only ios support
                 video.webkitExitFullscreen();
             }
-            // @ts-expect-error only ios support
             this._fullScreenOnAwake = video.webkitDisplayingFullscreen;
             return;
         }

--- a/cocos/webgpu/instantiated.ts
+++ b/cocos/webgpu/instantiated.ts
@@ -47,12 +47,10 @@ export const webgpuAdapter: any = {
 export const promiseForWebGPUInstantiation = (() => {
     if (WEBGPU) {
         return Promise.all([
-            // @ts-expect-error The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
             glslangLoader(new URL(glslangUrl, import.meta.url).href).then((res) => {
                 glslalgWasmModule.glslang = res;
             }),
             new Promise<void>((resolve) => {
-                // @ts-expect-error The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
                 fetch(new URL(webgpuUrl, import.meta.url).href).then((response) => {
                     response.arrayBuffer().then((buffer) => {
                         gfx.wasmBinary = buffer;

--- a/editor/src/marionette/preview.ts
+++ b/editor/src/marionette/preview.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../cocos/animation/marionette/animation-blend';
 import type { RuntimeID } from '../../../cocos/animation/marionette/graph-debug';
 import {
-    AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphPoseLayoutMaintainer, defaultTransformsTag, MetaValueRegistry,
+    AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphLayerWideBindingContext, AnimationGraphPoseLayoutMaintainer, defaultTransformsTag, MetaValueRegistry,
 } from '../../../cocos/animation/marionette/animation-graph-context';
 import { blendPoseInto, Pose } from '../../../cocos/animation/core/pose';
 
@@ -58,9 +58,9 @@ class AnimationGraphPartialPreviewer {
         return null;
     }
 
-    private _poseLayoutMaintainer: AnimationGraphPoseLayoutMaintainer;
-
-    private _evaluationContext: AnimationGraphEvaluationContext;
+    // NOTE: these two properties rely on lazy initialization.
+    private _poseLayoutMaintainer!: AnimationGraphPoseLayoutMaintainer;
+    private _evaluationContext!: AnimationGraphEvaluationContext;
 
     private _varInstances: Record<string, VarInstance> = {};
 
@@ -419,10 +419,11 @@ class MotionEvalRecord {
     }
 
     public rebind(bindContext: AnimationGraphBindingContext) {
+        // TODO: please fix type @Leslie Leigh
         const motionEval = this._motion[createEval]({
             additive: false,
             up: bindContext,
-        }, null);
+        } as unknown as AnimationGraphLayerWideBindingContext, null);
 
         if (!motionEval) {
             return;

--- a/pal/audio/audio-timer.ts
+++ b/pal/audio/audio-timer.ts
@@ -44,8 +44,8 @@ export default class AudioTimer {
     }
 
     public destroy () {
-        // @ts-expect-error Type 'undefined' is not assignable to type 'IDuration'
-        this._nativeAudio = undefined;
+        // NOTE: 'undefined' is not assignable to type 'IDuration'
+        this._nativeAudio = undefined as any;
     }
 
     get duration () {

--- a/pal/audio/minigame/player-minigame.ts
+++ b/pal/audio/minigame/player-minigame.ts
@@ -59,8 +59,8 @@ export class OneShotAudioMinigame {
         nativeAudio.onEnded(() => {
             this._onEndCb?.();
             nativeAudio.destroy();
-            // @ts-expect-error Type 'null' is not assignable to type 'InnerAudioContext'.
-            this._innerAudioContext = null;
+            // NOTE: Type 'null' is not assignable to type 'InnerAudioContext'.
+            this._innerAudioContext = null as any;
         });
     }
     public play (): void {
@@ -174,8 +174,8 @@ export class AudioPlayerMinigame implements OperationQueueable {
             // NOTE: innewAudioContext might not stop the audio playing, have to call it explicitly.
             this._innerAudioContext.stop();
             this._innerAudioContext.destroy();
-            // @ts-expect-error Type 'null' is not assignable to type 'InnerAudioContext'
-            this._innerAudioContext = null;
+            // NOTE: Type 'null' is not assignable to type 'InnerAudioContext'
+            this._innerAudioContext = null as any;
         }
     }
     private _onInterruptedBegin () {
@@ -250,8 +250,8 @@ export class AudioPlayerMinigame implements OperationQueueable {
     static loadOneShotAudio (url: string, volume: number): Promise<OneShotAudioMinigame> {
         return new Promise((resolve, reject) => {
             AudioPlayerMinigame.loadNative(url).then((innerAudioContext) => {
-                // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                resolve(new OneShotAudioMinigame(innerAudioContext, volume));
+                // HACK: AudioPlayer should be a friend class in OneShotAudio
+                resolve(new (OneShotAudioMinigame as any)(innerAudioContext, volume));
             }).catch(reject);
         });
     }

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -119,8 +119,8 @@ export class AudioPlayerWeb implements OperationQueueable {
     destroy () {
         this._audioTimer.destroy();
         if (this._audioBuffer) {
-            // @ts-expect-error need to release AudioBuffer instance
-            this._audioBuffer = null;
+            // NOTE: need to release AudioBuffer instance
+            this._audioBuffer = null as any;
         }
         audioBufferManager.tryReleasingCache(this._src);
         game.off(Game.EVENT_PAUSE, this._onInterruptedBegin, this);
@@ -182,8 +182,8 @@ export class AudioPlayerWeb implements OperationQueueable {
     static loadOneShotAudio (url: string, volume: number): Promise<OneShotAudioWeb> {
         return new Promise((resolve, reject) => {
             AudioPlayerWeb.loadNative(url).then((audioBuffer) => {
-                // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                const oneShotAudio = new OneShotAudioWeb(audioBuffer, volume, url);
+                // HACK: AudioPlayer should be a friend class in OneShotAudio
+                const oneShotAudio = new (OneShotAudioWeb as any)(audioBuffer, volume, url);
                 resolve(oneShotAudio);
             }).catch(reject);
         });

--- a/pal/audio/minigame/player.ts
+++ b/pal/audio/minigame/player.ts
@@ -90,13 +90,13 @@ export class AudioPlayer {
         return new Promise((resolve, reject) => {
             if (typeof minigame.tt === 'object' && typeof minigame.tt.getAudioContext !== 'undefined') {
                 AudioPlayerWeb.loadOneShotAudio(url, volume).then((oneShotAudioWeb) => {
-                    // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                    resolve(new OneShotAudio(oneShotAudioWeb));
+                    // HACK: AudioPlayer should be a friend class in OneShotAudio
+                    resolve(new (OneShotAudio as any)(oneShotAudioWeb));
                 }).catch(reject);
             } else {
                 AudioPlayerMinigame.loadOneShotAudio(url, volume).then((oneShotAudioMinigame) => {
-                    // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                    resolve(new OneShotAudio(oneShotAudioMinigame));
+                    // HACK: AudioPlayer should be a friend class in OneShotAudio
+                    resolve(new (OneShotAudio as any)(oneShotAudioMinigame));
                 }).catch(reject);
             }
         });

--- a/pal/audio/native/player.ts
+++ b/pal/audio/native/player.ts
@@ -187,8 +187,8 @@ export class AudioPlayer implements OperationQueueable {
     static loadOneShotAudio (url: string, volume: number): Promise<OneShotAudio> {
         return new Promise((resolve, reject) => {
             AudioPlayer.loadNative(url).then((url) => {
-                // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                resolve(new OneShotAudio(url, volume));
+                // HACK: AudioPlayer should be a friend class in OneShotAudio
+                resolve(new (OneShotAudio as any)(url, volume));
             }).catch(reject);
         });
     }

--- a/pal/audio/web/player-dom.ts
+++ b/pal/audio/web/player-dom.ts
@@ -123,8 +123,8 @@ export class AudioPlayerDOM implements OperationQueueable {
         game.off(Game.EVENT_PAUSE, this._onInterruptedBegin, this);
         game.off(Game.EVENT_RESUME, this._onInterruptedEnd, this);
         this._domAudio.removeEventListener('ended', this._onEnded);
-        // @ts-expect-error need to release DOM Audio instance
-        this._domAudio = null;
+        // NOTE: need to release DOM Audio instance
+        this._domAudio = null as any;
     }
     static load (url: string): Promise<AudioPlayerDOM> {
         return new Promise((resolve) => {
@@ -174,8 +174,8 @@ export class AudioPlayerDOM implements OperationQueueable {
     static loadOneShotAudio (url: string, volume: number): Promise<OneShotAudioDOM> {
         return new Promise((resolve, reject) => {
             AudioPlayerDOM.loadNative(url).then((domAudio) => {
-                // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                const oneShotAudio = new OneShotAudioDOM(domAudio, volume);
+                // HACK: AudioPlayer should be a friend class in OneShotAudio
+                const oneShotAudio = new (OneShotAudioDOM as any)(domAudio, volume);
                 resolve(oneShotAudio);
             }).catch(reject);
         });

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -246,8 +246,8 @@ export class AudioPlayerWeb implements OperationQueueable {
     destroy () {
         this._audioTimer.destroy();
         if (this._audioBuffer) {
-            // @ts-expect-error need to release AudioBuffer instance
-            this._audioBuffer = null;
+            // NOTE: need to release AudioBuffer instance
+            this._audioBuffer = null as any;
         }
         audioBufferManager.tryReleasingCache(this._src);
         game.off(Game.EVENT_PAUSE, this._onInterruptedBegin, this);
@@ -293,8 +293,8 @@ export class AudioPlayerWeb implements OperationQueueable {
     static loadOneShotAudio (url: string, volume: number): Promise<OneShotAudioWeb> {
         return new Promise((resolve, reject) => {
             AudioPlayerWeb.loadNative(url).then((audioBuffer) => {
-                // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                const oneShotAudio = new OneShotAudioWeb(audioBuffer, volume, url);
+                // HACK: AudioPlayer should be a friend class in OneShotAudio
+                const oneShotAudio = new (OneShotAudioWeb as any)(audioBuffer, volume, url);
                 resolve(oneShotAudio);
             }).catch(reject);
         });

--- a/pal/audio/web/player.ts
+++ b/pal/audio/web/player.ts
@@ -92,13 +92,13 @@ export class AudioPlayer {
             if (opts?.audioLoadMode === AudioType.DOM_AUDIO || !AudioContextAgent.support) {
                 if (!AudioContextAgent.support) { warnID(5201); }
                 AudioPlayerDOM.loadOneShotAudio(url, volume).then((oneShotAudioDOM) => {
-                    // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                    resolve(new OneShotAudio(oneShotAudioDOM));
+                    // HACK: AudioPlayer should be a friend class in OneShotAudio
+                    resolve(new (OneShotAudio as any)(oneShotAudioDOM));
                 }).catch(reject);
             } else {
                 AudioPlayerWeb.loadOneShotAudio(url, volume).then((oneShotAudioWeb) => {
-                    // @ts-expect-error AudioPlayer should be a friend class in OneShotAudio
-                    resolve(new OneShotAudio(oneShotAudioWeb));
+                    // HACK: AudioPlayer should be a friend class in OneShotAudio
+                    resolve(new (OneShotAudio as any)(oneShotAudioWeb));
                 }).catch(reject);
             }
         });

--- a/pal/input/web/gamepad-input.ts
+++ b/pal/input/web/gamepad-input.ts
@@ -243,10 +243,9 @@ export class GamepadInputDevice {
     private static _getWebGamePads (): (WebGamepad | null)[] {
         if (typeof navigator.getGamepads === 'function') {
             return navigator.getGamepads();
-            // @ts-expect-error Property 'webkitGetGamepads' does not exist on type 'Navigator'
-        } else if (typeof navigator.webkitGetGamepads === 'function') {
-            // @ts-expect-error Property 'webkitGetGamepads' does not exist on type 'Navigator'
-            return navigator.webkitGetGamepads() as (Gamepad | null)[];
+        } else if (typeof (navigator as any).webkitGetGamepads === 'function') {
+            // NOTE: 'webkitGetGamepads' is not a standard web interface
+            return (navigator as any).webkitGetGamepads() as (Gamepad | null)[];
         }
         return [];
     }

--- a/pal/input/web/mouse-input.ts
+++ b/pal/input/web/mouse-input.ts
@@ -39,12 +39,9 @@ export class MouseInputSource {
     private _isPressed = false;
     private _preMousePos: Vec2 = new Vec2();
 
-    // @ts-expect-error maybe not initialized
-    private _handleMouseDown: (event: MouseEvent) => void;
-    // @ts-expect-error maybe not initialized
-    private _handleMouseMove: (event: MouseEvent) => void;
-    // @ts-expect-error maybe not initialized
-    private _handleMouseUp: (event: MouseEvent) => void;
+    private _handleMouseDown!: (event: MouseEvent) => void;
+    private _handleMouseMove!: (event: MouseEvent) => void;
+    private _handleMouseUp!: (event: MouseEvent) => void;
 
     constructor () {
         if (systemInfo.hasFeature(Feature.EVENT_MOUSE)) {
@@ -114,8 +111,8 @@ export class MouseInputSource {
     private _registerPointerLockEvent () {
         const lockChangeAlert = () => {
             const canvas = this._canvas;
-            // @ts-expect-error undefined mozPointerLockElement
-            if (document.pointerLockElement === canvas || document.mozPointerLockElement === canvas) {
+            // NOTE: mozPointerLockElement is not a standard web interface
+            if (document.pointerLockElement === canvas || (document as any).mozPointerLockElement === canvas) {
                 this._pointLocked = true;
             } else {
                 this._pointLocked = false;
@@ -124,7 +121,8 @@ export class MouseInputSource {
         if ('onpointerlockchange' in document) {
             document.addEventListener('pointerlockchange', lockChangeAlert, false);
         } else if ('onmozpointerlockchange' in document) {
-            document.addEventListener('mozpointerlockchange', lockChangeAlert, false);
+            // NOTE: handle event compatibility
+            (document as any).addEventListener('mozpointerlockchange', lockChangeAlert, false);
         }
     }
 

--- a/pal/minigame/alipay.ts
+++ b/pal/minigame/alipay.ts
@@ -28,8 +28,7 @@ import { cloneObject } from '../utils';
 
 declare let my: any;
 
-// @ts-expect-error can't init minigame when it's declared
-const minigame: IMiniGame = {};
+const minigame: IMiniGame = {} as IMiniGame;
 cloneObject(minigame, my);
 
 // #region SystemInfo
@@ -80,16 +79,14 @@ minigame.onTouchCancel = function (cb) {
 // #endregion TouchEvent
 
 minigame.createInnerAudioContext = function (): InnerAudioContext {
-    const audio: InnerAudioContext = my.createInnerAudioContext();
-    // @ts-expect-error InnerAudioContext has onCanPlay
+    // NOTE: `onCanPlay` and `offCanPlay` is not standard minigame interface,
+    // so here we mark audio as type of any
+    const audio: any = my.createInnerAudioContext();
     audio.onCanplay = audio.onCanPlay.bind(audio);
-    // @ts-expect-error InnerAudioContext has offCanPlay
     audio.offCanplay = audio.offCanPlay.bind(audio);
-    // @ts-expect-error InnerAudioContext has onCanPlay
     delete audio.onCanPlay;
-    // @ts-expect-error InnerAudioContext has offCanPlay
     delete audio.offCanPlay;
-    return audio;
+    return audio as InnerAudioContext;
 };
 
 // #region Font

--- a/pal/minigame/baidu.ts
+++ b/pal/minigame/baidu.ts
@@ -28,8 +28,7 @@ import { cloneObject, createInnerAudioContextPolyfill } from '../utils';
 
 declare let swan: any;
 
-// @ts-expect-error can't init minigame when it's declared
-const minigame: IMiniGame = {};
+const minigame: IMiniGame = {} as IMiniGame;
 cloneObject(minigame, swan);
 
 // #region SystemInfo

--- a/pal/minigame/bytedance.ts
+++ b/pal/minigame/bytedance.ts
@@ -28,8 +28,7 @@ import { cloneObject, createInnerAudioContextPolyfill } from '../utils';
 
 declare let tt: any;
 
-// @ts-expect-error can't init minigame when it's declared
-const minigame: IMiniGame = {};
+const minigame: IMiniGame = {} as IMiniGame;
 cloneObject(minigame, tt);
 
 // #region platform related

--- a/pal/minigame/non-minigame.ts
+++ b/pal/minigame/non-minigame.ts
@@ -24,6 +24,5 @@
 
 import { IMiniGame } from 'pal/minigame';
 
-// @ts-expect-error can't init minigame when it's declared
-const minigame: IMiniGame = {};
+const minigame: IMiniGame = {} as IMiniGame;
 export { minigame };

--- a/pal/minigame/runtime.ts
+++ b/pal/minigame/runtime.ts
@@ -30,8 +30,7 @@ import { cloneObject, createInnerAudioContextPolyfill } from '../utils';
 
 declare let ral: any;
 
-// @ts-expect-error can't init minigame when it's declared
-const minigame: IMiniGame = {};
+const minigame: IMiniGame = {} as IMiniGame;
 cloneObject(minigame, ral);
 minigame.ral = ral;
 

--- a/pal/minigame/wechat.ts
+++ b/pal/minigame/wechat.ts
@@ -28,8 +28,7 @@ import { cloneObject, createInnerAudioContextPolyfill, versionCompare } from '..
 
 declare let wx: any;
 
-// @ts-expect-error can't init minigame when it's declared
-const minigame: IMiniGame = {};
+const minigame: IMiniGame = {} as IMiniGame;
 cloneObject(minigame, wx);
 
 // #region platform related
@@ -44,8 +43,8 @@ minigame.wx.onWheel = wx.onWheel?.bind(wx);
 
 // #region SystemInfo
 let _cachedSystemInfo: SystemInfo = wx.getSystemInfoSync();
-// @ts-expect-error TODO: move into minigame.d.ts
-minigame.testAndUpdateSystemInfoCache = function (testAmount: number, testInterval: number) {
+
+function testAndUpdateSystemInfoCache (testAmount: number, testInterval: number) {
     let successfullyTestTimes = 0;
     let intervalTimer: number | null = null;
     function testCachedSystemInfo () {
@@ -61,9 +60,9 @@ minigame.testAndUpdateSystemInfoCache = function (testAmount: number, testInterv
         _cachedSystemInfo = currentSystemInfo;
     }
     intervalTimer = setInterval(testCachedSystemInfo, testInterval);
-};
-// @ts-expect-error TODO: update when view resize
-minigame.testAndUpdateSystemInfoCache(10, 500);
+}
+testAndUpdateSystemInfoCache(10, 500);
+
 minigame.onWindowResize?.(() => {
     // update cached system info
     _cachedSystemInfo = wx.getSystemInfoSync() as SystemInfo;
@@ -158,9 +157,10 @@ minigame.getSafeArea = function () {
 };
 // #endregion SafeArea
 
+declare const canvas: any;  // defined in global
+
 // HACK: adapt GL.useProgram: use program not supported to unbind program on pc end
 if (systemInfo.platform === 'windows' && versionCompare(systemInfo.SDKVersion, '2.16.0') < 0) {
-    // @ts-expect-error canvas defined in global
     const locCanvas = canvas;
     if (locCanvas) {
         const webglRC = locCanvas.getContext('webgl');

--- a/pal/minigame/xiaomi.ts
+++ b/pal/minigame/xiaomi.ts
@@ -28,8 +28,7 @@ import { cloneObject, createInnerAudioContextPolyfill } from '../utils';
 
 declare let qg: any;
 
-// @ts-expect-error can't init minigame when it's declared
-const minigame: IMiniGame = {};
+const minigame: IMiniGame = {} as IMiniGame;
 cloneObject(minigame, qg);
 
 // #region SystemInfo

--- a/pal/screen-adapter/minigame/screen-adapter.ts
+++ b/pal/screen-adapter/minigame/screen-adapter.ts
@@ -32,13 +32,15 @@ import { Size } from '../../../cocos/core/math';
 import { OS } from '../../system-info/enum-type';
 import { Orientation } from '../enum-type';
 
+declare const my: any;
+
 // HACK: In some platform like CocosPlay or Alipay iOS end
 // the windowSize need to rotate when init screenAdapter if it's landscape
 let rotateLandscape = false;
 try {
     if (ALIPAY) {
         if (systemInfo.os === OS.IOS && !minigame.isDevTool) {
-            // @ts-expect-error TODO: use pal/fs
+            // TODO: use pal/fs
             const fs = my.getFileSystemManager();
             const screenOrientation = JSON.parse(fs.readFileSync({
                 filePath: 'game.json',

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -26,6 +26,16 @@ import { IFeatureMap } from 'pal/system-info';
 import { EventTarget } from '../../../cocos/core/event';
 import { BrowserType, NetworkType, OS, Platform, Language, Feature } from '../enum-type';
 
+// NOTE: these methods are implemented on native.
+declare function __getPlatform(): string;
+declare function __getCurrentLanguageCode(): string;
+declare function __getCurrentLanguage(): Language;
+declare function __getOS(): OS;
+declare function __getOSVersion(): string;
+declare function __restartVM(): void;
+declare function __close(): void;
+declare function __exit(): void;
+
 const networkTypeMap: Record<string, NetworkType> = {
     0: NetworkType.NONE,
     1: NetworkType.LAN,
@@ -70,7 +80,6 @@ class SystemInfo extends EventTarget {
         this.isNative = true;
         this.isBrowser = false;
 
-        // @ts-expect-error __getPlatform()
         this.platform = platformMap[__getPlatform()];
         this.isMobile = this.platform === Platform.ANDROID || this.platform === Platform.IOS || this.platform === Platform.OHOS;
 
@@ -83,15 +92,11 @@ class SystemInfo extends EventTarget {
         })();
 
         // init languageCode and language
-        // @ts-expect-error __getCurrentLanguageCode() defined in JSB
         const currLanguage = __getCurrentLanguageCode();
         this.nativeLanguage = currLanguage ? currLanguage.toLowerCase() : Language.UNKNOWN;
-        // @ts-expect-error __getCurrentLanguage() defined in JSB
         this.language = __getCurrentLanguage();
 
-        // @ts-expect-error __getOS() defined in JSB
         this.os = __getOS();
-        // @ts-expect-error __getOSVersion() defined in JSB
         this.osVersion = __getOSVersion();
         this.osMainVersion = parseInt(this.osVersion);
 
@@ -165,17 +170,14 @@ class SystemInfo extends EventTarget {
         return +(new Date());
     }
     public restartJSVM (): void {
-        // @ts-expect-error __restartVM() is defined in JSB
         __restartVM();
     }
 
     public close () {
-        // @ts-expect-error __close() is defined in JSB
         __close();
     }
 
     public exit () {
-        // @ts-expect-error __exit() is defined in JSB
         __exit();
     }
 }

--- a/pal/system-info/web/system-info.ts
+++ b/pal/system-info/web/system-info.ts
@@ -50,8 +50,8 @@ class SystemInfo extends EventTarget {
         super();
         const nav = window.navigator;
         const ua = nav.userAgent.toLowerCase();
-        // @ts-expect-error getBattery is not totally supported
-        nav.getBattery?.().then((battery) => {
+        // NOTE: getBattery is not totally supported on Web standard
+        (nav as any).getBattery?.().then((battery) => {
             this._battery = battery;
         });
 
@@ -208,12 +208,12 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_MOUSE]: supportMouse,
             [Feature.EVENT_TOUCH]: supportTouch || supportMouse,
             [Feature.EVENT_ACCELEROMETER]: (window.DeviceMotionEvent !== undefined || window.DeviceOrientationEvent !== undefined),
-            // @ts-expect-error undefined webkitGetGamepads
-            [Feature.EVENT_GAMEPAD]: (navigator.getGamepads !== undefined || navigator.webkitGetGamepads !== undefined),
+            // NOTE: webkitGetGamepads is not standard web interface
+            [Feature.EVENT_GAMEPAD]: (navigator.getGamepads !== undefined || (navigator as any).webkitGetGamepads !== undefined),
             [Feature.EVENT_HANDLE]: EDITOR || PREVIEW,
             [Feature.EVENT_HMD]: this.isXR,
-            // @ts-expect-error undefined xr
-            [Feature.EVENT_HANDHELD]: (typeof navigator.xr !== 'undefined'),
+            // NOTE: xr is not totally supported on web
+            [Feature.EVENT_HANDHELD]: (typeof (navigator as any).xr !== 'undefined'),
         };
 
         this._initPromise = [];
@@ -280,8 +280,8 @@ class SystemInfo extends EventTarget {
             for (let i = 0; i < changeList.length; i++) {
                 document.addEventListener(changeList[i], (event) => {
                     let visible = document[hiddenPropName];
-                    // @ts-expect-error QQ App need hidden property
-                    visible = visible || event.hidden;
+                    // NOTE: QQ App need hidden property
+                    visible = visible || (event as any).hidden;
                     if (visible) {
                         onHidden();
                     } else {

--- a/tests/asset-manager/finalizer.test.ts
+++ b/tests/asset-manager/finalizer.test.ts
@@ -1,7 +1,7 @@
 import { SpriteFrame } from "../../cocos/2d/assets/sprite-frame";
 import { Sprite } from "../../cocos/2d/components/sprite";
 import { assetManager, loader } from "../../cocos/asset/asset-manager";
-import releaseManager from "../../cocos/asset/asset-manager/release-manager";
+import { releaseManager } from "../../cocos/asset/asset-manager/release-manager";
 import { Texture2D } from "../../cocos/asset/assets/texture-2d";
 import { isValid } from "../../cocos/core/data/object";
 import { Scene, Node } from "../../cocos/scene-graph";


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/15855

### Changelog

* remove and ban `@ts-expect-error`

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
