### PR TITLE
Bugfix: ENGINE_PATH Validation during Build Process to Avoid Errors

### DIFF
--- a/scripts/build-engine/src/babel-plugins/decorator-parser.ts
+++ b/scripts/build-engine/src/babel-plugins/decorator-parser.ts
@@ -13,12 +13,7 @@ import * as t from '@babel/types';
 import path from 'path';
 import fs from 'fs';
 
-const enginePath = process.env.ENGINE_PATH!;
 const applyFnName = `apply`;
-
-if (!enginePath) {
-    throw new Error('ENGINE_PATH environment variable not set');
-}
 
 interface DecoratorParseResult {
     decoratorName?: string;
@@ -318,6 +313,11 @@ const cppClassMap: Map<string, { name: string, file: string, tip: string }[]> = 
 function getExportedClassesFromCppSourceCode() {
     if (cppClassMap.size > 0) {
         return cppClassMap;
+    }
+
+    const enginePath = process.env.ENGINE_PATH!;
+    if (!enginePath) {
+        throw new Error('ENGINE_PATH environment variable not set');
     }
 
     const cppSourceFiles: string[] = [];


### PR DESCRIPTION
During the build process, an error may occur if the ENGINE_PATH is not set, but this validation is only required when generating decorators. To avoid this error, we will delay the validation until the specific process that requires it.

### Changelog

* Delaying ENGINE_PATH Validation during Build Process to Avoid Errors

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
