### PR TITLE
publish build-engine@4.4.1-alpha.12

### DIFF
--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.4.1-alpha.11",
+  "version": "4.4.1-alpha.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.4.1-alpha.11",
+  "version": "4.4.1-alpha.12",
   "description": "",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "@babel/plugin-transform-for-of": "^7.9.0",
     "@babel/preset-env": "^7.8.7",
     "@cocos/babel-plugin-dynamic-import-vars": "^1.0.2",
-    "@cocos/creator-programming-babel-preset-cc": "^1.0.1-alpha.2",
+    "@cocos/creator-programming-babel-preset-cc": "1.0.1-alpha.2",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-json": "^4.0.2",


### PR DESCRIPTION
Re: #

### Changelog

* fix the build-engine dependency on creator-programming-babel-preset-cc

creator-programming-babel-preset-cc@1.0.1 would introduce a higher version of typescript, for now we have no plan to upgrade typescript

we need to fallback to creator-programming-babel-preset-cc@1.0.1-alpha.2

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
