### PR TITLE
fix JS error after 3d models open USE_INSTANCING on Android platform …

### DIFF
--- a/cocos/rendering/render-instanced-queue.ts
+++ b/cocos/rendering/render-instanced-queue.ts
@@ -88,7 +88,7 @@ export class RenderInstancedQueue {
      */
     public recordCommandBuffer (device: Device, renderPass: RenderPass, cmdBuff: CommandBuffer,
         descriptorSet: DescriptorSet | null = null, dynamicOffsets?: Readonly<number[]>) {
-        const it = this._renderQueue.length === 0 ? this.queue.values() : this._renderQueue.values();
+        const it = this._renderQueue.length === 0 ? this.queue.values() : this._renderQueue[Symbol.iterator]();
         let res = it.next();
 
         while (!res.done) {


### PR DESCRIPTION
fix JS error after 3d models open USE_INSTANCING on Android platform since v3.7.1