### PR TITLE
fix: correct editor-extends.d.ts and remove unreasonable type casting

### DIFF
--- a/@types/editor-extends.d.ts
+++ b/@types/editor-extends.d.ts
@@ -1,3 +1,22 @@
+interface EventEmitter {
+    addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    on(event: string | symbol, listener: (...args: any[]) => void): this;
+    once(event: string | symbol, listener: (...args: any[]) => void): this;
+    removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    off(event: string | symbol, listener: (...args: any[]) => void): this;
+    removeAllListeners(event?: string | symbol): this;
+    setMaxListeners(n: number): this;
+    getMaxListeners(): number;
+    listeners(event: string | symbol): Function[];
+    rawListeners(event: string | symbol): Function[];
+    emit(event: string | symbol, ...args: any[]): boolean;
+    listenerCount(event: string | symbol): number;
+    // Added in Node 6...
+    prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    eventNames(): Array<string | symbol>;
+}
+
 interface EditorAssetInfo {
     name: string; // 资源名字
     displayName: string; // 资源用于显示的名字
@@ -25,19 +44,21 @@ interface EditorExtendsScript {
     getCtors(uuid: string): { [uuid: string]: any }
 }
 
-interface EditorExtendsNode {
+interface EditorExtendsNode extends EventEmitter{
     add(uuid: string, node: any): any;
     remove(uuid: string): any;
     clear(): any;
     getNode(uuid: string): any;
     getNodes(): {[uuid: string]: any};
+
+
 }
 
 interface EditorExtendsPrefabUtils {
     addPrefabInstance(node: Node);
 }
 
-interface EditorExtendsComponent {
+interface EditorExtendsComponent extends EventEmitter{
     addMenu(component: Function, path: string, priority?: number);
     removeMenu(component: Function);
     getMenus(): { [uuid: string]: Object };

--- a/cocos/3d/lod/lodgroup-component.ts
+++ b/cocos/3d/lod/lodgroup-component.ts
@@ -629,9 +629,7 @@ export class LODGroup extends Component {
      */
     private _emitChangeNode (node: Node) {
         if (EDITOR) {
-            // TODO: Property 'emit' does not exist on type 'EditorExtendsNode'.
-            // workaround: mark Node as any
-            (EditorExtends.Node as any).emit('change', node.uuid, node);
+            EditorExtends.Node.emit('change', node.uuid, node);
         }
     }
 


### PR DESCRIPTION

Re: #https://github.com/cocos/3d-tasks/issues/16018

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
