### PR TITLE
Android Add InputSDK Dependency

### DIFF
--- a/.github/workflows/native-compile-platforms.yml
+++ b/.github/workflows/native-compile-platforms.yml
@@ -98,6 +98,7 @@ jobs:
           mkdir -p build-android/proj
           touch build-android/proj/cfg.cmake
           echo "set(CI_FORCE_MINIMAL_FEATURES ON)" >> build-android/proj/cfg.cmake
+          echo "set(COCOS_X_PATH $NATIVE_ROOT)" >> build-android/proj/cfg.cmake
 
           mkdir -p build-android/assets
 
@@ -163,6 +164,7 @@ jobs:
           echo "set(CC_USE_GLES2 ON)" >> build-android/proj/cfg.cmake
           echo "set(USE_WEBSOCKET_SERVER ON)" >> build-android/proj/cfg.cmake
           echo "set(CMAKE_CXX_STANDARD_REQUIRED ON)" >> build-android/proj/cfg.cmake
+          echo "set(COCOS_X_PATH $NATIVE_ROOT)" >> build-android/proj/cfg.cmake
 
           mkdir -p build-android/assets
 

--- a/scripts/native-pack-tool/source/platforms/android.ts
+++ b/scripts/native-pack-tool/source/platforms/android.ts
@@ -198,6 +198,7 @@ export class AndroidPackTool extends NativePackTool {
             content = content.replace(/PROP_MIN_SDK_VERSION=.*/, `PROP_MIN_SDK_VERSION=${Math.min(apiLevel, minimalSDKVersion)}`);
             content = content.replace(/PROP_APP_NAME=.*/, `PROP_APP_NAME=${this.params.projectName}`);
             content = content.replace(/PROP_ENABLE_INSTANT_APP=.*/, `PROP_ENABLE_INSTANT_APP=${options.androidInstant ? "true" : "false"}`);
+            content = content.replace(/PROP_ENABLE_INPUTSDK=.*/, `PROP_ENABLE_INPUTSDK=${options.inputSDK ? "true" : "false"}`);
             content = content.replace(/PROP_IS_DEBUG=.*/, `PROP_IS_DEBUG=${this.params.debug ? "true" : "false"}`);
 
             content = content.replace(/RES_PATH=.*/, `RES_PATH=${cchelper.fixPath(this.paths.buildDir)}`);

--- a/templates/android/build/gradle.properties
+++ b/templates/android/build/gradle.properties
@@ -39,6 +39,9 @@ PROP_APP_NAME=Cocos Game
 # Instant App
 PROP_ENABLE_INSTANT_APP=true
 
+# InputSDK
+PROP_ENABLE_INPUTSDK=false
+
 PROP_NDK_PATH=
 
 # Build variant

--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -26,7 +26,7 @@ android {
         externalNativeBuild {
             cmake {
                 targets "cocos"
-                arguments "-DRES_DIR=${RES_PATH}", "-DCOCOS_X_PATH=${COCOS_ENGINE_PATH}", "-DANDROID_STL=c++_static", "-DANDROID_TOOLCHAIN=clang", "-DANDROID_ARM_NEON=TRUE", "-DANDROID_LD=gold"
+                arguments "-DRES_DIR=${RES_PATH}", "-DANDROID_STL=c++_static", "-DANDROID_TOOLCHAIN=clang", "-DANDROID_ARM_NEON=TRUE"
             }
             ndk { abiFilters PROP_APP_ABI.split(':') }
         }
@@ -82,7 +82,7 @@ android {
                 }
             }
 
-            if (PROP_IS_DEBUG == "false") {
+            if (!Boolean.parseBoolean(PROP_IS_DEBUG)) {
                 getIsDefault().set(true)
             }
 
@@ -105,4 +105,7 @@ dependencies {
     implementation fileTree(dir: "${COCOS_ENGINE_PATH}/cocos/platform/android/java/libs", include: ['*.jar'])
     implementation project(':libservice')
     implementation project(':libcocos')
+    if (Boolean.parseBoolean(PROP_ENABLE_INPUTSDK)) {
+        implementation 'com.google.android.libraries.play.games:inputmapping:1.0.0-beta'
+    }
 }


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/15731

Deps: https://github.com/cocos/creator-runtime-extensions/pull/361

After selecting the "InputSDK" option in the build panel, add the corresponding dependencies to the Gradle configuration file.

### Changelog

* Add support for Android InputSDK

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
