### PR TITLE
use wechatprogram subpackge default and speedup launch time

### DIFF
--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -2715,30 +2715,10 @@ export function WebGLCmdFuncCopyTexImagesToTexture (
     case gl.TEXTURE_2D: {
         for (let i = 0; i < regions.length; i++) {
             const region = regions[i];
-            if (WECHAT_MINI_PROGRAM) {
-                // TODO: Property 'type' does not exist on type 'HTMLImageElement'.
-                // maybe we need a higher level implementation called `pal/image`, we provide `type` interface here.
-                // issue: https://github.com/cocos/cocos-engine/issues/14646
-                const texImg = texImages[n++] as any;
-                if (texImg.type !== 'undefined' && texImg.type === 'canvas') {
-                    const canvas = texImg;
-                    const ctx = canvas.getContext('2d');
-                    const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-                    gl.texSubImage2D(gl.TEXTURE_2D, region.texSubres.mipLevel,
-                        region.texOffset.x, region.texOffset.y, canvas.width, canvas.height,
-                        gpuTexture.glFormat, gpuTexture.glType, imgData.data);
-                } else {
-                    // console.debug('Copying image to texture 2D: ' + region.texExtent.width + ' x ' + region.texExtent.height);
-                    gl.texSubImage2D(gl.TEXTURE_2D, region.texSubres.mipLevel,
-                        region.texOffset.x, region.texOffset.y,
-                        gpuTexture.glFormat, gpuTexture.glType, texImg);
-                }
-            } else {
-                // console.debug('Copying image to texture 2D: ' + region.texExtent.width + ' x ' + region.texExtent.height);
-                gl.texSubImage2D(gl.TEXTURE_2D, region.texSubres.mipLevel,
-                    region.texOffset.x, region.texOffset.y,
-                    gpuTexture.glFormat, gpuTexture.glType, texImages[n++]);
-            }
+            // console.debug('Copying image to texture 2D: ' + region.texExtent.width + ' x ' + region.texExtent.height);
+            gl.texSubImage2D(gl.TEXTURE_2D, region.texSubres.mipLevel,
+                region.texOffset.x, region.texOffset.y,
+                gpuTexture.glFormat, gpuTexture.glType, texImages[n++]);
         }
         break;
     }

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -22,7 +22,6 @@
  THE SOFTWARE.
 */
 
-import { WECHAT_MINI_PROGRAM } from 'internal:constants';
 import { debug, error, errorID, CachedArray, cclegacy } from '../../core';
 import { WebGLCommandAllocator } from './webgl-command-allocator';
 import { WebGLEXT } from './webgl-define';

--- a/pal/minigame/wechat_mini_program.ts
+++ b/pal/minigame/wechat_mini_program.ts
@@ -183,8 +183,11 @@ gl.texSubImage2D = function (...args) {
         const canvas = args[6];
         if (typeof canvas.type !== 'undefined' && canvas.type === 'canvas') {
             const ctx = canvas.getContext('2d');
-            const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-            oldTexSubImage2D.call(gl, args[0], args[1], args[2], args[3], args[4], args[5], imgData);
+            const texOffsetX = args[2];
+            const texOffsetY = args[3];
+            const imgData = ctx.getImageData(texOffsetX, texOffsetY, canvas.width, canvas.height);
+            oldTexSubImage2D.call(gl, args[0], args[1], texOffsetX, texOffsetY,
+                canvas.width, canvas.height, args[4], args[5], new Uint8Array(imgData.data));
         } else {
             oldTexSubImage2D.apply(gl, args);
         }

--- a/pal/minigame/wechat_mini_program.ts
+++ b/pal/minigame/wechat_mini_program.ts
@@ -27,6 +27,8 @@ import { Orientation } from '../screen-adapter/enum-type';
 import { cloneObject, createInnerAudioContextPolyfill, versionCompare } from '../utils';
 
 declare let wx: any;
+// NOTE: getApp is defined on wechat miniprogram platform
+declare const getApp: any;
 
 // @ts-expect-error can't init minigame when it's declared
 const minigame: IMiniGame = {};
@@ -174,8 +176,7 @@ if (systemInfo.platform === 'windows' && versionCompare(systemInfo.SDKVersion, '
 }
 
 // HACK: adapt gl.texSubImage2D: gl.texSubImage2D do not support 2d canvas in wechat miniprogram
-// @ts-expect-error getApp defined in global
-const gl = getApp().GameGlobal.canvas.getContext('webgl') as any;
+const gl = getApp().GameGlobal.canvas.getContext('webgl');
 const oldTexSubImage2D = gl.texSubImage2D;
 gl.texSubImage2D = function (...args) {
     if (args.length === 7) {

--- a/platforms/minigame/platforms/wechat/wrapper/builtin/EventIniter/TouchEvent.js
+++ b/platforms/minigame/platforms/wechat/wrapper/builtin/EventIniter/TouchEvent.js
@@ -22,7 +22,13 @@ function touchEventHandlerFactory(type) {
     touchEvent.targetTouches = Array.prototype.slice.call(event.touches)
     touchEvent.changedTouches = event.changedTouches
     touchEvent.timeStamp = event.timeStamp
-    document.dispatchEvent(touchEvent)
+    if (typeof getApp === 'function') {
+      // for wechat miniprogram
+      GameGlobal.document.dispatchEvent(touchEvent)
+    } else {
+      // for wechat minigame
+      document.dispatchEvent(touchEvent)
+    }
   }
 }
 

--- a/templates/wechatprogram/app.json
+++ b/templates/wechatprogram/app.json
@@ -1,15 +1,16 @@
-{ "lazyCodeLoading":"requiredComponents",
-  "pages":[
-    "index"
+{
+  "pages": [
+      "index"
   ],
-  "window":{
-    "backgroundTextStyle":"light",
-    "navigationBarBackgroundColor": "#fff",
-    "navigationBarTitleText": "CocosCreator",
-    "navigationBarTextStyle":"black",
-    "navigationStyle": "custom",
-    "pageOrientation": "auto"
+  "window": {
+      "backgroundTextStyle": "light",
+      "navigationBarBackgroundColor": "#fff",
+      "navigationBarTitleText": "CocosCreator",
+      "navigationBarTextStyle": "black",
+      "navigationStyle": "custom",
+      "pageOrientation": "portrait"
   },
   "style": "v2",
-  "sitemapLocation": "sitemap.json"
+  "sitemapLocation": "sitemap.json",
+  "subPackages": []
 }

--- a/templates/wechatprogram/first-screen.js
+++ b/templates/wechatprogram/first-screen.js
@@ -264,7 +264,7 @@ function start(alpha, antialias, useWebgl2) {
         window.WebGL2RenderingContext = false;
         gl = window.canvas.getContext("webgl", options);
     }
-    canvas = gl.canvas;
+    canvas = window.canvas;
     initVertexBuffer();
     initProgressVertexBuffer();
     initTexture();

--- a/templates/wechatprogram/game.ejs
+++ b/templates/wechatprogram/game.ejs
@@ -1,20 +1,21 @@
-globalThis.__wxRequire = require;  // FIX: require cannot work in separate engine 
+globalThis.__wxRequire = require;
 var GameGlobal = getApp().GameGlobal;
 Page({
     onReady() {
         const query = wx.createSelectorQuery()
-        query.select('#myCanvas').node().exec((res) => {
-            // require('./miniapp-adapter');
+        query.select('#myCanvas').node().exec(async (res) => {
             const canvas = res[0].node;
             let width = canvas.width;
             let height = canvas.height;
-    
             const adapter = require('./miniapp-adapter');
             adapter.adapt(canvas, width, height);
             require('./web-adapter');
-
             const firstScreen = require('./first-screen'); 
             <%- include(cocosTemplate, {}) %>
+            const loader = require('load-module.js');
+            await loader.loadModules();
+
+            require('./application.js');
             // Adjust initial canvas size
             if (canvas && GameGlobal.devicePixelRatio >= 2) {
                 canvas.width *= 2; canvas.height *= 2;
@@ -25,17 +26,17 @@ Page({
             System.warmup({
                 importMap,
                 importMapUrl: '<%= importMapFile%>',
-                defaultHandler: (urlNoSchema) => {
-                    require('.' + urlNoSchema);
-                },
-                handlers: {
-                    'plugin:': (urlNoSchema) => {
-                        requirePlugin(urlNoSchema);
-                    },
-                    'project:': (urlNoSchema) => {
-                        require(urlNoSchema);
-                    },
-                },
+                // defaultHandler: (urlNoSchema) => {
+                //     require('.' + urlNoSchema);
+                // },
+                // handlers: {
+                //     'plugin:': (urlNoSchema) => {
+                //         requirePlugin(urlNoSchema);
+                //     },
+                //     'project:': (urlNoSchema) => {
+                //         require(urlNoSchema);
+                //     },
+                // },
             });
 
             firstScreen.start('<%= alpha %>', '<%= antialias %>', '<%= useWebgl2 %>').then(() => {
@@ -57,6 +58,7 @@ Page({
                     return firstScreen.setProgress(0.6).then(() => Promise.resolve(module));
                 }).then((cc) => {
                     require('./engine-adapter');
+                    require('src/chunks/bundle.js'); //bundle.js should reuqire after engine-adapter if use named register mode
                     return application.init(cc);
                 }).then(() => {
                     return firstScreen.end().then(() => application.start());

--- a/templates/wechatprogram/game.ejs
+++ b/templates/wechatprogram/game.ejs
@@ -58,7 +58,6 @@ Page({
                     return firstScreen.setProgress(0.6).then(() => Promise.resolve(module));
                 }).then((cc) => {
                     require('./engine-adapter');
-                    require('src/chunks/bundle.js'); //bundle.js should reuqire after engine-adapter if use named register mode
                     return application.init(cc);
                 }).then(() => {
                     return firstScreen.end().then(() => application.start());

--- a/templates/wechatprogram/miniapp-adapter.js
+++ b/templates/wechatprogram/miniapp-adapter.js
@@ -17,7 +17,7 @@ exports.adapt = function (canvas, width, height) {
             isFirstCall = false;
             return canvas;
         } else {
-            return wx.createOffscreenCanvas(width, height);
+            return wx.createOffscreenCanvas({type:"2d", width: width, height: height});
         }
     }
 

--- a/templates/wechatprogram/project.config.json
+++ b/templates/wechatprogram/project.config.json
@@ -43,7 +43,7 @@
     },
     "compileType": "miniprogram",
     "libVersion": "2.19.4",
-    "appid": "wx160703e6ec9ed84e",
+    "appid": "wx2c815291f1aa4d1c",
     "projectname": "miniprogram-92",
     "condition": {},
     "editorSetting": {


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/16071

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
