### PR TITLE
Synchronize the path of the generated binding files to CI

### DIFF
--- a/.github/workflows/native-bindings.yml
+++ b/.github/workflows/native-bindings.yml
@@ -3,6 +3,7 @@ name: <Native> Generate Code
 on:
   pull_request_target:
     types: [opened, synchronize, closed]
+  # pull_request:
     paths:
     - 'templates/**'
     - 'native/**'
@@ -18,8 +19,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install CMake & Clang Tidy
+        run: |
+          sudo apt update --fix-missing
+          sudo apt install -y ninja-build
+      - name: Download external
+        run: |
+          EXT_VERSION=`node ./.github/workflows/get-native-external-version.js`
+          git clone --branch $EXT_VERSION --depth 1 https://github.com/cocos/cocos-engine-external native/external
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
       - name: Generate decorators
         run: |
+          cd native
+          echo "Generate compile_commands.json & ninja target"
+          bash ./utils/generate_compile_commands_android.sh
+          echo "Generate binding code ..."
+          ninja -C build genbindings
+          cd ..
           npm install
           cd scripts/build-engine
           echo "Installing babel dependencies ..."

--- a/scripts/build-engine/src/babel-plugins/decorator-parser.ts
+++ b/scripts/build-engine/src/babel-plugins/decorator-parser.ts
@@ -435,7 +435,7 @@ function getExportedClassesFromCppSourceCode() {
     const toFullPath = (prefix: string) => (filename: string) => path.join(prefix, filename);
     const findInDir = (filterCb: { (p: string): boolean }) => (dir: string) => fs.readdirSync(dir).filter(filterCb).map(toFullPath(dir)).forEach((fp) => cppSourceFiles.push(fp));
 
-    ['native/cocos/bindings/manual', 'native/cocos/bindings/auto'].map(toFullPath(enginePath)).forEach(findInDir((x) => x.startsWith('jsb_') && x.endsWith('.cpp')));
+    ['native/cocos/bindings/manual', 'native/build/generated/cocos/bindings/auto'].map(toFullPath(enginePath)).forEach(findInDir((x) => x.startsWith('jsb_') && x.endsWith('.cpp')));
 
     const se_Class_create = /se::Class::create\((\{("\w+",\s*"\w+")+\}|("\w+"))/;
 


### PR DESCRIPTION
Re: #

### Changelog

* Reconfigure the path of the generated binding code for the dependencies used to generate decorators.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
