### PR TITLE
Read touch information in the UI thread

### DIFF
--- a/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
+++ b/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
@@ -46,11 +46,11 @@
 #include <chrono>
 
 namespace {
-void sendMsgToWorker(const cc::MessageType& type, OH_NativeXComponent* component, void* window) {
+void sendMsgToWorker(const cc::MessageType& type, void* data, void* window) {
     cc::OpenHarmonyPlatform* platform = dynamic_cast<cc::OpenHarmonyPlatform*>(cc::BasePlatform::getPlatform());
     CC_ASSERT(platform != nullptr);
-    cc::WorkerMessageData data{type, static_cast<void*>(component), window};
-    platform->enqueue(data);
+    cc::WorkerMessageData msg{type, static_cast<void*>(data), window};
+    platform->enqueue(msg);
 }
 
 void onSurfaceCreatedCB(OH_NativeXComponent* component, void* window) {
@@ -70,15 +70,35 @@ void onSurfaceCreatedCB(OH_NativeXComponent* component, void* window) {
 }
 
 void dispatchTouchEventCB(OH_NativeXComponent* component, void* window) {
-    sendMsgToWorker(cc::MessageType::WM_XCOMPONENT_TOUCH_EVENT, component, window);
+    OH_NativeXComponent_TouchEvent touchEvent;
+    int32_t ret = OH_NativeXComponent_GetTouchEvent(component, window, &touchEvent);
+    if (ret != OH_NATIVEXCOMPONENT_RESULT_SUCCESS) {
+        return;
+    }
+    // TODO(qgh):Is it possible to find an efficient way to do this, I thought about using a cache queue but it requires locking.
+    cc::TouchEvent* ev = new cc::TouchEvent;
+    ev->windowId = 1;
+    if (touchEvent.type == OH_NATIVEXCOMPONENT_DOWN) {
+        ev->type = cc::TouchEvent::Type::BEGAN;
+    } else if (touchEvent.type == OH_NATIVEXCOMPONENT_MOVE) {
+        ev->type = cc::TouchEvent::Type::MOVED;
+    } else if (touchEvent.type == OH_NATIVEXCOMPONENT_UP) {
+        ev->type = cc::TouchEvent::Type::ENDED;
+    } else if (touchEvent.type == OH_NATIVEXCOMPONENT_CANCEL) {
+        ev->type = cc::TouchEvent::Type::CANCELLED;
+    }
+    for(int i = 0; i < touchEvent.numPoints; ++i) {
+        ev->touches.emplace_back(touchEvent.touchPoints[i].x, touchEvent.touchPoints[i].y, touchEvent.touchPoints[i].id);
+    }
+    sendMsgToWorker(cc::MessageType::WM_XCOMPONENT_TOUCH_EVENT, reinterpret_cast<void*>(ev), window);
 }
 
 void onSurfaceChangedCB(OH_NativeXComponent* component, void* window) {
-    sendMsgToWorker(cc::MessageType::WM_XCOMPONENT_SURFACE_CHANGED, component, window);
+    sendMsgToWorker(cc::MessageType::WM_XCOMPONENT_SURFACE_CHANGED, reinterpret_cast<void*>(component), window);
 }
 
 void onSurfaceDestroyedCB(OH_NativeXComponent* component, void* window) {
-    sendMsgToWorker(cc::MessageType::WM_XCOMPONENT_SURFACE_DESTROY, component, window);
+    sendMsgToWorker(cc::MessageType::WM_XCOMPONENT_SURFACE_DESTROY, reinterpret_cast<void*>(component), window);
 }
 
 } // namespace
@@ -157,16 +177,23 @@ void OpenHarmonyPlatform::onMessageCallback(const uv_async_t* /* req */) {
         }
 
         if ((msgData.type >= MessageType::WM_XCOMPONENT_SURFACE_CREATED) && (msgData.type <= MessageType::WM_XCOMPONENT_SURFACE_DESTROY)) {
-            OH_NativeXComponent* nativexcomponet = reinterpret_cast<OH_NativeXComponent*>(msgData.data);
-            CC_ASSERT(nativexcomponet != nullptr);
-
-            if (msgData.type == MessageType::WM_XCOMPONENT_SURFACE_CREATED) {
+            if (msgData.type == MessageType::WM_XCOMPONENT_TOUCH_EVENT) {
+                TouchEvent* ev = reinterpret_cast<TouchEvent*>(msgData.data);
+                CC_ASSERT(ev != nullptr);
+                events::Touch::broadcast(*ev);
+                delete ev;
+                ev = nullptr;
+            } else if (msgData.type == MessageType::WM_XCOMPONENT_SURFACE_CREATED) {
+                OH_NativeXComponent* nativexcomponet = reinterpret_cast<OH_NativeXComponent*>(msgData.data);
+                CC_ASSERT(nativexcomponet != nullptr);
                 platform->onSurfaceCreated(nativexcomponet, msgData.window);
-            } else if (msgData.type == MessageType::WM_XCOMPONENT_TOUCH_EVENT) {
-                platform->dispatchTouchEvent(nativexcomponet, msgData.window);
             } else if (msgData.type == MessageType::WM_XCOMPONENT_SURFACE_CHANGED) {
+                OH_NativeXComponent* nativexcomponet = reinterpret_cast<OH_NativeXComponent*>(msgData.data);
+                CC_ASSERT(nativexcomponet != nullptr);
                 platform->onSurfaceChanged(nativexcomponet, msgData.window);
             } else if (msgData.type == MessageType::WM_XCOMPONENT_SURFACE_DESTROY) {
+                OH_NativeXComponent* nativexcomponet = reinterpret_cast<OH_NativeXComponent*>(msgData.data);
+                CC_ASSERT(nativexcomponet != nullptr);
                 platform->onSurfaceDestroyed(nativexcomponet, msgData.window);
             } else {
                 CC_ASSERT(false);
@@ -246,31 +273,6 @@ void OpenHarmonyPlatform::onSurfaceChanged(OH_NativeXComponent* component, void*
 void OpenHarmonyPlatform::onSurfaceDestroyed(OH_NativeXComponent* component, void* window) {
     SystemWindow* systemWindowIntf = getPlatform()->getInterface<SystemWindow>();
     systemWindowIntf->setWindowHandle(nullptr);
-}
-
-void OpenHarmonyPlatform::dispatchTouchEvent(OH_NativeXComponent* component, void* window) {
-    OH_NativeXComponent_TouchEvent touchEvent;
-    int32_t ret = OH_NativeXComponent_GetTouchEvent(component, window, &touchEvent);
-    if (ret != OH_NATIVEXCOMPONENT_RESULT_SUCCESS) {
-        return;
-    }
-
-    TouchEvent ev;
-    ev.windowId = 1;
-    if (touchEvent.type == OH_NATIVEXCOMPONENT_DOWN) {
-        ev.type = cc::TouchEvent::Type::BEGAN;
-    } else if (touchEvent.type == OH_NATIVEXCOMPONENT_MOVE) {
-        ev.type = cc::TouchEvent::Type::MOVED;
-    } else if (touchEvent.type == OH_NATIVEXCOMPONENT_UP) {
-        ev.type = cc::TouchEvent::Type::ENDED;
-    } else if (touchEvent.type == OH_NATIVEXCOMPONENT_CANCEL) {
-        ev.type = cc::TouchEvent::Type::CANCELLED;
-    }
-    for(int i = 0; i < touchEvent.numPoints; ++i) {
-        ev.touches.emplace_back(touchEvent.touchPoints[i].x, touchEvent.touchPoints[i].y, touchEvent.touchPoints[i].id);
-    }
-
-    events::Touch::broadcast(ev);
 }
 
 ISystemWindow *OpenHarmonyPlatform::createNativeWindow(uint32_t windowId, void *externalHandle) {

--- a/native/cocos/platform/openharmony/OpenHarmonyPlatform.h
+++ b/native/cocos/platform/openharmony/OpenHarmonyPlatform.h
@@ -67,7 +67,6 @@ public:
     void onSurfaceCreated(OH_NativeXComponent* component, void* window);
     void onSurfaceChanged(OH_NativeXComponent* component, void* window);
     void onSurfaceDestroyed(OH_NativeXComponent* component, void* window);
-    void dispatchTouchEvent(OH_NativeXComponent* component, void* window);
     
     static void onMessageCallback(const uv_async_t* req);
     static void timerCb(uv_timer_t* handle);


### PR DESCRIPTION
### Changelog
Read touch information in the UI thread

https://github.com/cocos/3d-tasks/issues/15998

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
