### PR TITLE
Add Visual Studio Option to Windows Build Panel

### DIFF
--- a/scripts/native-pack-tool/source/cocosConfig.ts
+++ b/scripts/native-pack-tool/source/cocosConfig.ts
@@ -7,27 +7,35 @@ export const cocosConfig = {
             generators: [
                 {
                     G: 'Visual Studio 17 2022',
+                    V: '2022',
                 },
                 {
                     G: 'Visual Studio 16 2019',
+                    V: '2019',
                 },
                 {
                     G: 'Visual Studio 15 2017',
+                    V: '2017',
                 },
                 {
                     G: 'Visual Studio 14 2015',
+                    V: '2015',
                 },
                 {
                     G: 'Visual Studio 12 2013',
+                    V: '2013',
                 },
                 {
                     G: 'Visual Studio 11 2012',
+                    V: '2012',
                 },
                 {
                     G: 'Visual Studio 10 2010',
+                    V: '2010',
                 },
                 {
                     G: 'Visual Studio 9 2008',
+                    V: '2008',
                 },
             ],
         },

--- a/scripts/native-pack-tool/source/platforms/windows.ts
+++ b/scripts/native-pack-tool/source/platforms/windows.ts
@@ -8,6 +8,7 @@ import { spawn } from "child_process";
 
 export interface IWindowsParam {
     targetPlatform: 'x64';
+    vsVersion: string;
 }
 
 export class WindowsPackTool extends NativePackTool {
@@ -37,13 +38,14 @@ export class WindowsPackTool extends NativePackTool {
 
         let generateArgs: string[] = [];
         if (!fs.existsSync(ps.join(nativePrjDir, 'CMakeCache.txt'))) {
-            const g = this.getCmakeGenerator();
+            const vsVersion = this.getCmakeGenerator();
             // const g = '';
-            if (g) {
-                const optlist = cocosConfig.cmake.windows.generators.filter((x) => x.G.toLowerCase() === g.toLowerCase());
-                if (optlist.length === 0) {
-                    generateArgs.push(`-G"${g}"`);
-                } else {
+            if (vsVersion) {
+                const optlist = cocosConfig.cmake.windows.generators.filter((x) => x.V === vsVersion);
+                if (optlist.length > 0) {
+                    generateArgs.push(`-G"${optlist[0].G}"`);
+                }
+                if (Number.parseInt(vsVersion) <= 2017) {
                     generateArgs.push('-A', this.params.platformParams.targetPlatform);
                 }
             } else {
@@ -129,9 +131,8 @@ export class WindowsPackTool extends NativePackTool {
         return ret;
     }
 
-    // TODO visual studio version
     getCmakeGenerator() {
-        return '';
+        return this.params.platformParams.vsVersion || '';
     }
 
     async run(): Promise<boolean> {


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16095

Deps: https://github.com/cocos/creator-runtime-extensions/pull/375

Allowing developers to specify the Visual Studio version, adding a CMake Generator option, and enabling developers to select a specific Visual Studio version for their project.

### Changelog

* Add CMake Generator Option to Windows Build Panel

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
