### PR TITLE
Adding Xcode Installation Check to Build Process on macOS

### DIFF
--- a/scripts/native-pack-tool/source/platforms/ios.ts
+++ b/scripts/native-pack-tool/source/platforms/ios.ts
@@ -83,6 +83,11 @@ export class IOSPackTool extends MacOSPackTool {
     }
 
     async generate() {
+
+        if(!await this.checkIfXcodeInstalled()) {
+            throw new Error(`Please check if Xcode is installed.`);
+        }
+
         if(this.shouldSkipGenerate()) {
             return false;
         }

--- a/scripts/native-pack-tool/source/platforms/mac-os.ts
+++ b/scripts/native-pack-tool/source/platforms/mac-os.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 import * as ps from 'path';
 import * as os from 'os';
 import { execSync } from "child_process";
+import { toolHelper } from "../utils";
 
 export interface IOrientation {
     landscapeLeft: boolean;
@@ -70,7 +71,7 @@ export abstract class MacOSPackTool extends NativePackTool {
             await this.xcodeFixAssetsReferences();
         }
     }
-    
+
     /**
      * When "Skip Xcode Project Update" is checked, changes to the contents of the "data" directory
      * still need to be synchronized with Xcode. One way to achieve this is to modify the Xcode
@@ -165,5 +166,25 @@ export abstract class MacOSPackTool extends NativePackTool {
                 console.error(e);
             }
         }
+    }
+
+    async checkIfXcodeInstalled() {
+        let xcodeFound = false;
+        const xcodeInstalled = await toolHelper.runCommand('xcode-select', ['-p'], (code, stdout, stderr) => {
+            if (code === 0) {
+                console.log(`[xcode-select] ${stdout}`);
+                if (stdout.indexOf('Xcode.app') > 0) {
+                    xcodeFound = true;
+                }
+            } else {
+                console.log(`[xcode-select] ${stdout}`);
+                console.error(`[xcode-select] ${stderr}`);
+            }
+        });
+        if (!xcodeInstalled) {
+            toolHelper.runCommand('xcode-select', ['--install']);
+            return false;
+        }
+        return xcodeFound;
     }
 }

--- a/scripts/native-pack-tool/source/platforms/mac.ts
+++ b/scripts/native-pack-tool/source/platforms/mac.ts
@@ -21,6 +21,11 @@ export class MacPackTool extends MacOSPackTool {
     }
 
     async generate() {
+
+        if(!await this.checkIfXcodeInstalled()) {
+            throw new Error(`Please check if Xcode is installed.`);
+        }
+
         if(this.shouldSkipGenerate()) {
             return false;
         }

--- a/scripts/native-pack-tool/source/utils.ts
+++ b/scripts/native-pack-tool/source/utils.ts
@@ -427,6 +427,22 @@ export const toolHelper = {
         }
     },
 
+    async runCommand(cmd:string, args:string[], cb?:(code:number, stdout:string, stderr:string)=>void): Promise<boolean> {
+        return new Promise<boolean>((resolve, reject) => {
+            const cp = spawn(cmd, args);
+            const stdErr:Buffer[] = [];
+            const stdOut:Buffer[] = [];
+            cp.stderr.on('data', (d)=>stdErr.push(d));
+            cp.stdout.on('data', (d)=>stdOut.push(d));
+            cp.on('close', (code, signal)=>{
+                if(cb) {
+                    cb(code, Buffer.concat(stdOut).toString('utf8'), Buffer.concat(stdErr).toString('utf8'));
+                }
+                resolve(code === 0);
+            });
+        });
+    },
+
     runCmake(args: string[]) {
         const cmakePath = Paths.cmakePath;
         // Delete environment variables start with `npm_`, which may cause compile error on windows


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/12791

This PR adds a check for Xcode installation before the build process on macOS to prevent errors and provide a more user-friendly message.

### Changelog

* Verifies if Xcode is installed on the system before proceeding with the build

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
