### PR TITLE
Fix OH platform can't play audio from background to foreground

### DIFF
--- a/templates/openharmony/entry/src/main/ets/MainAbility/MainAbility.ts
+++ b/templates/openharmony/entry/src/main/ets/MainAbility/MainAbility.ts
@@ -27,6 +27,7 @@ import nativerender from "libcocos.so";
 import { ContextType } from "../common/Constants"
 import window from '@ohos.window';
 import resourceManager from '@ohos.resourceManager';
+import avsession from '@ohos.multimedia.avsession';
 
 const nativeContext = nativerender.getContext(ContextType.ENGINE_UTILS);
 const nativeAppLifecycle = nativerender.getContext(ContextType.APP_LIFECYCLE);
@@ -36,6 +37,15 @@ export default class MainAbility extends UIAbility {
         globalThis.abilityWant = want;
         nativeAppLifecycle.onCreate();
         nativeContext.resourceManagerInit(this.context.resourceManager);
+        let tag = "createAudioSession";
+        // TODO(qgh): This is a temporary fix for audio not continuing to play when switching from background to foreground.
+        // The principle of the fix is to allow the app to continue playing audio after switching background, similar to music apps.
+        // After a while it will be killed by the system.
+        // @ts-ignore
+        avsession.createAVSession(this.context, tag, 'audio').then(async (session) =>{
+            globalThis.avsessionManager = session;
+            await globalThis.avsessionManager.activate();
+        })
     }
 
     onDestroy() {


### PR DESCRIPTION
https://github.com/cocos/3d-tasks/issues/16069

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
