### PR TITLE
Fix exception in material uniform animation binding

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1845,6 +1845,22 @@ Previous error occurred when instantiating animation clip %s on node %s.
 
 '%s' is not found from '%s'. It's specified as the root node to play animation clip '%s'.
 
+### 3940
+
+Error when animation attempted to bind material uniform target: target %s is not a material.
+
+### 3941
+
+Error when animation attempted to bind material uniform target: material %s has no recorded pass %s.
+
+### 3942
+
+Error when animation attempted to bind material uniform target: material %s at pass %s has no recorded uniform %s.
+
+### 3943
+
+Error when animation attempted to bind material uniform target: material %s at pass %s's uniform %s has no recorded channel %s.
+
 ### 4000
 
 <!-- DEPRECATED -->

--- a/cocos/animation/tracks/track.ts
+++ b/cocos/animation/tracks/track.ts
@@ -389,6 +389,9 @@ export class TrackBinding {
                 return null;
             }
             const runtimeProxy = proxy.forTarget(resultTarget);
+            if (!runtimeProxy) {
+                return null;
+            }
             const binding: RuntimeBinding = {
                 setValue: (value) => {
                     runtimeProxy.set(value);

--- a/cocos/animation/value-proxy-factories/uniform.ts
+++ b/cocos/animation/value-proxy-factories/uniform.ts
@@ -31,7 +31,7 @@ import { deviceManager, Type } from '../../gfx';
 import { Pass } from '../../render-scene/core/pass';
 import { getDefaultFromType, getStringFromType } from '../../render-scene/core/pass-utils';
 import { IValueProxy, IValueProxyFactory } from '../value-proxy';
-import { warn } from '../../core';
+import { warn, warnID } from '../../core';
 
 /**
  * @en
@@ -73,19 +73,38 @@ export class UniformProxyFactory implements IValueProxyFactory {
         this.uniformName = uniformName || '';
     }
 
-    public forTarget (target: Material): IValueProxy {
-        const pass = target.passes[this.passIndex];
-        const handle = pass.getHandle(this.uniformName);
-        if (!handle) {
-            throw new Error(`Material "${target.name}" has no uniform "${this.uniformName}"`);
+    public forTarget (target: unknown): IValueProxy | undefined {
+        if (!(target instanceof Material)) {
+            warnID(3940, target);
+            return undefined;
         }
+
+        const {
+            passIndex,
+            uniformName,
+            channelIndex,
+        } = this;
+
+        if (passIndex < 0 || passIndex >= target.passes.length) {
+            warnID(3941, target.name, passIndex);
+            return undefined;
+        }
+
+        const pass = target.passes[passIndex];
+        const handle = pass.getHandle(uniformName);
+        if (!handle) {
+            warnID(3942, target.name, passIndex, uniformName);
+            return undefined;
+        }
+
         const type = Pass.getTypeFromHandle(handle);
         if (type < Type.SAMPLER1D) {
-            const realHandle = this.channelIndex === undefined ? handle : pass.getHandle(this.uniformName, this.channelIndex, Type.FLOAT);
+            const realHandle = channelIndex === undefined ? handle : pass.getHandle(uniformName, channelIndex, Type.FLOAT);
             if (!realHandle) {
-                throw new Error(`Uniform "${this.uniformName} (in material ${target.name}) has no channel ${this.channelIndex!}"`);
+                warnID(3943, target.name, passIndex, uniformName, channelIndex);
+                return undefined;
             }
-            if (isUniformArray(pass, this.uniformName)) {
+            if (isUniformArray(pass, uniformName)) {
                 return {
                     set: (value: any) => {
                         pass.setUniformArray(realHandle, value);
@@ -99,7 +118,7 @@ export class UniformProxyFactory implements IValueProxyFactory {
             };
         } else {
             const binding = Pass.getBindingFromHandle(handle);
-            const prop = pass.properties[this.uniformName];
+            const prop = pass.properties[uniformName];
             const texName = prop && prop.value ? `${prop.value as string}${getStringFromType(prop.type)}` : getDefaultFromType(prop.type) as string;
             let dftTex = builtinResMgr.get<TextureBase>(texName);
             if (!dftTex) {

--- a/cocos/animation/value-proxy.ts
+++ b/cocos/animation/value-proxy.ts
@@ -56,6 +56,8 @@ export interface IValueProxyFactory {
      * @zh
      * 返回指定目标的曲线值代理。
      * @param target The target acquiring the value proxy.
+     * @returns The value proxy, or undefined if the proxy could not be created.
+     * In later case, a warn should be given before returning.
      */
-    forTarget (target: any): IValueProxy;
+    forTarget (target: any): IValueProxy | undefined;
 }

--- a/tests/animation/value-proxies/uniform.test.ts
+++ b/tests/animation/value-proxies/uniform.test.ts
@@ -1,0 +1,139 @@
+import { Track, UniformProxyFactory, VectorTrack } from "../../../cocos/animation/animation";
+import { AnimationClip } from "../../../cocos/animation/animation-clip";
+import { AnimationState } from "../../../cocos/animation/animation-state";
+import { Pass } from "../../../cocos/render-scene";
+import { Component, Node } from "../../../cocos/scene-graph";
+import { director, EffectAsset, js, Material, Vec3 } from "../../../exports/base";
+import { captureWarnIDs } from "../../utils/log-capture";
+
+describe(`Error sentences`, () => {
+    beforeAll(() => js.setClassName('MaterialHost', MaterialHost));
+    afterAll(() => js.unregisterClass(MaterialHost));
+
+    test(`Warn if input target is not a material`, () => {
+        const origin = new Node('SomeOrigin');
+        const materialHost = origin.addComponent(MaterialHost) as MaterialHost;
+
+        const track = new VectorTrack();
+        track.channels()[0].curve.assignSorted([[0.0, 0.0]]);
+        track.path.toComponent(MaterialHost);
+        track.proxy = new UniformProxyFactory();
+
+        bindThenAssertWarn(origin, track, [3940, materialHost]);
+    });
+
+    test(`Warn if recorded pass index is invalid`, () => {
+        const origin = new Node('SomeOrigin');
+        const materialHost = origin.addComponent(MaterialHost) as MaterialHost;
+        const material = materialHost.material = mockMaterial([
+            { uniforms: {} },
+            { uniforms: {} },
+            { uniforms: {} },
+        ]);
+        material.name = 'SomeMaterial';
+
+        const track = new VectorTrack();
+        track.channels()[0].curve.assignSorted([[0.0, 0.0]]);
+        track.path.toComponent(MaterialHost).toProperty('material');
+
+        const proxyFactory = track.proxy = new UniformProxyFactory();
+        for (const passIndex of [-2, -1, 3, 4]) {
+            proxyFactory.passIndex = passIndex;
+            bindThenAssertWarn(origin, track, [3941, material.name, proxyFactory.passIndex]);
+        }
+    });
+
+    test(`Warn if recorded uniform name is in invalid`, () => {
+        const origin = new Node('SomeOrigin');
+        const materialHost = origin.addComponent(MaterialHost) as MaterialHost;
+        const material = materialHost.material = mockMaterial([
+            { uniforms: { 'SomeUniform': { availableChannelCount: 3 } } },
+            { uniforms: {} },
+            { uniforms: {} },
+        ]);
+        material.name = 'SomeMaterial';
+
+        const track = new VectorTrack();
+        track.channels()[0].curve.assignSorted([[0.0, 0.0]]);
+        track.path.toComponent(MaterialHost).toProperty('material');
+        const proxyFactory = track.proxy = new UniformProxyFactory();
+        proxyFactory.passIndex = 1;
+        proxyFactory.uniformName = 'SomeUniform';
+        proxyFactory.channelIndex = 4;
+
+        bindThenAssertWarn(origin, track, [3942, material.name, proxyFactory.passIndex, proxyFactory.uniformName]);
+    });
+
+    test(`Warn if recorded channel index is invalid`, () => {
+        const origin = new Node('SomeOrigin');
+        const materialHost = origin.addComponent(MaterialHost) as MaterialHost;
+        const material = materialHost.material = mockMaterial([
+            { uniforms: {} },
+            { uniforms: { 'SomeUniform': { availableChannelCount: 3 } } },
+            { uniforms: {} },
+        ]);
+        material.name = 'SomeMaterial';
+
+        const track = new VectorTrack();
+        track.channels()[0].curve.assignSorted([[0.0, 0.0]]);
+        track.path.toComponent(MaterialHost).toProperty('material');
+        const proxyFactory = track.proxy = new UniformProxyFactory();
+        proxyFactory.passIndex = 1;
+        proxyFactory.uniformName = 'SomeUniform';
+
+        for (const channelIndex of [-1, -2, 3, 4]) {
+            proxyFactory.channelIndex = channelIndex;
+            bindThenAssertWarn(origin, track, [3943, material.name, proxyFactory.passIndex, proxyFactory.uniformName, proxyFactory.channelIndex]);
+        }
+    });
+
+    class MaterialHost extends Component {
+        public declare material: Material;
+    }
+
+    function bindThenAssertWarn(
+        root: Node,
+        track: Track,
+        expectedCapturedWarns: [warnId: number, ...optionalParams: any[]]
+    ) {
+        const animationClip = new AnimationClip();
+        animationClip.name = 'Meow';
+        animationClip.duration = 1.0;
+        animationClip.addTrack(track);
+
+        const warnWatcher = captureWarnIDs();
+
+        const state = new AnimationState(animationClip);
+        state.initialize(root);
+
+        expect(warnWatcher.captured).toHaveLength(2);
+        expect(warnWatcher.captured[0]).toStrictEqual(expectedCapturedWarns);
+        expect(warnWatcher.captured[1]).toStrictEqual([3937, 'Meow', root.name]);
+        warnWatcher.clear();
+        warnWatcher.stop();
+    }
+
+    function mockMaterial(passMocks: Array<{
+        uniforms: Record<string, { availableChannelCount: number }>;
+    }>) {
+        const passes = passMocks.map((passMock) => {
+            const pass = new Pass(director.root!);
+            jest.spyOn(pass, 'getHandle').mockImplementation((name, offset) => {
+                const uniformMock = passMock.uniforms[name];
+                if (!uniformMock) {
+                    return 0;
+                }
+                if (typeof offset !== 'undefined' && (offset < 0 || offset >= uniformMock.availableChannelCount)) {
+                    return 0;
+                }
+                return 1;
+            });
+            return pass;
+        });
+
+        const material = new Material();
+        jest.spyOn(material, 'passes', 'get').mockReturnValue(passes);
+
+        return material;
+    }
+});


### PR DESCRIPTION
### Changelog

* This PR fixes that there will be an exception thrown if material uniform animation data does not match the target to binding. Should closes #14752 .

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
