### PR TITLE
Fix 'switch' not adding break

### DIFF
--- a/native/cocos/bindings/jswrapper/napi/Object.cpp
+++ b/native/cocos/bindings/jswrapper/napi/Object.cpp
@@ -232,6 +232,7 @@ Object* Object::createTypedArray(Object::TypedArrayType type, const void* data, 
         case TypedArrayType::INT16:
             napiType  = napi_int16_array;
             sizeOfEle = 2;
+            break;
         case TypedArrayType::UINT16:
             napiType  = napi_uint16_array;
             sizeOfEle = 2;
@@ -239,9 +240,11 @@ Object* Object::createTypedArray(Object::TypedArrayType type, const void* data, 
         case TypedArrayType::INT32:
             napiType  = napi_int32_array;
             sizeOfEle = 4;
+            break;
         case TypedArrayType::UINT32:
             napiType  = napi_uint32_array;
             sizeOfEle = 4;
+            break;
         case TypedArrayType::FLOAT32:
             napiType  = napi_float32_array;
             sizeOfEle = 4;
@@ -307,6 +310,7 @@ Object* Object::createTypedArrayWithBuffer(TypedArrayType type, const Object *ob
         case TypedArrayType::INT16:
             napiType  = napi_int16_array;
             sizeOfEle = 2;
+            break;
         case TypedArrayType::UINT16:
             napiType  = napi_uint16_array;
             sizeOfEle = 2;
@@ -314,9 +318,11 @@ Object* Object::createTypedArrayWithBuffer(TypedArrayType type, const Object *ob
         case TypedArrayType::INT32:
             napiType  = napi_int32_array;
             sizeOfEle = 4;
+            break;
         case TypedArrayType::UINT32:
             napiType  = napi_uint32_array;
             sizeOfEle = 4;
+            break;
         case TypedArrayType::FLOAT32:
             napiType  = napi_float32_array;
             sizeOfEle = 4;


### PR DESCRIPTION

https://github.com/cocos/open-harmony/issues/172

### Changelog

Add break to the case of switch

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
