### PR TITLE
Fix Richtext miss string bug

### DIFF
--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -42,6 +42,9 @@ const _htmlTextParser = new HtmlTextParser();
 const RichTextChildName = 'RICHTEXT_CHILD';
 const RichTextChildImageName = 'RICHTEXT_Image_CHILD';
 
+const _tempSize = new Size();
+const _tempSizeLeft = new Size();
+
 /**
  * 富文本池。<br/>
  */
@@ -478,9 +481,6 @@ export class RichText extends Component {
     protected _updateRichTextStatus: () => void;
     protected _labelChildrenNum = 0; // only ISegment
 
-    private _tempSize = new Size();
-    private _tempSizeLeft = new Size();
-
     constructor () {
         super();
         if (EDITOR) {
@@ -585,14 +585,14 @@ export class RichText extends Component {
             return partStringArr;
         }
 
-        this._calculateSize(this._tempSize, styleIndex, text);
-        if (this._tempSize.x < 2048) {
+        this._calculateSize(_tempSize, styleIndex, text);
+        if (_tempSize.x < 2048) {
             partStringArr.push(text);
         } else {
             const multilineTexts = text.split('\n');
             for (let i = 0; i < multilineTexts.length; i++) {
-                this._calculateSize(this._tempSize, styleIndex, multilineTexts[i]);
-                if (this._tempSize.x < 2048) {
+                this._calculateSize(_tempSize, styleIndex, multilineTexts[i]);
+                if (_tempSize.x < 2048) {
                     partStringArr.push(multilineTexts[i]);
                 } else {
                     const thisPartSplitResultArr =  this.splitLongStringOver2048(multilineTexts[i], styleIndex);
@@ -614,8 +614,8 @@ export class RichText extends Component {
         let curEnd = longStr.length / 2;
         let curString = longStr.substring(curStart, curEnd);
         let leftString = longStr.substring(curEnd);
-        const curStringSize = this._calculateSize(this._tempSize, styleIndex, curString);
-        const leftStringSize = this._calculateSize(this._tempSizeLeft, styleIndex, leftString);
+        const curStringSize = this._calculateSize(_tempSize, styleIndex, curString);
+        const leftStringSize = this._calculateSize(_tempSizeLeft, styleIndex, leftString);
         let maxWidth = this._maxWidth;
         if (this._maxWidth === 0) {
             maxWidth = 2047.9; // Callback when maxWidth is 0
@@ -714,7 +714,7 @@ export class RichText extends Component {
 
     protected _measureText (styleIndex: number, string?: string) {
         const func = (s: string) => {
-            const width = this._calculateSize(this._tempSize, styleIndex, s).width;
+            const width = this._calculateSize(_tempSize, styleIndex, s).width;
             return width;
         };
         if (string) {

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -42,8 +42,8 @@ const _htmlTextParser = new HtmlTextParser();
 const RichTextChildName = 'RICHTEXT_CHILD';
 const RichTextChildImageName = 'RICHTEXT_Image_CHILD';
 
-const _tempSize = new Size();
-const _tempSizeLeft = new Size();
+const _tempSize = new Vec2();
+const _tempSizeLeft = new Vec2();
 
 /**
  * 富文本池。<br/>
@@ -714,7 +714,7 @@ export class RichText extends Component {
 
     protected _measureText (styleIndex: number, string?: string) {
         const func = (s: string) => {
-            const width = this._calculateSize(_tempSize, styleIndex, s).width;
+            const width = this._calculateSize(_tempSize, styleIndex, s).x;
             return width;
         };
         if (string) {
@@ -727,7 +727,7 @@ export class RichText extends Component {
     /**
     * @engineInternal
     */
-    protected _calculateSize (out: Size, styleIndex: number, s: string) {
+    protected _calculateSize (out: Vec2, styleIndex: number, s: string) {
         let label: ISegment;
         if (this._labelSegmentsCache.length === 0) {
             label = this._createFontLabel(s);
@@ -738,7 +738,8 @@ export class RichText extends Component {
         }
         label.styleIndex = styleIndex;
         this._applyTextAttribute(label);
-        out.set(label.node._uiProps.uiTransformComp!.contentSize);
+        const size = label.node._uiProps.uiTransformComp!.contentSize;
+        Vec2.set(out, size.x, size.y);
         return out;
     }
 

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -613,10 +613,14 @@ export class RichText extends Component {
         let leftString = longStr.substring(curEnd);
         let curStringSize = this._calculateSize(styleIndex, curString);
         let leftStringSize = this._calculateSize(styleIndex, leftString);
+        let maxWidth = this._maxWidth;
+        if (this._maxWidth === 0) {
+            maxWidth = 2047.9; // Callback when maxWidth is 0
+        }
 
         // a line should be an unit to split long string
         const lineCountForOnePart = 1;
-        const sizeForOnePart = lineCountForOnePart * this.maxWidth;
+        const sizeForOnePart = lineCountForOnePart * maxWidth;
 
         // divide text into some pieces of which the size is less than sizeForOnePart
         while (curStringSize.x > sizeForOnePart) {
@@ -690,10 +694,13 @@ export class RichText extends Component {
 
             // Exit: If the left part string size is less than 2048, the method will finish.
             if (leftStringSize.x < 2048) {
+                partStringArr.push(curString); // 跳行问题解决，但是空白太多
                 curStart = text.length;
                 curEnd = text.length;
                 curString = leftString;
-                partStringArr.push(curString);
+                if (leftString !== '') {
+                    partStringArr.push(curString);
+                }
                 break;
             } else {
                 curStringSize = this._calculateSize(styleIndex, curString);


### PR DESCRIPTION
Re: https://discord.com/channels/634690911896469525/634690911896469527/1091292440058675250

Fix RichText misc bug:

- Line feed error when maxWidth = 0 and the text is very long (width greater than 2048)
- When the text is very long (width greater than 2048), the text display is missing the penultimate line

[RichTextBug.zip](https://github.com/cocos/cocos-engine/files/11208975/RichTextBug.zip)
