### PR TITLE
fix ios inputOnToolbar missing cursor

### DIFF
--- a/native/cocos/ui/edit-box/EditBox-ios.mm
+++ b/native/cocos/ui/edit-box/EditBox-ios.mm
@@ -95,6 +95,7 @@ const bool INPUTBOX_HIDDEN = true; // Toggle if Inputbox is visible
  ************************************************************************/
 namespace {
 static bool g_isMultiline{false};
+static bool g_confirmHold{false};
 static int g_maxLength{INT_MAX};
 se::Value textInputCallback;
 
@@ -553,6 +554,7 @@ static EditboxManager *instance = nil;
 - (void) show: (const cc::EditBox::ShowInfo*)showInfo {
     g_maxLength = showInfo->maxLength;
     g_isMultiline = showInfo->isMultiline;
+    g_confirmHold = showInfo->confirmHold;
     
     if (g_isMultiline) {
         curView = [self createTextView:showInfo];
@@ -564,14 +566,22 @@ static EditboxManager *instance = nil;
     
     [view addSubview:[curView inputOnView]];
     [[curView inputOnView] becomeFirstResponder];
-    [[curView inputOnToolbar] becomeFirstResponder];
+     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+         if(![[curView inputOnToolbar] becomeFirstResponder]) {
+             CC_LOG_ERROR("inputOnToolbar becomeFirstResponder error!");
+         }
+    });
+
 }
 // Change the focus point to the TextField or TextView on the toolbar.
 - (void) hide {
-    [[curView inputOnView] becomeFirstResponder];
-    [[curView inputOnView] removeFromSuperview];
-    [[curView inputOnToolbar] resignFirstResponder];
-    [[curView inputOnView] resignFirstResponder];
+   if ([[curView inputOnToolbar] isFirstResponder]) {
+       [[curView inputOnToolbar] resignFirstResponder];
+   }
+   if ([[curView inputOnView] isFirstResponder]) {
+       [[curView inputOnView] resignFirstResponder];
+   }
+   [[curView inputOnView] removeFromSuperview];
 }
 
 - (InputBoxPair*) getCurrentViewInUse {
@@ -589,7 +599,8 @@ static EditboxManager *instance = nil;
 - (IBAction)buttonTapped:(UIButton *)button {
     const ccstd::string text([[[EditboxManager sharedInstance]getCurrentText] UTF8String]);
     callJSFunc("confirm", text);
-    cc::EditBox::complete();
+    if (!g_confirmHold)
+        cc::EditBox::complete();
 }
 @end
 /*************************************************************************
@@ -607,12 +618,12 @@ void EditBox::show(const cc::EditBox::ShowInfo &showInfo) {
 
 void EditBox::hide() {
     [[EditboxManager sharedInstance] hide];
-    EditBox::_isShown = true;
+    EditBox::_isShown = false;
 }
 
 bool EditBox::complete() {
     if(!EditBox::_isShown)
-        return true;
+        return false;
     NSString *text = [[EditboxManager sharedInstance] getCurrentText];
     callJSFunc("complete", [text UTF8String]);
     EditBox::hide();


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16114#
### Changelog
- fix ios inputOnToolbar cursor missing 
- revise some codes and add back missing codes in Editbox-ios.mm

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
