### PR TITLE
improve:WebGL2CmdFuncCopyTexImagesToTexture add option to use gl.texImage2D

### DIFF
--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2756,6 +2756,20 @@ export function WebGL2CmdFuncExecuteCmds (device: WebGL2Device, cmdPackage: WebG
     } // for
 }
 
+function isUseTexImage2D (texImages: Readonly<TexImageSource[]>, regions: Readonly<BufferTextureCopy[]>) {
+    if (texImages.length > 1 || regions.length > 1) return false;
+    const isVideoElement = texImages[0] instanceof HTMLVideoElement;
+    if (isVideoElement) {
+        const videoElement = texImages[0] as HTMLVideoElement;
+        const isSameSize = regions[0].texOffset.x === 0
+        && regions[0].texOffset.x === 0
+        && regions[0].texExtent.width === videoElement.videoWidth
+        && regions[0].texExtent.height === videoElement.videoHeight;
+        return isSameSize;
+    }
+    return false;
+}
+
 export function WebGL2CmdFuncCopyTexImagesToTexture (
     device: WebGL2Device,
     texImages: Readonly<TexImageSource[]>,
@@ -2774,11 +2788,16 @@ export function WebGL2CmdFuncCopyTexImagesToTexture (
 
     switch (gpuTexture.glTarget) {
     case gl.TEXTURE_2D: {
-        for (let k = 0; k < regions.length; k++) {
-            const region = regions[k];
-            gl.texSubImage2D(gl.TEXTURE_2D, region.texSubres.mipLevel,
-                region.texOffset.x, region.texOffset.y,
-                gpuTexture.glFormat, gpuTexture.glType, texImages[n++]);
+        if (isUseTexImage2D(texImages, regions)) {
+            gl.texImage2D(gl.TEXTURE_2D, regions[0].texSubres.mipLevel, gpuTexture.glInternalFmt, regions[0].texExtent.width,
+                regions[0].texExtent.height, 0, gpuTexture.glFormat, gpuTexture.glType, texImages[0]);
+        } else {
+            for (let k = 0; k < regions.length; k++) {
+                const region = regions[k];
+                gl.texSubImage2D(gl.TEXTURE_2D, region.texSubres.mipLevel,
+                    region.texOffset.x, region.texOffset.y,
+                    gpuTexture.glFormat, gpuTexture.glType, texImages[n++]);
+            }
         }
         break;
     }

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2756,7 +2756,7 @@ export function WebGL2CmdFuncExecuteCmds (device: WebGL2Device, cmdPackage: WebG
     } // for
 }
 
-function isUseTexImage2D (texImages: Readonly<TexImageSource[]>, regions: Readonly<BufferTextureCopy[]>) {
+function toUseTexImage2D (texImages: Readonly<TexImageSource[]>, regions: Readonly<BufferTextureCopy[]>) {
     if (texImages.length > 1 || regions.length > 1) return false;
     const isVideoElement = texImages[0] instanceof HTMLVideoElement;
     if (isVideoElement) {
@@ -2788,7 +2788,7 @@ export function WebGL2CmdFuncCopyTexImagesToTexture (
 
     switch (gpuTexture.glTarget) {
     case gl.TEXTURE_2D: {
-        if (isUseTexImage2D(texImages, regions)) {
+        if (toUseTexImage2D(texImages, regions)) {
             gl.texImage2D(gl.TEXTURE_2D, regions[0].texSubres.mipLevel, gpuTexture.glInternalFmt, regions[0].texExtent.width,
                 regions[0].texExtent.height, 0, gpuTexture.glFormat, gpuTexture.glType, texImages[0]);
         } else {

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2762,7 +2762,7 @@ function isUseTexImage2D (texImages: Readonly<TexImageSource[]>, regions: Readon
     if (isVideoElement) {
         const videoElement = texImages[0] as HTMLVideoElement;
         const isSameSize = regions[0].texOffset.x === 0
-        && regions[0].texOffset.x === 0
+        && regions[0].texOffset.y === 0
         && regions[0].texExtent.width === videoElement.videoWidth
         && regions[0].texExtent.height === videoElement.videoHeight;
         return isSameSize;


### PR DESCRIPTION
improve:WebGL2CmdFuncCopyTexImagesToTexture add option to use gl.texImage2D when copy video data to texture
because texImage2D(consume <1ms) is faster than texSubImage2D(consume 19ms) when copy 1080p video frame data.


![texImage2D_0 11ms](https://user-images.githubusercontent.com/4092367/231666870-746f9be2-d1f2-4918-a3e9-472898e3565e.png)
![texSubImage2D_19ms](https://user-images.githubusercontent.com/4092367/231666887-2e2b140d-e4ec-43af-b359-aaa6b5c90c50.png)


**Refer:** https://github.com/pixijs/pixijs/pull/6088


Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
