### PR TITLE
feature: custom gfx command(VK)

### DIFF
--- a/native/cocos/renderer/gfx-agent/CommandBufferAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/CommandBufferAgent.cpp
@@ -531,5 +531,15 @@ void CommandBufferAgent::completeQueryPool(QueryPool *queryPool) {
         });
 }
 
+void CommandBufferAgent::customCommand(CustomCommand &&cmd) {
+    ENQUEUE_MESSAGE_2(
+        _messageQueue, CommandBufferCompleteQueryPool,
+        actor, getActor(),
+        cmd, cmd,
+        {
+            actor->customCommand(std::move(cmd));
+        });
+}
+
 } // namespace gfx
 } // namespace cc

--- a/native/cocos/renderer/gfx-agent/CommandBufferAgent.h
+++ b/native/cocos/renderer/gfx-agent/CommandBufferAgent.h
@@ -68,6 +68,7 @@ public:
     void endQuery(QueryPool *queryPool, uint32_t id) override;
     void resetQueryPool(QueryPool *queryPool) override;
     void completeQueryPool(QueryPool *queryPool) override;
+    void customCommand(CustomCommand &&cmd) override;
 
     uint32_t getNumDrawCalls() const override { return _actor->getNumDrawCalls(); }
     uint32_t getNumInstances() const override { return _actor->getNumInstances(); }

--- a/native/cocos/renderer/gfx-base/GFXCommandBuffer.h
+++ b/native/cocos/renderer/gfx-base/GFXCommandBuffer.h
@@ -70,6 +70,9 @@ public:
     virtual void resetQueryPool(QueryPool *queryPool) = 0;
     virtual void completeQueryPool(QueryPool *queryPool) {}
 
+    using CustomCommand = std::function<void(void*)>;
+    virtual void customCommand(CustomCommand &&cmd) {}
+
     // barrier: excutionBarrier
     // bufferBarriers: array of BufferBarrier*, descriptions of access of buffers
     // buffers: array of MTL/VK/GLES buffers

--- a/native/cocos/renderer/gfx-validator/CommandBufferValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/CommandBufferValidator.cpp
@@ -564,5 +564,9 @@ void CommandBufferValidator::completeQueryPool(QueryPool *queryPool) {
     _actor->completeQueryPool(actorQueryPool);
 }
 
+void CommandBufferValidator::customCommand(CustomCommand &&cmd) {
+    _actor->customCommand(std::move(cmd));
+}
+
 } // namespace gfx
 } // namespace cc

--- a/native/cocos/renderer/gfx-validator/CommandBufferValidator.h
+++ b/native/cocos/renderer/gfx-validator/CommandBufferValidator.h
@@ -65,6 +65,7 @@ public:
     void endQuery(QueryPool *queryPool, uint32_t id) override;
     void resetQueryPool(QueryPool *queryPool) override;
     void completeQueryPool(QueryPool *queryPool) override;
+    void customCommand(CustomCommand &&cmd) override;
 
     uint32_t getNumDrawCalls() const override { return _actor->getNumDrawCalls(); }
     uint32_t getNumInstances() const override { return _actor->getNumInstances(); }

--- a/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
@@ -888,5 +888,9 @@ void CCVKCommandBuffer::resetQueryPool(QueryPool *queryPool) {
     vkQueryPool->_ids.clear();
 }
 
+void CCVKCommandBuffer::customCommand(CustomCommand &&cmd) {
+    cmd(reinterpret_cast<void*>(_gpuCommandBuffer->vkCommandBuffer));
+}
+
 } // namespace gfx
 } // namespace cc

--- a/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.h
+++ b/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.h
@@ -64,6 +64,7 @@ public:
     void beginQuery(QueryPool *queryPool, uint32_t id) override;
     void endQuery(QueryPool *queryPool, uint32_t id) override;
     void resetQueryPool(QueryPool *queryPool) override;
+    void customCommand(CustomCommand &&cmd) override;
 
 protected:
     friend class CCVKQueue;


### PR DESCRIPTION
Re: #

custom gfx command for plugin to invoke to vulkan cmd.

### Changelog

* feature: custom gfx command(VK)

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
