### PR TITLE
fixed issues 8940

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -297,6 +297,7 @@ Audio.State = {
                         clip.once('load', function () {
                             // In case set a new src when the old one hasn't finished loading
                             if (clip === self._src) {
+                                clip.loaded = true;
                                 self._onLoaded();
                             }
                         });

--- a/cocos2d/core/assets/CCAudioClip.js
+++ b/cocos2d/core/assets/CCAudioClip.js
@@ -78,7 +78,6 @@ var AudioClip = cc.Class({
                     this._audio = value;
                 }
                 if (this._audio) {
-                    // this.loaded = true;
                     this.emit('load');
                 }
             },
@@ -127,11 +126,6 @@ var AudioClip = cc.Class({
                 let self = this;
                 cc.assetManager.postLoadNative(this, function (err) {
                     self._loading = false;
-                    if (err) {
-                        cc.error(err);
-                    } else {
-                        self.loaded = true;
-                    }
                 });
             }
         }

--- a/cocos2d/core/assets/CCAudioClip.js
+++ b/cocos2d/core/assets/CCAudioClip.js
@@ -127,7 +127,11 @@ var AudioClip = cc.Class({
                 let self = this;
                 cc.assetManager.postLoadNative(this, function (err) {
                     self._loading = false;
-                    self.loaded = true;
+                    if (err) {
+                        cc.error(err);
+                    } else {
+                        self.loaded = true;
+                    }
                 });
             }
         }

--- a/cocos2d/core/assets/CCAudioClip.js
+++ b/cocos2d/core/assets/CCAudioClip.js
@@ -78,7 +78,7 @@ var AudioClip = cc.Class({
                     this._audio = value;
                 }
                 if (this._audio) {
-                    this.loaded = true;
+                    // this.loaded = true;
                     this.emit('load');
                 }
             },
@@ -127,6 +127,7 @@ var AudioClip = cc.Class({
                 let self = this;
                 cc.assetManager.postLoadNative(this, function (err) {
                     self._loading = false;
+                    self.loaded = true;
                 });
             }
         }


### PR DESCRIPTION
Re: [8940](https://github.com/cocos/cocos-engine/issues/8940)

This problem only occurs on mobile devices (currently only Android phones have this problem) because it takes longer to load Audio resources on mobile devices than on computers.
The problem is that the loaded state of audioClip cannot be set directly when setting _nativeAsset, but should be set in the execution callback after the native resource is actually loaded, otherwise the audio will not be played when you click play for the first time on the mobile device. The engine is modified as follows:

因为在手机设备上加载 Audio 资源所需要的时间比在电脑上来得长，所以此问题只有出现在手机设备上。
问题原因是 audioClip 的 loaded 状态不能在设置 _nativeAsset 时就被直接设置，而应该是在原生资源真正被加载完成后的执行回调里设置，否则会导致在手机设备（目前只有 Android 手机会有此问题）上第一次点击播放时无法播放音频。引擎修改方法如下：

<img width="692" alt="图片" src="https://user-images.githubusercontent.com/35944775/232368779-b1864023-cb6b-45c6-9a57-272b3db9ff60.png">
<img width="579" alt="图片" src="https://user-images.githubusercontent.com/35944775/232368837-07b00f2c-22a4-4c60-8ac0-5af48b876553.png">

