### PR TITLE
fixed issues 10946

### DIFF
--- a/cocos2d/videoplayer/video-player-impl.js
+++ b/cocos2d/videoplayer/video-player-impl.js
@@ -116,9 +116,9 @@ let VideoPlayerImpl = cc.Class({
         video.addEventListener("click", cbs.click);
 
         function onCanPlay () {
-            if (self._loaded || self._playing)
-                return;
             let video = self._video;
+            if (self._loaded || !video) return;
+
             if (video.readyState === READY_STATE.HAVE_ENOUGH_DATA ||
                 video.readyState === READY_STATE.HAVE_METADATA) {
                 video.currentTime = 0;


### PR DESCRIPTION
Re: [10946](https://github.com/cocos/cocos-engine/issues/10946)

On IOS mobile browsers, the play event is triggered before the canPlay event, so loaded cannot be set to true. onCanPlay function does not need to determine _playing, so it is removed.
在 IOS 手机浏览器上，play 事件比 canPlay 事件更早被执行，所以导致 loaded 无法被设置为 true。onCanPlay 函数中无需判断 _playing，所以去掉。