### PR TITLE
set default xcode target

### DIFF
--- a/templates/cmake/apple.cmake
+++ b/templates/cmake/apple.cmake
@@ -90,6 +90,7 @@ macro(cc_ios_after_target _target_name)
         IOS_INSTALL_COMBINED YES
         XCODE_ATTRIBUTE_SKIP_INSTALL NO
         XCODE_ATTRIBUTE_INSTALL_PATH "$(LOCAL_APPS_DIR)"
+        XCODE_GENERATE_SCHEME ON
     )
 
     cc_apple_set_launch_type(${CC_EXECUTABLE_NAME})
@@ -186,6 +187,7 @@ macro(cc_mac_after_target _target_name)
             MACOSX_BUNDLE_INFO_PLIST "${CC_PROJECT_DIR}/Info.plist"
             XCODE_ATTRIBUTE_SKIP_INSTALL NO
             XCODE_ATTRIBUTE_INSTALL_PATH "$(LOCAL_APPS_DIR)"
+            XCODE_GENERATE_SCHEME ON
         )
 
         cc_apple_set_launch_type(${CC_EXECUTABLE_NAME})


### PR DESCRIPTION
This PR addresses the issue where the Xcode project has multiple targets by default, requiring developers to select the correct one before executing Run. By setting a default target, we aim to simplify the process and improve the development experience.

### Changelog

* Set default target for Xcode project

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
