### PR TITLE
Adjusting automation testing service errors

### DIFF
--- a/.github/workflows/run_test_cases.yml
+++ b/.github/workflows/run_test_cases.yml
@@ -119,8 +119,6 @@ jobs:
           git -C $TEST_PROJECTS_EXTERNAL pull origin $AUTOTEST_VERSION --allow-unrelated-histories
           rm -rf $TEST_PROJECTS_EXTERNAL/extensions/automation-framework
           7z x -y $CCTEST_PLUGINS/*.zip -o$TEST_PROJECTS_EXTERNAL/extensions/automation-framework
-
-
   macOS-RunTestCases:
     if: |
       contains(github.event.pull_request.body, '[X] needs automatic test cases check') ||
@@ -166,7 +164,6 @@ jobs:
           echo "${{ steps.parse_pr.outputs.pr_head_sha }}"
           echo "${{ steps.parse_pr.outputs.pr_base_ref }}"
           echo "${{ steps.parse_pr.outputs.pr_base_sha }}"
-
       - name: Checkout engine
         uses: actions/checkout@v3
         with:
@@ -233,21 +230,55 @@ jobs:
           git -C $TEST_PROJECTS_EXTERNAL pull origin $AUTOTEST_VERSION --allow-unrelated-histories
           rm -rf $TEST_PROJECTS_EXTERNAL/extensions/automation-framework
           unzip -oq $CCTEST_PLUGINS/*.zip -d $TEST_PROJECTS_EXTERNAL/extensions/automation-framework
-
   Creator-PR-RunTestCases:
     runs-on: self-hosted-mac
     needs: [macOS-RunTestCases, Win-RunTestCases]
     steps:
+      - name: Get PR Number
+        id: get_pr
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "issue_comment") {
+            Write-Host "::set-output name=pr_number::${{ github.event.issue.number }}"
+          }
+          else {
+            Write-Host "::set-output name=pr_number::${{ github.event.pull_request.number }}"
+          }
+      - name: Get PR Details
+        id: pr_deatils
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/cocos/cocos-engine/pulls/${{ steps.get_pr.outputs.pr_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Parse Pull Request
+        id: parse_pr
+        shell: pwsh
+        run: |
+          $pull_request = @"
+          ${{ steps.pr_deatils.outputs.data }}
+          "@ | ConvertFrom-Json
+          Write-Host $pull_request
+          Write-Host "::set-output name=pr_html_url::$($pull_request.html_url)"
+          Write-Host "::set-output name=pr_author::$($pull_request.user.login)"
+          Write-Host "::set-output name=pr_head_ref::$($pull_request.head.ref)"
+          Write-Host "::set-output name=pr_head_sha::$($pull_request.head.sha)"
+          Write-Host "::set-output name=pr_base_ref::$($pull_request.base.ref)"
+          Write-Host "::set-output name=pr_base_sha::$($pull_request.base.sha)"
+      - name: Check Job Parameter
+        run: |
+          echo "${{ steps.parse_pr.outputs.pr_head_ref }}"
+          echo "${{ steps.parse_pr.outputs.pr_head_sha }}"
+          echo "${{ steps.parse_pr.outputs.pr_base_ref }}"
+          echo "${{ steps.parse_pr.outputs.pr_base_sha }}"
       - name: Run test cases
         timeout-minutes: 90
         id: run_test_cases
         run: |
-          sed -x
           scheduler cicd -p PR-TEST -v ${{ steps.parse_pr.outputs.pr_base_ref }} -g PR-TEST -r cctest.cocos.org 
-          JOBID='cat ../../test-projects/extensions/automation-framework/node_modules/@cctest/scheduler/logs/PR-TEST/nowJobId.log'
+          JOBID=`cat  /usr/local/lib/node_modules/@cctest/scheduler/logs/PR-TEST/nowJobId.log`
           cd ..
-          python3 -u ./python/main.py -target=job_result --jobid=$JOBID
-
+          python3 -u ./python/main.py --target=job_result --jobid=$JOBID
       - name: Update Comment
         uses: peter-evans/create-or-update-comment@v1
         with:


### PR DESCRIPTION
Error adjusting automatic test service directory, syntax error, etc

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
