### PR TITLE
feat: The graphics component supports the opacity property of nodes

### DIFF
--- a/cocos/2d/components/graphics.ts
+++ b/cocos/2d/components/graphics.ts
@@ -719,7 +719,7 @@ export class Graphics extends UIRenderer {
         const subModelList = this.model!.subModels;
         for (let i = 0; i < renderDataList.length; i++) {
             const renderData = renderDataList[i];
-            const dataCount = renderData.vertexStart * componentPerVertex
+            const dataCount = renderData.vertexStart * componentPerVertex;
             const vb = new Float32Array(dataCount);
             for (let j = 0; j < dataCount; j++) {
                 if (j % componentPerVertex === 6) {

--- a/cocos/2d/components/graphics.ts
+++ b/cocos/2d/components/graphics.ts
@@ -699,7 +699,37 @@ export class Graphics extends UIRenderer {
             this._uploadData();
         }
 
+        if (this.node._uiProps.colorDirty || this._isNeedUploadData) {
+            this._updateOpacity();
+        }
+
         render.commitModel(this, this.model, this.getMaterialInstance(0));
+    }
+
+    private _updateOpacity () {
+        const impl = this.impl;
+        if (!impl) {
+            return;
+        }
+
+        const renderDataList = impl.getRenderDataList();
+        if (renderDataList.length <= 0) {
+            return;
+        }
+        const subModelList = this.model!.subModels;
+        for (let i = 0; i < renderDataList.length; i++) {
+            const renderData = renderDataList[i];
+            const dataCount = renderData.vertexStart * componentPerVertex
+            const vb = new Float32Array(dataCount);
+            for (let j = 0; j < dataCount; j++) {
+                if (j % componentPerVertex === 6) {
+                    vb[j] = renderData.vData[j] * this.node._uiProps.opacity;
+                } else {
+                    vb[j] = renderData.vData[j];
+                }
+            }
+            subModelList[i].inputAssembler.vertexBuffers[0].update(vb);
+        }
     }
 
     protected _flushAssembler () {


### PR DESCRIPTION
Re: #
If we want graphics to do transparency animation, currently we can only modify the fillColor and strokeColor in the update method of the animation and redraw it again, which is not only troublesome but also has poor performance.
The issues link: https://forum.cocos.org/t/topic/43328/42
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
