### PR TITLE
fix: can't import 'cc' engine with physics module on OH platform

### DIFF
--- a/templates/openharmony/entry/src/main/ets/cocos/game.ts
+++ b/templates/openharmony/entry/src/main/ets/cocos/game.ts
@@ -28,10 +28,15 @@ const commonJSModuleMap: Record<string, Function> = {
 <% if (chunkBundleUrl) { %>
     '/src/chunks/<%= chunkBundleUrl%>'() { return import('./src/chunks/<%= chunkBundleUrl%>') },
 <% }  %> 
+<% if (useAotOptimization) {%>
+    '/src/<%= systemCCUrl%>' () { return import('./src/<%= systemCCUrl%>'); },
+<%} else {%>
+<% for (var i = 0; i < ccUrls.length; i++) {%> 
+    '/src/cocos-js/<%=ccUrls[i]%>' () { return import('./src/cocos-js/<%=ccUrls[i]%>'); },
+<% }} %>
 <% for (var j = 0; j < bundleJsList.length; j++) {%> 
     'assets/<%=bundleJsList[j]%>' () { return import('./assets/<%=bundleJsList[j]%>'); },
 <% } %>
-    '/src/<%= systemCCUrl%>' () { return import('./src/<%= systemCCUrl%>'); },
     '/src/settings.js' () { return import('./src/settings.js'); },
 }
 export function loadModule (name: string) {


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16149

### Changelog

* fix can't import 'cc' engine with physics module on OH platform

### Note

- when we use js engine with physics module, we have multiple entry
- while we have only one entry when use ts engine

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
