### PR TITLE
fix high frameRate screen use 60 framerate and refine logic

### DIFF
--- a/pal/pacer/pacer-web.ts
+++ b/pal/pacer/pacer-web.ts
@@ -24,7 +24,6 @@
 
 import { EDITOR } from 'internal:constants';
 import { assertIsTrue } from '../../cocos/core/data/utils/asserts';
-import { clearTimeoutRAF, setTimeoutRAF } from '../utils';
 
 export class Pacer {
     private _rafHandle = 0;
@@ -130,7 +129,6 @@ export class Pacer {
     }
 
     private _ctTime (id: number | undefined) {
-        clearTimeoutRAF(id);
         if (EDITOR || this._cAF === undefined || globalThis.__globalXR?.isWebXR) {
             clearTimeout(id);
         } else if (id) {

--- a/pal/pacer/pacer-web.ts
+++ b/pal/pacer/pacer-web.ts
@@ -26,7 +26,6 @@ import { EDITOR } from 'internal:constants';
 import { assertIsTrue } from '../../cocos/core/data/utils/asserts';
 
 export class Pacer {
-    private _rafHandle = 0;
     private _stHandle = 0;
     private _onTick: (() => void) | null = null;
     private _targetFrameRate = 60;
@@ -101,9 +100,8 @@ export class Pacer {
 
     stop (): void {
         if (!this._isPlaying) return;
-        this._cAF.call(window, this._rafHandle);
         this._ctTime(this._stHandle);
-        this._rafHandle = this._stHandle = 0;
+        this._stHandle = 0;
         this._isPlaying = false;
     }
 

--- a/pal/pacer/pacer-web.ts
+++ b/pal/pacer/pacer-web.ts
@@ -84,17 +84,7 @@ export class Pacer {
 
     start (): void {
         if (this._isPlaying) return;
-        // if (this._targetFrameRate === 60) {
-        //     const updateCallback = () => {
-        //         if (this._isPlaying) {
-        //             this._rafHandle = this._rAF.call(window, updateCallback);
-        //         }
-        //         if (this._onTick) {
-        //             this._onTick();
-        //         }
-        //     };
-        //     this._rafHandle = this._rAF.call(window, updateCallback);
-        // } else {
+
         const updateCallback = () => {
             this._startTime = performance.now();
             if (this._isPlaying) {
@@ -106,7 +96,7 @@ export class Pacer {
         };
         this._startTime = performance.now();
         this._stHandle = this._stTime(updateCallback);
-        // }
+
         this._isPlaying = true;
     }
 

--- a/pal/pacer/pacer-web.ts
+++ b/pal/pacer/pacer-web.ts
@@ -26,34 +26,12 @@ import { assertIsTrue } from '../../cocos/core/data/utils/asserts';
 import { clearTimeoutRAF, setTimeoutRAF } from '../utils';
 
 export class Pacer {
-    private _rafHandle = 0;
     private _stHandle = 0;
     private _onTick: (() => void) | null = null;
     private _targetFrameRate = 60;
     private _frameTime = 0;
     private _startTime = 0;
     private _isPlaying = false;
-    private _rAF: typeof requestAnimationFrame;
-    private _cAF: typeof cancelAnimationFrame;
-    constructor () {
-        this._rAF = window.requestAnimationFrame
-        || window.webkitRequestAnimationFrame
-        || window.mozRequestAnimationFrame
-        || window.oRequestAnimationFrame
-        || window.msRequestAnimationFrame
-        || this._stTime.bind(this);
-        this._cAF = window.cancelAnimationFrame
-        || window.cancelRequestAnimationFrame
-        || window.msCancelRequestAnimationFrame
-        || window.mozCancelRequestAnimationFrame
-        || window.oCancelRequestAnimationFrame
-        || window.webkitCancelRequestAnimationFrame
-        || window.msCancelAnimationFrame
-        || window.mozCancelAnimationFrame
-        || window.webkitCancelAnimationFrame
-        || window.ocancelAnimationFrame
-        || this._ctTime.bind(this);
-    }
 
     get targetFrameRate (): number {
         return this._targetFrameRate;
@@ -81,37 +59,24 @@ export class Pacer {
 
     start (): void {
         if (this._isPlaying) return;
-        if (this._targetFrameRate === 60) {
-            const updateCallback = () => {
-                if (this._isPlaying) {
-                    this._rafHandle = this._rAF.call(window, updateCallback);
-                }
-                if (this._onTick) {
-                    this._onTick();
-                }
-            };
-            this._rafHandle = this._rAF.call(window, updateCallback);
-        } else {
-            const updateCallback = () => {
-                this._startTime = performance.now();
-                if (this._isPlaying) {
-                    this._stHandle = this._stTime(updateCallback);
-                }
-                if (this._onTick) {
-                    this._onTick();
-                }
-            };
+        const updateCallback = () => {
             this._startTime = performance.now();
-            this._stHandle = this._stTime(updateCallback);
-        }
+            if (this._isPlaying) {
+                this._stHandle = this._stTime(updateCallback);
+            }
+            if (this._onTick) {
+                this._onTick();
+            }
+        };
+        this._startTime = performance.now();
+        this._stHandle = this._stTime(updateCallback);
         this._isPlaying = true;
     }
 
     stop (): void {
         if (!this._isPlaying) return;
-        this._cAF.call(window, this._rafHandle);
         this._ctTime(this._stHandle);
-        this._rafHandle = this._stHandle = 0;
+        this._stHandle = 0;
         this._isPlaying = false;
     }
 

--- a/pal/pacer/pacer-web.ts
+++ b/pal/pacer/pacer-web.ts
@@ -22,16 +22,41 @@
  THE SOFTWARE.
 */
 
+import { EDITOR } from 'internal:constants';
 import { assertIsTrue } from '../../cocos/core/data/utils/asserts';
 import { clearTimeoutRAF, setTimeoutRAF } from '../utils';
 
 export class Pacer {
+    private _rafHandle = 0;
     private _stHandle = 0;
     private _onTick: (() => void) | null = null;
     private _targetFrameRate = 60;
     private _frameTime = 0;
     private _startTime = 0;
     private _isPlaying = false;
+    private _callback: (() => void) | null = null;
+    private _delay = 0;
+    private _start = 0;
+    private _rAF: typeof requestAnimationFrame;
+    private _cAF: typeof cancelAnimationFrame;
+
+    constructor () {
+        this._rAF = window.requestAnimationFrame
+        || window.webkitRequestAnimationFrame
+        || window.mozRequestAnimationFrame
+        || window.oRequestAnimationFrame
+        || window.msRequestAnimationFrame;
+        this._cAF = window.cancelAnimationFrame
+        || window.cancelRequestAnimationFrame
+        || window.msCancelRequestAnimationFrame
+        || window.mozCancelRequestAnimationFrame
+        || window.oCancelRequestAnimationFrame
+        || window.webkitCancelRequestAnimationFrame
+        || window.msCancelAnimationFrame
+        || window.mozCancelAnimationFrame
+        || window.webkitCancelAnimationFrame
+        || window.ocancelAnimationFrame;
+    }
 
     get targetFrameRate (): number {
         return this._targetFrameRate;
@@ -59,6 +84,17 @@ export class Pacer {
 
     start (): void {
         if (this._isPlaying) return;
+        // if (this._targetFrameRate === 60) {
+        //     const updateCallback = () => {
+        //         if (this._isPlaying) {
+        //             this._rafHandle = this._rAF.call(window, updateCallback);
+        //         }
+        //         if (this._onTick) {
+        //             this._onTick();
+        //         }
+        //     };
+        //     this._rafHandle = this._rAF.call(window, updateCallback);
+        // } else {
         const updateCallback = () => {
             this._startTime = performance.now();
             if (this._isPlaying) {
@@ -70,25 +106,45 @@ export class Pacer {
         };
         this._startTime = performance.now();
         this._stHandle = this._stTime(updateCallback);
+        // }
         this._isPlaying = true;
     }
 
     stop (): void {
         if (!this._isPlaying) return;
+        this._cAF.call(window, this._rafHandle);
         this._ctTime(this._stHandle);
-        this._stHandle = 0;
+        this._rafHandle = this._stHandle = 0;
         this._isPlaying = false;
     }
+
+    _handleRAF = () => {
+        if (performance.now() - this._start < this._delay) {
+            this._rAF.call(window, this._handleRAF);
+        } else if (this._callback) {
+            this._callback();
+        }
+    };
 
     private _stTime (callback: () => void) {
         const currTime = performance.now();
         const elapseTime = Math.max(0, (currTime - this._startTime));
         const timeToCall = Math.max(0, this._frameTime - elapseTime);
-        const id = setTimeoutRAF(callback, timeToCall);
-        return id;
+        if (EDITOR || this._rAF === undefined || globalThis.__globalXR?.isWebXR) {
+            return setTimeout(callback, timeToCall);
+        }
+        this._start = currTime;
+        this._delay = timeToCall;
+        this._callback = callback;
+        return this._rAF.call(window, this._handleRAF);
     }
 
     private _ctTime (id: number | undefined) {
         clearTimeoutRAF(id);
+        if (EDITOR || this._cAF === undefined || globalThis.__globalXR?.isWebXR) {
+            clearTimeout(id);
+        } else if (id) {
+            this._cAF.call(window, id);
+        }
     }
 }

--- a/pal/utils.ts
+++ b/pal/utils.ts
@@ -220,13 +220,18 @@ export function setTimeoutRAF (callback: (...args: any[]) => void, delay: number
  * @returns Nothing.
  */
 export function clearTimeoutRAF (id) {
-    const raf = requestAnimationFrame
-    || window.requestAnimationFrame
-    || window.webkitRequestAnimationFrame
-    || window.mozRequestAnimationFrame
-    || window.oRequestAnimationFrame
-    || window.msRequestAnimationFrame;
-    if (raf === undefined || globalThis.__globalXR?.isWebXR) {
+    const caf = cancelAnimationFrame
+        || window.cancelAnimationFrame
+        || window.cancelRequestAnimationFrame
+        || window.msCancelRequestAnimationFrame
+        || window.mozCancelRequestAnimationFrame
+        || window.oCancelRequestAnimationFrame
+        || window.webkitCancelRequestAnimationFrame
+        || window.msCancelAnimationFrame
+        || window.mozCancelAnimationFrame
+        || window.webkitCancelAnimationFrame
+        || window.ocancelAnimationFrame;
+    if (caf === undefined || globalThis.__globalXR?.isWebXR) {
         clearTimeout(id);
     } else {
         cancelAnimationFrame(id);

--- a/pal/utils.ts
+++ b/pal/utils.ts
@@ -22,8 +22,10 @@
  THE SOFTWARE.
 */
 
+import { EDITOR } from 'internal:constants';
+
 /**
- * This method clones methods in minigame enviroment, sucb as `wx`, `swan` etc. to a module called minigame.
+ * This method clones methods in minigame environment, sub as `wx`, `swan` etc. to a module called minigame.
  * @param targetObject Usually it's specified as the minigame module.
  * @param originObj Original minigame environment such as `wx`, `swan` etc.
  */
@@ -199,7 +201,7 @@ export function setTimeoutRAF (callback: (...args: any[]) => void, delay: number
     || window.oRequestAnimationFrame
     || window.msRequestAnimationFrame;
 
-    if (raf === undefined || globalThis.__globalXR?.isWebXR) {
+    if (EDITOR || raf === undefined || globalThis.__globalXR?.isWebXR) {
         return setTimeout(callback, delay, ...args);
     }
 
@@ -231,7 +233,7 @@ export function clearTimeoutRAF (id) {
         || window.mozCancelAnimationFrame
         || window.webkitCancelAnimationFrame
         || window.ocancelAnimationFrame;
-    if (caf === undefined || globalThis.__globalXR?.isWebXR) {
+    if (EDITOR || caf === undefined || globalThis.__globalXR?.isWebXR) {
         clearTimeout(id);
     } else {
         cancelAnimationFrame(id);

--- a/pal/utils.ts
+++ b/pal/utils.ts
@@ -236,6 +236,6 @@ export function clearTimeoutRAF (id) {
     if (EDITOR || caf === undefined || globalThis.__globalXR?.isWebXR) {
         clearTimeout(id);
     } else {
-        cancelAnimationFrame(id);
+        caf(id);
     }
 }


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/14581

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
