### PR TITLE
fix editor simulator resize and change landscape not work

### DIFF
--- a/native/tools/simulator/frameworks/runtime-src/Classes/Game.cpp
+++ b/native/tools/simulator/frameworks/runtime-src/Classes/Game.cpp
@@ -56,6 +56,7 @@ Game::~Game() {
 int Game::init() {
     
     cc::pipeline::GlobalDSManager::setDescriptorSetLayout();
+    SimulatorApp::getInstance()->init();
     cc::ISystemWindowInfo info;
     info.width= SimulatorApp::getInstance()->getWidth();
     info.height = SimulatorApp::getInstance()->getHeight();

--- a/native/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.h
+++ b/native/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.h
@@ -36,6 +36,7 @@ class SimulatorApp {
 public:
     static SimulatorApp *getInstance();
     virtual ~SimulatorApp();
+    int init();
     int run();
     virtual int getWidth() const;
     virtual int getHeight() const;

--- a/native/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm
+++ b/native/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm
@@ -249,7 +249,7 @@ std::string getCurAppName(void)
     config->setScriptFile(parser->getEntryFile());
 }
 
--(void) run
+-(void) initialize
 {
     createFileUtils();
     SIMULATOR = self;
@@ -264,7 +264,10 @@ std::string getCurAppName(void)
     {
         _project.setScriptFile(_entryPath);
     }
+}
 
+-(void) run
+{
     [self createWindowAndView];
     [self startup];
 }
@@ -733,6 +736,11 @@ SimulatorApp::SimulatorApp() {
 
 SimulatorApp::~SimulatorApp() {
 
+}
+
+int SimulatorApp::init() {
+    [app initialize];
+    return 0;
 }
 
 int SimulatorApp::run() {

--- a/native/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorApp.cpp
+++ b/native/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorApp.cpp
@@ -226,7 +226,7 @@ int SimulatorApp::getPositionY() {
     GetWindowRect(_hwnd, &rect);
     return rect.top;
 }
-int SimulatorApp::initialize() {
+int SimulatorApp::init() {
     createFileUtils();
     INITCOMMONCONTROLSEX InitCtrls;
     InitCtrls.dwSize = sizeof(InitCtrls);

--- a/native/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorApp.cpp
+++ b/native/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorApp.cpp
@@ -226,8 +226,7 @@ int SimulatorApp::getPositionY() {
     GetWindowRect(_hwnd, &rect);
     return rect.top;
 }
-
-int SimulatorApp::run() {
+int SimulatorApp::initialize() {
     createFileUtils();
     INITCOMMONCONTROLSEX InitCtrls;
     InitCtrls.dwSize = sizeof(InitCtrls);
@@ -344,7 +343,10 @@ int SimulatorApp::run() {
     }
     _project.setFrameScale(frameScale);
     CC_LOG_DEBUG("FRAME SCALE = %0.2f", frameScale);
+}
 
+int SimulatorApp::run() {
+    cc::Size frameSize = _project.getFrameSize();
     // create opengl view
     const Rect frameRect = Rect(0, 0, frameSize.width, frameSize.height);
     ConfigParser::getInstance()->setInitViewSize(frameSize);

--- a/native/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorApp.h
+++ b/native/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorApp.h
@@ -38,7 +38,7 @@ class SimulatorApp {
 public:
     static SimulatorApp *getInstance();
     virtual ~SimulatorApp();
-    int initialize();
+    int init();
     int run();
 
     virtual void quit();

--- a/native/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorApp.h
+++ b/native/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorApp.h
@@ -38,6 +38,7 @@ class SimulatorApp {
 public:
     static SimulatorApp *getInstance();
     virtual ~SimulatorApp();
+    int initialize();
     int run();
 
     virtual void quit();


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/16124

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
