### PR TITLE
Introduce animation graph custom events; add experimental listening API

### DIFF
--- a/cocos/animation/marionette/animation-controller.ts
+++ b/cocos/animation/marionette/animation-controller.ts
@@ -25,7 +25,7 @@
 import { Component } from '../../scene-graph/component';
 import { AnimationGraph } from './animation-graph';
 import type { AnimationGraphRunTime } from './animation-graph';
-import { _decorator, assertIsNonNullable, assertIsTrue } from '../../core';
+import { EventTarget, _decorator, assertIsNonNullable, assertIsTrue } from '../../core';
 import { AnimationGraphEval } from './graph-eval';
 import type { MotionStateStatus, TransitionStatus, ClipStatus } from './state-machine/state-machine-eval';
 import { Value } from './variable';
@@ -101,7 +101,13 @@ export class AnimationController extends Component {
                 assertIsTrue(graph instanceof AnimationGraph);
                 originalGraph = graph;
             }
-            const graphEval = new AnimationGraphEval(originalGraph, this.node, this, clipOverrides);
+            const graphEval = new AnimationGraphEval(
+                originalGraph,
+                this.node,
+                this,
+                this._customEventTarget,
+                clipOverrides,
+            );
             this._graphEval = graphEval;
         }
     }
@@ -294,4 +300,42 @@ export class AnimationController extends Component {
         }
         return graphEval.getAuxiliaryCurveValue(curveName);
     }
+
+    /**
+     * @zh 监听自定义事件。
+     * @en Listens to the custom event.
+     *
+     * @param eventName @zh 要监听的自定义事件名。 @en Name of the custom event to listen.
+     *
+     * @param callback @zh 回调函数。当指定自定义事件触发时被调用。 @en Callback function. Called when the custom event is triggered.
+     *
+     * @param thisArg @zh 传给 `callback` 函数 的 `this` 参数。 @en `this` argument that will be passed to `callback` function.
+     * @experimental
+     */
+    public onCustomEvent_experimental<TThisArg = never> (eventName: string, callback: (this: TThisArg) => void, thisArg?: TThisArg) {
+        this._customEventTarget.on(eventName, callback, thisArg);
+    }
+
+    /**
+     * @zh 取消对自定义事件的监听。
+     * @en Cancels the listening(s) to specified custom event.
+     *
+     * @param eventName @zh 要移除监听的自定义事件名。 @en Name of the custom event to which the listening would be cancelled.
+     *
+     * @param callback @zh 当初监听指定的回调函数。若未指定，则会取消该自定义事件上的所有监听。
+     *                 @en Callback function that were originally specified to listen the custom event.
+     *                     If not specified, all listenings to that custom event will be cancelled.
+     *
+     * @param thisArg @zh 当初监听指定的回调函数的 `this` 参数。若未指定，则会取消该自定义事件上所有指定了 `callback` 回调、但未指定 `this` 参数的监听。
+     *                @en `this` argument that were originally specified to listen the custom event.
+     *                     If not specified, all listenings to that custom event
+     *                     on which the `callback` was specified but `this` argument was not specified
+     *                     will be cancelled.
+     * @experimental
+     */
+    public offCustomEvent_experimental<TThisArg = never> (eventName: string, callback?: (this: TThisArg) => void, thisArg?: TThisArg) {
+        this._customEventTarget.off(eventName, callback, thisArg);
+    }
+
+    private _customEventTarget = new EventTarget();
 }

--- a/cocos/animation/marionette/animation-graph-context.ts
+++ b/cocos/animation/marionette/animation-graph-context.ts
@@ -11,6 +11,7 @@ import { AnimationMask } from './animation-mask';
 import { error } from '../../core';
 import { partition } from '../../core/algorithm/partition';
 import { AnimationController } from './animation-controller';
+import { AnimationGraphCustomEventEmitter } from './event/custom-event-emitter';
 
 /**
  * This module contains stuffs related to animation graph's evaluation.
@@ -61,6 +62,12 @@ export class AnimationGraphBindingContext {
         poseLayoutMaintainer: AnimationGraphPoseLayoutMaintainer,
         varRegistry: VarRegistry,
         private _controller: AnimationController,
+
+        /**
+         * The associated custom event emitter.
+         * Any portion of the animation graph may hold and use this emitter to emit custom events.
+         */
+        public readonly customEventEmitter: AnimationGraphCustomEventEmitter,
     ) {
         this._origin = origin;
         this._layoutMaintainer = poseLayoutMaintainer;

--- a/cocos/animation/marionette/event/custom-event-emitter.ts
+++ b/cocos/animation/marionette/event/custom-event-emitter.ts
@@ -1,0 +1,12 @@
+/**
+ * Animation graph custom event emitter interface.
+ *
+ * This interface is served as the middleware between controller component and graph evaluation.
+ */
+export interface AnimationGraphCustomEventEmitter {
+    /**
+     * Emits a custom event.
+     * @param eventName Name of the custom event.
+     */
+    emit(eventName: string): void;
+}

--- a/cocos/animation/marionette/graph-eval.ts
+++ b/cocos/animation/marionette/graph-eval.ts
@@ -43,6 +43,7 @@ import {
     TransitionStatus,
 } from './state-machine/state-machine-eval';
 import { ReadonlyClipOverrideMap } from './clip-overriding';
+import { AnimationGraphCustomEventEmitter } from './event/custom-event-emitter';
 
 export class AnimationGraphEval {
     private _currentTransitionCache: TransitionStatus = {
@@ -50,7 +51,13 @@ export class AnimationGraphEval {
         time: 0.0,
     };
 
-    constructor (graph: AnimationGraph, root: Node, controller: AnimationController, clipOverrides: ReadonlyClipOverrideMap | null) {
+    constructor (
+        graph: AnimationGraph,
+        root: Node,
+        controller: AnimationController,
+        customEventEmitter: AnimationGraphCustomEventEmitter,
+        clipOverrides: ReadonlyClipOverrideMap | null,
+    ) {
         if (DEBUG) {
             if (graph.layers.length >= MAX_ANIMATION_LAYER) {
                 throw new Error(
@@ -76,6 +83,7 @@ export class AnimationGraphEval {
 
         const bindingContext = new AnimationGraphBindingContext(
             root, poseLayoutMaintainer, this._varInstances, controller,
+            customEventEmitter,
         );
         this._bindingContext = bindingContext;
 

--- a/editor/src/marionette/preview.ts
+++ b/editor/src/marionette/preview.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../cocos/animation/marionette/animation-graph-context';
 import { blendPoseInto, Pose } from '../../../cocos/animation/core/pose';
 import { AnimationController } from '../../../cocos/animation/marionette/animation-controller';
+import { EventTarget } from '../../../exports/base';
 
 class AnimationGraphPartialPreviewer {
     constructor(root: Node) {
@@ -82,6 +83,7 @@ class AnimationGraphPartialPreviewer {
 
         const bindingContext = new AnimationGraphBindingContext(
             this._root, this._poseLayoutMaintainer, this._varInstances, this._dummyAnimationController,
+            new EventTarget(),
         );
 
         poseLayoutMaintainer.startBind();

--- a/tests/animation/new-gen-anim/event.test.ts
+++ b/tests/animation/new-gen-anim/event.test.ts
@@ -1,0 +1,182 @@
+jest.mock('../../../cocos/animation/marionette/graph-eval');
+
+import { AnimationController } from "../../../cocos/animation/animation";
+import { AnimationGraphCustomEventEmitter } from "../../../cocos/animation/marionette/event/custom-event-emitter";
+import { AnimationGraphEval } from "../../../cocos/animation/marionette/graph-eval";
+import { AnimationGraph } from "../../../editor/exports/new-gen-anim";
+import { EventTarget, Node } from "../../../exports/base";
+import { AnimationGraphEvalMock } from './utils/eval-mock';
+import 'jest-extended';
+
+/**
+ * Test animation controller's event API itself.
+ * 
+ * Within the tests, events are emitted in a simulated way
+ * and these tests observe if the animation controller correctly forwards them to users callback
+ * after users' listening/un-listening behaviors.
+ */
+describe(`Animation controller custom event APIs`, () => {
+    beforeEach(() => {
+        stealControllerCustomEventEmitter();
+    });
+
+    afterEach(() => {
+        (AnimationGraphEval as jest.Mock).mockReset();
+    });
+
+    test(`On and Off`, () => {
+        const graphEvalMock = new AnimationGraphEventSimulator();
+
+        const callbackMockManager = new CallbackMockManager();
+
+        const event_a_callback_mock = callbackMockManager.add();
+        graphEvalMock.controller.onCustomEvent_experimental('event_a', event_a_callback_mock);
+        const event_b_callback_mock = callbackMockManager.add();
+        graphEvalMock.controller.onCustomEvent_experimental('event_b', event_b_callback_mock);
+
+        // Add 4 listeners, with different `this` arg, listen to 'a'.
+        const event_a_callback_with_this_arg = callbackMockManager.add();
+        const event_a_callback_this_args = Array.from({ length: 4 }, () => ({}));
+        const event_a_callback_this_args_backup = event_a_callback_this_args.slice();
+        for (let i = 0; i < event_a_callback_this_args.length; ++i) {
+            graphEvalMock.controller.onCustomEvent_experimental('event_a', event_a_callback_with_this_arg, event_a_callback_this_args[i]);
+        }
+
+        const check_event_a_callback_with_this_arg_to_be_called = () => {
+            expect(event_a_callback_with_this_arg).toBeCalledTimes(event_a_callback_this_args.length);
+            expect(event_a_callback_with_this_arg.mock.instances).toIncludeAllMembers(event_a_callback_this_args);
+        };
+
+        callbackMockManager.zeroCheck();
+
+        // The listeners should be called normally.
+        for (let i = 0; i < 2; ++i) {
+            graphEvalMock.simulateCustomEvent('event_a');
+            expect(event_a_callback_mock).toBeCalledTimes(1);
+            event_a_callback_mock.mockClear();
+            check_event_a_callback_with_this_arg_to_be_called();
+            event_a_callback_with_this_arg.mockClear();
+            callbackMockManager.zeroCheck();
+
+            graphEvalMock.simulateCustomEvent('event_b');
+            expect(event_b_callback_mock).toBeCalledTimes(1);
+            event_b_callback_mock.mockClear();
+            callbackMockManager.zeroCheck();
+        }
+
+        // Off the listener with no `this` arg.
+        graphEvalMock.controller.offCustomEvent_experimental('event_a', event_a_callback_mock);
+        // Should remove successfully.
+        graphEvalMock.simulateCustomEvent('event_a');
+        check_event_a_callback_with_this_arg_to_be_called();
+        event_a_callback_with_this_arg.mockClear();
+        callbackMockManager.zeroCheck();
+
+        // Off the listener with `this` arg, at middle, tail, then first.
+        for (let i = 0; i < 3; ++i) {
+            if (i === 0) {
+                graphEvalMock.controller.offCustomEvent_experimental(
+                    'event_a',
+                    event_a_callback_with_this_arg,
+                    event_a_callback_this_args[1],
+                );
+                event_a_callback_this_args.splice(1, 1);
+            } else if (i === 1) {
+                graphEvalMock.controller.offCustomEvent_experimental(
+                    'event_a',
+                    event_a_callback_with_this_arg,
+                    event_a_callback_this_args[event_a_callback_this_args.length - 1],
+                );
+                event_a_callback_this_args.splice(event_a_callback_this_args.length - 1, 1);
+            } else if (i === 2) {
+                graphEvalMock.controller.offCustomEvent_experimental(
+                    'event_a',
+                    event_a_callback_with_this_arg,
+                    event_a_callback_this_args[0],
+                );
+                event_a_callback_this_args.splice(0, 1);
+            }
+
+            graphEvalMock.simulateCustomEvent('event_a');
+            check_event_a_callback_with_this_arg_to_be_called();
+            event_a_callback_with_this_arg.mockClear();
+            callbackMockManager.zeroCheck();
+        }
+
+        // Re-add all event-a listeners.
+        graphEvalMock.controller.onCustomEvent_experimental('event_a', event_a_callback_mock);
+        event_a_callback_this_args.length = 0;
+        event_a_callback_this_args.push(...event_a_callback_this_args_backup);
+        for (let i = 0; i < event_a_callback_this_args.length; ++i) {
+            graphEvalMock.controller.onCustomEvent_experimental('event_a', event_a_callback_with_this_arg, event_a_callback_this_args[i]);
+        }
+        // Re-add should success.
+        graphEvalMock.simulateCustomEvent('event_a');
+        graphEvalMock.controller.offCustomEvent_experimental('event_a');
+        expect(event_a_callback_mock).toBeCalledTimes(1);
+        event_a_callback_mock.mockClear();
+        check_event_a_callback_with_this_arg_to_be_called();
+        event_a_callback_with_this_arg.mockClear();
+        callbackMockManager.zeroCheck();
+
+        // Off with no callback specified. All listeners should be removed.
+        graphEvalMock.controller.offCustomEvent_experimental('event_a');
+        graphEvalMock.simulateCustomEvent('event_a');
+        callbackMockManager.zeroCheck();
+    });
+});
+
+const stoleCustomEventEmitterMap = new WeakMap<AnimationGraphEval, AnimationGraphCustomEventEmitter>();
+
+function stealControllerCustomEventEmitter() {
+    const originalClass = jest.requireActual('../../../cocos/animation/marionette/graph-eval').AnimationGraphEval as typeof AnimationGraphEval;
+
+    const AnimationGraphEvalClassMock = (AnimationGraphEval as jest.Mock);
+
+    AnimationGraphEvalClassMock.mockImplementation((...args: ConstructorParameters<typeof AnimationGraphEval>) => {
+        const [graph, root, controller, originalEmitter, ...remain] = args;
+
+        const graphEval = new originalClass(graph, root, controller, new EventTarget(), ...remain);
+        stoleCustomEventEmitterMap.set(graphEval, originalEmitter);
+
+        return graphEval;
+    });
+}
+
+class AnimationGraphEventSimulator extends AnimationGraphEvalMock {
+    constructor(...events: string[]) {
+        super(
+            new Node(),
+            new AnimationGraph(),
+        );
+
+        // @ts-expect-error HACK
+        const graphEval = super.controller._graphEval;
+        expect(graphEval).not.toBeFalsy();
+        const mocked = stoleCustomEventEmitterMap.get(graphEval!);
+        expect(mocked).not.toBeUndefined();
+        this._mockedEventEmitter = mocked!;
+    }
+
+    public simulateCustomEvent(eventName: string) {
+        this._mockedEventEmitter.emit(eventName);
+    }
+
+    private _mockedEventEmitter: AnimationGraphCustomEventEmitter;
+}
+
+class CallbackMockManager {
+    private mocks: jest.Mock[] = [];
+
+    add () {
+        const mock = jest.fn();
+        this.mocks.push(mock);
+        return mock;
+    }
+
+    zeroCheck () {
+        for (const mock of this.mocks) {
+            expect(mock).not.toBeCalled();
+        }
+    }
+}

--- a/tests/animation/new-gen-anim/utils/eval-mock.ts
+++ b/tests/animation/new-gen-anim/utils/eval-mock.ts
@@ -15,6 +15,8 @@ export class AnimationGraphEvalMock {
             (animationGraph instanceof AnimationGraph) ? animationGraph : animationGraph.original!,
             node,
             controller,
+            // @ts-expect-error HACK here
+            controller._customEventTarget,
             (animationGraph instanceof AnimationGraph) ? null : animationGraph.clipOverrides,
         );
         // @ts-expect-error HACK

--- a/tests/animation/newgenanim.test.ts
+++ b/tests/animation/newgenanim.test.ts
@@ -5523,6 +5523,8 @@ function createAnimationGraphEval (animationGraph: AnimationGraph | AnimationGra
         (animationGraph instanceof AnimationGraph) ? animationGraph : animationGraph.original!,
         node,
         newGenAnim,
+        // @ts-expect-error HACK here
+        newGenAnim._customEventTarget,
         (animationGraph instanceof AnimationGraph) ? null : animationGraph.clipOverrides,
     );
     // @ts-expect-error HACK
@@ -5536,6 +5538,8 @@ function createAnimationGraphEval2 (animationGraph: AnimationGraph | AnimationGr
         (animationGraph instanceof AnimationGraph) ? animationGraph : animationGraph.original!,
         node,
         newGenAnim,
+        // @ts-expect-error HACK here
+        newGenAnim._customEventTarget,
         (animationGraph instanceof AnimationGraph) ? null : animationGraph.clipOverrides,
     );
     // @ts-expect-error HACK


### PR DESCRIPTION
Re: #

### Changelog

* This PR adds experimental APIs to allow user listen to **custom events**(see below). Note: this PR only adds the listening APIs itself, does not contain any event registering or dispatching.

**Custom Events**

Marionette system intends to support **custom events**, to enable users listen to animation graph events more flexibly in comparison with the current state machine component mechanism.

Custom events are registered some places in animation graphs and dispatched during graph evaluation. For example, users may register events on to a state or transition so that the event will be triggered when a state entered/exited, or transition started/finished/interrupted. Then, users may programmatically grab the animation controller component and handle the event with a call back function. A typical workflow is(suppose the user want to do some works once a specified state is entered):

- In animation graph editor, found that state, in the state's event configuration panel, type a event name to register a event.

- In code(most likely in `Component.start()`), invoke animation controller's API to listen to that event:

  ```ts
  controller.onCustomEvent_experimental('previously-registered-event-name', () => {
    // Some works
  });
  ```

------

### Design Details

- Why `controller.onCustomEvent` instead of `controller.on` like other components such as `Animation.on`, `RigidBody.on`?

  This is because the name is assigned by users, not `AnimationController` itself. We can't exclude the possibility of "animation controller needs to dispatch its self's event like graph initialized/graph destroyed/variable changed" or "the base component class add events like component destroyed/component mounted". If the thing really happened, the event names may conflict with users'.

- Are there extra arguments passed to call backs?

  No, at least not for now: we won't go so far until we collected many requirements.

- Are users able to specify extra arguments and receive the arguments in call backs like UI events?

  Same as above.

- Will state machine component mechanism be deprecated or dropped?

  The state component mechanism is landed since animation' was born. Engine teams found it's inconvenient to use it. Custom events is an experimental feature for now. But if it succeeds, we indeed want to deprecates the state component mechanism.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
