### PR TITLE
Complementarily implement pose graph

### DIFF
--- a/cocos/animation/marionette/asset-creation.ts
+++ b/cocos/animation/marionette/asset-creation.ts
@@ -40,5 +40,9 @@ export { VariableType } from './parametric';
 export { BindableNumber, BindableBoolean } from './parametric';
 export { AnimationMask } from './animation-mask';
 export { AnimationGraphVariant } from './animation-graph-variant';
+
 export type { PoseGraph } from './pose-graph/pose-graph';
-export type { PoseNode } from './pose-graph/pose-node';
+
+export * from './pose-graph/op/index'
+export type { EnterNodeInfo } from './pose-graph/foundation/authoring/enter-node-info';
+

--- a/cocos/animation/marionette/pose-graph/decorator/input.ts
+++ b/cocos/animation/marionette/pose-graph/decorator/input.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { error, js } from '../../../../core';
-import { NodeInputMappingOptions, globalNodeInputManager } from '../foundation/authoring/input-authoring';
+import { PoseGraphNodeInputMappingOptions, globalPoseGraphNodeInputManager } from '../foundation/authoring/input-authoring';
 import { PoseGraphType } from '../foundation/type-system';
 import { PoseNode } from '../pose-node';
 import { PureValueNode } from '../pure-value-node';
 
-export type { NodeInputMappingOptions };
+export type { PoseGraphNodeInputMappingOptions };
 
 /**
  * @zh
@@ -36,7 +36,7 @@ export type { NodeInputMappingOptions };
  * If the decorating property is **NOT** an array, the property will be mapped as an input.
  * Otherwise, each element of the property will be mapped as an input.
  */
-export function input (options: NodeInputMappingOptions): PropertyDecorator {
+export function input (options: PoseGraphNodeInputMappingOptions): PropertyDecorator {
     return (target, propertyKey) => {
         if (typeof propertyKey !== 'string') {
             error(`@input can be only applied to string-named fields.`);
@@ -55,6 +55,6 @@ export function input (options: NodeInputMappingOptions): PropertyDecorator {
             error(`@input can be only applied to fields of subclasses of PoseNode or PureValueNode.`);
             return;
         }
-        globalNodeInputManager.setPropertyNodeInputRecord(targetConstructor, propertyKey, options);
+        globalPoseGraphNodeInputManager.setPropertyNodeInputRecord(targetConstructor, propertyKey, options);
     };
 }

--- a/cocos/animation/marionette/pose-graph/decorator/input.ts
+++ b/cocos/animation/marionette/pose-graph/decorator/input.ts
@@ -4,7 +4,7 @@ import { error, js } from '../../../../core';
 import { NodeInputMappingOptions, globalNodeInputManager } from '../foundation/authoring/input-authoring';
 import { PoseGraphType } from '../foundation/type-system';
 import { PoseNode } from '../pose-node';
-import { XNode } from '../x-node';
+import { PureValueNode } from '../pure-value-node';
 
 export type { NodeInputMappingOptions };
 
@@ -22,7 +22,7 @@ export type { NodeInputMappingOptions };
  *
  * @zh 生成的装饰器对要装饰的属性所属的类有要求：
  * - 如果结点输入选项中指定了输入类型为姿势，则所属类必须是 `PoseNode` 的子类。
- * - 否则，所属类必须是 `PoseNode` 或 `XNode` 的子类。
+ * - 否则，所属类必须是 `PoseNode` 或 `PureValueNode` 的子类。
  * 如果所属类不符合要求，此装饰器无效。
  *
  * 如果要装饰的属性 **不是** 数组属性，则该属性将映射为一项输入；
@@ -30,7 +30,7 @@ export type { NodeInputMappingOptions };
  *
  * @en The generated has requirements on the class to which the decorating property belongs:
  * - If the node input option specifies that the input type is pose, then the belonging class should be subclass of `PoseNode`.
- * - Otherwise, the belonging class should be subclass of either `PoseNode` or `XNode`.
+ * - Otherwise, the belonging class should be subclass of either `PoseNode` or `PureValueNode`.
  * The decorator takes no effect if the belonging class does not fulfill the requirements.
  *
  * If the decorating property is **NOT** an array, the property will be mapped as an input.
@@ -51,8 +51,8 @@ export function input (options: NodeInputMappingOptions): PropertyDecorator {
         }
         if (
             !js.isChildClassOf(targetConstructor, PoseNode)
-            && !js.isChildClassOf(targetConstructor, XNode)) {
-            error(`@input can be only applied to fields of subclasses of PoseNode or XNode.`);
+            && !js.isChildClassOf(targetConstructor, PureValueNode)) {
+            error(`@input can be only applied to fields of subclasses of PoseNode or PureValueNode.`);
             return;
         }
         globalNodeInputManager.setPropertyNodeInputRecord(targetConstructor, propertyKey, options);

--- a/cocos/animation/marionette/pose-graph/decorator/input.ts
+++ b/cocos/animation/marionette/pose-graph/decorator/input.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+import { error, js } from '../../../../core';
+import { NodeInputMappingOptions, globalNodeInputManager } from '../foundation/authoring/input-authoring';
+import { PoseGraphType } from '../foundation/type-system';
+import { PoseNode } from '../pose-node';
+import { XNode } from '../x-node';
+
+export type { NodeInputMappingOptions };
+
+/**
+ * @zh
+ * 生成一个属性装饰器，将要装饰的属性映射为一或多项姿势图结点输入。
+ * @en
+ * Generates a property decorator, which maps the decorating property
+ * as one or more pose graph node inputs.
+ *
+ * @param options @zh 结点输入映射选项。 @en Node input mapping  options.
+ * @returns @zh 装饰器。 @en The decorator.
+ *
+ * @note
+ *
+ * @zh 生成的装饰器对要装饰的属性所属的类有要求：
+ * - 如果结点输入选项中指定了输入类型为姿势，则所属类必须是 `PoseNode` 的子类。
+ * - 否则，所属类必须是 `PoseNode` 或 `XNode` 的子类。
+ * 如果所属类不符合要求，此装饰器无效。
+ *
+ * 如果要装饰的属性 **不是** 数组属性，则该属性将映射为一项输入；
+ * 否则，该属性的每个元素都将映射为一项输入。
+ *
+ * @en The generated has requirements on the class to which the decorating property belongs:
+ * - If the node input option specifies that the input type is pose, then the belonging class should be subclass of `PoseNode`.
+ * - Otherwise, the belonging class should be subclass of either `PoseNode` or `XNode`.
+ * The decorator takes no effect if the belonging class does not fulfill the requirements.
+ *
+ * If the decorating property is **NOT** an array, the property will be mapped as an input.
+ * Otherwise, each element of the property will be mapped as an input.
+ */
+export function input (options: NodeInputMappingOptions): PropertyDecorator {
+    return (target, propertyKey) => {
+        if (typeof propertyKey !== 'string') {
+            error(`@input can be only applied to string-named fields.`);
+            return;
+        }
+        const targetConstructor = target.constructor;
+        if (options.type === PoseGraphType.POSE) {
+            if (!js.isChildClassOf(targetConstructor, PoseNode)) {
+                error(`@input specifying pose input can be only applied to fields of subclasses of PoseNode.`);
+                return;
+            }
+        }
+        if (
+            !js.isChildClassOf(targetConstructor, PoseNode)
+            && !js.isChildClassOf(targetConstructor, XNode)) {
+            error(`@input can be only applied to fields of subclasses of PoseNode or XNode.`);
+            return;
+        }
+        globalNodeInputManager.setPropertyNodeInputRecord(targetConstructor, propertyKey, options);
+    };
+}

--- a/cocos/animation/marionette/pose-graph/decorator/node.ts
+++ b/cocos/animation/marionette/pose-graph/decorator/node.ts
@@ -1,0 +1,54 @@
+import { error, js } from '../../../../core';
+import { PoseGraphNode } from '../foundation/pose-graph-node';
+
+import {
+    PoseGraphCreateNodeFactory,
+    PoseGraphNodeEditorMetadata,
+    PoseGraphNodeAppearanceOptions,
+    getOrCreateNodeEditorMetadata,
+} from '../foundation/authoring/node-authoring';
+
+export type {
+    PoseGraphCreateNodeContext,
+    PoseGraphCreateNodeEntry,
+    PoseGraphCreateNodeFactory,
+    PoseGraphNodeEditorMetadata,
+    PoseGraphNodeAppearanceOptions,
+} from '../foundation/authoring/node-authoring';
+
+function makeNodeEditorMetadataModifier (edit: (metadata: PoseGraphNodeEditorMetadata) => void): ClassDecorator {
+    return (target) => {
+        if (!checkDecoratingClass(target)) {
+            return;
+        }
+        const metadata = getOrCreateNodeEditorMetadata(target);
+        edit(metadata);
+    };
+}
+
+export const poseGraphNodeMenu = (menu: string) => makeNodeEditorMetadataModifier((metadata) => {
+    metadata.menu = menu;
+});
+
+export const poseGraphCreateNodeFactory = (factory: PoseGraphCreateNodeFactory<any>) => makeNodeEditorMetadataModifier((metadata) => {
+    metadata.factory = factory;
+});
+
+export const poseGraphNodeHide = (hide = true) => makeNodeEditorMetadataModifier((metadata) => {
+    metadata.hide = hide;
+});
+
+export const poseGraphNodeAppearance = (
+    appearance: Readonly<PoseGraphNodeAppearanceOptions>,
+) => makeNodeEditorMetadataModifier((metadata) => {
+    Object.assign(metadata.appearance ??= {}, appearance);
+});
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+function checkDecoratingClass (fn: Function): fn is Constructor<PoseGraphNode> {
+    if (!js.isChildClassOf(fn, PoseGraphNode)) {
+        error(`This kind of decorator should only be applied to pose graph node classes.`);
+        return false;
+    }
+    return true;
+}

--- a/cocos/animation/marionette/pose-graph/foundation/authoring/enter-node-info.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/authoring/enter-node-info.ts
@@ -1,0 +1,10 @@
+export type EnterNodeInfo = {
+    type: 'animation-blend';
+    target: import('../../../motion/animation-blend').AnimationBlend;
+} | {
+    type: 'state-machine';
+    target: import('../../../animation-graph').StateMachine;
+} | {
+    type: 'stash';
+    stashName: string;
+};

--- a/cocos/animation/marionette/pose-graph/foundation/authoring/input-authoring.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/authoring/input-authoring.ts
@@ -42,7 +42,7 @@ export type PoseGraphNodeInputInsertId = string;
  * @en Describes the options used
  * when a pose node class property is going to be mapped as node input(s).
  */
-export interface NodeInputMappingOptions {
+export interface PoseGraphNodeInputMappingOptions {
     /**
      * @zh 此属性或属性的元素映射的输入类型。
      * 输入的类型必须和属性（的元素）的实际值类型匹配。
@@ -110,11 +110,11 @@ export interface NodeInputMappingOptions {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-class NodeInputManager {
+class PoseGraphNodeInputManager {
     public setPropertyNodeInputRecord (
         constructor: Constructor,
         propertyKey: string,
-        options: NodeInputMappingOptions,
+        options: PoseGraphNodeInputMappingOptions,
     ) {
         let classInputRecord = this._classInputMap.get(constructor);
         if (!classInputRecord) {
@@ -457,4 +457,4 @@ function createDefaultInputValueByType (type: PoseGraphType) {
     }
 }
 
-export const globalNodeInputManager = new NodeInputManager();
+export const globalPoseGraphNodeInputManager = new PoseGraphNodeInputManager();

--- a/cocos/animation/marionette/pose-graph/foundation/authoring/input-authoring.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/authoring/input-authoring.ts
@@ -1,0 +1,453 @@
+import { Quat, Vec3, assertIsTrue, js } from '../../../../../core';
+import { PoseGraphNode, shellTag } from '../pose-graph-node';
+import { PoseGraphType } from '../type-system';
+import { NodeInputPath } from '../node-shell';
+import { OperationOnFreestandingNodeError } from '../errors';
+
+export type PoseGraphInputKey = NodeInputPath;
+
+export interface PropertyNodeInputMetadata {
+    displayName?: string;
+}
+
+interface ArrayPropertySyncGroup {
+    members: string[];
+}
+
+export interface PoseGraphNodeInputMetadata {
+    type: PoseGraphType;
+
+    displayName?: string;
+
+    deletable?: boolean;
+
+    insertPoint?: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Constructor = Function;
+
+interface PropertyNodeInputRecord {
+    type: PoseGraphType;
+    displayName?: string;
+    getArrayElementDisplayName?(index: number): string;
+    arraySyncGroup?: ArrayPropertySyncGroup;
+}
+
+export type PoseGraphNodeInputInsertId = string;
+
+/**
+ * @zh 描述一个姿势图结点类属性在映射为结点输入时的选项。
+ * @en Describes the options used
+ * when a pose node class property is going to be mapped as node input(s).
+ */
+export interface NodeInputMappingOptions {
+    /**
+     * @zh 此属性或属性的元素映射的输入类型。
+     * 输入的类型必须和属性（的元素）的实际值类型匹配。
+     *
+     * @en Type of the input(s) that the property associates.
+     * The input type should be matched with the actual value type of the property.
+     */
+    type: PoseGraphType;
+
+    /**
+     * @zh 此属性关联的输入的显示名称。
+     * @en Display of the input(s) that the property associates.
+     */
+    displayName?: string;
+
+    /**
+     * @zh 若有定义，当该属性是数组时，此方法被用来获取数组各个元素所映射的输入的显示名称。
+     * @en If specified and if the property is an array,
+     * this method will be used to retrieve the display name of input mapped by each element.
+     * @param index 数组元素的索引。
+     */
+    getArrayElementDisplayName?(index: number): string;
+
+    /**
+     * @zh 若有定义，当该属性是数组时，声明该数组属性属于指定的同步组。
+     * 同步组中的任何成员在进行输入增加、移除或挪动等操作时，其它成员也将进行该操作。
+     *
+     * @en If specified and if the property is an array,
+     * declares that the array property belongs to specified sync group.
+     * When any member of the sync group is performing input add/remove/move etc. operation,
+     * the other members will also perform that operation.
+     *
+     * @example
+     * @zh
+     * 对于如下结点类来说：
+     *
+     * ```ts
+     * class Blending extends PoseNode {
+     *     \@input({ type: PoseGraphType.POSE, syncGroup: 'blend-item' })
+     *     poses: PoseNode[] = [];
+     *
+     *     \@input({ type: PoseGraphType.FLOAT, syncGroup: 'blend-item' })
+     *     weights: number[] = [];
+     * }
+     * ```
+     *
+     * 当 `poses` 插入了一个新的输入后，`weights` 也会被插入一个新输入。
+     *
+     * @en
+     * For the following node class:
+     *
+     * ```ts
+     * class Blending extends PoseNode {
+     *     \@input({ type: PoseGraphType.POSE, syncGroup: 'blend-item' })
+     *     poses: PoseNode[] = [];
+     *
+     *     \@input({ type: PoseGraphType.FLOAT, syncGroup: 'blend-item' })
+     *     weights: number[] = [];
+     * }
+     * ```
+     *
+     * If a new input is inserted into `poses`, there will be also a new input inserted into weights.
+     */
+    arraySyncGroup?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+class NodeInputManager {
+    public setPropertyNodeInputRecord (
+        constructor: Constructor,
+        propertyKey: string,
+        options: NodeInputMappingOptions,
+    ) {
+        let classInputRecord = this._classInputMap.get(constructor);
+        if (!classInputRecord) {
+            classInputRecord = {
+                properties: {},
+            };
+            this._classInputMap.set(constructor, classInputRecord);
+        }
+        const {
+            arraySyncGroup,
+            ...unchanged
+        } = options;
+
+        const record: PropertyNodeInputRecord = unchanged;
+
+        const arraySyncGroupName = options.arraySyncGroup;
+        if (arraySyncGroupName) {
+            if (!classInputRecord.arraySyncGroups) {
+                classInputRecord.arraySyncGroups = {};
+            }
+            const group = classInputRecord.arraySyncGroups[arraySyncGroupName] ??= { members: [] };
+            if (!group.members.includes(propertyKey)) {
+                group.members.push(propertyKey);
+            }
+            record.arraySyncGroup = group;
+        }
+
+        classInputRecord.properties[propertyKey] = Object.freeze(record);
+    }
+
+    public getInputKeys (object: PoseGraphNode): readonly PoseGraphInputKey[] {
+        const result: PoseGraphInputKey[] = [];
+        const getInputKeysRecurse = (constructor: null | Constructor) => {
+            if (!constructor) {
+                return;
+            }
+            getInputKeysRecurse(js.getSuper(constructor));
+            const record = this._classInputMap.get(constructor);
+            if (!record) {
+                return;
+            }
+            for (const [propertyKey] of Object.entries(record.properties)) {
+                // Subclass's input mapping declaration overrides base's.
+                if (result.findIndex(([subClassPropertyKey]) => propertyKey === subClassPropertyKey) >= 0) {
+                    continue;
+                }
+                const field = object[propertyKey];
+                if (Array.isArray(field)) {
+                    for (let iElement = 0; iElement < field.length; ++iElement) {
+                        result.push([propertyKey, iElement]);
+                    }
+                } else {
+                    result.push([propertyKey]);
+                }
+            }
+        };
+        getInputKeysRecurse(object.constructor);
+        return result;
+    }
+
+    public isPoseInput (object: PoseGraphNode, key: PoseGraphInputKey) {
+        const [propertyKey] = key;
+        const propertyInputRecord = this._getPropertyNodeInputRecord(object.constructor, propertyKey);
+        if (!propertyInputRecord) {
+            return false;
+        }
+        return propertyInputRecord.type === PoseGraphType.POSE;
+    }
+
+    public getInputMetadata (object: PoseGraphNode, key: PoseGraphInputKey): Readonly<PoseGraphNodeInputMetadata> | undefined {
+        const [propertyKey, elementIndex = -1] = key;
+        const propertyInputRecord = this._getPropertyNodeInputRecord(object.constructor, propertyKey);
+        if (!propertyInputRecord) {
+            return undefined;
+        }
+        const field = object[propertyKey];
+        if (Array.isArray(field)) {
+            if (elementIndex < 0 || elementIndex >= field.length) {
+                return undefined;
+            } else {
+                const displayName = propertyInputRecord.getArrayElementDisplayName?.call(object, elementIndex)
+                    ?? `${propertyInputRecord.displayName ?? propertyKey} ${elementIndex}`;
+                return {
+                    type: propertyInputRecord.type,
+                    displayName,
+                    deletable: true,
+                    insertPoint: true,
+                };
+            }
+        }
+        return {
+            type: propertyInputRecord.type,
+            displayName: propertyInputRecord.displayName ?? propertyKey,
+        };
+    }
+
+    public hasInput (object: PoseGraphNode, key: PoseGraphInputKey) {
+        const [propertyKey, elementIndex = -1] = key;
+        const record = this._getPropertyNodeInputRecord(object.constructor, propertyKey);
+        if (!record) {
+            return false;
+        }
+        const field = object[propertyKey];
+        if (Array.isArray(field)) {
+            if (elementIndex < 0 || elementIndex >= field.length) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public getInputInsertInfos (object: PoseGraphNode): Readonly<Record<PoseGraphNodeInputInsertId, { displayName: string; }>> {
+        const result: Record<PoseGraphNodeInputInsertId, { displayName: string; }> = {};
+        for (let constructor = object.constructor; constructor; constructor = js.getSuper(constructor)) {
+            const classInputRecord = this._classInputMap.get(constructor);
+            if (!classInputRecord) {
+                continue;
+            }
+            for (const propertyKey in classInputRecord.properties) {
+                const propertyInputRecord = classInputRecord.properties[propertyKey];
+                const property = object[propertyKey];
+                if (Array.isArray(property)) {
+                    result[propertyKey] = { displayName: propertyKey };
+                }
+            }
+        }
+        return result;
+    }
+
+    public deleteInput (node: PoseGraphNode, key: PoseGraphInputKey) {
+        const [
+            propertyKey,
+            elementIndex = -1,
+        ] = key;
+        const propertyInputRecord = this._getPropertyNodeInputRecord(node.constructor, propertyKey);
+        if (!propertyInputRecord) {
+            return;
+        }
+        const property = node[propertyKey];
+        if (!Array.isArray(property)) {
+            return;
+        }
+        if (elementIndex < 0 || elementIndex >= property.length) {
+            return;
+        }
+
+        // If it's an array record and belongs to a sync group,
+        // Perform the deletion on all group members.
+        // > Note: currently we can only insert input to array.
+        // eslint-disable-next-line no-constant-condition
+        if (true) {
+            const { arraySyncGroup } = propertyInputRecord;
+            if (arraySyncGroup) {
+                this._deleteInputInArraySyncGroup(
+                    node,
+                    arraySyncGroup,
+                    property.length,
+                    elementIndex,
+                );
+                return;
+            }
+        }
+
+        deletePoseGraphNodeArrayElement(node, key);
+    }
+
+    public insertInput (node: PoseGraphNode, insertId: PoseGraphNodeInputInsertId) {
+        const propertyKey = insertId;
+        const propertyInputRecord = this._getPropertyNodeInputRecord(node.constructor, propertyKey);
+        if (!propertyInputRecord) {
+            return;
+        }
+        const property = node[propertyKey];
+        if (!Array.isArray(property)) {
+            return;
+        }
+
+        const hint = property.length; // Always insert from back.
+
+        // If it's an array record and belongs to a sync group,
+        // Perform the insertion on all group members.
+        // > Note: currently we can only insert input to array.
+        // eslint-disable-next-line no-constant-condition
+        if (true) {
+            const { arraySyncGroup } = propertyInputRecord;
+            if (arraySyncGroup) {
+                this._insertInputInArraySyncGroup(
+                    node,
+                    arraySyncGroup,
+                    property.length,
+                    hint,
+                );
+                return;
+            }
+        }
+
+        insertPoseGraphNodeArrayElement(
+            node,
+            [propertyKey, hint],
+            createDefaultInputValueByType(propertyInputRecord.type),
+        );
+    }
+
+    private _classInputMap = new WeakMap<Constructor, {
+        properties: Record<PropertyKey, PropertyNodeInputRecord>;
+        arraySyncGroups?: Record<string, ArrayPropertySyncGroup>;
+    }>();
+
+    private _getPropertyNodeInputRecord (constructor: null | Constructor, propertyKey: string): PropertyNodeInputRecord | undefined {
+        if (!constructor) {
+            return undefined;
+        }
+        const classInputRecord = this._classInputMap.get(constructor);
+        if (classInputRecord) {
+            const record = classInputRecord.properties[propertyKey];
+            if (record) {
+                return record;
+            }
+        }
+        return this._getPropertyNodeInputRecord(js.getSuper(constructor), propertyKey);
+    }
+
+    private _insertInputInArraySyncGroup (
+        node: PoseGraphNode,
+        syncGroup: ArrayPropertySyncGroup,
+        expectedOriginalSyncLength: number,
+        insertHint: number,
+    ) {
+        for (let iGroupMember = 0; iGroupMember < syncGroup.members.length; ++iGroupMember) {
+            const syncedPropertyKey = syncGroup.members[iGroupMember];
+            const syncedPropertyInputRecord = this._getPropertyNodeInputRecord(node.constructor, syncedPropertyKey);
+            assertIsTrue(syncedPropertyInputRecord);
+            const syncedProperty = node[syncedPropertyKey];
+            if (!Array.isArray(syncedProperty) || syncedProperty.length !== expectedOriginalSyncLength) {
+                // The property is declared with a "syncWith",
+                // but the sync target property is not an array or does not have a matched length.
+                // To avoid un-expectations, interrupt.
+                continue;
+            }
+            insertPoseGraphNodeArrayElement(
+                node,
+                [syncedPropertyKey, insertHint],
+                createDefaultInputValueByType(syncedPropertyInputRecord.type),
+            );
+        }
+    }
+
+    private _deleteInputInArraySyncGroup (
+        node: PoseGraphNode,
+        syncGroup: ArrayPropertySyncGroup,
+        expectedOriginalSyncLength: number,
+        index: number,
+    ) {
+        for (let iGroupMember = 0; iGroupMember < syncGroup.members.length; ++iGroupMember) {
+            const syncedPropertyKey = syncGroup.members[iGroupMember];
+            const syncedPropertyInputRecord = this._getPropertyNodeInputRecord(node.constructor, syncedPropertyKey);
+            assertIsTrue(syncedPropertyInputRecord);
+            const syncedProperty = node[syncedPropertyKey];
+            if (!Array.isArray(syncedProperty) || syncedProperty.length !== expectedOriginalSyncLength) {
+                // The property is declared with a "syncWith",
+                // but the sync target property is not an array or does not have a matched length.
+                // To avoid un-expectations, interrupt.
+                continue;
+            }
+            deletePoseGraphNodeArrayElement(node, [syncedPropertyKey, index]);
+        }
+    }
+}
+
+function insertPoseGraphNodeArrayElement (node: PoseGraphNode, inputKey: PoseGraphInputKey, value: unknown) {
+    const shell = node[shellTag];
+    if (!shell) {
+        throw new OperationOnFreestandingNodeError(node);
+    }
+
+    const [
+        propertyKey,
+        elementIndex = -1,
+    ] = inputKey;
+    const property = node[propertyKey];
+    if (!Array.isArray(property)) {
+        return;
+    }
+
+    // Insert the element itself.
+    property.splice(elementIndex, 0, value);
+
+    // Update bindings for following elements.
+    shell.moveArrayElementBindingForward(propertyKey, elementIndex + 1, false);
+}
+
+function deletePoseGraphNodeArrayElement (node: PoseGraphNode, inputKey: PoseGraphInputKey) {
+    const shell = node[shellTag];
+    if (!shell) {
+        throw new OperationOnFreestandingNodeError(node);
+    }
+
+    const [
+        propertyKey,
+        elementIndex = -1,
+    ] = inputKey;
+    const property = node[propertyKey];
+    if (!Array.isArray(property)) {
+        return;
+    }
+    if (elementIndex < 0 || elementIndex >= property.length) {
+        return;
+    }
+
+    // Delete the binding.
+    shell.deleteBinding(inputKey);
+
+    // Delete the element itself.
+    property.splice(elementIndex, 1);
+
+    // Update bindings for following elements.
+    shell.moveArrayElementBindingForward(propertyKey, elementIndex + 1, true);
+}
+
+function createDefaultInputValueByType (type: PoseGraphType) {
+    switch (type) {
+    default:
+        assertIsTrue(false);
+        // fallthrough
+    case PoseGraphType.FLOAT:
+    case PoseGraphType.INTEGER:
+        return 0;
+    case PoseGraphType.POSE:
+        return null;
+    case PoseGraphType.VEC3:
+        return new Vec3();
+    case PoseGraphType.QUAT:
+        return new Quat();
+    }
+}
+
+export const globalNodeInputManager = new NodeInputManager();

--- a/cocos/animation/marionette/pose-graph/foundation/authoring/node-authoring.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/authoring/node-authoring.ts
@@ -3,23 +3,23 @@ import { PoseGraphNode } from '../pose-graph-node';
 
 export {};
 
-export type PoseGraphCreateNodeContext = {
+export interface PoseGraphCreateNodeContext {
     animationGraph: AnimationGraph;
 
     layerIndex: number;
-};
+}
 
-export type PoseGraphCreateNodeEntry<TArg> = {
+export interface PoseGraphCreateNodeEntry<TArg> {
     arg: TArg;
 
     menu: string;
-};
+}
 
-export type PoseGraphCreateNodeFactory<TArg> = {
+export interface PoseGraphCreateNodeFactory<TArg> {
     listEntries(context: PoseGraphCreateNodeContext): Iterable<PoseGraphCreateNodeEntry<TArg>>;
 
     create: (arg: TArg) => PoseGraphNode;
-};
+}
 
 export interface PoseGraphNodeEditorMetadata {
     /**

--- a/cocos/animation/marionette/pose-graph/foundation/authoring/node-authoring.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/authoring/node-authoring.ts
@@ -1,0 +1,97 @@
+import type { AnimationGraph } from '../../../animation-graph';
+import { PoseGraphNode } from '../pose-graph-node';
+
+export {};
+
+export type PoseGraphCreateNodeContext = {
+    animationGraph: AnimationGraph;
+
+    layerIndex: number;
+};
+
+export type PoseGraphCreateNodeEntry<TArg> = {
+    arg: TArg;
+
+    menu: string;
+};
+
+export type PoseGraphCreateNodeFactory<TArg> = {
+    listEntries(context: PoseGraphCreateNodeContext): Iterable<PoseGraphCreateNodeEntry<TArg>>;
+
+    create: (arg: TArg) => PoseGraphNode;
+};
+
+export interface PoseGraphNodeEditorMetadata {
+    /**
+     * @zh
+     * 为 `true` 时表示此类型的结点对象不应该被编辑器创建和编辑。
+     * @en
+     * If `true`, nodes of this type should not be created and edited by editor.
+     */
+    hide?: boolean;
+
+    /**
+     * @zh
+     * 此类型的结点的菜单路径。
+     * @en
+     * The menu path of this type of nodes.
+     */
+    menu?: string;
+
+    /**
+     * @zh
+     * 创建此类型结点应使用的选项和方法。
+     * @en
+     * The options and factory should be taken to create this type of nodes.
+     */
+    factory?: PoseGraphCreateNodeFactory<unknown>;
+
+    /**
+     * @zh
+     * 此类型结点的外观配置。
+     * @en
+     * The appearance configs of this type of nodes.
+     */
+    appearance?: PoseGraphNodeAppearanceOptions;
+}
+
+/**
+ * @zh 描述某类型结点的编辑器外观选项。
+ * @en Describes the editor appearance of a type of nodes.
+ */
+export interface PoseGraphNodeAppearanceOptions {
+    /**
+     * @zh
+     * 主题颜色。目前应为以 “#” 开头的十六进制字符串颜色表示，例如 `"#FF00FF"`。
+     * @en
+     * Theme color. Currently should be a color hex string starting with "#", for example: `"#FF00FF"`.
+     */
+    themeColor?: `#${string}`;
+
+    /**
+     * @zh
+     * 为 `true` 时表示展示该类型结点时尽可能地使用“内联”样式。
+     * @en
+     * If `true`, indicates editor should show this type of nodes in "inline" style if possible.
+     */
+    inline?: boolean;
+}
+
+const nodeEditorMetadataMap = new WeakMap<Constructor<PoseGraphNode>, PoseGraphNodeEditorMetadata>();
+
+export function getPoseGraphNodeEditorMetadata (
+    classConstructor: Constructor<PoseGraphNode>,
+): Readonly<PoseGraphNodeEditorMetadata> | undefined {
+    return nodeEditorMetadataMap.get(classConstructor);
+}
+
+export function getOrCreateNodeEditorMetadata (constructor: Constructor<PoseGraphNode>) {
+    const existing = nodeEditorMetadataMap.get(constructor);
+    if (existing) {
+        return existing;
+    } else {
+        const metadata: PoseGraphNodeEditorMetadata = {};
+        nodeEditorMetadataMap.set(constructor, metadata);
+        return metadata;
+    }
+}

--- a/cocos/animation/marionette/pose-graph/foundation/errors.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/errors.ts
@@ -1,0 +1,13 @@
+import { PoseGraphNode } from './pose-graph-node';
+
+export class AddNonFreestandingNodeError extends Error {
+    constructor (node: PoseGraphNode) {
+        super(`Can not add the specified ${node.toString()} since it has already been added into another graph.`);
+    }
+}
+
+export class OperationOnFreestandingNodeError extends Error {
+    constructor (node: PoseGraphNode) {
+        super(`Can not perform specified operation on ${node.toString()} since it has not been added in to graph.`);
+    }
+}

--- a/cocos/animation/marionette/pose-graph/foundation/node-shell.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/node-shell.ts
@@ -1,0 +1,230 @@
+import { EditorExtendable } from '../../../../core';
+import { ccclass, serializable } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { PoseGraphNode } from './pose-graph-node';
+
+/**
+ * @zh
+ * 描述姿势图结点上的某项输入的路径。
+ * @en
+ * Describes the path to a input of a pose graph node.
+ *
+ * @internal Internally, the path is stored as an tuple.
+ * The first element of tuple is always the input's property key.
+ * There can be an optional second tuple element,
+ * which represents the input's property's element, if it's an array property.
+ */
+export type NodeInputPath = readonly [string] | readonly [string, number];
+
+/**
+ * @zh 表示姿势图结点的外壳。
+ *
+ * 结点外壳是附着在结点上的、对结点之间的连接（称之为绑定）的描述。
+ * 外壳由姿势图以及绑定系统操纵，结点对于其外壳是无感知的。
+ *
+ * @en Represents the shell of a pose graph node.
+ *
+ * The node shell is attached to a node,
+ * and describes the connections(so called binding) between nodes.
+ * Shells are manipulated by pose graph and binding system.
+ * Nodes are imperceptible to their shells.
+ */
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseGraphNodeShell`)
+export class PoseGraphNodeShell extends EditorExtendable {
+    /**
+     * @zh
+     * 获取此结点上的所有的绑定。
+     * @en
+     * Gets all bindings on this node.
+     * @returns @zh 绑定对象数组。 @en The binding objects array.
+     */
+    public getBindings () {
+        return this._bindings;
+    }
+
+    /**
+     * @zh
+     * 添加一项绑定。
+     * @en
+     * Adds a binding.
+     * @param inputPath @zh 要绑定的输入的路径。 @en Path of the input to bind.
+     * @param producer @zh 生产方结点。 @en The producer node.
+     * @param outputIndex @zh 要绑定的生产方的输出索引。 @en Index of the output to bind.
+     * @note
+     * @zh 绑定是由三元组输入路径、生产方结点和生产方索引唯一键定的。重复的添加相同绑定没有效果。
+     * @en A binding is keyed by the 3-element tuple: input path, producer node and producer output index.
+     * Redundantly adding a binding takes no effect.
+     */
+    public addBinding (inputPath: NodeInputPath, producer: PoseGraphNode, outputIndex: number) {
+        this._emplaceBinding(new PoseGraphNodeInputBinding(
+            inputPath,
+            producer,
+            outputIndex,
+        ));
+    }
+
+    /**
+     * @zh
+     * 删除指定输入上的绑定。
+     * @en
+     * Deletes the binding on specified input.
+     * @param inputPath @zh 要解绑的输入的路径。 @en Path of the input to unbind.
+     */
+    public deleteBinding (inputPath: NodeInputPath) {
+        const index = this._findBindingIndex(inputPath);
+        if (index >= 0) {
+            this._bindings.splice(index);
+        }
+    }
+
+    /**
+     * @zh
+     * 更新绑定，
+     * 对于具有相同属性键的、索引小于（或大于） `firstIndex` 的输入的绑定，
+     * 将它们替换为上一个（或下一个）索引上的绑定。
+     * @en
+     * Update bindings so that
+     * for the input bindings having specified property key but having element index less than the specified index,
+     * substitute them as previous(or next) index's binding.
+     * @param propertyKey @zh 输入的属性键。 @en The input's property key.
+     * @param firstIndex @zh 见描述。 @en See description.
+     * @param forward @en 替换的方向。`true` 表示向前替换，反之向后。
+     *              @en Substitution direction. `true` means substitute in forward, backward otherwise.
+     */
+    public moveArrayElementBindingForward (propertyKey: string, firstIndex: number, forward: boolean) {
+        // TODO: this method has worse performance!
+        const { _bindings: bindings } = this;
+
+        const oldBindings: PoseGraphNodeInputBinding[] = [];
+        for (let iBinding = 0;
+            iBinding < bindings.length; // Note: array length may be varied.
+            ++iBinding
+        ) {
+            const binding = bindings[iBinding];
+            const [consumerPropertyKey, consumerElementIndex = -1] = binding.inputPath;
+            if (consumerPropertyKey === propertyKey && consumerElementIndex >= firstIndex) {
+                oldBindings.push(binding);
+                bindings.splice(iBinding, 1);
+            }
+        }
+
+        for (const oldBinding of oldBindings) {
+            const [consumerPropertyKey, consumerElementIndex = -1] = oldBinding.inputPath;
+            this.addBinding(
+                [consumerPropertyKey, consumerElementIndex + (forward ? -1 : 1)],
+                oldBinding.producer,
+                oldBinding.outputIndex,
+            );
+        }
+    }
+
+    /**
+     * @zh
+     * 删除绑定到指定生产方结点的所有绑定。
+     * @en
+     * Deletes all the bindings bound to specified producer.
+     * @param producer @zh 生产方结点。 @en The producer node.
+     */
+    public deleteBindingTo (producer: PoseGraphNode) {
+        const { _bindings: bindings } = this;
+        for (let iBinding = 0;
+            iBinding < bindings.length; // Note: array length might vary
+            ++iBinding
+        ) {
+            const binding = bindings[iBinding];
+            if (binding.producer === producer) {
+                bindings.splice(iBinding, 1);
+            }
+        }
+    }
+
+    /**
+     * @zh
+     * 查找指定输入上的绑定。
+     * @en
+     * Finds the binding on specified input.
+     * @param inputPath @zh 要查找的输入的路径。 @en Path of the input to find.
+     */
+    public findBinding (inputPath: NodeInputPath): PoseGraphNodeInputBinding | undefined {
+        const bindingIndex = this._findBindingIndex(inputPath);
+        return bindingIndex >= 0 ? this._bindings[bindingIndex] : undefined;
+    }
+
+    @serializable
+    private _bindings: PoseGraphNodeInputBinding[] = [];
+
+    private _findBindingIndex (inputPath: NodeInputPath) {
+        return this._bindings.findIndex(
+            (searchElement) => isEqualNodeInputPath(searchElement.inputPath, inputPath),
+        );
+    }
+
+    private _emplaceBinding (binding: PoseGraphNodeInputBinding) {
+        const index = this._bindings.findIndex(
+            (searchElement) => isEqualNodeInputPath(searchElement.inputPath, binding.inputPath),
+        );
+        if (index >= 0) {
+            this._bindings[index] = binding;
+        } else {
+            this._bindings.push(binding);
+        }
+    }
+}
+
+function isEqualNodeInputPath (lhs: NodeInputPath, rhs: NodeInputPath) {
+    const [lhsPropertyKey, lhsElementIndex] = lhs;
+    const [rhsPropertyKey, rhsElementIndex] = rhs;
+    return lhsPropertyKey === rhsPropertyKey && lhsElementIndex === rhsElementIndex;
+}
+
+/**
+ * @zh 描述既定结点（作为消费方）和另一结点（作为生产方）之间的绑定信息。
+ * @en Describes the binding information between a given node(as consumer) and another node(as producer).
+ */
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseGraphNodeInputBinding`)
+class PoseGraphNodeInputBinding {
+    constructor (
+        inputPath: NodeInputPath,
+        producer: PoseGraphNode,
+        outputIndex: number,
+    ) {
+        this._inputPath = inputPath;
+        this._producer = producer;
+        this._outputIndex = outputIndex;
+    }
+
+    /**
+     * @zh 消费方结点的输入路径。
+     * @en Input path of consumer node.
+     */
+    get inputPath () {
+        return this._inputPath;
+    }
+
+    /**
+     * @zh 生产方结点。
+     * @en The producer node.
+     */
+    get producer () {
+        return this._producer;
+    }
+
+    /**
+     * @zh 生产方结点的输出索引。
+     * @en The producer node's output index.
+     */
+    get outputIndex () {
+        return this._outputIndex;
+    }
+
+    @serializable
+    private _inputPath: NodeInputPath;
+
+    @serializable
+    private _producer: PoseGraphNode;
+
+    @serializable
+    private _outputIndex = 0;
+}
+
+export type { PoseGraphNodeInputBinding };

--- a/cocos/animation/marionette/pose-graph/foundation/pose-graph-node.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/pose-graph-node.ts
@@ -1,8 +1,5 @@
-import { EditorExtendable, assertIsTrue } from '../../../../core';
+import { EditorExtendable } from '../../../../core';
 import { EnterNodeInfo } from './authoring/enter-node-info';
-import type { PoseGraphNodeShell } from './node-shell';
-
-export const shellTag = Symbol('Shell');
 
 /**
  * @zh
@@ -11,21 +8,6 @@ export const shellTag = Symbol('Shell');
  * Class of node in pose graph.
  */
 export class PoseGraphNode extends EditorExtendable {
-    /**
-     * @zh
-     * 该结点在姿势图中的外壳。
-     * 在结点添加到姿势图中时，该字段被置为相应的外壳对象；
-     * 当结点被移出姿势图时，该字段被置空。
-     * @en
-     * The node's shell in pose graph.
-     * This field is set to the corresponding shell object when this node is added into pose graph,
-     * is set to `undefined` when this node is removed from pose graph.
-     * @internal
-     */
-    get [shellTag] () {
-        return this._shell;
-    }
-
     /**
      * @internal Temporarily hack for deserialization callback.
      */
@@ -46,22 +28,4 @@ export class PoseGraphNode extends EditorExtendable {
      * Gets enter info of this node.
      */
     public getEnterInfo?(): EnterNodeInfo | undefined;
-
-    /**
-     * @internal
-     */
-    public _emplaceShell (shell: PoseGraphNodeShell) {
-        assertIsTrue(!this._shell);
-        this._shell = shell;
-    }
-
-    /**
-     * @internal
-     */
-    public _dropShell () {
-        assertIsTrue(this._shell);
-        this._shell = undefined;
-    }
-
-    private _shell: PoseGraphNodeShell | undefined = undefined;
 }

--- a/cocos/animation/marionette/pose-graph/foundation/pose-graph-node.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/pose-graph-node.ts
@@ -1,0 +1,67 @@
+import { EditorExtendable, assertIsTrue } from '../../../../core';
+import { EnterNodeInfo } from './authoring/enter-node-info';
+import type { PoseGraphNodeShell } from './node-shell';
+
+export const shellTag = Symbol('Shell');
+
+/**
+ * @zh
+ * 姿势图中的结点类。
+ * @en
+ * Class of node in pose graph.
+ */
+export class PoseGraphNode extends EditorExtendable {
+    /**
+     * @zh
+     * 该结点在姿势图中的外壳。
+     * 在结点添加到姿势图中时，该字段被置为相应的外壳对象；
+     * 当结点被移出姿势图时，该字段被置空。
+     * @en
+     * The node's shell in pose graph.
+     * This field is set to the corresponding shell object when this node is added into pose graph,
+     * is set to `undefined` when this node is removed from pose graph.
+     * @internal
+     */
+    get [shellTag] () {
+        return this._shell;
+    }
+
+    /**
+     * @internal Temporarily hack for deserialization callback.
+     */
+    __callOnAfterDeserializeRecursive?(): void;
+
+    /**
+     * @zh
+     * 获取该结点的标题。
+     * @en
+     * Gets title of this node.
+     */
+    public getTitle?(): string;
+
+    /**
+     * @zh
+     * 获取该结点的进入信息。
+     * @en
+     * Gets enter info of this node.
+     */
+    public getEnterInfo?(): EnterNodeInfo | undefined;
+
+    /**
+     * @internal
+     */
+    public _emplaceShell (shell: PoseGraphNodeShell) {
+        assertIsTrue(!this._shell);
+        this._shell = shell;
+    }
+
+    /**
+     * @internal
+     */
+    public _dropShell () {
+        assertIsTrue(this._shell);
+        this._shell = undefined;
+    }
+
+    private _shell: PoseGraphNodeShell | undefined = undefined;
+}

--- a/cocos/animation/marionette/pose-graph/foundation/type-system.ts
+++ b/cocos/animation/marionette/pose-graph/foundation/type-system.ts
@@ -1,0 +1,15 @@
+export {};
+
+export enum PoseGraphType {
+    FLOAT,
+
+    INTEGER,
+
+    BOOLEAN,
+
+    VEC3,
+
+    QUAT,
+
+    POSE,
+}

--- a/cocos/animation/marionette/pose-graph/graph-output-node.ts
+++ b/cocos/animation/marionette/pose-graph/graph-output-node.ts
@@ -4,7 +4,7 @@ import { CLASS_NAME_PREFIX_ANIM } from '../../define';
 import { PoseNode } from './pose-node';
 import { PoseGraphType } from './foundation/type-system';
 import { PoseGraphNode } from './foundation/pose-graph-node';
-import { globalNodeInputManager } from './foundation/authoring/input-authoring';
+import { globalPoseGraphNodeInputManager } from './foundation/authoring/input-authoring';
 
 @ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseGraphOutputNode`)
 export class PoseGraphOutputNode extends PoseGraphNode {
@@ -13,7 +13,7 @@ export class PoseGraphOutputNode extends PoseGraphNode {
     pose: PoseNode | null = null;
 }
 
-globalNodeInputManager.setPropertyNodeInputRecord(PoseGraphOutputNode, 'pose', {
+globalPoseGraphNodeInputManager.setPropertyNodeInputRecord(PoseGraphOutputNode, 'pose', {
     type: PoseGraphType.POSE,
 });
 

--- a/cocos/animation/marionette/pose-graph/graph-output-node.ts
+++ b/cocos/animation/marionette/pose-graph/graph-output-node.ts
@@ -1,0 +1,24 @@
+import { EDITOR } from 'internal:constants';
+import { ccclass, serializable } from '../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../define';
+import { PoseNode } from './pose-node';
+import { PoseGraphType } from './foundation/type-system';
+import { PoseGraphNode } from './foundation/pose-graph-node';
+import { globalNodeInputManager } from './foundation/authoring/input-authoring';
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseGraphOutputNode`)
+export class PoseGraphOutputNode extends PoseGraphNode {
+    // Don't use @input since it requires the owner class being subclass of `PoseNode`.
+    @serializable
+    pose: PoseNode | null = null;
+}
+
+globalNodeInputManager.setPropertyNodeInputRecord(PoseGraphOutputNode, 'pose', {
+    type: PoseGraphType.POSE,
+});
+
+if (EDITOR) {
+    PoseGraphOutputNode.prototype.getTitle = function getTitle (this: PoseGraphOutputNode) {
+        return '输出姿势';
+    };
+}

--- a/cocos/animation/marionette/pose-graph/instantiation.ts
+++ b/cocos/animation/marionette/pose-graph/instantiation.ts
@@ -1,19 +1,341 @@
-import { instantiate } from '../../../serialization/instantiate';
-import { PoseGraph } from './pose-graph';
-import { PoseNode } from './pose-node';
+// cSpell:words Evaluatable
 
-export function instantiatePoseGraph (poseGraph: PoseGraph): PoseNode | null {
-    return poseGraph.main
-        ? instantiatePoseNode(poseGraph.main)
-        : null;
+import { assertIsTrue, warn } from '../../../core';
+import { instantiate } from '../../../serialization';
+import { PoseNode } from './pose-node';
+import { PoseGraph } from './pose-graph';
+import { XNode, XNodeLinkContext } from './x-node';
+import { NodeInputPath } from './foundation/node-shell';
+import { PoseGraphNode, shellTag } from './foundation/pose-graph-node';
+
+type EvaluatableNode = PoseNode | XNode;
+
+function isEvaluatableNode (node: PoseGraphNode): node is EvaluatableNode {
+    return (node instanceof PoseNode || node instanceof XNode);
 }
 
-function instantiatePoseNode (node: PoseNode) {
+export function instantiatePoseGraph (
+    graph: PoseGraph,
+    linkContext: XNodeLinkContext,
+): PoseNode | undefined {
+    const {
+        outputNode,
+    } = graph;
+
+    const outputNodeShell = outputNode[shellTag];
+    assertIsTrue(outputNodeShell);
+    const bindings = outputNodeShell.getBindings();
+    // Output node can only has 1 or has no binding.
+    assertIsTrue(bindings.length < 2);
+    if (bindings.length === 0) {
+        return undefined;
+    }
+    // If the output node has a binding, it must be pose node.
+    const binding = bindings[0];
+    assertIsTrue(binding.outputIndex === 0);
+    assertIsTrue(binding.producer instanceof PoseNode);
+
+    const instantiationMap = new Map<PoseGraphNode, RuntimeNodeEvaluation>();
+    const mainRecord = instantiateNode(
+        binding.producer,
+        instantiationMap,
+        linkContext,
+    );
+    assertIsTrue(mainRecord instanceof PoseNode);
+
+    return mainRecord;
+}
+
+export interface PoseNodeDependencyEvaluation {
+    evaluate(): void;
+}
+
+function instantiateNode<TNode extends EvaluatableNode> (
+    node: TNode,
+    instantiationMap: Map<PoseGraphNode, RuntimeNodeEvaluation>,
+    linkContext: XNodeLinkContext,
+): RuntimeNodeEvaluation {
+    const {
+        [shellTag]: shell,
+    } = node;
+    assertIsTrue(shell, `Want to instantiate an unbound graph?`);
+
+    const existing = instantiationMap.get(node);
+    if (existing) {
+        return existing;
+    }
+
     const instantiated = instantiate(node);
+
+    // Invoke serialization callback.
     if ('__callOnAfterDeserializeRecursive' in instantiated) {
         (instantiated as unknown as {
             __callOnAfterDeserializeRecursive(): void;
         }).__callOnAfterDeserializeRecursive();
     }
-    return instantiated;
+
+    /** Link. */
+    if (instantiated instanceof XNode) {
+        instantiated.link(linkContext);
+    }
+
+    /** Alias. */
+    const consumerNode = instantiated;
+
+    /**
+     * Create the x-node property binding records.
+     */
+    const runtimeXNodePropertyBindings: RuntimeXNodePropertyBinding[] = [];
+    for (const {
+        producer: producerNode,
+        outputIndex: producerOutputIndex,
+        inputPath: consumerInputPath,
+    } of shell.getBindings()) {
+        if (!isEvaluatableNode(producerNode)) {
+            warn(`There's a input bound to a node with unrecognized type.`);
+            continue;
+        }
+        const producer = instantiateNode(producerNode, instantiationMap, linkContext);
+        if (producer instanceof PoseNode) {
+            // Rule: pose nodes can only be used to feed pose nodes.
+            assertIsTrue(consumerNode instanceof PoseNode);
+            // Core code: link pose nodes.
+            linkPoseNode(
+                consumerNode,
+                consumerInputPath,
+                producer,
+                producerOutputIndex,
+            );
+        } else {
+            const runtimeXNodePropertyBinding = linkXNode(
+                consumerNode,
+                consumerInputPath,
+                producer,
+                producerOutputIndex,
+            );
+            if (runtimeXNodePropertyBinding) {
+                runtimeXNodePropertyBindings.push(runtimeXNodePropertyBinding);
+            }
+        }
+    }
+
+    // Create the dependency evaluation.
+    const dependencyEvaluation = new DependencyEvaluation(runtimeXNodePropertyBindings);
+
+    // Create the evaluation record.
+    let evaluation: PoseNode | RuntimeNodeEvaluation;
+    if (consumerNode instanceof PoseNode) {
+        // If this is pose node. Injects the dependency.
+        consumerNode._setDependencyEvaluation(dependencyEvaluation);
+        evaluation = consumerNode;
+    } else {
+        // Otherwise, create the evaluation record.
+        const xNodeEvaluation = new RuntimeXNodeEvaluation(consumerNode, dependencyEvaluation);
+        evaluation = xNodeEvaluation;
+    }
+
+    instantiationMap.set(node, evaluation);
+    return evaluation;
+}
+
+class DependencyEvaluation implements PoseNodeDependencyEvaluation {
+    constructor (
+        bindingEvaluations: readonly RuntimeXNodePropertyBinding[],
+    ) {
+        this._bindingEvaluations = bindingEvaluations;
+    }
+
+    public evaluate (): void {
+        const {
+            _bindingEvaluations: bindingEvaluations,
+        } = this;
+
+        for (const binding of bindingEvaluations) {
+            binding.evaluate();
+        }
+    }
+
+    private _bindingEvaluations: readonly RuntimeXNodePropertyBinding[];
+}
+
+class RuntimeXNodeEvaluation {
+    constructor (
+        private _node: XNode,
+        private _dependency: DependencyEvaluation,
+    ) {
+        this._outputs = new Array(_node.outputCount);
+    }
+
+    get node () {
+        return this._node;
+    }
+
+    public get outputCount () {
+        return this._outputs.length;
+    }
+
+    public getDefaultOutput () {
+        return this.getOutput(0);
+    }
+
+    public getOutput (outputIndex: number) {
+        return this._outputs[outputIndex];
+    }
+
+    public evaluate () {
+        const {
+            _node: node,
+            _dependency: dependency,
+        } = this;
+        // Evaluate the dependency.
+        dependency.evaluate();
+        // Evaluate the node.
+        node.selfEvaluate(this._outputs);
+    }
+
+    protected _outputs: unknown[];
+}
+
+type RuntimeNodeEvaluation = PoseNode | RuntimeXNodeEvaluation;
+
+function linkPoseNode (
+    consumerNode: PoseNode,
+    consumerInputPath: NodeInputPath,
+    producerNode: PoseNode,
+    producerOutputIndex: number,
+) {
+    const [consumerPropertyKey, consumerElementIndex = -1] = consumerInputPath;
+    if (!(consumerPropertyKey in consumerNode)) {
+        // Invalid binding.
+        warn(`Invalid binding: consumer node has no property ${consumerPropertyKey}`);
+        return;
+    }
+
+    if (producerOutputIndex !== 0) {
+        // Rule: pose nodes have and only have one output.
+        warn(`Node ${producerNode.toString()} does not have specified output ${producerOutputIndex}.`);
+        return;
+    }
+
+    const consumerProperty = consumerNode[consumerPropertyKey];
+
+    // Plain property binding.
+
+    if (consumerElementIndex < 0) {
+        if (consumerProperty !== null) {
+            // Invalid binding.
+            warn(`Invalid binding: consumer node's input ${consumerPropertyKey} should be leaved as evaluation before evaluation.`);
+            return;
+        }
+
+        consumerNode[consumerPropertyKey] = producerNode;
+        return;
+    }
+
+    // The following is dedicated to array element bindings.
+
+    if (!Array.isArray(consumerProperty)) {
+        // Invalid binding.
+        warn(`Invalid binding: consumer node's input ${consumerPropertyKey} should be an array.`);
+        return;
+    }
+
+    if (consumerElementIndex >= consumerProperty.length) {
+        // Invalid binding.
+        warn(`Invalid binding: consumer node's input ${consumerPropertyKey} `
+            + `have length ${consumerProperty.length} but the binding specified ${consumerElementIndex}`);
+        return;
+    }
+    if (consumerProperty[consumerElementIndex] !== null) {
+        // Invalid binding.
+        warn(`Invalid binding: consumer node's input ${consumerPropertyKey}[${consumerElementIndex}] should be leaved as null before evaluation`);
+        return;
+    }
+
+    consumerProperty[consumerElementIndex] = producerNode;
+}
+
+interface RuntimeXNodePropertyBinding {
+    evaluate(): void;
+}
+
+class RuntimeXNodePlainPropertyBinding implements RuntimeXNodePropertyBinding {
+    constructor (
+        private _consumerNode: EvaluatableNode,
+        private _consumerPropertyKey: string,
+        private _producerRecord: RuntimeXNodeEvaluation,
+        private _producerOutputIndex: number,
+    ) {
+    }
+
+    public evaluate () {
+        this._producerRecord.evaluate();
+        this._consumerNode[this._consumerPropertyKey] = this._producerRecord.getOutput(this._producerOutputIndex);
+    }
+}
+
+class RuntimeXNodeArrayElementPropertyBinding implements RuntimeXNodePropertyBinding {
+    constructor (
+        private _consumerNode: EvaluatableNode,
+        private _consumerPropertyKey: string,
+        private _consumerElementIndex: number,
+        private _producerRecord: RuntimeXNodeEvaluation,
+        private _producerOutputIndex: number,
+    ) {
+    }
+
+    public evaluate () {
+        this._producerRecord.evaluate();
+        this._consumerNode[this._consumerPropertyKey][this._consumerElementIndex] = this._producerRecord.getOutput(this._producerOutputIndex);
+    }
+}
+
+function linkXNode (
+    consumerNode: EvaluatableNode,
+    consumerInputPath: NodeInputPath,
+    producerRecord: RuntimeXNodeEvaluation,
+    producerOutputIndex: number,
+): RuntimeXNodePropertyBinding | undefined {
+    const [consumerPropertyKey, consumerElementIndex = -1] = consumerInputPath;
+    if (!(consumerPropertyKey in consumerNode)) {
+        // Invalid binding.
+        warn(`Invalid binding: consumer node has no property ${consumerPropertyKey}`);
+        return undefined;
+    }
+
+    const consumerProperty = consumerNode[consumerPropertyKey];
+
+    // Plain property binding.
+
+    if (consumerElementIndex < 0) {
+        return new RuntimeXNodePlainPropertyBinding(
+            consumerNode,
+            consumerPropertyKey,
+            producerRecord,
+            producerOutputIndex,
+        );
+    }
+
+    // The following is dedicated to array element bindings.
+
+    if (!Array.isArray(consumerProperty)) {
+        // Invalid binding.
+        warn(`Invalid binding: consumer node's input ${consumerPropertyKey} should be an array.`);
+        return undefined;
+    }
+
+    if (consumerElementIndex >= consumerProperty.length) {
+        // Invalid binding.
+        warn(`Invalid binding: consumer node's input ${consumerPropertyKey} `
+            + `have length ${consumerProperty.length} but the binding specified ${consumerElementIndex}`);
+        return undefined;
+    }
+
+    return new RuntimeXNodeArrayElementPropertyBinding(
+        consumerNode,
+        consumerPropertyKey,
+        consumerElementIndex,
+        producerRecord,
+        producerOutputIndex,
+    );
 }

--- a/cocos/animation/marionette/pose-graph/op/index.ts
+++ b/cocos/animation/marionette/pose-graph/op/index.ts
@@ -1,0 +1,4 @@
+
+import * as poseGraphOp from './internal';
+
+export { poseGraphOp };

--- a/cocos/animation/marionette/pose-graph/op/internal.ts
+++ b/cocos/animation/marionette/pose-graph/op/internal.ts
@@ -1,0 +1,210 @@
+import { PoseNode } from '../pose-node';
+import { PoseGraphNodeInputInsertId, PoseGraphInputKey, globalNodeInputManager } from '../foundation/authoring/input-authoring';
+import { XNode } from '../x-node';
+import { assertIsTrue, error } from '../../../../core';
+import { PoseGraphType } from '../foundation/type-system';
+import { PoseGraphNode, shellTag } from '../foundation/pose-graph-node';
+import { PoseGraphOutputNode } from '../graph-output-node';
+
+export type {
+    PoseGraphInputKey as InputKey,
+    PoseGraphNodeInputMetadata as InputMetadata,
+    PoseGraphNodeInputInsertId as InputInsertId,
+} from '../foundation/authoring/input-authoring';
+
+export type OutputKey = number;
+
+export { PoseGraphNode as Node };
+
+export { PoseGraphType };
+
+const POSE_NODE_OUTPUT_BINDING_KEY = 0;
+
+export function getInputKeys (node: PoseGraphNode) {
+    return globalNodeInputManager.getInputKeys(node);
+}
+
+export function isValidInputKey (node: PoseGraphNode, key: PoseGraphInputKey) {
+    return globalNodeInputManager.hasInput(node, key);
+}
+
+export function getInputMetadata (node: PoseGraphNode, key: PoseGraphInputKey) {
+    return globalNodeInputManager.getInputMetadata(node, key);
+}
+
+export function getInputConstantValue (node: PoseGraphNode, key: PoseGraphInputKey): unknown {
+    if (!globalNodeInputManager.hasInput(node, key)) {
+        return undefined;
+    }
+    if (globalNodeInputManager.isPoseInput(node, key)) {
+        // Pose input's "constant value" is defined as `null`.
+        return null;
+    }
+    return getXNodeInputConstantValue(node, key);
+}
+
+export function getInputBinding (node: PoseGraphNode, key: PoseGraphInputKey): Readonly<{
+    producer: PoseGraphNode;
+    outputIndex: number;
+}> | undefined {
+    return node[shellTag]?.findBinding(key);
+}
+
+export function getInputInsertInfos (node: PoseGraphNode) {
+    return globalNodeInputManager.getInputInsertInfos(node);
+}
+
+export function insertInput (node: PoseGraphNode, insertId: PoseGraphNodeInputInsertId) {
+    return globalNodeInputManager.insertInput(node, insertId);
+}
+
+export function deleteInput (node: PoseGraphNode, key: PoseGraphInputKey) {
+    globalNodeInputManager.deleteInput(node, key);
+}
+
+export const getOutputKeys = (() => {
+    const poseNodeOutputKeys = Object.freeze([POSE_NODE_OUTPUT_BINDING_KEY]);
+
+    return (node: PoseGraphNode): readonly OutputKey[] => {
+        if (node instanceof PoseNode) {
+            return poseNodeOutputKeys;
+        } else if (node instanceof XNode) {
+            // TODO: optimize me
+            const outputCount = node.outputCount;
+            return Array.from({ length: outputCount }, (_, i) => i);
+        } else {
+            return [];
+        }
+    };
+})();
+
+export function getOutputType(node: PoseGraphNode, outputId: OutputKey) {
+    if (node instanceof PoseNode) {
+        return PoseGraphType.POSE;
+    } else if (node instanceof XNode) {
+        const outputIndex = Number(outputId);
+        if (outputIndex < 0 || outputIndex >= node.outputCount) {
+            throw new Error(`${node} does not have specified output key ${outputId}`);
+        } else {
+            return node.getOutputType(outputIndex);
+        }
+    } else {
+        throw new Error(`${node} does not have specified output key.`);
+    }
+}
+
+export function connectNode (node: PoseGraphNode, key: PoseGraphInputKey, producer: PoseGraphNode, outputKey?: OutputKey) {
+    const consumerNode = node;
+    const consumerShell = node[shellTag];
+    if (!consumerShell) {
+        error(`Consumer node is not with in graph!`);
+        return;
+    }
+
+    const inputMetadata = getInputMetadata(consumerNode, key);
+    if (!inputMetadata) {
+        error(`Consumer node does not have such specified input key ${key}`);
+        return;
+    }
+
+    let outputIndex = 0;
+    let outputType: PoseGraphType;
+    if (producer instanceof XNode) {
+        if (typeof outputKey !== 'number') {
+            error(`Output key is not specified.`);
+            return;
+        }
+        const outputIndex = Number(outputKey);
+        if (outputIndex < 0 || outputIndex >= producer.outputCount) {
+            error(`Producer node does not have such specified output key ${key}`);
+            return;
+        }
+        outputType = producer.getOutputType(outputIndex);
+    } else {
+        if ((outputKey ?? POSE_NODE_OUTPUT_BINDING_KEY) !== POSE_NODE_OUTPUT_BINDING_KEY) {
+            error(`Pose nodes have and only have single output.`);
+            return;
+        }
+        outputType = PoseGraphType.POSE;
+    }
+    
+    const inputType = inputMetadata.type;
+    if (inputType !== outputType) {
+        error(`Type mismatch: input has type ${PoseGraphType[inputType]}, output has type ${PoseGraphType[outputType]}.`);
+        return;
+    }
+
+    const [
+        propertyKey,
+        elementIndex = -1,
+    ] = key;
+    const property = consumerNode[propertyKey];
+    if (elementIndex >= 0) {
+        if (!Array.isArray(property)) {
+            return;
+        }
+        if (elementIndex >= property.length) {
+            return;
+        }
+        consumerShell.addBinding([propertyKey, elementIndex], producer, outputIndex);
+    } else {
+        consumerShell.addBinding([propertyKey], producer, outputIndex);
+    }
+}
+
+export function disconnectNode (node: PoseGraphNode, key: PoseGraphInputKey) {
+    node[shellTag]?.deleteBinding(key);
+}
+
+export function connectOutputNode(outputNode: PoseGraphOutputNode, producer: PoseNode) {
+    const outputNodeInputKeys = getInputKeys(outputNode);
+    assertIsTrue(outputNodeInputKeys.length === 1);
+    connectNode(outputNode, outputNodeInputKeys[0], producer);
+}
+
+export function hasInputBinding (
+    node: PoseGraphNode,
+    key: PoseGraphInputKey,
+    producerNode: PoseGraphNode,
+    producerOutputKey: OutputKey,
+) {
+    const binding = getInputBinding(node, key);
+    if (!binding) {
+        return false;
+    }
+    return binding.producer === producerNode && binding.outputIndex === producerOutputKey;
+}
+
+function getXNodeInputConstantValue (node: PoseGraphNode, inputKey: PoseGraphInputKey): unknown {
+    const [
+        propertyKey,
+        elementIndex = -1,
+     ] = inputKey;
+    const property = node[propertyKey];
+    if (!Array.isArray(property)) {
+        return property;
+    }
+    if (elementIndex < 0 || elementIndex >= property.length) {
+        return undefined;
+    }
+    return property[elementIndex];
+}
+
+export function isWellFormedInputKey(test: unknown): test is PoseGraphInputKey {
+    if (!Array.isArray(test)) {
+        return false;
+    }
+    if (test.length >= 2) {
+        return false;
+    }
+    if (typeof test[0] !== 'string') {
+        return false;
+    }
+    if (test.length > 1) {
+        const e1 = test[1];
+        if (typeof e1 !== 'number' || e1 < 0) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/cocos/animation/marionette/pose-graph/op/internal.ts
+++ b/cocos/animation/marionette/pose-graph/op/internal.ts
@@ -1,5 +1,5 @@
 import { PoseNode } from '../pose-node';
-import { PoseGraphNodeInputInsertId, PoseGraphInputKey, globalNodeInputManager } from '../foundation/authoring/input-authoring';
+import { PoseGraphNodeInputInsertId, PoseGraphInputKey, globalPoseGraphNodeInputManager } from '../foundation/authoring/input-authoring';
 import { PureValueNode } from '../pure-value-node';
 import { assertIsTrue, error } from '../../../../core';
 import { PoseGraphType } from '../foundation/type-system';
@@ -22,22 +22,22 @@ export { PoseGraphType };
 const POSE_NODE_OUTPUT_BINDING_KEY = 0;
 
 export function getInputKeys (node: PoseGraphNode) {
-    return globalNodeInputManager.getInputKeys(node);
+    return globalPoseGraphNodeInputManager.getInputKeys(node);
 }
 
 export function isValidInputKey (node: PoseGraphNode, key: PoseGraphInputKey) {
-    return globalNodeInputManager.hasInput(node, key);
+    return globalPoseGraphNodeInputManager.hasInput(node, key);
 }
 
 export function getInputMetadata (node: PoseGraphNode, key: PoseGraphInputKey) {
-    return globalNodeInputManager.getInputMetadata(node, key);
+    return globalPoseGraphNodeInputManager.getInputMetadata(node, key);
 }
 
 export function getInputConstantValue (node: PoseGraphNode, key: PoseGraphInputKey): unknown {
-    if (!globalNodeInputManager.hasInput(node, key)) {
+    if (!globalPoseGraphNodeInputManager.hasInput(node, key)) {
         return undefined;
     }
-    if (globalNodeInputManager.isPoseInput(node, key)) {
+    if (globalPoseGraphNodeInputManager.isPoseInput(node, key)) {
         // Pose input's "constant value" is defined as `null`.
         return null;
     }
@@ -52,15 +52,15 @@ export function getInputBinding (graph: PoseGraph, node: PoseGraphNode, key: Pos
 }
 
 export function getInputInsertInfos (node: PoseGraphNode) {
-    return globalNodeInputManager.getInputInsertInfos(node);
+    return globalPoseGraphNodeInputManager.getInputInsertInfos(node);
 }
 
 export function insertInput (graph: PoseGraph, node: PoseGraphNode, insertId: PoseGraphNodeInputInsertId) {
-    return globalNodeInputManager.insertInput(graph, node, insertId);
+    return globalPoseGraphNodeInputManager.insertInput(graph, node, insertId);
 }
 
 export function deleteInput (graph: PoseGraph, node: PoseGraphNode, key: PoseGraphInputKey) {
-    globalNodeInputManager.deleteInput(graph, node, key);
+    globalPoseGraphNodeInputManager.deleteInput(graph, node, key);
 }
 
 export const getOutputKeys = (() => {

--- a/cocos/animation/marionette/pose-graph/op/internal.ts
+++ b/cocos/animation/marionette/pose-graph/op/internal.ts
@@ -1,6 +1,6 @@
 import { PoseNode } from '../pose-node';
 import { PoseGraphNodeInputInsertId, PoseGraphInputKey, globalNodeInputManager } from '../foundation/authoring/input-authoring';
-import { XNode } from '../x-node';
+import { PureValueNode } from '../pure-value-node';
 import { assertIsTrue, error } from '../../../../core';
 import { PoseGraphType } from '../foundation/type-system';
 import { PoseGraphNode } from '../foundation/pose-graph-node';
@@ -41,7 +41,7 @@ export function getInputConstantValue (node: PoseGraphNode, key: PoseGraphInputK
         // Pose input's "constant value" is defined as `null`.
         return null;
     }
-    return getXNodeInputConstantValue(node, key);
+    return getPureValueInputConstantValue(node, key);
 }
 
 export function getInputBinding (graph: PoseGraph, node: PoseGraphNode, key: PoseGraphInputKey): Readonly<{
@@ -69,7 +69,7 @@ export const getOutputKeys = (() => {
     return (node: PoseGraphNode): readonly OutputKey[] => {
         if (node instanceof PoseNode) {
             return poseNodeOutputKeys;
-        } else if (node instanceof XNode) {
+        } else if (node instanceof PureValueNode) {
             // TODO: optimize me
             const outputCount = node.outputCount;
             return Array.from({ length: outputCount }, (_, i) => i);
@@ -82,7 +82,7 @@ export const getOutputKeys = (() => {
 export function getOutputType(node: PoseGraphNode, outputId: OutputKey) {
     if (node instanceof PoseNode) {
         return PoseGraphType.POSE;
-    } else if (node instanceof XNode) {
+    } else if (node instanceof PureValueNode) {
         const outputIndex = Number(outputId);
         if (outputIndex < 0 || outputIndex >= node.outputCount) {
             throw new Error(`${node} does not have specified output key ${outputId}`);
@@ -110,7 +110,7 @@ export function connectNode (graph: PoseGraph, node: PoseGraphNode, key: PoseGra
 
     let outputIndex = 0;
     let outputType: PoseGraphType;
-    if (producer instanceof XNode) {
+    if (producer instanceof PureValueNode) {
         if (typeof outputKey !== 'number') {
             error(`Output key is not specified.`);
             return;
@@ -177,7 +177,7 @@ export function hasInputBinding (
     return binding.producer === producerNode && binding.outputIndex === producerOutputKey;
 }
 
-function getXNodeInputConstantValue (node: PoseGraphNode, inputKey: PoseGraphInputKey): unknown {
+function getPureValueInputConstantValue (node: PoseGraphNode, inputKey: PoseGraphInputKey): unknown {
     const [
         propertyKey,
         elementIndex = -1,

--- a/cocos/animation/marionette/pose-graph/op/internal.ts
+++ b/cocos/animation/marionette/pose-graph/op/internal.ts
@@ -194,7 +194,7 @@ export function isWellFormedInputKey(test: unknown): test is PoseGraphInputKey {
     if (!Array.isArray(test)) {
         return false;
     }
-    if (test.length >= 2) {
+    if (test.length > 2) {
         return false;
     }
     if (typeof test[0] !== 'string') {
@@ -202,7 +202,7 @@ export function isWellFormedInputKey(test: unknown): test is PoseGraphInputKey {
     }
     if (test.length > 1) {
         const e1 = test[1];
-        if (typeof e1 !== 'number' || e1 < 0) {
+        if (typeof e1 !== 'number' || e1 < 0 || !Number.isFinite(e1)) {
             return false;
         }
     }

--- a/cocos/animation/marionette/pose-graph/pose-node.ts
+++ b/cocos/animation/marionette/pose-graph/pose-node.ts
@@ -1,5 +1,5 @@
 import { TEST } from 'internal:constants';
-import { assertIsTrue, EditorExtendable } from '../../../core';
+import { assertIsTrue } from '../../../core';
 import { ccclass } from '../../../core/data/decorators';
 import { Pose } from '../../core/pose';
 import { CLASS_NAME_PREFIX_ANIM } from '../../define';
@@ -9,6 +9,8 @@ import {
     AnimationGraphSettleContext,
     AnimationGraphUpdateContext,
 } from '../animation-graph-context';
+import { PoseGraphNode } from './foundation/pose-graph-node';
+import type { PoseNodeDependencyEvaluation } from './instantiation';
 
 const POSE_NODE_EVALUATION_STACK_ORDER_DEBUG_ENABLED = !!TEST;
 
@@ -18,7 +20,7 @@ const POSE_NODE_EVALUATION_STACK_ORDER_DEBUG_ENABLED = !!TEST;
  * Pose nodes are nodes in pose graph that yields pose objects.
  */
 @ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNode`)
-export abstract class PoseNode extends EditorExtendable {
+export abstract class PoseNode extends PoseGraphNode {
     /**
      * Starts the bind stage on this pose node.
      *
@@ -61,7 +63,7 @@ export abstract class PoseNode extends EditorExtendable {
      * @note Subclasses shall not override this method and should override `doUpdate` instead.
      */
     public update (context: AnimationGraphUpdateContext) {
-        // TODO: update dependencies.
+        this._dependencyEvaluation?.evaluate();
         this.doUpdate(context);
     }
 
@@ -98,6 +100,11 @@ export abstract class PoseNode extends EditorExtendable {
         return context.pushDefaultedPose();
     }
 
+    /** @internal */
+    public _setDependencyEvaluation (dependency: PoseNodeDependencyEvaluation) {
+        this._dependencyEvaluation = dependency;
+    }
+
     /**
      * Implement this method to performs the update stage on this pose node.
      *
@@ -116,4 +123,6 @@ export abstract class PoseNode extends EditorExtendable {
      * @returns The result pose.
      */
     protected abstract doEvaluate (context: AnimationGraphEvaluationContext): Pose;
+
+    private _dependencyEvaluation: PoseNodeDependencyEvaluation | undefined = undefined;
 }

--- a/cocos/animation/marionette/pose-graph/pure-value-node.ts
+++ b/cocos/animation/marionette/pose-graph/pure-value-node.ts
@@ -4,7 +4,14 @@ import { PoseGraphType } from './foundation/type-system';
 
 type Outputs = unknown[];
 
-export abstract class XNode extends PoseGraphNode {
+/**
+ * Base class of all pure value nodes in pose graph.
+ *
+ * Pure value nodes are nodes in pose graph that yields non-pose-object value(s).
+ *
+ * Sometimes, pure values nodes are also abbreviated as pv nodes.
+ */
+export abstract class PureValueNode extends PoseGraphNode {
     constructor (outputTypes: readonly PoseGraphType[]) {
         super();
         this._outputTypes = outputTypes;
@@ -18,7 +25,7 @@ export abstract class XNode extends PoseGraphNode {
         return this._outputTypes[outputIndex];
     }
 
-    public link (context: XNodeLinkContext) {
+    public link (context: PureValueNodeLinkContext) {
     }
 
     private _outputTypes: readonly PoseGraphType[] = [];
@@ -26,7 +33,7 @@ export abstract class XNode extends PoseGraphNode {
     public abstract selfEvaluate(outputs: Outputs): void;
 }
 
-export abstract class SingleOutputXNode<TValue = unknown> extends XNode {
+export abstract class SingleOutputPVNode<TValue = unknown> extends PureValueNode {
     constructor (outputType: PoseGraphType) {
         super([outputType]);
     }
@@ -38,6 +45,6 @@ export abstract class SingleOutputXNode<TValue = unknown> extends XNode {
     protected abstract selfEvaluateDefaultOutput(): TValue;
 }
 
-export interface XNodeLinkContext {
+export interface PureValueNodeLinkContext {
     getVar(name: string): VarInstance | undefined;
 }

--- a/cocos/animation/marionette/pose-graph/x-node.ts
+++ b/cocos/animation/marionette/pose-graph/x-node.ts
@@ -1,0 +1,43 @@
+import { VarInstance } from '../variable';
+import { PoseGraphNode } from './foundation/pose-graph-node';
+import { PoseGraphType } from './foundation/type-system';
+
+type Outputs = unknown[];
+
+export abstract class XNode extends PoseGraphNode {
+    constructor (outputTypes: readonly PoseGraphType[]) {
+        super();
+        this._outputTypes = outputTypes;
+    }
+
+    get outputCount () {
+        return this._outputTypes.length;
+    }
+
+    public getOutputType (outputIndex: number) {
+        return this._outputTypes[outputIndex];
+    }
+
+    public link (context: XNodeLinkContext) {
+    }
+
+    private _outputTypes: readonly PoseGraphType[] = [];
+
+    public abstract selfEvaluate(outputs: Outputs): void;
+}
+
+export abstract class SingleOutputXNode<TValue = unknown> extends XNode {
+    constructor (outputType: PoseGraphType) {
+        super([outputType]);
+    }
+
+    public selfEvaluate (outputs: Outputs): void {
+        outputs[0] = this.selfEvaluateDefaultOutput();
+    }
+
+    protected abstract selfEvaluateDefaultOutput(): TValue;
+}
+
+export interface XNodeLinkContext {
+    getVar(name: string): VarInstance | undefined;
+}

--- a/cocos/animation/marionette/state-machine/state-machine-eval.ts
+++ b/cocos/animation/marionette/state-machine/state-machine-eval.ts
@@ -1706,7 +1706,7 @@ class PoseStateEval extends StateEval {
 
     public constructor (state: PoseState, context: AnimationGraphBindingContext) {
         super(state);
-        const poseEval = instantiatePoseGraph(state.graph);
+        const poseEval = instantiatePoseGraph(state.graph, context);
         if (poseEval) {
             poseEval.bind(context);
             this._rootPoseNodeEval = poseEval;

--- a/editor/exports/new-gen-anim.ts
+++ b/editor/exports/new-gen-anim.ts
@@ -43,3 +43,5 @@ export {
 export {
     getVariableValueAttributes,
 } from '../src/marionette/get-variable-value-attributes';
+
+export * from '../src/marionette/pose-graph-editor-api';

--- a/editor/src/marionette/pose-graph-editor-api.ts
+++ b/editor/src/marionette/pose-graph-editor-api.ts
@@ -3,7 +3,8 @@ import {
     getPoseGraphNodeEditorMetadata, PoseGraphCreateNodeContext, PoseGraphNodeAppearanceOptions,
 } from "../../../cocos/animation/marionette/pose-graph/foundation/authoring/node-authoring";
 import { js } from "../../../cocos/core/utils";
-import { PoseNode, XNode } from "../../exports/new-gen-anim";
+import { PoseNode } from "../../../cocos/animation/marionette/pose-graph/pose-node";
+import { PureValueNode } from "../../../cocos/animation/marionette/pose-graph/pure-value-node";
 
 type Constructor<T = unknown> = new (...args: any[]) => T;
 
@@ -19,10 +20,10 @@ export function* getCreatePoseGraphNodeEntries(
 ): Iterable<PoseGraphCreateNodeEntry> {
     type AbstractedConstructor<T = unknown> = abstract new (...args: any[]) => T;
 
-    if ((classConstructor as AbstractedConstructor) === PoseNode || (classConstructor as AbstractedConstructor) === XNode) {
+    if ((classConstructor as AbstractedConstructor) === PoseNode || (classConstructor as AbstractedConstructor) === PureValueNode) {
         return;
     }
-    const nodeClassMetadata = getPoseGraphNodeEditorMetadata(classConstructor as Constructor<PoseNode | XNode>);
+    const nodeClassMetadata = getPoseGraphNodeEditorMetadata(classConstructor as Constructor<PoseNode | PureValueNode>);
     if (nodeClassMetadata) {
         if (nodeClassMetadata.factory) {
             yield* nodeClassMetadata.factory.listEntries(createNodeContext);
@@ -42,9 +43,9 @@ export function createPoseGraphNode(
     classConstructor: Constructor<PoseGraphNode>,
     arg: unknown,
 ): PoseGraphNode {
-    const nodeClassMetadata = getPoseGraphNodeEditorMetadata(classConstructor as Constructor<PoseNode | XNode>);
+    const nodeClassMetadata = getPoseGraphNodeEditorMetadata(classConstructor as Constructor<PoseNode | PureValueNode>);
     if (nodeClassMetadata?.factory) {
-        return nodeClassMetadata.factory.create(arg) as PoseNode | XNode;
+        return nodeClassMetadata.factory.create(arg) as PoseNode | PureValueNode;
     }
     return new classConstructor();
 }
@@ -55,7 +56,7 @@ export function getNodeTitle(node: PoseGraphNode) {
     if (node.getTitle) {
         return node.getTitle();
     }
-    const classConstructor = node.constructor as Constructor<PoseNode | XNode>;
+    const classConstructor = node.constructor as Constructor<PoseNode | PureValueNode>;
     const metadata = getPoseGraphNodeEditorMetadata(classConstructor);
     if (metadata?.menu) {
         return metadata.menu.split('/').pop() ?? '';

--- a/editor/src/marionette/pose-graph-editor-api.ts
+++ b/editor/src/marionette/pose-graph-editor-api.ts
@@ -1,0 +1,76 @@
+import { PoseGraphNode } from "../../../cocos/animation/marionette/pose-graph/foundation/pose-graph-node";
+import {
+    getPoseGraphNodeEditorMetadata, PoseGraphCreateNodeContext, PoseGraphNodeAppearanceOptions,
+} from "../../../cocos/animation/marionette/pose-graph/foundation/authoring/node-authoring";
+import { js } from "../../../cocos/core/utils";
+import { PoseNode, XNode } from "../../exports/new-gen-anim";
+
+type Constructor<T = unknown> = new (...args: any[]) => T;
+
+export interface PoseGraphCreateNodeEntry {
+    menu: string;
+
+    arg: unknown;
+}
+
+export function* getCreatePoseGraphNodeEntries(
+    classConstructor: Constructor<PoseGraphNode>,
+    createNodeContext: PoseGraphCreateNodeContext,
+): Iterable<PoseGraphCreateNodeEntry> {
+    type AbstractedConstructor<T = unknown> = abstract new (...args: any[]) => T;
+
+    if ((classConstructor as AbstractedConstructor) === PoseNode || (classConstructor as AbstractedConstructor) === XNode) {
+        return;
+    }
+    const nodeClassMetadata = getPoseGraphNodeEditorMetadata(classConstructor as Constructor<PoseNode | XNode>);
+    if (nodeClassMetadata) {
+        if (nodeClassMetadata.factory) {
+            yield* nodeClassMetadata.factory.listEntries(createNodeContext);
+            return;
+        } else if (nodeClassMetadata.menu) {
+            yield { arg: undefined, menu: nodeClassMetadata.menu };
+            return;
+        } else if (nodeClassMetadata.hide) {
+            return;
+        }
+    }
+    const displayName = js.getClassName(classConstructor) || classConstructor.name;
+    yield { arg: undefined, menu: displayName };
+}
+
+export function createPoseGraphNode(
+    classConstructor: Constructor<PoseGraphNode>,
+    arg: unknown,
+): PoseGraphNode {
+    const nodeClassMetadata = getPoseGraphNodeEditorMetadata(classConstructor as Constructor<PoseNode | XNode>);
+    if (nodeClassMetadata?.factory) {
+        return nodeClassMetadata.factory.create(arg) as PoseNode | XNode;
+    }
+    return new classConstructor();
+}
+
+export type { PoseGraphCreateNodeContext };
+
+export function getNodeTitle(node: PoseGraphNode) {
+    if (node.getTitle) {
+        return node.getTitle();
+    }
+    const classConstructor = node.constructor as Constructor<PoseNode | XNode>;
+    const metadata = getPoseGraphNodeEditorMetadata(classConstructor);
+    if (metadata?.menu) {
+        return metadata.menu.split('/').pop() ?? '';
+    }
+    const className = js.getClassName(node);
+    if (className) {
+        return className;
+    }
+    return classConstructor.name;
+}
+
+export type { PoseGraphNodeAppearanceOptions };
+
+export function getNodeAppearanceOptions(node: PoseGraphNode) {
+    const classConstructor = node.constructor as Constructor<PoseGraphNode>;
+    const metadata = getPoseGraphNodeEditorMetadata(classConstructor);
+    return metadata?.appearance;
+}

--- a/editor/src/marionette/visit.ts
+++ b/editor/src/marionette/visit.ts
@@ -6,9 +6,11 @@ import {
     StateMachine,
     SubStateMachine,
     AnimationGraph,
+    PoseState,
 } from "../../../cocos/animation/marionette/animation-graph";
 import { MotionState } from "../../../cocos/animation/marionette/state-machine/motion-state";
 import { EditorExtendableObject } from "../../../cocos/core/data/editor-extras-tag";
+import { PoseGraphNode } from "../../../cocos/animation/marionette/pose-graph/foundation/pose-graph-node";
 
 export function* visitAnimationGraphEditorExtras(animationGraph: AnimationGraph): Generator<EditorExtendableObject> {
     for (const layer of animationGraph.layers) {
@@ -60,6 +62,10 @@ export function* visitAnimationClips(animationGraph: AnimationGraph): Generator<
                 if (motion) {
                     yield* visitMotion(motion);
                 }
+            } else if (state instanceof PoseState) {
+                for (const shell of state.graph.nodes()) {
+                    yield* visitPoseNode(shell);
+                }
             } else if (state instanceof SubStateMachine) {
                 yield* visitStateMachine(state.stateMachine);
             }
@@ -76,6 +82,15 @@ export function* visitAnimationClips(animationGraph: AnimationGraph): Generator<
                 if (childMotion) {
                     yield* visitMotion(childMotion);
                 }
+            }
+        }
+    }
+
+    function* visitPoseNode(node: PoseGraphNode): Generator<AnimationClip> {
+        // FIXME: HACK HERE
+        for (const [_, v] of Object.entries(node)) {
+            if (v instanceof Motion) {
+                yield* visitMotion(v);
             }
         }
     }

--- a/scripts/native-pack-tool/package-lock.json
+++ b/scripts/native-pack-tool/package-lock.json
@@ -746,7 +746,7 @@
     },
     "json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {

--- a/tests/animation/new-gen-anim/event.test.ts
+++ b/tests/animation/new-gen-anim/event.test.ts
@@ -3,7 +3,7 @@ jest.mock('../../../cocos/animation/marionette/graph-eval');
 import { AnimationController } from "../../../cocos/animation/animation";
 import { AnimationGraphCustomEventEmitter } from "../../../cocos/animation/marionette/event/custom-event-emitter";
 import { AnimationGraphEval } from "../../../cocos/animation/marionette/graph-eval";
-import { AnimationGraph } from "../../../editor/exports/new-gen-anim";
+import { AnimationGraph } from "../../../cocos/animation/marionette/animation-graph";
 import { EventTarget, Node } from "../../../exports/base";
 import { AnimationGraphEvalMock } from './utils/eval-mock';
 import 'jest-extended';

--- a/tests/animation/new-gen-anim/pose-graph/pose-graph-authoring.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-graph-authoring.test.ts
@@ -745,4 +745,19 @@ test(`Input/output query`, () => {
     }
 });
 
+test(`isWellFormedInputKey()`, () => {
+    expect(poseGraphOp.isWellFormedInputKey(['a'])).toBe(true);
+    expect(poseGraphOp.isWellFormedInputKey(['a', 0])).toBe(true);
+    expect(poseGraphOp.isWellFormedInputKey(['a', 1])).toBe(true);
+
+    expect(poseGraphOp.isWellFormedInputKey('a')).toBe(false);
+    expect(poseGraphOp.isWellFormedInputKey(0)).toBe(false);
+    expect(poseGraphOp.isWellFormedInputKey(1)).toBe(false);
+    expect(poseGraphOp.isWellFormedInputKey([1, 'a'])).toBe(false);
+    expect(poseGraphOp.isWellFormedInputKey(['a', -1])).toBe(false);
+    expect(poseGraphOp.isWellFormedInputKey(['a', -Infinity])).toBe(false);
+    expect(poseGraphOp.isWellFormedInputKey(['a', Infinity])).toBe(false);
+    expect(poseGraphOp.isWellFormedInputKey(['a', Number.NaN])).toBe(false);
+})
+
 test.todo(`Disallow connect a pose node to multiple inputs`);

--- a/tests/animation/new-gen-anim/pose-graph/pose-graph-authoring.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-graph-authoring.test.ts
@@ -1,0 +1,731 @@
+import { Pose } from "../../../../cocos/animation/core/pose";
+import { AnimationGraph, PoseGraph } from "../../../../cocos/animation/marionette/asset-creation";
+import { assertIsTrue, lerp, quat, v3 } from "../../../../cocos/core";
+import { Node } from "../../../../cocos/scene-graph";
+import { captureErrors, captureWarns } from '../../../utils/log-capture';
+import { input } from "../../../../cocos/animation/marionette/pose-graph/decorator/input";
+import 'jest-extended';
+import { poseGraphOp } from "../../../../cocos/animation/marionette/pose-graph/op";
+import { PoseGraphType } from "../../../../cocos/animation/marionette/pose-graph/foundation/type-system";
+import { PoseGraphNode } from "../../../../cocos/animation/marionette/pose-graph/foundation/pose-graph-node";
+import { AddNonFreestandingNodeError } from "../../../../cocos/animation/marionette/pose-graph/foundation/errors";
+import { poseGraphCreateNodeFactory, poseGraphNodeAppearance, poseGraphNodeHide, poseGraphNodeMenu } from "../../../../cocos/animation/marionette/pose-graph/decorator/node";
+import { PoseGraphNodeEditorMetadata, getPoseGraphNodeEditorMetadata } from "../../../../cocos/animation/marionette/pose-graph/foundation/authoring/node-authoring";
+import { createPoseGraph, findInputKeyHavingDisplayName, getTheOnlyInputKey, getTheOnlyOutputKey, normalizeNodeInputMetadata, UnimplementedPoseNode, UnimplementedXNode } from "./utils/misc";
+import { PoseNode } from "../../../../cocos/animation/marionette/pose-graph/pose-node";
+
+describe(`Class PoseGraph`, () => {
+    test(`Default`, () => {
+        const graph = createPoseGraph();
+
+        // By default, pose graph has no node.
+        expect([...graph.nodes()]).toStrictEqual(expect.arrayContaining([
+            graph.outputNode,
+        ]));
+    });
+
+    test(`Add and remove node`, () => {
+        const graph = createPoseGraph();
+
+        // Add a node.
+        const node = new UnimplementedPoseNode();
+        graph.addNode(node);
+        expect([...graph.nodes()]).toStrictEqual(expect.arrayContaining([
+            graph.outputNode,
+            node,
+        ]));
+
+        // Can not add a node twice.
+        expect(() => graph.addNode(node)).toThrowError(AddNonFreestandingNodeError);
+
+        // Add another node.
+        const anotherNode = new UnimplementedXNode([]);
+        graph.addNode(anotherNode);
+        expect([...graph.nodes()]).toStrictEqual(expect.arrayContaining([
+            graph.outputNode,
+            node,
+            anotherNode,
+        ]));
+
+        // Remove a node.
+        graph.removeNode(anotherNode);
+        expect([...graph.nodes()]).toStrictEqual(expect.arrayContaining([
+            graph.outputNode,
+            node,
+        ]));
+
+        // The node removed can be later added again to node.
+        graph.addNode(anotherNode);
+        expect([...graph.nodes()]).toStrictEqual(expect.arrayContaining([
+            graph.outputNode,
+            node,
+            anotherNode,
+        ]));
+        // Still don't add a node twice.
+        expect(() => graph.addNode(anotherNode)).toThrowError(AddNonFreestandingNodeError);
+
+        // Remove a pose which was marked as main.
+        poseGraphOp.connectNode(graph.outputNode, getTheOnlyInputKey(graph.outputNode), node);
+        expect(poseGraphOp.getInputBinding(graph.outputNode, getTheOnlyInputKey(graph.outputNode))).toStrictEqual(expect.objectContaining({
+            producer: node,
+            outputIndex: 0,
+        }));
+        graph.removeNode(node);
+        expect([...graph.nodes()]).toStrictEqual(expect.arrayContaining([
+            graph.outputNode,
+            anotherNode,
+        ]));
+        expect(poseGraphOp.getInputBinding(graph.outputNode, getTheOnlyInputKey(graph.outputNode))).toBeUndefined();
+    });
+});
+
+describe(`Input decorator @input`, () => {
+    // No need to test for now.
+    // test.skip(`Should emit error if not string-named field`, () => {
+    //     const tag = Symbol();
+
+    //     const errorWatcher = captureErrors();
+
+    //     class _Node extends PoseNode {
+    //         @input({ type: PoseGraphType.POSE, })
+    //         0: PoseNode | null = null;
+
+    //         bind() { return unusedBind(); }
+    //     }
+
+    //     expect(errorWatcher.captured).toHaveLength(1);
+    //     expect(errorWatcher.captured[0]).toMatchSnapshot();
+
+    //     expect(getPoseInputFieldKeys(new _Node())).toHaveLength(0);
+
+    //     errorWatcher.stop();
+    // });
+
+    test(`@input specifying pose input can be only applied to fields of subclasses of PoseNode`, () => {
+        const errorWatcher = captureErrors();
+
+        for (const define of [defineSubClassOfPoseGraphNode, defineOtherClass]) {
+            define();
+
+            expect(errorWatcher.captured).toHaveLength(1);
+            expect(errorWatcher.captured[0]).toMatchObject([
+                '@input specifying pose input can be only applied to fields of subclasses of PoseNode.',
+            ]);
+            
+            errorWatcher.clear();
+        }
+
+        function defineSubClassOfPoseGraphNode() {
+            class _Node extends PoseGraphNode {
+                @input({ type: PoseGraphType.POSE })
+                pose: PoseNode | null = null;
+            };
+            return _Node;
+        };
+
+        function defineOtherClass() {
+            class _Node {
+                @input({ type: PoseGraphType.POSE })
+                pose: PoseNode | null = null;
+            };
+            return _Node;
+        };
+    });
+
+    test(`@input can be only applied to fields of subclasses of PoseNode or XNode.`, () => {
+        const errorWatcher = captureErrors();
+
+        for (const define of [defineSubClassOfPoseGraphNode, defineOtherClass]) {
+            define();
+
+            expect(errorWatcher.captured).toHaveLength(1);
+            expect(errorWatcher.captured[0]).toMatchObject([
+                '@input can be only applied to fields of subclasses of PoseNode or XNode.',
+            ]);
+            
+            errorWatcher.clear();
+        }
+
+        function defineSubClassOfPoseGraphNode() {
+            class _Node extends PoseGraphNode {
+                @input({ type: PoseGraphType.FLOAT })
+                v = 6;
+            };
+            return _Node;
+        }
+
+        function defineOtherClass() {
+            class _Node {
+                @input({ type: PoseGraphType.FLOAT })
+                v = 6;
+            };
+            return _Node;
+        }
+    });
+});
+
+describe(`Node editor decorators`, () => {
+    test(`@poseGraphNodeMenu`, () => {
+        checkInjection(
+            poseGraphNodeMenu('some-menu-item-1/some-menu-item-2'),
+            { menu: 'some-menu-item-1/some-menu-item-2' },
+        );
+    });
+
+    test(`@poseGraphNodeHide`, () => {
+        checkInjection(
+            poseGraphNodeHide(true),
+            { hide: true },
+        );
+    });
+
+    test(`@poseGraphNodeAppearance`, () => {
+        checkInjection(
+            poseGraphNodeAppearance({ themeColor: '#ff0012', inline: true }),
+            { appearance: { themeColor: '#ff0012', inline: true } },
+        );
+    });
+
+    test(`@poseGraphCreateNodeFactory`, () => {
+        const factory = {
+            listEntries: () => [],
+            create() { throw new Error(`Should never be invoked.`); },
+        };
+        checkInjection(
+            poseGraphCreateNodeFactory(factory),
+            { factory },
+        );
+    });
+
+    test(`All node decorators should be node dedicated.`, () => {
+        const errorWatcher = captureErrors();
+
+        for (const decorator of [
+            poseGraphNodeMenu(''),
+            poseGraphNodeAppearance({}),
+            poseGraphCreateNodeFactory({
+                listEntries: () => [],
+                create() { throw new Error(`Should never be invoked.`); },
+            }),
+        ] as const) {
+            @decorator
+            class NotPoseGraphNode {}
+
+            expect(errorWatcher.captured).toStrictEqual([
+                ['This kind of decorator should only be applied to pose graph node classes.'],
+            ]);
+
+            errorWatcher.clear();
+        }
+    });
+
+    function checkInjection(decorator: ClassDecorator, expectedMetadata: PoseGraphNodeEditorMetadata) {
+        @decorator
+        class SomePoseGraphNode extends PoseGraphNode {}
+
+        expect(getPoseGraphNodeEditorMetadata(SomePoseGraphNode)).toMatchObject(expectedMetadata);
+    }
+});
+
+describe(`Node`, () => {
+    type PosePropertyName = 'pose_input_with_no_displayName_specified' | 'pose_input_with_displayName_specified';
+
+    type XNodePropertyName = 'x_node_input_with_no_displayName_specified' | 'x_node_input_with_displayName_specified';
+
+    interface PoseGraphNodeTestSuite {
+        makeFundamental: (poseGraph: PoseGraph) => {
+            node: PoseGraphNode,
+        };
+        makeArrayInput: (poseGraph: PoseGraph) => {
+            node: PoseGraphNode;
+            visitArray: () => unknown[];
+        };
+    }
+
+    const testSuitePoseNode: PoseGraphNodeTestSuite = (() => {
+        class Fundamental_Node extends UnimplementedPoseNode {
+            @input({ type: PoseGraphType.POSE, })
+            pose_input_with_no_displayName_specified: PoseNode | null = null;
+
+            @input({ type: PoseGraphType.POSE,  displayName: 'SomeDisPlayName' })
+            pose_input_with_displayName_specified: PoseNode | null = null;
+
+            @input({ type: PoseGraphType.FLOAT })
+            x_node_input_with_no_displayName_specified = 1;
+
+            @input({ type: PoseGraphType.FLOAT, displayName: 'XNode_SomeDisPlayName' })
+            x_node_input_with_displayName_specified = 2;
+
+            /**
+             * Does not observed by this test case.
+             */
+            @input({ type: PoseGraphType.POSE,  })
+            array_inputs: Array<PoseNode | null> = [];
+        }
+
+        class ArrayInput_Node extends UnimplementedPoseNode {
+            @input({ type: PoseGraphType.POSE, })
+            array_inputs: Array<PoseNode | null> = [];
+        }
+
+        return {
+            makeFundamental: (poseGraph) => {
+                const node = poseGraph.addNode(new Fundamental_Node());
+                return {
+                    node,
+                    visitProperty: (propertyKey: string) => node[propertyKey],
+                };
+            },
+            makeArrayInput: (poseGraph) => {
+                const node = poseGraph.addNode(new ArrayInput_Node());
+                return {
+                    node,
+                    visitArray: () => node.array_inputs,
+                };
+            },
+        };
+    })();
+
+    const testSuiteXNode: PoseGraphNodeTestSuite = (() => {
+        class Fundamental_Node extends UnimplementedXNode {
+            @input({ type: PoseGraphType.FLOAT })
+            x_node_input_with_no_displayName_specified = 1;
+
+            @input({ type: PoseGraphType.FLOAT, displayName: 'XNode_SomeDisPlayName' })
+            x_node_input_with_displayName_specified = 2;
+
+            /**
+             * Does not observed by this test case.
+             */
+            @input({ type: PoseGraphType.POSE,  })
+            array_inputs: Array<PoseNode | null> = [];
+        }
+
+        class ArrayInput_Node extends UnimplementedXNode {
+            @input({ type: PoseGraphType.FLOAT })
+            array_inputs: number[] = [];
+        }
+
+        return {
+            makeFundamental: (poseGraph: PoseGraph) => {
+                const node = poseGraph.addNode(new Fundamental_Node([PoseGraphType.FLOAT]));
+                return {
+                    node,
+                };
+            },
+            makeArrayInput: (poseGraph: PoseGraph) => {
+                const node = poseGraph.addNode(new ArrayInput_Node([PoseGraphType.FLOAT]));
+                return {
+                    node,
+                    visitArray: () => node.array_inputs,
+                };
+            },
+        };
+    })();
+
+    describe.each([
+        [`Pose Node`, testSuitePoseNode],
+        [`X Node`, testSuiteXNode],
+    ] as [title: string, suite: PoseGraphNodeTestSuite][])(`%s`, (_, {
+        makeFundamental: makeMainNode,
+        makeArrayInput: makeArrayNode,
+    }) => {
+        test(`Fundamental`, () => {
+            const animationGraph = new AnimationGraph();
+            const { graph: poseGraph } = animationGraph.addLayer().stateMachine.addPoseState();
+
+            const {
+                node: mainNode,
+            } = makeMainNode(poseGraph);
+
+            const shouldContainPoseInputs = mainNode instanceof PoseNode;
+
+            // Pose input keys and metadata query.
+            const rawKeys = poseGraphOp.getInputKeys(mainNode);
+            expect(rawKeys).toHaveLength(shouldContainPoseInputs ? 4 : 2);
+            expect(rawKeys).toSatisfyAll((k) => poseGraphOp.isValidInputKey(mainNode, k));
+            const metadataTable = rawKeys.map((k) => normalizeNodeInputMetadata(poseGraphOp.getInputMetadata(mainNode, k)));
+            expect(metadataTable).toStrictEqual(expect.arrayContaining([
+                expect.objectContaining({
+                    displayName: 'x_node_input_with_no_displayName_specified',
+                    deletable: false,
+                    insertPoint: false,
+                    type: PoseGraphType.FLOAT,
+                }),
+                expect.objectContaining({
+                    displayName: 'XNode_SomeDisPlayName',
+                    deletable: false,
+                    insertPoint: false,
+                    type: PoseGraphType.FLOAT,
+                }),
+            ]));
+            if (shouldContainPoseInputs) {
+                expect(metadataTable).toStrictEqual(expect.arrayContaining([
+                    expect.objectContaining({
+                        displayName: 'pose_input_with_no_displayName_specified',
+                        deletable: false,
+                        insertPoint: false,
+                    }),
+                    expect.objectContaining({
+                        displayName: 'SomeDisPlayName',
+                        deletable: false,
+                        insertPoint: false,
+                    }),
+                ]));
+            }
+    
+            // Pose inputs binding query.
+            // Note: only pose node can binding poses.
+            if (shouldContainPoseInputs) {
+                for (const [
+                    expectedDisplayName,
+                    expectedPropertyName,
+                ] of [
+                    ['pose_input_with_no_displayName_specified', 'pose_input_with_no_displayName_specified'],
+                    ['SomeDisPlayName', 'pose_input_with_displayName_specified'],
+                ] as [
+                    expectedDisplayName: string,
+                    expectedPropertyName: PosePropertyName,
+                ][]) {
+                    const key = rawKeys.find((k) => poseGraphOp.getInputMetadata(mainNode, k)?.displayName === expectedDisplayName);
+                    expect(key).not.toBeUndefined();
+                    assertIsTrue(key);
+                    // Initial: no binding.
+                    expect(poseGraphOp.getInputBinding(mainNode, key)).toBeUndefined();
+                    // Connect and reconnect.
+                    for (let i = 0; i < 2; ++i) {
+                        const bindingPose = poseGraph.addNode(new UnimplementedPoseNode());
+                        // Connect.
+                        poseGraphOp.connectNode(mainNode, key, bindingPose);
+                        // `poseGraphOp.getInputBinding` should returns the connected pose.
+                        expect(poseGraphOp.getInputBinding(mainNode, key)).toStrictEqual(expect.objectContaining({
+                            producer: bindingPose,
+                            outputIndex: 0,
+                        }));
+                    }
+                    // Disconnect.
+                    poseGraphOp.disconnectNode(mainNode, key);
+                    expect(poseGraphOp.getInputBinding(mainNode, key)).toBeUndefined();
+                }
+            }
+
+            // X-node input binding query.
+            for (const [
+                expectedDisplayName,
+                expectedPropertyName,
+            ] of [
+                ['x_node_input_with_no_displayName_specified', 'x_node_input_with_no_displayName_specified'],
+                ['XNode_SomeDisPlayName', 'x_node_input_with_displayName_specified'],
+            ] as [
+                expectedDisplayName: string,
+                expectedPropertyName: XNodePropertyName,
+            ][]) {
+                const key = rawKeys.find((k) => poseGraphOp.getInputMetadata(mainNode, k)?.displayName === expectedDisplayName);
+                expect(key).not.toBeUndefined();
+                assertIsTrue(key);
+                // Initial: no binding.
+                expect(poseGraphOp.getInputBinding(mainNode, key)).toBeUndefined();
+                // Connect and reconnect.
+                for (let i = 0; i < 2; ++i) {
+                    const bindingNode = poseGraph.addNode(new UnimplementedXNode([PoseGraphType.FLOAT]));
+                    // Connect.
+                    poseGraphOp.connectNode(mainNode, key, bindingNode, 0);
+                    // Query the binding.
+                    expect(poseGraphOp.getInputBinding(mainNode, key)).toStrictEqual(expect.objectContaining({
+                        producer: bindingNode,
+                        outputIndex: getTheOnlyOutputKey(bindingNode),
+                    }));
+                }
+                // Disconnect.
+                poseGraphOp.disconnectNode(mainNode, key);
+                expect(poseGraphOp.getInputBinding(mainNode, key)).toBeUndefined();
+            }
+        });
+    
+        test(`Array input`, () => {
+            const animationGraph = new AnimationGraph();
+            const { graph: poseGraph } = animationGraph.addLayer().stateMachine.addPoseState();
+
+            const {
+                node,
+                visitArray,
+            } = makeArrayNode(poseGraph);
+
+            expect(poseGraphOp.getInputKeys(node)).toStrictEqual([]);
+    
+            // Array input.
+            const inputInsertInfos = Object.entries(poseGraphOp.getInputInsertInfos(node));
+            expect(inputInsertInfos).toHaveLength(1);
+            expect(inputInsertInfos.map(([_, v]) => v)).toStrictEqual(expect.arrayContaining([
+                expect.objectContaining({
+                    displayName: 'array_inputs',
+                }),
+            ]));
+    
+            // Inserts inputs.
+            for (let i = 0; i < 5; ++i) {
+                poseGraphOp.insertInput(node, inputInsertInfos[0][0]);
+                const expectedElementCount = i + 1;
+                expect(visitArray()).toHaveLength(expectedElementCount);
+                const keys = poseGraphOp.getInputKeys(node);
+                expect(keys).toHaveLength(expectedElementCount);
+                const metadataTable = keys.map((k) => normalizeNodeInputMetadata(poseGraphOp.getInputMetadata(node, k)));
+                expect(metadataTable).toStrictEqual(expect.arrayContaining(Array.from({ length: expectedElementCount }, (_, j) => {
+                    return expect.objectContaining({
+                        displayName: `array_inputs ${j}`,
+                        deletable: true,
+                        insertPoint: true,
+                    });
+                })));
+            }
+    
+            // Delete a middle element.
+            const middleInputKey = poseGraphOp.getInputKeys(node).find((k) => poseGraphOp.getInputMetadata(node, k)?.displayName === `array_inputs 3`);
+            expect(middleInputKey).not.toBeUndefined();
+            assertIsTrue(middleInputKey);
+            poseGraphOp.deleteInput(node, middleInputKey);
+            {
+                expect(visitArray()).toHaveLength(4);
+                const keys = poseGraphOp.getInputKeys(node);
+                expect(keys).toHaveLength(4);
+                const metadataTable = keys.map((k) => poseGraphOp.getInputMetadata(node, k));
+                expect(metadataTable).toStrictEqual(expect.arrayContaining(Array.from({ length: 4 }, (_, j) => {
+                    return expect.objectContaining({
+                        displayName: `array_inputs ${j}`,
+                        deletable: true,
+                        insertPoint: true,
+                    });
+                })));
+            }
+        });
+    });
+
+    describe(`Array input properties sync`, () => {
+        test(`The group has only one member`, () => {
+            class SomeNode extends UnimplementedPoseNode {
+                @input({ type: PoseGraphType.POSE,  arraySyncGroup: 'sync-group-1' })
+                public prop: PoseNode[] = [];
+            }
+
+            const poseGraph = createPoseGraph();
+            const node = poseGraph.addNode(new SomeNode());
+            const insertIds = Object.keys(poseGraphOp.getInputInsertInfos(node));
+            expect(insertIds).toHaveLength(1);
+            poseGraphOp.insertInput(node, insertIds[0]);
+            // The insertion should succeed with one key inserted!
+            expect(poseGraphOp.getInputKeys(node)).toHaveLength(1);
+        });
+
+        test(`The group has only more than one member`, () => {
+            class SomeNode extends UnimplementedPoseNode {
+                @input({ type: PoseGraphType.POSE,  arraySyncGroup: 'sync-group-1' })
+                public prop1: PoseNode[] = [];
+
+                @input({ type: PoseGraphType.POSE,  arraySyncGroup: 'sync-group-1' })
+                public prop2: PoseNode[] = [];
+
+                @input({ type: PoseGraphType.FLOAT, arraySyncGroup: 'sync-group-1' })
+                public prop3: number[] = [];
+            }
+
+            const poseGraph = createPoseGraph();
+            const node = poseGraph.addNode(new SomeNode());
+
+            const GROUP_MEMBER_COUNT = 3; 
+
+            const insertIds = Object.keys(poseGraphOp.getInputInsertInfos(node));
+            expect(insertIds).toHaveLength(GROUP_MEMBER_COUNT);
+
+            const expectedProp1ConstantValue: null[] = [];
+            const expectedProp2ConstantValue: null[] = [];
+            const expectedProp3ConstantValue: number[] = [];
+            const check = () => {
+                expect(poseGraphOp.getInputKeys(node)).toHaveLength(3 * expectedProp1ConstantValue.length);
+                expect(node.prop1).toStrictEqual(expectedProp1ConstantValue);
+                expect(node.prop2).toStrictEqual(expectedProp2ConstantValue);
+                expect(node.prop3).toStrictEqual(expectedProp3ConstantValue);
+            };
+
+            // Fire 4 times insertion on prop1/prop2/prop3... in turn.
+            for (let i = 0; i < 4; ++i) {
+                poseGraphOp.insertInput(node, insertIds[i % GROUP_MEMBER_COUNT]);
+
+                // The insertion should causes both all props extending 1 element with its type-specified default value.
+                expectedProp1ConstantValue.push(null);
+                expectedProp2ConstantValue.push(null);
+                expectedProp3ConstantValue.push(0.0);
+                check();
+
+                // Fill elements with different constant values to inspect if we're doing something right.
+                expectedProp3ConstantValue[i] = node.prop3[i] = 1 + lerp(0, 1, i / 4);
+            }
+
+            // Now perform deletion.
+            for (let i = 0; i < 3; ++i) {
+                const deleteIndex = i === 0
+                    ? 1 // Deletes the middle
+                    : i === 1
+                        ? 1 // the tail
+                        : 0; // the head
+                const propName = i === 0
+                    ? 'prop1'
+                    : i === 1
+                        ? 'prop2'
+                        : 'prop3';
+                poseGraphOp.deleteInput(
+                    node,
+                    findInputKeyHavingDisplayName(node, `${propName} ${deleteIndex}`),
+                );
+
+                // The deletion should causes both all props delete its element at specified index.
+                expectedProp1ConstantValue.splice(deleteIndex, 1);
+                expectedProp2ConstantValue.splice(deleteIndex, 1);
+                expectedProp3ConstantValue.splice(deleteIndex, 1);
+                check();
+            }
+        });
+    });
+
+    test(`connecting()`, () => {
+        const poseGraph = createPoseGraph();
+
+        class PoseNode1 extends UnimplementedPoseNode {
+            @input({ type: PoseGraphType.FLOAT })
+            public x_node_prop = 2;
+
+            @input({ type: PoseGraphType.POSE, })
+            public pose_prop: Pose | null = null;
+        }
+
+        class XNode1 extends UnimplementedXNode {
+            constructor() { super([PoseGraphType.FLOAT]); }
+            @input({ type: PoseGraphType.FLOAT })
+            public x_node_prop = 2;
+        }
+
+        const poseNode1 = poseGraph.addNode(new PoseNode1());
+        const poseNode2 = poseGraph.addNode(new PoseNode1());
+        const xNode1 = poseGraph.addNode(new XNode1());
+        const xNode2 = poseGraph.addNode(new XNode1());
+
+        const logCapture = captureErrors();
+
+        // OK: connect x-node to x-node input of pose node.
+        poseGraphOp.connectNode(
+            poseNode1,
+            findInputKeyHavingDisplayName(poseNode1, 'x_node_prop'),
+            xNode1,
+            getTheOnlyOutputKey(xNode1),
+        );
+        expect(logCapture.captured).toHaveLength(0);
+
+        // OK: connect x-node to x-node input of x-node.
+        poseGraphOp.connectNode(
+            xNode2,
+            findInputKeyHavingDisplayName(poseNode1, 'x_node_prop'),
+            xNode1,
+            getTheOnlyOutputKey(xNode1),
+        );
+        expect(logCapture.captured).toHaveLength(0);
+
+        // Error: connect x-node to pose input of pose node.
+        poseGraphOp.connectNode(
+            poseNode1,
+            findInputKeyHavingDisplayName(poseNode1, 'pose_prop'),
+            xNode1,
+            getTheOnlyOutputKey(xNode1),
+        );
+        expect(logCapture.captured).toHaveLength(1);
+        expect(logCapture.captured[0]).toStrictEqual([`Type mismatch: input has type POSE, output has type FLOAT.`]);
+        logCapture.clear();
+
+        // OK: connect pose node to pose input of pose node.
+        poseGraphOp.connectNode(
+            poseNode1,
+            findInputKeyHavingDisplayName(poseNode1, 'pose_prop'),
+            poseNode2,
+            getTheOnlyOutputKey(poseNode2),
+        );
+        expect(logCapture.captured).toHaveLength(0);
+
+        // Error: connect pose node to x-node input of pose node.
+        poseGraphOp.connectNode(
+            poseNode1,
+            findInputKeyHavingDisplayName(poseNode1, 'x_node_prop'),
+            poseNode2,
+            getTheOnlyOutputKey(poseNode2),
+        );
+        expect(logCapture.captured).toHaveLength(1);
+        expect(logCapture.captured[0]).toStrictEqual([`Type mismatch: input has type FLOAT, output has type POSE.`]);
+        logCapture.clear();
+
+        // Error: connect pose node to x-node input of x-node node.
+        poseGraphOp.connectNode(
+            xNode1,
+            findInputKeyHavingDisplayName(poseNode1, 'x_node_prop'),
+            poseNode1,
+            getTheOnlyOutputKey(poseNode1),
+        );
+        expect(logCapture.captured).toHaveLength(1);
+        expect(logCapture.captured[0]).toStrictEqual([`Type mismatch: input has type FLOAT, output has type POSE.`]);
+        logCapture.clear();
+    });
+});
+
+test(`Inputs from base classes`, () => {
+    class Base extends UnimplementedPoseNode {
+        @input({ type: PoseGraphType.FLOAT })
+        base_xNode_input = 1.0;
+
+        @input({ type: PoseGraphType.POSE, })
+        base_pose_input: Pose | null = null;
+
+        @input({ type: PoseGraphType.POSE })
+        base_input_about_to_be_overrode: Pose | null = null;
+    }
+
+    class Sub extends Base {
+        @input({ type: PoseGraphType.FLOAT })
+        sub_xNode_input = 2.0;
+
+        @input({ type: PoseGraphType.POSE, })
+        sub_pose_input: Pose | null = null;
+
+        @input({ type: PoseGraphType.POSE })
+        base_input_about_to_be_overrode: Pose | null = null;
+    }
+
+    const poseGraph = createPoseGraph();
+    const node = poseGraph.addNode(new Sub());
+
+    {
+        const inputKeys = poseGraphOp.getInputKeys(node);
+        for (const inputKey of inputKeys) {
+            expect(poseGraphOp.isValidInputKey(node, inputKey)).toBeTrue();
+            expect(poseGraphOp.getInputBinding(node, inputKey)).toBeUndefined();
+        }
+        expect(inputKeys.map((key) => ({
+            displayName: poseGraphOp.getInputMetadata(node, key)?.displayName,
+            value: poseGraphOp.getInputConstantValue(node, key),
+        }))).toStrictEqual([
+            // Base inputs first.
+            { displayName: 'base_xNode_input', value: 1.0 },
+            { displayName: 'base_pose_input', value: null },
+            { displayName: 'base_input_about_to_be_overrode', value: null },
+            { displayName: 'sub_xNode_input', value: 2.0 },
+            { displayName: 'sub_pose_input', value: null },
+        ]);
+    }
+});
+
+describe(`Input value assignment`, () => {
+    test.todo(`Assign number input`);
+
+    // Shall not use simple assignment but Vec3.copy.
+    test.todo(`Assign vec3 input`);
+
+    // Shall not use simple assignment but Quat.copy.
+    test.todo(`Assign quat input`);
+});
+
+test.todo(`Disallow connect a pose node to multiple inputs`);

--- a/tests/animation/new-gen-anim/pose-graph/pose-graph-authoring.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-graph-authoring.test.ts
@@ -728,4 +728,21 @@ describe(`Input value assignment`, () => {
     test.todo(`Assign quat input`);
 });
 
+test(`Input/output query`, () => {
+    const poseGraph = createPoseGraph();
+
+    // Query on the unique output node.
+    {
+        // Root output node does not has any output.
+        expect(poseGraphOp.getOutputKeys(poseGraph.outputNode)).toStrictEqual([]);
+
+        // Root output node has a pose input.
+        const inputKeys = poseGraphOp.getInputKeys(poseGraph.outputNode);
+        expect(inputKeys).toHaveLength(1);
+        expect(poseGraphOp.getInputMetadata(poseGraph.outputNode, inputKeys[0])).toStrictEqual(expect.objectContaining({
+            type: PoseGraphType.POSE,
+        }));
+    }
+});
+
 test.todo(`Disallow connect a pose node to multiple inputs`);

--- a/tests/animation/new-gen-anim/pose-graph/pose-graph-runtime.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-graph-runtime.test.ts
@@ -1,0 +1,301 @@
+import { AuxiliaryCurveHandle } from "../../../../cocos/animation/core/animation-handle";
+import { Pose } from "../../../../cocos/animation/core/pose";
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from "../../../../cocos/animation/marionette/animation-graph-context";
+import { AnimationGraph, PoseGraph } from "../../../../cocos/animation/marionette/asset-creation";
+import { assertIsTrue, lerp, quat, v3 } from "../../../../cocos/core";
+import { Node } from "../../../../cocos/scene-graph";
+import { captureErrors, captureWarns } from '../../../utils/log-capture';
+import { input } from "../../../../cocos/animation/marionette/pose-graph/decorator/input";
+import { createAnimationGraph } from "../utils/factory";
+import { AnimationGraphEvalMock } from "../utils/eval-mock";
+import 'jest-extended';
+import { poseGraphOp } from "../../../../cocos/animation/marionette/pose-graph/op";
+import { PoseGraphType } from "../../../../cocos/animation/marionette/pose-graph/foundation/type-system";
+import { getTheOnlyInputKey, getTheOnlyOutputKey, UnimplementedPoseNode } from "./utils/misc";
+import { PoseNode } from "../../../../cocos/animation/marionette/pose-graph/pose-node";
+import { XNode } from "../../../../cocos/animation/marionette/pose-graph/x-node";
+
+describe(`Pose node instantiation`, () => {
+    test(`Should be instantiated at animation graph initialization stage`, () => {
+        class PoseNodeMock extends PoseNode {
+            public settle(context: AnimationGraphSettleContext): void { }
+            public reenter(): void { }
+            protected doUpdate(context: AnimationGraphUpdateContext): void { }
+
+            public static counter = 0;
+
+            public static constructorMock: jest.Mock<void, [PoseNodeMock]> = jest.fn();
+            
+            constructor() {
+                super();
+                this._yieldingValue = PoseNodeMock.#valueGenerator++;
+                PoseNodeMock.constructorMock(this);
+            }
+
+            get expectedYieldingValue() {
+                return this._yieldingValue;
+            }
+
+            public bind(context: AnimationGraphBindingContext): void {
+                this._handle = context.bindAuxiliaryCurve('x');
+            }
+
+            protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+                const pose = context.pushDefaultedPose();
+                expect(this._handle).not.toBeNull();
+                pose.auxiliaryCurves[this._handle!.index] = this._yieldingValue;
+                return pose;
+            }
+
+            static #valueGenerator = 0;
+            private _yieldingValue: number;
+            private _handle: AuxiliaryCurveHandle | null = null;
+        }
+
+        const animationGraph = new AnimationGraph();
+        const layer = animationGraph.addLayer();
+        const poseState = layer.stateMachine.addPoseState();
+        const poseNodeMock = poseState.graph.addNode(new PoseNodeMock());
+        poseGraphOp.connectNode(poseState.graph.outputNode, getTheOnlyInputKey(poseState.graph.outputNode), poseNodeMock);
+        layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
+
+        expect(PoseNodeMock.constructorMock).toBeCalledTimes(1);
+        PoseNodeMock.constructorMock.mockClear();
+
+        const instances = Array.from({ length: 2 }, () => {
+            const node1 = new Node();
+            const evalMock = new AnimationGraphEvalMock(node1, animationGraph);
+            expect(PoseNodeMock.constructorMock).toBeCalledTimes(1);
+            const node = PoseNodeMock.constructorMock.mock.calls[0][0];
+            PoseNodeMock.constructorMock.mockClear();
+            return {
+                node,
+                evalMock,
+            };
+        });
+        
+        for (const { node: node, evalMock } of instances) {
+            evalMock.step(0.2);
+            expect(evalMock.controller.getAuxiliaryCurveValue_experimental('x')).toBe(node.expectedYieldingValue);
+        }
+    });
+});
+
+describe(`Pose node binding and settlement`, () => {
+    test(`Should be called at animation graph bind stage`, () => {
+        const poseNode1BindMethodMock = jest.fn();
+        const poseNode1SettleMethodMock = jest.fn();
+        const poseNode2BindMethodMock = jest.fn();
+        const poseNode2SettleMethodMock = jest.fn();
+
+        class PoseNode1 extends UnimplementedPoseNode {
+            public bind(context: AnimationGraphBindingContext) {
+                poseNode1BindMethodMock();
+            }
+
+            public settle(context: AnimationGraphSettleContext) {
+                poseNode1SettleMethodMock();
+            }
+        }
+
+        class PoseNode2 extends UnimplementedPoseNode {
+            public bind(context: AnimationGraphBindingContext) {
+                poseNode2BindMethodMock();
+            }
+
+            public settle(context: AnimationGraphSettleContext) {
+                poseNode2SettleMethodMock();
+            }
+        }
+
+        const animationGraph = createAnimationGraph({
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'empty': { type: 'empty' },
+                        'pose1': {
+                            type: 'pose',
+                            graph: { rootNode: new PoseNode1() },
+                        },
+                        'pose2': {
+                            type: 'pose',
+                            graph: { rootNode: new PoseNode2() },
+                        },
+                    },
+                },
+            }],
+        });
+
+        const evalMock = new AnimationGraphEvalMock(new Node(), animationGraph);
+
+        const bindMocks = [poseNode1BindMethodMock, poseNode2BindMethodMock];
+        const settleMocks = [poseNode1SettleMethodMock, poseNode2SettleMethodMock];
+
+        // Both nodes' bind() should be called.
+        for (const bindMock of bindMocks) {
+            expect(bindMock).toBeCalledTimes(1);
+        }
+        // Both nodes' settle() should be called.
+        for (const settleMock of settleMocks) {
+            expect(settleMock).toBeCalledTimes(1);
+        }
+        // All settle() happen after all bind().
+        for (const bindMock of bindMocks) {
+            for (const settleMock of settleMocks) {
+                expect(bindMock.mock.invocationCallOrder[0]).toBeLessThan(settleMock.mock.invocationCallOrder[0]);
+            }
+        }
+        for (const mock of [...bindMocks, ...settleMocks]) {
+            mock.mockClear();
+        }
+
+        // No further bind/settle calls.
+        evalMock.step(0.3);
+        for (const mock of [...bindMocks, ...settleMocks]) {
+            expect(mock).not.toBeCalled();
+        }
+    });
+});
+
+describe(`Pose node reentering`, () => {
+    test(`Enter a pose node state should trigger the root pose node's reenter() method`, () => {
+        class PoseNodeMock extends UnimplementedPoseNode {
+            public reenterRecorder = jest.fn();
+
+            public reenter(...args: Parameters<PoseNode['reenter']>) {
+                this.reenterRecorder(...args);
+            }
+
+            public bind(context: AnimationGraphBindingContext): void { }
+
+            protected doEvaluate(context: AnimationGraphEvaluationContext): Pose { return context.pushDefaultedPose(); }
+        }
+
+        const poseNodeMock = new PoseNodeMock();
+
+        const animationGraph = createAnimationGraph({
+            variableDeclarations: {
+                'IncomingTransitionActivated': { type: 'boolean', value: false },
+                'OutgoingTransitionActivated': { type: 'boolean', value: false },
+            },
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'empty': { type: 'empty' },
+                        'pose': {
+                            type: 'pose',
+                            graph: {
+                                rootNode: poseNodeMock,
+                            },
+                        },
+                    },
+                    entryTransitions: [{ to: 'pose' }],
+                    transitions: [{
+                        from: 'pose',
+                        to: 'empty',
+                        duration: 0.3,
+                        conditions: [{ type: 'unary', operand: { type: 'variable', name: 'OutgoingTransitionActivated' } }],
+                    }, {
+                        from: 'empty',
+                        to: 'pose',
+                        duration: 0.3,
+                        conditions: [{ type: 'unary', operand: { type: 'variable', name: 'IncomingTransitionActivated' } }],
+                    }],
+                },
+            }],
+        });
+
+        const evalMock = new AnimationGraphEvalMock(new Node(), animationGraph);
+
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenterRecorder).toBeCalledTimes(1);
+        poseNodeMock.reenterRecorder.mockClear();
+
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenterRecorder).toBeCalledTimes(0);
+
+        evalMock.controller.setValue('OutgoingTransitionActivated', true);
+        evalMock.step(0.4);
+        expect(poseNodeMock.reenterRecorder).toBeCalledTimes(0);
+
+        evalMock.controller.setValue('OutgoingTransitionActivated', false);
+        evalMock.controller.setValue('IncomingTransitionActivated', true);
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenterRecorder).toBeCalledTimes(1);
+        poseNodeMock.reenterRecorder.mockClear();
+
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenterRecorder).toBeCalledTimes(0);
+    });
+});
+
+describe(`Pose node ticking`, () => {
+    test(`XNode dependencies should be evaluated before pose node updating`, () => {
+        let xNodeOutputValue = 0.0;
+    
+        const poseNodeUpdateMethodMock = jest.fn();
+        const xNodeEvaluateMethodMock = jest.fn(() => xNodeOutputValue);
+    
+        class ObservedXNode extends XNode {
+            constructor() {
+                super([PoseGraphType.FLOAT]);
+            }
+    
+            public selfEvaluate(outputs: unknown[]): void {
+                outputs[0] = xNodeEvaluateMethodMock();
+            }
+        }
+    
+        class ObservedPoseNode extends UnimplementedPoseNode {
+            @input({ type: PoseGraphType.FLOAT })
+            public value = 0.0;
+    
+            public bind() { }
+            
+            protected doUpdate() {
+                poseNodeUpdateMethodMock(this.value);
+            }
+    
+            protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+                return context.pushDefaultedPose();
+            }
+        }
+    
+        const animationGraph = new AnimationGraph();
+        const layer = animationGraph.addLayer();
+        const poseState = layer.stateMachine.addPoseState();
+        const poseNode = poseState.graph.addNode(new ObservedPoseNode());
+        const xNode = poseState.graph.addNode(new ObservedXNode());
+        const keys = poseGraphOp.getInputKeys(poseNode);
+        expect(keys).toHaveLength(1);
+        poseGraphOp.connectNode(poseNode, keys[0], xNode, getTheOnlyOutputKey(xNode));
+        poseGraphOp.connectNode(poseState.graph.outputNode, getTheOnlyInputKey(poseState.graph.outputNode), poseNode);
+        layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
+    
+        const node = new Node();
+        for (let i = 0; i < 2; ++i) {
+            // Change the x-node's evaluation result.
+            xNodeOutputValue = 0.1 + 0.1 * i;
+    
+            const evalMock = new AnimationGraphEvalMock(node, animationGraph);
+            evalMock.step(0.2);
+    
+            // Pose node's doUpdate() should have been called.
+            expect(poseNodeUpdateMethodMock).toHaveBeenCalledTimes(1);
+    
+            // X-node's evaluate() should have been called.
+            expect(xNodeEvaluateMethodMock).toHaveBeenCalledTimes(1);
+    
+            // X-node's evaluate() should happen before Pose node's doUpdate().
+            expect(xNodeEvaluateMethodMock.mock.invocationCallOrder[0]).toBeLessThan(
+                poseNodeUpdateMethodMock.mock.invocationCallOrder[0],
+            );
+    
+            // Pose nodes's doUpdate() should have received the x-node's return.
+            expect(poseNodeUpdateMethodMock.mock.calls[0][0]).toBe(xNodeEvaluateMethodMock.mock.results[0].value);
+    
+            poseNodeUpdateMethodMock.mockClear();
+            xNodeEvaluateMethodMock.mockClear();
+        }
+    });
+});

--- a/tests/animation/new-gen-anim/pose-graph/pose-graph-runtime.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-graph-runtime.test.ts
@@ -56,7 +56,7 @@ describe(`Pose node instantiation`, () => {
         const layer = animationGraph.addLayer();
         const poseState = layer.stateMachine.addPoseState();
         const poseNodeMock = poseState.graph.addNode(new PoseNodeMock());
-        poseGraphOp.connectNode(poseState.graph.outputNode, getTheOnlyInputKey(poseState.graph.outputNode), poseNodeMock);
+        poseGraphOp.connectNode(poseState.graph, poseState.graph.outputNode, getTheOnlyInputKey(poseState.graph.outputNode), poseNodeMock);
         layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
 
         expect(PoseNodeMock.constructorMock).toBeCalledTimes(1);
@@ -268,8 +268,8 @@ describe(`Pose node ticking`, () => {
         const xNode = poseState.graph.addNode(new ObservedXNode());
         const keys = poseGraphOp.getInputKeys(poseNode);
         expect(keys).toHaveLength(1);
-        poseGraphOp.connectNode(poseNode, keys[0], xNode, getTheOnlyOutputKey(xNode));
-        poseGraphOp.connectNode(poseState.graph.outputNode, getTheOnlyInputKey(poseState.graph.outputNode), poseNode);
+        poseGraphOp.connectNode(poseState.graph, poseNode, keys[0], xNode, getTheOnlyOutputKey(xNode));
+        poseGraphOp.connectNode(poseState.graph, poseState.graph.outputNode, getTheOnlyInputKey(poseState.graph.outputNode), poseNode);
         layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
     
         const node = new Node();

--- a/tests/animation/new-gen-anim/pose-graph/top-level-pose-node.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/top-level-pose-node.test.ts
@@ -19,7 +19,7 @@ test(`Additivity inheritance`, () => {
 
         const poseState = layer.stateMachine.addPoseState();
         const poseNodeMock = poseState.graph.addNode(new additivityCheckMock.PoseNodeMock());
-        connectOutputNode(poseState.graph.outputNode, poseNodeMock);
+        connectOutputNode(poseState.graph, poseState.graph.outputNode, poseNodeMock);
         layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
 
         void new AnimationGraphEvalMock(new Node(), graph);

--- a/tests/animation/new-gen-anim/pose-graph/top-level-pose-node.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/top-level-pose-node.test.ts
@@ -1,0 +1,30 @@
+import { AnimationGraph } from "../../../../cocos/animation/marionette/animation-graph";
+import { connectOutputNode } from "../../../../cocos/animation/marionette/pose-graph/op/internal";
+import { Node } from "../../../../cocos/scene-graph";
+import { AnimationGraphEvalMock } from "../utils/eval-mock";
+import { createAdditivityCheckMock } from "./utils/additive";
+
+test(`Additivity inheritance`, () => {
+    /// - The additivity of top level pose's binding context is inherited from animation graph layer.
+
+    t(true);
+    t(false);
+
+    function t(additive: boolean) {
+        const additivityCheckMock = createAdditivityCheckMock();
+
+        const graph = new AnimationGraph();
+        const layer = graph.addLayer();
+        layer.additive = additive;
+
+        const poseState = layer.stateMachine.addPoseState();
+        const poseNodeMock = poseState.graph.addNode(new additivityCheckMock.PoseNodeMock());
+        connectOutputNode(poseState.graph.outputNode, poseNodeMock);
+        layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
+
+        void new AnimationGraphEvalMock(new Node(), graph);
+
+        expect(additivityCheckMock.bindMock).toBeCalledTimes(1);
+        expect(additivityCheckMock.bindMock.mock.calls[0][0]).toBe(additive);
+    }
+});

--- a/tests/animation/new-gen-anim/pose-graph/utils/additive.ts
+++ b/tests/animation/new-gen-anim/pose-graph/utils/additive.ts
@@ -1,0 +1,48 @@
+import { AnimationController } from "../../../../../cocos/animation/animation";
+import { AnimationGraphBindingContext, AnimationGraphPoseLayoutMaintainer, AnimationGraphSettleContext, AnimationGraphUpdateContext, AuxiliaryCurveRegistry } from "../../../../../cocos/animation/marionette/animation-graph-context";
+import { PoseNode } from "../../../../../cocos/animation/marionette/pose-graph/pose-node";
+import { Node } from "../../../../../cocos/scene-graph";
+
+export function createAdditivityCheckMock() {
+    const bindMock = jest.fn<void, [additive: boolean]>();
+
+    const bindMock2 = jest.fn(function(...args: Parameters<PoseNode['bind']>) {
+        const [context] = args;
+        bindMock(context.additive);
+    });
+
+    class PoseNodeMock extends PoseNode {
+        public settle(context: AnimationGraphSettleContext): void { }
+        public reenter(): void { }
+        protected doUpdate(context: AnimationGraphUpdateContext): void { }
+        bind = bindMock2;
+        doEvaluate = jest.fn();
+    }
+
+    return {
+        bindMock,
+        PoseNodeMock: PoseNodeMock,
+    };
+}
+
+export function createPoseNodeBindContextMock_WithAdditive(additive: boolean): AnimationGraphBindingContext {
+    const node = new Node();
+    const controller = node.addComponent(AnimationController) as AnimationController;
+    const auxiliaryCurveRegistry = new AuxiliaryCurveRegistry();
+    const varRegistry = {};
+    const poseLayoutMaintainer = new AnimationGraphPoseLayoutMaintainer(node, auxiliaryCurveRegistry);
+    const result = new AnimationGraphBindingContext(
+        node,
+        poseLayoutMaintainer,
+        varRegistry,
+        controller,
+        // @ts-expect-error HACK here
+        controller._customEventTarget,
+    );
+    result._pushAdditiveFlag(additive);
+    return result;
+}
+
+export function invokePoseNodeBindMethod(poseNode: PoseNode, context: AnimationGraphBindingContext) {
+    poseNode.bind(context);
+}

--- a/tests/animation/new-gen-anim/pose-graph/utils/misc.ts
+++ b/tests/animation/new-gen-anim/pose-graph/utils/misc.ts
@@ -1,0 +1,83 @@
+import { AnimationGraph } from "../../../../../cocos/animation/marionette/asset-creation";
+import { poseGraphOp } from "../../../../../cocos/animation/marionette/pose-graph/op";
+import { PoseGraphNode } from "../../../../../cocos/animation/marionette/pose-graph/foundation/pose-graph-node";
+import { Pose } from "../../../../../cocos/animation/core/pose";
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from "../../../../../cocos/animation/marionette/animation-graph-context";
+import { Quat, Vec3 } from "../../../../../exports/base";
+import { PoseNode } from "../../../../../cocos/animation/marionette/pose-graph/pose-node";
+import { XNode } from "../../../../../cocos/animation/marionette/pose-graph/x-node";
+
+export function normalizeNodeInputMetadata(nodeInputMetadata?: poseGraphOp.InputMetadata) {
+    return nodeInputMetadata ? {
+        deletable: false,
+        insertPoint: false,
+        ...nodeInputMetadata
+    } : undefined;
+}
+
+export function createPoseGraph() {
+    return new AnimationGraph().addLayer().stateMachine.addPoseState().graph;
+}
+
+export function getTheOnlyInputKey(node: PoseGraphNode) {
+    const keys = poseGraphOp.getInputKeys(node);
+    expect(keys).toHaveLength(1);
+    return keys[0];
+}
+
+export function getTheOnlyOutputKey(node: PoseGraphNode) {
+    const outputs = poseGraphOp.getOutputKeys(node);
+    expect(outputs).toHaveLength(1);
+    return outputs[0];
+}
+
+export function findInputKeyHavingDisplayName(node: PoseGraphNode, displayName: string) {
+    const key = poseGraphOp.getInputKeys(node)
+        .find((inputKey) => poseGraphOp.getInputMetadata(node, inputKey)?.displayName === displayName);
+    expect(key).not.toBeUndefined();
+    return key!;
+}
+
+export function checkZeroPose(pose: Pose) {
+    for (let iTransform = 0; iTransform < pose.transforms.length; ++iTransform) {
+        expect(pose.transforms.getPosition(iTransform, new Vec3())).toMatchObject({
+            x: 0, y: 0, z: 0
+        });
+        expect(pose.transforms.getRotation(iTransform, new Quat())).toMatchObject({
+            x: 0, y: 0, z: 0, w: 1,
+        });
+        expect(pose.transforms.getScale(iTransform, new Vec3())).toMatchObject({
+            x: 0, y: 0, z: 0
+        });
+    }
+
+    for (let iAuxiliaryCurve = 0; iAuxiliaryCurve < pose.auxiliaryCurves.length; ++iAuxiliaryCurve) {
+        expect(pose.auxiliaryCurves[iAuxiliaryCurve]).toBe(0);
+    }
+}
+
+export class UnimplementedPoseNode extends PoseNode {
+    public settle(context: AnimationGraphSettleContext): void {
+        
+    }
+    public reenter(): void {
+        
+    }
+
+    public bind(context: AnimationGraphBindingContext): void {
+    }
+
+    protected doUpdate(context: AnimationGraphUpdateContext): void {
+        
+    }
+
+    protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+        throw new Error("Method not implemented.");
+    }
+}
+
+export class UnimplementedXNode extends XNode {
+    public selfEvaluate(outputs: unknown[]): void {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/tests/animation/new-gen-anim/pose-graph/utils/misc.ts
+++ b/tests/animation/new-gen-anim/pose-graph/utils/misc.ts
@@ -5,7 +5,7 @@ import { Pose } from "../../../../../cocos/animation/core/pose";
 import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from "../../../../../cocos/animation/marionette/animation-graph-context";
 import { Quat, Vec3 } from "../../../../../exports/base";
 import { PoseNode } from "../../../../../cocos/animation/marionette/pose-graph/pose-node";
-import { XNode } from "../../../../../cocos/animation/marionette/pose-graph/x-node";
+import { PureValueNode } from "../../../../../cocos/animation/marionette/pose-graph/pure-value-node";
 
 export function normalizeNodeInputMetadata(nodeInputMetadata?: poseGraphOp.InputMetadata) {
     return nodeInputMetadata ? {
@@ -76,7 +76,7 @@ export class UnimplementedPoseNode extends PoseNode {
     }
 }
 
-export class UnimplementedXNode extends XNode {
+export class UnimplementedPVNode extends PureValueNode {
     public selfEvaluate(outputs: unknown[]): void {
         throw new Error("Method not implemented.");
     }

--- a/tests/animation/new-gen-anim/utils/factory.ts
+++ b/tests/animation/new-gen-anim/utils/factory.ts
@@ -404,7 +404,7 @@ export type PoseNodeParams = PoseNode | Node_;
 function fillPoseGraph(poseGraph: PoseGraph, params: PoseGraphParams) {
     if (params.rootNode) {
         const root = createPoseNode(poseGraph, params.rootNode);
-        poseGraphOp.connectOutputNode(poseGraph.outputNode, root);
+        poseGraphOp.connectOutputNode(poseGraph, poseGraph.outputNode, root);
     }
 }
 

--- a/tests/animation/new-gen-anim/utils/factory.ts
+++ b/tests/animation/new-gen-anim/utils/factory.ts
@@ -1,15 +1,16 @@
 import { AnimationClip } from "../../../../cocos/animation/animation-clip";
 import { AnimationGraph, AnimationTransition, EmptyStateTransition, isAnimationTransition, PoseState, PoseTransition, State, StateMachine, SubStateMachine, Transition } from "../../../../cocos/animation/marionette/animation-graph";
-import { PoseGraph, PoseNode, TCBinding, TCBindingValueType } from "../../../../cocos/animation/marionette/asset-creation";
+import { PoseGraph, poseGraphOp, TCBinding, TCBindingValueType } from "../../../../cocos/animation/marionette/asset-creation";
 import { Motion, ClipMotion, AnimationBlend1D, AnimationBlend2D } from "../../../../cocos/animation/marionette/motion";
 import { BinaryCondition, TriggerCondition, UnaryCondition } from "../../../../cocos/animation/marionette/state-machine/condition";
 import { MotionState } from "../../../../cocos/animation/marionette/state-machine/motion-state";
 import { Bindable } from "../../../../cocos/animation/marionette/parametric";
 import { TriggerResetMode } from "../../../../cocos/animation/marionette/variable";
-import { Vec2 } from "../../../../exports/base";
+import { assertIsTrue, Vec2 } from "../../../../exports/base";
 import { TCVariableBinding } from "../../../../cocos/animation/marionette/state-machine/condition/binding/variable-binding";
 import { TCAuxiliaryCurveBinding } from "../../../../cocos/animation/marionette/state-machine/condition/binding/auxiliary-curve-binding";
 import { TCStateWeightBinding } from "../../../../cocos/animation/marionette/state-machine/condition/binding/state-weight-binding";
+import { PoseNode } from "../../../../cocos/animation/marionette/pose-graph/pose-node";
 
 export function createAnimationGraph(params: AnimationGraphParams): AnimationGraph {
     const animationGraph = new AnimationGraph();
@@ -159,7 +160,7 @@ function fillTransition(transition: Transition, params: TransitionAttributes) {
 
     function assertsIsDurableTransition(transition: Transition): asserts transition is (AnimationTransition | EmptyStateTransition | PoseTransition) {
         if (!isAnimationTransition(transition) && !(transition instanceof EmptyStateTransition) && !(transition instanceof PoseTransition)) {
-            throw new Error(`The transition should be animation/empty transition.`);
+            throw new Error(`The transition should be animation/empty/pose transition.`);
         }
     }
 
@@ -394,21 +395,44 @@ export type MotionParams = {
     }>;
 };
 
-export interface PoseGraphParams {
+interface PoseGraphParams {
     rootNode?: PoseNodeParams;
 }
 
-export type PoseNodeParams = PoseNode;
+export type PoseNodeParams = PoseNode | Node_;
 
 function fillPoseGraph(poseGraph: PoseGraph, params: PoseGraphParams) {
     if (params.rootNode) {
         const root = createPoseNode(poseGraph, params.rootNode);
-        poseGraph.main = root;
+        poseGraphOp.connectOutputNode(poseGraph.outputNode, root);
     }
 }
 
-export function createPoseNode(poseGraph: PoseGraph, params: PoseNodeParams): NonNullable<PoseGraph['main']> {
-    poseGraph.addNode(params);
-    return params;
+declare global {
+    interface PoseNodeFactoryRegistry {
+    }
+}
+
+type Map_ = {
+    [k in keyof PoseNodeFactoryRegistry]: PoseNodeFactoryRegistry[k] & { type: k };
+}
+
+const poseNodeFactoryMap: Record<string, (poseGraph: PoseGraph, params: any) => PoseNode> = {};
+
+export function addPoseNodeFactory<T extends keyof PoseNodeFactoryRegistry> (
+    type: T, factory: (poseGraph: PoseGraph, params: PoseNodeFactoryRegistry[T]) => PoseNode) {
+    poseNodeFactoryMap[type] = factory;
+}
+
+export type Node_ = Map_[keyof Map_];
+
+export function createPoseNode(poseGraph: PoseGraph, params: PoseNodeParams): PoseNode {
+    if (params instanceof PoseNode) {
+        return poseGraph.addNode(params);
+    } else if (!(params.type in poseNodeFactoryMap)) {
+        throw new Error(`${params.type} factory does not exist.`);
+    } else {
+        return poseNodeFactoryMap[params.type](poseGraph, params);
+    }
 }
 


### PR DESCRIPTION
Re: #

### Changelog

* This PR complementarily implements the pose graph introduced in PR #14779 .

### Design Detail

- There're values flowing in pose graph. The type of value can be pose, floating point number, integer, boolean, vector 3, quaternion. The type is represented by enumeration `PoseGraphType`.

- Pose graphs contains nodes, referenced as **pose graph node**, and is represented by class `PoseGraphNode`.

- Pose graph nodes, decided by its node class, can have zero or more inputs and zero or more outputs. Each input or output has definitely a type associated. Values flow between inputs/outputs:

  - An input receives value of that type from other nodes' output, or from constant;

  - An output sends value of that type to other nodes' input.

  - Nodes having outputs usually take their possible inputs and generate outputs.
 
  If such a flowing is established between a output and a input, say that a **binding** is formed between them.

- This PR introduces only 3 kinds of pose graph nodes (as subclass of `PoseGraphNode`):

  - **pose node**, represented by class `PoseNode`, as defined in PR #14779 .

    Pose nodes have **exactly one** output of pose type, and zero or more inputs of any type.

  - **x-node**, represented by class `XNode`.

    X-nodes have **one or more** outputs, and have zero or more inputs. **Neither** of input and output of a x-node can have pose type. 

  - **pose graph output node**, represented by class `PoseGraphOutputNode`.

    The pose graph output node is unique (per pose graph), built-in and undeletable. It has exactly one input of pose type and has no output. Pose flowed to its input would be served as the output pose of the animation graph.

### Implementation Detail

#### Internal Concept: Node Shell

A pose graph node is a freestanding object, meaning it does not belong to any pose graph yet, can be directly created by `new` operator. When a pose graph node is added into graph, say it's non-freestanding. A pose graph node can not be added into more than one pose graph.

Internally, when a pose graph node is added into graph, a **node shell** is automatically created and associated to it. The shell object records the "incoming" bindings of the node. The reason of such design is:

- In general, in an abstract graph data structure, nodes and edges are stored separately. The shell objects are essentially "single forward edge".

- Pose graph nodes themselves don't have to concern about their input/output connections. They just focus on computation logic. Value flowing should be handled by binding system.

- This makes duplication easy:

  - Make duplicating a single node easy: only duplicate the node itself.

  - Make duplicating a subgraph easy: duplicate the subgraph nodes and the bindings limited to the subgraph.

Node shells are never known by external from graph.

#### Input declaration

- Inputs of a node are _mapped_ to the node's properties by applying decorator `@input` to the properties(both data field and accessor is ok):

  - `@input` can only be applied to properties of subclasses of `PoseNode` and `XNode`.

  - `@input` requires a type to be specified. `@input` specifying pose type can only be applied to properties of subclasses of `PoseNode`.

  - If `@input` is well applied to a property, the property is mapped as one or more inputs:

    - If the property is **NOT** an array, it's mapped as a single input with specified type.

    - If the property is an array, each element of it is mapped as an input with specified type.

  If a property or its element is mapped as input, value received from the input will be set onto that property or to that element.

- 

#### Output declaration

- Pose nodes don't have to declare their outputs.

- X-nodes declares their output count, type by specifying them to the base class `XNode`.

#### Instantiation

When a animation graph is instantiated(in per animation controller), the within pose graphs will be instantiated. The instantiation starts from the graph's output node and go recursively: each reached node is instantiated, then their input/output is connected.

The instantiation of a pose graph node(note: only pose node and x-node can be and will be instantiated) is call `cc.instantiate()` on it, that's, duplicate a copy of it. The evaluation status is recorded directly in the copy. This method very differs from previous: the instantiating stuff has a `createEval()` which yields another type of object "xx-evaluator", then pass data from original stuff to the evaluator. The reason is:

- It's more convenient. Don't have to create another "xx-evaluator" and pass data. Evaluation is done in place.

- It does not waste memory in most time. Usually, all non-evaluator-specific data should be passed to the "xx-evaluator". So in memory usage aspect, they have a flat hand.

But this manner has a little cons: a node has two states: **being evaluated** and **not being evaluated**!

Let's talk about how the binding system work now. Binding system treats the following kinds of binding in different manner:

- The binding between pose nodes(_a_ --> _b_).

  When encountered such binding type, binding system directly assign pose node _a_ to _b_'s property or _b_'s property's element.

- The binding comes from X-Node _a_ and flows into X-Node/Pose Node(b)

  When encountered such binding type, binding system creates a `DependencyEvaluation` record object for _b_. When a `DependencyEvaluation` executes, it:

  - evaluates _a_ and store the result into array `outputs`.

  - fetch the corresponding result in `outputs` then assign to _b_'s property or _b_'s property's element.

  Binding system roughly injects `DependencyEvaluation` object into `PoseNode`. Then it will be called by `PoseNode`'s update() method. For recursive x-nodes connection, recursive `DependencyEvaluation`s are created for them and connected.

#### Node input identity representation

The node input requires to be uniquely referenced by binding system and in pose graph authoring(especially in editor), then we need something like "id" of node input.

The "id" of a node input is internally called **input path**(represented by `InputPath`) represented as a tuple `[string]` or `[string, number]`. The first element is the name of the class property mapped as input(s). The possible second element is the element index in case of array element input mapping.

The detail construction of a input path is opacity to external(for example, editor), but it's transparent within engine. To encapsulate, we used **input key**(represented by `InputKey`) as an alias of input path and expose it to external. The input key, for external, is only guaranteed to be a value which can be `JSON.stringfy`.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
