### PR TITLE
[DON'T MERGE] Add `_decorator.ccclass.forward()` helper decorator to allow transfer cc-class information

### DIFF
--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -24,7 +24,7 @@
 */
 
 export { uniquelyReferenced } from './decorators/serializable';
-export { ccclass } from './decorators/ccclass';
+export { ccclass, transferCCClass } from './decorators/ccclass';
 export { property } from './decorators/property';
 export { requireComponent, executionOrder, disallowMultiple, allowReplicated } from './decorators/component';
 export { executeInEditMode, menu, playOnFocus, inspector, icon, help } from './decorators/editable';

--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -24,7 +24,7 @@
 */
 
 export { uniquelyReferenced } from './decorators/serializable';
-export { ccclass, transferCCClass } from './decorators/ccclass';
+export { ccclass } from './decorators/ccclass';
 export { property } from './decorators/property';
 export { requireComponent, executionOrder, disallowMultiple, allowReplicated } from './decorators/component';
 export { executeInEditMode, menu, playOnFocus, inspector, icon, help } from './decorators/editable';

--- a/cocos/core/data/decorators/ccclass.ts
+++ b/cocos/core/data/decorators/ccclass.ts
@@ -28,6 +28,77 @@ import { CCClass } from '../class';
 import { doValidateMethodWithProps_DEV } from '../utils/preprocess-class';
 import { CACHE_KEY, makeSmartClassDecorator } from './utils';
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace ccclassNamespace {
+    /**
+     * @zh
+     * 返回一个装饰器，它运作时会直接调用指定的另一个装饰器。
+     * 当指定的装饰器返回新的类时，将原本构造函数上关联的所有 cc-class 相关的信息转移到新的构造函数上。
+     *
+     * 当你的类装饰器会返回新的类时，你需要将你的类装饰器包裹在此方法中来转移所有 cc-class 相关的信息。
+     *
+     * @en
+     * Returns a decorator, when this decorator works,
+     * it will immediately invoke another specified decorator.
+     * In case of the specified decorator returning new class,
+     * all cc-class information that was associated to original constructor
+     * are transferred to new constructor.
+     *
+     * If your class decorator is going to return a new class.
+     * You have to wrap your decorator by this method to transfer all cc-class information to the new class.
+     *
+     * @param originalConstructor @zh 原始构造函数。 @en The original constructor.
+     *
+     * @param newConstructor @zh 新的接收 cc 属性构造函数。 @en The new constructor which accepts the properties.
+     *
+     * @example
+     *
+     * @zh
+     * ```ts
+     * const someClassDecorator: ClassDecorator = (constructor) => {
+     *      class NewClass {}
+     *      return NewClass;
+     * };
+     *
+     * \@ccclass('SomeClass')
+     * // 如果你不包裹，得到的类不能再作为正常的 cc 类来用，
+     * // 比如，它不能再被序列化或展示在编辑器中。
+     * \@ccclass.forward(someClassDecorator)
+     * class SomeClass {
+     *   \@property someProperty = '';
+     * }
+     * ```
+     *
+     * @en
+     *
+     * ```ts
+     * const someClassDecorator: ClassDecorator = (constructor) => {
+     *      class NewClass {}
+     *      return NewClass;
+     * };
+     *
+     * \@ccclass('SomeClass')
+     * // If you do not wrap,
+     * // the result class will not be able to used as a normal cc-class,
+     * // for example, will not be able to be serialized or be shown in editor.
+     * \@ccclass.forward(someClassDecorator)
+     * class SomeClass {
+     *   \@property someProperty = '';
+     * }
+     * ```
+     */
+    export function forward (classDecorator: ClassDecorator): ClassDecorator {
+        return (originalConstructor) => {
+            const maybeNewConstructor = classDecorator(originalConstructor);
+            if (!maybeNewConstructor) {
+                return undefined;
+            }
+            transferCCClass(originalConstructor, maybeNewConstructor);
+            return maybeNewConstructor;
+        };
+    }
+}
+
 /**
  * @en Declare a standard class as a CCClass, please refer to the [document](https://docs.cocos.com/creator3d/manual/en/scripting/ccclass.html)
  * @zh 将标准写法的类声明为 CC 类，具体用法请参阅[类型定义](https://docs.cocos.com/creator3d/manual/zh/scripting/ccclass.html)。
@@ -50,7 +121,7 @@ import { CACHE_KEY, makeSmartClassDecorator } from './utils';
  * }
  * ```
  */
-export const ccclass: ((name?: string) => ClassDecorator) & ClassDecorator = makeSmartClassDecorator<string>((constructor, name) => {
+export const ccclass = Object.assign(makeSmartClassDecorator<string>((constructor, name) => {
     let base = getSuper(constructor);
     if (base === Object) {
         base = null;
@@ -89,62 +160,9 @@ export const ccclass: ((name?: string) => ClassDecorator) & ClassDecorator = mak
     }
 
     return res;
-});
+}), ccclassNamespace);
 
-/**
- * @zh
- * 将指定构造函数上关联的所有 cc-class 相关的信息转移到新的构造函数上。
- *
- * 当你的类装饰器会返回新的类时，你需要调用此方法来转移所有 cc-class 相关的信息。
- *
- * @en
- * Transfers all cc-class information that was originally associated to specified constructor
- * instead to new constructor.
- *
- * If your class decorator is going to return a new class.
- * You have to invoke this methods to transfer all cc-class information to the new class.
- *
- * @param originalConstructor @zh 原始构造函数。 @en The original constructor.
- *
- * @param newConstructor @zh 新的接收 cc 属性构造函数。 @en The new constructor which accepts the properties.
- *
- * @example
- *
- * @zh
- * ```ts
- * const someClassDecorator: ClassDecorator = (constructor) => {
- *      class NewClass {}
- *      // 如果你缺少了下面的语句，得到的类不能再作为正常的 cc 类来用，
- *      // 比如，它不能再被序列化或展示在编辑器中。
- *      transferCCClass(constructor, NewClass);
- *      return NewClass;
- * };
- *
- * \@ccclass('SomeClass')
- * class SomeClass {
- *   \@property someProperty = '';
- * }
- * ```
- *
- * @en
- *
- * ```ts
- * const someClassDecorator: ClassDecorator = (constructor) => {
- *      class NewClass {}
- *      // If you missed the following statement,
- *      // the result class will not be able to used as a normal cc-class,
- *      // for example, will not be able to be serialized or be shown in editor.
- *      transferCCClass(constructor, NewClass);
- *      return NewClass;
- * };
- *
- * \@ccclass('SomeClass')
- * class SomeClass {
- *   \@property someProperty = '';
- * }
- * ```
- */
-export function transferCCClass (
+function transferCCClass (
     // eslint-disable-next-line @typescript-eslint/ban-types
     originalConstructor: Function,
 
@@ -165,6 +183,8 @@ export function transferCCClass (
     tryTransferConstructorProperty(originalConstructor, newConstructor, '_sealed');
 }
 
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
 function tryTransferConstructorProperty (
     // eslint-disable-next-line @typescript-eslint/ban-types
     originalConstructor: Function,
@@ -174,7 +194,8 @@ function tryTransferConstructorProperty (
 
     propertyKey: typeof CACHE_KEY | '__props__' | '__attrs__' | '__values__' | '__ctors__' | '_sealed',
 ) {
-    if (propertyKey in originalConstructor) {
+    // eslint-disable-next-line no-prototype-builtins
+    if (hasOwnProperty.call(originalConstructor, propertyKey)) {
         newConstructor[propertyKey] = originalConstructor[propertyKey];
         delete originalConstructor[propertyKey];
     }

--- a/cocos/core/utils/js-typed.ts
+++ b/cocos/core/utils/js-typed.ts
@@ -231,6 +231,7 @@ export function createMap (forceDictMode?: boolean): any {
 
 /**
  * @internal
+ * @engineInternal
  */
 export function transferCCClassIdAndName (
     // eslint-disable-next-line @typescript-eslint/ban-types

--- a/cocos/core/utils/js-typed.ts
+++ b/cocos/core/utils/js-typed.ts
@@ -230,6 +230,29 @@ export function createMap (forceDictMode?: boolean): any {
 }
 
 /**
+ * @internal
+ */
+export function transferCCClassIdAndName (
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    originalConstructor: Function,
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    newConstructor: Function,
+) {
+    const className = (originalConstructor.prototype as unknown as { [classNameTag]: string | undefined })[classNameTag];
+    const classId = getClassId(originalConstructor, false);
+
+    unregisterClass(originalConstructor);
+
+    if (className) {
+        doSetClassName(className, newConstructor as Constructor<any>);
+    }
+    if (classId) {
+        _setClassId(classId, newConstructor as Constructor<any>);
+    }
+}
+
+/**
  * @en
  * Gets class name of the object, if object is just a {} (and which class named 'Object'), it will return "".
  * (modified from <a href="http://stackoverflow.com/questions/1249531/how-to-get-a-javascript-objects-class">the code of stackoverflow post</a>)
@@ -719,10 +742,12 @@ export function unregisterClass (...constructors: Function[]) {
         const p = constructor.prototype;
         const classId = p[classIdTag];
         if (classId) {
+            delete p[classIdTag];
             delete _idToClass[classId];
         }
         const classname = p[classNameTag];
         if (classname) {
+            delete p[classNameTag];
             delete _nameToClass[classname];
         }
         const aliases = p[aliasesTag];
@@ -732,6 +757,7 @@ export function unregisterClass (...constructors: Function[]) {
                 delete _nameToClass[alias];
                 delete _idToClass[alias];
             }
+            delete p[aliasesTag];
         }
     }
 }


### PR DESCRIPTION
Re: #14959

### Changelog

* Add a helper decorator `_decorator.ccclass.forward()` to allow transfer cc-class information from one class to another. This function is introduced for solving problems similar to #14959 : user may return a different class in class decorator.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
