### PR TITLE
Animation graph: state machine adjustment

### DIFF
--- a/cocos/animation/marionette/animation-graph.ts
+++ b/cocos/animation/marionette/animation-graph.ts
@@ -87,14 +87,6 @@ export type { TransitionView as Transition };
 
 export type TransitionInternal = Transition;
 
-export enum TransitionInterruptionSource {
-    NONE,
-    CURRENT_STATE,
-    NEXT_STATE,
-    CURRENT_STATE_THEN_NEXT_STATE,
-    NEXT_STATE_THEN_CURRENT_STATE,
-}
-
 @ccclass(`${CLASS_NAME_PREFIX_ANIM}AnimationTransition`)
 class AnimationTransition extends Transition {
     /**
@@ -140,19 +132,6 @@ class AnimationTransition extends Transition {
         this._exitCondition = value;
     }
 
-    /**
-     * @internal This field is exposed for **experimental editor only** usage.
-     */
-    get interruptible () {
-        return this.interruptionSource !== TransitionInterruptionSource.NONE;
-    }
-
-    set interruptible (value) {
-        this.interruptionSource = value
-            ? TransitionInterruptionSource.CURRENT_STATE_THEN_NEXT_STATE
-            : TransitionInterruptionSource.NONE;
-    }
-
     public copyTo (that: AnimationTransition) {
         super.copyTo(that);
         that.duration = this.duration;
@@ -161,14 +140,7 @@ class AnimationTransition extends Transition {
         that.exitCondition = this.exitCondition;
         that.destinationStart = this.destinationStart;
         that.relativeDestinationStart = this.relativeDestinationStart;
-        that.interruptible = this.interruptible;
     }
-
-    /**
-     * @internal This field is exposed for **internal** usage.
-     */
-    @serializable
-    public interruptionSource = TransitionInterruptionSource.NONE;
 
     @serializable
     private _exitCondition = 1.0;

--- a/cocos/animation/marionette/state-machine/state-machine-eval.ts
+++ b/cocos/animation/marionette/state-machine/state-machine-eval.ts
@@ -443,8 +443,6 @@ class TopLevelStateMachineEvaluation {
                 break;
             }
 
-            ++iterations;
-
             const transition = this._matchNextTransition(matchingSource);
             if (!transition) {
                 break;

--- a/cocos/animation/marionette/state-machine/state-machine-eval.ts
+++ b/cocos/animation/marionette/state-machine/state-machine-eval.ts
@@ -1,7 +1,7 @@
 import { DEBUG } from 'internal:constants';
 import {
     StateMachine, State, isAnimationTransition,
-    SubStateMachine, EmptyState, EmptyStateTransition, TransitionInterruptionSource,
+    SubStateMachine, EmptyState, EmptyStateTransition,
     PoseState, PoseTransition,
 } from '../animation-graph';
 import { MotionEval, MotionEvalContext, MotionPort } from '../motion';
@@ -9,7 +9,7 @@ import { createEval } from '../create-eval';
 import { BindContext, validateVariableExistence, validateVariableType, VariableType } from '../parametric';
 import { ConditionEval, TriggerCondition } from './condition';
 import { MotionState } from './motion-state';
-import { warnID, assertIsTrue, assertIsNonNullable } from '../../../core';
+import { warnID, assertIsTrue, assertIsNonNullable, Pool, approx, clamp01 } from '../../../core';
 import { AnimationClip } from '../../animation-clip';
 import type { AnimationController } from '../animation-controller';
 import { StateMachineComponent } from './state-machine-component';
@@ -125,6 +125,7 @@ class TopLevelStateMachineEvaluation {
         this._topLevelEntry = entry;
         this._topLevelExit = exit;
         this._currentNode = entry;
+        entry.increaseActiveReference();
         this._resetTrigger = context.triggerResetter;
     }
 
@@ -145,10 +146,12 @@ class TopLevelStateMachineEvaluation {
     }
 
     public update (context: AnimationGraphUpdateContext) {
-        this._transitionAlpha = 0.0;
-        if (!this.exited) {
-            this._eval(context);
-        }
+        assertIsTrue(!this.exited);
+
+        this._loopMatchTransitions();
+        this._resetStateTickFlagsAndWeights();
+        this._updateActivatedTransitions(context.deltaTime);
+        this._commitStateUpdates(context);
     }
 
     public evaluate (context: AnimationGraphEvaluationContext): Pose {
@@ -162,9 +165,7 @@ class TopLevelStateMachineEvaluation {
     public getCurrentStateStatus (): Readonly<MotionStateStatus> | null {
         const { _currentNode: currentNode } = this;
         if (currentNode.kind === NodeKind.animation) {
-            return currentNode.getFromPortStatus();
-        } else if (currentNode.kind === NodeKind.transitionSnapshot) {
-            return currentNode.first.getFromPortStatus();
+            return currentNode.getStatus();
         } else if (currentNode.kind === NodeKind.pose) {
             return currentNode.status;
         } else {
@@ -175,69 +176,57 @@ class TopLevelStateMachineEvaluation {
     public getCurrentClipStatuses (): Iterable<ClipStatus> {
         const { _currentNode: currentNode } = this;
         if (currentNode.kind === NodeKind.animation) {
-            return currentNode.getClipStatuses(1.0 - this._transitionAlpha);
-        } else if (currentNode.kind === NodeKind.transitionSnapshot) {
-            return currentNode.first.getClipStatuses(1.0 - this._transitionAlpha);
+            return currentNode.getClipStatuses(currentNode.absoluteWeight);
         } else {
             return emptyClipStatusesIterable;
         }
     }
 
     public getCurrentTransition (transitionStatus: TransitionStatus): boolean {
-        const { _currentTransitionPath: currentTransitionPath } = this;
-        if (currentTransitionPath.length !== 0) {
-            const lastNode = currentTransitionPath[currentTransitionPath.length - 1];
-            if (!isRealState(lastNode.to)) {
-                return false;
-            }
-            const {
-                duration,
-                normalizedDuration,
-            } = currentTransitionPath[0];
-            const durationInSeconds = transitionStatus.duration = normalizedDuration
-                ? duration * (this._currentNode.kind === NodeKind.animation
-                    ? this._currentNode.duration
-                    : this._currentNode.kind === NodeKind.transitionSnapshot
-                        ? this._currentNode.first.duration
-                        : 0.0
-                )
-                : duration;
-            transitionStatus.time = this._transitionProgress * durationInSeconds;
-            return true;
-        } else {
+        const { _activatedTransitions: activatedTransitions } = this;
+        if (activatedTransitions.length === 0) {
             return false;
         }
+        const lastActivatedTransition = activatedTransitions[activatedTransitions.length - 1];
+        const baseDurationState = activatedTransitions.length === 1
+            ? this._currentNode
+            : activatedTransitions[activatedTransitions.length - 2].destination;
+        const absoluteDuration = lastActivatedTransition.getAbsoluteDuration(baseDurationState);
+        transitionStatus.duration = absoluteDuration;
+        transitionStatus.time = lastActivatedTransition.normalizedElapsedTime * absoluteDuration;
+        return true;
     }
 
     public getNextStateStatus (): Readonly<MotionStateStatus> | null {
-        const {
-            _currentTransitionToNode: currentTransitionToNode,
-        } = this;
-        if (!currentTransitionToNode) {
+        const { _activatedTransitions: activatedTransitions } = this;
+        if (activatedTransitions.length === 0) {
             return null;
         }
-        switch (currentTransitionToNode.kind) {
+        const lastState = activatedTransitions[activatedTransitions.length - 1].destination;
+        switch (lastState.kind) {
         default:
             break;
         case NodeKind.pose:
-            return currentTransitionToNode.status;
+            return lastState.status;
         case NodeKind.animation:
-            return currentTransitionToNode.getToPortStatus();
+            return lastState.getStatus();
         }
         return null;
     }
 
     public getNextClipStatuses (): Iterable<ClipStatus> {
-        const { _currentTransitionPath: currentTransitionPath } = this;
-        const nCurrentTransitionPath = currentTransitionPath.length;
-        if (nCurrentTransitionPath === 0) {
+        const { _activatedTransitions: activatedTransitions } = this;
+        if (activatedTransitions.length === 0) {
             return emptyClipStatusesIterable;
         }
-        const to = currentTransitionPath[nCurrentTransitionPath - 1].to;
-        if (to.kind !== NodeKind.animation) {
+        const lastActivatedTransition = activatedTransitions[activatedTransitions.length - 1];
+        const lastState = lastActivatedTransition.destination;
+        switch (lastState.kind) {
+        default:
             return emptyClipStatusesIterable;
+        case NodeKind.animation:
+            return lastState.getClipStatuses(lastActivatedTransition.destination.absoluteWeight) ?? emptyClipStatusesIterable;
         }
-        return to.getClipStatuses(this._transitionAlpha) ?? emptyClipStatusesIterable;
     }
 
     public overrideClips (overrides: ReadonlyClipOverrideMap, context: AnimationGraphBindingContext) {
@@ -245,9 +234,7 @@ class TopLevelStateMachineEvaluation {
         const nMotionStates = motionStates.length;
         for (let iMotionState = 0; iMotionState < nMotionStates; ++iMotionState) {
             const node = motionStates[iMotionState];
-            if (node.kind === NodeKind.animation) {
-                node.overrideClips(overrides, context);
-            }
+            node.overrideClips(overrides, context);
         }
     }
 
@@ -255,7 +242,7 @@ class TopLevelStateMachineEvaluation {
     /**
      * Preserved here for clip overriding.
      */
-    private _motionStates: MotionStateEval[] = [];
+    private _motionStates: VMSMEval[] = [];
     /**
      * Preserved here for settle stage.
      */
@@ -263,19 +250,10 @@ class TopLevelStateMachineEvaluation {
     private _topLevelEntry: NodeEval;
     private _topLevelExit: NodeEval;
     private _currentNode: NodeEval;
-    private _currentTransitionToNode: RealState | null = null;
-    private _currentTransitionPath: TransitionEval[] = [];
-    private _transitionProgress = 0;
+    private _pendingTransitionPath: TransitionEval[] = [];
+    private _activatedTransitions: ActivatedTransition[] = [];
+    private _activatedTransitionPool = ActivatedTransition.createPool(4);
     private declare _triggerReset: TriggerResetter;
-    private _transitionAlpha = 0.0;
-    private _fromUpdated = false;
-    private _fromUpdateDeltaTime = 0.0;
-    private _toUpdated = false;
-    private _toUpdateDeltaTime = 0.0;
-    /**
-     * A virtual state which represents the transition snapshot captured when a transition is interrupted.
-     */
-    private _transitionSnapshot = new TransitionSnapshotEval();
     private _updateContextGenerator = new AnimationGraphUpdateContextGenerator();
     private _additive = false;
 
@@ -292,9 +270,9 @@ class TopLevelStateMachineEvaluation {
         let anyNode: SpecialStateEval | undefined;
         let exitEval: SpecialStateEval | undefined;
 
-        const nodeEvaluations = nodes.map((node): NodeEval | null => {
+        const nodeEvaluations = nodes.map((node): NodeEval | VMSMEval | null => {
             if (node instanceof MotionState) {
-                const motionStateEval = new MotionStateEval(node, context, clipOverrides);
+                const motionStateEval = new VMSMEval(node, context, clipOverrides);
                 this._motionStates.push(motionStateEval);
                 return motionStateEval;
             } else if (node === graph.entryState) {
@@ -353,7 +331,7 @@ class TopLevelStateMachineEvaluation {
         if (DEBUG) {
             for (const nodeEval of nodeEvaluations) {
                 if (nodeEval) {
-                    nodeEval.__DEBUG_ID__ = `${nodeEval.name}(from ${__DEBUG_ID__})`;
+                    nodeEval.setPrefix_debug(`${__DEBUG_ID__}/`);
                 }
             }
         }
@@ -361,9 +339,8 @@ class TopLevelStateMachineEvaluation {
         for (let iNode = 0; iNode < nodes.length; ++iNode) {
             const node = nodes[iNode];
             const outgoingTemplates = graph.getOutgoings(node);
-            const outgoingTransitions: TransitionEval[] = [];
 
-            let fromNode: NodeEval;
+            let fromNode: NodeEval | VMSMEval;
             if (node instanceof SubStateMachine) {
                 const subStateMachineInfo = subStateMachineInfos[iNode];
                 assertIsNonNullable(subStateMachineInfo);
@@ -381,7 +358,7 @@ class TopLevelStateMachineEvaluation {
                     assertIsTrue(false, 'Bad animation data');
                 }
 
-                let toNode: NodeEval;
+                let toNode: NodeEval | VMSMEval;
                 if (outgoingNode instanceof SubStateMachine) {
                     const subStateMachineInfo = subStateMachineInfos[iOutgoingNode];
                     assertIsNonNullable(subStateMachineInfo);
@@ -389,7 +366,11 @@ class TopLevelStateMachineEvaluation {
                 } else {
                     const nodeEval = nodeEvaluations[iOutgoingNode];
                     assertIsNonNullable(nodeEval);
-                    toNode = nodeEval;
+                    if (nodeEval instanceof VMSMEval) {
+                        toNode = nodeEval.entry;
+                    } else {
+                        toNode = nodeEval;
+                    }
                 }
 
                 const conditions = outgoing.conditions.map((condition) => condition[createEval](context));
@@ -404,7 +385,6 @@ class TopLevelStateMachineEvaluation {
                     relativeDestinationStart: false,
                     exitCondition: 0.0,
                     exitConditionEnabled: false,
-                    interruption: TransitionInterruptionSource.NONE,
                     activated: false,
                 };
 
@@ -415,7 +395,6 @@ class TopLevelStateMachineEvaluation {
                     transitionEval.exitCondition = outgoing.exitCondition;
                     transitionEval.destinationStart = outgoing.destinationStart;
                     transitionEval.relativeDestinationStart = outgoing.relativeDestinationStart;
-                    transitionEval.interruption = outgoing.interruptionSource;
                 } else if (outgoing instanceof EmptyStateTransition) {
                     transitionEval.duration = outgoing.duration;
                     transitionEval.destinationStart = outgoing.destinationStart;
@@ -431,190 +410,174 @@ class TopLevelStateMachineEvaluation {
                         (transitionEval.triggers ??= []).push(condition.trigger);
                     }
                 });
-                outgoingTransitions.push(transitionEval);
-            }
 
-            fromNode.outgoingTransitions = outgoingTransitions;
+                fromNode.addTransition(transitionEval);
+            }
         }
 
         return stateMachineInfo;
     }
 
     /**
-     * Updates this layer, return when the time piece exhausted or the graph reached exit state.
-     * @param deltaTime The time piece to update.
-     * @returns Remain time piece.
+     * Loop match transitions util no match,
+     * or util `MAX_ITERATIONS` is reached(in case of circular transition formed).
      */
-    private _eval (context: AnimationGraphUpdateContext) {
-        assertIsTrue(!this.exited);
-
-        const haltOnNonMotionState = this._continueDanglingTransition();
-        if (haltOnNonMotionState) {
-            return 0.0;
-        }
-
+    private _loopMatchTransitions () {
         const MAX_ITERATIONS = 100;
 
-        let remainTimePiece = context.deltaTime;
-        for (let continueNextIterationForce = true, // Force next iteration even remain time piece is zero
-            iterations = 0;
-            continueNextIterationForce || remainTimePiece > 0.0;
-        ) {
-            continueNextIterationForce = false;
+        const {
+            _pendingTransitionPath: pendingTransitionPath,
+            _activatedTransitions: activatedTransitions,
+        } = this;
+        assertIsTrue(pendingTransitionPath.length === 0);
 
-            if (iterations === MAX_ITERATIONS) {
+        let matchingSource = activatedTransitions.length === 0
+            ? this._currentNode
+            : activatedTransitions[activatedTransitions.length - 1].destination;
+        for (let iterations = 0;
+            /* The terminal condition is handled in loop body */;
+            ++iterations
+        ) {
+            if (iterations >= MAX_ITERATIONS) {
                 warnID(14000, MAX_ITERATIONS);
                 break;
             }
 
             ++iterations;
 
-            // Update current transition if we're in transition.
-            // If currently no transition, we simple fallthrough.
-            if (this._currentTransitionPath.length > 0) {
-                const transitionMatch = this._detectInterruption(remainTimePiece, interruptingTransitionMatchCache);
-                if (transitionMatch) {
-                    remainTimePiece -= transitionMatch.requires;
-                    const ranIntoNonMotionState = this._interrupt(transitionMatch);
-                    if (ranIntoNonMotionState) {
-                        break;
-                    }
-                    continueNextIterationForce = true;
-                    continue;
-                }
+            const transition = this._matchNextTransition(matchingSource);
+            if (!transition) {
+                break;
+            }
 
-                const currentUpdatingConsume = this._updateCurrentTransition(remainTimePiece);
-                remainTimePiece -= currentUpdatingConsume;
-                if (this._currentNode.kind === NodeKind.exit) {
-                    break;
-                }
-                if (this._currentTransitionPath.length === 0) {
-                    // If the update invocation finished the transition,
-                    // We force restart the iteration
-                    continueNextIterationForce = true;
-                }
+            const destinationState = transition.to;
+            const currentMatchingSource = matchingSource;
+            matchingSource = destinationState;
+
+            if (!isRealState(destinationState)) {
+                pendingTransitionPath.push(transition);
                 continue;
             }
 
-            const { _currentNode: currentNode } = this;
-
-            const transitionMatch = this._matchCurrentNodeTransition(remainTimePiece);
-
-            if (transitionMatch) {
-                const {
-                    transition,
-                    requires: updateRequires,
-                } = transitionMatch;
-
-                remainTimePiece -= updateRequires;
-
-                this._accumulateCurrentStateDeltaTime(updateRequires);
-
-                const ranIntoNonMotionState = this._switchTo(transition);
-                if (ranIntoNonMotionState) {
-                    break;
-                }
-
-                continueNextIterationForce = true;
-            } else { // If no transition matched, we update current node.
-                this._accumulateCurrentStateDeltaTime(remainTimePiece);
-                remainTimePiece = 0.0;
-                continue;
+            // We found a self transition A->A, the transition is meaningless and not allowed.
+            if (destinationState === currentMatchingSource) {
+                break;
             }
+
+            this._activateTransition(pendingTransitionPath, transition);
+            pendingTransitionPath.length = 0;
         }
 
-        this._commitStateUpdates(context);
+        pendingTransitionPath.length = 0;
+    }
 
-        return remainTimePiece;
+    private _resetStateTickFlagsAndWeights () {
+        const {
+            _currentNode: currentNode,
+            _activatedTransitions: activatedTransitions,
+        } = this;
+
+        currentNode.resetTickFlagsAndWeight();
+        for (let iTransition = 0; iTransition < activatedTransitions.length; ++iTransition) {
+            const { destination } = activatedTransitions[iTransition];
+            destination.resetTickFlagsAndWeight();
+        }
     }
 
     private _commitStateUpdates (parentContext: AnimationGraphUpdateContext) {
         const {
-            _currentNode: currentState,
-            _currentTransitionToNode: nextState,
+            _currentNode: currentNode,
+            _activatedTransitions: activatedTransitions,
             _updateContextGenerator: updateContextGenerator,
-            _transitionAlpha: transitionAlpha,
         } = this;
 
-        const currentStateWeight = nextState ? (1.0 - transitionAlpha) : 1.0;
+        // Update head state.
+        this._commitStateUpdate(currentNode, parentContext);
 
-        if (this._fromUpdated) {
-            const { _fromUpdateDeltaTime: fromUpdateDeltaTime } = this;
-            this._fromUpdated = false;
-            this._fromUpdateDeltaTime = 0.0;
-            if (currentState.kind === NodeKind.animation) {
-                currentState.triggerFromPortUpdate(this._controller);
-            } else if (currentState.kind === NodeKind.pose) {
-                const updateContext = updateContextGenerator.generate(
-                    fromUpdateDeltaTime,
-                    parentContext.indicativeWeight * currentStateWeight,
-                );
-                currentState.update(updateContext);
-            }
+        // Update states in transitions.
+        for (let iTransition = 0; iTransition < activatedTransitions.length; ++iTransition) {
+            const transition = activatedTransitions[iTransition];
+            const { destination } = transition;
+            this._commitStateUpdate(destination, parentContext);
         }
+    }
 
-        if (nextState && this._toUpdated) {
-            const { _toUpdateDeltaTime: toUpdateDeltaTime } = this;
-            this._toUpdated = false;
-            this._toUpdateDeltaTime = 0.0;
-            if (nextState.kind === NodeKind.animation) {
-                nextState.triggerToPortUpdate(this._controller);
-            } else if (nextState.kind === NodeKind.pose) {
-                const updateContext = updateContextGenerator.generate(
-                    toUpdateDeltaTime,
-                    parentContext.indicativeWeight * (1.0 - currentStateWeight),
-                );
-                nextState.update(updateContext);
-            }
+    private _commitStateUpdate (state: NodeEval, parentContext: AnimationGraphUpdateContext) {
+        const {
+            _updateContextGenerator: updateContextGenerator,
+        } = this;
+        if (state.testTickFlag(StateTickFlag.UPDATED)) { // Don't evaluate a pose more than once.
+            return;
+        }
+        state.setTickFlag(StateTickFlag.UPDATED);
+        if (state.kind === NodeKind.animation) {
+            state.update(parentContext.deltaTime, this._controller);
+        } else if (state.kind === NodeKind.pose) {
+            const updateContext = updateContextGenerator.generate(
+                parentContext.deltaTime,
+                parentContext.indicativeWeight * state.absoluteWeight,
+            );
+            state.update(updateContext);
         }
     }
 
     private _sample (context: AnimationGraphEvaluationContext): Pose | null {
         const {
             _currentNode: currentNode,
-            _currentTransitionToNode: currentTransitionToNode,
+            _activatedTransitions: activatedTransitions,
         } = this;
 
-        this.passthroughWeight = 1.0;
+        let passthroughWeight = 1.0;
 
-        const destinationWeight = currentTransitionToNode ? this._transitionAlpha : 0.0;
-
-        let finalPose: Pose | null;
+        // Evaluate head state.
+        let finalPose: Pose | null = null;
+        let sumActualBlendedWeight = 0.0;
         if (currentNode.kind === NodeKind.animation) {
-            finalPose = currentNode.sampleFromPort(context) ?? this._pushNullishPose(context);
+            finalPose = currentNode.evaluate(context) ?? this._pushNullishPose(context);
         } else if (currentNode.kind === NodeKind.pose) {
             finalPose = currentNode.evaluate(context) ?? this._pushNullishPose(context);
-        } else if (currentNode.kind === NodeKind.transitionSnapshot) {
-            finalPose = currentNode.sample(context) ?? this._pushNullishPose(context);
         } else {
-            this.passthroughWeight -= (1.0 - destinationWeight);
+            passthroughWeight -= currentNode.absoluteWeight;
             finalPose = null;
         }
+        if (finalPose) {
+            sumActualBlendedWeight = currentNode.absoluteWeight;
+        }
+        currentNode.setTickFlag(StateTickFlag.EVALUATED);
 
-        if (!currentTransitionToNode) {
-            return finalPose;
+        for (let iTransition = 0; iTransition < activatedTransitions.length; ++iTransition) {
+            const transition = activatedTransitions[iTransition];
+            const { destination } = transition;
+            if (destination.testTickFlag(StateTickFlag.EVALUATED)) { // Don't evaluate a pose more than once.
+                continue;
+            }
+            destination.setTickFlag(StateTickFlag.EVALUATED);
+            const destAbsoluteWeight = destination.absoluteWeight;
+            let destPose: Pose | null;
+            if (destination.kind === NodeKind.empty) {
+                passthroughWeight -= destAbsoluteWeight;
+                destPose = null;
+            } else {
+                destPose = destination.evaluate(context) ?? this._pushNullishPose(context);
+            }
+            if (!destPose) { // We can't get a pose from transition destination.
+                continue;
+            }
+            if (!finalPose) { // All previous states can't get a pose.
+                finalPose = destPose;
+            } else {
+                sumActualBlendedWeight += destAbsoluteWeight;
+                if (sumActualBlendedWeight) {
+                    const t = destAbsoluteWeight / sumActualBlendedWeight;
+                    blendPoseInto(finalPose, destPose, t);
+                    context.popPose();
+                } else {
+                    finalPose = destPose;
+                }
+            }
         }
 
-        let destPose: Pose | null;
-        if (currentTransitionToNode.kind === NodeKind.animation) {
-            destPose = currentTransitionToNode.sampleToPort(context) ?? this._pushNullishPose(context);
-        } else if (currentTransitionToNode.kind === NodeKind.pose) {
-            destPose = currentTransitionToNode.evaluate(context) ?? this._pushNullishPose(context);
-        } else {
-            this.passthroughWeight -= this._transitionAlpha;
-            destPose = null;
-        }
-
-        // If either(or both) of the states is empty. Returns the non empty state(or null).
-        if (!destPose) {
-            return finalPose;
-        }
-        if (!finalPose) {
-            return destPose;
-        }
-
-        blendPoseInto(finalPose, destPose, destinationWeight);
-        context.popPose();
+        this.passthroughWeight = passthroughWeight;
 
         return finalPose;
     }
@@ -626,41 +589,25 @@ class TopLevelStateMachineEvaluation {
     }
 
     /**
-     * Searches for a transition which should be performed
-     * if current node update for no more than `deltaTime`.
-     * @param deltaTime
+     * Searches for a transition which should be performed.
+     * @param sourceState The transition source state.
+     * @param useFromPort See `this._matchTransition`.
      * @returns
      */
-    private _matchCurrentNodeTransition (deltaTime: Readonly<number>): TransitionMatch | null {
-        const currentNode = this._currentNode;
-
-        const transitionMatch = transitionMatchCache.reset();
-
-        this._matchTransition(
-            currentNode,
-            true,
-            currentNode,
-            deltaTime,
-            transitionMatch,
+    private _matchNextTransition (sourceState: NodeEval): TransitionEval | null {
+        const transition = this._matchTransition(
+            sourceState,
+            sourceState,
         );
-        if (transitionMatch.hasZeroCost()) {
-            return transitionMatch;
+        if (transition) {
+            return transition;
         }
 
-        if (currentNode.kind === NodeKind.animation) {
-            this._matchAnyScoped(
-                currentNode,
-                true,
-                deltaTime,
-                transitionMatch,
-            );
-            if (transitionMatch.hasZeroCost()) {
-                return transitionMatch;
+        if (sourceState.kind === NodeKind.animation) {
+            const transition = this._matchAnyScoped(sourceState);
+            if (transition) {
+                return transition;
             }
-        }
-
-        if (transitionMatch.isValid()) {
-            return transitionMatch;
         }
 
         return null;
@@ -670,28 +617,21 @@ class TopLevelStateMachineEvaluation {
      * Notes the real node is used:
      * - to determinate the starting state machine from where the any states are matched;
      * - so we can solve transitions' relative durations.
-     * @param isCurrentState See `_matchTransition`.
+     * @param useFromPort See `_matchTransition`.
      */
-    private _matchAnyScoped (realNode: MotionStateEval, isCurrentState: boolean, deltaTime: number, result: TransitionMatchCache) {
-        let transitionMatchUpdated = false;
+    private _matchAnyScoped (realNode: VMSMInternalState) {
         for (let ancestor: StateMachineInfo | null = realNode.stateMachine;
             ancestor !== null;
             ancestor = ancestor.parent) {
-            const updated = this._matchTransition(
+            const transition = this._matchTransition(
                 ancestor.any,
-                isCurrentState,
                 realNode,
-                deltaTime,
-                result,
             );
-            if (updated) {
-                transitionMatchUpdated = true;
-            }
-            if (result.hasZeroCost()) {
-                break;
+            if (transition) {
+                return transition;
             }
         }
-        return transitionMatchUpdated;
+        return null;
     }
 
     /**
@@ -699,22 +639,14 @@ class TopLevelStateMachineEvaluation {
      * if specified node updates for no more than `deltaTime` and less than `result.requires`.
      * We solve the relative durations of transitions based on duration of `realNode`.
      *
-     * @param isCurrentState True if `node` is current state or "interruption source state"(see `getInterruptionSourceMotion`) of current state.
-     * In detail:
-     * | State machine                          | This method is used for            | `isCurrentState` should be    |
-     * | -------------------------------------- | ---------------------------------- | ----------------------------- |
-     * | No transition <br/> Current state is A | detecting transition from A        | true                          |
-     * | In transition <br/> A --> B            | detecting interruption from A or B | true for A <br/> false for B  |
-     *
-     * @returns True if a transition match is updated into the `result`.
+     * @returns The transition matched, or null if there's no matched transition.
      */
     private _matchTransition (
-        node: NodeEval, isCurrentState: boolean, realNode: NodeEval, deltaTime: Readonly<number>, result: TransitionMatchCache,
+        node: NodeEval, realNode: NodeEval,
     ) {
         assertIsTrue(node === realNode || node.kind === NodeKind.any);
         const { outgoingTransitions } = node;
         const nTransitions = outgoingTransitions.length;
-        let resultUpdated = false;
         for (let iTransition = 0; iTransition < nTransitions; ++iTransition) {
             const transition = outgoingTransitions[iTransition];
             if (transition.activated) {
@@ -728,9 +660,7 @@ class TopLevelStateMachineEvaluation {
             if (nConditions === 0) {
                 if (node.kind === NodeKind.entry || node.kind === NodeKind.exit) {
                     // These kinds of transition is definitely chosen.
-                    result.set(transition, 0.0);
-                    resultUpdated = true;
-                    break;
+                    return transition;
                 }
                 if (!transition.exitConditionEnabled) {
                     // Invalid transition, ignored.
@@ -738,15 +668,11 @@ class TopLevelStateMachineEvaluation {
                 }
             }
 
-            let deltaTimeRequired = 0.0;
-
             if (realNode.kind === NodeKind.animation && transition.exitConditionEnabled) {
                 const exitTime = realNode.duration * transition.exitCondition;
-                const currentStateTime = isCurrentState ? realNode.fromPortTime : realNode.toPortTime;
-                deltaTimeRequired = Math.max(exitTime - currentStateTime, 0.0);
-                // Note: the >= is reasonable in compare to >: we select the first-minimal requires.
-                if (deltaTimeRequired > deltaTime || deltaTimeRequired >= result.requires) {
-                    continue;
+                const currentStateTime = realNode.time;
+                if (currentStateTime < exitTime) {
+                    break;
                 }
             }
 
@@ -762,464 +688,168 @@ class TopLevelStateMachineEvaluation {
                 continue;
             }
 
-            if (deltaTimeRequired === 0.0) {
-                // Exit condition is disabled or the exit condition is just 0.0.
-                result.set(transition, 0.0);
-                resultUpdated = true;
-                break;
-            }
-
-            assertIsTrue(deltaTimeRequired <= result.requires);
-            result.set(transition, deltaTimeRequired);
-            resultUpdated = true;
+            // Arrive here means all conditions are satisfied,
+            // and either the exit condition is disabled or the exit condition is just 0.0.
+            return transition;
         }
-        return resultUpdated;
-    }
-
-    /**
-     * Try switch current node or transition snapshot using specified transition.
-     * @param transition The transition.
-     * @returns If the transition finally ran into entry/exit state.
-     */
-    private _switchTo (transition: TransitionEval) {
-        this._consumeTransition(transition);
-
-        const motionNode = this._matchTransitionPathUntilMotion();
-        if (motionNode) {
-            // Apply transitions
-            this._doTransitionToMotion(motionNode);
-            return false;
-        } else {
-            return true;
-        }
-    }
-
-    /**
-     * Called every frame(not every iteration).
-     * Returns if we ran into an entry/exit node and still no satisfied transition matched this frame.
-     */
-    private _continueDanglingTransition () {
-        const {
-            _currentTransitionPath: currentTransitionPath,
-        } = this;
-
-        const lenCurrentTransitionPath = currentTransitionPath.length;
-
-        if (lenCurrentTransitionPath === 0) {
-            return false;
-        }
-
-        const lastTransition = currentTransitionPath[lenCurrentTransitionPath - 1];
-        const tailNode = lastTransition.to;
-
-        if (!isRealState(tailNode)) {
-            const motionNode = this._matchTransitionPathUntilMotion();
-            if (motionNode) {
-                // Apply transitions
-                this._doTransitionToMotion(motionNode);
-                return false;
-            } else {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private _matchTransitionPathUntilMotion () {
-        const {
-            _currentTransitionPath: currentTransitionPath,
-        } = this;
-
-        const lenCurrentTransitionPath = currentTransitionPath.length;
-        assertIsTrue(lenCurrentTransitionPath !== 0);
-
-        const lastTransition = currentTransitionPath[lenCurrentTransitionPath - 1];
-        let tailNode = lastTransition.to;
-        for (; !isRealState(tailNode);) {
-            const transitionMatch = transitionMatchCache.reset();
-            this._matchTransition(
-                tailNode,
-                false,
-                tailNode,
-                0.0,
-                transitionMatch,
-            );
-            if (!transitionMatch.transition) {
-                break;
-            }
-            const transition = transitionMatch.transition;
-            this._consumeTransition(transition);
-            tailNode = transition.to;
-        }
-
-        return isRealState(tailNode) ? tailNode : null;
-    }
-
-    private _consumeTransition (transition: TransitionEval) {
-        const { to } = transition;
-
-        if (to.kind === NodeKind.entry) {
-            // We're entering a state machine
-            this._callEnterMethods(to);
-        }
-
-        transition.activated = true;
-        this._currentTransitionPath.push(transition);
-    }
-
-    private _resetTriggersAlongThePath () {
-        const { _currentTransitionPath: currentTransitionPath } = this;
-
-        const nTransitions = currentTransitionPath.length;
-        for (let iTransition = 0; iTransition < nTransitions; ++iTransition) {
-            const transition = currentTransitionPath[iTransition];
-            this._resetTriggersOnTransition(transition);
-        }
-    }
-
-    private _doTransitionToMotion (targetNode: RealState) {
-        const {
-            _currentTransitionPath: currentTransitionPath,
-        } = this;
-
-        assertIsTrue(currentTransitionPath.length !== 0);
-
-        // Reset triggers
-        this._resetTriggersAlongThePath();
-
-        this._transitionProgress = 0.0;
-        this._currentTransitionToNode = targetNode;
-        this._toUpdated = false;
-
-        if (targetNode.kind === NodeKind.animation) {
-            const {
-                destinationStart,
-                relativeDestinationStart,
-            } = currentTransitionPath[0];
-            const destinationStartRatio = relativeDestinationStart
-                ? destinationStart
-                : targetNode.duration === 0
-                    ? 0.0
-                    : destinationStart / targetNode.duration;
-            targetNode.resetToPort(destinationStartRatio);
-        } else if (targetNode.kind === NodeKind.pose) {
-            targetNode.reenter();
-        }
-        this._callEnterMethods(targetNode);
-    }
-
-    /**
-     * Update current transition.
-     * Asserts: `!!this._currentTransition`.
-     * @param deltaTime Time piece.
-     * @returns
-     */
-    private _updateCurrentTransition (deltaTime: number) {
-        const {
-            _currentTransitionPath: currentTransitionPath,
-            _currentTransitionToNode: currentTransitionToNode,
-        } = this;
-
-        assertIsNonNullable(currentTransitionPath.length > 0);
-        assertIsNonNullable(currentTransitionToNode);
-
-        const currentTransition = currentTransitionPath[0];
-
-        const {
-            duration: transitionDuration,
-            normalizedDuration,
-        } = currentTransition;
-
-        const fromNode = this._currentNode;
-        const toNode = currentTransitionToNode;
-
-        let contrib = 0.0;
-        let ratio = 0.0;
-        if (transitionDuration <= 0) {
-            contrib = 0.0;
-            ratio = 1.0;
-        } else {
-            assertIsTrue(isRealState(fromNode) || fromNode.kind === NodeKind.transitionSnapshot);
-            const { _transitionProgress: transitionProgress } = this;
-            const durationSeconds = (fromNode.kind === NodeKind.empty || fromNode.kind === NodeKind.pose)
-                ? transitionDuration
-                : normalizedDuration
-                    ? transitionDuration * (fromNode.kind === NodeKind.animation ? fromNode.duration : fromNode.first.duration)
-                    : transitionDuration;
-            const progressSeconds = transitionProgress * durationSeconds;
-            const remain = durationSeconds - progressSeconds;
-            assertIsTrue(remain >= 0.0);
-            contrib = Math.min(remain, deltaTime);
-            ratio = this._transitionProgress = (progressSeconds + contrib) / durationSeconds;
-            assertIsTrue(ratio >= 0.0 && ratio <= 1.0);
-        }
-
-        const toNodeName = toNode?.name ?? '<Empty>';
-
-        this._transitionAlpha = ratio;
-
-        const shouldUpdatePorts = contrib !== 0;
-        const hasFinished = ratio === 1.0;
-
-        if (shouldUpdatePorts) {
-            this._accumulateCurrentStateDeltaTime(contrib);
-        }
-
-        if (shouldUpdatePorts) {
-            this._toUpdated = true;
-            this._toUpdateDeltaTime += contrib;
-            if (toNode.kind === NodeKind.animation && shouldUpdatePorts) {
-                toNode.updateToPort(contrib);
-            }
-        }
-
-        if (hasFinished) {
-            // Transition done.
-            this._finishCurrentTransition();
-        }
-
-        return contrib;
-    }
-
-    private _finishCurrentTransition () {
-        const {
-            _currentTransitionPath: currentTransitionPath,
-            _currentTransitionToNode: currentTransitionToNode,
-        } = this;
-
-        assertIsNonNullable(currentTransitionPath.length > 0);
-        assertIsNonNullable(currentTransitionToNode);
-
-        const fromNode = this._currentNode;
-        const toNode = currentTransitionToNode;
-
-        this._callExitMethods(fromNode);
-        // Exiting overrides the updating
-        // Processed below.
-        // this._fromUpdated = false;
-        const { _currentTransitionPath: transitions } = this;
-        const nTransition = transitions.length;
-        for (let iTransition = 0; iTransition < nTransition; ++iTransition) {
-            const { to } = transitions[iTransition];
-            if (to.kind === NodeKind.exit) {
-                this._callExitMethods(to);
-            }
-        }
-        this._fromUpdated = this._toUpdated;
-        this._fromUpdateDeltaTime = this._toUpdateDeltaTime;
-        this._toUpdated = false;
-        this._toUpdateDeltaTime = 0.0;
-        this._dropCurrentTransition(true);
-        this._currentNode = toNode;
-        if (fromNode.kind === NodeKind.transitionSnapshot) {
-            fromNode.clear();
-        }
-    }
-
-    private _dropCurrentTransition (inactivate: boolean) {
-        const {
-            _currentTransitionPath: currentTransitionPath,
-            _currentTransitionToNode: currentTransitionToNode,
-        } = this;
-        assertIsNonNullable(currentTransitionToNode);
-        if (currentTransitionToNode.kind === NodeKind.animation) {
-            currentTransitionToNode.finishTransition();
-        }
-        if (inactivate) {
-            const nTransitions = currentTransitionPath.length;
-            for (let iTransition = 0; iTransition < nTransitions; ++iTransition) {
-                currentTransitionPath[iTransition].activated = false;
-            }
-        }
-        this._currentTransitionToNode = null;
-        currentTransitionPath.length = 0;
-        // Make sure we won't suffer from precision problem
-        this._transitionAlpha = 0.0;
-    }
-
-    private _detectInterruption (remainTimePiece: number, result: InterruptingTransitionMatchCache): InterruptingTransitionMatch | null {
-        const {
-            _currentTransitionPath: currentTransitionPath,
-            _currentNode: currentNode,
-            _currentTransitionToNode: currentTransitionToNode,
-        } = this;
-
-        if (currentNode.kind !== NodeKind.animation
-            && currentNode.kind !== NodeKind.transitionSnapshot) {
-            return null;
-        }
-
-        if (!currentTransitionToNode
-            || currentTransitionToNode.kind !== NodeKind.animation) {
-            return null;
-        }
-
-        assertIsTrue(currentTransitionPath.length !== 0);
-        const currentTransition = currentTransitionPath[0];
-        const { interruption } = currentTransition;
-        if (interruption === TransitionInterruptionSource.NONE) {
-            return null;
-        }
-
-        const transitionMatch = transitionMatchCache.reset();
-        let transitionMatchSource: MotionStateEval | null = null;
-
-        // We have to decide what to be used as unit 1
-        // to interpret the relative transition duration.
-        const anyTransitionMeasureBaseState = currentNode.kind === NodeKind.animation
-            ? currentNode
-            : currentNode.first;
-        let transitionMatchUpdated = this._matchAnyScoped(
-            anyTransitionMeasureBaseState,
-            true,
-            remainTimePiece,
-            transitionMatch,
-        );
-        if (transitionMatchUpdated) {
-            transitionMatchSource = anyTransitionMeasureBaseState; // TODO: shall be any?
-        }
-        if (transitionMatch.hasZeroCost()) {
-            // TODO
-        }
-
-        let motion0: MotionStateEval;
-        let motion0IsCurrentState = false;
-        if (interruption === TransitionInterruptionSource.CURRENT_STATE
-            || interruption === TransitionInterruptionSource.CURRENT_STATE_THEN_NEXT_STATE) {
-            motion0 = getInterruptionSourceMotion(currentNode);
-            motion0IsCurrentState = true;
-        } else {
-            motion0 = currentTransitionToNode;
-            motion0IsCurrentState = false;
-        }
-        transitionMatchUpdated = this._matchTransition(
-            motion0,
-            motion0IsCurrentState,
-            motion0,
-            remainTimePiece,
-            transitionMatch,
-        );
-        if (transitionMatchUpdated) {
-            transitionMatchSource = motion0;
-        }
-        if (transitionMatch.hasZeroCost()) {
-            // TODO
-        }
-
-        let motion1: MotionStateEval | null = null;
-        let motion1IsCurrentState = false;
-        if (interruption === TransitionInterruptionSource.NEXT_STATE_THEN_CURRENT_STATE) {
-            motion1 = getInterruptionSourceMotion(currentNode);
-            motion1IsCurrentState = true;
-        } else if (interruption === TransitionInterruptionSource.CURRENT_STATE_THEN_NEXT_STATE) {
-            motion1 = currentTransitionToNode;
-            motion1IsCurrentState = false;
-        }
-        if (motion1) {
-            transitionMatchUpdated = this._matchTransition(
-                motion1,
-                motion1IsCurrentState,
-                motion1,
-                remainTimePiece,
-                transitionMatch,
-            );
-            if (transitionMatchUpdated) {
-                transitionMatchSource = motion1;
-            }
-            if (transitionMatch.hasZeroCost()) {
-                // TODO
-            }
-        }
-
-        if (transitionMatchCache.transition) {
-            assertIsNonNullable(transitionMatchSource);
-            return result.set(
-                transitionMatchSource,
-                transitionMatchCache.transition,
-                transitionMatchCache.requires,
-            );
-        }
-
         return null;
     }
 
-    /**
-     * Important: `transitionSource` may not be `this._currentNode`.
-     */
-    private _interrupt ({
-        from: transitionSource,
-        transition,
-        requires: transitionRequires,
-    }: InterruptingTransitionMatch) {
-        const {
-            _currentNode: currentNode,
-        } = this;
-        assertIsTrue(currentNode.kind === NodeKind.animation || currentNode.kind === NodeKind.transitionSnapshot);
-        // If we're interrupting motion->*,
-        // we update the motion then do the first enqueue to transition snapshot.
-        this._accumulateCurrentStateDeltaTime(transitionRequires);
-        if (currentNode.kind === NodeKind.animation) {
-            const { _transitionSnapshot: transitionSnapshot } = this;
-            assertIsTrue(transitionSnapshot.empty);
-            transitionSnapshot.enqueue(currentNode, 1.0);
+    private _activateTransition (
+        prefix: readonly TransitionEval[],
+        lastTransition: TransitionEval,
+    ) {
+        const destinationState = lastTransition.to;
+        assertIsTrue(isRealState(destinationState));
+
+        const activatedTransition = this._activatedTransitionPool.alloc();
+        activatedTransition.reset(prefix, lastTransition);
+        this._activatedTransitions.push(activatedTransition);
+
+        // Reset triggers along the path.
+        const nTransitions = activatedTransition.path.length;
+        for (let iTransition = 0; iTransition < nTransitions; ++iTransition) {
+            const transition = activatedTransition.path[iTransition];
+            this._resetTriggersOnTransition(transition);
         }
-        this._takeCurrentTransitionSnapshot(transitionSource);
-        // Drop transitions.
-        // Do not inactivate the transitions since in snapshot mode, transitions are treated as inactivated.
-        // They will be inactivated when the snapshot is cleared.
-        this._dropCurrentTransition(false);
-        // Install the snapshot as "current"
-        this._currentNode = this._transitionSnapshot;
-        const ranIntoNonMotionState = this._switchTo(transition);
-        return ranIntoNonMotionState;
+
+        // Increase active reference on the state.
+        const previousActiveReferenceCount = destinationState.activeReferenceCount;
+        destinationState.increaseActiveReference();
+
+        // If this is the initial activation, reenter the state.
+        if (previousActiveReferenceCount === 0) {
+            if (destinationState.kind === NodeKind.animation) {
+                const {
+                    destinationStart,
+                    isRelativeDestinationStart,
+                } = activatedTransition;
+                const destinationStartRatio = isRelativeDestinationStart
+                    ? destinationStart
+                    : destinationState.duration === 0
+                        ? 0.0
+                        : destinationStart / destinationState.duration;
+                destinationState.reenter(destinationStartRatio);
+            } else if (destinationState.kind === NodeKind.pose) {
+                destinationState.reenter();
+            }
+        }
+
+        // Call enter hooks on detailed transitions.
+        for (let iDetailedTransition = 0; iDetailedTransition < activatedTransition.path.length; ++iDetailedTransition) {
+            const detailedTransition = activatedTransition.path[iDetailedTransition];
+            // We're entering a state machine
+            this._callEnterMethods(detailedTransition.to);
+        }
     }
 
     /**
-     * A thing to note is `transitionSource` may not be `this._currentNode`.
+     * Update transitions, also update states within(includes the case of no transition).
+     * @param deltaTime Time piece.
+     * @returns
      */
-    private _takeCurrentTransitionSnapshot (transitionSource: MotionStateEval) {
+    private _updateActivatedTransitions (deltaTime: number) {
         const {
-            _currentTransitionPath: currentTransitionPath,
-            _currentTransitionToNode: currentTransitionToNode,
-            _transitionSnapshot: transitionSnapshot,
+            _activatedTransitions: activatedTransitions,
         } = this;
 
-        assertIsTrue(currentTransitionPath.length !== 0);
-        assertIsTrue(currentTransitionToNode && currentTransitionToNode.kind === NodeKind.animation);
+        let iTransition = activatedTransitions.length - 1;
 
-        const currentTransition = currentTransitionPath[0];
+        // Asserts: while updating transition sequences,
+        // the "update consume time" of the last transition, let's say _t_,
+        // always not less than those of preceding transitions.
+        // The reason is, if it's less than, means the last transition does not consume all the `deltaTime`,
+        // which further means the last transition was done and
+        // once the last transition was done, all preceding transitions are dropped.
+        //
+        // All states involved after updating shall also update _t_ times.
 
+        let remainingWeight = 1.0;
+
+        let lastTransitionIndex = iTransition;
+        for (; iTransition >= 0; --iTransition) {
+            const transition = activatedTransitions[iTransition];
+            const sourceState = iTransition === 0
+                ? this._currentNode
+                : activatedTransitions[iTransition - 1].destination;
+            transition.update(deltaTime, sourceState);
+
+            // Once the transition is done, all previous transitions should be dropped
+            // and we could break loop directly.
+            if (transition.done) {
+                this._dropActivatedTransitions(lastTransitionIndex);
+                break;
+            }
+
+            // Allocate weight for the destination state.
+            const destinationWeight = transition.normalizedElapsedTime * remainingWeight;
+            transition.destination.increaseAbsoluteWeight(destinationWeight);
+            remainingWeight *= (1.0 - transition.normalizedElapsedTime);
+
+            lastTransitionIndex = iTransition - 1;
+        }
+
+        // Allocate remain weight to the latest current state.
+        this._currentNode.increaseAbsoluteWeight(remainingWeight);
+    }
+
+    /**
+     * Drops the transitions from `0` to `lastTransitionIndex` in `this._activatedTransitions`.
+     * @note This methods may modifies the length of `this._activatedTransitions`.
+     */
+    private _dropActivatedTransitions (lastTransitionIndex: number) {
         const {
-            duration: transitionDuration,
-            normalizedDuration,
-        } = currentTransition;
+            _activatedTransitions: activatedTransition,
+            _activatedTransitionPool: activatedTransitionPool,
+        } = this;
+        assertIsTrue(lastTransitionIndex >= 0 && lastTransitionIndex < activatedTransition.length);
 
-        const fromNode = transitionSource;
-        let ratio = 0.0;
-        if (transitionDuration <= 0) {
-            ratio = 1.0;
+        const lenSubpath = (lastTransitionIndex - 0) + 1;
+
+        const newCurrentState = activatedTransition[lastTransitionIndex].destination;
+
+        // Call exist hooks, then destroy the transition instance.
+        this._callExitMethods(this._currentNode);
+        for (let iTransition = 0; iTransition <= lastTransitionIndex; ++iTransition) {
+            const transition = activatedTransition[iTransition];
+
+            // Except last transition,
+            // all transitions' should have their destination state decreasing active reference.
+            // The last transition don't need to decrease
+            // since it will become current node.
+            if (iTransition !== lastTransitionIndex) {
+                transition.destination.decreaseActiveReference();
+            }
+
+            // Call exit hooks on detailed transitions.
+            // If this is NOT the last transition, all detailed transitions would be exit.
+            // Otherwise, the last detailed transition is not included.
+            const iLastExitingDetailedTransition = iTransition === lastTransitionIndex
+                ? transition.path.length - 1
+                : transition.path.length;
+            for (let iDetailedTransition = 0; iDetailedTransition < iLastExitingDetailedTransition; ++iDetailedTransition) {
+                const detailedTransition = transition.path[iDetailedTransition];
+                this._callExitMethods(detailedTransition.to);
+            }
+
+            activatedTransitionPool.free(transition);
+        }
+
+        // Splice the subpath.
+        if (lastTransitionIndex === activatedTransition.length - 1) {
+            // Optimize for the usual case: there's only one transition.
+            activatedTransition.length = 0;
         } else {
-            const { _transitionProgress: transitionProgress } = this;
-            const durationSeconds = normalizedDuration ? transitionDuration * fromNode.duration : transitionDuration;
-            const progressSeconds = transitionProgress * durationSeconds;
-            const remain = durationSeconds - progressSeconds;
-            assertIsTrue(remain >= 0.0);
-            ratio = progressSeconds / durationSeconds;
-            assertIsTrue(ratio >= 0.0 && ratio <= 1.0);
+            // General case: this should be same with `activatedTransition.splice(firstTransitionIndex, lenSubpath)`.
+            for (let iTransition = lastTransitionIndex + 1; iTransition < activatedTransition.length; ++iTransition) {
+                activatedTransition[iTransition - lenSubpath] = activatedTransition[iTransition];
+            }
+            activatedTransition.length -= lenSubpath;
         }
 
-        transitionSnapshot.enqueue(currentTransitionToNode, ratio);
-        transitionSnapshot.transferTransitions(currentTransitionPath);
-    }
-
-    private _accumulateCurrentStateDeltaTime (deltaTime: number) {
-        const { _currentNode: currentNode } = this;
-        this._fromUpdated = true;
-        this._fromUpdateDeltaTime += deltaTime;
-        if (currentNode.kind === NodeKind.animation) {
-            currentNode.updateFromPort(deltaTime);
-        }
+        // Redefine the very first state.
+        this._currentNode.decreaseActiveReference();
+        this._currentNode = newCurrentState;
     }
 
     private _resetTriggersOnTransition (transition: TransitionEval) {
@@ -1244,7 +874,7 @@ class TopLevelStateMachineEvaluation {
         default:
             break;
         case NodeKind.animation: {
-            node.components.callMotionStateEnterMethods(controller, node.getToPortStatus());
+            node.components.callMotionStateEnterMethods(controller, node.getStatus());
             break;
         }
         case NodeKind.entry:
@@ -1259,7 +889,7 @@ class TopLevelStateMachineEvaluation {
         default:
             break;
         case NodeKind.animation: {
-            node.components.callMotionStateExitMethods(controller, node.getFromPortStatus());
+            node.components.callMotionStateExitMethods(controller, node.getStatus());
             break;
         }
         case NodeKind.exit:
@@ -1274,39 +904,12 @@ export { TopLevelStateMachineEvaluation };
 /**
  * A real state is a state on which the state machine can really reside.
  */
-type RealState = MotionStateEval | PoseStateEval | EmptyStateEval;
+type RealState = VMSMInternalState | PoseStateEval | EmptyStateEval;
 
 function isRealState (stateEval: NodeEval): stateEval is RealState  {
     return stateEval.kind === NodeKind.animation
         || stateEval.kind === NodeKind.empty
         || stateEval.kind === NodeKind.pose;
-}
-
-/**
- * Gets the motion of current motion state or transition snapshot
- * whose outgoing transitions, called "interruption source", will be inspected to
- * detect the interrupting transition.
- */
-function getInterruptionSourceMotion (state: MotionStateEval | TransitionSnapshotEval) {
-    // If current state is a motion state, then it's the result.
-    // Otherwise the current state is a transition snapshot --
-    // we support nested interruptions, eg,
-    // _A->B_ was interrupted by _B->C_,
-    // then _(A->B)->C_ can be interrupted further by _C->D_.
-    // In such cases, we need to decide which transition could interrupt _(A->B)->C_.
-    // Outgoing transitions from destination motion are always inspected.
-    // And as the code following suggested, we order that:
-    // outgoing transitions from **the first** motion of "current transition snapshot"
-    // are also inspected. No other transitions are considered.
-    // This means for instance, in above example,
-    // _(A->B)->C_ can and can only be further interrupted by:
-    // - _A->D_, since it's outgoing from _A_;
-    // - _C->D_, since it's outgoing from _D_.
-    // However it can not be interrupted by _B->C_.
-    //
-    // > Tip: The term "nested interruption" was taken from here:
-    // > https://stackoverflow.com/a/24128928
-    return state.kind === NodeKind.animation ? state : state.first;
 }
 
 function createStateStatusCache (): MotionStateStatus {
@@ -1330,71 +933,9 @@ const emptyClipStatusesIterable: Iterable<ClipStatus> = Object.freeze({
     },
 });
 
-interface TransitionMatch {
-    /**
-     * The matched result.
-     */
-    transition: TransitionEval;
-
-    /**
-     * The after after which the transition can happen.
-     */
-    requires: number;
-}
-
-interface InterruptingTransitionMatch extends TransitionMatch {
-    from: MotionStateEval;
-}
-
-class TransitionMatchCache {
-    public transition: TransitionMatch['transition'] | null = null;
-
-    public requires = Infinity;
-
-    public hasZeroCost (): this is TransitionMatch {
-        return this.requires === 0;
-    }
-
-    public isValid (): this is TransitionMatch {
-        return this.transition !== null;
-    }
-
-    public set (transition: TransitionMatch['transition'], requires: number) {
-        this.transition = transition;
-        this.requires = requires;
-        return this;
-    }
-
-    public reset () {
-        this.requires = Infinity;
-        this.transition = null;
-        return this;
-    }
-}
-
-const transitionMatchCache = new TransitionMatchCache();
-
-class InterruptingTransitionMatchCache {
-    public transition: TransitionMatch['transition'] | null = null;
-
-    public requires = 0.0;
-
-    public from: InterruptingTransitionMatch['from'] | null = null;
-
-    public set (from: MotionStateEval, transition: TransitionMatch['transition'], requires: number) {
-        this.from = from;
-        this.transition = transition;
-        this.requires = requires;
-        return this as InterruptingTransitionMatch;
-    }
-}
-
-const interruptingTransitionMatchCache = new InterruptingTransitionMatchCache();
-
 enum NodeKind {
     entry, exit, any, animation,
     empty,
-    transitionSnapshot,
     pose,
 }
 
@@ -1412,7 +953,97 @@ export class StateEval {
 
     public readonly name: string;
 
-    public outgoingTransitions: readonly TransitionEval[] = [];
+    public outgoingTransitions: TransitionEval[] = [];
+
+    /**
+     * The absolute weight of this state.
+     */
+    get absoluteWeight () {
+        return this._absoluteWeight;
+    }
+
+    /**
+     * The count which counts how many places referencing this state:
+     * - If the state is activated as current state, the count increased.
+     * - If the state is activated as a transition destination, the count increased.
+     */
+    get activeReferenceCount () {
+        return this._activeReferenceCount;
+    }
+
+    public setPrefix_debug (prefix: string) {
+        this.__DEBUG_ID__ = `${prefix}${this.name}`;
+    }
+
+    public addTransition (transition: TransitionEval) {
+        this.outgoingTransitions.push(transition);
+    }
+
+    /**
+     * Increases an active reference.
+     */
+    public increaseActiveReference () {
+        if (this._activeReferenceCount === 0) {
+            this._absoluteWeight = 0.0;
+            this._tickFlags = 0;
+        }
+        ++this._activeReferenceCount;
+    }
+
+    /**
+     * Decrease an active reference.
+     */
+    public decreaseActiveReference () {
+        if (DEBUG) {
+            this._checkActivated();
+        }
+        --this._activeReferenceCount;
+    }
+
+    public resetTickFlagsAndWeight () {
+        this._checkActivated();
+        this._absoluteWeight = 0.0;
+        this._tickFlags = 0;
+    }
+
+    public increaseAbsoluteWeight (weight: number) {
+        this._absoluteWeight += weight;
+    }
+
+    public testTickFlag (flag: StateTickFlag) {
+        if (DEBUG) {
+            this._checkActivated();
+        }
+        return !!(this._tickFlags & flag);
+    }
+
+    public setTickFlag (flag: StateTickFlag) {
+        if (DEBUG) {
+            this._checkActivated();
+        }
+        assertIsTrue(!this.testTickFlag(flag), `Can not set ${StateTickFlag[flag]} since it has been set!`);
+        this._tickFlags |= flag;
+    }
+
+    private _activeReferenceCount = 0;
+    private _tickFlags = 0;
+    private _absoluteWeight = 0.0;
+
+    private _checkActivated () {
+        assertIsTrue(this._activeReferenceCount > 0, `The state has not been activated`);
+    }
+}
+
+enum StateTickFlag {
+    /**
+     * The state has been updated in this tick?
+     */
+    UPDATED = 1,
+
+    /**
+     * The state has been evaluated in this tick?
+     */
+    EVALUATED = 2,
 }
 
 type StateMachineComponentMotionStateCallbackName = keyof Pick<
@@ -1494,15 +1125,18 @@ interface StateMachineInfo {
     components: InstantiatedComponents | null;
 }
 
-export class MotionStateEval extends StateEval {
-    constructor (node: MotionState, context: AnimationGraphBindingContext, overrides: ReadonlyClipOverrideMap | null) {
-        super(node);
+/**
+ * Track the evaluation of a virtual motion state-machine.
+ */
+class VMSMEval {
+    constructor (state: MotionState, context: AnimationGraphBindingContext, overrides: ReadonlyClipOverrideMap | null) {
+        const name = state.name;
 
-        this._baseSpeed = node.speed;
+        this._baseSpeed = state.speed;
         this._setSpeedMultiplier(1.0);
 
-        if (node.speedMultiplierEnabled && node.speedMultiplier) {
-            const speedMultiplierVarName = node.speedMultiplier;
+        if (state.speedMultiplierEnabled && state.speedMultiplier) {
+            const speedMultiplierVarName = state.speedMultiplier;
             const varInstance = context.getVar(speedMultiplierVarName);
             if (validateVariableExistence(varInstance, speedMultiplierVarName)) {
                 validateVariableType(varInstance.type, VariableType.FLOAT, speedMultiplierVarName);
@@ -1512,20 +1146,18 @@ export class MotionStateEval extends StateEval {
             }
         }
 
-        const sourceEval = node.motion?.[createEval](context, overrides) ?? null;
+        const sourceEval = state.motion?.[createEval](context, overrides) ?? null;
         if (sourceEval) {
-            Object.defineProperty(sourceEval, '__DEBUG_ID__', { value: this.name });
+            Object.defineProperty(sourceEval, '__DEBUG_ID__', { value: name });
         }
 
         this._source = sourceEval;
 
-        this._fromPort = new MotionStateEvalPort(sourceEval?.createPort() ?? null);
-        this._toPort = new MotionStateEvalPort(sourceEval?.createPort() ?? null);
+        this._publicState = new VMSMInternalState(this, state, sourceEval?.createPort());
+        this._privateState = new VMSMInternalState(this, state, sourceEval?.createPort());
 
-        this.components = new InstantiatedComponents(node);
+        this.components = new InstantiatedComponents(state);
     }
-
-    public readonly kind = NodeKind.animation;
 
     public declare components: InstantiatedComponents;
 
@@ -1533,86 +1165,41 @@ export class MotionStateEval extends StateEval {
         return this._source?.duration ?? 0.0;
     }
 
-    get fromPortTime () {
-        return this._fromPort.progress * this.duration;
+    get speed () {
+        return this._speed;
     }
 
-    get toPortTime () {
-        if (DEBUG) {
-            // See `this.finishTransition()`
-            assertIsTrue(!Number.isNaN(this._toPort.progress));
+    get entry () {
+        return this._publicState;
+    }
+
+    get stateMachine () {
+        return this._stateMachine;
+    }
+
+    set stateMachine (value) {
+        this._stateMachine = value;
+        this._publicState.stateMachine = value;
+        this._privateState.stateMachine = value;
+    }
+
+    public setPrefix_debug (prefix: string) {
+        this._publicState.setPrefix_debug(prefix);
+        this._privateState.setPrefix_debug(prefix);
+    }
+
+    public addTransition (transition: Readonly<TransitionEval>) {
+        // If the transition is a self transition,
+        // copy the transition but modify it so that it point to the private state.
+        if (transition.to === this._publicState) {
+            this._publicState.addTransition({
+                ...transition,
+                to: this._privateState,
+            });
+        } else {
+            this._publicState.addTransition(transition);
         }
-        return this._toPort.progress * this.duration;
-    }
-
-    public updateFromPort (deltaTime: number) {
-        this._fromPort.progress = calcProgressUpdate(
-            this._fromPort.progress,
-            this.duration,
-            deltaTime * this._speed,
-        );
-    }
-
-    public updateToPort (deltaTime: number) {
-        if (DEBUG) {
-            // See `this.finishTransition()`
-            assertIsTrue(!Number.isNaN(this._toPort.progress));
-        }
-        this._toPort.progress = calcProgressUpdate(
-            this._toPort.progress,
-            this.duration,
-            deltaTime * this._speed,
-        );
-    }
-
-    public triggerFromPortUpdate (controller: AnimationController) {
-        this.components.callMotionStateUpdateMethods(controller, this.getFromPortStatus());
-    }
-
-    public triggerToPortUpdate (controller: AnimationController) {
-        this.components.callMotionStateUpdateMethods(controller, this.getToPortStatus());
-    }
-
-    public getFromPortStatus (): Readonly<MotionStateStatus> {
-        return this._fromPort.getStatus(this.name);
-    }
-
-    public getToPortStatus (): Readonly<MotionStateStatus> {
-        if (DEBUG) {
-            // See `this.finishTransition()`
-            assertIsTrue(!Number.isNaN(this._toPort.progress));
-        }
-        return this._toPort.getStatus(this.name);
-    }
-
-    public resetToPort (at: number) {
-        this._toPort.progress = at;
-    }
-
-    public finishTransition () {
-        this._fromPort.progress = this._toPort.progress;
-        if (DEBUG) {
-            // Well, this statement exists for debugging purpose.
-            // Once the transition was finished, this method is called to
-            // switch this motion from "target" to "source".
-            // After, this motion can no longer be used as "target"
-            // unless `this.resetToPort()` is called.
-            // Let's set progress of this motion's "to port" to NaN,
-            // to catch such a violation.
-            this._toPort.progress = Number.NaN;
-        }
-    }
-
-    public sampleFromPort (context: AnimationGraphEvaluationContext): Pose | null {
-        return this._fromPort.evaluate(context) ?? null;
-    }
-
-    public sampleToPort (context: AnimationGraphEvaluationContext): Pose | null {
-        if (DEBUG) {
-            // See `this.finishTransition()`
-            assertIsTrue(!Number.isNaN(this._toPort.progress));
-        }
-        return this._toPort.evaluate(context) ?? null;
+        this._privateState.addTransition(transition);
     }
 
     public getClipStatuses (baseWeight: number): Iterable<ClipStatus> {
@@ -1631,39 +1218,77 @@ export class MotionStateEval extends StateEval {
     }
 
     private _source: MotionEval | null = null;
-    private _fromPort: MotionStateEvalPort;
-    private _toPort: MotionStateEvalPort;
     private _baseSpeed = 1.0;
     private _speed = 1.0;
+    private _publicState: VMSMInternalState;
+    private _privateState: VMSMInternalState;
+    private declare _stateMachine: StateMachineInfo;
+    private declare _debugId: string;
 
     private _setSpeedMultiplier (value: number) {
         this._speed = this._baseSpeed * value;
     }
 }
 
-class MotionStateEvalPort {
-    constructor (motionPort: MotionPort | null) {
-        this.motionPort = motionPort;
+class VMSMInternalState extends StateEval {
+    public readonly kind = NodeKind.animation;
+
+    constructor (
+        container: VMSMEval,
+        containerState: MotionState,
+        port: MotionPort | undefined,
+    ) {
+        super(containerState);
+        this._container = container;
+        this._port = port;
     }
 
-    public readonly motionPort: MotionPort | null = null;
-
-    public progress = 0.0;
-
-    public readonly statusCache: MotionStateStatus = createStateStatusCache();
-
-    public evaluate (context: AnimationGraphEvaluationContext) {
-        return this.motionPort?.evaluate(this.progress, context);
+    get duration () {
+        return this._container.duration;
     }
 
-    public getStatus (name: string): Readonly<MotionStateStatus> {
-        const { statusCache: stateStatus } = this;
+    get components () {
+        return this._container.components;
+    }
+
+    get time () {
+        return this._progress * this._container.duration;
+    }
+
+    public reenter (initialTimeNormalized: number) {
+        this._progress = initialTimeNormalized;
+    }
+
+    public getStatus () {
+        const { _statusCache: stateStatus } = this;
         if (DEBUG) {
-            stateStatus.__DEBUG_ID__ = name;
+            stateStatus.__DEBUG_ID__ = this.name;
         }
-        stateStatus.progress = normalizeProgress(this.progress);
+        stateStatus.progress = normalizeProgress(this._progress);
         return stateStatus;
     }
+
+    public getClipStatuses (baseWeight: number): Iterable<ClipStatus> {
+        return this._container.getClipStatuses(baseWeight);
+    }
+
+    public update (deltaTime: number, controller: AnimationController) {
+        this._progress = calcProgressUpdate(
+            this._progress,
+            this.duration,
+            deltaTime * this._container.speed,
+        );
+        this._container.components.callMotionStateUpdateMethods(controller, this.getStatus());
+    }
+
+    public evaluate (context: AnimationGraphEvaluationContext) {
+        return this._port?.evaluate(this._progress, context) ?? null;
+    }
+
+    private _container: VMSMEval;
+    private _progress = 0.0;
+    private _port: MotionPort | undefined;
+    private readonly _statusCache: MotionStateStatus = createStateStatusCache();
 }
 
 function calcProgressUpdate (currentProgress: number, duration: number, deltaTime: number) {
@@ -1747,87 +1372,7 @@ class PoseStateEval extends StateEval {
     private _elapsedTime = 0.0;
 }
 
-class QueuedMotion {
-    constructor (public motion: MotionStateEval, public weight: number) {
-    }
-}
-
-class TransitionSnapshotEval extends StateEval {
-    public readonly kind = NodeKind.transitionSnapshot;
-
-    constructor () {
-        super({ name: `[[TransitionSnapshotEval]]` });
-    }
-
-    get empty () {
-        return this._queue.length === 0;
-    }
-
-    get first () {
-        const { _queue: queue } = this;
-        assertIsTrue(queue.length > 0);
-        return queue[0].motion;
-    }
-
-    public sample (context: AnimationGraphEvaluationContext): Pose {
-        const { _queue: queue } = this;
-        const nQueue = queue.length;
-        assertIsTrue(nQueue !== 0);
-        let finalPose: Pose | null = null;
-        let sumWeight = 0.0;
-        for (let iQueuedMotions = 0; iQueuedMotions < nQueue; ++iQueuedMotions) {
-            const {
-                motion,
-                weight: snapshotWeight,
-            } = queue[iQueuedMotions];
-            // Here implies: motions added to snapshot should have been switched from "target" to "source".
-            const queuedMotionPose = motion.sampleFromPort(context) ?? context.pushDefaultedPose();
-            sumWeight += snapshotWeight;
-            if (!finalPose) {
-                finalPose = queuedMotionPose;
-            } else {
-                if (sumWeight) {
-                    const t = snapshotWeight / sumWeight;
-                    blendPoseInto(finalPose, queuedMotionPose, t);
-                }
-                context.popPose();
-            }
-        }
-        return finalPose ?? context.pushDefaultedPose();
-    }
-
-    public clear () {
-        this._queue.length = 0;
-
-        const { _heldTransitions: heldTransitions } = this;
-        const nTransitions = heldTransitions.length;
-        for (let iTransition = 0; iTransition < nTransitions; ++iTransition) {
-            heldTransitions[iTransition].activated = false;
-        }
-    }
-
-    public enqueue (state: MotionStateEval, weight: number) {
-        const { _queue: queue } = this;
-        const nQueue = queue.length;
-        const complementWeight = 1.0 - weight;
-        for (let iQueuedMotions = 0; iQueuedMotions < nQueue; ++iQueuedMotions) {
-            queue[iQueuedMotions].weight *= complementWeight;
-        }
-        queue.push(new QueuedMotion(state, weight));
-    }
-
-    public transferTransitions (transitions: readonly TransitionEval[]) {
-        if (DEBUG) {
-            assertIsTrue(transitions.every((transition) => transition.activated));
-        }
-        this._heldTransitions.push(...transitions);
-    }
-
-    private _queue: QueuedMotion[] = [];
-    private _heldTransitions: TransitionEval[] = [];
-}
-
-export type NodeEval = MotionStateEval | SpecialStateEval | EmptyStateEval | TransitionSnapshotEval | PoseStateEval;
+export type NodeEval = VMSMInternalState | SpecialStateEval | EmptyStateEval | PoseStateEval;
 
 interface TransitionEval {
     to: NodeEval;
@@ -1842,10 +1387,112 @@ interface TransitionEval {
      * Bound triggers, once this transition satisfied. All triggers would be reset.
      */
     triggers: string[] | undefined;
-    interruption: TransitionInterruptionSource;
 
     /**
      * Whether the transition is activated, if it has already been activated, it can not be activated(matched) again.
      */
     activated: boolean;
+}
+
+/**
+ * Describes an activated transition to a **real state**.
+ */
+class ActivatedTransition {
+    /**
+     * The normalized time elapsed.
+     */
+    public normalizedElapsedTime = 0.0;
+
+    /**
+     * The detailed transitions along which the transition is activated.
+     * At least has one.
+     */
+    public path: TransitionEval[] = [];
+
+    public declare destination: RealState;
+
+    get done () {
+        return approx(this.normalizedElapsedTime, 1.0, 1e-6);
+    }
+
+    get destinationStart () {
+        return this.path[0].destinationStart;
+    }
+
+    get isRelativeDestinationStart () {
+        return this.path[0].relativeDestinationStart;
+    }
+
+    public getAbsoluteDuration (baseDurationState: NodeEval) {
+        return this._getAbsoluteDurationUnscaled(baseDurationState) * this._durationMultiplier;
+    }
+
+    public update (deltaTime: number, fromState: NodeEval) {
+        // If the transitions is not starting with a concrete state.
+        // We can directly finish the transition.
+        if (!isRealState(fromState)) {
+            this.normalizedElapsedTime = 1.0;
+            return;
+        }
+        const transitionDurationAbsolute = this.getAbsoluteDuration(fromState);
+        let contrib = 0.0;
+        if (transitionDurationAbsolute <= 0.0) {
+            contrib = 0.0;
+            this.normalizedElapsedTime = 1.0;
+        } else {
+            const elapsedTransitionTime = this.normalizedElapsedTime * transitionDurationAbsolute;
+            const remainTransitionTime = transitionDurationAbsolute - elapsedTransitionTime;
+            assertIsTrue(remainTransitionTime >= 0.0);
+            contrib = Math.min(remainTransitionTime, deltaTime);
+            const newTransitionProgress = clamp01((elapsedTransitionTime + contrib) / transitionDurationAbsolute);
+            this.normalizedElapsedTime = newTransitionProgress;
+            assertIsTrue(newTransitionProgress >= 0.0 && newTransitionProgress <= 1.0);
+        }
+    }
+
+    public static createPool (initialCapacity: number) {
+        const destructor = !DEBUG
+            ? undefined
+            : (transitionInstance: ActivatedTransition) => {
+                transitionInstance.normalizedElapsedTime = Number.NaN;
+            };
+
+        const pool = new Pool<ActivatedTransition>(
+            () => new ActivatedTransition(),
+            initialCapacity,
+            destructor,
+        );
+
+        return pool;
+    }
+
+    public reset (
+        prefix: readonly TransitionEval[],
+        lastTransition: TransitionEval,
+    ) {
+        const destinationState = lastTransition.to;
+        assertIsTrue(isRealState(destinationState));
+        this.normalizedElapsedTime = 0.0;
+        this.destination = destinationState;
+        this.path = [...prefix, lastTransition];
+        // More the existing destination weight, less the transition duration.
+        this._durationMultiplier = 1.0 - destinationState.absoluteWeight;
+    }
+
+    private _durationMultiplier = 1.0;
+
+    private _getAbsoluteDurationUnscaled (baseDurationState: NodeEval) {
+        assertIsTrue(this.path.length !== 0);
+        const {
+            duration,
+            normalizedDuration,
+        } = this.path[0];
+        if (!normalizedDuration) {
+            return duration;
+        }
+        const baseDuration = baseDurationState.kind === NodeKind.animation
+            ? baseDurationState.duration
+            : 1.0;
+        return baseDuration * duration;
+    }
 }

--- a/cocos/animation/marionette/state-machine/state-machine-eval.ts
+++ b/cocos/animation/marionette/state-machine/state-machine-eval.ts
@@ -190,7 +190,7 @@ class TopLevelStateMachineEvaluation {
         const lastActivatedTransition = activatedTransitions[activatedTransitions.length - 1];
         const baseDurationState = activatedTransitions.length === 1
             ? this._currentNode
-            : activatedTransitions[activatedTransitions.length - 2].destination;
+            : activatedTransitions[activatedTransitions.length - 2].destination; // Else, the previous transition's destination state.
         const absoluteDuration = lastActivatedTransition.getAbsoluteDuration(baseDurationState);
         transitionStatus.duration = absoluteDuration;
         transitionStatus.time = lastActivatedTransition.normalizedElapsedTime * absoluteDuration;
@@ -589,7 +589,6 @@ class TopLevelStateMachineEvaluation {
     /**
      * Searches for a transition which should be performed.
      * @param sourceState The transition source state.
-     * @param useFromPort See `this._matchTransition`.
      * @returns
      */
     private _matchNextTransition (sourceState: NodeEval): TransitionEval | null {
@@ -612,10 +611,9 @@ class TopLevelStateMachineEvaluation {
     }
 
     /**
-     * Notes the real node is used:
+     * @param realNode Is used:
      * - to determinate the starting state machine from where the any states are matched;
      * - so we can solve transitions' relative durations.
-     * @param useFromPort See `_matchTransition`.
      */
     private _matchAnyScoped (realNode: VMSMInternalState) {
         for (let ancestor: StateMachineInfo | null = realNode.stateMachine;
@@ -802,7 +800,7 @@ class TopLevelStateMachineEvaluation {
         } = this;
         assertIsTrue(lastTransitionIndex >= 0 && lastTransitionIndex < activatedTransition.length);
 
-        const lenSubpath = (lastTransitionIndex - 0) + 1;
+        const lenSubpath = lastTransitionIndex + 1;
 
         const newCurrentState = activatedTransition[lastTransitionIndex].destination;
 

--- a/tests/animation/animation-graph-asset.test.ts
+++ b/tests/animation/animation-graph-asset.test.ts
@@ -107,7 +107,6 @@ describe('Animation graph asset', () => {
             t1.exitCondition = 0.2;
             t1.destinationStart = 0.3;
             t1.relativeDestinationStart = true;
-            t1.interruptible = true;
             const t2 = mainLayer.stateMachine.connect(m1, m2);
             // @ts-expect-error Type mismatch
             t1.copyTo(t2);

--- a/tests/animation/animation-graph-asset.test.ts
+++ b/tests/animation/animation-graph-asset.test.ts
@@ -220,7 +220,6 @@ describe('Animation graph asset', () => {
             expect(lhs.exitCondition).toBe(rhs.exitCondition);
             expect(lhs.destinationStart).toBe(rhs.destinationStart);
             expect(lhs.relativeDestinationStart).toBe(rhs.relativeDestinationStart);
-            expect(lhs.interruptible).toBe(rhs.interruptible);
         }
 
         function assertsEqualEmptyStateTransition(lhs: EmptyStateTransition, rhs: EmptyStateTransition) {

--- a/tests/animation/new-gen-anim/interruption.test.ts
+++ b/tests/animation/new-gen-anim/interruption.test.ts
@@ -55,19 +55,19 @@ describe(`Interruption matching`, () => {
         const evalMock = new AnimationGraphEvalMock(valueObserver.root, animationGraph);
     
         // Satisfies interruption's exit time condition.
-        evalMock.step(exitTimeAbsolute * 1.01);
+        evalMock.step(exitTimeAbsolute + 1e-6); // Past the exit condition
+        evalMock.step(exitTimeAbsolute * 0.01);
     
         // Satisfies interruption's condition.
-        const timeBeforeInterruptionEnabled = evalMock.current;
         evalMock.controller.setValue('interruption_enabled', true);
         evalMock.step(0.1);
         // The interruption should have taken place.
         expect(valueObserver.value).toBeCloseTo(
             lerp(
                 lerp(
-                    fixture.motion_1.getExpected(timeBeforeInterruptionEnabled),
-                    fixture.motion_2.getExpected(timeBeforeInterruptionEnabled),
-                    timeBeforeInterruptionEnabled / originalTransitionDuration,
+                    fixture.motion_1.getExpected(evalMock.current),
+                    fixture.motion_2.getExpected(evalMock.current),
+                    evalMock.current / originalTransitionDuration,
                 ),
                 fixture.motion_3.getExpected(evalMock.lastDeltaTime),
                 evalMock.lastDeltaTime / interruptingTransitionDuration,

--- a/tests/animation/new-gen-anim/interruption.test.ts
+++ b/tests/animation/new-gen-anim/interruption.test.ts
@@ -39,7 +39,6 @@ describe(`Interruption matching`, () => {
                     entryTransitions: [{ to: 'motion_1' }],
                     transitions: [{
                         from: 'motion_1', to: 'motion_2', exitTimeEnabled: false, duration: originalTransitionDuration,
-                        interruptible: true,
                         conditions: [{ type: 'unary', operator: 'to-be-true', operand: { type: 'variable', name: 'original_transition_activated' } }],
                     }, {
                         from: 'motion_2', to: 'motion_3',

--- a/tests/animation/new-gen-anim/transition-sequence.test.ts
+++ b/tests/animation/new-gen-anim/transition-sequence.test.ts
@@ -1,0 +1,1084 @@
+import { AnimationController } from "../../../cocos/animation/animation";
+import { AnimationGraph, AnimationTransition, EmptyState, EmptyStateTransition, isAnimationTransition, Layer, State, SubStateMachine, Transition } from "../../../cocos/animation/marionette/animation-graph";
+import { UnaryCondition } from "../../../cocos/animation/marionette/state-machine/condition";
+import { MotionState } from "../../../cocos/animation/marionette/state-machine/motion-state";
+import { assertIsTrue, lerp } from "../../../cocos/core";
+import { AnimationGraphEvalMock } from "./utils/eval-mock";
+import { ConstantRealValueAnimationFixture, LinearRealValueAnimationFixture } from "./utils/fixtures";
+import { SingleRealValueObserver } from "./utils/single-real-value-observer";
+import '../../utils/matchers/value-type-asymmetric-matchers';
+import { createAnimationGraph, StateParams, TransitionParams } from "./utils/factory";
+import { ApplyAnimationFixturePoseNode } from "./utils/apply-animation-fixture-pose-node";
+
+const DEFAULT_VALUE = 6.666;
+
+// m: Motion | +: Entry | -: Exit
+type SequenceString = string;
+
+const MAX_TRANSITIONS_PER_FRAME = 100;
+
+describe(`Transition sequence`, () => {
+    describe(`At a moment`, () => {
+        describe(`Zero transitions`, () => {
+            const commonCheck = (mock: ReturnType<typeof mockTransitionSequence>) => {
+                const { controller } = mock;
+                expect(controller.getCurrentTransition(0)).toBeNull();
+                expect(mock.controller.getNextStateStatus(0)).toBeNull();
+            };
+    
+            test(`Head is a motion`, () => {
+                const mock = mockTransitionSequence({
+                    head: { type: 'motion', animation: { from: 1, to: 2 }, progress: 0.8 },
+                    transitions: [],
+                });
+                commonCheck(mock);
+                expect(mock.observer.value).toBeCloseTo(lerp(1, 2, 0.8));
+                expect(mock.controller.getCurrentStateStatus(0)).toMatchObject({
+                    progress: 0.8,
+                });
+            });
+    
+            test(`Head is an empty state`, () => {
+                const mock = mockTransitionSequence({
+                    head: { type: 'empty' },
+                    transitions: [],
+                });
+                commonCheck(mock);
+                expect(mock.observer.value).toBeCloseTo(DEFAULT_VALUE);
+                expect(mock.controller.getCurrentStateStatus(0)).toBeNull();
+            });
+        });
+    
+        describe(`Tail transitions are routes`, () => {
+            const routeTransitions: TransitionFixture[] = [
+                { progress: 0.1, destination: { type: 'enter' } },
+                { progress: 0.2, destination: { type: 'exit' } },
+                { progress: 0.3, destination: { type: 'enter' } },
+                { progress: 0.4, destination: { type: 'enter' } },
+                { progress: 0.5, destination: { type: 'exit' } },
+                { progress: 0.6, destination: { type: 'exit' } },
+                { progress: 0.7, destination: { type: 'enter' } },
+            ];
+    
+            test(`All transitions are route transitions`, () => {
+                const mock = mockTransitionSequence({
+                    head: { type: 'enter' },
+                    transitions: [
+                        ...routeTransitions,
+                    ],
+                });
+    
+                expect(mock.observer.value).toBeCloseTo(DEFAULT_VALUE);
+                expect(mock.controller.getCurrentStateStatus(0)).toBeNull();
+                expect(mock.controller.getCurrentTransition(0)).toBeNull();
+                expect(mock.controller.getNextStateStatus(0)).toBeNull();
+            });
+    
+            test(`Not all transitions are route transitions`, () => {
+                const mock = mockTransitionSequence({
+                    head: { type: 'motion', animation: { from: 0.1, to: 0.3 }, progress: 0.3 },
+                    transitions: [
+                        ...routeTransitions,
+                    ],
+                });
+    
+                expect(mock.observer.value).toBeCloseTo(lerp(0.1, 0.3, 0.3));
+                expect(mock.controller.getCurrentStateStatus(0)).toMatchObject({
+                    progress: 0.3,
+                });
+                expect(mock.controller.getCurrentTransition(0)).toBeNull();
+                expect(mock.controller.getNextStateStatus(0)).toBeNull();
+            });
+        });
+    
+        describe(`Tail transitions are not routes`, () => {
+            // Note: in this case head transitions can not be routes.
+    
+            test.each([
+                'mm',
+                'mmm',
+                'mmmmm',
+                'm+m',
+                'm++m',
+                'm++-m',
+                'm+m++-m',
+            ])(`%s`, (seq) => {
+                const nStates = seq.length;
+                expect(nStates).toBeGreaterThan(1);
+    
+                const { sequence, states, transitions } = generateTransitionSequence(
+                    seq,
+                    (stateIndex: number): MotionStateFixture => {
+                        const t = stateIndex / nStates;
+                        return {
+                            type: 'motion',
+                            animation: { from: lerp(0.4, 0.8, t), to: lerp(-6.666, 0.88, t) },
+                            progress: 0.1 * (stateIndex + 1),
+                        };
+                    },
+                    (transitionIndex: number) => {
+                        const t = transitionIndex / (nStates - 1);
+                        return lerp(0.1, 1, t);
+                    },
+                );
+    
+                const mock = mockTransitionSequence(sequence);
+    
+                const motions = states.filter((state) => state.type === 'motion') as MotionStateFixture[];
+                expect(motions.length).toBeGreaterThan(1);
+    
+                let expectedValue = lerp(motions[0].animation.from, motions[0].animation.to, motions[0].progress);
+                motions.slice(1).forEach((motion, motionIndex) => {
+                    const lastMotion = motions[motionIndex]; // motions[motionIndex - 1 + 1]
+                    const lastStateIndex = states.indexOf(lastMotion);
+                    expect(lastStateIndex).toBeGreaterThanOrEqual(0);
+                    const transitionIndex = lastStateIndex;
+                    const motionTransition = transitions[transitionIndex];
+                    
+                    const motionValue = lerp(motion.animation.from, motion.animation.to, motion.progress);
+                    expectedValue = lerp(expectedValue, motionValue, motionTransition.progress);
+                });
+    
+                expect(mock.observer.value).toBeCloseTo(expectedValue);
+            });
+        });
+    });
+
+    test(`Exact same concurrent transitions`, () => {
+        // A->B->C
+        // `A->B` and `B->C` happened at same time and have same duration.
+
+        const fixture = {
+            initialValue: 0.1,
+            a: new LinearRealValueAnimationFixture(1, 2, 3),
+            b: new LinearRealValueAnimationFixture(4, 5, 6),
+            c: new LinearRealValueAnimationFixture(7, 8, 9),
+            transitionDuration: 0.5,
+        };
+
+        const observer = new SingleRealValueObserver(fixture.initialValue);
+        const graph = new AnimationGraph();
+        const layer = graph.addLayer();
+        const [ mA, mB, mC ] = ([[fixture.a, 'A'], [fixture.b, 'B'], [fixture.c, 'C']] as const).map(([animation, name]) => {
+            const s = layer.stateMachine.addMotion();
+            s.name = name;
+            s.motion = animation.createMotion(observer.getCreateMotionContext());
+            return s;
+        });
+        layer.stateMachine.connect(layer.stateMachine.entryState, mA);
+        ([
+            [mA, mB],
+            [mB, mC],
+        ] as const).forEach(([from, to], transitionIndex) => {
+            const transition = layer.stateMachine.connect(from, to);
+            transition.exitConditionEnabled = false;
+            transition.duration = fixture.transitionDuration;
+            const [condition] = transition.conditions = [new UnaryCondition()];
+            condition.operator = UnaryCondition.Operator.TRUTHY;
+            condition.operand.variable = `${transitionIndex}`;
+            graph.addBoolean(condition.operand.variable, true); // Trigger at start
+        });
+
+        const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+
+        evalMock.goto(fixture.transitionDuration * 0.3);
+        expect(observer.value).toBeCloseTo(
+            lerp(
+                lerp(
+                    fixture.a.getExpected(evalMock.current),
+                    fixture.b.getExpected(evalMock.current),
+                    0.3,
+                ),
+                fixture.c.getExpected(evalMock.current),
+                0.3,
+            ),
+            6,
+        );
+
+        evalMock.goto(fixture.transitionDuration * 1.01);
+        expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+            __DEBUG_ID__: 'C',
+            progress: expect.toBeAround(evalMock.current / fixture.c.duration, 6),
+        });
+        expect(observer.value).toBeCloseTo(
+            fixture.c.getExpected(evalMock.current),
+            6,
+        );
+    });
+
+    describe(`Transition dropping`, () => {
+        test(`Later transition has longer duration than previous`, () => {
+            /// ## Spec
+            /// If later transition has longer duration than previous,
+            /// previous transitions are dropped before the later transition.
+
+            const { evalMock, getMotionID } = generate([1, 1.5, 6]);
+
+            evalMock.goto(0.3);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(0),
+                progress: expect.toBeAround(0.3, 6),
+            });
+
+            evalMock.goto(0.9);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(0),
+                progress: expect.toBeAround(0.9, 6),
+            });
+
+            evalMock.goto(1.2);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(1),
+                progress: expect.toBeAround(evalMock.current - Math.trunc(evalMock.current), 6),
+            });
+
+            evalMock.goto(1.6);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(2),
+                progress: expect.toBeAround(evalMock.current - Math.trunc(evalMock.current), 6),
+            });
+
+            evalMock.goto(6.2);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(3),
+                progress: expect.toBeAround(evalMock.current - Math.trunc(evalMock.current), 6),
+            });
+            expect(evalMock.controller.getCurrentTransition(0)).toBeNull();
+        });
+
+        test(`Later transition has shorter duration than previous`, () => {
+            /// ## Spec
+            /// If later transition has shorter duration than previous,
+            /// once the later transition is dropped, all previous transitions are dropped.
+
+            const { evalMock, getMotionID } = generate([2, 6, 1.5]);
+
+            evalMock.goto(0.3);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(0),
+                progress: expect.toBeAround(evalMock.current - Math.trunc(evalMock.current), 6),
+            });
+
+            evalMock.goto(1.4);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(0),
+                progress: expect.toBeAround(evalMock.current - Math.trunc(evalMock.current), 6),
+            });
+
+            evalMock.goto(1.6);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(3),
+                progress: expect.toBeAround(evalMock.current - Math.trunc(evalMock.current), 6),
+            });
+        });
+
+        test(`Drop a middle transition`, () => {
+            const { evalMock, getMotionID } = generate([6, 5, 8]);
+
+            evalMock.goto(5.1);
+            expect(evalMock.controller.getCurrentStateStatus(0)).toMatchObject({
+                __DEBUG_ID__: getMotionID(2),
+                progress: expect.toBeAround(evalMock.current - Math.trunc(evalMock.current), 6),
+            });
+            expect(evalMock.controller.getCurrentTransition(0)).toMatchObject({
+                duration: 8.0,
+                time: expect.toBeAround(evalMock.current, 6),
+            });
+        });
+
+        function generate(
+            transitionDurations: readonly number[],
+        ) {
+            const observer = new SingleRealValueObserver(0.0);
+            const graph = new AnimationGraph();
+            const layer = graph.addLayer();
+            const states = Array.from({ length: transitionDurations.length + 1 }, (_, index) => {
+                const s = layer.stateMachine.addMotion();
+                s.name = `${index}`;
+                s.motion = new ConstantRealValueAnimationFixture(index, 1.0).createMotion(observer.getCreateMotionContext());
+                return s;
+            });
+            layer.stateMachine.connect(layer.stateMachine.entryState, states[0]);
+            for (let transitionIndex = 0; transitionIndex < transitionDurations.length; ++transitionIndex) {
+                const fromMotion = states[transitionIndex];
+                const toMotion = states[transitionIndex + 1];
+                const transition = layer.stateMachine.connect(fromMotion, toMotion);
+                transition.exitConditionEnabled = false;
+                transition.duration = transitionDurations[transitionIndex];
+                const [condition] = transition.conditions = [new UnaryCondition()];
+                condition.operator = UnaryCondition.Operator.TRUTHY;
+                condition.operand.variable = `${transitionIndex}`;
+                graph.addBoolean(condition.operand.variable, true); // Trigger at start
+            }
+            const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+            return {
+                evalMock,
+                observer,
+                getMotionID(motionIndex: number) {
+                    return `${motionIndex}`;
+                },
+            };
+        }
+    });
+
+    test(`Transition to a state multiple times through different transitions`, () => {
+        const fixture = {
+            a_animation: new LinearRealValueAnimationFixture(1., 2., 3.),
+            b_animation: new LinearRealValueAnimationFixture(4., 5., 6.),
+            c_animation: new LinearRealValueAnimationFixture(7., 8., 9.),
+        };
+
+        const observer = new SingleRealValueObserver();
+
+        enum TransitionId {
+            A_B,
+            B_C,
+            C_B,
+        }
+
+        const uniformTransitionDuration = 0.3;
+
+        const graph = createAnimationGraph({
+            variableDeclarations: { 'transitionId': { type: 'int', value: TransitionId.A_B } },
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'A': { type: 'motion', motion: fixture.a_animation.createMotion(observer.getCreateMotionContext()) },
+                        'B': { type: 'motion', motion: fixture.b_animation.createMotion(observer.getCreateMotionContext()) },
+                        'C': { type: 'motion', motion: fixture.c_animation.createMotion(observer.getCreateMotionContext()) },
+                    },
+                    entryTransitions: [{ to: 'A' }],
+                    transitions: [{
+                        from: 'A', to: 'B',
+                        duration: uniformTransitionDuration,
+                        exitTimeEnabled: false,
+                        conditions: [{ type: 'binary', 'operator': '==', 'lhsBinding': { type: 'variable', variableName: 'transitionId' }, rhs: TransitionId.A_B }],
+                    }, {
+                        from: 'B', to: 'C',
+                        duration: uniformTransitionDuration,
+                        exitTimeEnabled: false,
+                        conditions:  [{ type: 'binary', 'operator': '==', 'lhsBinding': { type: 'variable', variableName: 'transitionId' }, rhs: TransitionId.A_B }],
+                    }, {
+                        from: 'C', to: 'B',
+                        duration: uniformTransitionDuration,
+                        exitTimeEnabled: false,
+                        conditions:  [{ type: 'binary', 'operator': '==', 'lhsBinding': { type: 'variable', variableName: 'transitionId' }, rhs: TransitionId.A_B }],
+                    }],
+                },
+            }],
+        });
+        
+        const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+
+        evalMock.step(uniformTransitionDuration * 0.1);
+        evalMock.controller.setValue('transitionId', TransitionId.B_C);
+        evalMock.step(uniformTransitionDuration * 0.1);
+        evalMock.controller.setValue('transitionId', TransitionId.C_B);
+        evalMock.step(uniformTransitionDuration * 0.1);
+    });
+
+    test(`A state repeatedly exists in a transition sequence`, () => {
+        const fixture = {
+            a_animation: new LinearRealValueAnimationFixture(1., 2., 3.),
+            b_animation: new LinearRealValueAnimationFixture(4., 5., 6.),
+        };
+
+        const observer = new SingleRealValueObserver();
+
+        enum TransitionId {
+            A_B,
+            B_A,
+        }
+
+        const uniformTransitionDuration = 0.3;
+
+        const graph = createAnimationGraph({
+            variableDeclarations: { 'transitionId': { type: 'int', value: TransitionId.A_B } },
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'A': { type: 'motion', motion: fixture.a_animation.createMotion(observer.getCreateMotionContext()) },
+                        'B': { type: 'motion', motion: fixture.b_animation.createMotion(observer.getCreateMotionContext()) },
+                    },
+                    entryTransitions: [{ to: 'A' }],
+                    transitions: [{
+                        from: 'A', to: 'B',
+                        duration: uniformTransitionDuration,
+                        exitTimeEnabled: false,
+                        conditions: [{ type: 'binary', 'operator': '==', 'lhsBinding': { type: 'variable', variableName: 'transitionId' }, rhs: TransitionId.A_B }],
+                    }, {
+                        from: 'B', to: 'A',
+                        duration: uniformTransitionDuration,
+                        exitTimeEnabled: false,
+                        conditions:  [{ type: 'binary', 'operator': '==', 'lhsBinding': { type: 'variable', variableName: 'transitionId' }, rhs: TransitionId.A_B }],
+                    }],
+                },
+            }],
+        });
+        
+        const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+
+        // A --> B
+        evalMock.step(uniformTransitionDuration * 0.1);
+        // A --> B --> A
+        evalMock.controller.setValue('transitionId', TransitionId.B_A);
+        evalMock.step(uniformTransitionDuration * 0.1);
+        // A --> B --> A --> B
+        evalMock.controller.setValue('transitionId', TransitionId.A_B);
+        evalMock.step(uniformTransitionDuration * 0.1);
+        // A --> B --> A --> B --> A
+        evalMock.controller.setValue('transitionId', TransitionId.B_A);
+        evalMock.step(uniformTransitionDuration * 0.1);
+
+        // B --> A --> B --> A
+        evalMock.goto(uniformTransitionDuration * (1 + 0.1 * 0 + 0.01));
+        
+        // A --> B --> A
+        evalMock.goto(uniformTransitionDuration * (1 + 0.1 * 1 + 0.01));
+
+        // B --> A
+        evalMock.goto(uniformTransitionDuration * (1 + 0.1 * 2 + 0.01));
+
+        // A
+        evalMock.goto(uniformTransitionDuration * (1 + 0.1 * 3 + 0.01));
+    });
+
+    test(`Transition to a state multiple times through different transitions`, () => {
+        const fixture = {
+            a_animation: new LinearRealValueAnimationFixture(1., 2., 3.),
+            b_animation: new LinearRealValueAnimationFixture(4., 5., 6.),
+            c_animation: new LinearRealValueAnimationFixture(7., 8., 9.),
+        };
+
+        const observer = new SingleRealValueObserver();
+
+        enum TransitionId {
+            A_B,
+            B_C,
+            C_B,
+        }
+
+        const uniformTransitionDuration = 0.3;
+
+        const graph = createAnimationGraph({
+            variableDeclarations: { 'transitionId': { type: 'int', value: TransitionId.A_B } },
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'A': { type: 'motion', motion: fixture.a_animation.createMotion(observer.getCreateMotionContext()) },
+                        'B': { type: 'motion', motion: fixture.b_animation.createMotion(observer.getCreateMotionContext()) },
+                        'C': { type: 'motion', motion: fixture.c_animation.createMotion(observer.getCreateMotionContext()) },
+                    },
+                    entryTransitions: [{ to: 'A' }],
+                    transitions: [{
+                        from: 'A', to: 'B',
+                        duration: uniformTransitionDuration,
+                        exitTimeEnabled: false,
+                        conditions: [{ type: 'binary', 'operator': '==', 'lhsBinding': { type: 'variable', variableName: 'transitionId' }, rhs: TransitionId.A_B }],
+                    }, {
+                        from: 'B', to: 'C',
+                        duration: uniformTransitionDuration,
+                        exitTimeEnabled: false,
+                        conditions:  [{ type: 'binary', 'operator': '==', 'lhsBinding': { type: 'variable', variableName: 'transitionId' }, rhs: TransitionId.A_B }],
+                    }, {
+                        from: 'C', to: 'B',
+                        duration: uniformTransitionDuration,
+                        exitTimeEnabled: false,
+                        conditions:  [{ type: 'binary', 'operator': '==', 'lhsBinding': { type: 'variable', variableName: 'transitionId' }, rhs: TransitionId.A_B }],
+                    }],
+                },
+            }],
+        });
+        
+        const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+
+        evalMock.step(uniformTransitionDuration * 0.1);
+        evalMock.controller.setValue('transitionId', TransitionId.B_C);
+        evalMock.step(uniformTransitionDuration * 0.1);
+        evalMock.controller.setValue('transitionId', TransitionId.C_B);
+        evalMock.step(uniformTransitionDuration * 0.1);
+    });
+});
+
+describe(`Circular transitions`, () => {
+    describe(`Circular self transition A->A`, () => {
+        test(`Motion state self transition A->A has special semantic`, () => {
+            const fixture = {
+                a_animation: new LinearRealValueAnimationFixture(1., 2., 3.),
+            };
+
+            const observer = new SingleRealValueObserver();
+
+            const {
+                graph, uniformTransitionDuration,
+                enableTransition, disableTransition,
+            } = createSelfTransitioningGraph({
+                type: 'motion',
+                motion: fixture.a_animation.createMotion(observer.getCreateMotionContext()),
+            }); 
+
+            const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+    
+            // Run the state to 30%.
+            const state_1_start_time = evalMock.current;
+            evalMock.step(fixture.a_animation.duration * 0.3);
+            expect(observer.value).toBeCloseTo(
+                fixture.a_animation.getExpected(evalMock.current - state_1_start_time),
+                5,
+            );
+
+            // Enable the transition, and step the duration for 20%.
+            // This forms transition "State:1 --> State:2 --> State:1 --> State:2 --> ...."
+            enableTransition(evalMock.controller);
+            evalMock.step(uniformTransitionDuration * 0.2);
+            expect(observer.value).toBeCloseTo(1.32, 5);
+
+            // Once disabled, all things become normal.
+            disableTransition(evalMock.controller);
+            evalMock.step(uniformTransitionDuration * 1.0);
+            evalMock.step(0.1);
+            expect(evalMock.controller.getCurrentTransition(0)).toBeNull();
+            expect(observer.value).toBeCloseTo(1.4533333333333334, 5);
+        });
+
+        test(`Non-motion-state self transition A->A is takes no effect`, () => {
+            const fixture = {
+                a_animation: new LinearRealValueAnimationFixture(1., 2., 3.),
+            };
+
+            const observer = new SingleRealValueObserver();
+
+            const {
+                graph, uniformTransitionDuration,
+                enableTransition,
+            } = createSelfTransitioningGraph({
+                type: 'pose',
+                graph: { rootNode: new ApplyAnimationFixturePoseNode(fixture.a_animation, observer) },
+            }); 
+
+            const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+
+            // Run the state to 30%.
+            evalMock.step(fixture.a_animation.duration * 0.3);
+            expect(observer.value).toBeCloseTo(fixture.a_animation.getExpected(evalMock.current), 5);
+
+            // Enable the transition, but the transition has no effect.
+            enableTransition(evalMock.controller);
+            evalMock.step(uniformTransitionDuration * 0.1);
+            expect(observer.value).toBeCloseTo(fixture.a_animation.getExpected(evalMock.current), 5);
+        });
+
+        function createSelfTransitioningGraph(state: StateParams) {
+            const uniformTransitionDuration = 0.3;
+    
+            const graph = createAnimationGraph({
+                variableDeclarations: {
+                    'A-->A': { type: 'boolean', value: false },
+                },
+                layers: [{
+                    stateMachine: {
+                        states: {
+                            'A': state,
+                        },
+                        entryTransitions: [{ to: 'A' }],
+                        transitions: [{
+                            from: 'A', to: 'A',
+                            duration: uniformTransitionDuration,
+                            exitTimeEnabled: state.type === 'motion' ? false : undefined,
+                            conditions: [{ type: 'unary', 'operator': 'to-be-true', 'operand': { type: 'variable', name: 'A-->A' } }],
+                        }],
+                    },
+                }],
+            });
+
+            return {
+                graph,
+                uniformTransitionDuration,
+                enableTransition: (controller: AnimationController) => controller.setValue('A-->A', true),
+                disableTransition: (controller: AnimationController) => controller.setValue('A-->A', false),
+            };
+        }
+    });
+
+    test(`Rule: loop transition sequence having always-true conditions forms infinite loop`, () => {
+        const fixtures = {
+            first_state_animation: new LinearRealValueAnimationFixture(1, 2, 3),
+            verbose_loop_prefix_length: 3,
+        };
+
+        const verboseLoopPrefixPathConfig = Array.from({ length: fixtures.verbose_loop_prefix_length }, (_, verboseIndex) => {
+            const t = verboseIndex / fixtures.verbose_loop_prefix_length;
+            return {
+                stateName: `verbose-${verboseIndex}`,
+                transitionDuration: lerp(0.1, 0.9, t) * fixtures.first_state_animation.duration,
+                animation: new LinearRealValueAnimationFixture(
+                    0.1 * verboseIndex,
+                    0.2 * verboseIndex,
+                    fixtures.first_state_animation.duration * lerp(1.2, 2, t),
+                ),
+            };
+        });
+
+        const lastLoopPathDuration = 0.95 * fixtures.first_state_animation.duration;
+
+        const observer = new SingleRealValueObserver();
+
+        const animationGraph = createAnimationGraph({
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'first': { type: 'pose', graph: { rootNode: new ApplyAnimationFixturePoseNode(fixtures.first_state_animation, observer) } },
+                        ...verboseLoopPrefixPathConfig.reduce((result, { stateName, animation }, verboseIndex) => {
+                            result[stateName] = { type: 'pose', graph: { rootNode: new ApplyAnimationFixturePoseNode(animation, observer) } };
+                            return result;
+                        }, {} as Record<string, StateParams>),
+                    },
+                    entryTransitions: [{ to: 'first' }],
+                    transitions: [
+                        ...verboseLoopPrefixPathConfig.map(({ stateName, transitionDuration }, verboseIndex): TransitionParams => {
+                            return {
+                                from: verboseIndex === 0 ? 'first' : verboseLoopPrefixPathConfig[verboseIndex - 1].stateName,
+                                to: stateName,
+                                duration: transitionDuration,
+                                conditions: [{ type: 'unary', operator: 'to-be-true', 'operand': { type: 'constant', value: true } }],
+                            };
+                        }),
+                        {
+                            from: verboseLoopPrefixPathConfig.length === 0 ? 'first' : verboseLoopPrefixPathConfig[verboseLoopPrefixPathConfig.length - 1].stateName,
+                            to: 'first',
+                            duration: lastLoopPathDuration,
+                            conditions: [{ type: 'unary', operator: 'to-be-true', 'operand': { type: 'constant', value: true } }],
+                        },
+                    ],
+                },
+            }],
+        });
+
+        const evalMock = new AnimationGraphEvalMock(observer.root, animationGraph);
+
+        const stateCount = verboseLoopPrefixPathConfig.length + 1;
+
+        const firstStateIndex = stateCount - 1;
+
+        const getStateFixture = (stateIndex: number) => {
+            expect(stateIndex).toBeGreaterThanOrEqual(0);
+            expect(stateIndex).toBeLessThan(stateCount);
+            if (stateIndex === stateCount - 1) {
+                return {
+                    animation: fixtures.first_state_animation,
+                    incomingTransitionDuration: lastLoopPathDuration,
+                };
+            } else {
+                return {
+                    animation: verboseLoopPrefixPathConfig[stateIndex].animation,
+                    incomingTransitionDuration: verboseLoopPrefixPathConfig[stateIndex].transitionDuration,
+                };
+            }
+        };
+
+        let ticked = false;
+        const expectation = {
+            stateElapsedTimes: new Array(stateCount).fill(0.0),
+            headStateIndex: firstStateIndex,
+            transitions: [] as Array<{
+                destStateIndex: number;
+                expectedElapsedTransitionTime: number;
+                transitionDuration: number;
+            }>,
+        };
+
+        const minTransitionDuration = Math.min(...Array.from({ length: stateCount }, (_, stateIndex) =>
+            getStateFixture(stateIndex).incomingTransitionDuration));
+        for (const minTransitionDurationRatio of [
+            0.3,
+            0.5,
+            0.9,
+        ]) {
+            const tickDeltaTime = minTransitionDuration * minTransitionDurationRatio;
+            // Tick.
+            evalMock.goto(tickDeltaTime);
+            // Check.
+            calculateExpectedTickResult(evalMock.lastDeltaTime);
+        }
+
+        /**
+         * Ticks the graph by specified time, then check the tick result.
+         */
+        function calculateExpectedTickResult(tickDeltaTime: number) {
+            const isFirstTick = !ticked;
+            ticked = true;
+
+            // Every tick, upto `MAX_TRANSITIONS_PER_FRAME` transitions will be appended to transition.
+            {
+                const lastStateIndexBeforeTick = expectation.transitions.length === 0
+                    ? expectation.headStateIndex
+                    : expectation.transitions[expectation.transitions.length - 1].destStateIndex;
+
+                const stateWeightsBeforeTick = new Array(stateCount).fill(0.0);
+                if (!isFirstTick) {
+                    const [lastStateWeight, destinationWeights] = computeExpectedWeightsOfTransitionSequence(
+                        ...expectation.transitions.map(
+                            ({ expectedElapsedTransitionTime, transitionDuration }): [number, number] => [expectedElapsedTransitionTime, transitionDuration])
+                    );
+                    expectation.transitions.forEach(({ destStateIndex }, transitionIndex) => {
+                        stateWeightsBeforeTick[destStateIndex] += destinationWeights[transitionIndex];
+                    });
+                    stateWeightsBeforeTick[lastStateIndexBeforeTick] += lastStateWeight;
+                }
+
+                const expectedNewTransitionsCount = isFirstTick
+                    ? MAX_TRANSITIONS_PER_FRAME - 1 // The first tick will exclude Entry -> Head consume 1 iteration
+                    : MAX_TRANSITIONS_PER_FRAME;
+                for (let iteration = 0; iteration < expectedNewTransitionsCount; ++iteration) {
+                    const destStateIndex = Math.floor((lastStateIndexBeforeTick + 1 + iteration) % stateCount);
+                    expectation.transitions.push({
+                        destStateIndex,
+                        transitionDuration: (1.0 - stateWeightsBeforeTick[destStateIndex]) * getStateFixture(destStateIndex).incomingTransitionDuration,
+                        expectedElapsedTransitionTime: 0.0,
+                    });
+                }
+            }
+
+            // Then all transitions update.
+            for (let iTransition = expectation.transitions.length - 1; iTransition >= 0; --iTransition) {
+                const transition = expectation.transitions[iTransition];
+                transition.expectedElapsedTransitionTime += tickDeltaTime;
+                const { destStateIndex, transitionDuration } = transition;
+                if (transition.expectedElapsedTransitionTime > transitionDuration) {
+                    expectation.transitions.splice(0, iTransition + 1);
+                    expectation.headStateIndex = destStateIndex;
+                    break;
+                }
+            }
+
+            // Then all activated states update.
+            const activatedStates = new Set<number>();
+            for (const { destStateIndex } of expectation.transitions) {
+                if (!activatedStates.has(destStateIndex)) {
+                    activatedStates.add(destStateIndex);
+                    expectation.stateElapsedTimes[destStateIndex] += tickDeltaTime;
+                }
+            }
+            for (let iState = 0; iState < stateCount; ++iState) {
+                if (!activatedStates.has(iState)) {
+                    expectation.stateElapsedTimes[iState] = 0.0;
+                }
+            }
+
+            // Check if the result matches.
+            expect(observer.value).toBeCloseTo(computeExpectedTransitionSequenceResult(
+                getStateFixture(expectation.headStateIndex).animation.getExpected(expectation.stateElapsedTimes[expectation.headStateIndex]),
+                ...expectation.transitions.map(({ expectedElapsedTransitionTime, transitionDuration, destStateIndex }) => {
+                    return [
+                        getStateFixture(destStateIndex).animation.getExpected(expectation.stateElapsedTimes[destStateIndex]),
+                        expectedElapsedTransitionTime,
+                        transitionDuration,
+                    ] as [number, number, number];
+                }),
+            ), 5);
+        }
+    });
+});
+
+function computeExpectedTransitionSequenceResult(
+    headValue: number,
+    ...tail: Array<[value: number, transitionTime: number, transitionDuration: number]>
+): number {
+    const [headWeight, destinationWeights] = computeExpectedWeightsOfTransitionSequence(
+        ...tail.map(([_, ...transition]) => transition)
+    );
+    let result = headValue * headWeight;
+    tail.forEach(([destinationValue], transitionIndex) => {
+        result += destinationValue * destinationWeights[transitionIndex];
+    });
+    return result;
+}
+
+function computeExpectedWeightsOfTransitionSequence(
+    ...transitions: Array<[transitionTime: number, transitionDuration: number]>
+): [number, number[]] {
+    let remainingWeight = 1.0;
+    const destStateWeights = new Array(transitions.length).fill(0.0);
+    for (let iTransition = transitions.length - 1; iTransition >= 0; --iTransition) {
+        const [transitionTime, transitionDuration] = transitions[iTransition];
+        expect(transitionTime).toBeGreaterThanOrEqual(0.0);
+        expect(transitionTime).toBeLessThanOrEqual(transitionDuration);
+        const transitionRatio = transitionTime / transitionDuration;
+        destStateWeights[iTransition] = (remainingWeight * transitionRatio);
+        remainingWeight = remainingWeight * (1.0 - transitionRatio);
+    }
+    return [
+        remainingWeight,
+        destStateWeights,
+    ];
+}
+
+function generateTransitionSequence(
+    sequenceString: SequenceString,
+    generateMotion: (stateIndex: number) => MotionStateFixture,
+    generateTransitionProgress: (transitionIndex: number) => number,
+) {
+    const states = [...sequenceString].map((s, stateIndex): StateFixture => {
+        switch (s) {
+            case 'm': return generateMotion(stateIndex);
+            case '+': return { type: 'enter' };
+            default: expect(false).toBeTruthy();
+            case '-': return { type: 'exit' };
+        }
+    });
+
+    const transitions = states.slice(1).map((motion, transitionIndex) => ({
+        destination: motion,
+        progress: states[transitionIndex].type === 'motion' ? generateTransitionProgress(transitionIndex) : 0.0,
+    }));
+
+    return {
+        states,
+        transitions,
+        sequence: {
+            head: states[0],
+            transitions,
+        },
+    };
+}
+
+function mockTransitionSequence(sequenceFixture: TransitionSequenceFixture): {
+    controller: AnimationController,
+    observer: SingleRealValueObserver,
+} {
+    const observer = new SingleRealValueObserver(DEFAULT_VALUE);
+
+    const {
+        graph,
+        updates,
+    } = makeGraphByTransitionSequenceFixture(sequenceFixture, 1.0, observer);
+
+    const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+
+    for (const update of updates) {
+        for (const varName of update.variables) {
+            evalMock.controller.setValue(varName, true);
+        }
+        evalMock.step(update.deltaTime);
+    }
+
+    return {
+        controller: evalMock.controller,
+        observer,
+    };
+}
+
+function makeGraphByTransitionSequenceFixture(
+    fixture: TransitionSequenceFixture,
+    elapsedTime: number,
+    observer: SingleRealValueObserver,
+) {
+    const graph = new AnimationGraph();
+    const layer = graph.addLayer();
+
+    const stateMachineStack: (Layer | SubStateMachine)[] = [layer];
+    let fromState: State;
+    const addState = (fixture: StateFixture): State => {
+        if (stateMachineStack.length === 0) {
+            throw new Error(`Bad transition sequence! Incorrect "exit" state occurrence.`);
+        }
+        const stateMachine = stateMachineStack[stateMachineStack.length - 1].stateMachine;
+        if (fixture.type === 'enter') {
+            const state = stateMachine.addSubStateMachine();
+            state.name = `State machine ${stateMachineStack.length}`;
+            stateMachineStack.push(state);
+            fromState = state.stateMachine.entryState;
+            return state;
+        } else if (fixture.type === 'exit') {
+            if (stateMachineStack.length === 1) {
+                throw new Error(`Bad transition sequence! Incorrect "exit" state occurrence: attempt to exit the top level state machine.`);
+            }
+            fromState = stateMachineStack[stateMachineStack.length - 1] as SubStateMachine;
+            stateMachineStack.pop();
+            return stateMachine.exitState;
+        } else if (fixture.type === 'empty') {
+            const state = stateMachine.addEmpty();
+            fromState = state;
+            return state;
+        } else {
+            const state = stateMachine.addMotion();
+            expect(fixture.progress).not.toBeCloseTo(0.0);
+            const motionDuration = elapsedTime / fixture.progress;
+            const animation = new LinearRealValueAnimationFixture(fixture.animation.from, fixture.animation.to, motionDuration);
+            state.motion = animation.createMotion(observer.getCreateMotionContext());
+            fromState = state;
+            return state;
+        }
+    };
+
+    const headState = addState(fixture.head);
+    headState.name = 'Head';
+    layer.stateMachine.connect(layer.stateMachine.entryState, headState);
+    fromState = headState;
+
+    type TrueState = MotionState | EmptyState;
+
+    const transitionMockMap = new Map<Transition, TransitionFixture>();
+    const transitionTriggerVarNameMap = new Map<Transition, string>();
+
+    interface TransitionSequence {
+        headRoutes: Transition[];
+        tail?: {
+            firstState: TrueState;
+            firstStateFixture: MotionStateFixture;
+            trueTransitions: Array<{
+                firstTransition: EmptyStateTransition | AnimationTransition;
+                routes: Transition[];
+                to: MotionState | EmptyState;
+            }>;
+            tailRoutes: {
+                firstTransition?: EmptyStateTransition | AnimationTransition;
+                routes: Transition[],
+            };
+        };
+    }
+
+    const transitionSeq: TransitionSequence = {
+        headRoutes: [],
+    };
+
+    const isTrueState = (state: State): state is (MotionState | EmptyState) => {
+        return state instanceof MotionState || state instanceof EmptyState;
+    };
+
+    const isDurableTransition = (transition: Transition): transition is (AnimationTransition | EmptyStateTransition) => {
+        return isAnimationTransition(transition) || transition instanceof EmptyStateTransition;
+    };
+    
+    stateMachineStack.length = 0;
+    stateMachineStack.push(layer);
+    const transitions = fixture.transitions.map((transitionMock, transitionIndex) => {
+        const stateMachine = stateMachineStack[stateMachineStack.length - 1].stateMachine;
+        const fromStateBefore = fromState;
+
+        const triggeringVarName = `Trigger ${transitionIndex}`;
+        graph.addBoolean(triggeringVarName, true);
+
+        const toState = addState(transitionMock.destination);
+        toState.name = `TransitionDestination ${transitionIndex}`;
+        const transition = stateMachine.connect(fromStateBefore, toState);
+        if (isDurableTransition(transition)) {
+            expect(transitionMock.progress).not.toBeCloseTo(0.0);
+            const transitionDuration = elapsedTime / transitionMock.progress;
+            transition.duration = transitionDuration;
+        }
+        if (isAnimationTransition(transition)) {
+            transition.exitConditionEnabled = false;
+        }
+
+        const [condition] = transition.conditions = [new UnaryCondition()];
+        condition.operator = UnaryCondition.Operator.TRUTHY;
+        condition.operand.variable = triggeringVarName;
+
+        transitionMockMap.set(transition, transitionMock);
+        transitionTriggerVarNameMap.set(transition, triggeringVarName);
+
+        return {
+            transition,
+            transitionMock,
+        };
+    });
+
+    if (isTrueState(headState)) {
+        transitionSeq.tail = {
+            firstState: headState,
+            firstStateFixture: fixture.head as MotionStateFixture,
+            trueTransitions: [],
+            tailRoutes: {
+                routes: [],
+            },
+        };
+    }
+    transitions.forEach(({ transition, transitionMock, }, transitionIndex) => {
+        const { to: toState } = transition;
+
+        if (!transitionSeq.tail) {
+            transitionSeq.headRoutes.push(transition);
+        } else if (!transitionSeq.tail.tailRoutes.firstTransition) {
+            expect(isDurableTransition(transition));
+            assertIsTrue(isDurableTransition(transition));
+            transitionSeq.tail.tailRoutes.firstTransition = transition;
+        } else {
+            transitionSeq.tail.tailRoutes.routes.push(transition);
+        }
+
+        if (isTrueState(toState)) {
+            if (!transitionSeq.tail) {
+                transitionSeq.tail = {
+                    firstState: toState,
+                    firstStateFixture: transitionMock.destination as MotionStateFixture,
+                    trueTransitions: [],
+                    tailRoutes: {
+                        routes: [],
+                    },
+                };
+            }
+            if (transitionSeq.tail.tailRoutes.firstTransition) {
+                transitionSeq.tail.trueTransitions.push({
+                    firstTransition: transitionSeq.tail.tailRoutes.firstTransition,
+                    routes: transitionSeq.tail.tailRoutes.routes,
+                    to: toState,
+                });
+                transitionSeq.tail.tailRoutes.routes.length = 0;
+                transitionSeq.tail.tailRoutes.firstTransition = undefined;
+            }
+            transitionSeq.tail.firstState = toState;
+        }
+    });
+
+    const updates: {
+        variables: string[];
+        deltaTime: number;
+    }[] = [];
+
+    updates.push({
+        variables: [],
+        deltaTime: elapsedTime,
+    });
+
+    return {
+        graph,
+        updates,
+        transitionSequence: transitionSeq,
+    };
+}
+
+interface TransitionSequenceFixture {
+    head: StateFixture;
+    transitions: TransitionFixture[];
+}
+
+type StateFixtureBase = { };
+
+type StateFixture = StateMachineEnterStateFixture | StateMachineExitStateFixture | MotionStateFixture | EmptyStateFixture;
+
+interface StateMachineEnterStateFixture extends StateFixtureBase {
+    type: 'enter';
+};
+
+interface StateMachineExitStateFixture extends StateFixtureBase {
+    type: 'exit';
+};
+
+interface MotionStateFixture extends StateFixtureBase {
+    type: 'motion';
+    animation: { from: number; to: number; };
+    progress: number;
+};
+
+interface EmptyStateFixture extends StateFixtureBase {
+    type: 'empty';
+};
+
+interface TransitionFixture {
+    destination: StateFixture;
+    progress: number;
+    motionTransition?: {
+        duration: number;
+    };
+}

--- a/tests/animation/new-gen-anim/utils/apply-animation-fixture-pose-node.ts
+++ b/tests/animation/new-gen-anim/utils/apply-animation-fixture-pose-node.ts
@@ -1,0 +1,36 @@
+import { Pose } from "../../../../cocos/animation/core/pose";
+import { AnimationGraphBindingContext, AnimationGraphSettleContext, AnimationGraphUpdateContext, AnimationGraphEvaluationContext } from "../../../../cocos/animation/marionette/animation-graph-context";
+import { PoseNode } from "../../../../cocos/animation/marionette/pose-graph/pose-node";
+import { RealValueAnimationFixture } from "./fixtures";
+import { SingleRealValueObserver } from "./single-real-value-observer";
+
+export class ApplyAnimationFixturePoseNode extends PoseNode {
+    constructor(
+        private _fixture: RealValueAnimationFixture,
+        private _observer: SingleRealValueObserver,
+    ) {
+        super();
+    }
+
+    public bind(context: AnimationGraphBindingContext): void {
+        this._poseWriter = this._observer.createPoseWriter(context);
+    }
+
+    public settle(context: AnimationGraphSettleContext): void { }
+
+    public reenter(): void {
+        this._time = 0.0;
+    }
+
+    protected doUpdate(context: AnimationGraphUpdateContext): void {
+        this._time += context.deltaTime;
+    }
+
+    protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+        expect(this._poseWriter).not.toBeUndefined();
+        return this._poseWriter!.write(this._fixture.getExpected(this._time), context);
+    }
+
+    private _poseWriter: ReturnType<SingleRealValueObserver['createPoseWriter']> | undefined;
+    private _time = 0.0;
+}

--- a/tests/animation/new-gen-anim/utils/factory.ts
+++ b/tests/animation/new-gen-anim/utils/factory.ts
@@ -192,11 +192,6 @@ function fillTransition(transition: Transition, params: TransitionAttributes) {
         assertsIsEmptyOrAnimationTransition(transition);
         transition.relativeDestinationStart = params.relativeDestinationStart;
     }
-
-    if (typeof params.interruptible !== 'undefined') {
-        assertsIsMotionTransition(transition);
-        transition.interruptible = params.interruptible;
-    }
 }
 
 export function createTCBinding(params: TCBindingParams) {
@@ -311,20 +306,20 @@ export type StateParams = ({
     name?: string;
 };
 
-type TransitionParams = {
+export type TransitionParams = {
     from: string;
     to: string;
 } & TransitionAttributes;
 
-interface EntryTransitionParams extends TransitionAttributes {
+export interface EntryTransitionParams extends TransitionAttributes {
     to: string;
 }
 
-interface AnyTransitionParams extends TransitionAttributes {
+export interface AnyTransitionParams extends TransitionAttributes {
     to: string;
 }
 
-interface ExitTransitionParams extends TransitionAttributes {
+export interface ExitTransitionParams extends TransitionAttributes {
     from: string;
 }
 
@@ -336,7 +331,6 @@ interface TransitionAttributes {
     relativeDuration?: boolean;
     destinationStart?: number;
     relativeDestinationStart?: boolean;
-    interruptible?: boolean;
 }
 
 type TransitionConditionParams = {

--- a/tests/animation/new-gen-anim/utils/single-real-value-observer.ts
+++ b/tests/animation/new-gen-anim/utils/single-real-value-observer.ts
@@ -1,7 +1,10 @@
 import { VectorTrack } from "../../../../cocos/animation/animation";
 import { AnimationClip } from "../../../../cocos/animation/animation-clip";
+import { Pose } from "../../../../cocos/animation/core/pose";
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext } from "../../../../cocos/animation/marionette/animation-graph-context";
 import { ClipMotion } from "../../../../cocos/animation/marionette/motion";
 import { Node } from "../../../../cocos/scene-graph";
+import { Vec3 } from "../../../../exports/base";
 import { CreateMotionContext } from "./fixtures";
 
 type NonNullableClipMotion = Omit<ClipMotion, 'clip'> & { 'clip': NonNullable<ClipMotion['clip']> };
@@ -40,6 +43,20 @@ export class SingleRealValueObserver {
                 const clipMotion = new ClipMotion();
                 clipMotion.clip = clip;
                 return clipMotion as NonNullableClipMotion;
+            },
+        };
+    }
+
+    public createPoseWriter(bindingContext: AnimationGraphBindingContext): {
+        write(value: number, context: AnimationGraphEvaluationContext): Pose;
+    } {
+        const handle = bindingContext.bindTransform('');
+        expect(handle).not.toBeNull();
+        return {
+            write(value, context) {
+                const pose = context.pushDefaultedPose();
+                pose.transforms.setPosition(handle!.index, new Vec3(value));
+                return pose;
             },
         };
     }


### PR DESCRIPTION
Re: #

### Changelog

This PR adjusts some aspects related animation graph state machine:

- Remove the experimental transition interruption mechanism.

- Adds the support for multiple transitions.

- Redefine the evaluation behaviour of a state machine, especially related to transition exit condition.

- Optimize implementation of self-transitioning motion states.

Details are illustrated as following.

#### Remove Existing Transition Interruption Mechanism

The existing transition interruption mechanism was introduced in 3.6, in PR #11158 . It's marked as experimental until now. In practise, animation team found it's not worth maintaining:

- Users don't have requirements on it or give it a feed back. 

  Search in [discussion](https://forum.cocos.org/search?q=interruption), it appears that users don't actually talk about it. We're not able to collect much feedbacks.

- The mechanism is not able to satisfy the new requirement of pose graph, introduced in this version.

  The existing mechanism has two pitfalls make it becoming a obstacle to pose graph:

  - It stops the interrupted state from updating. This in practise make it unable to implement some effects about for example states in transition sequence `A --> B --> C` can update parallelly.

  - Transition `A --> B` can be interrupted by `A --> C`. This makes the transition relationship more complex and the definition of "current state" being vague. For example, given `A-->B-->C`, should we match interruptions from the middle state `B`?

  - We will have a similar but more nice alternative "multiple transitions" support.

#### Support multiple transitions

The multiple transitions is now supported to overcome pitfalls of mentioned existing interruption:

- If there's already been a transition sequence $[S_0, S_1, ..., S_n]$ , the state machine will still attempt to match a transition outgoing from $S_n$, if there's a match hit, the matched transition would be appended to the transition sequence and hence formed $[S_0, S_1, ..., S_n, S_{n+1}]$.

- In transition sequence $[S_0, S_1, ..., S_n]$ , all transitions are subjected to update, so as the involved states. As for the state weight allocation, the $S_n$ will have its weight **accumulated by** $t$, where $t$ is the transition ratio, and states in $[S_0, S_{n-1}]$ will recursively have their respective weights **accumulated by** "corresponding transition ratio but multiplied by $1 - t$".

- The update of transition sequence $[S_0, S_1, ..., S_n]$ is begin from last to first. If during update, found that the $i$-th transition has finished, then the prefix transitions $[S_0, S_1, ..., S_i]$ will be dropped, and the result transition sequence becomes $[S_i, ...,  S_n]$.

### Redefine the evaluation behaviour

Prior to this PR, a state machine has the following evaluation flow:

0. Let `deltaTime` be the update delta time passed to the state machine.
1. Loop util `deltaTime == 0`:
  1.1 If there's a transition:
     - Step the transition for `t` time, the `t` is no more than `deltaTime`.
     - `deltaTime -= t`
     - Go to 1 .
  1.2 Try to match a transition:
     - If matched:
       - `deltaTime -= t`, where `t` is the cost of the match, especially the required time to satsify the exit condition of the match transition.
       - Go to 1.
     - Otherwise, update current state, and break.

Look through the algorithm, you can find that the algorithm is complex. It's complex since it want to perform a **steady** evaluation, that's:

For delta time `t`, if after updating current state `s` (no more than `t`), an exit condition can be satisfied so that a transition can be matched, then it will first update `s`, then `s` will be subtracted from the delta time.

This is certainly more steady behaviour. But it increase the implementation complexity and sometimes "steady" can not be actually achieved:

- The steady behaviour requires the transition matching system not only returns the matched transition, but also returns a "cost time". And internally, the matching system have to confirm the "minimal cost time".

- The problem is actually a race between "update the state" and "update the state then match transition then update the transition". This solution does solve. But, there's another more complex race: "update the transition" and "update the transition then interruption", which is hard to solve.

After all, animation team decides to change the behaviour to simplify the evaluation. In a frame:

- First, loop try to match transitions, util no transition can be matched. During matching, no update will be performed. If the exit condition is not satisfied before update, the belonging transition won't be matched.

- Then, update the formed transition sequence, as well as the states.

The new mechanism has no other pitfalls if the FPS is not too small(ie. the detal time is too big).

#### Optimize implementation of self-transitioning motion states

Prior to this PR, a motion state will definitely have a `MotionStateEval` record. In the record, it however has two "ports". One is called "from port", another is called "to port". The reason it's implemented as such is to support self transition of a motion state:

- When there's a transition to the motion state, its "to port" will be activated.

- When the motion state becomes "current" state, its "from port" will be activated, with inherited animation progress from "to port".

- So, motion state self transition `A --> A` is actually the transition from "from port" to "to port".

To implement this, the code use many `if-else` to identify different ports. For example:

- When sampling a "current state", if it's a motion state, its "from port" will be sampled; Instead when sampling a "destination state", if it's a motion state, its "to port" will be sampled.

- When a state becomes "current state" and if the state is a motion state, then firstly asserts the state's "to port" is activated. Then transfer the animation progress of "to port" to "from port".

- When deciding if an exit condition holding, the transition matching system must know if the matching source state is "from port" or "to port".

- etc ...(you can view the code)

This PR after all optimized the implementation:

- A motion state, during evaluation, will be treated as a "virtual state machine". In code, it's called `VMSM`(Virtual Motion State Machine). This virtual state machine has two states: one is public to external(outsides the virtual state machine), one is private. Both the states has state kind `animation`. Entry of the virtual state machine is the public state. Both state sampling the same motion but has independent animation time.

- If there's a transition into the motion state, the transition will be redirected to the public state. But if there's a self-transition, the transition will be converted into a `public-state --> private-state` transition and reverse `private-state --> public-state`. Note, no other transitions can directly transition into the private state.

- Outgoing transitions(from the motion state), speed, state-machine-components will all be inherited by both the public and private state.

Here's a diagram illustrate this:

```mermaid
---
title: the internal illustration of a Motion State
---
stateDiagram-v2
    SomeStateA --> VMSM
   state VMSM {
       [*] --> public
       public --> [*]
       private --> [*]
       public --> private
       private --> public
   }
   VMSM --> SomeStateB
```

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
