### PR TITLE
Optimize warn message if state machine matched too many transitions n a frame

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -3257,7 +3257,7 @@ Can not decode CCON binary: lack of text decoder.
 
 ### 14000
 
-Graph update has been interrupted since too many transitions(greater than %s) occurred during one frame.
+State machine matched too many transitions(greater than %s) during this frame: %s.
 
 ### 14100
 

--- a/tests/animation/new-gen-anim/transition-sequence.test.ts
+++ b/tests/animation/new-gen-anim/transition-sequence.test.ts
@@ -9,13 +9,12 @@ import { SingleRealValueObserver } from "./utils/single-real-value-observer";
 import '../../utils/matchers/value-type-asymmetric-matchers';
 import { createAnimationGraph, StateParams, TransitionParams } from "./utils/factory";
 import { ApplyAnimationFixturePoseNode } from "./utils/apply-animation-fixture-pose-node";
+import { MAX_TRANSITIONS_PER_FRAME } from "../../../cocos/animation/marionette/state-machine/state-machine-eval";
 
 const DEFAULT_VALUE = 6.666;
 
 // m: Motion | +: Entry | -: Exit
 type SequenceString = string;
-
-const MAX_TRANSITIONS_PER_FRAME = 100;
 
 describe(`Transition sequence`, () => {
     describe(`At a moment`, () => {
@@ -710,10 +709,6 @@ describe(`Circular transitions`, () => {
 
             // Every tick, upto `MAX_TRANSITIONS_PER_FRAME` transitions will be appended to transition.
             {
-                const lastStateIndexBeforeTick = expectation.transitions.length === 0
-                    ? expectation.headStateIndex
-                    : expectation.transitions[expectation.transitions.length - 1].destStateIndex;
-
                 const stateWeightsBeforeTick = new Array(stateCount).fill(0.0);
                 if (!isFirstTick) {
                     const [lastStateWeight, destinationWeights] = computeExpectedWeightsOfTransitionSequence(
@@ -723,9 +718,12 @@ describe(`Circular transitions`, () => {
                     expectation.transitions.forEach(({ destStateIndex }, transitionIndex) => {
                         stateWeightsBeforeTick[destStateIndex] += destinationWeights[transitionIndex];
                     });
-                    stateWeightsBeforeTick[lastStateIndexBeforeTick] += lastStateWeight;
+                    stateWeightsBeforeTick[expectation.headStateIndex] += lastStateWeight;
                 }
 
+                const lastStateIndexBeforeTick = expectation.transitions.length === 0
+                    ? expectation.headStateIndex
+                    : expectation.transitions[expectation.transitions.length - 1].destStateIndex;
                 const expectedNewTransitionsCount = isFirstTick
                     ? MAX_TRANSITIONS_PER_FRAME - 1 // The first tick will exclude Entry -> Head consume 1 iteration
                     : MAX_TRANSITIONS_PER_FRAME;


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
