### PR TITLE
Lint rule: prefer interface style type definition

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -140,3 +140,6 @@ rules:
     '@typescript-eslint/consistent-type-assertions': [error, {
         assertionStyle: 'as'
     }]
+
+    # Prefer the interface style.
+    '@typescript-eslint/consistent-type-definitions': [error, interface]

--- a/cocos/animation/marionette/graph-eval.ts
+++ b/cocos/animation/marionette/graph-eval.ts
@@ -325,7 +325,7 @@ export class AnimationGraphEval {
  * @en
  * Describes how to override animation clips in an animation graph.
  */
-export type ReadonlyClipOverrideMap = {
+export interface ReadonlyClipOverrideMap {
     /**
      * @zh
      * 获取指定原始动画剪辑应替换成的动画剪辑。
@@ -339,7 +339,7 @@ export type ReadonlyClipOverrideMap = {
      * If the original animation clip should not be overrode, `undefined` should be returned.
      */
     get(animationClip: AnimationClip): AnimationClip | undefined;
-};
+}
 
 /**
  * @en

--- a/cocos/animation/tracks/track.ts
+++ b/cocos/animation/tracks/track.ts
@@ -310,6 +310,11 @@ class TrackPath {
     private _paths: TargetPath[] = [];
 }
 
+interface AnimationFunction {
+    getValue: () => any;
+    setValue: (val: any) => void
+}
+
 /**
  * Composite of track path and value proxy.
  * Not exposed to external. If there is any reason it should be exposed,
@@ -324,7 +329,7 @@ export class TrackBinding {
     @serializable
     public proxy: IValueProxyFactory | undefined;
 
-    private static _animationFunctions = new WeakMap<Constructor, Map<string | number, { getValue: () => any, setValue: (val: any) => void}>>();
+    private static _animationFunctions = new WeakMap<Constructor, Map<string | number, AnimationFunction>>();
 
     public parseTrsPath () {
         if (this.proxy) {

--- a/cocos/animation/tracks/track.ts
+++ b/cocos/animation/tracks/track.ts
@@ -42,11 +42,11 @@ const parseTrsPathTag = Symbol('ConvertAsTrsPath');
 
 export const trackBindingTag = Symbol('TrackBinding');
 
-export type RuntimeBinding<T = unknown> = {
+export interface RuntimeBinding<T = unknown> {
     setValue(value: T): void;
 
     getValue?(): T;
-};
+}
 
 export type Binder = (binding: TrackBinding) => undefined | RuntimeBinding;
 
@@ -324,7 +324,7 @@ export class TrackBinding {
     @serializable
     public proxy: IValueProxyFactory | undefined;
 
-    private static _animationFunctions = new WeakMap<Constructor, Map<string | number, { getValue:() => any, setValue: (val: any) => void}>>();
+    private static _animationFunctions = new WeakMap<Constructor, Map<string | number, { getValue: () => any, setValue: (val: any) => void}>>();
 
     public parseTrsPath () {
         if (this.proxy) {

--- a/tests/animation/animaion-clip-migration-3.x.test.ts
+++ b/tests/animation/animaion-clip-migration-3.x.test.ts
@@ -566,13 +566,13 @@ describe('Animation Clip Migration 3.x', () => {
             bezierPoints: [.04,.94,.53,.63],
         });
 
-        type TimeBezierTestCase = {
+        interface TimeBezierTestCase {
             t0: number;
             t1: number;
             v0: number;
             v1: number;
             bezierPoints: BezierControlPoints;
-        };
+        }
 
         function testTimeBezierCurveConversion (testCase: TimeBezierTestCase) {
             const curve = new RealCurve();

--- a/tests/animation/new-gen-anim/utils/node-transform-value-observer.ts
+++ b/tests/animation/new-gen-anim/utils/node-transform-value-observer.ts
@@ -136,10 +136,10 @@ export class NodeTransformValueObserver {
 }
 
 namespace NodeTransformValueObserver {
-    export type Value = {
+    export interface Value {
         position: number;
         rotation: number;
         scale: number;
         eulerAngles: number;
-    };
+    }
 }

--- a/tests/core/algorithm/partition.test.ts
+++ b/tests/core/algorithm/partition.test.ts
@@ -1,7 +1,7 @@
 import { partition } from "../../../cocos/core/algorithm/partition";
 
 test(`Partition algorithm`, () => {
-    type Element = { /** The value. */ v: number, /** Result of the predicate function. */ p: boolean };
+    interface Element { /** The value. */ v: number, /** Result of the predicate function. */ p: boolean }
 
     const p = (array: Element[]) => {
         const nFirstGroup = partition(array, (element) => element.p);


### PR DESCRIPTION
Re: #

### Changelog

* After discussion with @holycanvas , we prefer to use a consistent type definition style: prefer `interface A { /* ... */ }` over `type A = { /* ... */ }`.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
