### PR TITLE
[DON'T MERGE] Implement enum types as non-intrusive, support named enum

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -2647,6 +2647,18 @@ Failed to init builtin asset's raw path.
 
 Sorry, 'cc.Enum' not available on this platform, please report this error here: <https://github.com/cocos-creator/engine/issues/new>
 
+### 7102
+
+The name '%s' has already been registered for %s.
+
+### 7103
+
+The enumeration has already been registered as %s.
+
+### 7104
+
+The enumeration has already been registered as anonymous.
+
 ### 7200
 
 Method 'initWithTMXFile' is no effect now, please set property 'tmxAsset' instead.

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -28,7 +28,7 @@ import { errorID, warnID, error } from '../platform/debug';
 import * as js from '../utils/js';
 import { getSuper } from '../utils/js';
 import { BitMask } from '../value-types';
-import { Enum } from '../value-types/enum';
+import { Enum, EnumType } from '../value-types/enum';
 import * as attributeUtils from './utils/attribute';
 import { IAcceptableAttributes } from './utils/attribute-defines';
 import { preprocessAttrs } from './utils/preprocess-class';
@@ -406,6 +406,7 @@ const PrimitiveTypes = {
 interface IParsedAttribute extends IAcceptableAttributes {
     ctor?: Function;
     enumList?: readonly any[];
+    enumType?: EnumType;
     bitmaskList?: any[];
 }
 type OnAfterProp = (constructor: Function, mainPropertyName: string) => void;

--- a/cocos/core/data/utils/attribute-internal.ts
+++ b/cocos/core/data/utils/attribute-internal.ts
@@ -33,4 +33,5 @@ export function setPropertyEnumType (objectOrConstructor: object, propertyName: 
 export function setPropertyEnumTypeOnAttrs (attrs: Record<string, any>, propertyName: string, enumType: EnumType): void {
     attrs[`${propertyName}${DELIMETER}type`] = 'Enum';
     attrs[`${propertyName}${DELIMETER}enumList`] = Enum.getList(enumType);
+    attrs[`${propertyName}${DELIMETER}enumType`] = enumType;
 }

--- a/editor/exports/enum.ts
+++ b/editor/exports/enum.ts
@@ -1,0 +1,5 @@
+
+export {
+    getEnumName,
+    findEnum,
+} from '../../cocos/core/value-types/enum';

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -13,8 +13,8 @@ import { CCClass } from '../../cocos/core/data/class';
 import { property } from '../../cocos/core/data/decorators/property';
 import { getClassByName, unregisterClass } from '../../cocos/core/utils/js-typed';
 import { LegacyPropertyDecorator } from '../../cocos/core/data/decorators/utils';
-import { CCBoolean, CCFloat, CCInteger, CCString } from '../../exports/base';
-import { PrimitiveType } from '../../cocos/core/data/utils/attribute';
+import { CCBoolean, ccenum, CCFloat, CCInteger, CCString } from '../../exports/base';
+import { attr, PrimitiveType } from '../../cocos/core/data/utils/attribute';
 
 test('Decorators signature', () => {
     class Foo {}
@@ -332,6 +332,21 @@ describe(`Decorators`, () => {
             });
             
         });
+    });
+
+    test(`Enum type`, () => {
+        enum SomeEnum { A }
+        ccenum(SomeEnum);
+
+        @ccclass('Foo')
+        class Foo {
+            @property({ type: SomeEnum })
+            bar = SomeEnum.A;
+        }
+
+        expect(attr(Foo, 'bar')).toStrictEqual(expect.objectContaining({
+            enumType: SomeEnum,
+        }));
     });
 });
 

--- a/tests/core/enum.test.ts
+++ b/tests/core/enum.test.ts
@@ -1,0 +1,91 @@
+import { Enum, findEnum, getEnumName, unregisterEnum } from "../../cocos/core/value-types/enum";
+import { ccenum } from "../../exports/base";
+import { captureErrorIDs } from '../utils/log-capture';
+
+test(`Enum registration`, () => {
+    const errorIDWatcher = captureErrorIDs();
+
+    // `ccenum()` not providing name does **NOT** assign a name to that enum.
+    enum AnonymousEnum1 {}
+    ccenum(AnonymousEnum1);
+    expect(getEnumName(AnonymousEnum1)).toBeUndefined();
+
+    // `ccenum()` with an empty string does **NOT** assign a name to that enum.
+    {
+        enum AnonymousEnum2 {}
+        ccenum(AnonymousEnum2, '');
+        expect(getEnumName(AnonymousEnum2)).toBeUndefined();
+        expect(findEnum('')).toBeUndefined();
+    }
+
+    // `ccenum()` with a non-empty name does assign a name to that enum.
+    enum Enum3 {}
+    ccenum(Enum3, 'SomeEnum');
+    expect(Enum.isEnum(Enum3)).toBe(true);
+    expect(getEnumName(Enum3)).toBe('SomeEnum');
+    expect(findEnum(getEnumName(Enum3)!)).toBe(Enum3);
+
+    // Registering an already-registered named enum **abort the registration**, errors are logged.
+    {
+        for (const name of [undefined, '', 'SomeEnum', 'SomeAbsentEnumName'] as const) {
+            ccenum(Enum3, name);
+            // Errors are logged.
+            expect(errorIDWatcher.captured).toStrictEqual([
+                [7103, 'SomeEnum'],
+            ]);
+            errorIDWatcher.clear();
+            // The already-existing enum is not effected.
+            expect(Enum.isEnum(Enum3)).toBe(true);
+            expect(getEnumName(Enum3)).toBe('SomeEnum');
+            expect(findEnum(getEnumName(Enum3)!)).toBe(Enum3);
+        }
+    }
+
+    // Registering an already-registered anonymous enum **abort the registration**, errors are logged.
+    {
+        for (const name of [undefined, '', 'SomeEnum', 'SomeAbsentEnumName'] as const) {
+            ccenum(AnonymousEnum1, name);
+            // Errors are logged.
+            expect(errorIDWatcher.captured).toStrictEqual([
+                [7104],
+            ]);
+            errorIDWatcher.clear();
+            // The already-existing enum is not effected.
+            expect(Enum.isEnum(AnonymousEnum1)).toBe(true);
+            expect(getEnumName(AnonymousEnum1)).toBeUndefined();
+        }
+    }
+
+    // `ccenum()` with an already existing name **abort the registration**, errors are logged.
+    {
+        enum UnregisteredEnum {}
+        for (const enumType of [
+            UnregisteredEnum,
+        ] as const) {
+            ccenum(enumType, 'SomeEnum');
+            // Errors are logged.
+            expect(errorIDWatcher.captured).toStrictEqual([
+                [7102, 'SomeEnum'],
+            ]);
+            errorIDWatcher.clear();
+        }
+        // The registration failed.
+        expect(Enum.isEnum(UnregisteredEnum)).toBe(false);
+        expect(getEnumName(UnregisteredEnum)).toBeUndefined();
+        // The already-existing enum is not effected.
+        expect(Enum.isEnum(Enum3)).toBe(true);
+        expect(getEnumName(Enum3)).toBe('SomeEnum');
+        expect(findEnum(getEnumName(Enum3)!)).toBe(Enum3);
+    }
+
+    // Unregister a named enum.
+    unregisterEnum(getEnumName(Enum3)!);
+    expect(Enum.isEnum(Enum3)).toBe(false);
+    expect(getEnumName(Enum3)).toBeUndefined();
+
+    // Then the named enum can be registered again.
+    ccenum(Enum3, 'Enum3_1');
+    expect(Enum.isEnum(Enum3)).toBe(true);
+    expect(getEnumName(Enum3)).toBe('Enum3_1');
+    expect(findEnum(getEnumName(Enum3)!)).toBe(Enum3);
+});

--- a/tests/scene-graph/layers.test.ts
+++ b/tests/scene-graph/layers.test.ts
@@ -1,6 +1,7 @@
 import { ccclass, property } from '../../cocos/core/data/class-decorator';
 import { attr } from '../../cocos/core/data/utils/attribute';
 import { Layers } from '../../cocos/scene-graph/layers';
+import { Enum } from '../../exports/base';
 
 @ccclass('LayerFlagUser')
 class LayerFlagUser{
@@ -17,7 +18,7 @@ test('Add/Remove layer', () => {
         attr(LayerFlagUser,'visibility').bitmaskList.findIndex((e) => e.name === 'abcd')
     ).toBeGreaterThanOrEqual(0);
     expect(
-        attr(LayerFlagUser,'visibilityEnum').enumList.findIndex((e) => e.name === 'abcd')
+        Enum.getList(attr(LayerFlagUser,'visibilityEnum').enumType).findIndex((e) => e.name === 'abcd')
     ).toBeGreaterThanOrEqual(0);
 
     Layers.deleteLayer(1);
@@ -25,6 +26,6 @@ test('Add/Remove layer', () => {
         attr(LayerFlagUser,'visibility').bitmaskList.findIndex((e) => e.name === 'abcd')
     ).toBeLessThan(0);
     expect(
-        attr(LayerFlagUser,'visibilityEnum').enumList.findIndex((e) => e.name === 'abcd')
+        Enum.getList(attr(LayerFlagUser,'visibilityEnum').enumType).findIndex((e) => e.name === 'abcd')
     ).toBeLessThan(0);
 });


### PR DESCRIPTION
Re: #

### Changelog

* Implement enumeration types as non-intrusive.

* Support named enumerations:

  - Registering(unregister) an enumeration with name.

  - Query the name of an enumeration. (in editor)

  - Retrieving enumeration by name. (in editor)

* In `@type(enumType)`, instead of storing the "enumList", store the enumeration type itself.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
