### PR TITLE
Animation graph: pose graph stash

### DIFF
--- a/cocos/animation/core/pose-heap-allocator.ts
+++ b/cocos/animation/core/pose-heap-allocator.ts
@@ -1,0 +1,201 @@
+import { TEST } from 'internal:constants';
+import { assertIsTrue } from '../../core/data/utils/asserts';
+import { Pose } from './pose';
+import { TransformArray } from './transform-array';
+
+const MAX_POSE_PER_PAGE = 8;
+
+const allocationInfoTag = Symbol('PoseHeapAllocator');
+
+type PagedPose = Pose & {
+    [allocationInfoTag]: AllocationInfo;
+};
+
+function isPagedPose (pose: Pose): pose is PagedPose {
+    return allocationInfoTag in pose;
+}
+
+const POSE_ALLOCATOR_DEBUG_FULL = TEST;
+
+export class PoseHeapAllocator {
+    constructor (transformCount: number, metaValueCount: number) {
+        this._transformCount = transformCount;
+        this._metaValueCount = metaValueCount;
+    }
+
+    public get allocatedCount () {
+        return this._allocatedCount;
+    }
+
+    public allocatePose (): Pose {
+        ++this._allocatedCount;
+        const { _pages: pages } = this;
+        const nPages = pages.length;
+
+        // Debug check our promise on `this._foremostPossibleFreePage`.
+        if (POSE_ALLOCATOR_DEBUG_FULL) {
+            for (let iPage = 0; iPage < this._foremostPossibleFreePage; ++iPage) {
+                const page = pages[iPage];
+                assertIsTrue(page.freeCount === 0);
+            }
+        }
+
+        for (let iPage = this._foremostPossibleFreePage; iPage < nPages; ++iPage) {
+            const page = pages[iPage];
+            const pose = page.tryAllocate();
+            if (pose) {
+                pose[allocationInfoTag].pageIndex = iPage;
+                if (page.freeCount === 0) {
+                    // Only step one, even the next page is not free.
+                    ++this._foremostPossibleFreePage;
+                }
+                return pose;
+            }
+        }
+
+        const pose = this._allocatePoseInNewPage();
+        // Update the flag, no matter if its capacity is 1.
+        this._foremostPossibleFreePage = pose[allocationInfoTag].pageIndex;
+        return pose;
+    }
+
+    public destroyPose (pose: Pose) {
+        assertIsTrue(isPagedPose(pose));
+        const { _pages: pages } = this;
+        const nPages = pages.length;
+        const pageIndex = pose[allocationInfoTag].pageIndex;
+        assertIsTrue(pageIndex >= 0 && pageIndex < nPages);
+        const page = pages[pageIndex];
+        page.deallocate(pose);
+        --this._allocatedCount;
+
+        // If the destruction performed on former page,
+        // update the flag so that next allocation find from this.
+        if (pageIndex < this._foremostPossibleFreePage) {
+            assertIsTrue(page.freeCount > 0);
+            this._foremostPossibleFreePage = pageIndex;
+        }
+    }
+
+    private _transformCount = 0;
+
+    private _metaValueCount = 0;
+
+    private _pages: PosePage[] = [];
+
+    private _allocatedCount = 0;
+
+    /**
+     * Index of the page that:
+     * - All former pages are busy.
+     * - This page and the following pages're possible having free location to allocate.
+     */
+    private _foremostPossibleFreePage = 0;
+
+    private _allocatePoseInNewPage (): PagedPose {
+        const page = new PosePage(this._transformCount, this._metaValueCount, 4);
+        const pageIndex = this._pages.length;
+        this._pages.push(page);
+        const pose = page.tryAllocate();
+        assertIsTrue(pose); // Shall not fail
+        pose[allocationInfoTag].pageIndex = pageIndex;
+        return pose;
+    }
+}
+
+class AllocationInfo {
+    get pageIndex () {
+        return this._id >> POSE_INDEX_BITS;
+    }
+
+    set pageIndex (value) {
+        this._id &= POSE_INDEX_MASK;
+        this._id |= (value << POSE_INDEX_BITS);
+    }
+
+    get poseIndex () {
+        return this._id & POSE_INDEX_MASK;
+    }
+
+    set poseIndex (value) {
+        this._id &= ~POSE_INDEX_MASK;
+        this._id |= value;
+    }
+
+    /**
+     * ((page index) << POSE_INDEX_BITS) + (pose index into page)
+     */
+    private _id = -1;
+}
+
+const POSE_INDEX_MASK = 0b111;
+const POSE_INDEX_BITS = 3;
+assertIsTrue(POSE_INDEX_MASK + 1 >= MAX_POSE_PER_PAGE);
+
+class PosePage {
+    constructor (private _transformCount: number, private _metaValueCount: number, private _capacity: number) {
+        const byteLength = (TransformArray.BYTES_PER_ELEMENT * _transformCount
+            + Float64Array.BYTES_PER_ELEMENT * _metaValueCount) * _capacity;
+        this._buffer = new ArrayBuffer(byteLength);
+        this._poses = new Array(_capacity).fill(null);
+        this._freeCount = _capacity;
+    }
+
+    get capacity () {
+        return this._capacity;
+    }
+
+    get freeCount () {
+        return this._freeCount;
+    }
+
+    public tryAllocate (): PagedPose | null {
+        const { _poses: poses, _idleFlags: idleFlags, _capacity: capacity } = this;
+        const idlePoseIndex = findRightmostSetBit(idleFlags);
+        if (idlePoseIndex >= capacity) {
+            return null;
+        }
+        assertIsTrue(idlePoseIndex >= 0 && idlePoseIndex < poses.length);
+        const pose = poses[idlePoseIndex] ??= this._createPose(idlePoseIndex);
+        pose[allocationInfoTag].poseIndex = idlePoseIndex;
+        this._idleFlags &= ~(1 << idlePoseIndex);
+        assertIsTrue(this._freeCount > 0);
+        --this._freeCount;
+        return pose;
+    }
+
+    public deallocate (pose: PagedPose) {
+        const { _poses: poses } = this;
+        const poseIndex = pose[allocationInfoTag].poseIndex;
+        assertIsTrue(poseIndex >= 0 && poseIndex < poses.length);
+        assertIsTrue(poses[poseIndex] === pose);
+        // Set as idle
+        this._idleFlags |= (1 << poseIndex);
+        assertIsTrue(this._freeCount < this._capacity);
+        ++this._freeCount;
+    }
+
+    private _buffer: ArrayBuffer;
+
+    private _idleFlags = 0xF;
+
+    private _poses: (PagedPose | null)[];
+
+    private _freeCount = 0;
+
+    private _createPose (index: number) {
+        const transformsByteLength = TransformArray.BYTES_PER_ELEMENT * this._transformCount;
+        const baseOffset = (transformsByteLength
+            + Float64Array.BYTES_PER_ELEMENT * this._metaValueCount) * index;
+        const transforms = new TransformArray(this._buffer, baseOffset, this._transformCount);
+        const metaValues = new Float64Array(this._buffer, baseOffset + transformsByteLength, this._metaValueCount);
+        const pose = Pose._create(transforms, metaValues);
+        pose[allocationInfoTag] = new AllocationInfo();
+        return pose as PagedPose;
+    }
+}
+
+function findRightmostSetBit (bits: number) {
+    // Math.log(2) === -Infinity
+    return bits === 0 ? Infinity : Math.log2(bits & -bits);
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose.ts
@@ -4,8 +4,8 @@ import { RuntimeStash } from '../stash/runtime-stash';
 import { PoseNode } from '../pose-node';
 import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from '../../animation-graph-context';
 
-@ccclass(`${CLASS_NAME_PREFIX_ANIM}UseStashedPose`)
-export class UseStashedPose extends PoseNode {
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeUseStashedPose`)
+export class PoseNodeUseStashedPose extends PoseNode {
     @serializable
     @editable
     public stashName = '';

--- a/cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose.ts
@@ -1,0 +1,43 @@
+import { ccclass, editable, serializable } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { RuntimeStash } from '../stash/runtime-stash';
+import { PoseNode } from '../pose-node';
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from '../../animation-graph-context';
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}UseStashedPose`)
+export class UseStashedPose extends PoseNode {
+    @serializable
+    @editable
+    public stashName = '';
+
+    public bind (context: AnimationGraphBindingContext) {
+        const {
+            stashName,
+        } = this;
+
+        // If stashName is empty, silently ignore.
+        if (!stashName) {
+            return;
+        }
+
+        const runtimeStash = context.stashView.bindStash(stashName);
+        this._runtimeStash = runtimeStash;
+    }
+
+    public settle (context: AnimationGraphSettleContext): void {
+    }
+
+    public reenter () {
+        this._runtimeStash?.reenter();
+    }
+
+    protected doUpdate (context: AnimationGraphUpdateContext): void {
+        this._runtimeStash?.requestUpdate(context);
+    }
+
+    protected doEvaluate (context: AnimationGraphEvaluationContext) {
+        return this._runtimeStash?.evaluate(context) ?? context.pushDefaultedPose();
+    }
+
+    private _runtimeStash: RuntimeStash | undefined = undefined;
+}

--- a/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
+++ b/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
@@ -1,0 +1,320 @@
+import { DEBUG } from 'internal:constants';
+import { approx, assertIsTrue, error } from '../../../../core';
+import { Pose } from '../../../core/pose';
+import { PoseGraphStash } from '../../animation-graph';
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext,
+    AnimationGraphSettleContext, AnimationGraphUpdateContext, AnimationGraphUpdateContextGenerator,
+} from '../../animation-graph-context';
+import { InstantiatedPoseGraph, instantiatePoseGraph } from '../instantiation';
+
+interface RuntimeStash {
+    reenter(): void;
+
+    requestUpdate (context: AnimationGraphUpdateContext): void;
+
+    evaluate (context: AnimationGraphEvaluationContext): Pose | null;
+}
+
+/**
+ * Traces the state of a stash record. The transition is described as following.
+ *
+  ```mermaid
+    stateDiagram-v2
+      [*] --> Uninitialized
+      Uninitialized --> Unsettled: `set`
+
+      Unsettled --> Settled: `settle()`
+      Settled --> Unsettled: `rebind()`(not supported yet)
+
+      Settled --> Pending: `reenter()`
+      Pending --> Pending: Repeatedly renter through `reenter()`, no effect
+
+      Pending --> Update
+      state Update {
+        [*] --> Updating: `update()`
+        Updating --> Updating: `update()`, circular dependency formed, no effect
+        Updating --> Updated: The `update()` returned
+        Updated --> Updated: `update()`, no effect
+        Updated --> [*]
+      }
+
+      Update --> Evaluate
+      state Evaluate {
+        [*] --> Evaluating: `evaluate()`
+        Evaluating --> Evaluating: `evaluate()`, circular dependency formed, return the default pose
+        Evaluating --> Evaluated: The `evaluate()` returned
+        Evaluated --> Evaluated: `evaluate()`, no effect
+        Evaluated --> [*]
+      }
+
+      Settled --> Settled: The stash was not touched in last tick and still not been touched in this tick
+      Pending --> Settled: The stash was touched in last tick but does not being touched in this tick.
+      Update --> Pending: End of tick, the stash is updated but not evaluated in this tick
+      Evaluate --> Pending: End of tick, The stash is evaluated in this tick
+  ```
+ *
+ * - Stash records are created at the beginning of layer instantiation, before instantiation of any other things.
+ *   All records' initial states are `UNINITIALIZED`.
+ *
+ * - Each stash is fed into the record, cause the record's state transition into `UNSETTLED`.
+ *   Then the stash's graph starts its bind stage.
+ *
+ * - After all things in animation graph completed their bind stage, each stash would be settled.
+ *   Then the stash was put in `SETTLED` state.
+ *
+ * - For each animation graph tick:
+ *
+ *   - If the stash was not accessed in last tick(asserts its state would be `SETTLED`),
+ *     but should be accessed in this tick. The stash would call `reenter()` of its graph.
+ *     Then the stash was put in `PENDING` state.
+ *
+ *   - Then, the stash will run into `UPDATING` and then `UPDATED` stage in animation graph update stage.
+ *     The stash only updates once, if there're multiple update threads, the later update takes no effect.
+ *     If circular dependency occurred, the update as well takes no effect.
+ *
+ *   - Then, the stash will run into `EVALUATING` and then `EVALUATED` stage in animation graph evaluation stage.
+ *     The stash only evaluates once and the evaluation result is cached,
+ *     if there're multiple evaluation threads, the evaluation result is duplicated.
+ *     If circular dependency occurred, the evaluation returns default pose.
+ *
+ *   - At the end of tick,
+ *
+ *      - If the stash is not updated and is not evaluated in this tick, it will be put back into `SETTLED` stage.
+ *
+ *      - Otherwise, it will be put in `PENDING` state.
+ */
+enum StashRecordState {
+    /**
+     * The stash record is created, but there's no stash set.
+     * The record shall not be in this state after binding stage.
+     */
+    UNINITIALIZED,
+
+    /**
+     * The stash has already been set into the stash record,
+     * but haven't not been settled.
+     */
+    UNSETTLED,
+
+    /**
+     * The stash has been settled. A `reenter` is required to activate the stash.
+     */
+    SETTLED,
+
+    /**
+     * The stash is not activated but have not been updated or evaluated in last frame.
+     */
+    PENDING,
+
+    /**
+     * The stash is being updated.
+     */
+    UPDATING,
+
+    /**
+     * The stash has been updated and is ready to evaluate, but it has not been evaluated.
+     */
+    UPDATED,
+
+    /**
+     * The stash is being evaluated.
+     */
+    EVALUATING,
+
+    /**
+     * The stash has been evaluated once.
+     */
+    EVALUATED,
+}
+
+class RuntimeStashRecord implements RuntimeStash {
+    public constructor (
+        private _allocator: PoseStashAllocator,
+    ) {
+    }
+
+    public set (stash: PoseGraphStash, context: AnimationGraphBindingContext) {
+        assertIsTrue(this._state === StashRecordState.UNINITIALIZED, `The stash has already been set.`);
+        const instantiatedPoseGraph = instantiatePoseGraph(stash.graph, context);
+        instantiatedPoseGraph.bind(context);
+        this._instantiatedPoseGraph = instantiatedPoseGraph;
+        this._state = StashRecordState.UNSETTLED;
+    }
+
+    public settle (context: AnimationGraphSettleContext) {
+        assertIsTrue(
+            this._state === StashRecordState.UNSETTLED // First time settle
+            || this._state === StashRecordState.SETTLED, // Resettle
+        );
+        assertIsTrue(this._instantiatedPoseGraph);
+        this._instantiatedPoseGraph.settle(context);
+        this._state = StashRecordState.SETTLED;
+    }
+
+    public reset () {
+        switch (this._state) {
+        case StashRecordState.SETTLED:
+            // The stash was not touched in last tick and still not been touched in this tick.
+            break;
+        case StashRecordState.PENDING:
+            // The stash was touched in last tick but does not being touched in this tick.
+            this._state = StashRecordState.SETTLED;
+            break;
+        case StashRecordState.UPDATED:
+            // Note: shall this means the stash is updated but not evaluated.
+            // fallthrough
+        case StashRecordState.EVALUATED:
+            if (this._evaluationCache) {
+                this._allocator.destroyPose(this._evaluationCache);
+                this._evaluationCache = null;
+            }
+            this._maxRequestedUpdateTime = 0.0;
+            this._state = StashRecordState.PENDING;
+            break;
+        case StashRecordState.UNINITIALIZED:
+        default:
+            assertIsTrue(false, `Unexpected stash state`);
+        }
+    }
+
+    public reenter () {
+        assertIsTrue(
+            this._state === StashRecordState.SETTLED
+            || this._state === StashRecordState.PENDING
+            || this._state === StashRecordState.UPDATED, // The stash has been updated in other place, but here again reenters.
+        );
+        assertIsTrue(this._instantiatedPoseGraph);
+        if (this._state === StashRecordState.SETTLED) {
+            this._state = StashRecordState.PENDING;
+            this._instantiatedPoseGraph.reenter();
+        }
+    }
+
+    public requestUpdate (context: AnimationGraphUpdateContext) {
+        const { deltaTime } = context;
+        assertIsTrue(
+            this._state === StashRecordState.PENDING
+            || this._state === StashRecordState.UPDATING
+            || this._state === StashRecordState.UPDATED,
+        );
+        assertIsTrue(this._instantiatedPoseGraph);
+
+        // We entered a loop, stop.
+        if (this._state === StashRecordState.UPDATING) {
+            return;
+        }
+
+        // Note: even `deltaTime < this._maxRequestedUpdateTime`(the `diffDeltaTime` becomes 0.0),
+        // the `context.directiveAbsoluteWeight` might not be 0.0.
+        // We still need to trigger an update since some nodes(such as MotionNode) needs to accumulate weight.
+        const diffDeltaTime = Math.max(0.0, deltaTime - this._maxRequestedUpdateTime);
+        // We accepted two same time-length update, don't do redundant updates.
+        // After PR #14990, this should always true.
+        if (this._state === StashRecordState.UPDATED) {
+            if (approx(diffDeltaTime, 0.0, 1e-8)) {
+                return;
+            } else {
+                // eslint-disable-next-line no-lonely-if
+                if (DEBUG) {
+                    error(`Arrived here indicates a violent of PR #14990. Please report the BUG.`);
+                    return;
+                }
+            }
+        }
+        this._state = StashRecordState.UPDATING;
+        this._maxRequestedUpdateTime = Math.max(deltaTime, this._maxRequestedUpdateTime);
+        const updateContext = this._updateContextGenerator.generate(
+            diffDeltaTime,
+            context.indicativeWeight,
+        );
+        this._instantiatedPoseGraph.update(updateContext);
+        this._state = StashRecordState.UPDATED;
+    }
+
+    public evaluate (context: AnimationGraphEvaluationContext) {
+        assertIsTrue(
+            this._state === StashRecordState.UPDATED
+            || this._state === StashRecordState.EVALUATING
+            || this._state === StashRecordState.EVALUATED,
+        );
+        assertIsTrue(this._instantiatedPoseGraph);
+        if (this._state === StashRecordState.EVALUATING) {
+            // Circular reference occurred.
+            this._state = StashRecordState.EVALUATED;
+        } else if (this._state === StashRecordState.UPDATED) {
+            assertIsTrue(!this._evaluationCache);
+            this._state = StashRecordState.EVALUATING;
+            const pose = this._instantiatedPoseGraph?.evaluate(context);
+            this._state = StashRecordState.EVALUATED;
+            if (pose) {
+                const heapPose = this._allocator.allocatePose();
+                heapPose.transforms.set(pose.transforms);
+                heapPose.auxiliaryCurves.set(pose.auxiliaryCurves);
+                this._evaluationCache = heapPose;
+                context.popPose();
+            }
+            this._state = StashRecordState.EVALUATED;
+        }
+        return this._evaluationCache
+            ? context.pushDuplicatedPose(this._evaluationCache)
+            : null;
+    }
+
+    private _state = StashRecordState.UNINITIALIZED;
+    private _instantiatedPoseGraph: InstantiatedPoseGraph | undefined = undefined;
+    private _maxRequestedUpdateTime = 0.0;
+    private _evaluationCache: Pose | null = null;
+    private _updateContextGenerator = new AnimationGraphUpdateContextGenerator();
+}
+
+interface RuntimeStashView {
+    bindStash(id: string): RuntimeStash | undefined;
+}
+
+export interface PoseStashAllocator {
+    allocatePose(): Pose;
+
+    destroyPose(pose: Pose): void;
+}
+
+export class RuntimeStashManager implements RuntimeStashView {
+    constructor (allocator: PoseStashAllocator) {
+        this._allocator = allocator;
+    }
+
+    public bindStash (id: string) {
+        return this._stashEvaluations[id] as RuntimeStash;
+    }
+
+    public getStash (id: string): RuntimeStashRecord | undefined {
+        return this._stashEvaluations[id];
+    }
+
+    public addStash (id: string) {
+        this._stashEvaluations[id] = new RuntimeStashRecord(this._allocator);
+    }
+
+    public setStash (id: string, stash: PoseGraphStash, context: AnimationGraphBindingContext) {
+        assertIsTrue(id in this._stashEvaluations);
+        this._stashEvaluations[id].set(stash, context);
+    }
+
+    public reset () {
+        for (const stashId in this._stashEvaluations) {
+            const record = this._stashEvaluations[stashId];
+            record.reset();
+        }
+    }
+
+    public settle (context: AnimationGraphSettleContext) {
+        for (const stashId in this._stashEvaluations) {
+            const record = this._stashEvaluations[stashId];
+            record.settle(context);
+        }
+    }
+
+    private _allocator: PoseStashAllocator;
+    private _stashEvaluations: Record<string, RuntimeStashRecord> = {};
+}
+
+export type { RuntimeStash, RuntimeStashView };

--- a/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
+++ b/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
@@ -29,28 +29,28 @@ interface RuntimeStash {
       Settled --> Pending: `reenter()`
       Pending --> Pending: Repeatedly renter through `reenter()`, no effect
 
-      Pending --> Update
+      Pending --> Update: `update()`
       state Update {
-        [*] --> Updating: `update()`
+        [*] --> Updating
         Updating --> Updating: `update()`, circular dependency formed, no effect
         Updating --> Updated: The `update()` returned
         Updated --> Updated: `update()`, no effect
         Updated --> [*]
       }
 
-      Update --> Evaluate
+      Update --> Evaluate: `evaluate()`
       state Evaluate {
-        [*] --> Evaluating: `evaluate()`
+        [*] --> Evaluating
         Evaluating --> Evaluating: `evaluate()`, circular dependency formed, return the default pose
         Evaluating --> Evaluated: The `evaluate()` returned
         Evaluated --> Evaluated: `evaluate()`, no effect
         Evaluated --> [*]
       }
 
-      Settled --> Settled: The stash was not touched in last tick and still not been touched in this tick
-      Pending --> Settled: The stash was touched in last tick but does not being touched in this tick.
-      Update --> Pending: End of tick, the stash is updated but not evaluated in this tick
-      Evaluate --> Pending: End of tick, The stash is evaluated in this tick
+      Settled --> Settled: At the end of tick
+      Pending --> Settled: At the end of tick
+      Update --> Pending: At the end of tick
+      Evaluate --> Pending: At the end of tick
   ```
  *
  * - Stash records are created at the beginning of layer instantiation, before instantiation of any other things.

--- a/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
+++ b/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
@@ -43,7 +43,7 @@ interface RuntimeStash {
         [*] --> Evaluating
         Evaluating --> Evaluating: `evaluate()`, circular dependency formed, return the default pose
         Evaluating --> Evaluated: The `evaluate()` returned
-        Evaluated --> Evaluated: `evaluate()`, no effect
+        Evaluated --> Evaluated: `evaluate()`, cache is returned
         Evaluated --> [*]
       }
 

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/stash-pose.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/stash-pose.test.ts
@@ -1,0 +1,350 @@
+import { AnimationGraphEvaluationContext, AnimationGraphSettleContext } from "../../../../../cocos/animation/marionette/animation-graph-context";
+import { PoseNode } from "../../../../../cocos/animation/marionette/pose-graph/pose-node";
+import { Node } from "../../../../../cocos/scene-graph";
+import { AnimationGraphEvalMock } from "../../utils/eval-mock";
+import { createAnimationGraph, LayerStashParams, StateParams } from "../../utils/factory";
+import { LinearRealValueAnimationFixture } from "../../utils/fixtures";
+import { SingleRealValueObserver } from "../../utils/single-real-value-observer";
+import '../../../../utils/matchers/value-type-asymmetric-matchers';
+
+import './utils/factories/all';
+import { ApplyAnimationFixturePoseNode } from "../../utils/apply-animation-fixture-pose-node";
+
+test(`Stash pose`, () => {
+    const fixture = {
+        stashed_animation: new LinearRealValueAnimationFixture(0, 666, 666),
+    };
+
+    const observer = new SingleRealValueObserver();
+
+    const animationGraph = createAnimationGraph({
+        layers: [{
+            stashes: {
+                'stashed': {
+                    graph: {
+                        rootNode: new ApplyAnimationFixturePoseNode(fixture.stashed_animation, observer),
+                    },
+                },
+            },
+            stateMachine: {
+                states: [0, 1].reduce((result, index) => {
+                    result[`${index}`] = {
+                        type: 'pose',
+                        graph: {
+                            rootNode: { type: 'use-stash', stashId: 'stashed' },
+                        },
+                    };
+                    return result;
+                }, {} as Record<string, StateParams>),
+                entryTransitions: [{ to: '0' }],
+                transitions: [{
+                    from: '0',
+                    to: '1',
+                    duration: 0.3,
+                    conditions: [{ type: 'unary', operand: { type: 'constant', value: true } }],
+                }],
+            },
+        }],
+    });
+
+    const evalMock = new AnimationGraphEvalMock(observer.root, animationGraph);
+
+    evalMock.step(0.1);
+    expect(observer.value).toBeCloseTo(fixture.stashed_animation.getExpected(evalMock.current), 5);
+});
+
+describe(`Exit and reentering`, () => {
+    test(`reenter() shall be called only at first tick of successive not-being-exited ticks`, () => {
+        const poseNodeMock = new PoseNodeMock();
+    
+        const animationGraph = createAnimationGraph({
+            variableDeclarations: {
+                't': { type: 'boolean', value: false },
+            },
+            layers: [{
+                stashes: {
+                    'stash': { graph: { rootNode: poseNodeMock } },
+                },
+                stateMachine: {
+                    states: {
+                        'use-stash-1': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'stash' } } },
+                        'use-stash-2': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'stash' } } },
+                    },
+                    entryTransitions: [{ to: 'use-stash-1' }],
+                    transitions: [{
+                        from: 'use-stash-1',
+                        to: 'use-stash-2',
+                        duration: 0.3,
+                        conditions: [{ type: 'unary', operand: { type: 'variable', name: 't' } }],
+                    }],
+                },
+            }],
+        });
+    
+        const evalMock = new AnimationGraphEvalMock(new Node(), animationGraph);
+    
+        // Enter use-stash-1.
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(1);
+        poseNodeMock.reenter_.mockClear();
+    
+        // Reside a while.
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(0);
+    
+        // Transition to use-stash-2.
+        evalMock.controller.setValue('t', true);
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(0);
+    
+        // Reside a while.
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(0);
+    
+        // Finish the transition.
+        evalMock.step(0.4);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(0);
+    });
+
+    test(`Caused by state entering & leaving`, () => {
+        const poseNodeMock = new PoseNodeMock();
+    
+        const animationGraph = createAnimationGraph({
+            variableDeclarations: {
+                'EnterStashState': { type: 'boolean', value: false },
+                'LeaveStashState': { type: 'boolean', value: false },
+            },
+            layers: [{
+                stashes: {
+                    'Stash': { graph: { rootNode: poseNodeMock } },
+                },
+                stateMachine: {
+                    states: {
+                        'UseStash': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'Stash' } } },
+                        'Empty': { type: 'empty' },
+                    },
+                    entryTransitions: [{ to: 'UseStash' }],
+                    transitions: [{
+                        from: 'UseStash',
+                        to: 'Empty',
+                        duration: 0.3,
+                        conditions: [{ type: 'unary', operand: { type: 'variable', name: 'LeaveStashState' } }],
+                    }, {
+                        from: 'Empty',
+                        to: 'UseStash',
+                        duration: 0.3,
+                        conditions: [{ type: 'unary', operand: { type: 'variable', name: 'EnterStashState' } }],
+                    }],
+                },
+            }],
+        });
+    
+        const evalMock = new AnimationGraphEvalMock(new Node(), animationGraph);
+    
+        // Enter <UseStash> state from state machine entry does cause the stash reentering.
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(1);
+        poseNodeMock.reenter_.mockClear();
+    
+        // Reside a while. Now we have been leaved the <UseStash> state.
+        evalMock.controller.setValue('LeaveStashState', true);
+        evalMock.step(0.3);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(0);
+    
+        // Again transition to the <UseStash>, stash's reenter() should be called.
+        evalMock.controller.setValue('EnterStashState', true);
+        evalMock.controller.setValue('LeaveStashState', false);
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(1);
+        poseNodeMock.reenter_.mockClear();
+    
+        // Finish the transition.
+        evalMock.step(0.4);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(0);
+    
+        // Again leave the <UseStash>.
+        evalMock.controller.setValue('EnterStashState', false);
+        evalMock.controller.setValue('LeaveStashState', true);
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(0);
+
+        // Finish the transition.
+        evalMock.step(0.4);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(0);
+
+        // Again transition to the <UseStash>, stash's reenter() should be called.
+        evalMock.controller.setValue('LeaveStashState', false);
+        evalMock.controller.setValue('EnterStashState', true);
+        evalMock.step(0.1);
+        expect(poseNodeMock.reenter_).toBeCalledTimes(1);
+        poseNodeMock.reenter_.mockClear();
+    
+    });
+});
+
+describe(`Stash update`, () => {
+    test(`Multiple threading stash update`, () => {
+    
+        const poseNodeMock = new PoseNodeMock();
+    
+        const animationGraph = createAnimationGraph({
+            variableDeclarations: {
+                't': { type: 'boolean', value: true },
+            },
+            layers: [{
+                stashes: {
+                    'stash': { graph: { rootNode: poseNodeMock } },
+                },
+                stateMachine: {
+                    states: {
+                        'Motion': { type: 'motion', motion: { type: 'clip-motion', clip: { duration: 1.0 } } },
+                        'UseStash1': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'stash' } } },
+                        'UseStash2': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'stash' } } },
+                    },
+                    entryTransitions: [{ to: 'Motion' }],
+                    transitions: [{
+                        from: 'Motion',
+                        to: 'UseStash1',
+                        duration: 0.1,
+                        exitTimeEnabled: true,
+                        exitTime: 0.9,
+                    }, {
+                        from: 'UseStash1',
+                        to: 'UseStash2',
+                        duration: 0.3,
+                        conditions: [{ type: 'unary', operand: { type: 'variable', name: 't' } }],
+                    }],
+                },
+            }],
+        });
+
+        // [0s, 0.9s): Motion
+        // [0.9s-1.0s): Motion --> UseStash1
+        // [1.0s-1.2s): UseStash1 --> UseStash2
+        // [3s-∞): UseStash2
+
+        for (const timePoint of [1.15, 1.2]) {
+            const evalMock = new AnimationGraphEvalMock(new Node(), animationGraph);
+            evalMock.goto(0.91); // Past the exit condition
+            const stash1_start_time = evalMock.current;
+            evalMock.goto(timePoint);
+            expect(poseNodeMock.update_).toBeCalledTimes(1);
+            expect(poseNodeMock.update_).toHaveBeenNthCalledWith(1, expect.objectContaining({
+                deltaTime: expect.toBeAround(evalMock.current - stash1_start_time),
+            }));
+            poseNodeMock.update_.mockClear();
+            expect(poseNodeMock.doEvaluate_).toBeCalledTimes(1);
+            poseNodeMock.doEvaluate_.mockClear();
+        }
+    });
+});
+
+describe(`Dependent stashes`, () => {
+    describe(`Stash creation order should not affect dependency relationship`, () => {
+        test.each([
+            [`A is created before B; B depends on A`, true],
+            [`A is created before B; A depends on B`, false],
+        ])('%s', (_, isADependsOnB) => {
+            const poseNodeMock = new PoseNodeMock();
+
+            const stashes: Record<string, LayerStashParams> = isADependsOnB
+                ? {
+                    'StashA': { graph: { rootNode: { type: 'use-stash', stashId: 'StashB' } } },
+                    'StashB': { graph: { rootNode: poseNodeMock } },
+                } : {
+                    'StashA': { graph: { rootNode: poseNodeMock } },
+                    'StashB': { graph: { rootNode: { type: 'use-stash', stashId: 'StashA' } } },
+                };
+
+            const dependingState = isADependsOnB ? 'UseStashA' : 'UseStashB';
+
+            const dependedState = isADependsOnB ? 'UseStashB' : 'UseStashA';
+    
+            const animationGraph = createAnimationGraph({
+                variableDeclarations: { 'T': { type: 'boolean' } },
+                layers: [{
+                    stashes,
+                    stateMachine: {
+                        states: {
+                            'UseStashA': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'StashA' } } },
+                            'UseStashB': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'StashB' } } },
+                        },
+                        entryTransitions: [{ to: dependingState }],
+                        transitions: [{
+                            from: dependingState,
+                            to: dependedState,
+                            duration: 0.3,
+                            conditions: [{ type: 'unary', operand: { type: 'variable', name: 'T' } }],
+                        }],
+                    },
+                }],
+            });
+        
+            const evalMock = new AnimationGraphEvalMock(new Node(), animationGraph);
+    
+            // Enter the depending state.
+            evalMock.step(0.1);
+            expect(poseNodeMock.reenter_).toBeCalledTimes(1);
+            poseNodeMock.reenter_.mockClear();
+            expect(poseNodeMock.update_).toBeCalledTimes(1);
+            expect(poseNodeMock.update_).toBeCalledWith(expect.objectContaining({
+                deltaTime: 0.1,
+            }));
+            poseNodeMock.update_.mockClear();
+            expect(poseNodeMock.doEvaluate_).toBeCalledTimes(1);
+        });
+    });
+    
+    test(`Circular dependent stash`, () => {
+        // The evaluation result of a stash is undefined if there's circular dependency between stashes.
+        const animationGraph = createAnimationGraph({
+            variableDeclarations: { 'T': { type: 'boolean' } },
+            layers: [{
+                stashes: {
+                    'stash': { graph: { rootNode: { type: 'use-stash', stashId: 'stash' } } },
+                },
+                stateMachine: {
+                    states: {
+                        'UseStash': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'stash' } } },
+                    },
+                    entryTransitions: [{ to: 'UseStash' }],
+                },
+            }],
+        });
+
+        const evalMock = new AnimationGraphEvalMock(new Node(), animationGraph);
+
+        evalMock.step(0.1);
+    });
+});
+
+class PoseNodeMock extends PoseNode {
+    public reenter_ = jest.fn();
+
+    public update_ = jest.fn();
+
+    public doEvaluate_ = jest.fn();
+
+    public bind() { }
+
+    public settle(context: AnimationGraphSettleContext): void {
+        
+    }
+
+    public reenter(...args: Parameters<PoseNode['reenter']>) {
+        this.reenter_(...args);
+    }
+
+    public doUpdate(...args: Parameters<PoseNode['update']>) {
+        const [context] = args;
+        this.update_({
+            deltaTime: context.deltaTime,
+            indicativeWeight: context.indicativeWeight,
+        });
+    }
+
+    protected doEvaluate(context: AnimationGraphEvaluationContext) {
+        this.doEvaluate_(context);
+        return context.pushDefaultedPose();
+    }
+}

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/evaluation-mock.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/evaluation-mock.ts
@@ -13,10 +13,7 @@ import {
     AnimationGraphSettleContext,
     AnimationGraphUpdateContext,
 } from '../../../../../../cocos/animation/marionette/animation-graph-context';
-import { BindContext } from '../../../../../../cocos/animation/marionette/parametric';
-import { MotionCoordination } from '../../../../../../cocos/animation/marionette/pose-graph/coordination/motion-coordination';
-import { RuntimeCoordinator } from '../../../../../../cocos/animation/marionette/pose-graph/coordination/runtime-coordinator';
-import { AllPreviousLayersResultManagerImpl } from '../../../../../../cocos/animation/marionette/pose-graph/default-top-level-pose-node';
+import { BindContext } from '../../../../../../cocos/animation/marionette/parametric';;
 import { PoseGraph } from '../../../../../../cocos/animation/marionette/pose-graph/pose-graph';
 import { PoseNode, PoseTransformSpaceRequirement } from '../../../../../../cocos/animation/marionette/pose-graph/pose-node';
 import { RuntimeStashManager } from '../../../../../../cocos/animation/marionette/pose-graph/stash/runtime-stash';
@@ -115,13 +112,10 @@ export class PoseNodeEvaluationMock<TAnimationResult> {
         );
         this._poseLayoutMaintainer.startBind();
 
-        const allPreviousLayersResultManager = new AllPreviousLayersResultManagerImpl();
         const poseAllocator = new DeferredPoseStashAllocator();
         const stashManager = new RuntimeStashManager(poseAllocator);
         bindContext._setLayerWideContextProperties(
             stashManager,
-            new RuntimeCoordinator(),
-            allPreviousLayersResultManager,
         );
 
         this._resultObserver = resultFactory.create(origin, bindContext);

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/all.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/all.ts
@@ -1,2 +1,4 @@
 
+import './use-stash-factory';
+
 export {};

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/use-stash-factory.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/use-stash-factory.ts
@@ -1,0 +1,18 @@
+
+import { UseStashedPose } from '../../../../../../../cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose';
+import '../../../../utils/factory';
+import { addPoseNodeFactory } from '../../../../utils/factory';
+
+declare global {
+    interface PoseNodeFactoryRegistry {
+        'use-stash': {
+            stashId: string;
+        };
+    }
+}
+
+addPoseNodeFactory('use-stash', (poseGraph, params) => {
+    const node = new UseStashedPose();
+    node.stashName = params.stashId;
+    return poseGraph.addNode(node);
+});

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/use-stash-factory.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/use-stash-factory.ts
@@ -1,5 +1,5 @@
 
-import { UseStashedPose } from '../../../../../../../cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose';
+import { PoseNodeUseStashedPose } from '../../../../../../../cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose';
 import '../../../../utils/factory';
 import { addPoseNodeFactory } from '../../../../utils/factory';
 
@@ -12,7 +12,7 @@ declare global {
 }
 
 addPoseNodeFactory('use-stash', (poseGraph, params) => {
-    const node = new UseStashedPose();
+    const node = new PoseNodeUseStashedPose();
     node.stashName = params.stashId;
     return poseGraph.addNode(node);
 });

--- a/tests/animation/new-gen-anim/utils/factory.ts
+++ b/tests/animation/new-gen-anim/utils/factory.ts
@@ -35,6 +35,12 @@ export function createAnimationGraph(params: AnimationGraphParams): AnimationGra
     }
     for (const layerParams of params.layers) {
         const layer = animationGraph.addLayer();
+        if (layerParams.stashes) {
+            for (const [stashId, stashParams] of Object.entries(layerParams.stashes)) {
+                const stash = layer.addStash(stashId);
+                fillPoseGraph(stash.graph, stashParams.graph);
+            }
+        }
         fillStateMachine(layer.stateMachine, layerParams.stateMachine);
         if (typeof layerParams.additive !== 'undefined') {
             layer.additive = layerParams.additive;
@@ -293,6 +299,7 @@ export type VariableDeclarationParams = {
 interface LayerParams {
     stateMachine: StateMachineParams;
     additive?: boolean;
+    stashes?: Record<string, LayerStashParams>;
 }
 
 export interface StateMachineParams {
@@ -415,6 +422,10 @@ export type MotionParams = {
         threshold: { x: number; y: number; };
     }>;
 };
+
+export interface LayerStashParams {
+    graph: PoseGraphParams;
+}
 
 interface PoseGraphParams {
     rootNode?: PoseNodeParams;


### PR DESCRIPTION
Re: #

### Changelog

* This PR introduces and implements the pose graph stash concept.

### Design Detail

- An animation graph layer may contain zero or more layerwise-uniquely-named pose graph stash(abbr: stash).

- A stash contains an isolated pose graph. In any portion of the layer, where pose node is allowed, a stash can be referenced through the pose node `UseStashedPose`. The references can occur multiple times in the layer. The references can also occur in stashes themself, formed a cross-stash reference(in other word, one stash can reference other stashes).

- Binding and settling stage will propagate to stashes. However, stashes themselves are not positively re-entered/updated/evaluated. Instead, these actions performed on the referencing `UseStashedPose` does fire a request to the stash to perform these actions on the stash. In a tick, if there're no corresponding requests on the stash, the stash do not perform the corresponding actions in that tick.

- During one tick, a stash may accept multiple re-entering/updating/evaluation requests, but it will actually perform those actions only once in that tick.

- The life time of a stash can be represented by the following diagram and was detailed in source comments in [cocos/animation/marionette/pose-graph/stash/runtime-stash.ts](https://github.com/cocos/cocos-engine/pull/15050/files#diff-3ac7bb6a73529b990d25de674bd73cc5f95751e0a5e6790cebf89d4fa1bae38bR56-R84)

  ```mermaid
    stateDiagram-v2
      [*] --> Uninitialized
      Uninitialized --> Unsettled: `set`

      Unsettled --> Settled: `settle()`
      Settled --> Unsettled: `rebind()`(not supported yet)

      Settled --> Pending: `reenter()`
      Pending --> Pending: Repeatedly renter through `reenter()`, no effect

      Pending --> Update: `update()`
      state Update {
        [*] --> Updating
        Updating --> Updating: `update()`, circular dependency formed, no effect
        Updating --> Updated: The `update()` returned
        Updated --> Updated: `update()`, no effect
        Updated --> [*]
      }

      Update --> Evaluate: `evaluate()`
      state Evaluate {
        [*] --> Evaluating
        Evaluating --> Evaluating: `evaluate()`, circular dependency formed, return the default pose
        Evaluating --> Evaluated: The `evaluate()` returned
        Evaluated --> Evaluated: `evaluate()`, cache is returned
        Evaluated --> [*]
      }

      Settled --> Settled: At the end of tick
      Pending --> Settled: At the end of tick
      Update --> Pending: At the end of tick
      Evaluate --> Pending: At the end of tick
  ```

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
