### PR TITLE
Reverse the arguments meaning of Transform.multiply

### DIFF
--- a/cocos/animation/core/transform.ts
+++ b/cocos/animation/core/transform.ts
@@ -104,7 +104,7 @@ export class Transform {
      * - The scale should be uniformed, ie. all components should be the same.
      * - Each component of the scale shall be non-negative.
      */
-    public static multiply (out: Transform, first: ReadonlyTransform, second: ReadonlyTransform) {
+    public static multiply (out: Transform, second: ReadonlyTransform, first: ReadonlyTransform) {
         // May reference to https://zhuanlan.zhihu.com/p/119066087
         // for the reason about restrictions on uniform scales.
 

--- a/tests/animation/core/transform.test.ts
+++ b/tests/animation/core/transform.test.ts
@@ -103,7 +103,7 @@ test('Multiply/Calculate relative', () => {
         childLocal.scale = new Vec3(0.6, 0.5, 0.0);
 
         const childGlobal = new Transform();
-        expect(Transform.multiply(childGlobal, childLocal, parentGlobal)).toBe(childGlobal);
+        expect(Transform.multiply(childGlobal, parentGlobal, childLocal)).toBe(childGlobal);
         expect(Vec3.equals(
             childGlobal.scale,
             new Vec3(0.0, 2.5, 0.0),
@@ -137,7 +137,7 @@ test('Multiply/Calculate relative', () => {
 
         // Let's verify the multiply again.
         const childGlobal2 = new Transform();
-        expect(Transform.multiply(childGlobal2, childLocal2, parentGlobal)).toBe(childGlobal2);
+        expect(Transform.multiply(childGlobal2, parentGlobal, childLocal2)).toBe(childGlobal2);
         expect(Transform.equals(childGlobal, childGlobal2)).toBe(true);
     }
 
@@ -155,7 +155,7 @@ test('Multiply/Calculate relative', () => {
         childLocal.scale = new Vec3(MAGIC.charCodeAt(4), MAGIC.charCodeAt(4), MAGIC.charCodeAt(4));
 
         const childGlobal = new Transform();
-        expect(Transform.multiply(childGlobal, childLocal, parentGlobal)).toBe(childGlobal);
+        expect(Transform.multiply(childGlobal, parentGlobal, childLocal)).toBe(childGlobal);
         expect(Transform.equals(childGlobal, multiplyInFormOfMatrix(new Transform(), childLocal, parentGlobal))).toBe(true);
         expect(Vec3.equals(
             childGlobal.scale,


### PR DESCRIPTION
Re: #

### Changelog

* Reverse the arguments meaning of `Transform.multiply`(internal API) so that `Transform.multiply(t1, t2)` means: apply `t2` first then `t1`. This behaviour match what `Quat.multiply`, `Mat4.multiply` does.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
