### PR TITLE
如何解决sourcemap不准确的bug

### DIFF
--- a/gulp/tasks/engine.js
+++ b/gulp/tasks/engine.js
@@ -237,10 +237,10 @@ exports.buildPreview = function (sourceFile, outputFile, callback, devMode) {
     if (!devMode) {
         bundler = bundler
             .pipe(Sourcemaps.init({loadMaps: true}))
-            .pipe(Utils.uglify('preview', {physics_cannon: true}))
-            .pipe(Optimizejs({
-                sourceMap: false
-            }))
+            // .pipe(Utils.uglify('preview', {physics_cannon: true}))
+            // .pipe(Optimizejs({
+            //     sourceMap: false
+            // }))
             .pipe(Sourcemaps.write('./', {
                 sourceRoot: '../',
                 includeContent: false,


### PR DESCRIPTION
论坛帖子： https://forum.cocos.org/t/creator/73177/4?u=xu_yanfeng


- 进入到engine根目录执行`npm i`安装依赖，主要是把gulp装上
![image](https://github.com/cocos/cocos-engine/assets/7894208/af71d713-b5e5-481b-8570-e9f0779a1ffb)

- 安装完毕后，就会有一个node_modules目录
![image](https://github.com/cocos/cocos-engine/assets/7894208/4a030ff6-3c7b-495b-b8ae-30725e58ee71)

- 修改对应的代码，如这个pr所示，注释掉那部分代码
- 执行对应的gulp task
    - linux: `./node_modules/.bin/gulp build-html5-preview`
    - win: `"./node_modules/.bin/gulp.cmd" build-html5-preview`
![image](https://github.com/cocos/cocos-engine/assets/7894208/f30c4e12-4424-4894-8427-dc6f0336067b)
- 一切顺利就会生成新的js和map文件，这样就能完美调试，不会发生断点错位的问题了
![image](https://github.com/cocos/cocos-engine/assets/7894208/7386c309-c968-4e82-a6ae-598e1fa2b701)


产生这个问题的原因： https://www.zhihu.com/question/62276604