### PR TITLE
Handle space conversion during pose graph evaluation, introduce base pose node class to modify pose

### DIFF
--- a/cocos/animation/core/pose.ts
+++ b/cocos/animation/core/pose.ts
@@ -17,9 +17,20 @@ export class Pose {
     /**
      * @internal
      */
+    public _poseTransformSpace = PoseTransformSpace.LOCAL;
+
+    /**
+     * @internal
+     */
     public static _create (transforms: TransformArray, auxiliaryCurves: Float64Array) {
         return new Pose(transforms, auxiliaryCurves);
     }
+}
+
+export enum PoseTransformSpace {
+    LOCAL,
+
+    COMPONENT,
 }
 
 export class TransformFilter {

--- a/cocos/animation/core/pose.ts
+++ b/cocos/animation/core/pose.ts
@@ -28,8 +28,14 @@ export class Pose {
 }
 
 export enum PoseTransformSpace {
+    /**
+     * Transforms are stored relative to their parent nodes.
+     */
     LOCAL,
 
+    /**
+     * Transforms are stored relative to the belonging animation controller's node's space.
+     */
     COMPONENT,
 }
 

--- a/cocos/animation/marionette/graph-eval.ts
+++ b/cocos/animation/marionette/graph-eval.ts
@@ -36,6 +36,7 @@ import {
     AnimationGraphUpdateContext, AnimationGraphUpdateContextGenerator,
     AnimationGraphSettleContext,
 } from './animation-graph-context';
+import { PoseTransformSpaceRequirement } from './pose-graph/pose-node';
 import { DefaultTopLevelPoseNode } from './pose-graph/default-top-level-pose-node';
 import {
     ClipStatus,
@@ -134,7 +135,7 @@ export class AnimationGraphEval {
         );
         rootPoseNode.update(updateContext);
 
-        const finalPose = rootPoseNode.evaluate(evaluationContext);
+        const finalPose = rootPoseNode.evaluate(evaluationContext, PoseTransformSpaceRequirement.LOCAL);
 
         if (this._hasAutoTrigger) {
             const { _varInstances: varInstances } = this;

--- a/cocos/animation/marionette/pose-graph/instantiation.ts
+++ b/cocos/animation/marionette/pose-graph/instantiation.ts
@@ -2,7 +2,7 @@
 
 import { assertIsTrue, warn } from '../../../core';
 import { instantiate } from '../../../serialization';
-import { PoseNode } from './pose-node';
+import { PoseNode, PoseTransformSpaceRequirement } from './pose-node';
 import { PoseGraph } from './pose-graph';
 import { PureValueNode, PureValueNodeLinkContext } from './pure-value-node';
 import { NodeInputPath } from './foundation/node-shell';
@@ -42,7 +42,7 @@ class InstantiatedPoseGraph {
     }
 
     public evaluate (context: AnimationGraphEvaluationContext) {
-        return this._rootPoseNode?.evaluate(context) ?? null;
+        return this._rootPoseNode?.evaluate(context, PoseTransformSpaceRequirement.LOCAL) ?? null;
     }
 }
 

--- a/cocos/animation/marionette/pose-graph/pose-nodes/modify-pose-base.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/modify-pose-base.ts
@@ -1,0 +1,251 @@
+import { DEBUG, EDITOR } from 'internal:constants';
+import { ccclass, editable, serializable, type } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { PoseNode, PoseTransformSpaceRequirement } from '../pose-node';
+import { input } from '../decorator/input';
+import { poseGraphNodeHide } from '../decorator/node';
+import { Pose, PoseTransformSpace } from '../../../core/pose';
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from '../../animation-graph-context';
+import { PoseGraphType } from '../foundation/type-system';
+import { assertIsTrue, CachedArray, Pool } from '../../../../core';
+import { Transform } from '../../../core/transform';
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeModifyPoseBase`)
+@poseGraphNodeHide()
+export abstract class PoseNodeModifyPoseBase extends PoseNode {
+    @serializable
+    @input({ type: PoseGraphType.POSE, displayName: '输入姿势' })
+    public input: PoseNode | null = null;
+
+    public settle (context: AnimationGraphSettleContext) {
+        this.input?.settle(context);
+        this._spaceFlagTable = new PoseTransformSpaceFlagTable(context.transformCount);
+    }
+
+    public reenter () {
+        this.input?.reenter();
+    }
+
+    public bind (context: AnimationGraphBindingContext): void {
+        this.input?.bind(context);
+    }
+
+    protected doUpdate (context: AnimationGraphUpdateContext) {
+        this.input?.update(context);
+    }
+
+    protected doEvaluate (context: AnimationGraphEvaluationContext): Pose {
+        const poseTransformSpaceRequirement = this.getPoseTransformSpaceRequirement();
+        const inputPose = this.input?.evaluate(context, poseTransformSpaceRequirement)
+            ?? PoseNode.evaluateDefaultPose(context, poseTransformSpaceRequirement);
+
+        const { _modificationQueue: modificationQueue } = this;
+        assertIsTrue(modificationQueue.length === 0);
+        this.modifyPose(context, inputPose, modificationQueue);
+
+        applyTransformModificationQueue(context, inputPose, modificationQueue, this._spaceFlagTable);
+        modificationQueue.clear();
+
+        return inputPose;
+    }
+
+    protected abstract getPoseTransformSpaceRequirement(): PoseTransformSpaceRequirement;
+
+    protected abstract modifyPose(
+        context: AnimationGraphEvaluationContext,
+        pose: Pose,
+        transformModificationQueue: TransformModificationQueue,
+    ): void;
+
+    private _modificationQueue = new TransformModificationQueue();
+    private _spaceFlagTable = new PoseTransformSpaceFlagTable(0);
+}
+
+class TransformModification {
+    public transformIndex = -1;
+    public transform = new Transform();
+}
+
+export type { TransformModification };
+
+class TransformModificationQueue {
+    get length () {
+        return this._array.length;
+    }
+
+    get array () {
+        return this._array.array;
+    }
+
+    public push (transformIndex: number, transform: Transform) {
+        if (DEBUG) {
+            assertIsTrue(transformIndex > this._debugLastTransformIndex, `Unexpected transform modification order`);
+            this._debugLastTransformIndex = transformIndex;
+        }
+        const mod = this._pool.alloc();
+        mod.transformIndex = transformIndex;
+        Transform.copy(mod.transform, transform);
+        this._array.push(mod);
+    }
+
+    public clear () {
+        const length = this._array.length;
+        for (let iMod = 0; iMod < length; ++iMod) {
+            const mod = this._array.get(iMod);
+            assertIsTrue(mod);
+            this._pool.free(mod);
+        }
+        this._array.clear();
+        if (DEBUG) {
+            this._debugLastTransformIndex = -1;
+        }
+    }
+
+    private _pool: Pool<TransformModification> = new Pool(() => new TransformModification(), 3);
+    private _array = new CachedArray<TransformModification>(3);
+    private _debugLastTransformIndex = -1;
+}
+
+export type { TransformModificationQueue };
+
+class PoseTransformSpaceFlagTable {
+    constructor (nTransforms: number) {
+        this._transformFlags = new Array(nTransforms);
+    }
+
+    /**
+     * Set all transforms' flags to false.
+     */
+    public clear () {
+        this._transformFlags.fill(false);
+    }
+
+    /**
+     * Test if the transform's flag is set to true.
+     * @param transformIndex Transform index.
+     * @returns True if the transform's flag is set to true.
+     */
+    public test (transformIndex: number) {
+        return this._transformFlags[transformIndex];
+    }
+
+    /**
+     * Sets the transform's flag to true.
+     * @param transformIndex Transform index.
+     */
+    public set (transformIndex: number) {
+        this._transformFlags[transformIndex] = true;
+    }
+
+    /**
+     * Sets the transform's flag to false.
+     * @param transformIndex Transform index.
+     */
+    public unset (transformIndex: number) {
+        this._transformFlags[transformIndex] = false;
+    }
+
+    private _transformFlags: boolean[] = [];
+}
+
+const cacheTransform_spaceConversion = new Transform();
+const cacheParentTransform_spaceConversion = new Transform();
+
+function applyTransformModificationQueue (
+    context: AnimationGraphEvaluationContext,
+    pose: Pose,
+    queue: TransformModificationQueue,
+    spaceFlagTable: PoseTransformSpaceFlagTable,
+) {
+    const nMods = queue.length;
+    if (nMods === 0) {
+        return;
+    }
+
+    if (DEBUG) {
+        let debugLastModTransformIndex = -1;
+        for (let iMod = 0; iMod < nMods; ++iMod) {
+            const { transformIndex } = queue.array[iMod];
+            // Ensure the modifications are queued from parent to child.
+            assertIsTrue(transformIndex > debugLastModTransformIndex);
+            debugLastModTransformIndex = transformIndex;
+        }
+    }
+
+    // In case of local space pose, no space conversion needed.
+    if (pose._poseTransformSpace === PoseTransformSpace.LOCAL) {
+        for (let iMod = 0; iMod < nMods; ++iMod) {
+            const { transformIndex, transform } = queue.array[iMod];
+            pose.transforms.setTransform(transformIndex, transform);
+        }
+        return;
+    }
+
+    assertIsTrue(pose._poseTransformSpace === PoseTransformSpace.COMPONENT);
+
+    // In the following, the flag of a transform is defined as:
+    // - False if it's in component space,
+    // - True if it's in local space or is component space but need to be converted into local space.
+
+    // At initial, all transforms are in component space.
+    spaceFlagTable.clear();
+
+    // From parent to child, collect all transforms needs to be converted into local space.
+    const firstTransformToConvert = queue.array[0].transformIndex;
+    let lastTransformToConvert = firstTransformToConvert;
+    for (let iMod = 0; iMod < nMods; ++iMod) {
+        const { transformIndex } = queue.array[iMod];
+        spaceFlagTable.set(transformIndex); // Set as "need to be converted".
+        lastTransformToConvert = transformIndex;
+    }
+    for (let transformIndex = firstTransformToConvert;
+        transformIndex < pose.transforms.length;
+        ++transformIndex) {
+        const parentTransformIndex = context.parentTable[transformIndex];
+        if (parentTransformIndex < 0) {
+            continue;
+        }
+        // If parent need be converted, then the child need to be converted to.
+        if (spaceFlagTable.test(parentTransformIndex)) {
+            spaceFlagTable.set(transformIndex); // Set as "need to be converted".
+            lastTransformToConvert = transformIndex;
+        }
+    }
+
+    // From child to parent, convert transforms in to local space.
+    // Now the "need to be converted" flags are turned into "in local space".
+    for (let transformIndex = lastTransformToConvert;
+        transformIndex >= firstTransformToConvert;
+        --transformIndex) {
+        if (spaceFlagTable.test(transformIndex)) {
+            const parentTransformIndex = context.parentTable[transformIndex];
+            if (parentTransformIndex >= 0) {
+                const transform = pose.transforms.getTransform(transformIndex, cacheTransform_spaceConversion);
+                const parentTransform = pose.transforms.getTransform(parentTransformIndex, cacheParentTransform_spaceConversion);
+                Transform.calculateRelative(transform, transform, parentTransform);
+                pose.transforms.setTransform(transformIndex, transform);
+            }
+        }
+    }
+
+    // From parent to child, apply modifications, these modified transforms are now in component space.
+    for (let iMod = 0; iMod < nMods; ++iMod) {
+        const { transformIndex, transform } = queue.array[iMod];
+        pose.transforms.setTransform(transformIndex, transform);
+        spaceFlagTable.unset(transformIndex); // Set as "in component space".
+    }
+
+    // Finally, from parent to child, recalculate component space back.
+    for (let transformIndex = firstTransformToConvert;
+        transformIndex <= lastTransformToConvert;
+        ++transformIndex) {
+        if (spaceFlagTable.test(transformIndex)) {
+            const parentTransformIndex = context.parentTable[transformIndex];
+            assertIsTrue(parentTransformIndex >= 0); // These changes should all be children of transforms in modification queue.
+            const transform = pose.transforms.getTransform(transformIndex, cacheTransform_spaceConversion);
+            const parentTransform = pose.transforms.getTransform(parentTransformIndex, cacheParentTransform_spaceConversion);
+            Transform.multiply(transform, parentTransform, transform);
+            pose.transforms.setTransform(transformIndex, transform);
+        }
+    }
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/transform-space.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/transform-space.ts
@@ -1,0 +1,38 @@
+import { ccenum } from '../../../../core';
+
+/**
+ * @zh
+ * 表示某些姿势图结点在接受变换输入（包括整个变换或者单独的位置旋转）时，
+ * 该变换所在的空间。
+ * @en
+ * Represents the space of input transforms(including whole transform or individual position or rotation)
+ * accepted by certain pose graph nodes.
+ */
+export enum TransformSpace {
+    /**
+     * @zh 表示该变换是在世界空间中描述的。
+     * @en Indicates the transform is described in world space.
+     */
+    WORLD,
+
+    /**
+     * @zh 表示该变换是在动画图所在组件（即动画控制器组件）的所属结点的本地空间中描述的。
+     * @en Indicates the transform is described in local space of the node
+     * to which the animation graph's belonging component(ie. the animation controller) is attached.
+     */
+    COMPONENT,
+
+    /**
+     * @zh 表示该变换是在应用到的目标结点的父结点的本地空间中描述的。
+     * @en Indicates the transform is described in local space of the applying node(bone).
+     */
+    PARENT,
+
+    /**
+     * @zh 表示该变换是在应用到的目标结点的本地空间中描述的。
+     * @en Indicates the transform is described in local space of the applying node(bone).
+     */
+    LOCAL,
+}
+
+ccenum(TransformSpace);

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/single-pose-modifier.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/single-pose-modifier.test.ts
@@ -1,0 +1,128 @@
+import { TransformHandle } from "../../../../../cocos/animation/core/animation-handle";
+import { Pose, PoseTransformSpace } from "../../../../../cocos/animation/core/pose";
+import { Transform } from "../../../../../cocos/animation/core/transform";
+import { AnimationGraphBindingContext, AnimationGraphSettleContext, AnimationGraphUpdateContext, AnimationGraphEvaluationContext } from "../../../../../cocos/animation/marionette/animation-graph-context";
+import { AnimationGraph, PoseGraph, poseGraphOp, PoseNode } from "../../../../../cocos/animation/marionette/asset-creation";
+import { PoseTransformSpaceRequirement } from "../../../../../cocos/animation/marionette/pose-graph/pose-node";
+import { PoseNodeModifyPoseBase, TransformModificationQueue } from "../../../../../cocos/animation/marionette/pose-graph/pose-nodes/modify-pose-base";
+import { Node } from "../../../../../exports/base";
+import { AnimationGraphEvalMock } from "../../utils/eval-mock";
+import { generateHierarchyFixture } from "../../utils/hierarchy-fixture";
+import { PoseRecord } from "../../utils/pose-record";
+import { PoseNode_ModifyDefaultPose } from "../utils/helping-nodes/pose-node-modify-default-pose";
+import { getTheOnlyInputKey, getTheOnlyOutputKey } from "../utils/misc";
+
+describe(`Base PoseNode PoseNodeModifyPoseBase`, () => {
+    const hierarchyLeafNodeIds = [
+        '1.2.2.1.2',
+    ];
+
+    describe(`Modification queue`, () => {
+        test(`No effect if modifier queue is empty`, () => {
+            const hierarchy = generateHierarchyFixture(hierarchyLeafNodeIds);
+
+            const {
+                componentSpace: poseRecordComponentSpace,
+                localSpace: poseRecordLocalSpace,
+            } = hierarchy.generateRandomPose();
+
+            const evalMock = createPoseModifierNodeRunner(hierarchy.origin, poseRecordLocalSpace, (poseGraph) => {
+                return poseGraph.addNode(new PoseNode_CommitSpecifiedModifications([]));
+            });
+
+            evalMock.step(0.2);
+        });
+
+        test(`Should throw in debug mode if the modification is queued in unexpected order`, () => {
+            const hierarchy = generateHierarchyFixture(hierarchyLeafNodeIds);
+
+            const {
+                componentSpace: poseRecordComponentSpace,
+                localSpace: poseRecordLocalSpace,
+            } = hierarchy.generateRandomPose();
+
+            expect(() => {
+                createPoseModifierNodeRunner(hierarchy.origin, poseRecordLocalSpace, (poseGraph) => {
+                    return poseGraph.addNode(new PoseNode_CommitSpecifiedModifications([
+                        [hierarchy.getNodeNameById('1.2.1.1')!, new Transform()],
+                        [hierarchy.getNodeNameById('1.2.1')!, new Transform()],
+                    ]));
+                }).step(0.2);
+            }).toThrowError();
+
+            expect(() => {
+                createPoseModifierNodeRunner(hierarchy.origin, poseRecordLocalSpace, (poseGraph) => {
+                    return poseGraph.addNode(new PoseNode_CommitSpecifiedModifications([
+                        [hierarchy.getNodeNameById('1.2.1.1')!, new Transform()],
+                        [hierarchy.getNodeNameById('1.2.1.1')!, new Transform()],
+                    ]));
+                }).step(0.2);
+            }).toThrowError();
+        });
+
+        test(`Modify multiple transform`, () => {
+            const hierarchy = generateHierarchyFixture(hierarchyLeafNodeIds);
+
+            const {
+                componentSpace: poseRecordComponentSpace,
+                localSpace: poseRecordLocalSpace,
+            } = hierarchy.generateRandomPose();
+
+            const modifications: [string, Transform][] = [];
+
+            const evalMock = createPoseModifierNodeRunner(hierarchy.origin, poseRecordLocalSpace, (poseGraph) => {
+                return poseGraph.addNode(new PoseNode_CommitSpecifiedModifications(modifications));
+            });
+
+            evalMock.step(0.2);
+        });
+    });
+});
+
+function createPoseModifierNodeRunner(node: Node, inputPoseRecordLocalSpace: PoseRecord, setup: (poseGraph: PoseGraph) => PoseNode) {
+    return createPoseGraphRunner(node, (poseGraph) => {
+        const input = poseGraph.addNode(new PoseNode_ModifyDefaultPose(PoseTransformSpace.COMPONENT, inputPoseRecordLocalSpace));
+        const modifier = setup(poseGraph);
+        poseGraphOp.connectNode(poseGraph, modifier, getTheOnlyInputKey(modifier), input, getTheOnlyOutputKey(input));
+        return modifier;
+    });
+}
+
+function createPoseGraphRunner(node: Node, setup: (poseGraph: PoseGraph) => PoseNode) {
+    const animationGraph = new AnimationGraph();
+    const layer = animationGraph.addLayer();
+    const poseState = layer.stateMachine.addPoseState();
+    const mainNode = setup(poseState.graph);
+    poseGraphOp.connectOutputNode(poseState.graph, poseState.graph.outputNode, mainNode);
+    layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
+    const evalMock = new AnimationGraphEvalMock(node, animationGraph);
+    evalMock.step(0.2);
+    return evalMock;
+}
+
+class PoseNode_CommitSpecifiedModifications extends PoseNodeModifyPoseBase {
+    constructor(private _modifications: [string, Transform][]) {
+        super();
+    }
+
+    public bind(context: AnimationGraphBindingContext) {
+        super.bind(context);
+        this._boundModifications = this._modifications.map(([nodeName, transform]) => {
+            const handle = context.bindTransformByName(nodeName);
+            expect(handle).not.toBeNull();
+            return [handle!, transform];
+        });
+    }
+
+    protected getPoseTransformSpaceRequirement(): PoseTransformSpaceRequirement {
+        return PoseTransformSpaceRequirement.COMPONENT;
+    }
+
+    protected modifyPose(context: AnimationGraphEvaluationContext, pose: Pose, modificationQueue: TransformModificationQueue) {
+        for (const [{ index: transformIndex }, transform] of this._boundModifications) {
+            modificationQueue.push(transformIndex, transform);
+        }
+    }
+
+    private _boundModifications: [TransformHandle, Transform][] = [];
+}

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/evaluation-mock.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/evaluation-mock.ts
@@ -1,0 +1,169 @@
+import { AnimationController } from '../../../../../../cocos/animation/animation';
+import { TransformHandle } from '../../../../../../cocos/animation/core/animation-handle';
+import { Pose } from '../../../../../../cocos/animation/core/pose';
+import { PoseHeapAllocator } from '../../../../../../cocos/animation/core/pose-heap-allocator';
+import {
+    AnimationGraphEvaluationContext,
+    AnimationGraphUpdateContextGenerator,
+    AnimationGraphPoseLayoutMaintainer,
+    AnimationGraphBindingContext,
+    DeferredPoseStashAllocator,
+    defaultTransformsTag,
+    AuxiliaryCurveRegistry,
+    AnimationGraphSettleContext,
+    AnimationGraphUpdateContext,
+} from '../../../../../../cocos/animation/marionette/animation-graph-context';
+import { BindContext } from '../../../../../../cocos/animation/marionette/parametric';
+import { MotionCoordination } from '../../../../../../cocos/animation/marionette/pose-graph/coordination/motion-coordination';
+import { RuntimeCoordinator } from '../../../../../../cocos/animation/marionette/pose-graph/coordination/runtime-coordinator';
+import { AllPreviousLayersResultManagerImpl } from '../../../../../../cocos/animation/marionette/pose-graph/default-top-level-pose-node';
+import { PoseGraph } from '../../../../../../cocos/animation/marionette/pose-graph/pose-graph';
+import { PoseNode, PoseTransformSpaceRequirement } from '../../../../../../cocos/animation/marionette/pose-graph/pose-node';
+import { RuntimeStashManager } from '../../../../../../cocos/animation/marionette/pose-graph/stash/runtime-stash';
+import { VarInstance } from '../../../../../../cocos/animation/marionette/variable';
+import { Node } from '../../../../../../cocos/scene-graph';
+import { assertIsTrue, Vec3 } from '../../../../../../exports/base';
+
+export class TransformHierarchy {
+    private _node = new Node();
+    private _children: TransformHierarchy[];
+
+    get node() {
+        return this._node;
+    }
+
+    public addChild(name: string) {
+        const child = new TransformHierarchy();
+        child._node.name = name;
+        this._children.push(child);
+        return child;
+    }
+}
+
+export interface AnimationResultObserver<T> {
+    readonly value: T;
+}
+
+export abstract class AnimationPart<T> {
+    abstract create(origin: Node, bindContext: BindContext): AnimationResultObserver<T>;
+
+    abstract createPoseNodeMockGenerating(value: T): PoseNode;
+}
+
+export class AnimationObserver_SingleRealValue extends AnimationPart<number> {
+    constructor(private _initialValue: number) {
+        super();
+    }
+
+    get initialValue() { return this._initialValue; }
+
+    create(origin: Node, bindContext: BindContext) {
+        const bone1 = new Node('Bone1');
+        bone1.position = new Vec3(this._initialValue);
+        origin.addChild(bone1);
+
+        // WARN! Handle creation!
+        void bindContext.bindTransform('Bone1');
+
+        return {
+            get value() {
+                return bone1.position.x;
+            },
+        };
+    }
+
+    createPoseNodeMockGenerating(value: number): PoseNode {
+        class PoseNodeMock extends PoseNode {
+            public settle(context: AnimationGraphSettleContext): void { }
+
+            public reenter(): void { }
+
+            protected doUpdate(context: AnimationGraphUpdateContext): void { }
+
+            public bind(context: AnimationGraphBindingContext): void {
+                const handle = context.bindTransform('Bone1');
+                expect(handle).not.toBeNull();
+                assertIsTrue(handle);
+                this._handle = handle;
+            }
+
+            protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+                const pose = context.pushDefaultedPose();
+                pose.transforms.setPosition( this._handle.index, new Vec3(value));
+                return pose;
+            }
+
+            private _handle: TransformHandle;
+        }
+
+        return new PoseNodeMock();
+    }
+}
+
+export class PoseNodeEvaluationMock<TAnimationResult> {
+    constructor(private _pose: PoseNode, resultFactory: AnimationPart<TAnimationResult>) {
+        const origin = new Node();
+        const animationController = origin.addComponent(AnimationController) as AnimationController;
+
+        this._poseLayoutMaintainer = new AnimationGraphPoseLayoutMaintainer(origin, this._auxiliaryCurveRegistry);
+
+        const bindContext = new AnimationGraphBindingContext(
+            origin, this._poseLayoutMaintainer, this._varRegistry,
+            animationController,
+            // @ts-expect-error HACK here
+            animationController._customEventTarget,
+        );
+        this._poseLayoutMaintainer.startBind();
+
+        const allPreviousLayersResultManager = new AllPreviousLayersResultManagerImpl();
+        const poseAllocator = new DeferredPoseStashAllocator();
+        const stashManager = new RuntimeStashManager(poseAllocator);
+        bindContext._setLayerWideContextProperties(
+            stashManager,
+            new RuntimeCoordinator(),
+            allPreviousLayersResultManager,
+        );
+
+        this._resultObserver = resultFactory.create(origin, bindContext);
+
+        _pose.bind(bindContext);
+
+        bindContext._unsetLayerWideContextProperties();
+
+        this._poseLayoutMaintainer.endBind();
+
+        const evaluationContext = this._poseLayoutMaintainer.createEvaluationContext();
+        this._evaluationContext = evaluationContext;
+        this._poseLayoutMaintainer.fetchDefaultTransforms(evaluationContext[defaultTransformsTag]);
+    }
+
+    public get resultObserver() {
+        return this._resultObserver;
+    }
+
+    public updateOnly(deltaTime: number, weight: number) {
+        const updateContextGenerator = new AnimationGraphUpdateContextGenerator();
+        const updateContext = updateContextGenerator.generate(deltaTime, weight);
+        this._pose.update(updateContext);
+    }
+
+    public evaluateOnly() {
+        const pose = this._pose.evaluate(this._evaluationContext, PoseTransformSpaceRequirement.NO);
+        this._poseLayoutMaintainer.apply(pose);
+        this._evaluationContext.popPose();
+    }
+
+    public step(deltaTime: number, weight: number) {
+        this.updateOnly(deltaTime, weight);
+        this.evaluateOnly();
+    }
+
+    private _animationController = new AnimationController();
+    private _varRegistry: Record<string, VarInstance> = {};
+    private _auxiliaryCurveRegistry = new AuxiliaryCurveRegistry();
+    private _poseLayoutMaintainer: AnimationGraphPoseLayoutMaintainer;
+    private _evaluationContext: AnimationGraphEvaluationContext;
+    private _resultObserver: AnimationResultObserver<TAnimationResult>;
+}
+
+export const DEFAULT_NUM_DIGITS = 5;

--- a/tests/animation/new-gen-anim/pose-graph/pose-transform-space.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-transform-space.test.ts
@@ -1,0 +1,409 @@
+import { TransformHandle } from '../../../../cocos/animation/core/animation-handle';
+import { Pose, PoseTransformSpace } from '../../../../cocos/animation/core/pose';
+import { AnimationGraphBindingContext, AnimationGraphSettleContext, AnimationGraphUpdateContext, AnimationGraphEvaluationContext } from '../../../../cocos/animation/marionette/animation-graph-context';
+import { Node } from '../../../../cocos/scene-graph';
+import { assertIsTrue, Mat4, Quat, Vec3 } from '../../../../exports/base';
+import { PoseNode, PoseTransformSpaceRequirement } from './../../../../cocos/animation/marionette/pose-graph/pose-node';
+import { input } from '../../../../cocos/animation/marionette/pose-graph/decorator/input';
+import { PoseGraphType } from '../../../../cocos/animation/marionette/pose-graph/foundation/type-system';
+import { AnimationGraph } from '../../../../cocos/animation/marionette/animation-graph';
+import { PoseGraph, poseGraphOp } from '../../../../cocos/animation/marionette/asset-creation';
+import { getTheOnlyInputKey, getTheOnlyOutputKey } from './utils/misc';
+import { AnimationGraphEvalMock } from '../utils/eval-mock';
+import { Transform } from '../../../../cocos/animation/core/transform';
+import { TransformSpace } from '../../../../cocos/animation/marionette/pose-graph/pose-nodes/transform-space';
+import { generateHierarchyFixture } from '../utils/hierarchy-fixture';
+import { PoseNode_MapPoseRecord } from './utils/helping-nodes/pose-node-map-pose-record';
+import { PoseNode_ModifyDefaultPose } from './utils/helping-nodes/pose-node-modify-default-pose';
+import { PoseRecord } from '../utils/pose-record';
+
+describe(`Pose transform space`, () => {
+    describe(`Pushing default poses`, () => {
+        test.each([
+            [`EvaluationContext.pushDefaultPose() yielding local space default pose`, PoseTransformSpace.LOCAL],
+            [`EvaluationContext.pushDefaultedPoseInComponentSpace() yielding component space default pose`, PoseTransformSpace.COMPONENT],
+        ])('%s', (_title, space) => {
+            const fixture = {
+                hierarchy: generateHierarchyFixture(),
+            };
+
+            const animationGraph = createPoseNodeRunner((poseGraph) => {
+                return poseGraph.addNode(new PoseNode_Check_EvaluationContext_pushDefaultPose(
+                    space,
+                    space === PoseTransformSpace.LOCAL
+                        ? fixture.hierarchy.getInitialLocalSpacePoseRecord()
+                        : fixture.hierarchy.getInitialComponentSpacePoseRecord(),
+                ));;
+            });
+    
+            const evalMock = new AnimationGraphEvalMock(fixture.hierarchy.origin, animationGraph);
+            evalMock.step(0.2);
+        });
+    });
+
+    describe(`PoseNode.evaluate() converts spaces`, () => {
+        test.each([
+            ['Local -> Local', PoseTransformSpace.LOCAL, PoseTransformSpaceRequirement.LOCAL],
+            ['Local -> Component', PoseTransformSpace.LOCAL, PoseTransformSpaceRequirement.COMPONENT],
+            ['Local -> No', PoseTransformSpace.LOCAL, PoseTransformSpaceRequirement.NO],
+
+            ['Component -> Component', PoseTransformSpace.COMPONENT, PoseTransformSpaceRequirement.COMPONENT],
+            ['Component -> Local', PoseTransformSpace.COMPONENT, PoseTransformSpaceRequirement.LOCAL],
+            ['Component -> No', PoseTransformSpace.COMPONENT, PoseTransformSpaceRequirement.NO],
+        ])(`%s`, (_, inSpace: PoseTransformSpace, requiringSpace: PoseTransformSpaceRequirement) => {
+            const fixture = {
+                hierarchy: generateHierarchyFixture(),
+            };
+
+            const {
+                localSpace: localSpacePoseRecord,
+                componentSpace: componentSpaceRecord,
+            } = fixture.hierarchy.generateRandomPose();
+
+            const inSpaceRecord = inSpace === PoseTransformSpace.LOCAL ? localSpacePoseRecord : componentSpaceRecord;
+
+            const expectedOutSpaceRecord = requiringSpace === PoseTransformSpaceRequirement.LOCAL
+                ? localSpacePoseRecord
+                : requiringSpace === PoseTransformSpaceRequirement.COMPONENT
+                    ? componentSpaceRecord
+                    : inSpaceRecord;
+
+            const animationGraph = createPoseNodeRunner((poseGraph) => {
+                // Add a node which modifying default pose according to our specified.
+                const producerNode = poseGraph.addNode(new PoseNode_ModifyDefaultPose(
+                    inSpace,
+                    inSpaceRecord,
+                ));
+
+                // Add a node which take the producer node and invoke `producerNode.evaluate()` according to the out space.
+                const consumerNode = poseGraph.addNode(new PoseNode_Check_PoseNode_evaluate(
+                    requiringSpace,
+                    expectedOutSpaceRecord,
+                ));
+
+                poseGraphOp.connectNode(poseGraph, consumerNode, getTheOnlyInputKey(consumerNode), producerNode, getTheOnlyOutputKey(consumerNode));
+
+                return consumerNode;
+            });
+    
+            const evalMock = new AnimationGraphEvalMock(fixture.hierarchy.origin, animationGraph);
+            evalMock.step(0.2);
+        });
+    });
+
+    describe(`Pose Transform Space <=> Transform Space`, () => {
+        const specPoseTransformToTargetSpace: readonly [
+            poseSpace: PoseTransformSpace,
+            transformSpace: TransformSpace,
+            calcExpectedApplyingTransform: (hierarchy: ReturnType<typeof generateHierarchyFixture>, localSpacePoseRecord: PoseRecord, nodeName: string) => Transform,
+        ][] = [
+            // * -> World
+            [PoseTransformSpace.COMPONENT, TransformSpace.WORLD,
+                (hierarchy) => hierarchy.getComponentToWorldTransform(),
+            ],
+            [PoseTransformSpace.LOCAL, TransformSpace.WORLD, (hierarchy, localSpacePoseRecord, nodeName) => {
+                return Transform.multiply(new Transform(),
+                    hierarchy.getComponentToWorldTransform(), // Component -> World
+                    hierarchy.computeComponentSpaceTransform( // Local -> Component
+                        localSpacePoseRecord,
+                        nodeName,
+                    ),
+                );
+            }],
+
+            // * -> Component
+            [PoseTransformSpace.COMPONENT, TransformSpace.COMPONENT, () => Transform.IDENTITY as Transform],
+            [PoseTransformSpace.LOCAL, TransformSpace.COMPONENT, (hierarchy, localSpacePoseRecord, nodeName) => {
+                return hierarchy.computeComponentSpaceTransform(
+                    localSpacePoseRecord,
+                    nodeName,
+                );
+            }],
+
+            // * -> Parent
+            [PoseTransformSpace.COMPONENT, TransformSpace.PARENT, (hierarchy, localSpacePoseRecord, nodeName) => {
+                return Transform.invert(new Transform(), hierarchy.computeComponentSpaceTransform(
+                    localSpacePoseRecord,
+                    hierarchy.getParentNodeName(nodeName),
+                ));
+            }],
+            [PoseTransformSpace.LOCAL, TransformSpace.PARENT, () => Transform.IDENTITY as Transform],
+
+            // * -> Local
+            [PoseTransformSpace.LOCAL, TransformSpace.LOCAL, (hierarchy, localSpacePoseRecord, nodeName) => {
+                return Transform.invert(new Transform(), localSpacePoseRecord.transforms[nodeName]);
+            }],
+            [PoseTransformSpace.COMPONENT, TransformSpace.LOCAL, (hierarchy, localSpacePoseRecord, nodeName) => {
+                return Transform.invert(new Transform(), hierarchy.computeComponentSpaceTransform(
+                    localSpacePoseRecord,
+                    nodeName,
+                ));
+            }],
+        ];
+
+        describe(`PoseNode._convertPoseSpaceTransformToTargetSpace()`, () => {
+    
+            const specs = specPoseTransformToTargetSpace.map(([poseTransformSpace, transformSpace, ...remain]) => {
+                return [
+                    `${PoseTransformSpace[poseTransformSpace]} => ${TransformSpace[transformSpace]}`,
+                    poseTransformSpace,
+                    transformSpace,
+                    ...remain,
+                ] as const;
+            });
+    
+            test.each(specs)(`Conversion: %s`, (_, poseSpace, outSpace, calcExpectedAppliedTransformOf) => {
+                const fixture = {
+                    hierarchy: generateHierarchyFixture(),
+                };
+        
+                const {
+                    localSpace: localSpacePoseRecord,
+                    componentSpace: componentSpacePoseRecord,
+                } = fixture.hierarchy.generateRandomPose();
+
+                const poseRecord = poseSpace === PoseTransformSpace.LOCAL ? localSpacePoseRecord : componentSpacePoseRecord;
+    
+                const nodesToTest = ['Middle 1.2.1', 'Root 1', 'Leaf 1.2.1.1'];
+    
+                for (const nodeToTest of nodesToTest) {
+                    const expectedAppliedTransform = calcExpectedAppliedTransformOf(fixture.hierarchy, localSpacePoseRecord, nodeToTest);
+
+                    const inTransform = new Transform();
+                    inTransform.position = new Vec3(0.512, -7.89, 4.13);
+    
+                    const animationGraph = createPoseNodeRunner((poseGraph) => {
+                        return poseGraph.addNode(new PoseNode_Check_EvaluationContext_convertPoseSpaceTransformToTargetSpace(
+                            poseSpace,
+                            poseRecord,
+                            inTransform,
+                            outSpace,
+                            expectedAppliedTransform,
+                            nodeToTest,
+                        ));
+                    });
+        
+                    const evalMock = new AnimationGraphEvalMock(fixture.hierarchy.origin, animationGraph);
+                    evalMock.step(0.2);
+                }
+            });
+        });
+    
+        describe(`PoseNode._convertTransformToPoseTransformSpace()`, () => {
+            const specs = specPoseTransformToTargetSpace.map(([poseTransformSpace, transformSpace, calc]) => {
+                return [
+                    `${TransformSpace[transformSpace]} => ${PoseTransformSpace[poseTransformSpace]}`,
+                    transformSpace,
+                    poseTransformSpace,
+                    (...args: Parameters<typeof calc>) => Transform.invert(new Transform(), calc(...args)),
+                ] as const;
+            });
+    
+            test.each(specs)(`Conversion: %s`, (_, inSpace, poseSpace, calcExpectedAppliedTransformOf) => {
+                const fixture = {
+                    hierarchy: generateHierarchyFixture(),
+                };
+        
+                const {
+                    localSpace: localSpacePoseRecord,
+                    componentSpace: componentSpacePoseRecord,
+                } = fixture.hierarchy.generateRandomPose();
+
+                const poseRecord = poseSpace === PoseTransformSpace.LOCAL ? localSpacePoseRecord : componentSpacePoseRecord;
+    
+                const nodesToTest = ['Middle 1.2.1', 'Root 1', 'Leaf 1.2.1.1'];
+    
+                for (const nodeToTest of nodesToTest) {
+                    const expectedAppliedTransform = calcExpectedAppliedTransformOf(fixture.hierarchy, localSpacePoseRecord, nodeToTest);
+    
+                    const inTransform = new Transform();
+                    inTransform.position = new Vec3(0.512, -7.89, 4.13);
+    
+                    const animationGraph = createPoseNodeRunner((poseGraph) => {
+                        return poseGraph.addNode(new PoseNode_Check_EvaluationContext_convertTransformToPoseTransformSpace(
+                            poseSpace,
+                            poseRecord,
+                            inTransform,
+                            inSpace,
+                            expectedAppliedTransform,
+                            nodeToTest,
+                        ));
+                    });
+        
+                    const evalMock = new AnimationGraphEvalMock(fixture.hierarchy.origin, animationGraph);
+                    evalMock.step(0.2);
+                }
+            });
+        });
+    });
+});
+
+function createPoseNodeRunner(setup: (poseGraph: PoseGraph) => PoseNode) {
+    const animationGraph = new AnimationGraph();
+    const layer = animationGraph.addLayer();
+    const poseState = layer.stateMachine.addPoseState();
+    const mainNode = setup(poseState.graph);
+    poseGraphOp.connectOutputNode(poseState.graph, poseState.graph.outputNode, mainNode);
+    layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
+    return animationGraph;
+}
+
+/**
+ * A pose node checking the result pose of `EvaluationContext.pushDefaultPose()` or `EvaluationContext.pushDefaultedPoseInComponentSpace()` during evaluation.
+ */
+class PoseNode_Check_EvaluationContext_pushDefaultPose extends PoseNode_MapPoseRecord {
+    constructor(
+        private _space: PoseTransformSpace,
+        record: PoseRecord,
+    ) {
+        super(record);
+    }
+
+    protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+        expect(this.transformHandleMap).not.toBeUndefined();
+        const pose = this._space === PoseTransformSpace.LOCAL
+            ? context.pushDefaultedPose()
+            : context.pushDefaultedPoseInComponentSpace();
+        for (const [handle, expectedTransform] of this.transformHandleMap!) {
+            const actualTransform = pose.transforms.getTransform(handle.index, new Transform());
+            expect(Transform.equals(actualTransform, expectedTransform)).toBe(true);
+        }
+        return pose;
+    }
+}
+
+/**
+ * A pose node checking the result pose of `PoseNode.evaluate` during evaluation.
+ */
+class PoseNode_Check_PoseNode_evaluate extends PoseNode_MapPoseRecord {
+    constructor(
+        private _spaceRequirement: PoseTransformSpaceRequirement,
+        expectedPoseRecord: PoseRecord,
+    ) {
+        super(expectedPoseRecord);
+    }
+
+    @input({ type: PoseGraphType.POSE })
+    input: PoseNode | null = null;
+
+    public bind(context: AnimationGraphBindingContext): void {
+        super.bind(context);
+        expect(this.input).not.toBeNull();
+        this.input!.bind(context);
+    }
+
+    public settle(context: AnimationGraphSettleContext): void {
+        super.settle(context);
+        expect(this.input).not.toBeNull();
+        this.input!.settle(context);
+    }
+
+    public reenter(): void {
+        super.reenter();
+        expect(this.input).not.toBeNull();
+        this.input!.reenter();
+    }
+
+    protected doUpdate(context: AnimationGraphUpdateContext): void {
+        super.doUpdate(context);
+        expect(this.input).not.toBeNull();
+        this.input!.update(context);
+    }
+
+    protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+        expect(this.input).not.toBeNull();
+        const pose = this.input!.evaluate(context, this._spaceRequirement);
+        expect(this.transformHandleMap).not.toBeUndefined();
+        for (const [transformHandle, expectedTransform] of this.transformHandleMap!) {
+            expect(Transform.equals(
+                pose.transforms.getTransform(transformHandle.index, new Transform()),
+                expectedTransform,
+            )).toBe(true);
+        }
+        return pose;
+    }
+};
+
+/**
+ * A pose node checking the result pose of `EvaluationContext._convertPoseSpaceTransformToTargetSpace` during evaluation.
+ */
+class PoseNode_Check_EvaluationContext_convertPoseSpaceTransformToTargetSpace extends PoseNode_ModifyDefaultPose {
+    constructor(
+        poseSpace: PoseTransformSpace,
+        record: PoseRecord,
+        private _inTransform: Transform,
+        private _outTransformSpace: TransformSpace,
+        private _expectedApplyingOutTransform: Transform,
+        private _targetNodeName: string,
+    ) {
+        super(poseSpace, record);
+    }
+
+    bind(context: AnimationGraphBindingContext) {
+        super.bind(context);
+        this._targetNodeHandle = context.bindTransformByName(this._targetNodeName) ?? undefined;
+    }
+
+    protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+        expect(this._targetNodeHandle).not.toBeUndefined();
+        const pose = super.doEvaluate(context);
+
+        const actualOutTransform = Transform.clone(this._inTransform);
+        context._convertPoseSpaceTransformToTargetSpace(
+            actualOutTransform,
+            this._outTransformSpace,
+            pose,
+            this._targetNodeHandle!.index,
+        );
+
+        const expectedOutTransform = Transform.clone(this._inTransform);
+        Transform.multiply(expectedOutTransform, this._expectedApplyingOutTransform, expectedOutTransform);
+
+        expect(Transform.equals(actualOutTransform, expectedOutTransform)).toBe(true);
+        return pose;
+    }
+
+    private _targetNodeHandle: TransformHandle | undefined = undefined;
+}
+
+/**
+ * A pose node checking the result pose of `EvaluationContext._convertTransformToPoseTransformSpace` during evaluation.
+ */
+class PoseNode_Check_EvaluationContext_convertTransformToPoseTransformSpace extends PoseNode_ModifyDefaultPose {
+    constructor(
+        poseSpace: PoseTransformSpace,
+        record: PoseRecord,
+        private _inTransform: Transform,
+        private _inTransformSpace: TransformSpace,
+        private _expectedApplyingOutTransform: Transform,
+        private _targetNodeName: string,
+    ) {
+        super(poseSpace, record);
+    }
+
+    bind(context: AnimationGraphBindingContext) {
+        super.bind(context);
+        this._targetNodeHandle = context.bindTransformByName(this._targetNodeName) ?? undefined;
+    }
+
+    protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+        expect(this._targetNodeHandle).not.toBeUndefined();
+        const pose = super.doEvaluate(context);
+
+        const actualOutTransform = Transform.clone(this._inTransform);
+        context._convertTransformToPoseTransformSpace(
+            actualOutTransform,
+            this._inTransformSpace,
+            pose,
+            this._targetNodeHandle!.index,
+        );
+
+        const expectedOutTransform = Transform.clone(this._inTransform);
+        Transform.multiply(expectedOutTransform, this._expectedApplyingOutTransform, expectedOutTransform);
+
+        expect(Transform.equals(actualOutTransform, expectedOutTransform)).toBe(true);
+        return pose;
+    }
+
+    private _targetNodeHandle: TransformHandle | undefined = undefined;
+}

--- a/tests/animation/new-gen-anim/pose-graph/utils/helping-nodes/pose-node-map-pose-record.ts
+++ b/tests/animation/new-gen-anim/pose-graph/utils/helping-nodes/pose-node-map-pose-record.ts
@@ -1,0 +1,29 @@
+import { TransformHandle } from "../../../../../../cocos/animation/core/animation-handle";
+import { Transform } from "../../../../../../cocos/animation/core/transform";
+import { AnimationGraphBindingContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from "../../../../../../cocos/animation/marionette/animation-graph-context";
+import { PoseNode } from "../../../../../../cocos/animation/marionette/pose-graph/pose-node";
+import { PoseRecord } from "../../../utils/pose-record";
+
+export abstract class PoseNode_MapPoseRecord extends PoseNode {
+    constructor(
+        private _record: PoseRecord,
+    ) {
+        super();
+    }
+
+    public bind(context: AnimationGraphBindingContext): void {
+        this.transformHandleMap = new Map(Object.entries(this._record.transforms).map(([nodeName, transformRecord]) => {
+            const handle = context.bindTransformByName(nodeName);
+            expect(handle).not.toBeNull();
+            return [handle!, transformRecord];
+        }));
+    }
+
+    public settle(context: AnimationGraphSettleContext): void { }
+
+    public reenter(): void { }
+
+    protected doUpdate(context: AnimationGraphUpdateContext): void { }
+
+    protected transformHandleMap: Map<TransformHandle, Transform> | undefined = undefined;
+}

--- a/tests/animation/new-gen-anim/pose-graph/utils/helping-nodes/pose-node-modify-default-pose.ts
+++ b/tests/animation/new-gen-anim/pose-graph/utils/helping-nodes/pose-node-modify-default-pose.ts
@@ -1,0 +1,25 @@
+import { Pose, PoseTransformSpace } from "../../../../../../cocos/animation/core/pose";
+import { AnimationGraphEvaluationContext } from "../../../../../../cocos/animation/marionette/animation-graph-context";
+import { PoseRecord } from "../../../utils/hierarchy-fixture";
+import { PoseNode_MapPoseRecord } from "./pose-node-map-pose-record";
+
+/**
+ * A pose node modify the result pose of `EvaluationContext.pushDefaultPose()` or `EvaluationContext.pushDefaultedPoseInComponentSpace()` during evaluation.
+ */
+export class PoseNode_ModifyDefaultPose extends PoseNode_MapPoseRecord {
+    constructor(
+        private _defaultPoseTransformSpace: PoseTransformSpace,
+        record: PoseRecord,
+    ) {
+        super(record);
+    }
+
+    protected doEvaluate(context: AnimationGraphEvaluationContext): Pose {
+        expect(this.transformHandleMap).not.toBeUndefined();
+        const pose = this._defaultPoseTransformSpace === PoseTransformSpace.LOCAL ? context.pushDefaultedPose() : context.pushDefaultedPoseInComponentSpace();
+        for (const [handle, transformRecord] of this.transformHandleMap!) {
+            pose.transforms.setTransform(handle.index, transformRecord)
+        }
+        return pose;
+    }
+}

--- a/tests/animation/new-gen-anim/utils/hierarchy-fixture.ts
+++ b/tests/animation/new-gen-anim/utils/hierarchy-fixture.ts
@@ -1,0 +1,271 @@
+import { Transform } from "../../../../cocos/animation/core/transform";
+import { Node, Quat, Vec3 } from "../../../../exports/base";
+import { PoseRecord } from "./pose-record";
+
+/**
+ * Generates the following hierarchy:
+```
+Origin
+├── Root 1
+│   ├── Leaf 1.1
+│   └── Middle 1.2
+│       ├── Middle 1.2.1
+│       │   └── Leaf 1.2.1.1
+│       └── Leaf 1.2.2
+├── Root 2
+│   └── Leaf 2.1
+├── (Non-animated)Root 3
+│   ├── Leaf 3.3
+│   └── (Non-animated)Middle 3.4
+│       └── Left 3.4.1
+└── Root 4
+    └── (Non-animated)Middle 4.1
+        └── Leaf 4.1.1
+```
+ */
+export function generateHierarchyFixture(
+    leafNodeIds = [
+        '1.1',
+        '1.2.1.1',
+        '1.2.2',
+        '2.1',
+    ],
+) {
+    const nonAnimatingNodeIds = [
+        '3',
+        '3.4',
+        '4.1',
+    ];
+
+    class ObservedNode {
+        private static _observeIdGenerator = 0;
+
+        get node() {
+            return this._node;
+        }
+
+        constructor(name: string, observedParent: ObservedNode | undefined) {
+            const observeId = ++ObservedNode._observeIdGenerator;
+
+            const node = new Node(name);
+            node.setPosition(new Vec3(observeId, observeId, observeId));
+            node.setScale(new Vec3(observeId, observeId, observeId));
+            node.setRotation(Quat.fromEuler(new Quat(), observeId, observeId, observeId));
+            if (observedParent) {
+                node.parent = observedParent._node;
+            }
+
+            this._initialLocalTransform = new Transform();
+            this._initialLocalTransform.position = Vec3.clone(node.position);
+            this._initialLocalTransform.rotation = Quat.clone(node.rotation);
+            this._initialLocalTransform.scale = Vec3.clone(node.scale);
+
+            this._initialComponentTransform = new Transform();
+            this._initialComponentTransform.position = Vec3.clone(node.worldPosition);
+            this._initialComponentTransform.rotation = Quat.clone(node.worldRotation);
+            this._initialComponentTransform.scale = Vec3.clone(node.worldScale);
+
+            this._node = node;
+        }
+
+        get initialLocalTransform() {
+            return this._initialLocalTransform;
+        }
+
+        get initialComponentTransform() {
+            return this._initialComponentTransform;
+        }
+
+        private _node: Node;
+        private _initialLocalTransform = new Transform();
+        private _initialComponentTransform = new Transform();
+    }
+    
+    const idToNodeMap = new Map<string, ObservedNode>();
+
+    for (const leafNodeId of leafNodeIds) {
+        let parent: ObservedNode | undefined;
+        const parts = leafNodeId.split('.');
+        for (let iPart = 0; iPart < parts.length; ++iPart) {
+            const id = parts.slice(0, iPart + 1).join('.');
+            let node = idToNodeMap.get(id);
+            if (!node) {
+                let prefix = iPart === parts.length - 1
+                    ? 'Leaf'
+                    : iPart === 0
+                        ? 'Root'
+                        : 'Middle';
+
+                if (nonAnimatingNodeIds.includes(id)) {
+                    prefix = `(Uninvolved)${prefix}`;
+                }
+                node = new ObservedNode(`${prefix} ${id}`, parent);
+                idToNodeMap.set(id, node);
+            }
+            parent = node;
+        }
+    }
+
+    const origin = new Node();
+
+    for (const node of idToNodeMap.values()) {
+        if (!node.node.parent) {
+            node.node.parent = origin;
+        }
+    }
+
+    // Give origin some transform.
+    {
+        origin.setPosition(1, 2, 3);
+        origin.setRotation(Quat.fromEuler(new Quat(), 4, 5, 6));
+        origin.setScale(new Vec3(7, 7, 7));
+    }
+
+    // Give the origin a parent.
+    {
+        const originParent = new Node();
+        originParent.addChild(origin);
+        originParent.setPosition(8, 9, 10);
+        origin.setRotation(Quat.fromEuler(new Quat(), 11, 12, 13));
+        origin.setScale(new Vec3(1.4, 1.4, 1.4));
+    }
+
+    const getObservedNodeByName = (name: string) => {
+        const node = [...idToNodeMap.values()].find((node) => node.node.name === name);
+        return node;
+    };
+
+    return {
+        origin,
+
+        getNodeNameById(id: string) {
+            return idToNodeMap.get(id)?.node.name;
+        },
+
+        getComponentToWorldTransform() {
+            const result = new Transform();
+            result.position = origin.worldPosition;
+            result.rotation = origin.worldRotation;
+            result.scale = origin.worldScale;
+            return result;
+        },
+
+        getWorldToComponentTransform() {
+            const result = this.getComponentToWorldTransform();
+            Transform.invert(result, result);
+            return result;
+        },
+
+        getParentNodeName(from: string) {
+            const fromNode = [...idToNodeMap.values()].find((node) => node.node.name === from);
+            expect(fromNode).not.toBeUndefined();
+            const parentNode = fromNode!.node.parent;
+            expect(parentNode).not.toBeNull();
+            if (parentNode === origin) {
+                return '';
+            } else {
+                expect([...idToNodeMap.values()].find((node) => node.node === parentNode)).not.toBeUndefined();
+                return parentNode!.name;
+            }
+        },
+
+        computeComponentSpaceTransform(pose: PoseRecord, nodeName: string) {
+            const result = new Transform();
+            if (nodeName === '') {
+                return result;
+            }
+
+            const fromNode = [...idToNodeMap.values()].find((node) => node.node.name === nodeName);
+            expect(fromNode).not.toBeUndefined();
+            for (let node: Node | null = fromNode!.node; node; node = node.parent) {
+                if (node === origin) {
+                    return result;
+                }
+                let nodeTransform: Transform;
+                if (node.name in pose.transforms) {
+                    nodeTransform = pose.transforms[node.name];
+                } else {
+                    const observed = getObservedNodeByName(node.name);
+                    expect(observed).not.toBeFalsy();
+                    nodeTransform = observed!.initialLocalTransform;
+                }
+                Transform.multiply(result, nodeTransform, result);
+            }
+            throw new Error(`Unexpected`);
+        },
+
+        /**
+         * Gets the local space initial pose record of all animated nodes.
+         */
+        getInitialLocalSpacePoseRecord() {
+            const record: PoseRecord = { transforms: {} };
+            for (const [nodeId, node] of idToNodeMap) {
+                if (!nonAnimatingNodeIds.includes(nodeId)) {
+                    record.transforms[node.node.name] = node.initialLocalTransform;
+                }
+            }
+            return record;
+        },
+
+        /**
+         * Gets the component space initial pose record of all animated nodes.
+         */
+        getInitialComponentSpacePoseRecord() {
+            const record: PoseRecord = { transforms: {} };
+            for (const [nodeId, node] of idToNodeMap) {
+                if (!nonAnimatingNodeIds.includes(nodeId)) {
+                    record.transforms[node.node.name] = node.initialComponentTransform;
+                }
+            }
+            return record;
+        },
+
+        /**
+         * Generates a (pseudo) random pose and return it in both local space and component space. 
+         */
+        generateRandomPose() {
+            const involvedNodes = new Set(
+                [...idToNodeMap]
+                    .map(([id, node]) => nonAnimatingNodeIds.includes(id) ? undefined : node.node)
+                    .filter((node): node is Node => !!node),
+            );
+
+            const generatedLocalSpaceTransforms: Record<string, Transform> = {};
+            const generatedComponentSpaceTransforms: Record<string, Transform> = {};
+
+            let counter = 0;
+            function g(node: Node, generatedComponent: Transform) {
+                for (const child of node.children) {
+                    let childLocalTransform: Transform;
+                    if (!involvedNodes.has(child)) {
+                        const observed = [...idToNodeMap].find(([id, node]) => node.node === child);
+                        expect(observed).not.toBeUndefined();
+                        childLocalTransform = Transform.copy(new Transform(), observed![1].initialLocalTransform);
+                    } else {
+                        const id = ++counter;
+                        childLocalTransform = new Transform();
+                        childLocalTransform.position = new Vec3(id * 0.1, id * 0.2, id * 0.3);
+                        childLocalTransform.rotation = Quat.fromEuler(new Quat(), id * 0.4, id * 0.5, id * 0.6);
+                        childLocalTransform.scale = new Vec3(id * 0.7, id * 0.7, id * 0.7);
+                    }
+
+                    const childComponentTransform = Transform.multiply(new Transform(), generatedComponent, childLocalTransform);
+
+                    if (involvedNodes.has(child)) {
+                        generatedLocalSpaceTransforms[child.name] = childLocalTransform;
+                        generatedComponentSpaceTransforms[child.name] = childComponentTransform;
+                    }
+
+                    g(child, childComponentTransform);
+                }
+            }
+            
+            g(origin, new Transform());
+
+            return {
+                localSpace: { transforms: generatedLocalSpaceTransforms },
+                componentSpace: { transforms: generatedComponentSpaceTransforms },
+            };
+        },
+    };
+}

--- a/tests/animation/new-gen-anim/utils/pose-record.ts
+++ b/tests/animation/new-gen-anim/utils/pose-record.ts
@@ -1,0 +1,5 @@
+import { Transform } from "../../../../cocos/animation/core/transform";
+
+export interface PoseRecord {
+    transforms: Record<string, Transform>;
+}


### PR DESCRIPTION
Re: #

### Changelog

* Handle space conversion during pose graph evaluation.

* Introduce a base pose node class `PoseNodeModifyPoseBase` which implements a basic framework to modify poses.

### Design Detail

#### Pose Transform Space

- The pose objects in any time have their node transforms stored **either in local space or component space**, the space kind is represented by enumeration `PoseTransformSpace`.

- When evaluating a pose nose, the caller must indicate its expected pose transform space, or indicates it does not care the space. Then, the pose node base class will convert the pose accordingly. This "space requirement" of caller is denoted by enumeration `PoseTransformSpaceRequirement`.

- During evaluation, the evaluation context provides methods to:

  - Allocate a local space/component space default pose.

  - Convert pose between local space and component space.

To implement above, the pose object starts to hold the space its transforms are current belongs. the evaluation context starts to hold a "parent table", which describes the nodes(bones)' hierarchy.

---------------------------------------------

#### (Input) Transform Space

It's a common case that pose nodes may have position/rotation/scale input related to some nodes(bones), the space of the inputs should be explicitly specified.

This PR supports the following kinds of (input) transform space: world, component, local and parent. The space kinds are represented by enumeration `TransformSpace`

During evaluation, the evaluation context provides methods to convert between the input transform spaces and pose's current space.

--------------------------

#### Base Pose Node: `PoseNodeModifyPoseBase`

In addition, the PR introduces a new pose node base class: `PoseNodeModifyPoseBase`, which modify the incoming pose. As for how to modify the pose is specified in subclasses(for example, coming soon IK node). In abstract, this node:

- Evaluates the incoming pose node and results a input pose.

- Call protected method `.modifyPose(pose, context, modificationQueue)`. Subclasses are expected to overwrite this method to implement the modification logic. But however, subclasses in general won't directly write to the pose object. Instead, they commit changes to `modicficationQueue` -- a transform modification queue and the changes are handled by the base class uniformly.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
