### PR TITLE
remove `rangeMin` decorator from camera near

### DIFF
--- a/cocos/misc/camera-component.ts
+++ b/cocos/misc/camera-component.ts
@@ -372,7 +372,6 @@ export class Camera extends Component {
      * @zh 相机的近裁剪距离，应在可接受范围内尽量取最大。
      */
     @displayOrder(10)
-    @rangeMin(0)
     @tooltip('i18n:camera.near')
     get near () {
         return this._near;


### PR DESCRIPTION
Re: When using Ortographic Projection it doesn't allow to set `near` less than zero and because of that, we can see through the mesh when it's close to the bottom of camera

As a temporary fix you can set `_near` property inside Camera component in scene
<img width="339" alt="image" src="https://github.com/cocos/cocos-engine/assets/24970784/b3884687-9290-4172-842c-2c8b64389468">

### Changelog

* remove `rangeMin` decorator from camera near

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
