### PR TITLE
Pose graph: add motion playing and sampling node

### DIFF
--- a/cocos/animation/marionette/animation-graph-context.ts
+++ b/cocos/animation/marionette/animation-graph-context.ts
@@ -16,6 +16,7 @@ import { TransformSpace } from './pose-graph/pose-nodes/transform-space';
 import { PoseStashAllocator, RuntimeStashView } from './pose-graph/stash/runtime-stash';
 import { PoseHeapAllocator } from '../core/pose-heap-allocator';
 import { RuntimeMotionSyncManager } from './pose-graph/motion-sync/runtime-motion-sync';
+import { ReadonlyClipOverrideMap } from './clip-overriding';
 
 /**
  * This module contains stuffs related to animation graph's evaluation.
@@ -102,6 +103,10 @@ export class AnimationGraphBindingContext {
      */
     get triggerResetter () {
         return this._triggerResetter;
+    }
+
+    get clipOverrides () {
+        return this._clipOverrides;
     }
 
     /**
@@ -211,6 +216,13 @@ export class AnimationGraphBindingContext {
         this._motionSyncManager = undefined;
     }
 
+    /**
+     * @internal
+     */
+    public _setClipOverrides (clipOverrides: ReadonlyClipOverrideMap | undefined) {
+        this._clipOverrides = clipOverrides;
+    }
+
     private _origin: Node;
 
     private _layoutMaintainer: AnimationGraphPoseLayoutMaintainer;
@@ -225,6 +237,8 @@ export class AnimationGraphBindingContext {
     private _isLayerWideContextPropertiesSet = false;
     private _stashView: RuntimeStashView | undefined;
     private _motionSyncManager: RuntimeMotionSyncManager | undefined;
+    private _clipOverrides: ReadonlyClipOverrideMap | undefined = undefined;
+
     private _resetTrigger (triggerName: string) {
         const varInstance = this._varRegistry[triggerName];
         if (!varInstance) {

--- a/cocos/animation/marionette/animation-graph-context.ts
+++ b/cocos/animation/marionette/animation-graph-context.ts
@@ -15,6 +15,7 @@ import { AnimationGraphCustomEventEmitter } from './event/custom-event-emitter';
 import { TransformSpace } from './pose-graph/pose-nodes/transform-space';
 import { PoseStashAllocator, RuntimeStashView } from './pose-graph/stash/runtime-stash';
 import { PoseHeapAllocator } from '../core/pose-heap-allocator';
+import { RuntimeMotionSyncManager } from './pose-graph/motion-sync/runtime-motion-sync';
 
 /**
  * This module contains stuffs related to animation graph's evaluation.
@@ -182,15 +183,22 @@ export class AnimationGraphBindingContext {
         return this._stashView;
     }
 
+    public get motionSyncManager (): RuntimeMotionSyncManager {
+        assertIsTrue(this._motionSyncManager);
+        return this._motionSyncManager;
+    }
+
     /**
      * @internal
      */
     public _setLayerWideContextProperties (
         stashView: RuntimeStashView,
+        motionSyncManager: RuntimeMotionSyncManager,
     ) {
         assertIsTrue(!this._isLayerWideContextPropertiesSet);
         this._isLayerWideContextPropertiesSet = true;
         this._stashView = stashView;
+        this._motionSyncManager = motionSyncManager;
     }
 
     /**
@@ -200,6 +208,7 @@ export class AnimationGraphBindingContext {
         assertIsTrue(this._isLayerWideContextPropertiesSet);
         this._isLayerWideContextPropertiesSet = false;
         this._stashView = undefined;
+        this._motionSyncManager = undefined;
     }
 
     private _origin: Node;
@@ -215,6 +224,7 @@ export class AnimationGraphBindingContext {
 
     private _isLayerWideContextPropertiesSet = false;
     private _stashView: RuntimeStashView | undefined;
+    private _motionSyncManager: RuntimeMotionSyncManager | undefined;
     private _resetTrigger (triggerName: string) {
         const varInstance = this._varRegistry[triggerName];
         if (!varInstance) {

--- a/cocos/animation/marionette/graph-eval.ts
+++ b/cocos/animation/marionette/graph-eval.ts
@@ -86,6 +86,7 @@ export class AnimationGraphEval {
             root, poseLayoutMaintainer, this._varInstances, controller,
             customEventEmitter,
         );
+        bindingContext._setClipOverrides(clipOverrides ?? undefined);
         this._bindingContext = bindingContext;
 
         const settleContext = new AnimationGraphSettleContext(poseLayoutMaintainer);

--- a/cocos/animation/marionette/motion/clip-motion.ts
+++ b/cocos/animation/marionette/motion/clip-motion.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { editorExtrasTag, _decorator, EditorExtendable } from '../../../core';
+import { editorExtrasTag, _decorator, EditorExtendable, editable, serializable } from '../../../core';
 import { additiveSettingsTag, AnimationClip } from '../../animation-clip';
 import { cloneAnimationGraphEditorExtrasFrom } from '../animation-graph-editor-extras-clone-helper';
 import { createEval } from '../create-eval';
@@ -42,6 +42,8 @@ const { ccclass, type } = _decorator;
 @ccclass('cc.animation.ClipMotion')
 export class ClipMotion extends Motion {
     @type(AnimationClip)
+    @editable
+    @serializable
     public clip: AnimationClip | null = null;
 
     public [createEval] (context: AnimationGraphBindingContext, overrides: ReadonlyClipOverrideMap | null) {

--- a/cocos/animation/marionette/pose-graph/motion-sync/motion-sync-info.ts
+++ b/cocos/animation/marionette/pose-graph/motion-sync/motion-sync-info.ts
@@ -1,0 +1,9 @@
+import { ccclass, editable, serializable } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}MotionSyncInfo`)
+export class MotionSyncInfo {
+    @editable
+    @serializable
+    group = '';
+}

--- a/cocos/animation/marionette/pose-graph/motion-sync/runtime-motion-sync.ts
+++ b/cocos/animation/marionette/pose-graph/motion-sync/runtime-motion-sync.ts
@@ -1,0 +1,146 @@
+import { DEBUG } from 'internal:constants';
+import { approx, assertIsTrue } from '../../../../core';
+import { MotionSyncInfo } from './motion-sync-info';
+
+export class RuntimeMotionSyncManager {
+    public register (syncInfo: MotionSyncInfo): RuntimeMotionSyncRecord {
+        const {
+            group: groupName,
+        } = syncInfo;
+        let group = this._groups.find((group) => group.name === groupName);
+        if (!group) {
+            group = new Group(groupName);
+            this._groups.push(group);
+        }
+        return group.addMember();
+    }
+
+    public sync () {
+        for (const group of this._groups) {
+            group.sync();
+        }
+    }
+
+    private _groups: Group[] = [];
+}
+
+class Group {
+    constructor (public readonly name: string) {
+    }
+
+    public addMember (): RuntimeMotionSyncRecordImpl {
+        const record = new RuntimeMotionSyncRecordImpl();
+        this._records.push(record);
+        return record;
+    }
+
+    public sync () {
+        const {
+            _records: records,
+        } = this;
+        const nRecords = records.length;
+        assertIsTrue(nRecords > 0);
+
+        const { _lastLeader: lastLeader } = this;
+        this._lastLeader = undefined;
+
+        // Do nothing if all of records are inactive.
+        if (records.every((r) => !r.active)) {
+            return;
+        }
+
+        // Sort records so that higher weighted records are in front,
+        // inactive records are treated having weight -1.
+        records.sort((a, b) => {
+            const kA = a.active ? a.weight : -1.0;
+            const kB = b.active ? b.weight : -1.0;
+            return kB - kA;
+        });
+
+        // Assertion: inactive records are in tail.
+        if (DEBUG) {
+            const firstInactiveRecord = records.findIndex((r) => !r.active);
+            assertIsTrue((firstInactiveRecord < 0 ? [] : records.slice(firstInactiveRecord))
+                .every((r) => !r.active));
+        }
+
+        // Here's an optimization:
+        // if two or more records have almost same weight. Their order is indeterminate.
+        // To avoid this, we prefer the leader during previous sync.
+        let leaderIndex = 0;
+        const leaderWeight = records[0].weight;
+        // If the first record is just the last leader, everyone is happy, nothing to do.
+        if (records[leaderIndex] !== lastLeader) {
+            for (let iRecord = 0; iRecord < nRecords; ++iRecord) {
+                const record = records[iRecord];
+                if (!record.active || !approx(record.weight, leaderWeight, 1e-6)) {
+                    break;
+                }
+                if (record === lastLeader) {
+                    leaderIndex = iRecord;
+                    break;
+                }
+            }
+        }
+
+        // Assertion: the first record is active. It becomes the leader.
+        assertIsTrue(records[leaderIndex].active);
+
+        this._lastLeader = records[leaderIndex];
+
+        // Sync followers to follow the leader.
+        const leaderNormalizedTime = records[leaderIndex].normalizedTime;
+        for (let iRecord = 0; iRecord < nRecords; ++iRecord) {
+            const record = records[iRecord];
+            if (!record.active) {
+                break;
+            }
+            record.normalizedTime = leaderNormalizedTime;
+            record.reset();
+        }
+    }
+
+    private _lastLeader: RuntimeMotionSyncRecordImpl | undefined = undefined;
+    private _records: RuntimeMotionSyncRecordImpl[] = [];
+}
+
+class RuntimeMotionSyncRecordImpl implements RuntimeMotionSyncRecord {
+    public notifyRenter (): void {
+        this.reset();
+        this.normalizedTime = 0.0;
+    }
+
+    public notifyUpdate (normalizedDeltaTime: number, weight: number) {
+        this.normalizedTime += normalizedDeltaTime;
+        // Note: we're allowing update multiple times. The first update becomes "activate".
+        if (this.active) {
+            this.weight += weight;
+        } else {
+            this.active = true;
+            this.weight = weight;
+        }
+    }
+
+    public reset () {
+        this.active = false;
+        this.weight = 0.0;
+    }
+
+    public normalizedTime = 0.0;
+
+    public weight = 0.0;
+
+    public active = false;
+
+    public getSyncedEnterTime (): number {
+        return this.normalizedTime;
+    }
+}
+
+export interface RuntimeMotionSyncRecord {
+    notifyRenter(): void;
+
+    notifyUpdate(deltaTime: number, weight: number): void;
+
+    getSyncedEnterTime(): number;
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/all.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/all.ts
@@ -1,5 +1,8 @@
 import './state-machine';
 
+import './play-motion';
+import './sample-motion';
+
 import './additively-blend';
 
 import './blend-in-proportion';

--- a/cocos/animation/marionette/pose-graph/pose-nodes/play-motion.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/play-motion.ts
@@ -1,0 +1,139 @@
+import { EDITOR } from 'internal:constants';
+import { ccclass, displayName, editable, serializable } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { ClipMotion } from '../../motion/clip-motion';
+import { createEval } from '../../create-eval';
+import { Motion, MotionEval, MotionPort } from '../../motion/motion';
+import { PoseNode } from '../pose-node';
+import { input } from '../decorator/input';
+import { PoseGraphType } from '../foundation/type-system';
+import { MotionSyncInfo } from '../motion-sync/motion-sync-info';
+import { RuntimeMotionSyncRecord } from '../motion-sync/runtime-motion-sync';
+import { poseGraphCreateNodeFactory, poseGraphNodeAppearance, poseGraphNodeCategory } from '../decorator/node';
+import { POSE_GRAPH_NODE_MENU_PREFIX_POSE } from './menu-common';
+import { getEnterInfo, getTileBase, makeCreateNodeFactory } from './play-or-sample-motion-pose-node-shared';
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext,
+    AnimationGraphSettleContext, AnimationGraphUpdateContext,
+} from '../../animation-graph-context';
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodePlayMotion`)
+@poseGraphNodeCategory(POSE_GRAPH_NODE_MENU_PREFIX_POSE)
+@poseGraphCreateNodeFactory(makeCreateNodeFactory(
+    (motion) => {
+        const node = new PoseNodePlayMotion();
+        node.motion = motion;
+        return node;
+    },
+))
+@poseGraphNodeAppearance({
+    themeColor: '#227F9B',
+})
+export class PoseNodePlayMotion extends PoseNode {
+    @serializable
+    @editable
+    public motion: Motion | null = new ClipMotion();
+
+    @serializable
+    @editable
+    public readonly syncInfo = new MotionSyncInfo();
+
+    @serializable
+    @input({ type: PoseGraphType.FLOAT })
+    public speedMultiplier = 1.0;
+
+    /**
+     * The weight of this node indicated in last update.
+     */
+    get lastIndicativeWeight () {
+        return this._workspace?.lastIndicativeWeight ?? 0.0;
+    }
+
+    /**
+     * Normalized time elapsed on specified motion.
+     */
+    get elapsedMotionTime () {
+        return this._workspace?.normalizedTime ?? 0.0;
+    }
+
+    public bind (context: AnimationGraphBindingContext) {
+        const { motion } = this;
+        if (!motion) {
+            return;
+        }
+        const motionEval = motion[createEval](context, context.clipOverrides ?? null);
+        if (!motionEval) {
+            return;
+        }
+        this._workspace = new Workspace(motionEval, motionEval.createPort());
+        if (this.syncInfo.group) {
+            this._runtimeSyncRecord = context.motionSyncManager.register(this.syncInfo);
+        }
+    }
+
+    public settle (context: AnimationGraphSettleContext): void {
+
+    }
+
+    public reenter () {
+        if (this._workspace) {
+            const { _runtimeSyncRecord: runtimeSyncRecord } = this;
+            if (runtimeSyncRecord) {
+                runtimeSyncRecord.notifyRenter();
+            } else {
+                this._workspace.normalizedTime = 0.0;
+            }
+            this._workspace.lastIndicativeWeight = 0.0;
+        }
+    }
+
+    protected doUpdate (context: AnimationGraphUpdateContext): void {
+        if (this._workspace) {
+            const { deltaTime } = context;
+            const { _runtimeSyncRecord: runtimeSyncRecord } = this;
+            const duration = this._workspace.motionEval.duration;
+            let normalizedDeltaTime = 0.0;
+            if (duration !== 0.0) {
+                normalizedDeltaTime = (deltaTime * this.speedMultiplier) / duration;
+            }
+            if (runtimeSyncRecord) {
+                runtimeSyncRecord.notifyUpdate(normalizedDeltaTime, context.indicativeWeight);
+            } else {
+                this._workspace.normalizedTime += normalizedDeltaTime;
+            }
+        }
+    }
+
+    public doEvaluate (context: AnimationGraphEvaluationContext) {
+        if (!this._workspace) {
+            return context.pushDefaultedPose();
+        } else {
+            const normalizedTime = this._runtimeSyncRecord
+                ? this._runtimeSyncRecord.getSyncedEnterTime()
+                : this._workspace.normalizedTime;
+            return this._workspace.motionEvalPort.evaluate(normalizedTime, context);
+        }
+    }
+
+    private _workspace: Workspace | null = null;
+    private _runtimeSyncRecord: RuntimeMotionSyncRecord | undefined = undefined;
+}
+
+class Workspace {
+    constructor (
+        public motionEval: MotionEval,
+        public motionEvalPort: MotionPort,
+    ) {
+
+    }
+
+    public normalizedTime = 0.0;
+    public lastIndicativeWeight = 0.0;
+}
+
+if (EDITOR) {
+    PoseNodePlayMotion.prototype.getTitle = function getTitle (this: PoseNodePlayMotion) {
+        return getTileBase(`ENGINE.classes.${CLASS_NAME_PREFIX_ANIM}PoseNodePlayMotion.title`, this.motion);
+    };
+
+    PoseNodePlayMotion.prototype.getEnterInfo = getEnterInfo;
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/play-or-sample-motion-pose-node-shared.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/play-or-sample-motion-pose-node-shared.ts
@@ -1,0 +1,64 @@
+import { ClipMotion, AnimationBlend, AnimationBlend1D, AnimationBlend2D } from '../../motion';
+import { Motion } from '../../motion/motion';
+import { EnterNodeInfo } from '../foundation/authoring/enter-node-info';
+import { PoseGraphCreateNodeFactory } from '../decorator/node';
+import { PoseNode } from '../pose-node';
+
+export {};
+
+export function getEnterInfo (this: { motion: Motion | null }): EnterNodeInfo | undefined {
+    if (!this.motion || !(this.motion instanceof AnimationBlend)) {
+        return undefined;
+    }
+    return {
+        type: 'animation-blend',
+        target: this.motion,
+    };
+}
+
+type CreateNodeArg = {
+    type: 'clip-motion';
+} | {
+    type: 'animation-blend-1d' | 'animation-blend-2d';
+};
+
+export function makeCreateNodeFactory (
+    create_: (motion: Motion | null) => PoseNode,
+): PoseGraphCreateNodeFactory<CreateNodeArg> {
+    return {
+        listEntries: (context) => [{
+            arg: { type: 'clip-motion' },
+            menu: 'i18n:ENGINE.animation_graph.pose_graph_node_sub_menus.play_or_sample_clip_motion',
+        }, {
+            arg: { type: 'animation-blend-1d' },
+            menu: 'i18n:ENGINE.animation_graph.pose_graph_node_sub_menus.play_or_sample_animation_blend_1d',
+        }, {
+            arg: { type: 'animation-blend-2d' },
+            menu: 'i18n:ENGINE.animation_graph.pose_graph_node_sub_menus.play_or_sample_animation_blend_2d',
+        }],
+        create: (arg) => {
+            let motion: Motion | null = null;
+            switch (arg.type) {
+            case 'clip-motion': motion = new ClipMotion(); break;
+            case 'animation-blend-1d': motion = new AnimationBlend1D(); break;
+            case 'animation-blend-2d': motion = new AnimationBlend2D(); break;
+            default: break;
+            }
+            return create_(motion);
+        },
+    };
+}
+
+export function getTileBase (titleI18nKey: string, motion: Motion | null) {
+    let motionName = '';
+    if (motion instanceof ClipMotion) {
+        if (!motion.clip) {
+            return undefined;
+        } else {
+            motionName = motion.clip.name;
+        }
+    } else {
+        motionName = 'Unnamed Animation Blend';
+    }
+    return [titleI18nKey, { motionName }] as [string, Record<string, string>];
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/sample-motion.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/sample-motion.ts
@@ -1,0 +1,92 @@
+import { EDITOR } from 'internal:constants';
+import { clamp01 } from '../../../../core';
+import { ccclass, editable, serializable } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { ClipMotion } from '../../motion/clip-motion';
+import { createEval } from '../../create-eval';
+import { Motion, MotionEval, MotionPort } from '../../motion/motion';
+import { PoseNode } from '../pose-node';
+import { Pose } from '../../../core/pose';
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from '../../animation-graph-context';
+import { input } from '../decorator/input';
+import { poseGraphCreateNodeFactory, poseGraphNodeAppearance, poseGraphNodeCategory } from '../decorator/node';
+import { POSE_GRAPH_NODE_MENU_PREFIX_POSE } from './menu-common';
+import { getEnterInfo, getTileBase, makeCreateNodeFactory } from './play-or-sample-motion-pose-node-shared';
+import { PoseGraphType } from '../foundation/type-system';
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeSampleMotion`)
+@poseGraphNodeCategory(POSE_GRAPH_NODE_MENU_PREFIX_POSE)
+@poseGraphCreateNodeFactory(makeCreateNodeFactory(
+    (motion) => {
+        const node = new PoseNodeSampleMotion();
+        node.motion = motion;
+        return node;
+    },
+))
+@poseGraphNodeAppearance({ themeColor: '#D97721' })
+export class PoseNodeSampleMotion extends PoseNode {
+    @serializable
+    @editable
+    public motion: Motion | null = new ClipMotion();
+
+    @serializable
+    @editable
+    @input({ type: PoseGraphType.FLOAT })
+    public time = 0.0;
+
+    @serializable
+    @editable
+    public useNormalizedTime = false;
+
+    public bind (context: AnimationGraphBindingContext) {
+        const { motion } = this;
+        if (!motion) {
+            return;
+        }
+        const motionEval = motion[createEval](context, context.clipOverrides ?? null);
+        if (!motionEval) {
+            return;
+        }
+        const workspace = new SampleMotionWorkspace(motionEval, motionEval.createPort());
+        this._workspace = workspace;
+    }
+
+    public settle (context: AnimationGraphSettleContext): void { }
+
+    public reenter (): void { }
+
+    protected doUpdate (context: AnimationGraphUpdateContext): void {
+    }
+
+    protected doEvaluate (context: AnimationGraphEvaluationContext): Pose {
+        const { _workspace: workspace } = this;
+
+        if (!workspace) {
+            return context.pushDefaultedPose();
+        }
+
+        const time = this.time;
+        const normalizedTime = this.useNormalizedTime
+            ? time
+            : time / workspace.motionEval.duration;
+        return workspace.motionEvalPort.evaluate(clamp01(normalizedTime), context);
+    }
+
+    private _workspace: SampleMotionWorkspace | null = null;
+}
+
+class SampleMotionWorkspace {
+    constructor (
+        public motionEval: MotionEval,
+        public motionEvalPort: MotionPort,
+    ) {
+    }
+}
+
+if (EDITOR) {
+    PoseNodeSampleMotion.prototype.getTitle = function getTitle (this: PoseNodeSampleMotion) {
+        return getTileBase(`ENGINE.classes.${CLASS_NAME_PREFIX_ANIM}PoseNodeSampleMotion.title`, this.motion);
+    };
+
+    PoseNodeSampleMotion.prototype.getEnterInfo = getEnterInfo;
+}

--- a/cocos/animation/marionette/state-machine/state-machine-eval.ts
+++ b/cocos/animation/marionette/state-machine/state-machine-eval.ts
@@ -1440,6 +1440,10 @@ class PoseStateEval extends EventifiedStateEval {
         return this._statusCache;
     }
 
+    public countMotionTime () {
+        return this._instantiatedPoseGraph?.countMotionTime() ?? 0.0;
+    }
+
     private _instantiatedPoseGraph: InstantiatedPoseGraph;
 
     private readonly _statusCache: MotionStateStatus = createStateStatusCache();

--- a/editor/i18n/en/animation.js
+++ b/editor/i18n/en/animation.js
@@ -8,6 +8,11 @@ module.exports = {
             pose_nodes_blend: 'Blend',
             pose_nodes_ik: 'Inverse Kinematic',
         },
+        pose_graph_node_sub_menus: {
+            play_or_sample_clip_motion: 'Animation Clip',
+            play_or_sample_animation_blend_1d: 'Animation Blend 1D',
+            play_or_sample_animation_blend_2d: 'Animation Blend 2D',
+        },
     },
 
     classes: {
@@ -19,6 +24,64 @@ module.exports = {
                         'emptyStatePose': {
                             displayName: 'Empty State Pose',
                         },
+                    },
+                },
+                'ClipMotion': {
+                    properties: {
+                        'clip': {
+                            displayName: 'Clip',
+                            tooltip: 'The animation clip.',
+                        },
+                    },
+                },
+                'MotionSyncInfo': {
+                    properties: {
+                        'group': {
+                            displayName: 'Group',
+                        },
+                    },
+                },
+                'PoseNodePlayMotion': {
+                    displayName: 'Play Animation',
+                    title: 'Play {motionName}',
+                    properties: {
+                        'motion': {
+                            displayName: 'Motion',
+                            tooltip: 'The motion to play.',
+                        },
+                        'syncInfo': {
+                            displayName: 'Sync',
+                        },
+                    },
+                    inputs: {
+                        'speedMultiplier': {
+                            displayName: 'Speed Multiplier',
+                        },
+                    },
+                    createPoseNodeOnAssetDragHandler: {
+                        displayName: 'Play',
+                    },
+                },
+                'PoseNodeSampleMotion': {
+                    displayName: 'Sample Animation',
+                    title: 'Sample {motionName}',
+                    properties: {
+                        'motion': {
+                            displayName: 'Motion',
+                            tooltip: 'The motion to sample.',
+                        },
+                        'useNormalizedTime': {
+                            displayName: 'Use Normalized Time',
+                            tooltip: 'Whether to use normalized time, ie. time in range [0, 1].',
+                        },
+                    },
+                    inputs: {
+                        'time': {
+                            displayName: 'Time',
+                        },
+                    },
+                    createPoseNodeOnAssetDragHandler: {
+                        displayName: 'Sample',
                     },
                 },
                 'PoseNodeBlendInProportion': {

--- a/editor/i18n/zh/animation.js
+++ b/editor/i18n/zh/animation.js
@@ -8,6 +8,11 @@ module.exports = {
             pose_nodes_blend: '混合',
             pose_nodes_ik: '反向动力学',
         },
+        pose_graph_node_sub_menus: {
+            play_or_sample_clip_motion: '动画剪辑',
+            play_or_sample_animation_blend_1d: '一维动画混合',
+            play_or_sample_animation_blend_2d: '二维动画混合',
+        },
     },
 
     classes: {
@@ -19,6 +24,64 @@ module.exports = {
                         'emptyStatePose': {
                             displayName: '空状态姿势',
                         },
+                    },
+                },
+                'ClipMotion': {
+                    properties: {
+                        'clip': {
+                            displayName: '剪辑',
+                            tooltip: '动画剪辑。',
+                        },
+                    },
+                },
+                'MotionSyncInfo': {
+                    properties: {
+                        'group': {
+                            displayName: '组',
+                        },
+                    },
+                },
+                'PoseNodePlayMotion': {
+                    displayName: '播放动画',
+                    title: '播放 {motionName}',
+                    properties: {
+                        'motion': {
+                            displayName: '动作',
+                            tooltip: '要播放的动作。',
+                        },
+                        'syncInfo': {
+                            displayName: '同步',
+                        },
+                    },
+                    inputs: {
+                        'speedMultiplier': {
+                            displayName: '速度乘数',
+                        },
+                    },
+                    createPoseNodeOnAssetDragHandler: {
+                        displayName: '播放',
+                    },
+                },
+                'PoseNodeSampleMotion': {
+                    displayName: '采样动画',
+                    title: '采样 {motionName}',
+                    properties: {
+                        'motion': {
+                            displayName: '动作',
+                            tooltip: '要采样的动作。',
+                        },
+                        'useNormalizedTime': {
+                            displayName: '使用标准化时间',
+                            tooltip: '是否使用标准化时间，即 [0, 1] 范围的时间。',
+                        },
+                    },
+                    inputs: {
+                        'time': {
+                            displayName: '时刻',
+                        },
+                    },
+                    createPoseNodeOnAssetDragHandler: {
+                        displayName: '采样',
                     },
                 },
                 'PoseNodeBlendInProportion': {

--- a/editor/src/marionette/pose-graph/drag/handlers/play-motion.ts
+++ b/editor/src/marionette/pose-graph/drag/handlers/play-motion.ts
@@ -1,0 +1,15 @@
+
+import { registerCreatePoseNodeOnAssetDragHandler } from '../registry';
+import { PoseNodePlayMotion } from '../../../../../../cocos/animation/marionette/pose-graph/pose-nodes/play-motion';
+import { ClipMotion } from '../../../../../../cocos/animation/marionette/motion';
+import { AnimationClip } from '../../../../../../cocos/animation/animation-clip';
+
+registerCreatePoseNodeOnAssetDragHandler(AnimationClip, {
+    displayName: 'i18n:ENGINE.classes.cc.animation.PoseNodePlayMotion.createPoseNodeOnAssetDragHandler.displayName',
+    handle: (asset) => {
+        const node = new PoseNodePlayMotion();
+        const clipMotion = node.motion = new ClipMotion();
+        clipMotion.clip = asset;
+        return node;
+    },
+});

--- a/editor/src/marionette/pose-graph/drag/handlers/sample-motion.ts
+++ b/editor/src/marionette/pose-graph/drag/handlers/sample-motion.ts
@@ -1,0 +1,15 @@
+
+import { registerCreatePoseNodeOnAssetDragHandler } from '../registry';
+import { PoseNodeSampleMotion } from '../../../../../../cocos/animation/marionette/pose-graph/pose-nodes/sample-motion';
+import { ClipMotion } from '../../../../../../cocos/animation/marionette/motion';
+import { AnimationClip } from '../../../../../../cocos/animation/animation-clip';
+
+registerCreatePoseNodeOnAssetDragHandler(AnimationClip, {
+    displayName: 'i18n:ENGINE.classes.cc.animation.PoseNodeSampleMotion.createPoseNodeOnAssetDragHandler.displayName',
+    handle: (asset) => {
+        const node = new PoseNodeSampleMotion();
+        const clipMotion = node.motion = new ClipMotion();
+        clipMotion.clip = asset;
+        return node;
+    },
+});

--- a/editor/src/marionette/pose-graph/drag/index.ts
+++ b/editor/src/marionette/pose-graph/drag/index.ts
@@ -1,3 +1,6 @@
 
 export { getPoseGraphAssetDragHandlersMap, createPoseNodeOnAssetDrag } from './registry';
 export type { PoseGraphAssetDragHandlersInfo } from './registry';
+
+import './handlers/play-motion';
+import './handlers/sample-motion';

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/motion-node.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/motion-node.test.ts
@@ -1,0 +1,137 @@
+import { createAnimationGraph } from '../../utils/factory';
+import { AnimationGraphEvalMock } from '../../utils/eval-mock';
+import { LinearRealValueAnimationFixture } from '../../utils/fixtures';
+import { SingleRealValueObserver } from '../../utils/single-real-value-observer';
+import { lerp } from '../../../../../cocos/core';
+
+import './utils/factories/all';
+
+test(`Motion Sync`, () => {
+    const WITH_SYNC: boolean = true;
+
+    const fixture = {
+        motion_f: new LinearRealValueAnimationFixture(1., 2., 3.),
+        motion_r: new LinearRealValueAnimationFixture(4., 5., 7.),
+        blend_proportion_f: 0.3,
+        transition_duration: 0.3,
+    };
+
+    const observer = new SingleRealValueObserver();
+
+    const graph = createAnimationGraph({
+        variableDeclarations: { 'blend': { type: 'boolean', value: false } },
+        layers: [{
+            stashes: {
+                'f': { graph: { rootNode: { type: 'motion', motion: fixture.motion_f.createMotion(observer.getCreateMotionContext()), syncInfo: WITH_SYNC ? { group: 'locomotion' } : undefined } } },
+                'r': { graph: { rootNode: { type: 'motion', motion: fixture.motion_r.createMotion(observer.getCreateMotionContext()), syncInfo: WITH_SYNC ? { group: 'locomotion' } : undefined } } }
+            },
+            stateMachine: {
+                states: {
+                    'f': { type: 'pose', graph: { rootNode: { type: 'use-stash', stashId: 'f' } } },
+                    'fr': {
+                        type: 'pose',
+                        graph: {
+                            rootNode: {
+                                type: 'blend-in-proportion',
+                                items: [
+                                    { pose: { type: 'use-stash', stashId: 'f' }, proportion: fixture.blend_proportion_f },
+                                    { pose: { type: 'use-stash', stashId: 'r' }, proportion: 1.0 - fixture.blend_proportion_f },
+                                ],
+                            },
+                        },
+                    },
+                },
+                entryTransitions: [{ to: 'f' }],
+                transitions: [{
+                    from: 'f',
+                    to: 'fr',
+                    conditions: [{ type: 'unary', operator: 'to-be-true', operand: { type: 'variable', name: 'blend' } }],
+                    duration: 0.3,
+                }, {
+                    from: 'fr',
+                    to: 'f',
+                    conditions: [{ type: 'unary', operator: 'to-be-false', operand: { type: 'variable', name: 'blend' } }],
+                    duration: 0.3,
+                }],
+            },
+        }],
+    });
+
+    const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+
+    // Play `f` to 20%.
+    evalMock.step(fixture.motion_f.duration * 0.2);
+
+    /**
+     * Let: 
+     *   - x = `transitionRatioLeaderBound`
+     *   - a = `fixture.motion_f.duration`
+     *   - $w_f$ as weight of f, $w_f = (1 - x) + (x * a)$
+     *   - $w_r$ as weight of r, $w_r = x * (1 - a)$
+     * 
+     * If `w_f > w_r`, f is the leader. Otherwise r becomes the leader.
+     * 
+     * $$
+     * w_f > w_r
+     * (1 - x) + (x * a) > x * (1 - a)
+     * 1 - x + ax - x + ax > 0
+     * (2a - 2)x > -1
+     * x < 1 / (2 - 2a)
+     * $$
+     */
+    const transitionRatioLeaderBound = 1 / (2 - 2 * fixture.blend_proportion_f);
+
+    // Trigger the transition.
+    const transitionStartTime = evalMock.current;
+    evalMock.controller.setValue('blend', true);
+
+    let lastRTime = 0.0;
+
+    // Within leader bound, the leader should be f.
+    for (const transitionRatio of [
+        transitionRatioLeaderBound * 0.2,
+        transitionRatioLeaderBound * 0.8,
+    ]) {
+        evalMock.goto(transitionStartTime + fixture.transition_duration * transitionRatio);
+        checkFToFRBlend(
+            evalMock.current,
+            evalMock.current / fixture.motion_f.duration * fixture.motion_r.duration,
+            transitionRatio,
+        );
+        lastRTime = evalMock.current / fixture.motion_f.duration * fixture.motion_r.duration;
+    }
+
+    // Out of leader bound, the leader should become r.
+    for (const transitionRatio of [
+        transitionRatioLeaderBound + (1.0 - transitionRatioLeaderBound) * 0.2,
+        transitionRatioLeaderBound + (1.0 - transitionRatioLeaderBound) * 0.8,
+    ]) {
+        evalMock.goto(transitionStartTime + fixture.transition_duration * transitionRatio);
+        const rTime = lastRTime + evalMock.lastDeltaTime;
+        const rRatio = rTime / fixture.motion_r.duration;
+        const fTime = rRatio * fixture.motion_f.duration;
+        checkFToFRBlend(
+            fTime,
+            rTime,
+            transitionRatio,
+        );
+        lastRTime = rTime;
+    }
+
+    function checkFToFRBlend(fTime: number, rTime: number, transitionRatio: number) {
+        expect(observer.value).toBeCloseTo(
+            lerp(
+                fixture.motion_f.getExpected(fTime),
+                lerp(
+                    fixture.motion_f.getExpected(fTime),
+                    WITH_SYNC
+                        ? fixture.motion_r.getExpected(rTime)
+                        : fixture.motion_r.getExpected(fixture.transition_duration * transitionRatio),
+                        (1.0 - fixture.blend_proportion_f),
+                ),
+                transitionRatio,
+            ),
+            5,
+        );
+    }
+});

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/sample-motion.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/sample-motion.test.ts
@@ -1,0 +1,38 @@
+import { AnimationGraph } from "../../../../../cocos/animation/marionette/animation-graph";
+import { connectOutputNode } from "../../../../../cocos/animation/marionette/pose-graph/op/internal";
+import { PoseNodeSampleMotion } from "../../../../../cocos/animation/marionette/pose-graph/pose-nodes/sample-motion";
+import { Node } from "../../../../../cocos/scene-graph";
+import { AnimationGraphEvalMock } from "../../utils/eval-mock";
+import { LinearRealValueAnimationFixture } from '../../utils/fixtures';
+import { SingleRealValueObserver } from "../../utils/single-real-value-observer";
+
+describe(`Use normalized time`, () => {
+    test.each([
+        [true],
+        [false],
+    ])(`if %`, (useNormalizedTime) => {
+        const fixture = {
+            animation: new LinearRealValueAnimationFixture(2., 6., 5.),
+        };
+
+        const observer = new SingleRealValueObserver();
+        const graph = new AnimationGraph();
+        const layer = graph.addLayer();
+        const poseState = layer.stateMachine.addPoseState();
+        const poseNode = poseState.graph.addNode(new PoseNodeSampleMotion());
+        connectOutputNode(poseState.graph, poseState.graph.outputNode, poseNode);
+        layer.stateMachine.connect(layer.stateMachine.entryState, poseState);
+
+        poseNode.motion = fixture.animation.createMotion(observer.getCreateMotionContext());
+        poseNode.time = 0.2;
+        poseNode.useNormalizedTime = useNormalizedTime;
+
+        const evalMock = new AnimationGraphEvalMock(observer.root, graph);
+
+        evalMock.step(9999.0);
+        const expectedSampleTime = useNormalizedTime
+            ? 0.2 * fixture.animation.duration
+            : 0.2;
+        expect(observer.value).toBeCloseTo(fixture.animation.getExpected(expectedSampleTime));
+    })
+});

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/evaluation-mock.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/evaluation-mock.ts
@@ -17,6 +17,7 @@ import { BindContext } from '../../../../../../cocos/animation/marionette/parame
 import { PoseGraph } from '../../../../../../cocos/animation/marionette/pose-graph/pose-graph';
 import { PoseNode, PoseTransformSpaceRequirement } from '../../../../../../cocos/animation/marionette/pose-graph/pose-node';
 import { RuntimeStashManager } from '../../../../../../cocos/animation/marionette/pose-graph/stash/runtime-stash';
+import { RuntimeMotionSyncManager } from '../../../../../../cocos/animation/marionette/pose-graph/motion-sync/runtime-motion-sync';
 import { VarInstance } from '../../../../../../cocos/animation/marionette/variable';
 import { Node } from '../../../../../../cocos/scene-graph';
 import { assertIsTrue, Vec3 } from '../../../../../../exports/base';
@@ -116,6 +117,7 @@ export class PoseNodeEvaluationMock<TAnimationResult> {
         const stashManager = new RuntimeStashManager(poseAllocator);
         bindContext._setLayerWideContextProperties(
             stashManager,
+            new RuntimeMotionSyncManager(),
         );
 
         this._resultObserver = resultFactory.create(origin, bindContext);

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/all.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/all.ts
@@ -1,4 +1,5 @@
 
+import './motion-node-factory';
 import './use-stash-factory';
 import './state-machine-node-factory';
 

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/motion-node-factory.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/utils/factories/motion-node-factory.ts
@@ -1,0 +1,25 @@
+
+import { Motion } from '../../../../../../../cocos/animation/marionette/motion';
+import { PoseNodePlayMotion } from '../../../../../../../cocos/animation/marionette/pose-graph/pose-nodes/play-motion';
+import '../../../../utils/factory';
+import { addPoseNodeFactory, createMotion, MotionParams } from '../../../../utils/factory';
+
+declare global {
+    interface PoseNodeFactoryRegistry {
+        'motion': {
+            motion: Motion | MotionParams;
+            syncInfo?: {
+                group: string;
+            };
+        };
+    }
+}
+
+addPoseNodeFactory('motion', (poseGraph, params) => {
+    const node = new PoseNodePlayMotion();
+    node.motion = params.motion instanceof Motion ? params.motion : createMotion(params.motion);
+    if (params.syncInfo) {
+        node.syncInfo.group = params.syncInfo.group;
+    }
+    return poseGraph.addNode(node);
+});


### PR DESCRIPTION
Re: #

### Changelog

* This PR adds the following pose nodes into pose graph:

  - `PlayMotionNode` plays a motion.

    Besides, each node may specify a sync info to indicate how to sync the motion with motions in other `PlayMotionNode`. All motions having same `group` specified in sync info will have their progress synced.

  - `SampleMotionNode` samples a motion at specified time.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
