### PR TITLE
Pose graph: add pose modifying nodes

### DIFF
--- a/cocos/animation/marionette/pose-graph/pose-nodes/all.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/all.ts
@@ -8,4 +8,10 @@ import './filtering-blend';
 
 import './choose-pose/index';
 
+import './apply-transform';
+import './copy-transform';
+import './set-auxiliary-curve';
+
+import './ik/two-bone-ik-solver';
+
 export {};

--- a/cocos/animation/marionette/pose-graph/pose-nodes/apply-transform.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/apply-transform.ts
@@ -1,0 +1,266 @@
+import { EDITOR } from 'internal:constants';
+import { ccclass, editable, serializable, type, visible } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { PoseNode, PoseTransformSpaceRequirement } from '../pose-node';
+import {
+    AnimationGraphBindingContext, AnimationGraphEvaluationContext,
+} from '../../animation-graph-context';
+import { input } from '../decorator/input';
+import { approx, assertIsTrue, ccenum, error, Quat, Vec3 } from '../../../../core';
+import { TransformHandle } from '../../../core/animation-handle';
+import { poseGraphNodeAppearance, poseGraphNodeCategory } from '../decorator/node';
+import { POSE_GRAPH_NODE_MENU_PREFIX_POSE } from './menu-common';
+import { IntensitySpecification } from './intensity-specification';
+import { Pose } from '../../../core/pose';
+import { PoseNodeModifyPoseBase, TransformModificationQueue } from './modify-pose-base';
+import { PoseGraphType } from '../foundation/type-system';
+import { TransformSpace } from './transform-space';
+import { Transform } from '../../../core/transform';
+
+enum TransformOperation {
+    LEAVE_UNCHANGED,
+
+    REPLACE,
+
+    ADD,
+}
+
+ccenum(TransformOperation);
+
+const APPLY_INTENSITY_EPSILON = 1e-5;
+
+const cacheTransform = new Transform();
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeApplyTransform`)
+@poseGraphNodeCategory(POSE_GRAPH_NODE_MENU_PREFIX_POSE)
+@poseGraphNodeAppearance({ themeColor: '#72A869' })
+export class PoseNodeApplyTransform extends PoseNodeModifyPoseBase {
+    @serializable
+    @editable
+    public node = '';
+
+    @serializable
+    @editable
+    @type(TransformOperation)
+    public positionOperation = TransformOperation.LEAVE_UNCHANGED;
+
+    @serializable
+    @editable
+    @input({ type: PoseGraphType.VEC3 })
+    @visible(function (this: PoseNodeApplyTransform) { return this.positionOperation !== TransformOperation.LEAVE_UNCHANGED; })
+    public position = new Vec3();
+
+    @serializable
+    @editable
+    @type(TransformOperation)
+    public rotationOperation = TransformOperation.LEAVE_UNCHANGED;
+
+    @serializable
+    @editable
+    @input({ type: PoseGraphType.QUAT })
+    @visible(function (this: PoseNodeApplyTransform) { return this.rotationOperation !== TransformOperation.LEAVE_UNCHANGED; })
+    public rotation = new Quat();
+
+    @serializable
+    @editable
+    public intensity = new IntensitySpecification();
+
+    @serializable
+    @editable
+    @type(TransformSpace)
+    public transformSpace: TransformSpace = TransformSpace.WORLD;
+
+    @input({ type: PoseGraphType.FLOAT })
+    public get intensityValue () {
+        return this.intensity.value;
+    }
+
+    public set intensityValue (value) {
+        this.intensity.value = value;
+    }
+
+    public bind (context: AnimationGraphBindingContext) {
+        const {
+            node: nodeName,
+        } = this;
+
+        super.bind(context);
+
+        if (!nodeName) {
+            return;
+        }
+
+        const transformHandle = context.bindTransformByName(nodeName);
+        if (!transformHandle) {
+            error(`Failed to bind transform ${nodeName}`);
+            return;
+        }
+
+        this._transformHandle = transformHandle;
+
+        this.intensity.bind(context);
+    }
+
+    protected getPoseTransformSpaceRequirement () {
+        return PoseTransformSpaceRequirement.NO;
+    }
+
+    protected modifyPose (context: AnimationGraphEvaluationContext, inputPose: Pose, modificationQueue: TransformModificationQueue) {
+        const {
+            _transformHandle: transformHandle,
+        } = this;
+
+        if (!transformHandle) {
+            return inputPose;
+        }
+
+        const intensity = this.intensity.evaluate(inputPose);
+
+        // If intensity is too small. Takes no effect.
+        if (intensity < APPLY_INTENSITY_EPSILON) {
+            return inputPose;
+        }
+
+        const fullIntensity = approx(intensity, 1.0, APPLY_INTENSITY_EPSILON);
+
+        const { index: transformIndex } = transformHandle;
+
+        const nodeTransform = inputPose.transforms.getTransform(transformIndex, cacheTransform);
+
+        const { rotationOperation } = this;
+        if (rotationOperation !== TransformOperation.LEAVE_UNCHANGED) {
+            const { rotation, transformSpace: rotationSpace } = this;
+            context._convertPoseSpaceTransformToTargetSpace(
+                nodeTransform,
+                rotationSpace,
+                inputPose,
+                transformIndex,
+            );
+            switch (rotationOperation) {
+            default:
+            case TransformOperation.REPLACE:
+                replaceRotation(nodeTransform, rotation, intensity, fullIntensity);
+                break;
+            case TransformOperation.ADD:
+                addRotation(nodeTransform, rotation, intensity, fullIntensity);
+                break;
+            }
+            context._convertTransformToPoseTransformSpace(
+                nodeTransform,
+                rotationSpace,
+                inputPose,
+                transformIndex,
+            );
+        }
+
+        const { positionOperation } = this;
+        if (positionOperation !== TransformOperation.LEAVE_UNCHANGED) {
+            const { position, transformSpace: positionSpace } = this;
+            context._convertPoseSpaceTransformToTargetSpace(
+                nodeTransform,
+                positionSpace,
+                inputPose,
+                transformIndex,
+            );
+            switch (positionOperation) {
+            default:
+            case TransformOperation.REPLACE:
+                replacePosition(nodeTransform, position, intensity, fullIntensity);
+                break;
+            case TransformOperation.ADD:
+                addPosition(nodeTransform, position, intensity, fullIntensity);
+                break;
+            }
+            context._convertTransformToPoseTransformSpace(
+                nodeTransform,
+                positionSpace,
+                inputPose,
+                transformIndex,
+            );
+        }
+
+        modificationQueue.push(transformIndex, nodeTransform);
+
+        return inputPose;
+    }
+
+    private _transformHandle: TransformHandle | null = null;
+}
+
+const {
+    replace: replacePosition,
+    add: addPosition,
+} = (() => {
+    const cacheInput = new Vec3();
+    const cacheResult = new Vec3();
+
+    return {
+        replace,
+        add,
+    };
+
+    function replace (transform: Transform, value: Readonly<Vec3>, intensity: number, fullIntensity: boolean) {
+        if (fullIntensity) {
+            transform.position = value;
+        } else {
+            const inputPosition = Vec3.copy(cacheInput, transform.position);
+            Vec3.lerp(inputPosition, inputPosition, value, intensity);
+            transform.position = inputPosition;
+        }
+    }
+
+    function add (transform: Transform, value: Readonly<Vec3>, intensity: number, fullIntensity: boolean) {
+        const result = cacheResult;
+        if (fullIntensity) {
+            Vec3.copy(result, value);
+        } else {
+            Vec3.slerp(result, Vec3.ZERO, value, intensity);
+        }
+        Vec3.add(result, transform.position, result);
+        transform.position = result;
+    }
+})();
+
+const {
+    replace: replaceRotation,
+    add: addRotation,
+} = (() => {
+    const cacheInput = new Quat();
+    const cacheResult = new Quat();
+
+    return {
+        replace,
+        add,
+    };
+
+    function replace (transform: Transform, value: Readonly<Quat>, intensity: number, fullIntensity: boolean) {
+        if (fullIntensity) {
+            transform.rotation = value;
+        } else {
+            const inputRotation = Quat.copy(cacheInput, transform.rotation);
+            Quat.slerp(inputRotation, inputRotation, value, intensity);
+            transform.rotation = inputRotation;
+        }
+    }
+
+    function add (transform: Transform, value: Readonly<Quat>, intensity: number, fullIntensity: boolean) {
+        const inputRotation = Quat.copy(cacheInput, transform.rotation);
+        const resultRotation = cacheResult;
+        if (fullIntensity) {
+            Quat.copy(resultRotation, value);
+        } else {
+            Quat.slerp(resultRotation, Quat.IDENTITY, value, intensity);
+        }
+        Quat.multiply(resultRotation, resultRotation, inputRotation);
+        transform.rotation = resultRotation;
+    }
+})();
+
+if (EDITOR) {
+    PoseNodeApplyTransform.prototype.getTitle = function getTitle (this: PoseNodeApplyTransform) {
+        if (this.node) {
+            return [`ENGINE.classes.${CLASS_NAME_PREFIX_ANIM}PoseNodeApplyTransform.title`, { nodeName: this.node }];
+        }
+        return undefined;
+    };
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/apply-transform.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/apply-transform.ts
@@ -47,7 +47,7 @@ export class PoseNodeApplyTransform extends PoseNodeModifyPoseBase {
     @serializable
     @editable
     @input({ type: PoseGraphType.VEC3 })
-    @visible(function (this: PoseNodeApplyTransform) { return this.positionOperation !== TransformOperation.LEAVE_UNCHANGED; })
+    @visible(function visible(this: PoseNodeApplyTransform) { return this.positionOperation !== TransformOperation.LEAVE_UNCHANGED; })
     public position = new Vec3();
 
     @serializable
@@ -58,7 +58,7 @@ export class PoseNodeApplyTransform extends PoseNodeModifyPoseBase {
     @serializable
     @editable
     @input({ type: PoseGraphType.QUAT })
-    @visible(function (this: PoseNodeApplyTransform) { return this.rotationOperation !== TransformOperation.LEAVE_UNCHANGED; })
+    @visible(function visible(this: PoseNodeApplyTransform) { return this.rotationOperation !== TransformOperation.LEAVE_UNCHANGED; })
     public rotation = new Quat();
 
     @serializable

--- a/cocos/animation/marionette/pose-graph/pose-nodes/copy-transform.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/copy-transform.ts
@@ -1,0 +1,101 @@
+import { EDITOR } from 'internal:constants';
+import { ccclass, editable, serializable, type } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { PoseTransformSpaceRequirement } from '../pose-node';
+import { ccenum } from '../../../../core';
+import { TransformHandle } from '../../../core/animation-handle';
+import { poseGraphNodeAppearance, poseGraphNodeCategory } from '../decorator/node';
+import { POSE_GRAPH_NODE_MENU_PREFIX_POSE } from './menu-common';
+import { Pose } from '../../../core/pose';
+import { PoseNodeModifyPoseBase } from './modify-pose-base';
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext } from '../../animation-graph-context';
+import { Transform } from '../../../core/transform';
+
+const cacheTransform = new Transform();
+
+export enum CopySpace {
+    /**
+     * Transforms are stored relative to their parent nodes.
+     */
+    LOCAL,
+
+    /**
+     * Transforms are stored relative to the belonging animation controller's node's space.
+     */
+    COMPONENT,
+}
+ccenum(CopySpace);
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeCopyTransform`)
+@poseGraphNodeCategory(POSE_GRAPH_NODE_MENU_PREFIX_POSE)
+@poseGraphNodeAppearance({ themeColor: '#72A869' })
+export class PoseNodeCopyTransform extends PoseNodeModifyPoseBase {
+    @serializable
+    @editable
+    public sourceNodeName = '';
+
+    @serializable
+    @editable
+    public targetNodeName = '';
+
+    @serializable
+    @editable
+    @type(CopySpace)
+    public space: CopySpace = CopySpace.COMPONENT;
+
+    public bind (context: AnimationGraphBindingContext): void {
+        super.bind(context);
+        const sourceTransformHandle = context.bindTransformByName(this.sourceNodeName);
+        const targetTransformHandle = context.bindTransformByName(this.targetNodeName);
+        if (!sourceTransformHandle || !targetTransformHandle) {
+            sourceTransformHandle?.destroy();
+            targetTransformHandle?.destroy();
+            return;
+        }
+        this._workspace = new Workspace(
+            sourceTransformHandle,
+            targetTransformHandle,
+        );
+    }
+
+    protected modifyPose (context: AnimationGraphEvaluationContext, inputPose: Pose) {
+        const {
+            _workspace: workspace,
+        } = this;
+        if (!workspace) {
+            return;
+        }
+        const {
+            hSource: { index: sourceTransformIndex },
+            hTarget: { index: targetTransformIndex },
+        } = workspace;
+        const transform = inputPose.transforms.getTransform(sourceTransformIndex, cacheTransform);
+        inputPose.transforms.setTransform(targetTransformIndex, transform);
+    }
+
+    protected getPoseTransformSpaceRequirement () {
+        return this.space === CopySpace.COMPONENT ? PoseTransformSpaceRequirement.COMPONENT : PoseTransformSpaceRequirement.LOCAL;
+    }
+
+    private _workspace: Workspace | undefined = undefined;
+}
+
+class Workspace {
+    constructor (
+        public hSource: TransformHandle,
+        public hTarget: TransformHandle,
+    ) {
+    }
+}
+
+if (EDITOR) {
+    PoseNodeCopyTransform.prototype.getTitle = function getTitle (this: PoseNodeCopyTransform) {
+        if (this.sourceNodeName && this.targetNodeName) {
+            return [`ENGINE.classes.${CLASS_NAME_PREFIX_ANIM}PoseNodeCopyTransform.title`, {
+                sourceNodeName: this.sourceNodeName,
+                targetNodeName: this.targetNodeName,
+            }];
+        }
+        return undefined;
+    };
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/ik/menu.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/ik/menu.ts
@@ -1,0 +1,4 @@
+import { POSE_GRAPH_NODE_MENU_PREFIX_POSE } from '../menu-common';
+
+export const POSE_GRAPH_NODE_MENU_PREFIX_IK = `${POSE_GRAPH_NODE_MENU_PREFIX_POSE}/`
+    + `i18n:ENGINE.animation_graph.pose_graph_node_sub_categories.pose_nodes_ik/`;

--- a/cocos/animation/marionette/pose-graph/pose-nodes/ik/solve-two-bone-ik.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/ik/solve-two-bone-ik.ts
@@ -1,0 +1,194 @@
+import { DEBUG } from 'internal:constants';
+import { approx, clamp, Quat, Vec3 } from '../../../../../core';
+import { Transform } from '../../../../core/transform';
+import { debugTwoBoneIKDraw } from './two-bone-ik-debugger';
+
+const SANITY_CHECK_ENABLED = DEBUG;
+
+class TwoBoneIKPositionSanityChecker {
+    public reset (a: Readonly<Vec3>, b: Readonly<Vec3>, c: Readonly<Vec3>) {
+        Vec3.copy(this._a, a);
+        this._dAB = Vec3.distance(a, b);
+        this._dBC = Vec3.distance(b, c);
+    }
+
+    public check (_a: Readonly<Vec3>, _b: Readonly<Vec3>, _c: Readonly<Vec3>) {
+        const CHECK_EPSILON = 1e-3;
+        const dAB = Vec3.distance(_a, _b);
+        const dBC = Vec3.distance(_b, _c);
+        if (!approx(Vec3.distance(_a, this._a), 0.0, CHECK_EPSILON)) {
+            // eslint-disable-next-line no-debugger
+            debugger;
+            return false;
+        }
+        if (!approx(dAB, this._dAB, CHECK_EPSILON)) {
+            // eslint-disable-next-line no-debugger
+            debugger;
+            return false;
+        }
+        if (!approx(dBC, this._dBC, CHECK_EPSILON)) {
+            // eslint-disable-next-line no-debugger
+            debugger;
+            return false;
+        }
+        return true;
+    }
+
+    private _a = new Vec3();
+    private declare _dAB: number;
+    private declare _dBC: number;
+}
+
+/**
+ * 解算双骨骼（三关节）的 IK 问题。
+ * 三关节分别称为根关节、中间关节和末端关节。例如，分别对应于大腿、膝盖和脚关节。
+ * @param root 根关节转换（世界空间）。
+ * @param middle 中间关节转换（世界空间）。
+ * @param end 末端关节转换（世界空间）。
+ * @param target 末端关节要抵达的目标位置（世界空间）。
+ * @param hint 中间关节的提示位置（世界空间），用于决定中间关节的朝向。
+ */
+export const solveTwoBoneIK = (() => {
+    const cacheQuat = new Quat();
+    const cacheHint = new Vec3();
+    const cacheBSolved = new Vec3();
+    const cacheCSolved = new Vec3();
+
+    const calculateRotationBetweenRays = (() => {
+        const cacheVec3_1 = new Vec3();
+        const cacheVec3_2 = new Vec3();
+        return (
+            out: Quat,
+            sourceOrigin: Readonly<Vec3>, sourceDestination: Readonly<Vec3>,
+            targetOrigin: Readonly<Vec3>, targetDestination: Readonly<Vec3>,
+        // eslint-disable-next-line arrow-body-style
+        ) => {
+            return Quat.rotationTo(
+                out,
+                Vec3.subtract(cacheVec3_1, sourceDestination, sourceOrigin).normalize(),
+                Vec3.subtract(cacheVec3_2, targetDestination, targetOrigin).normalize(),
+            );
+        };
+    })();
+
+    return (
+        root: Transform,
+        middle: Transform,
+        end: Transform,
+        target: Vec3,
+        middlePositionHint?: Vec3,
+        debugKey?: unknown | undefined,
+    ) => {
+        const hint = Vec3.copy(cacheHint, middlePositionHint ?? middle.position);
+
+        const pA = root.position;
+        const pB = middle.position;
+        const pC = end.position;
+        const qC = end.rotation;
+
+        if (DEBUG) {
+            if (typeof debugKey !== undefined) {
+                debugTwoBoneIKDraw(debugKey, pA, pB, pC);
+            }
+        }
+
+        const bSolved = cacheBSolved;
+        const cSolved = cacheCSolved;
+        solveTwoBoneIKPositions(
+            pA,
+            pB,
+            pC,
+            target,
+            hint,
+            bSolved,
+            cSolved,
+        );
+
+        const qA = calculateRotationBetweenRays(
+            cacheQuat,
+            pA, pB,
+            pA, bSolved,
+        );
+        Quat.multiply(qA, qA, root.rotation);
+        root.rotation = qA;
+
+        const qB = calculateRotationBetweenRays(
+            cacheQuat,
+            pB, pC,
+            bSolved, cSolved,
+        );
+        Quat.multiply(qB, qB, middle.rotation);
+        middle.rotation = qB;
+        middle.position = bSolved;
+
+        end.position = cSolved;
+    };
+})();
+
+export const solveTwoBoneIKPositions = (() => {
+    const cacheDirAT = new Vec3();
+    const cacheDirAB = new Vec3();
+    const cacheDirHeightLine = new Vec3();
+    const cacheSanityChecker = SANITY_CHECK_ENABLED
+        ? new TwoBoneIKPositionSanityChecker()
+        : undefined;
+
+    return (
+        a: Readonly<Vec3>,
+        b: Readonly<Vec3>,
+        c: Readonly<Vec3>,
+        target: Readonly<Vec3>,
+        middleTarget: Readonly<Vec3>,
+        bSolved: Vec3,
+        cSolved: Vec3,
+    ) => {
+        const sanityCheck = cacheSanityChecker
+            ? (() => {
+                cacheSanityChecker?.reset(a, b, c);
+                return () => cacheSanityChecker.check(a, bSolved, cSolved);
+            })()
+            : undefined;
+
+        const dAB = Vec3.distance(a, b);
+        const dBC = Vec3.distance(b, c);
+        const dAT = Vec3.distance(a, target);
+
+        const dirAT = Vec3.subtract(cacheDirAT, target, a);
+        dirAT.normalize();
+
+        const chainLength = dAB + dBC;
+        if (dAT >= chainLength) {
+            // Target is too far
+            Vec3.scaleAndAdd(bSolved, a, dirAT, dAB);
+            Vec3.scaleAndAdd(cSolved, a, dirAT, chainLength);
+            sanityCheck?.();
+            return;
+        }
+
+        // Now we should have a solution with target reached.
+        // And then solve the middle joint B as Ḃ.
+        Vec3.copy(cSolved, target);
+        // Calculate ∠BAC's cosine.
+        const cosḂAT = clamp(
+            (dAB * dAB + dAT * dAT - dBC * dBC) / (2 * dAB * dAT),
+            -1.0,
+            1.0,
+        );
+        // Then use basic trigonometry(instead of rotation) to solve Ḃ.
+        // Let D the intersect point of the height line passing Ḃ.
+        const dirAB = Vec3.subtract(cacheDirAB, middleTarget, a);
+        const dirHeightLine = Vec3.projectOnPlane(cacheDirHeightLine, dirAB, dirAT);
+        dirHeightLine.normalize();
+        const dAD = dAB * cosḂAT;
+        const hSqr = dAB * dAB - dAD * dAD;
+        if (hSqr < 0) {
+            // TODO: 'Shall handle this case';
+            // eslint-disable-next-line no-debugger
+            debugger;
+        }
+        const h = Math.sqrt(hSqr);
+        Vec3.scaleAndAdd(bSolved, a, dirAT, dAD);
+        Vec3.scaleAndAdd(bSolved, bSolved, dirHeightLine, h);
+        sanityCheck?.();
+    };
+})();

--- a/cocos/animation/marionette/pose-graph/pose-nodes/ik/two-bone-ik-debugger.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/ik/two-bone-ik-debugger.ts
@@ -1,0 +1,76 @@
+import { MeshRenderer } from '../../../../../3d';
+import { createMesh } from '../../../../../3d/misc';
+import { Material } from '../../../../../asset/assets';
+import { Color, Vec3 } from '../../../../../core';
+import { legacyCC } from '../../../../../core/global-exports';
+import { PrimitiveMode } from '../../../../../gfx';
+import { Node } from '../../../../../scene-graph';
+
+export class TwoBoneIKDebugger {
+    constructor () {
+        const node = new Node();
+        legacyCC.director.getScene().addChild(node);
+
+        const meshRenderer = node.addComponent(MeshRenderer);
+        meshRenderer.material = (() => {
+            const material = new Material();
+            material.reset({
+                effectName: 'builtin-unlit',
+                states: {
+                    primitive: PrimitiveMode.LINE_LIST,
+                },
+                defines: {
+                    USE_VERTEX_COLOR: true,
+                },
+            });
+            return material;
+        })();
+
+        this._node = node;
+        this._meshRenderer = meshRenderer;
+    }
+
+    public draw (a: Readonly<Vec3>, b: Readonly<Vec3>, c: Readonly<Vec3>) {
+        const color1 = Color.RED;
+        const color2 = Color.BLUE;
+        const positions: number[] = [
+            a.x, a.y, a.z,
+            b.x, b.y, b.z,
+            b.x, b.y, b.z,
+            c.x, c.y, c.z,
+        ];
+        const colors: number[] = [
+            color1.x, color1.y, color1.z, color1.w,
+            color1.x, color1.y, color1.z, color1.w,
+            color2.x, color2.y, color2.z, color2.w,
+            color2.x, color2.y, color2.z, color2.w,
+        ];
+        const mesh = createMesh({
+            positions,
+            colors,
+            primitiveMode: PrimitiveMode.LINE_LIST,
+        });
+        this._meshRenderer.mesh = mesh;
+    }
+
+    private _node: Node;
+    private _meshRenderer: MeshRenderer;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+const debuggerMap = new WeakMap<object, TwoBoneIKDebugger>();
+
+export function debugTwoBoneIKDraw (
+    key: unknown,
+    a: Readonly<Vec3>, b: Readonly<Vec3>, c: Readonly<Vec3>,
+) {
+    if (typeof key !== 'object' || !key) {
+        return;
+    }
+    let ikDebugger = debuggerMap.get(key);
+    if (!ikDebugger) {
+        ikDebugger = new TwoBoneIKDebugger();
+        debuggerMap.set(key, ikDebugger);
+    }
+    ikDebugger.draw(a, b, c);
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/ik/two-bone-ik-solver.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/ik/two-bone-ik-solver.ts
@@ -54,18 +54,18 @@ class TargetSpecification {
 
     @serializable
     @editable
-    @visible(function (this: TargetSpecification) { return this.type === TargetSpecificationType.VALUE; })
+    @visible(function visible(this: TargetSpecification) { return this.type === TargetSpecificationType.VALUE; })
     public targetPosition = new Vec3();
 
     @serializable
     @editable
     @type(TransformSpace)
-    @visible(function (this: TargetSpecification) { return this.type === TargetSpecificationType.VALUE; })
+    @visible(function visible(this: TargetSpecification) { return this.type === TargetSpecificationType.VALUE; })
     public targetPositionSpace = TransformSpace.WORLD;
 
     @serializable
     @editable
-    @visible(function (this: TargetSpecification) { return this.type === TargetSpecificationType.BONE; })
+    @visible(function visible(this: TargetSpecification) { return this.type === TargetSpecificationType.BONE; })
     public targetBone = '';
 
     public bind (context: AnimationGraphBindingContext, sourceBoneHandle: TransformHandle) {
@@ -183,11 +183,6 @@ export class PoseNodeTwoBoneIKSolver extends PoseNodeModifyPoseBase {
             hEndEffector: { index: iEndEffectorTransform },
         } = workspace;
 
-        // // TODO: bad performance!
-        // // Save local space pose.
-        // const localPose = context.pushDuplicatedPose(inputPose);
-        // context._poseTransformsSpaceComponentToLocal(localPose);
-
         // Fetch transforms.
         const rootTransform = inputPose.transforms.getTransform(iRootTransform, cacheRootTransform);
         const middleTransform = inputPose.transforms.getTransform(iMiddleTransform, cacheMiddleTransform);
@@ -209,31 +204,6 @@ export class PoseNodeTwoBoneIKSolver extends PoseNodeModifyPoseBase {
         modificationQueue.push(iRootTransform, rootTransform);
         modificationQueue.push(iMiddleTransform, middleTransform);
         modificationQueue.push(iEndEffectorTransform, endEffectorTransform);
-
-        // // TODO: bad performance!
-        // {
-        //     // Push transforms.
-        //     inputPose.transforms.setTransform(iRootTransform, rootTransform);
-        //     inputPose.transforms.setTransform(iMiddleTransform, middleTransform);
-        //     inputPose.transforms.setTransform(iEndEffectorTransform, endEffectorTransform);
-
-        //     // Calculate local transforms of these 3 bones.
-        //     context._poseTransformsSpaceComponentToLocal(inputPose);
-        //     inputPose._poseTransformSpace = PoseTransformSpace.COMPONENT; // TODO:!!
-        //     const rootLocalTransform = inputPose.transforms.getTransform(iRootTransform, cacheRootTransform);
-        //     const middleLocalTransform = inputPose.transforms.getTransform(iMiddleTransform, cacheMiddleTransform);
-        //     const endEffectorLocalTransform = inputPose.transforms.getTransform(iEndEffectorTransform, cacheEndEffectorTransform);
-
-        //     // Write these bones' local transforms back into original local pose.
-        //     localPose.transforms.setTransform(iRootTransform, rootLocalTransform);
-        //     localPose.transforms.setTransform(iMiddleTransform, middleLocalTransform);
-        //     localPose.transforms.setTransform(iEndEffectorTransform, endEffectorLocalTransform);
-
-        //     // Recalculate skeletal space.
-        //     context._poseTransformsSpaceLocalToComponent(localPose);
-        //     inputPose.transforms.set(localPose.transforms);
-        // }
-        // context.popPose();
     }
 
     private _workspace: Workspace | undefined = undefined;

--- a/cocos/animation/marionette/pose-graph/pose-nodes/ik/two-bone-ik-solver.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/ik/two-bone-ik-solver.ts
@@ -1,0 +1,260 @@
+import { EDITOR } from 'internal:constants';
+import { ccclass, editable, serializable, type, visible } from '../../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../../define';
+import { PoseTransformSpaceRequirement } from '../../pose-node';
+import { assertIsTrue, ccenum, Vec3 } from '../../../../../core';
+import { TransformHandle } from '../../../../core/animation-handle';
+import { input } from '../../decorator/input';
+import { poseGraphNodeCategory } from '../../decorator/node';
+import { Pose } from '../../../../core/pose';
+import { PoseNodeModifyPoseBase, TransformModificationQueue } from '../modify-pose-base';
+import { solveTwoBoneIK } from './solve-two-bone-ik';
+import { Transform } from '../../../../core/transform';
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext } from '../../../animation-graph-context';
+import { PoseGraphType } from '../../foundation/type-system';
+import { TransformSpace } from '../transform-space';
+import { POSE_GRAPH_NODE_MENU_PREFIX_IK } from './menu';
+
+const cacheRootTransform = new Transform();
+const cacheMiddleTransform = new Transform();
+const cacheEndEffectorTransform = new Transform();
+const cacheEndEffectorTargetPosition = new Vec3();
+const cachePoleTargetPosition = new Vec3();
+const cacheTransform_evaluateTarget = new Transform();
+
+enum TargetSpecificationType {
+    /**
+     * Targets nothing.
+     */
+    NONE,
+
+    /**
+     * Targets the specified vector value.
+     */
+    VALUE,
+
+    /**
+     * Targets the specified bone.
+     */
+    BONE,
+}
+
+ccenum(TargetSpecificationType);
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeTwoBoneIKSolver.TargetSpecification`)
+class TargetSpecification {
+    constructor (type?: TargetSpecificationType) {
+        this.type = type ?? TargetSpecificationType.NONE;
+    }
+
+    @serializable
+    @editable
+    @type(TargetSpecificationType)
+    public type = TargetSpecificationType.VALUE;
+
+    @serializable
+    @editable
+    @visible(function (this: TargetSpecification) { return this.type === TargetSpecificationType.VALUE; })
+    public targetPosition = new Vec3();
+
+    @serializable
+    @editable
+    @type(TransformSpace)
+    @visible(function (this: TargetSpecification) { return this.type === TargetSpecificationType.VALUE; })
+    public targetPositionSpace = TransformSpace.WORLD;
+
+    @serializable
+    @editable
+    @visible(function (this: TargetSpecification) { return this.type === TargetSpecificationType.BONE; })
+    public targetBone = '';
+
+    public bind (context: AnimationGraphBindingContext, sourceBoneHandle: TransformHandle) {
+        this._sourceBoneHandle = sourceBoneHandle;
+        if (this.type === TargetSpecificationType.BONE && this.targetBone) {
+            this._targetBoneHandle = context.bindTransformByName(this.targetBone) ?? undefined;
+        }
+    }
+
+    public evaluate (outTargetPosition: Vec3, pose: Pose, context: AnimationGraphEvaluationContext) {
+        assertIsTrue(this._sourceBoneHandle);
+        if (this._targetBoneHandle) {
+            pose.transforms.getPosition(this._targetBoneHandle.index, outTargetPosition);
+        } else if (this.type === TargetSpecificationType.NONE) {
+            pose.transforms.getPosition(this._sourceBoneHandle.index, outTargetPosition);
+        } else {
+            const targetTransform = Transform.setIdentity(cacheTransform_evaluateTarget);
+            targetTransform.position = this.targetPosition;
+            context._convertTransformToPoseTransformSpace(
+                targetTransform,
+                this.targetPositionSpace,
+                pose,
+                this._sourceBoneHandle.index,
+            );
+            Vec3.copy(outTargetPosition, targetTransform.position);
+        }
+        return outTargetPosition;
+    }
+
+    private _sourceBoneHandle: TransformHandle | undefined = undefined;
+    private _targetBoneHandle: TransformHandle | undefined = undefined;
+}
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeTwoBoneIKSolver`)
+@poseGraphNodeCategory(POSE_GRAPH_NODE_MENU_PREFIX_IK)
+export class PoseNodeTwoBoneIKSolver extends PoseNodeModifyPoseBase {
+    @serializable
+    @editable
+    public debug = false;
+
+    @serializable
+    @editable
+    public endEffectorBoneName = '';
+
+    @serializable
+    @editable
+    public readonly endEffectorTarget = new TargetSpecification(TargetSpecificationType.VALUE);
+
+    @input({ type: PoseGraphType.VEC3 })
+    get endEffectorTargetPosition () {
+        return this.endEffectorTarget.targetPosition;
+    }
+
+    set endEffectorTargetPosition (value) {
+        Vec3.copy(this.endEffectorTarget.targetPosition, value);
+    }
+
+    @serializable
+    @editable
+    public readonly poleTarget = new TargetSpecification(TargetSpecificationType.NONE);
+
+    @input({ type: PoseGraphType.VEC3 })
+    get poleTargetPosition () {
+        return this.poleTarget.targetPosition;
+    }
+
+    set poleTargetPosition (value) {
+        Vec3.copy(this.poleTarget.targetPosition, value);
+    }
+
+    public bind (context: AnimationGraphBindingContext): void {
+        super.bind(context);
+        if (this.endEffectorBoneName) {
+            const parentBoneName = context.getParentBoneNameByName(this.endEffectorBoneName);
+            const ikRootBoneName = parentBoneName
+                ? context.getParentBoneNameByName(parentBoneName)
+                : '';
+            if (parentBoneName && ikRootBoneName) {
+                const hEndEffector = context.bindTransformByName(this.endEffectorBoneName);
+                const hMiddle = context.bindTransformByName(parentBoneName);
+                const hIKRoot = context.bindTransformByName(ikRootBoneName);
+                if (!hEndEffector || !hMiddle || !hIKRoot) {
+                    hEndEffector?.destroy();
+                    hMiddle?.destroy();
+                    hIKRoot?.destroy();
+                } else {
+                    this.endEffectorTarget.bind(context, hEndEffector);
+                    this.poleTarget.bind(context, hMiddle);
+                    this._workspace = new Workspace(
+                        hEndEffector,
+                        hMiddle,
+                        hIKRoot,
+                    );
+                }
+            }
+        }
+    }
+
+    protected getPoseTransformSpaceRequirement () {
+        return PoseTransformSpaceRequirement.COMPONENT;
+    }
+
+    protected modifyPose (context: AnimationGraphEvaluationContext, inputPose: Pose, modificationQueue: TransformModificationQueue) {
+        const {
+            _workspace: workspace,
+        } = this;
+
+        if (!workspace) {
+            return;
+        }
+
+        const {
+            hRoot: { index: iRootTransform },
+            hMiddle: { index: iMiddleTransform },
+            hEndEffector: { index: iEndEffectorTransform },
+        } = workspace;
+
+        // // TODO: bad performance!
+        // // Save local space pose.
+        // const localPose = context.pushDuplicatedPose(inputPose);
+        // context._poseTransformsSpaceComponentToLocal(localPose);
+
+        // Fetch transforms.
+        const rootTransform = inputPose.transforms.getTransform(iRootTransform, cacheRootTransform);
+        const middleTransform = inputPose.transforms.getTransform(iMiddleTransform, cacheMiddleTransform);
+        const endEffectorTransform = inputPose.transforms.getTransform(iEndEffectorTransform, cacheEndEffectorTransform);
+
+        const endEffectorTargetPosition = this.endEffectorTarget.evaluate(cacheEndEffectorTargetPosition, inputPose, context);
+        const poleTargetPosition = this.poleTarget.evaluate(cachePoleTargetPosition, inputPose, context);
+
+        // Solve.
+        solveTwoBoneIK(
+            rootTransform,
+            middleTransform,
+            endEffectorTransform,
+            endEffectorTargetPosition,
+            poleTargetPosition,
+            this.debug ? this : undefined,
+        );
+
+        modificationQueue.push(iRootTransform, rootTransform);
+        modificationQueue.push(iMiddleTransform, middleTransform);
+        modificationQueue.push(iEndEffectorTransform, endEffectorTransform);
+
+        // // TODO: bad performance!
+        // {
+        //     // Push transforms.
+        //     inputPose.transforms.setTransform(iRootTransform, rootTransform);
+        //     inputPose.transforms.setTransform(iMiddleTransform, middleTransform);
+        //     inputPose.transforms.setTransform(iEndEffectorTransform, endEffectorTransform);
+
+        //     // Calculate local transforms of these 3 bones.
+        //     context._poseTransformsSpaceComponentToLocal(inputPose);
+        //     inputPose._poseTransformSpace = PoseTransformSpace.COMPONENT; // TODO:!!
+        //     const rootLocalTransform = inputPose.transforms.getTransform(iRootTransform, cacheRootTransform);
+        //     const middleLocalTransform = inputPose.transforms.getTransform(iMiddleTransform, cacheMiddleTransform);
+        //     const endEffectorLocalTransform = inputPose.transforms.getTransform(iEndEffectorTransform, cacheEndEffectorTransform);
+
+        //     // Write these bones' local transforms back into original local pose.
+        //     localPose.transforms.setTransform(iRootTransform, rootLocalTransform);
+        //     localPose.transforms.setTransform(iMiddleTransform, middleLocalTransform);
+        //     localPose.transforms.setTransform(iEndEffectorTransform, endEffectorLocalTransform);
+
+        //     // Recalculate skeletal space.
+        //     context._poseTransformsSpaceLocalToComponent(localPose);
+        //     inputPose.transforms.set(localPose.transforms);
+        // }
+        // context.popPose();
+    }
+
+    private _workspace: Workspace | undefined = undefined;
+}
+
+if (EDITOR) {
+    PoseNodeTwoBoneIKSolver.prototype.getTitle = function getTitle (this: PoseNodeTwoBoneIKSolver) {
+        if (this.endEffectorBoneName) {
+            return [`ENGINE.classes.${CLASS_NAME_PREFIX_ANIM}PoseNodeTwoBoneIKSolver.title`, {
+                endEffectorBoneName: this.endEffectorBoneName,
+            }];
+        }
+        return undefined;
+    };
+}
+
+class Workspace {
+    constructor (
+        public hEndEffector: TransformHandle,
+        public hMiddle: TransformHandle,
+        public hRoot: TransformHandle,
+    ) {
+    }
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/intensity-specification.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/intensity-specification.ts
@@ -1,0 +1,48 @@
+import { ccenum } from '../../../../core';
+import { ccclass, editable, serializable, type, visible } from '../../../../core/data/decorators';
+import { AuxiliaryCurveHandle } from '../../../core/animation-handle';
+import { Pose } from '../../../core/pose';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { AnimationGraphBindingContext } from '../../animation-graph-context';
+
+enum IntensityType {
+    VALUE,
+
+    AUXILIARY_CURVE,
+}
+ccenum(IntensityType);
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}IntensitySpecification`)
+export class IntensitySpecification {
+    @type(IntensityType)
+    @serializable
+    @editable
+    public type = IntensityType.VALUE;
+
+    @serializable
+    @editable
+    @visible(function visible (this: IntensitySpecification) { return this.type === IntensityType.VALUE; })
+    public value = 1.0;
+
+    @serializable
+    @editable
+    @visible(function visible (this: IntensitySpecification) { return this.type === IntensityType.AUXILIARY_CURVE; })
+    public auxiliaryCurveName = '';
+
+    public bind (context: AnimationGraphBindingContext) {
+        if (this.type === IntensityType.AUXILIARY_CURVE && this.auxiliaryCurveName) {
+            const handle = context.bindAuxiliaryCurve(this.auxiliaryCurveName);
+            this._handle = handle;
+        }
+    }
+
+    public evaluate (pose: Readonly<Pose>) {
+        if (this.type === IntensityType.AUXILIARY_CURVE && this._handle) {
+            const value = pose.auxiliaryCurves[this._handle.index];
+            return value;
+        }
+        return this.value;
+    }
+
+    private _handle: AuxiliaryCurveHandle | undefined = undefined;
+}

--- a/cocos/animation/marionette/pose-graph/pose-nodes/modify-pose-base.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/modify-pose-base.ts
@@ -14,29 +14,29 @@ import { Transform } from '../../../core/transform';
 @poseGraphNodeHide()
 export abstract class PoseNodeModifyPoseBase extends PoseNode {
     @serializable
-    @input({ type: PoseGraphType.POSE, displayName: '输入姿势' })
-    public input: PoseNode | null = null;
+    @input({ type: PoseGraphType.POSE })
+    public pose: PoseNode | null = null;
 
     public settle (context: AnimationGraphSettleContext) {
-        this.input?.settle(context);
+        this.pose?.settle(context);
         this._spaceFlagTable = new PoseTransformSpaceFlagTable(context.transformCount);
     }
 
     public reenter () {
-        this.input?.reenter();
+        this.pose?.reenter();
     }
 
     public bind (context: AnimationGraphBindingContext): void {
-        this.input?.bind(context);
+        this.pose?.bind(context);
     }
 
     protected doUpdate (context: AnimationGraphUpdateContext) {
-        this.input?.update(context);
+        this.pose?.update(context);
     }
 
     protected doEvaluate (context: AnimationGraphEvaluationContext): Pose {
         const poseTransformSpaceRequirement = this.getPoseTransformSpaceRequirement();
-        const inputPose = this.input?.evaluate(context, poseTransformSpaceRequirement)
+        const inputPose = this.pose?.evaluate(context, poseTransformSpaceRequirement)
             ?? PoseNode.evaluateDefaultPose(context, poseTransformSpaceRequirement);
 
         const { _modificationQueue: modificationQueue } = this;

--- a/cocos/animation/marionette/pose-graph/pose-nodes/set-auxiliary-curve.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/set-auxiliary-curve.ts
@@ -1,0 +1,83 @@
+import { EDITOR } from 'internal:constants';
+import { ccclass, editable, serializable, type } from '../../../../core/data/decorators';
+import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { ccenum } from '../../../../core';
+import { AuxiliaryCurveHandle } from '../../../core/animation-handle';
+import { input } from '../decorator/input';
+import { poseGraphNodeCategory } from '../decorator/node';
+import { POSE_GRAPH_NODE_MENU_PREFIX_POSE } from './menu-common';
+import { Pose } from '../../../core/pose';
+import { PoseNodeModifyPoseBase } from './modify-pose-base';
+import { AnimationGraphBindingContext, AnimationGraphEvaluationContext } from '../../animation-graph-context';
+import { PoseGraphType } from '../foundation/type-system';
+import { PoseTransformSpaceRequirement } from '../pose-node';
+
+enum SetAuxiliaryCurveFlag {
+    LEAVE_UNCHANGED,
+
+    REPLACE,
+
+    ADD,
+}
+
+ccenum(SetAuxiliaryCurveFlag);
+
+@ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeSetAuxiliaryCurve`)
+@poseGraphNodeCategory(POSE_GRAPH_NODE_MENU_PREFIX_POSE)
+export class PoseNodeSetAuxiliaryCurve extends PoseNodeModifyPoseBase {
+    @serializable
+    @editable
+    public curveName = '';
+
+    @serializable
+    @editable
+    @input({ type: PoseGraphType.FLOAT })
+    public curveValue = 0.0;
+
+    @serializable
+    @editable
+    @type(SetAuxiliaryCurveFlag)
+    public flag = SetAuxiliaryCurveFlag.REPLACE;
+
+    public bind (context: AnimationGraphBindingContext): void {
+        super.bind(context);
+        if (this.curveName) {
+            this._handle = context.bindAuxiliaryCurve(this.curveName);
+        }
+    }
+
+    protected getPoseTransformSpaceRequirement () {
+        return PoseTransformSpaceRequirement.NO;
+    }
+
+    protected modifyPose (context: AnimationGraphEvaluationContext, inputPose: Pose) {
+        const {
+            _handle: handle,
+        } = this;
+        if (!handle) {
+            return;
+        }
+        switch (this.flag) {
+        case SetAuxiliaryCurveFlag.REPLACE:
+            inputPose.auxiliaryCurves[handle.index] = this.curveValue;
+            break;
+        case SetAuxiliaryCurveFlag.ADD:
+            inputPose.auxiliaryCurves[handle.index] += this.curveValue;
+            break;
+        case SetAuxiliaryCurveFlag.LEAVE_UNCHANGED:
+        default:
+            break;
+        }
+    }
+
+    private _handle: AuxiliaryCurveHandle | undefined = undefined;
+}
+
+if (EDITOR) {
+    PoseNodeSetAuxiliaryCurve.prototype.getTitle = function getTitle (this: PoseNodeSetAuxiliaryCurve) {
+        if (!this.curveName) {
+            return undefined;
+        }
+        return [`ENGINE.classes.${CLASS_NAME_PREFIX_ANIM}PoseNodeSetAuxiliaryCurve.title`, { curveName: this.curveName }];
+    };
+}

--- a/editor/i18n/en/animation.js
+++ b/editor/i18n/en/animation.js
@@ -6,6 +6,7 @@ module.exports = {
         pose_graph_node_sub_categories: {
             pose_nodes: 'Pose Nodes',
             pose_nodes_blend: 'Blend',
+            pose_nodes_ik: 'Inverse Kinematic',
         },
     },
 
@@ -98,6 +99,124 @@ module.exports = {
                         },
                         'choice': {
                             displayName: 'Choice',
+                        },
+                    },
+                },
+                'PoseNodeModifyPoseBase': {
+                    inputs: {
+                        'pose': {
+                            displayName: 'Pose',
+                        },
+                    },
+                },
+                'PoseNodeApplyTransform': {
+                    displayName: 'Apply Transform',
+                    title: 'Transform {nodeName}',
+                    properties: {
+                        'positionOperation': {
+                            displayName: 'Position Operation',
+                            tooltip: 'Specify how to process position.',
+                        },
+                        'rotationOperation': {
+                            displayName: 'Rotation Operation',
+                            tooltip: 'Specify how to process rotation.',
+                        },
+                        'transformSpace': {
+                            displayName: 'Transform Space',
+                            tooltip: 'Specify the space of the position and rotation.',
+                        },
+                    },
+                    inputs: {
+                        __extends__: 'classes.cc.animation.PoseNodeModifyPoseBase.inputs',
+                        'position': {
+                            displayName: 'Position',
+                        },
+                        'rotation': {
+                            displayName: 'Rotation',
+                        },
+                        'intensity': {
+                            displayName: 'Intensity',
+                        },
+                    },
+                },
+                'PoseNodeCopyTransform': {
+                    displayName: 'Copy Transform',
+                    title: 'Copy {sourceNodeName}\'s transform to {targetNodeName}',
+                    properties: {
+                        'sourceNodeName': {
+                            displayName: 'Source Node',
+                            tooltip: 'Name of the source node.',
+                        },
+                        'targetNodeName': {
+                            displayName: 'Target Node',
+                            tooltip: 'Name of the target node.',
+                        },
+                        'space': {
+                            displayName: 'Space',
+                            tooltip: 'Specify the transform space in which the transform would be copied.',
+                        },
+                    },
+                    inputs: {
+                        __extends__: 'classes.cc.animation.PoseNodeModifyPoseBase.inputs',
+                    },
+                },
+                'PoseNodeSetAuxiliaryCurve': {
+                    displayName: 'Set Auxiliary Curve',
+                    title: 'Set Auxiliary Curve {curveName}',
+                    inputs: {
+                        __extends__: 'classes.cc.animation.PoseNodeModifyPoseBase.inputs',
+                        'curveValue': {
+                            displayName: 'Value',
+                        },
+                    },
+                },
+                'PoseNodeTwoBoneIKSolver': {
+                    displayName: 'Two Bone IK Solver',
+                    title: 'Solve Two Bone IK: {endEffectorBoneName}',
+                    properties: {
+                        'endEffectorBoneName': {
+                            displayName: 'End Effector Bone',
+                            tooltip: 'Name of the end effector bone.',
+                        },
+                        'endEffectorTarget': {
+                            displayName: 'End Effector Target',
+                            tooltip: 'Specify the end effector\'s target.',
+                        },
+                        'poleTarget': {
+                            displayName: 'Pole Target',
+                            tooltip: 'Specify the pole target, ie. the middle bone\'s trending location..',
+                        },
+                    },
+                    inputs: {
+                        __extends__: 'classes.cc.animation.PoseNodeModifyPoseBase.inputs',
+                        'endEffectorTargetPosition': {
+                            displayName: 'End Effector Target',
+                        },
+                        'poleTargetPosition': {
+                            displayName: 'Pole Target',
+                        },
+                        'intensityValue': {
+                            displayName: 'Intensity',
+                        },
+                    },
+                    'TargetSpecification': {
+                        properties: {
+                            'type': {
+                                displayName: 'Type',
+                                tooltip: 'Target type.',
+                            },
+                            'targetPosition': {
+                                displayName: 'Target Position',
+                                tooltip: 'Target position.',
+                            },
+                            'targetPositionSpace': {
+                                displayName: 'Target Position Space',
+                                tooltip: 'Space of the target position.',
+                            },
+                            'targetBone': {
+                                displayName: 'Target Bone',
+                                tooltip: 'Name of target bone.',
+                            },
                         },
                     },
                 },

--- a/editor/i18n/zh/animation.js
+++ b/editor/i18n/zh/animation.js
@@ -6,6 +6,7 @@ module.exports = {
         pose_graph_node_sub_categories: {
             pose_nodes: '姿势结点',
             pose_nodes_blend: '混合',
+            pose_nodes_ik: '反向动力学',
         },
     },
 
@@ -98,6 +99,124 @@ module.exports = {
                         },
                         'choice': {
                             displayName: '选择',
+                        },
+                    },
+                },
+                'PoseNodeModifyPoseBase': {
+                    inputs: {
+                        'pose': {
+                            displayName: '姿势',
+                        },
+                    },
+                },
+                'PoseNodeApplyTransform': {
+                    displayName: '应用变换',
+                    title: '变换 {nodeName}',
+                    properties: {
+                        'positionOperation': {
+                            displayName: '位置操作',
+                            tooltip: '指定应如何处理位置。',
+                        },
+                        'rotationOperation': {
+                            displayName: '旋转操作',
+                            tooltip: '指定应如何处理旋转。',
+                        },
+                        'transformSpace': {
+                            displayName: '变换空间',
+                            tooltip: '指定位置和旋转的空间。',
+                        },
+                    },
+                    inputs: {
+                        __extends__: 'classes.cc.animation.PoseNodeModifyPoseBase.inputs',
+                        'position': {
+                            displayName: '位置',
+                        },
+                        'rotation': {
+                            displayName: '旋转',
+                        },
+                        'intensityValue': {
+                            displayName: '强度',
+                        },
+                    },
+                },
+                'PoseNodeCopyTransform': {
+                    displayName: '拷贝变换',
+                    title: '拷贝 {sourceNodeName} 的变换至 {targetNodeName}',
+                    properties: {
+                        'sourceNodeName': {
+                            displayName: '源结点',
+                            tooltip: '源结点的名称。',
+                        },
+                        'targetNodeName': {
+                            displayName: '目标结点',
+                            tooltip: '目标结点的名称。',
+                        },
+                        'space': {
+                            displayName: '空间',
+                            tooltip: '拷贝发生的空间。',
+                        },
+                    },
+                    inputs: {
+                        __extends__: 'classes.cc.animation.PoseNodeModifyPoseBase.inputs',
+                    },
+                },
+                'PoseNodeSetAuxiliaryCurve': {
+                    displayName: '设置辅助曲线',
+                    title: '设置辅助曲线 {curveName}',
+                    inputs: {
+                        __extends__: 'classes.cc.animation.PoseNodeModifyPoseBase.inputs',
+                        'curveValue': {
+                            displayName: '值',
+                        },
+                    },
+                },
+                'PoseNodeTwoBoneIKSolver': {
+                    displayName: '双骨骼 IK 结算器',
+                    title: '解算双骨骼 IK：{endEffectorBoneName}',
+                    properties: {
+                        'endEffectorBoneName': {
+                            displayName: '终端执行器骨骼',
+                            tooltip: '终端执行器骨骼的名称。',
+                        },
+                        'endEffectorTarget': {
+                            displayName: '终端执行器目标',
+                            tooltip: '指定终端执行器的目标。',
+                        },
+                        'poleTarget': {
+                            displayName: '极向目标',
+                            tooltip: '指定极向的目标，也即中间骨骼的趋向位置。',
+                        },
+                    },
+                    inputs: {
+                        __extends__: 'classes.cc.animation.PoseNodeModifyPoseBase.inputs',
+                        'endEffectorTargetPosition': {
+                            displayName: '终端执行器目标',
+                        },
+                        'poleTargetPosition': {
+                            displayName: '极目标',
+                        },
+                        'intensityValue': {
+                            displayName: '强度',
+                        },
+                    },
+                    'TargetSpecification': {
+                        properties: {
+                            'type': {
+                                displayName: '类型',
+                                tooltip: '目标类型。',
+                            },
+                            'targetPosition': {
+                                displayName: '目标位置',
+                                tooltip: '目标位置。',
+                            },
+                            'targetPositionSpace': {
+                                displayName: '目标位置空间',
+                                tooltip: '目标位置的空间。',
+                            },
+                            'targetBone': {
+                                displayName: '目标骨骼',
+                                tooltip: '目标骨骼的名称。',
+                            },
                         },
                     },
                 },

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/ik/two-bone-ik-solver.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/ik/two-bone-ik-solver.test.ts
@@ -1,0 +1,24 @@
+
+describe(`Error-formed`, () => {
+    test.todo(`End effector not specified`);
+    
+    describe(`Failed to bind bones`, () => {
+        test.todo(`Failed to bind end effector bone`);
+
+        test.todo(`Failed to bind middle bone`);
+
+        test.todo(`Failed to bind root bone`);
+    });
+
+    test.todo(`Input not specified`);
+
+    test.todo(`Evaluate in skeletal space`);
+
+    describe(`End effector target`, () => {
+        test.todo(`End effector target bone is not specified`);
+
+        test.todo(`End effector target bone is specified but invalid`);
+
+        test.todo(`End effector target bone is specified and valid`);
+    });
+});

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/intensity-specification.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/intensity-specification.test.ts
@@ -1,0 +1,8 @@
+
+describe(`Type: auxiliary curve`, () => {
+    test.todo(`Curve name is valid`);
+
+    test.todo(`Curve name is invalid`);
+});
+
+test.todo(`Type: value`);


### PR DESCRIPTION
Re: #

### Changelog

* This PR adds the following pose modifying nodes:
  - `ApplyTransform` apply a transform, in position term and rotation term, to an animated node of a pose.
  - `CopyTransform` copies transform of one animated node to another animated node of a pose.
  - `TwoBoneIKSolver` solves two bone ik problem.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
