### PR TITLE
 Add editor api to stash pose graph; Config some nodes' editor behavior

### DIFF
--- a/cocos/animation/marionette/pose-graph/graph-output-node.ts
+++ b/cocos/animation/marionette/pose-graph/graph-output-node.ts
@@ -5,8 +5,13 @@ import { PoseNode } from './pose-node';
 import { PoseGraphType } from './foundation/type-system';
 import { PoseGraphNode } from './foundation/pose-graph-node';
 import { globalPoseGraphNodeInputManager } from './foundation/authoring/input-authoring';
+import { poseGraphNodeAppearance } from './decorator/node';
 
 @ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseGraphOutputNode`)
+@poseGraphNodeAppearance({
+    themeColor: '#CD3A58',
+    inline: true,
+})
 export class PoseGraphOutputNode extends PoseGraphNode {
     // Don't use @input since it requires the owner class being subclass of `PoseNode`.
     @serializable

--- a/cocos/animation/marionette/pose-graph/pose-nodes/all.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/all.ts
@@ -1,3 +1,5 @@
+import './use-stashed-pose';
+
 import './state-machine';
 
 import './additively-blend';

--- a/cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/use-stashed-pose.ts
@@ -1,10 +1,36 @@
+import { EDITOR } from 'internal:constants';
+import { warn } from '../../../../core';
 import { ccclass, editable, serializable } from '../../../../core/data/decorators';
 import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
+import { PoseGraphCreateNodeFactory, poseGraphCreateNodeFactory, poseGraphNodeAppearance, poseGraphNodeCategory } from '../decorator/node';
+import { POSE_GRAPH_NODE_MENU_PREFIX_POSE } from './menu-common';
 import { RuntimeStash } from '../stash/runtime-stash';
 import { PoseNode } from '../pose-node';
 import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, AnimationGraphSettleContext, AnimationGraphUpdateContext } from '../../animation-graph-context';
 
+const createNodeFactory: PoseGraphCreateNodeFactory<string> = {
+    // eslint-disable-next-line arrow-body-style
+    listEntries: (context) => {
+        // eslint-disable-next-line arrow-body-style
+        return [...context.animationGraph.layers[context.layerIndex].stashes()].map(([stashId]) => {
+            return {
+                arg: stashId,
+                menu: stashId,
+            };
+        });
+    },
+
+    create: (arg) => {
+        const node = new PoseNodeUseStashedPose();
+        node.stashName = arg;
+        return node;
+    },
+};
+
 @ccclass(`${CLASS_NAME_PREFIX_ANIM}PoseNodeUseStashedPose`)
+@poseGraphNodeCategory(POSE_GRAPH_NODE_MENU_PREFIX_POSE)
+@poseGraphCreateNodeFactory(createNodeFactory)
+@poseGraphNodeAppearance({ inline: true })
 export class PoseNodeUseStashedPose extends PoseNode {
     @serializable
     @editable
@@ -40,4 +66,20 @@ export class PoseNodeUseStashedPose extends PoseNode {
     }
 
     private _runtimeStash: RuntimeStash | undefined = undefined;
+}
+
+if (EDITOR) {
+    PoseNodeUseStashedPose.prototype.getTitle = function getTitle (this: PoseNodeUseStashedPose) {
+        if (this.stashName) {
+            return [`ENGINE.classes.${CLASS_NAME_PREFIX_ANIM}PoseNodeUseStashedPose.title`, { stashName: this.stashName }];
+        }
+        return undefined;
+    };
+
+    PoseNodeUseStashedPose.prototype.getEnterInfo = function getTitle (this: PoseNodeUseStashedPose) {
+        return {
+            type: 'stash',
+            stashName: this.stashName,
+        };
+    };
 }

--- a/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
+++ b/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
@@ -206,7 +206,7 @@ class RuntimeStashRecord implements RuntimeStash {
 
         // Note: even `deltaTime < this._maxRequestedUpdateTime`(the `diffDeltaTime` becomes 0.0),
         // the `context.directiveAbsoluteWeight` might not be 0.0.
-        // We still need to trigger an update since some nodes(such as MotionNode) needs to accumulate weight.
+        // We still need to trigger an update since some nodes(such as PlayMotion) needs to accumulate weight.
         const diffDeltaTime = Math.max(0.0, deltaTime - this._maxRequestedUpdateTime);
         // We accepted two same time-length update, don't do redundant updates.
         // After PR #14990, this should always true.

--- a/editor/i18n/en/animation.js
+++ b/editor/i18n/en/animation.js
@@ -13,6 +13,13 @@ module.exports = {
     classes: {
         'cc': {
             'animation': {
+                'PoseGraphOutputNode': {
+                    displayName: 'Output Pose',
+                },
+                'PoseNodeUseStashedPose': {
+                    displayName: 'Use Stashed Pose',
+                    title: 'Use Stashed Pose {stashName}',
+                },
                 'PoseNodeStateMachine': {
                     displayName: 'State Machine',
                     inputs: {

--- a/editor/i18n/zh/animation.js
+++ b/editor/i18n/zh/animation.js
@@ -13,6 +13,13 @@ module.exports = {
     classes: {
         'cc': {
             'animation': {
+                'PoseGraphOutputNode': {
+                    displayName: '输出姿势',
+                },
+                'PoseNodeUseStashedPose': {
+                    displayName: '使用暂存的姿势',
+                    title: '使用暂存的姿势 {stashName}',
+                },
                 'PoseNodeStateMachine': {
                     displayName: '状态机',
                     inputs: {


### PR DESCRIPTION
Re: #

### Changelog

* Add editor API to stash a pose graph.
* Configure the create-node-factory, appearance, title and enter-info of `UseStashedPose` node.
* Configure the appearance and display name of `PoseGraphOutputNode`.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
