### PR TITLE
[fix] physics-2d contact disable not working #15149

### DIFF
--- a/cocos/physics-2d/box2d/physics-contact.ts
+++ b/cocos/physics-2d/box2d/physics-contact.ts
@@ -76,7 +76,6 @@ export class PhysicsContact implements IPhysics2DContact {
     public colliderB: Collider2D | null = null;
 
     public disabled = false;
-    public disabledOnce = false;
 
     private _impulse: b2.ContactImpulse | null = null;
     private _inverted = false;
@@ -90,7 +89,6 @@ export class PhysicsContact implements IPhysics2DContact {
         this.colliderA = (b2contact.m_fixtureA.m_userData as b2Shape2D).collider;
         this.colliderB = (b2contact.m_fixtureB.m_userData as b2Shape2D).collider;
         this.disabled = false;
-        this.disabledOnce = false;
         this._impulse = null;
 
         this._inverted = false;

--- a/cocos/physics-2d/box2d/physics-contact.ts
+++ b/cocos/physics-2d/box2d/physics-contact.ts
@@ -76,6 +76,7 @@ export class PhysicsContact implements IPhysics2DContact {
     public colliderB: Collider2D | null = null;
 
     public disabled = false;
+    public disabledOnce = false;
 
     private _impulse: b2.ContactImpulse | null = null;
     private _inverted = false;
@@ -89,6 +90,7 @@ export class PhysicsContact implements IPhysics2DContact {
         this.colliderA = (b2contact.m_fixtureA.m_userData as b2Shape2D).collider;
         this.colliderB = (b2contact.m_fixtureB.m_userData as b2Shape2D).collider;
         this.disabled = false;
+        this.disabledOnce = false;
         this._impulse = null;
 
         this._inverted = false;

--- a/cocos/physics-2d/box2d/platform/physics-contact-listener.ts
+++ b/cocos/physics-2d/box2d/platform/physics-contact-listener.ts
@@ -29,6 +29,14 @@ import { Contact2DType, PhysicsSystem2D } from '../../framework';
 import { PhysicsContact } from '../physics-contact';
 import { b2Shape2D } from '../shapes/shape-2d';
 
+/**
+ * @en
+ * The contact listener responsible for all contact events between colliders.
+ * @zh
+ * 负责处理所有碰撞体之间的触发事件。
+ * @class PhysicsContactListener
+ * @extends b2.ContactListener
+ */
 export class PhysicsContactListener extends b2.ContactListener {
     static readonly _contactMap = new Map<string, PhysicsContact>();
 

--- a/cocos/physics-2d/framework/physics-types.ts
+++ b/cocos/physics-2d/framework/physics-types.ts
@@ -127,10 +127,43 @@ export enum ERaycast2DType {
     All
 }
 
+/**
+ * @en
+ * Physics2D contact event types.
+ * @zh
+ * 2D物理接触事件类型。
+ */
 export const Contact2DType = {
+    /**
+     * @en
+     * The event type of non contact.
+     * @zh
+     * 无接触的事件类型。
+     */
     None: 'none-contact',
+
+    /**
+     * @en
+     * The event type of the contact start.
+     * @zh
+     * 开始接触的事件类型。
+     */
     BEGIN_CONTACT: 'begin-contact',
+
+    /**
+     * @en
+     * The event type of the contact stay.
+     * @zh
+     * 保持接触的事件类型。
+     */
     STAY_CONTACT: 'stay-contact',
+
+    /**
+     * @en
+     * The event type of the contact end.
+     * @zh
+     * 结束接触的事件类型。
+     */
     END_CONTACT: 'end-contact',
 
     /**

--- a/cocos/physics-2d/spec/i-physics-contact.ts
+++ b/cocos/physics-2d/spec/i-physics-contact.ts
@@ -204,17 +204,17 @@ export interface IPhysics2DContact {
     /**
      * @en
      * If set disabled to true, the contact will be ignored until contact end.
-     * If you just want to disabled contact for current time step or sub-step, please use disabledOnce.
      * @zh
      * 如果 disabled 被设置为 true，那么直到接触结束此接触都将被忽略。
-     * 如果只是希望在当前时间步或子步中忽略此接触，请使用 disabledOnce 。
      */
     disabled: boolean;
+
     /**
      * @en
      * Disabled contact for current time step or sub-step.
      * @zh
      * 在当前时间步或子步中忽略此接触。
+     * @deprecated Since v3.8.0, disabledOnce is no longer supported.
      */
     disabledOnce: boolean;
 


### PR DESCRIPTION
Re:  https://github.com/cocos/cocos-engine/issues/15149

**Current mechanism:**
Every frame, physics-2d emits events once in PhysicsContactListener::finalizeContactEvent()
![image](https://github.com/cocos/cocos-engine/assets/9999378/037be969-7420-434f-af24-5016ba10cdee)

This new mechanism does not support "disabledOnce", which does not make sense any more.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
