### PR TITLE
fix: ban wasm support on iOS

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -629,7 +629,7 @@
         "WASM_SUPPORT_MODE": {
             "comment": "Whether support wasm, here we provide 3 options:\n0: The platform doesn't support WASM\n1: The platform supports WASM\n2: The platform may support WASM, especially on Web platform",
             "type": "number",
-            "value": "$HTML5 ? 2 : ($NATIVE ? ($OPEN_HARMONY?0:1): ($MINIGAME? ($WECHAT?1:0) :0))",
+            "value": "$HTML5 ? 2 : ($NATIVE ? (($OPEN_HARMONY||$IOS)?0:1): ($MINIGAME? ($WECHAT?1:0) :0))",
             "internal": true
         }
     },


### PR DESCRIPTION
Re: #

### Changelog



### NOTE
- currently our V8 engine doesn't support WebAssembly since it doesn't support JIT, 
- we need to integrate a third party of lib to support WebAssembly on our V8 engine, tracking issue here: https://github.com/cocos/cocos-engine/issues/15170

![image](https://github.com/cocos/cocos-engine/assets/17872773/76e19521-676c-4bdc-8bef-87dad8f25121)




-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
