### PR TITLE
fix: node, asset title text overflow in inspector

### DIFF
--- a/editor/inspector/contributions/asset.css
+++ b/editor/inspector/contributions/asset.css
@@ -18,6 +18,7 @@
 :host > .container > .header {
     display: flex;
     flex: 1;
+    min-width: 0;
 }
 
 :host > .container > .header > .icon {

--- a/editor/inspector/contributions/node.css
+++ b/editor/inspector/contributions/node.css
@@ -50,6 +50,9 @@
 .header > .name,
 .component-header .name {
     flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .scene {
@@ -138,6 +141,8 @@
 
 .component .component-header {
     flex: 1;
+    min-width: 0;
+
     display: flex;
     align-items: center;
 }


### PR DESCRIPTION
Re: #

### Changelog

* For node, asset type inspector panel. Show ellipsis when title text has exceeded its parent container

![image](https://github.com/cocos/cocos-engine/assets/20528478/aca4562b-0a68-4688-b979-a19a22d4e0c1)

![image](https://github.com/cocos/cocos-engine/assets/20528478/96f76192-b616-4f53-916b-8cd59eb5b1b4)



-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
