### PR TITLE
Animation graph: fix embedded player evaluation

### DIFF
--- a/cocos/animation/marionette/motion/animation-blend-1d.ts
+++ b/cocos/animation/marionette/motion/animation-blend-1d.ts
@@ -78,9 +78,14 @@ export class AnimationBlend1D extends AnimationBlend {
         return that;
     }
 
-    public [createEval] (context: AnimationGraphBindingContext, clipOverrides: ReadonlyClipOverrideMap | null) {
+    public [createEval] (
+        context: AnimationGraphBindingContext,
+        clipOverrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
+    ) {
         const evaluation = new AnimationBlend1DEval(
-            context, clipOverrides, this, this._items, this._items.map(({ threshold }) => threshold), 0.0,
+            context, clipOverrides, ignoreEmbeddedPlayers,
+            this, this._items, this._items.map(({ threshold }) => threshold), 0.0,
         );
         const initialValue = bindOr(
             context,
@@ -105,9 +110,10 @@ class AnimationBlend1DEval extends AnimationBlendEval {
     constructor (
         context: AnimationGraphBindingContext,
         overrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
         base: AnimationBlend, items: AnimationBlendItem[], thresholds: readonly number[], input: number,
     ) {
-        super(context, overrides, base, items, [input]);
+        super(context, overrides, ignoreEmbeddedPlayers, base, items, [input]);
         this._thresholds = thresholds;
         this.doEval();
     }

--- a/cocos/animation/marionette/motion/animation-blend-2d.ts
+++ b/cocos/animation/marionette/motion/animation-blend-2d.ts
@@ -106,7 +106,11 @@ export class AnimationBlend2D extends AnimationBlend {
         return that;
     }
 
-    public [createEval] (context: AnimationGraphBindingContext, clipOverrides: ReadonlyClipOverrideMap | null) {
+    public [createEval] (
+        context: AnimationGraphBindingContext,
+        clipOverrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
+    ) {
         const { algorithm } = this;
         let evaluation: AnimationBlendEval;
         switch (algorithm) {
@@ -115,6 +119,7 @@ export class AnimationBlend2D extends AnimationBlend {
             evaluation = new PolarSpaceGradientBandBlend2DEval(
                 context,
                 clipOverrides,
+                ignoreEmbeddedPlayers,
                 this,
                 this._items,
                 this._polarSpaceGBI,
@@ -129,6 +134,7 @@ export class AnimationBlend2D extends AnimationBlend {
             evaluation =  new AnimationBlend2DEval(
                 context,
                 clipOverrides,
+                ignoreEmbeddedPlayers,
                 this,
                 this._items,
                 this._items.map(({ threshold }) => threshold),
@@ -187,13 +193,14 @@ class AnimationBlend2DEval extends AnimationBlendEval {
     constructor (
         context: AnimationGraphBindingContext,
         clipOverrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
         base: AnimationBlend,
         items: AnimationBlendItem[],
         thresholds: readonly Vec2[],
         algorithm: Algorithm.SIMPLE_DIRECTIONAL | Algorithm.FREEFORM_CARTESIAN,
         inputs: [number, number],
     ) {
-        super(context, clipOverrides, base, items, inputs);
+        super(context, clipOverrides, ignoreEmbeddedPlayers, base, items, inputs);
         this._thresholds = thresholds;
         this._algorithm = algorithm;
         this.doEval();
@@ -222,12 +229,13 @@ class PolarSpaceGradientBandBlend2DEval extends AnimationBlendEval {
     constructor (
         context: AnimationGraphBindingContext,
         clipOverrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
         base: AnimationBlend,
         items: AnimationBlendItem[],
         interpolator: PolarSpaceGradientBandInterpolator2D,
         inputs: [number, number],
     ) {
-        super(context, clipOverrides, base, items, inputs);
+        super(context, clipOverrides, ignoreEmbeddedPlayers, base, items, inputs);
         this._interpolator = interpolator;
         this.doEval();
     }

--- a/cocos/animation/marionette/motion/animation-blend-direct.ts
+++ b/cocos/animation/marionette/motion/animation-blend-direct.ts
@@ -72,10 +72,15 @@ export class AnimationBlendDirect extends AnimationBlend {
         return that;
     }
 
-    public [createEval] (context: AnimationGraphBindingContext, clipOverrides: ReadonlyClipOverrideMap | null) {
+    public [createEval] (
+        context: AnimationGraphBindingContext,
+        clipOverrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
+    ) {
         const myEval: AnimationBlendDirectEval = new AnimationBlendDirectEval(
             context,
             clipOverrides,
+            ignoreEmbeddedPlayers,
             this,
             this._items,
             new Array<number>(this._items.length).fill(0.0),

--- a/cocos/animation/marionette/motion/animation-blend.ts
+++ b/cocos/animation/marionette/motion/animation-blend.ts
@@ -38,7 +38,11 @@ import { blendPoseInto, Pose } from '../../core/pose';
 const { ccclass, serializable } = _decorator;
 
 export interface AnimationBlend extends Motion, EditorExtendable {
-    [createEval] (_context: AnimationGraphBindingContext, overrides: ReadonlyClipOverrideMap | null): MotionEval | null;
+    [createEval] (
+        _context: AnimationGraphBindingContext,
+        overrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
+    ): MotionEval | null;
 }
 
 @ccclass(`${CLASS_NAME_PREFIX_ANIM}AnimationBlendItem`)
@@ -79,11 +83,12 @@ export class AnimationBlendEval implements MotionEval {
     constructor (
         context: AnimationGraphBindingContext,
         overrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
         base: AnimationBlend,
         children: AnimationBlendItem[],
         inputs: number[],
     ) {
-        this._childEvaluators = children.map((child) => child.motion?.[createEval](context, overrides) ?? null);
+        this._childEvaluators = children.map((child) => child.motion?.[createEval](context, overrides, ignoreEmbeddedPlayers) ?? null);
         this._weights = new Array(this._childEvaluators.length).fill(0);
         this._inputs = [...inputs];
         if (RUNTIME_ID_ENABLED) {

--- a/cocos/animation/marionette/motion/motion.ts
+++ b/cocos/animation/marionette/motion/motion.ts
@@ -67,7 +67,11 @@ export interface MotionEval {
 // since we ever made a historical mistaken: take a look at `MotionState`'s class name...
 @ccclass(`${CLASS_NAME_PREFIX_ANIM}MotionBase`)
 export abstract class Motion extends EditorExtendable {
-    abstract [createEval] (context: AnimationGraphBindingContext, clipOverrides: ReadonlyClipOverrideMap | null): MotionEval | null;
+    abstract [createEval] (
+        context: AnimationGraphBindingContext,
+        clipOverrides: ReadonlyClipOverrideMap | null,
+        ignoreEmbeddedPlayers: boolean,
+    ): MotionEval | null;
 
     abstract clone(): Motion;
 }

--- a/cocos/animation/marionette/pose-graph/pose-nodes/play-motion.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/play-motion.ts
@@ -60,7 +60,7 @@ export class PoseNodePlayMotion extends PoseNode {
         if (!motion) {
             return;
         }
-        const motionEval = motion[createEval](context, context.clipOverrides ?? null);
+        const motionEval = motion[createEval](context, context.clipOverrides ?? null, false);
         if (!motionEval) {
             return;
         }

--- a/cocos/animation/marionette/pose-graph/pose-nodes/sample-motion.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/sample-motion.ts
@@ -43,7 +43,7 @@ export class PoseNodeSampleMotion extends PoseNode {
         if (!motion) {
             return;
         }
-        const motionEval = motion[createEval](context, context.clipOverrides ?? null);
+        const motionEval = motion[createEval](context, context.clipOverrides ?? null, true);
         if (!motionEval) {
             return;
         }

--- a/cocos/animation/marionette/state-machine/state-machine-eval.ts
+++ b/cocos/animation/marionette/state-machine/state-machine-eval.ts
@@ -1223,7 +1223,7 @@ class VMSMEval {
             }
         }
 
-        const sourceEval = state.motion?.[createEval](context, overrides) ?? null;
+        const sourceEval = state.motion?.[createEval](context, overrides, false) ?? null;
         if (sourceEval) {
             Object.defineProperty(sourceEval, '__DEBUG_ID__', { value: name });
         }

--- a/editor/src/marionette/preview.ts
+++ b/editor/src/marionette/preview.ts
@@ -428,7 +428,7 @@ class MotionEvalRecord {
     }
 
     public rebind(bindContext: AnimationGraphBindingContext) {
-        const motionEval = this._motion[createEval](bindContext, null);
+        const motionEval = this._motion[createEval](bindContext, null, true);
 
         if (!motionEval) {
             return;

--- a/tests/animation/embedded-player/evaluate-embedded-players-in-animation-graph.test.ts
+++ b/tests/animation/embedded-player/evaluate-embedded-players-in-animation-graph.test.ts
@@ -1,0 +1,171 @@
+import { Node } from "../../../cocos/scene-graph";
+import { AnimationClip } from "../../../cocos/animation/animation-clip";
+import { createAnimationGraph, StateParams } from '../new-gen-anim/utils/factory';
+import { ClipMotion, Motion } from "../../../cocos/animation/marionette/motion";
+import { AnimationGraphEvalMock } from "../new-gen-anim/utils/eval-mock";
+import '../new-gen-anim/pose-graph/pose-nodes/utils/factories/all';
+import '../../utils/matchers/value-type-asymmetric-matchers';
+import { PoseNodeSampleMotion } from "../../../cocos/animation/marionette/pose-graph/pose-nodes/sample-motion";
+
+describe('Evaluate embedded players in animation graph', () => {
+    test(`In motion state`, () => {
+        runTest(true, (motion) => {
+            return {
+                type: 'motion',
+                motion,
+            };
+        });
+    });
+
+    test(`In PoseNodePlayMotion`, () => {
+        runTest(true, (motion) => {
+            return {
+                type: 'procedural',
+                graph: { rootNode: { type: 'motion', motion } },
+            };
+        });
+    });
+
+    test(`In PoseNodeSampleMotion`, () => {
+        runTest(false, (motion) => {
+            return {
+                type: 'procedural',
+                graph: { rootNode: (() => {
+                    const sampleMotionNode = new PoseNodeSampleMotion();
+                    sampleMotionNode.motion = motion;
+                    return sampleMotionNode;
+                })() },
+            };
+        });
+    });
+
+    function runTest(
+        shouldEval: boolean,
+        createState: (motion: Motion) => StateParams,
+    ) {
+        const fixture = {
+            clip_duration: 0.8,
+            clip_speed: 0.6,
+        };
+
+        const clip = new AnimationClip();
+        clip.duration = fixture.clip_duration;
+        clip.speed = fixture.clip_speed;
+        clip.wrapMode = AnimationClip.WrapMode.Loop;
+
+        const node = new Node();
+
+        const embeddedPlayerEvaluation = new EmbeddedPlayerEvaluationMock();
+        jest.spyOn(clip, 'createEmbeddedPlayerEvaluator').mockImplementation((targetNode: Node) => {
+            expect(targetNode).toBe(node);
+            return embeddedPlayerEvaluation as unknown as ReturnType<AnimationClip['createEmbeddedPlayerEvaluator']>;
+        });
+        jest.spyOn(clip, 'containsAnyEmbeddedPlayer').mockImplementation(() => {
+            return true;
+        });
+
+        const motion = new ClipMotion();
+        motion.clip = clip;
+
+        const stateParams = createState(motion);
+        const animationGraph = createAnimationGraph({
+            variableDeclarations: {
+                'enter_the_state': { type: 'boolean' },
+                'exit_the_state': { type: 'boolean' },
+            },
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'empty': { type: 'empty' },
+                        'state': stateParams,
+                    },
+                    entryTransitions: [{ to: 'empty' }],
+                    transitions: [{
+                        from: 'empty', to: 'state',
+                        duration: 0.3,
+                        conditions: [{ type: 'unary', operand: { type: 'variable', name: 'enter_the_state', } }],
+                    }, {
+                        from: 'state', to: 'empty',
+                        duration: 0.3,
+                        exitTimeEnabled: stateParams.type === 'motion' ? false : undefined,
+                        conditions: [{ type: 'unary', operator: 'to-be-false', operand: { type: 'variable', name: 'enter_the_state', } }],
+                    }],
+                },
+            }],
+        });
+
+        const evalMock = new AnimationGraphEvalMock(node, animationGraph);
+        
+        embeddedPlayerEvaluation.zeroCheck();
+
+        // The state is not entered, nothing should happen.
+        for (let i = 0; i < 2; ++i) {
+            evalMock.step(0.2);
+            embeddedPlayerEvaluation.zeroCheck();
+        }
+
+        // Enter the state, step to 10% of clip.
+        const state_enter_time = evalMock.current;
+
+        const checkEmbeddedPlayerEvalCall = () => {
+            if (!shouldEval) {
+                embeddedPlayerEvaluation.zeroCheck();
+                return;
+            }
+            const elapsedTime = (evalMock.current - state_enter_time) * fixture.clip_speed;
+            const normalized = elapsedTime / fixture.clip_duration;
+            expect(embeddedPlayerEvaluation.evaluate).toBeCalledTimes(1);
+            expect(embeddedPlayerEvaluation.evaluate.mock.calls[0]).toEqual([
+                expect.toBeAround((normalized - Math.trunc(normalized)) * fixture.clip_duration, 5),
+                Math.trunc(normalized),
+            ]);
+            embeddedPlayerEvaluation.evaluate.mockClear();
+            embeddedPlayerEvaluation.zeroCheck();
+        };
+
+        evalMock.controller.setValue('enter_the_state', true);
+        evalMock.step(fixture.clip_duration * 0.1);
+        checkEmbeddedPlayerEvalCall();
+
+        // Continue updates.
+        for (let i = 0; i < 2; ++i) {
+            evalMock.step(fixture.clip_duration * 0.2);
+            checkEmbeddedPlayerEvalCall();
+        }
+
+        // Cross iterations
+        evalMock.step(fixture.clip_duration * 0.8);
+        checkEmbeddedPlayerEvalCall();
+
+        // Start to exit the state.
+        evalMock.controller.setValue('enter_the_state', false);
+        evalMock.step(0.1);
+        checkEmbeddedPlayerEvalCall();
+
+        // Full exit the state.
+        evalMock.step(0.3);
+        embeddedPlayerEvaluation.zeroCheck();
+    }
+});
+
+// @ts-expect-error
+class EmbeddedPlayerEvaluationMock implements ReturnType<AnimationClip['createEmbeddedPlayerEvaluator']> {
+    public notifyHostSpeedChanged: jest.Mock<void, [number]> = jest.fn();
+
+    public notifyHostPlay: jest.Mock<void, [number]> = jest.fn();
+
+    public notifyHostPause: jest.Mock<void, [number]> = jest.fn();
+
+    public notifyHostStop: jest.Mock = jest.fn();
+
+    public evaluate: jest.Mock<void, [number, number]> = jest.fn();
+
+    public zeroCheck() {
+        expect(this.notifyHostSpeedChanged).not.toBeCalled();
+        expect(this.notifyHostPlay).not.toBeCalled();
+        expect(this.notifyHostPause).not.toBeCalled();
+        expect(this.notifyHostStop).not.toBeCalled();
+        expect(this.evaluate).not.toBeCalled();
+    }
+}
+


### PR DESCRIPTION
Re: [Internal Issue/Creator 3.8 走查表/通过状态机调用的动画，播放粒子和动画嵌入播放器失效](https://doc.weixin.qq.com/sheet/e3_AN0ABAYcADYLwxE1uR5SqyMXkilIb?scode=ADcAmwdCAAoW8rF14AALkAiAYnADY&tab=srddf3)

### Changelog

* This PR fixes that embedded players are not evaluated in animation graph.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
