### PR TITLE
Revert "Windows devices  input fix (#14073)"

### DIFF
--- a/pal/input/web/mouse-input.ts
+++ b/pal/input/web/mouse-input.ts
@@ -39,9 +39,9 @@ export class MouseInputSource {
     private _isPressed = false;
     private _preMousePos: Vec2 = new Vec2();
 
-    private _handleMouseDown!: (event: PointerEvent) => void;
-    private _handleMouseMove!: (event: PointerEvent) => void;
-    private _handleMouseUp!: (event: PointerEvent) => void;
+    private _handleMouseDown!: (event: MouseEvent) => void;
+    private _handleMouseMove!: (event: MouseEvent) => void;
+    private _handleMouseUp!: (event: MouseEvent) => void;
 
     constructor () {
         if (systemInfo.hasFeature(Feature.EVENT_MOUSE)) {
@@ -90,18 +90,17 @@ export class MouseInputSource {
 
     private _registerEvent () {
         // register mouse down event
-        window.addEventListener('pointerdown', () => {
+        window.addEventListener('mousedown', () => {
             this._isPressed = true;
         });
-        this._canvas?.addEventListener('pointerdown', this._handleMouseDown);
+        this._canvas?.addEventListener('mousedown', this._handleMouseDown);
 
         // register mouse move event
-        this._canvas?.addEventListener('pointermove', this._handleMouseMove);
+        this._canvas?.addEventListener('mousemove', this._handleMouseMove);
 
         // register mouse up event
-        const handleMouseUp = this._handleMouseUp;
-        window.addEventListener('pointerup', handleMouseUp);
-        this._canvas?.addEventListener('pointerup', handleMouseUp);
+        window.addEventListener('mouseup', this._handleMouseUp);
+        this._canvas?.addEventListener('mouseup', this._handleMouseUp);
 
         // register wheel event
         this._canvas?.addEventListener('wheel', this._handleMouseWheel.bind(this));
@@ -128,9 +127,9 @@ export class MouseInputSource {
     }
 
     private _createCallback (eventType: InputEventType) {
-        return (pointerEvent: PointerEvent) => {
-            const location = this._getLocation(pointerEvent);
-            const { button, buttons } = pointerEvent;
+        return (mouseEvent: MouseEvent) => {
+            const location = this._getLocation(mouseEvent);
+            const { button, buttons } = mouseEvent;
             let targetButton = button;
             switch (eventType) {
             case InputEventType.MOUSE_DOWN:
@@ -160,14 +159,14 @@ export class MouseInputSource {
             const eventMouse = new EventMouse(eventType, false, this._preMousePos);
             eventMouse.setLocation(location.x, location.y);
             eventMouse.setButton(targetButton);
-            eventMouse.movementX = pointerEvent.movementX;
-            eventMouse.movementY = pointerEvent.movementY;
+            eventMouse.movementX = mouseEvent.movementX;
+            eventMouse.movementY = mouseEvent.movementY;
 
             // update previous mouse position.
             this._preMousePos.set(location.x, location.y);
-            pointerEvent.stopPropagation();
-            if (pointerEvent.target === this._canvas) {
-                pointerEvent.preventDefault();
+            mouseEvent.stopPropagation();
+            if (mouseEvent.target === this._canvas) {
+                mouseEvent.preventDefault();
             }
             this._eventTarget.emit(eventType, eventMouse);
         };

--- a/pal/input/web/touch-input.ts
+++ b/pal/input/web/touch-input.ts
@@ -53,21 +53,30 @@ export class TouchInputSource {
 
     private _registerEvent () {
         // IDEA: need to register on window ?
-        this._canvas?.addEventListener('pointerdown', this._createCallback(InputEventType.TOUCH_START));
-        this._canvas?.addEventListener('pointermove', this._createCallback(InputEventType.TOUCH_MOVE));
-        this._canvas?.addEventListener('pointerup', this._createCallback(InputEventType.TOUCH_END));
-        this._canvas?.addEventListener('pointercancel', this._createCallback(InputEventType.TOUCH_CANCEL));
+        this._canvas?.addEventListener('touchstart', this._createCallback(InputEventType.TOUCH_START));
+        this._canvas?.addEventListener('touchmove', this._createCallback(InputEventType.TOUCH_MOVE));
+        this._canvas?.addEventListener('touchend', this._createCallback(InputEventType.TOUCH_END));
+        this._canvas?.addEventListener('touchcancel', this._createCallback(InputEventType.TOUCH_CANCEL));
     }
 
     private _createCallback (eventType: InputEventType) {
-        return (event: PointerEvent) => {
+        return (event: TouchEvent) => {
             const canvasRect = this._getCanvasRect();
             const handleTouches: Touch[] = [];
-            const location = this._getLocation(event, canvasRect);
-            const touch = touchManager.getTouch(event.pointerId, location.x, location.y);
-            if (touch) {
+            const length = event.changedTouches.length;
+            for (let i = 0; i < length; ++i) {
+                const changedTouch = event.changedTouches[i];
+                const touchID = changedTouch.identifier;
+                if (touchID === null) {
+                    continue;
+                }
+                const location = this._getLocation(changedTouch, canvasRect);
+                const touch = touchManager.getTouch(touchID, location.x, location.y);
+                if (!touch) {
+                    continue;
+                }
                 if (eventType === InputEventType.TOUCH_END || eventType === InputEventType.TOUCH_CANCEL) {
-                    touchManager.releaseTouch(event.pointerId);
+                    touchManager.releaseTouch(touchID);
                 }
                 handleTouches.push(touch);
             }
@@ -95,11 +104,12 @@ export class TouchInputSource {
         return new Rect(0, 0, 0, 0);
     }
 
-    private _getLocation (touch: PointerEvent, canvasRect: Rect): Vec2 {
+    private _getLocation (touch: globalThis.Touch, canvasRect: Rect): Vec2 {
         // webxr has been converted to screen coordinates via camera
         if (globalThis.__globalXR && globalThis.__globalXR.ar && globalThis.__globalXR.ar.isWebXR()) {
             return new Vec2(touch.clientX, touch.clientY);
         }
+
         let x = touch.clientX - canvasRect.x;
         let y = canvasRect.y + canvasRect.height - touch.clientY;
         if (screenAdapter.isFrameRotated) {


### PR DESCRIPTION
Re: 
https://github.com/cocos/3d-tasks/issues/16578
https://github.com/cocos/3d-tasks/issues/16494
https://github.com/cocos/3d-tasks/issues/16575
https://github.com/cocos/3d-tasks/issues/16485

### Changelog

* This reverts commit 64a9c8721deb6a0494fec9e320a7c8395518cba7.
* PointerEvent is a new standard web interface, but has compatibility issues

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
