### PR TITLE
Marionette/PoseGraph: fix that a pose node can be connected multi times

### DIFF
--- a/cocos/animation/marionette/pose-graph/op/internal.ts
+++ b/cocos/animation/marionette/pose-graph/op/internal.ts
@@ -136,6 +136,15 @@ export function connectNode (graph: PoseGraph, node: PoseGraphNode, key: PoseGra
         return;
     }
 
+    // We currently do not allow a pose producer to be connected to multiple consumers.
+    if (outputType === PoseGraphType.POSE) {
+        for (const node of graph.nodes()) {
+            const shell = graph.getShell(node);
+            assertIsTrue(shell);
+            shell.deleteBindingTo(producer);
+        }
+    }
+
     const [
         propertyKey,
         elementIndex = -1,
@@ -158,7 +167,8 @@ export function disconnectNode (graph: PoseGraph, node: PoseGraphNode, key: Pose
     graph.getShell(node)?.deleteBinding(key);
 }
 
-export function connectOutputNode(graph: PoseGraph, outputNode: PoseGraphOutputNode, producer: PoseNode) {
+export function connectOutputNode(graph: PoseGraph, producer: PoseNode) {
+    const { outputNode } = graph;
     const outputNodeInputKeys = getInputKeys(outputNode);
     assertIsTrue(outputNodeInputKeys.length === 1);
     connectNode(graph, outputNode, outputNodeInputKeys[0], producer);

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/blend-two-pose-shared.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/blend-two-pose-shared.ts
@@ -67,7 +67,7 @@ export function includeTestsFor_BlendTwoPoseLike_PoseNode<TPoseNode extends Pose
             poseGraphOp.connectNode(poseGraph, blendingNode, composeInputKeyInternally(expectedPoseInput1KeyProp), inputPose1);
             poseGraphOp.connectNode(poseGraph, blendingNode, composeInputKeyInternally(expectedPoseInput2KeyProp), inputPose2);
             poseGraphOp.connectNode(poseGraph, blendingNode, composeInputKeyInternally(expectedRatioInputKeyProp), ratioInput, getTheOnlyOutputKey(ratioInput));
-            poseGraphOp.connectOutputNode(poseGraph, poseGraph.outputNode, blendingNode);
+            poseGraphOp.connectOutputNode(poseGraph, blendingNode);
         };
 
         const graph = createAnimationGraph({

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/sample-motion.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/sample-motion.test.ts
@@ -20,7 +20,7 @@ describe(`Use normalized time`, () => {
         const layer = graph.addLayer();
         const proceduralPoseState = layer.stateMachine.addProceduralPoseState();
         const poseNode = proceduralPoseState.graph.addNode(new PoseNodeSampleMotion());
-        connectOutputNode(proceduralPoseState.graph, proceduralPoseState.graph.outputNode, poseNode);
+        connectOutputNode(proceduralPoseState.graph, poseNode);
         layer.stateMachine.connect(layer.stateMachine.entryState, proceduralPoseState);
 
         poseNode.motion = fixture.animation.createMotion(observer.getCreateMotionContext());

--- a/tests/animation/new-gen-anim/pose-graph/pose-nodes/single-pose-modifier.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-nodes/single-pose-modifier.test.ts
@@ -93,7 +93,7 @@ function createPoseGraphRunner(node: Node, setup: (poseGraph: PoseGraph) => Pose
     const layer = animationGraph.addLayer();
     const proceduralPoseState = layer.stateMachine.addProceduralPoseState();
     const mainNode = setup(proceduralPoseState.graph);
-    poseGraphOp.connectOutputNode(proceduralPoseState.graph, proceduralPoseState.graph.outputNode, mainNode);
+    poseGraphOp.connectOutputNode(proceduralPoseState.graph, mainNode);
     layer.stateMachine.connect(layer.stateMachine.entryState, proceduralPoseState);
     const evalMock = new AnimationGraphEvalMock(node, animationGraph);
     evalMock.step(0.2);

--- a/tests/animation/new-gen-anim/pose-graph/pose-transform-space.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/pose-transform-space.test.ts
@@ -243,7 +243,7 @@ function createPoseNodeRunner(setup: (poseGraph: PoseGraph) => PoseNode) {
     const layer = animationGraph.addLayer();
     const proceduralPoseState = layer.stateMachine.addProceduralPoseState();
     const mainNode = setup(proceduralPoseState.graph);
-    poseGraphOp.connectOutputNode(proceduralPoseState.graph, proceduralPoseState.graph.outputNode, mainNode);
+    poseGraphOp.connectOutputNode(proceduralPoseState.graph, mainNode);
     layer.stateMachine.connect(layer.stateMachine.entryState, proceduralPoseState);
     return animationGraph;
 }

--- a/tests/animation/new-gen-anim/pose-graph/top-level-pose-node.test.ts
+++ b/tests/animation/new-gen-anim/pose-graph/top-level-pose-node.test.ts
@@ -19,7 +19,7 @@ test(`Additivity inheritance`, () => {
 
         const proceduralPoseState = layer.stateMachine.addProceduralPoseState();
         const poseNodeMock = proceduralPoseState.graph.addNode(new additivityCheckMock.PoseNodeMock());
-        connectOutputNode(proceduralPoseState.graph, proceduralPoseState.graph.outputNode, poseNodeMock);
+        connectOutputNode(proceduralPoseState.graph, poseNodeMock);
         layer.stateMachine.connect(layer.stateMachine.entryState, proceduralPoseState);
 
         void new AnimationGraphEvalMock(new Node(), graph);

--- a/tests/animation/new-gen-anim/utils/factory.ts
+++ b/tests/animation/new-gen-anim/utils/factory.ts
@@ -438,7 +438,7 @@ function fillPoseGraph(poseGraph: PoseGraph, params: PoseGraphParams) {
         params(poseGraph);
     } else if (params.rootNode) {
         const root = createPoseNode(poseGraph, params.rootNode);
-        poseGraphOp.connectOutputNode(poseGraph, poseGraph.outputNode, root);
+        poseGraphOp.connectOutputNode(poseGraph, root);
     }
 }
 


### PR DESCRIPTION
Re: #

### Changelog

* Constraints so that a pose node can only be connected to at most one node.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
