### PR TITLE
fix slogan dislocation on android device

### DIFF
--- a/templates/wechatgame/first-screen.js
+++ b/templates/wechatgame/first-screen.js
@@ -460,21 +460,19 @@ function start(alpha, antialias, useWebgl2) {
     programBg = initShaders(VS_BG, FS_BG);
     programProgress = initShaders(VS_PROGRESSBAR, FS_PROGRESSBAR);
     tick();
-    return Promise.all([
-        loadBackground('background.png').then(() => {
-          updateBgVertexBuffer();
-          updateBgTexture();
-        }),
-        loadSlogan('slogan.png').then(() => {
-          updateSloganVertexBuffer();
-          updateSloganTexture();
-        }),
-        loadImage('logo.png').then(() => {
-            updateVertexBuffer();
-            updateLogoTexture();
-        })
-      ]).then(() => {
+    //logo should be loaded earlier than slogan
+    return loadImage('logo.png').then(() => {
+        updateVertexBuffer();
+        updateLogoTexture();
+        return loadSlogan('slogan.png');
+    }).then(() => {
+        updateSloganVertexBuffer();
+        updateSloganTexture();
+        return loadBackground('background.png');
+    }).then(() => {
+        updateBgVertexBuffer();
+        updateBgTexture();
         return setProgress(0);
-      });
+    });
 }
 module.exports = { start, end, setProgress };

--- a/templates/wechatgame/first-screen.js
+++ b/templates/wechatgame/first-screen.js
@@ -460,18 +460,22 @@ function start(alpha, antialias, useWebgl2) {
     programBg = initShaders(VS_BG, FS_BG);
     programProgress = initShaders(VS_PROGRESSBAR, FS_PROGRESSBAR);
     tick();
-    //logo should be loaded earlier than slogan
-    return loadImage('logo.png').then(() => {
-        updateVertexBuffer();
-        updateLogoTexture();
-        return loadSlogan('slogan.png');
-    }).then(() => {
-        updateSloganVertexBuffer();
-        updateSloganTexture();
-        return loadBackground('background.png');
-    }).then(() => {
-        updateBgVertexBuffer();
-        updateBgTexture();
+    return Promise.all([
+        //logo should be loaded earlier than slogan
+        loadImage('logo.png').then(() => {
+            updateVertexBuffer();
+            updateLogoTexture();
+        }).then(() => {
+            loadSlogan('slogan.png').then(() => {
+                updateSloganVertexBuffer();
+                updateSloganTexture();
+            })
+        }),
+        loadBackground('background.png').then(() => {
+            updateBgVertexBuffer();
+            updateBgTexture();
+        })
+    ]).then(() => {
         return setProgress(0);
     });
 }

--- a/templates/wechatgame/first-screen.js
+++ b/templates/wechatgame/first-screen.js
@@ -466,10 +466,10 @@ function start(alpha, antialias, useWebgl2) {
             updateVertexBuffer();
             updateLogoTexture();
         }).then(() => {
-            loadSlogan('slogan.png').then(() => {
+            return loadSlogan('slogan.png').then(() => {
                 updateSloganVertexBuffer();
                 updateSloganTexture();
-            })
+            });
         }),
         loadBackground('background.png').then(() => {
             updateBgVertexBuffer();


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/16592#issuecomment-1566786549

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
