### PR TITLE
Update adb device output validation to handle older versions

### DIFF
--- a/scripts/native-pack-tool/source/platforms/android.ts
+++ b/scripts/native-pack-tool/source/platforms/android.ts
@@ -334,7 +334,7 @@ export class AndroidPackTool extends NativePackTool {
         }
 
         if (!this.checkConnectedDevices(adbPath)) {
-            throw new Error(`can not find any connected devices, please connect you device or start an Android emulator`);
+            console.error(`can not find any connected devices, please connect you device or start an Android emulator`);
         }
 
         if (await this.checkApkInstalled(adbPath)) {
@@ -361,7 +361,7 @@ export class AndroidPackTool extends NativePackTool {
                     const chuckStr: string = typeof chunk === 'string' ? chunk : (chunkAny.buffer && chunkAny.buffer instanceof ArrayBuffer ? chunkAny.toString() : chunkAny.toString());
                     const lines = chuckStr.split('\n');
                     for (let line of lines) {
-                        if (/^[0-9a-fA-F]+\s+\w+/.test(line)) {
+                        if (/^[0-9a-zA-Z]+\s+\w+/.test(line)) {
                             return true; // device connected
                         }
                     }


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16478

The adb device command output format has changed in newer versions of adb. Older versions can output device IDs containing characters beyond just hex digits. This updates the validation logic to handle these older versions gracefully instead of throwing an exception.

### Changelog

* bugfix: handle adb devices output for older version

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
