### PR TITLE
Launch app with `Executable Name` settings

### DIFF
--- a/scripts/native-pack-tool/source/base/default.ts
+++ b/scripts/native-pack-tool/source/base/default.ts
@@ -521,6 +521,7 @@ export class CocosParams<T> {
     public cmakePath: string;
     public platform: string;
     public platformName: string;
+    public executableName: string;
     /**
      * engine root
      */
@@ -586,6 +587,7 @@ export class CocosParams<T> {
         this.buildDir = params.buildDir;
         this.xxteaKey = params.xxteaKey;
         this.encrypted = params.encrypted;
+        this.executableName = params.executableName;
         Object.assign(this.cMakeConfig, params.cMakeConfig);
         this.platformParams = params.platformParams;
     }

--- a/scripts/native-pack-tool/source/platforms/windows.ts
+++ b/scripts/native-pack-tool/source/platforms/windows.ts
@@ -137,11 +137,26 @@ export class WindowsPackTool extends NativePackTool {
 
     async run(): Promise<boolean> {
         const executableDir = ps.join(this.paths.nativePrjDir, this.params.debug ? 'Debug' : 'Release')
-        const executableName = `${this.params.projectName}.exe`;
-        if (!fs.existsSync(ps.join(executableDir, executableName))) {
-            throw new Error(`[windows run] '${executableName}' is not found within ' + ${executableDir}!`);
+        let executableFile: string;
+        let targetFile: string;
+        if (this.params.executableName) {
+            executableFile = ps.join(executableDir, this.params.executableName + '.exe');
+            targetFile = this.params.executableName;
+        } else {
+            if (/^[0-9a-zA-Z_-]+$/.test(this.params.projectName)) {
+                executableFile = ps.join(executableDir, this.params.projectName + '.exe');
+                targetFile = this.params.projectName;
+            } else {
+                const executableFiles = ['CocosGame', this.params.projectName].map(x => ps.join(executableDir, x + '.exe')).filter(x => fs.existsSync(x));
+                executableFile = executableFiles[0];
+                targetFile = 'CocosGame';
+            }
         }
-        await cchelper.runCmd(executableName, [], false, executableDir);
+
+        if (!executableFile || !fs.existsSync(executableFile)) {
+            throw new Error(`[windows run] '${targetFile}' is not found within ' + ${executableDir}!`);
+        }
+        await cchelper.runCmd(ps.basename(executableFile), [], false, executableDir);
         return true;
     }
 }


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16682

Launch ExecutableName.exe by default instead of ProjectName.exe, fallback to ProjectName.exe if executableName is not found.

### Changelog

* [bugfix]: Default executable name was hard coded as projectName.exe instead of the actual built executable name.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
