### PR TITLE
Fix type mismatch in submodel setPasses method

### DIFF
--- a/native/cocos/renderer/pipeline/PlanarShadowQueue.cpp
+++ b/native/cocos/renderer/pipeline/PlanarShadowQueue.cpp
@@ -22,11 +22,11 @@
  THE SOFTWARE.
 ****************************************************************************/
 
+#include "PlanarShadowQueue.h"
 #include "Define.h"
 #include "InstancedBuffer.h"
 #include "PipelineSceneData.h"
 #include "PipelineStateManager.h"
-#include "PlanarShadowQueue.h"
 #include "RenderInstancedQueue.h"
 #include "RenderPipeline.h"
 #include "core/geometry/AABB.h"
@@ -153,7 +153,7 @@ void PlanarShadowQueue::destroy() {
 
 int PlanarShadowQueue::getShadowPassIndex(const scene::SubModel *subModel) const {
     int i = 0;
-    for (const auto &pass : subModel->getPasses()) {
+    for (const auto &pass : *(subModel->getPasses())) {
         if (pass->getPhase() == _phaseID) {
             return i;
         }

--- a/native/cocos/renderer/pipeline/ReflectionProbeBatchedQueue.cpp
+++ b/native/cocos/renderer/pipeline/ReflectionProbeBatchedQueue.cpp
@@ -110,7 +110,7 @@ void ReflectionProbeBatchedQueue::clear() {
 
 void ReflectionProbeBatchedQueue::add(const scene::Model *model) {
     for (const auto &subModel : model->getSubModels()) {
-        //Filter transparent objects
+        // Filter transparent objects
         const bool isTransparent = subModel->getPass(0)->getBlendState()->targets[0].blend;
         if (isTransparent) {
             continue;
@@ -187,7 +187,7 @@ bool ReflectionProbeBatchedQueue::isUseReflectMapPass(const scene::SubModel *sub
 
 int ReflectionProbeBatchedQueue::getDefaultPassIndex(const scene::SubModel *subModel) const {
     int i = 0;
-    for (const auto &pass : subModel->getPasses()) {
+    for (const auto &pass : *(subModel->getPasses())) {
         if (pass->getPhase() == _phaseID) {
             return i;
         }
@@ -198,7 +198,7 @@ int ReflectionProbeBatchedQueue::getDefaultPassIndex(const scene::SubModel *subM
 
 int ReflectionProbeBatchedQueue::getReflectMapPassIndex(const scene::SubModel *subModel) const {
     int i = 0;
-    for (const auto &pass : subModel->getPasses()) {
+    for (const auto &pass : *(subModel->getPasses())) {
         if (pass->getPhase() == _phaseReflectMapID) {
             return i;
         }

--- a/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -486,7 +486,7 @@ bool RenderAdditiveLightQueue::getLightPassIndex(const scene::Model *model, ccst
 
     for (const auto &subModel : model->getSubModels()) {
         int lightPassIndex = 0;
-        for (const auto &pass : subModel->getPasses()) {
+        for (const auto &pass : *(subModel->getPasses())) {
             if (pass->getPhase() == _phaseID) {
                 hasValidLightPass = true;
                 break;

--- a/native/cocos/renderer/pipeline/ShadowMapBatchedQueue.cpp
+++ b/native/cocos/renderer/pipeline/ShadowMapBatchedQueue.cpp
@@ -158,7 +158,7 @@ void ShadowMapBatchedQueue::destroy() {
 
 int ShadowMapBatchedQueue::getShadowPassIndex(const scene::SubModel *subModel) const {
     int i = 0;
-    for (const auto &pass : subModel->getPasses()) {
+    for (const auto &pass : *(subModel->getPasses())) {
         if (pass->getPhase() == _phaseID) {
             return i;
         }

--- a/native/cocos/renderer/pipeline/custom/NativeExecutor.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeExecutor.cpp
@@ -2082,7 +2082,7 @@ void addRenderObject(
     const auto subModelCount = subModels.size();
     for (uint32_t subModelIdx = 0; subModelIdx < subModelCount; ++subModelIdx) {
         const auto& subModel = subModels[subModelIdx];
-        const auto& passes = subModel->getPasses();
+        const auto& passes = *(subModel->getPasses());
         const auto passCount = passes.size();
         for (uint32_t passIdx = 0; passIdx < passCount; ++passIdx) {
             auto& pass = *passes[passIdx];

--- a/native/cocos/renderer/pipeline/deferred/GbufferStage.cpp
+++ b/native/cocos/renderer/pipeline/deferred/GbufferStage.cpp
@@ -98,7 +98,7 @@ void GbufferStage::dispenseRenderObject2Queues() {
         const auto subModelCount = subModels.size();
         for (subModelIdx = 0; subModelIdx < subModelCount; ++subModelIdx) {
             const auto &subModel = subModels[subModelIdx];
-            const auto &passes = subModel->getPasses();
+            const auto &passes = *(subModel->getPasses());
             const auto passCount = passes.size();
             for (passIdx = 0; passIdx < passCount; ++passIdx) {
                 const auto &pass = passes[passIdx];

--- a/native/cocos/renderer/pipeline/deferred/LightingStage.cpp
+++ b/native/cocos/renderer/pipeline/deferred/LightingStage.cpp
@@ -43,11 +43,11 @@
 #include "gfx-base/GFXDevice.h"
 #include "pipeline/Define.h"
 #include "profiler/Profiler.h"
+#include "scene/PointLight.h"
+#include "scene/RangedDirectionalLight.h"
 #include "scene/RenderScene.h"
 #include "scene/SphereLight.h"
 #include "scene/SpotLight.h"
-#include "scene/PointLight.h"
-#include "scene/RangedDirectionalLight.h"
 
 namespace cc {
 namespace pipeline {
@@ -263,8 +263,7 @@ void LightingStage::gatherLights(scene::Camera *camera) {
 
         if (sceneData->isHDR()) {
             tmpArray.w = light->getLuminanceHDR() * exposure * _lightMeterScale;
-        }
-        else {
+        } else {
             tmpArray.w = light->getLuminanceLDR();
         }
 
@@ -681,7 +680,7 @@ void LightingStage::putTransparentObj2Queue() {
         const auto *const model = ro.model;
         for (const auto &subModel : model->getSubModels()) {
             p = 0;
-            for (const auto &pass : subModel->getPasses()) {
+            for (const auto &pass : *(subModel->getPasses())) {
                 // TODO(): need to fallback unlit and gizmo material.
                 if (pass->getPhase() != _phaseID) continue;
                 for (k = 0; k < _renderQueues.size(); k++) {
@@ -970,7 +969,7 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
         const auto &subModels = model->getSubModels();
         for (m = 0; m < subModels.size(); ++m) {
             const auto &subModel = subModels[m];
-            const auto &passes = subModel->getPasses();
+            const auto &passes = *(subModel->getPasses());
             auto passCount = passes.size();
             for (p = 0; p < passCount; ++p) {
                 const auto &pass = passes[p];

--- a/native/cocos/renderer/pipeline/forward/ForwardStage.cpp
+++ b/native/cocos/renderer/pipeline/forward/ForwardStage.cpp
@@ -108,7 +108,7 @@ void ForwardStage::dispenseRenderObject2Queues() {
         const auto subModelCount = subModels.size();
         for (uint32_t subModelIdx = 0; subModelIdx < subModelCount; ++subModelIdx) {
             const auto &subModel = subModels[subModelIdx];
-            const auto &passes = subModel->getPasses();
+            const auto &passes = *(subModel->getPasses());
             const auto passCount = passes.size();
             for (uint32_t passIdx = 0; passIdx < passCount; ++passIdx) {
                 const auto &pass = passes[passIdx];

--- a/native/cocos/scene/Model.cpp
+++ b/native/cocos/scene/Model.cpp
@@ -38,10 +38,10 @@
 #include "renderer/pipeline/custom/RenderInterfaceTypes.h"
 #include "scene/Model.h"
 #include "scene/Pass.h"
+#include "scene/ReflectionProbe.h"
+#include "scene/ReflectionProbeManager.h"
 #include "scene/RenderScene.h"
 #include "scene/SubModel.h"
-#include "scene/ReflectionProbeManager.h"
-#include "scene/ReflectionProbe.h"
 
 namespace {
 const cc::gfx::SamplerInfo LIGHTMAP_SAMPLER_HASH{
@@ -207,8 +207,8 @@ void Model::updateUBOs(uint32_t stamp) {
         _localBuffer->write(_lightmapUVParam, sizeof(float) * pipeline::UBOLocal::LIGHTINGMAP_UVPARAM);
         _localBuffer->write(_shadowBias, sizeof(float) * (pipeline::UBOLocal::LOCAL_SHADOW_BIAS));
 
-        auto * probe = scene::ReflectionProbeManager::getInstance()->getReflectionProbeById(_reflectionProbeId);
-        auto * blendProbe = scene::ReflectionProbeManager::getInstance()->getReflectionProbeById(_reflectionProbeBlendId);
+        auto *probe = scene::ReflectionProbeManager::getInstance()->getReflectionProbeById(_reflectionProbeId);
+        auto *blendProbe = scene::ReflectionProbeManager::getInstance()->getReflectionProbeById(_reflectionProbeBlendId);
         if (probe) {
             if (probe->getProbeType() == scene::ReflectionProbe::ProbeType::PLANAR) {
                 const Vec4 plane = {probe->getNode()->getUp().x, probe->getNode()->getUp().y, probe->getNode()->getUp().z, 1.F};
@@ -233,8 +233,8 @@ void Model::updateUBOs(uint32_t stamp) {
                     const Vec4 boxSize = {boudingBox.x, boudingBox.y, boudingBox.z, static_cast<float>(blendProbe->getCubeMap() ? blendProbe->getCubeMap()->mipmapLevel() + mipAndUseRGBE : 1 + mipAndUseRGBE)};
                     _localBuffer->write(boxSize, sizeof(float) * (pipeline::UBOLocal::REFLECTION_PROBE_BLEND_DATA2));
                 } else if (_reflectionProbeType == scene::UseReflectionProbeType::BLEND_PROBES_AND_SKYBOX) {
-                    //blend with skybox
-                    const Vec4 pos = { 0.F, 0.F, 0.F, _reflectionProbeBlendWeight };
+                    // blend with skybox
+                    const Vec4 pos = {0.F, 0.F, 0.F, _reflectionProbeBlendWeight};
                     _localBuffer->write(pos, sizeof(float) * (pipeline::UBOLocal::REFLECTION_PROBE_BLEND_DATA1));
                 }
             }
@@ -468,7 +468,7 @@ ccstd::vector<IMacroPatch> Model::getMacroPatches(index_t subModelIndex) {
         }
     }
 
-    patches.push_back({CC_USE_REFLECTION_PROBE, static_cast<int32_t>(_reflectionProbeType) });
+    patches.push_back({CC_USE_REFLECTION_PROBE, static_cast<int32_t>(_reflectionProbeType)});
 
     if (_lightmap != nullptr) {
         bool stationary = false;
@@ -516,7 +516,7 @@ void Model::updateAttributesAndBinding(index_t subModelIndex) {
 
     ccstd::vector<gfx::Attribute> attributes;
     ccstd::unordered_map<ccstd::string, gfx::Attribute> attributeMap;
-    for (const auto &pass : subModel->getPasses()) {
+    for (const auto &pass : *(subModel->getPasses())) {
         gfx::Shader *shader = pass->getShaderVariant(subModel->getPatches());
         for (const auto &attr : shader->getAttributes()) {
             if (attributeMap.find(attr.name) == attributeMap.end()) {

--- a/native/cocos/scene/SubModel.cpp
+++ b/native/cocos/scene/SubModel.cpp
@@ -92,7 +92,7 @@ void SubModel::update() {
     }
 }
 
-void SubModel::setPasses(const std::shared_ptr<ccstd::vector<IntrusivePtr<Pass>>> &pPasses) {
+void SubModel::setPasses(const SharedPassArray &pPasses) {
     if (!pPasses || pPasses->size() > MAX_PASS_COUNT) {
         debug::errorID(12004, MAX_PASS_COUNT);
         return;
@@ -128,7 +128,7 @@ Pass *SubModel::getPass(uint32_t index) const {
     return passes[index];
 }
 
-void SubModel::initialize(RenderingSubMesh *subMesh, const std::shared_ptr<ccstd::vector<IntrusivePtr<Pass>>> &pPasses, const ccstd::vector<IMacroPatch> &patches) {
+void SubModel::initialize(RenderingSubMesh *subMesh, const SharedPassArray &pPasses, const ccstd::vector<IMacroPatch> &patches) {
     _device = Root::getInstance()->getDevice();
     CC_ASSERT(!pPasses->empty());
     gfx::DescriptorSetInfo dsInfo;

--- a/native/cocos/scene/SubModel.h
+++ b/native/cocos/scene/SubModel.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
+#include "base/Ptr.h"
 #include "base/RefCounted.h"
 #include "core/assets/RenderingSubMesh.h"
 #include "renderer/gfx-base/GFXDescriptorSet.h"
@@ -42,6 +44,8 @@ struct InstancedAttributeBlock {
     ccstd::vector<gfx::Attribute> attributes;
 };
 
+using SharedPassArray = std::shared_ptr<ccstd::vector<IntrusivePtr<Pass>>>;
+
 class SubModel : public RefCounted {
 public:
     SubModel();
@@ -56,7 +60,7 @@ public:
     inline void setDescriptorSet(gfx::DescriptorSet *descriptorSet) { _descriptorSet = descriptorSet; }
     inline void setInputAssembler(gfx::InputAssembler *ia) { _inputAssembler = ia; }
     inline void setShaders(const ccstd::vector<IntrusivePtr<gfx::Shader>> &shaders) { _shaders = shaders; }
-    void setPasses(const std::shared_ptr<ccstd::vector<IntrusivePtr<Pass>>> &passes);
+    void setPasses(const SharedPassArray &passes);
     inline void setPriority(pipeline::RenderPriority priority) { _priority = priority; }
     inline void setOwner(Model *model) { _owner = model; }
     void setSubMesh(RenderingSubMesh *subMesh);
@@ -68,7 +72,7 @@ public:
     inline gfx::DescriptorSet *getWorldBoundDescriptorSet() const { return _worldBoundDescriptorSet; }
     inline gfx::InputAssembler *getInputAssembler() const { return _inputAssembler; }
     inline const ccstd::vector<IntrusivePtr<gfx::Shader>> &getShaders() const { return _shaders; }
-    inline const ccstd::vector<IntrusivePtr<Pass>> &getPasses() const { return *_passes; }
+    inline const SharedPassArray &getPasses() const { return _passes; }
     inline const ccstd::vector<IMacroPatch> &getPatches() const { return _patches; }
     inline pipeline::RenderPriority getPriority() const { return _priority; }
     inline RenderingSubMesh *getSubMesh() const { return _subMesh; }
@@ -79,7 +83,7 @@ public:
     inline int32_t getInstancedSHIndex() const { return _instancedSHIndex; }
     int32_t getInstancedAttributeIndex(const ccstd::string &name) const;
 
-    void initialize(RenderingSubMesh *subMesh, const std::shared_ptr<ccstd::vector<IntrusivePtr<Pass>>> &passes, const ccstd::vector<IMacroPatch> &patches);
+    void initialize(RenderingSubMesh *subMesh, const SharedPassArray &passes, const ccstd::vector<IMacroPatch> &patches);
     void destroy();
     void onPipelineStateChanged();
     void onMacroPatchesStateChanged(const ccstd::vector<IMacroPatch> &patches);
@@ -114,7 +118,7 @@ protected:
     ccstd::vector<IMacroPatch> _patches;
     ccstd::vector<IntrusivePtr<gfx::Shader>> _shaders;
 
-    std::shared_ptr<ccstd::vector<IntrusivePtr<Pass>>> _passes;
+    SharedPassArray _passes;
 
     int32_t _reflectionProbeType{0};
 

--- a/native/tools/swig-config/scene.i
+++ b/native/tools/swig-config/scene.i
@@ -481,7 +481,7 @@ using namespace cc;
 %attribute(cc::scene::Model, int32_t, reflectionProbeBlendId, getReflectionProbeBlendId, setReflectionProbeBlendId);
 %attribute(cc::scene::Model, float, reflectionProbeBlendWeight, getReflectionProbeBlendWeight, setReflectionProbeBlendWeight);
 
-%attribute(cc::scene::SubModel, std::shared_ptr<ccstd::vector<cc::IntrusivePtr<cc::scene::Pass>>> &, passes, getPasses, setPasses);
+%attribute(cc::scene::SubModel, cc::scene::SharedPassArray &, passes, getPasses, setPasses);
 %attribute(cc::scene::SubModel, ccstd::vector<cc::IntrusivePtr<cc::gfx::Shader>> &, shaders, getShaders, setShaders);
 %attribute(cc::scene::SubModel, cc::RenderingSubMesh*, subMesh, getSubMesh, setSubMesh);
 %attribute(cc::scene::SubModel, cc::pipeline::RenderPriority, priority, getPriority, setPriority);


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16625

The getPasses() method in the submodel class returns a `vector<>` objects, whereas the setPasses() method expects a `shared_ptr<vector<>>`. This type mismatch can cause a crash in binding code.

### Changelog

* Change the return type of Submodel::getPasses to `shared_ptr<vector<>>`

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
