### PR TITLE
reset delegate value when cleanup scriptengine

### DIFF
--- a/native/cocos/bindings/manual/jsb_websocket.cpp
+++ b/native/cocos/bindings/manual/jsb_websocket.cpp
@@ -24,6 +24,7 @@
 
 #include "jsb_websocket.h"
 #include "MappingUtils.h"
+#include "base/std/container/unordered_set.h"
 #include "cocos/base/DeferredReleasePool.h"
 #include "cocos/bindings/jswrapper/SeApi.h"
 #include "cocos/bindings/manual/jsb_conversions.h"
@@ -58,12 +59,20 @@
  WebSocket implements EventTarget;
  */
 
+#define GET_DELEGATE_FN(name) \
+    _JSDelegate.isObject() && _JSDelegate.toObject()->getProperty(name, &func)
+
 namespace {
 se::Class *jsbWebSocketClass = nullptr;
-}
+ccstd::unordered_set<JsbWebSocketDelegate *> jsbWebSocketDelegates;
+} // namespace
 
+JsbWebSocketDelegate::JsbWebSocketDelegate() {
+    jsbWebSocketDelegates.insert(this);
+}
 JsbWebSocketDelegate::~JsbWebSocketDelegate() {
     CC_LOG_INFO("In the destructor of JSbWebSocketDelegate(%p)", this);
+    jsbWebSocketDelegates.erase(this);
 }
 
 void JsbWebSocketDelegate::onOpen(cc::network::WebSocket *ws) {
@@ -88,7 +97,7 @@ void JsbWebSocketDelegate::onOpen(cc::network::WebSocket *ws) {
     jsObj->setProperty("target", target);
 
     se::Value func;
-    bool ok = _JSDelegate.toObject()->getProperty("onopen", &func);
+    bool ok = GET_DELEGATE_FN("onopen");
     if (ok && func.isObject() && func.toObject()->isFunction()) {
         se::ValueArray args;
         args.push_back(se::Value(jsObj));
@@ -117,7 +126,7 @@ void JsbWebSocketDelegate::onMessage(cc::network::WebSocket *ws, const cc::netwo
     jsObj->setProperty("target", target);
 
     se::Value func;
-    bool ok = _JSDelegate.toObject()->getProperty("onmessage", &func);
+    bool ok = GET_DELEGATE_FN("onmessage");
     if (ok && func.isObject() && func.toObject()->isFunction()) {
         se::ValueArray args;
         args.push_back(se::Value(jsObj));
@@ -174,7 +183,7 @@ void JsbWebSocketDelegate::onClose(cc::network::WebSocket *ws, uint16_t code, co
         jsObj->setProperty("wasClean", se::Value(wasClean));
 
         se::Value func;
-        bool ok = _JSDelegate.toObject()->getProperty("onclose", &func);
+        bool ok = GET_DELEGATE_FN("onclose");
         if (ok && func.isObject() && func.toObject()->isFunction()) {
             se::ValueArray args;
             args.push_back(se::Value(jsObj));
@@ -185,7 +194,9 @@ void JsbWebSocketDelegate::onClose(cc::network::WebSocket *ws, uint16_t code, co
 
         // JS Websocket object now can be GC, since the connection is closed.
         wsObj->unroot();
-        _JSDelegate.toObject()->unroot();
+        if (_JSDelegate.isObject()) {
+            _JSDelegate.toObject()->unroot();
+        }
 
         // Websocket instance is attached to global object in 'WebSocket_close'
         // It's safe to detach it here since JS 'onclose' method has been already invoked.
@@ -216,7 +227,7 @@ void JsbWebSocketDelegate::onError(cc::network::WebSocket *ws, const cc::network
     jsObj->setProperty("target", target);
 
     se::Value func;
-    bool ok = _JSDelegate.toObject()->getProperty("onerror", &func);
+    bool ok = GET_DELEGATE_FN("onerror");
     if (ok && func.isObject() && func.toObject()->isFunction()) {
         se::ValueArray args;
         args.push_back(se::Value(jsObj));
@@ -229,6 +240,11 @@ void JsbWebSocketDelegate::onError(cc::network::WebSocket *ws, const cc::network
 void JsbWebSocketDelegate::setJSDelegate(const se::Value &jsDelegate) {
     CC_ASSERT(jsDelegate.isObject());
     _JSDelegate = jsDelegate;
+    se::ScriptEngine::getInstance()->addBeforeCleanupHook([this]() {
+        if (jsbWebSocketDelegates.find(this) != jsbWebSocketDelegates.end()) {
+            _JSDelegate.setUndefined();
+        }
+    });
 }
 
 static bool webSocketFinalize(se::State &s) {

--- a/native/cocos/bindings/manual/jsb_websocket.h
+++ b/native/cocos/bindings/manual/jsb_websocket.h
@@ -34,7 +34,7 @@ class Value;
 
 class JsbWebSocketDelegate : public cc::RefCounted, public cc::network::WebSocket::Delegate {
 public:
-    JsbWebSocketDelegate() = default;
+    JsbWebSocketDelegate();
 
     void onOpen(cc::network::WebSocket *ws) override;
 


### PR DESCRIPTION
When the ScriptEngine is cleaned up, all other se::Value instances should be reset as well, otherwise their state could stay invalid.


Notice:

Call onclose callback before reset `_JSDelegate` may be needed.

### Changelog

* bugfix: clear _JSDelegate object when scriptengine cleanup

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
