### PR TITLE
[fix] physx Character Controller filter bug

### DIFF
--- a/cocos/physics/physx/character-controllers/physx-character-controller.ts
+++ b/cocos/physics/physx/character-controllers/physx-character-controller.ts
@@ -63,7 +63,7 @@ export class PhysXCharacterController implements IBaseCharacterController {
     }
 
     constructor () {
-        this._filterData = { word0: 1, word1: 1, word2: 10000, word3: 0 };
+        this._filterData = { word0: 1, word1: 1, word2: 1, word3: 0 };
     }
 
     // virtual
@@ -203,7 +203,12 @@ export class PhysXCharacterController implements IBaseCharacterController {
     // eBLOCK = 2   //!< a hit on the shape blocks the query (does not block overlap queries)
     static queryCallback = {
         preFilter (filterData: any, shape: any, _actor: any, _out: any): number {
-            const collider = getWrapShape<PhysXShape>(shape).collider;
+            const pxShape = getWrapShape<PhysXShape>(shape);
+            if (!pxShape) {
+                return PX.QueryHitType.eNONE;
+            }
+
+            const collider = pxShape.collider;
             if (!(filterData.word0 & collider.getMask()) || !(filterData.word1 & collider.getGroup())) {
                 return PX.QueryHitType.eNONE;
             }

--- a/cocos/physics/physx/physx-shared-body.ts
+++ b/cocos/physics/physx/physx-shared-body.ts
@@ -121,7 +121,7 @@ export class PhysXSharedBody {
         this.id = PhysXSharedBody.idCounter++;
         this.node = node;
         this.wrappedWorld = wrappedWorld;
-        this._filterData = { word0: 1, word1: 1, word2: 0, word3: 0 };
+        this._filterData = { word0: 1, word1: 1, word2: 1, word3: 0 };
     }
 
     private _initActor (): void {

--- a/cocos/physics/physx/shapes/physx-shape.ts
+++ b/cocos/physics/physx/shapes/physx-shape.ts
@@ -216,7 +216,7 @@ export class PhysXShape implements IBaseShape {
         if (this._collider.needCollisionEvent) {
             this._word3 |= EFilterDataWord3.DETECT_CONTACT_EVENT | EFilterDataWord3.DETECT_CONTACT_POINT;
         }
-        filterData.word2 = this.id;
+        //filterData.word2 = this.id;//useless
         filterData.word3 = this._word3;
         this.setFilerData(filterData);
     }

--- a/native/cocos/physics/physx/PhysXSharedBody.cpp
+++ b/native/cocos/physics/physx/PhysXSharedBody.cpp
@@ -56,7 +56,7 @@ PhysXSharedBody::PhysXSharedBody(
                                   _mType(ERigidBodyType::STATIC),
                                   _mIsStatic(true),
                                   _mIndex(-1),
-                                  _mFilterData(1, 1, 0, 0),
+                                  _mFilterData(1, 1, 1, 0),
                                   _mStaticActor(nullptr),
                                   _mDynamicActor(nullptr),
                                   _mWrappedWorld(world),

--- a/native/cocos/physics/physx/character-controllers/PhysXCharacterController.cpp
+++ b/native/cocos/physics/physx/character-controllers/PhysXCharacterController.cpp
@@ -101,7 +101,7 @@ physx::PxQueryHitType::Enum QueryFilterCallback::postFilter(const physx::PxFilte
 
 PhysXCharacterController::PhysXCharacterController() {
     _mObjectID = PhysXWorld::getInstance().addWrapperObject(reinterpret_cast<uintptr_t>(this));
-    _mFilterData = physx::PxFilterData(1, 1, 10000, 0 );
+    _mFilterData = physx::PxFilterData(1, 1, 1, 0 );
 };
 
 void PhysXCharacterController::release() {


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/16713
physx applyFilterEquation() 会忽略掉cct和collider的filterData 所有字段与操作 为0的collider

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
