### PR TITLE
Marionette/PoseGraph: allow specifing start time for PoseNodePlayMotion

### DIFF
--- a/cocos/animation/marionette/pose-graph/motion-sync/runtime-motion-sync.ts
+++ b/cocos/animation/marionette/pose-graph/motion-sync/runtime-motion-sync.ts
@@ -105,9 +105,9 @@ class Group {
 }
 
 class RuntimeMotionSyncRecordImpl implements RuntimeMotionSyncRecord {
-    public notifyRenter (): void {
+    public notifyRenter (normalizedTime: number): void {
         this.reset();
-        this.normalizedTime = 0.0;
+        this.normalizedTime = normalizedTime;
     }
 
     public notifyUpdate (normalizedDeltaTime: number, weight: number) {
@@ -138,7 +138,7 @@ class RuntimeMotionSyncRecordImpl implements RuntimeMotionSyncRecord {
 }
 
 export interface RuntimeMotionSyncRecord {
-    notifyRenter(): void;
+    notifyRenter(normalizedTime: number): void;
 
     notifyUpdate(deltaTime: number, weight: number): void;
 

--- a/cocos/animation/marionette/pose-graph/pose-node.ts
+++ b/cocos/animation/marionette/pose-graph/pose-node.ts
@@ -165,5 +165,12 @@ export abstract class PoseNode extends PoseGraphNode {
      */
     protected abstract doEvaluate(context: AnimationGraphEvaluationContext): Pose;
 
+    /**
+     * TODO: some nodes access dependencies in reenter(). See: cocos/cocos-engine#15305
+     */
+    protected _forceEvaluateEvaluation (): void {
+        this._dependencyEvaluation?.evaluate();
+    }
+
     private _dependencyEvaluation: PoseNodeDependencyEvaluation | undefined = undefined;
 }

--- a/editor/i18n/en/animation.js
+++ b/editor/i18n/en/animation.js
@@ -62,6 +62,11 @@ module.exports = {
                         },
                     },
                     inputs: {
+                        'startTime': {
+                            displayName: 'Start Time',
+                            tooltip: 'Specify where to begin playing the motion. ' +
+                                'The time\'s unit is seconds and the value would be clamped into [0, motion\'s duration].',
+                        },
                         'speedMultiplier': {
                             displayName: 'Speed Multiplier',
                         },

--- a/editor/i18n/zh/animation.js
+++ b/editor/i18n/zh/animation.js
@@ -62,6 +62,10 @@ module.exports = {
                         },
                     },
                     inputs: {
+                        'startTime': {
+                            displayName: '起始时间',
+                            tooltip: '指定从何时开始播放该动作。其单位为秒，其值会被限制在 [0, 动作周期] 范围内。',
+                        },
                         'speedMultiplier': {
                             displayName: '速度乘数',
                         },

--- a/tests/animation/new-gen-anim/pose-graph/utils/misc.ts
+++ b/tests/animation/new-gen-anim/pose-graph/utils/misc.ts
@@ -6,6 +6,9 @@ import { AnimationGraphBindingContext, AnimationGraphEvaluationContext, Animatio
 import { assertIsTrue, Quat, Vec3 } from "../../../../../exports/base";
 import { PoseNode } from "../../../../../cocos/animation/marionette/pose-graph/pose-node";
 import { PureValueNode } from "../../../../../cocos/animation/marionette/pose-graph/pure-value-node";
+import { PoseGraphType } from "../../../../../cocos/animation/marionette/pose-graph/foundation/type-system";
+import { PVNodeGetVariableFloat } from "../../../../../cocos/animation/marionette/pose-graph/pure-value-nodes/get-variable";
+import { AnimationGraphEvalMock } from "../../utils/eval-mock";
 
 export function normalizeNodeInputMetadata(nodeInputMetadata?: poseGraphOp.InputMetadata) {
     return nodeInputMetadata ? {
@@ -29,6 +32,10 @@ export function getTheOnlyOutputKey(node: PoseGraphNode) {
     const outputs = poseGraphOp.getOutputKeys(node);
     expect(outputs).toHaveLength(1);
     return outputs[0];
+}
+
+export function getTheOnlyOutputKey2(node: PoseGraphNode) {
+    return [node, getTheOnlyOutputKey(node)] as const;
 }
 
 export function composeInputKeyInternally(propertyName: string, elementIndex?: number): poseGraphOp.InputKey {
@@ -82,4 +89,17 @@ export class UnimplementedPVNode extends PureValueNode {
     public selfEvaluate(outputs: unknown[]): void {
         throw new Error("Method not implemented.");
     }
+}
+
+export function createVariableGettingNode(type: PoseGraphType, varName: string) {
+    let result: PVNodeGetVariableFloat;
+    switch (type) {
+        case PoseGraphType.FLOAT:
+            result = new PVNodeGetVariableFloat();
+            break;
+        default:
+            throw new Error(`Unrecognized pose graph type: ${type}`);
+    }
+    result.variableName = varName;
+    return result;
 }

--- a/tests/animation/new-gen-anim/pose-graph/utils/simple-pose-graph-runner.ts
+++ b/tests/animation/new-gen-anim/pose-graph/utils/simple-pose-graph-runner.ts
@@ -1,0 +1,80 @@
+import { PoseGraph } from "../../../../../cocos/animation/marionette/asset-creation";
+import { Node } from "../../../../../exports/base";
+import { AnimationGraphEvalMock } from "../../utils/eval-mock";
+import { createAnimationGraph, VariableDeclarationParams } from "../../utils/factory";
+
+export class SimplePoseGraphRunner {
+    constructor({
+        root,
+        poseGraphInitializer,
+        enterDuration = 0.0,
+        leaveDuration = 0.0,
+        variables = {},
+    }: {
+        root: Node;
+        poseGraphInitializer: (poseGraph: PoseGraph) => void,
+        enterDuration?: number;
+        leaveDuration?: number;
+        variables?: Record<string, VariableDeclarationParams>;
+    }) {
+        const animationGraph = createAnimationGraph({
+            variableDeclarations: {
+                'activated': { type: 'boolean', value: false },
+                ...variables,
+            },
+            layers: [{
+                stateMachine: {
+                    states: {
+                        'empty': { type: 'empty' },
+                        'play': {
+                            type: 'procedural',
+                            graph: poseGraphInitializer,
+                        },
+                    },
+                    entryTransitions: [{
+                        to: 'empty',
+                    }],
+                    transitions: [{
+                        from: 'empty', to: 'play',
+                        duration: enterDuration,
+                        conditions: [{ type: 'unary', operator: 'to-be-true', operand: { type: 'variable', name: 'activated' } }],
+                    }, {
+                        from: 'play', to: 'empty',
+                        duration: leaveDuration,
+                        conditions: [{ type: 'unary', operator: 'to-be-false', operand: { type: 'variable', name: 'activated' } }],
+                    }],
+                },
+            }],
+        });
+    
+        const evalMock = new AnimationGraphEvalMock(root, animationGraph);
+        this._evalMock = evalMock;
+        this._leaveDuration = leaveDuration;
+    }
+
+    get evalMock() {
+        return this._evalMock;
+    }
+
+    public enter() {
+        this._evalMock.controller.setValue('activated', true);
+    }
+
+    public leave() {
+        this._evalMock.controller.setValue('activated', false);
+    }
+
+    public reenter() {
+        this.leave();
+        this._evalMock.step(this._leaveDuration + 0.1);
+        this.enter();
+    }
+
+    private _evalMock: AnimationGraphEvalMock;
+    private _enterDuration: number;
+    private _leaveDuration: number;
+}
+
+export namespace SimplePoseGraphRunner {
+    export type Options = ConstructorParameters<typeof SimplePoseGraphRunner>[0];
+}

--- a/tests/animation/new-gen-anim/utils/fixtures.ts
+++ b/tests/animation/new-gen-anim/utils/fixtures.ts
@@ -2,6 +2,7 @@ import { Track, VectorTrack } from "../../../../cocos/animation/animation";
 import { AnimationClip } from "../../../../cocos/animation/animation-clip";
 import { ClipMotion, AnimationBlend1D } from "../../../../cocos/animation/marionette/motion";
 import { blend1D } from "../../../../cocos/animation/marionette/motion/blend-1d";
+import { WrapMode } from "../../../../cocos/animation/types";
 import { lerp, RealCurve } from "../../../../cocos/core";
 
 export interface CreateMotionContext {
@@ -11,6 +12,7 @@ export interface CreateMotionContext {
         name?: string;
         duration: number;
         additive?: boolean;
+        wrapMode?: WrapMode;
     }) => NonNullableClipMotion;
 }
 
@@ -25,7 +27,9 @@ export interface RealValueAnimationFixture {
 }
 
 export class LinearRealValueAnimationFixture implements RealValueAnimationFixture {
-    constructor(public from: number, public to: number, public duration: number, private additive: boolean = false) {
+    constructor(public from: number, public to: number, public duration: number, private additive: boolean = false, private options: {
+        loop?: boolean;
+    } = {}) {
     }
 
     public getExpected(time: number) {
@@ -46,6 +50,7 @@ export class LinearRealValueAnimationFixture implements RealValueAnimationFixtur
             {
                 duration: this.duration,
                 additive: this.additive,
+                wrapMode: this.options.loop ? WrapMode.Loop : WrapMode.Normal,
             },
         );
     }

--- a/tests/animation/new-gen-anim/utils/node-transform-value-observer.ts
+++ b/tests/animation/new-gen-anim/utils/node-transform-value-observer.ts
@@ -1,6 +1,7 @@
 import { QuatTrack, VectorTrack } from "../../../../cocos/animation/animation";
 import { additiveSettingsTag, AnimationClip } from "../../../../cocos/animation/animation-clip";
 import { ClipMotion } from "../../../../cocos/animation/marionette/motion";
+import { WrapMode } from "../../../../cocos/animation/types";
 import { Quat, toDegree, toRadian, Vec3 } from "../../../../cocos/core";
 import { Node } from "../../../../cocos/scene-graph";
 import { CreateMotionContext } from "./fixtures";
@@ -84,12 +85,14 @@ export class NodeTransformValueObserver {
                 name = '',
                 duration,
                 additive = false,
+                wrapMode = WrapMode.Normal,
             }) {
                 const clip = new AnimationClip();
                 clip.name = name;
                 clip.enableTrsBlending = true;
                 clip.duration = duration;
                 clip[additiveSettingsTag].enabled = additive;
+                clip.wrapMode = wrapMode;
                 { // translation
                     const track = new VectorTrack();
                     track.componentsCount = 3;

--- a/tests/animation/new-gen-anim/utils/single-real-value-observer.ts
+++ b/tests/animation/new-gen-anim/utils/single-real-value-observer.ts
@@ -3,6 +3,7 @@ import { additiveSettingsTag, AnimationClip } from "../../../../cocos/animation/
 import { Pose } from "../../../../cocos/animation/core/pose";
 import { AnimationGraphBindingContext, AnimationGraphEvaluationContext } from "../../../../cocos/animation/marionette/animation-graph-context";
 import { ClipMotion } from "../../../../cocos/animation/marionette/motion";
+import { WrapMode } from "../../../../cocos/animation/types";
 import { Node } from "../../../../cocos/scene-graph";
 import { Vec3 } from "../../../../exports/base";
 import { CreateMotionContext } from "./fixtures";
@@ -31,12 +32,14 @@ export class SingleRealValueObserver {
                 name = '',
                 duration,
                 additive = false,
+                wrapMode = WrapMode.Normal,
             }) {
                 const clip = new AnimationClip();
                 clip.name = name;
                 clip.enableTrsBlending = true;
                 clip.duration = duration;
                 clip[additiveSettingsTag].enabled = additive;
+                clip.wrapMode = wrapMode;
                 const track = new VectorTrack();
                 track.componentsCount = 3;
                 track.path.toProperty('position');


### PR DESCRIPTION
Re: #

### Changelog

* This PR added a "Start Time" input to pose node `PoseNodePlayMotion`, to specify the start play time of the motion when the motion starts to play or replay.

Note, this PR introduced a issue: pose nodes may require to access dependency nodes in re-enter stage. I have recorded the issue in #15305  and did some hacks in this PR to temporarily overcome the problem.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
