### PR TITLE
add proguard-configs for android/release

### DIFF
--- a/.github/workflows/native-compile-platforms.yml
+++ b/.github/workflows/native-compile-platforms.yml
@@ -112,7 +112,8 @@ jobs:
 
           echo "Compile Android - cmake ..."
           echo "ANDORID_NDK ${ANDROID_NDK} or ${ANDROID_NDK_HOME}"
-          ./gradlew :CocosGame:assembleDebug --quiet
+          # ./gradlew :CocosGame:assembleDebug --quiet
+          ./gradlew :CocosGame:assembleRelease --quiet
           echo "Compile Android Debug Done!"
 
   compile_android:

--- a/templates/android/template/app/proguard-rules.pro
+++ b/templates/android/template/app/proguard-rules.pro
@@ -40,3 +40,15 @@
 -dontwarn android.webkit.WebView
 -dontwarn android.net.http.SslError
 -dontwarn android.webkit.WebViewClient
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn android.hardware.BatteryState
+-dontwarn android.hardware.lights.Light
+-dontwarn android.hardware.lights.LightState$Builder
+-dontwarn android.hardware.lights.LightState
+-dontwarn android.hardware.lights.LightsManager$LightsSession
+-dontwarn android.hardware.lights.LightsManager
+-dontwarn android.hardware.lights.LightsRequest$Builder
+-dontwarn android.hardware.lights.LightsRequest
+-dontwarn android.net.ssl.SSLSockets
+-dontwarn android.os.VibratorManager

--- a/templates/android/template/instantapp/proguard-rules.pro
+++ b/templates/android/template/instantapp/proguard-rules.pro
@@ -40,3 +40,15 @@
 -dontwarn android.webkit.WebView
 -dontwarn android.net.http.SslError
 -dontwarn android.webkit.WebViewClient
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn android.hardware.BatteryState
+-dontwarn android.hardware.lights.Light
+-dontwarn android.hardware.lights.LightState$Builder
+-dontwarn android.hardware.lights.LightState
+-dontwarn android.hardware.lights.LightsManager$LightsSession
+-dontwarn android.hardware.lights.LightsManager
+-dontwarn android.hardware.lights.LightsRequest$Builder
+-dontwarn android.hardware.lights.LightsRequest
+-dontwarn android.net.ssl.SSLSockets
+-dontwarn android.os.VibratorManager


### PR DESCRIPTION
When using Proguard for obfuscation in Release mode, Proguard may report errors because some classes are incorrectly obfuscated.
To fix this, we need to add keep rules for Proguard to avoid obfuscating these classes.

### Changelog

* bugfix: when upgrading gradle to 8.0.2 modifying proguard configurations is required
* Android CI compile in release mode

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
