### PR TITLE
add boundary to avoid physx assert error

### DIFF
--- a/cocos/physics/physx/joints/physx-configurable-joint.ts
+++ b/cocos/physics/physx/joints/physx-configurable-joint.ts
@@ -112,11 +112,11 @@ export class PhysXConfigurableJoint extends PhysXJoint implements IConfigurableC
         limitCone.restitution = angularLimit.swingRestitution;
 
         if (angularLimit.swingMotion1 === EConstraintMode.LIMITED) {
-            limitCone.yAngle = toRadian(angularLimit.swingExtent1) * 0.5;
+            limitCone.yAngle = toRadian(Math.max(angularLimit.swingExtent1, 1e-9)) * 0.5;
             this._impl.setSwingLimit(limitCone);
         }
         if (angularLimit.swingMotion2 === EConstraintMode.LIMITED) {
-            limitCone.zAngle = toRadian(angularLimit.swingExtent2) * 0.5;
+            limitCone.zAngle = toRadian(Math.max(angularLimit.swingExtent2, 1e-9)) * 0.5;
             this._impl.setSwingLimit(limitCone);
         }
     }
@@ -138,8 +138,8 @@ export class PhysXConfigurableJoint extends PhysXJoint implements IConfigurableC
         limitPair.restitution = angularLimit.twistRestitution;
 
         if (angularLimit.twistMotion === EConstraintMode.LIMITED) {
-            limitPair.lower = toRadian(angularLimit.twistExtent) * -0.5;
-            limitPair.upper = toRadian(angularLimit.twistExtent) * 0.5;
+            limitPair.lower = toRadian(Math.max(angularLimit.twistExtent, 1e-9)) * -0.5;
+            limitPair.upper = toRadian(Math.max(angularLimit.twistExtent, 1e-9)) * 0.5;
             this._impl.setTwistLimit(limitPair);
         }
     }

--- a/native/cocos/physics/physx/joints/PhysXGenericJoint.cpp
+++ b/native/cocos/physics/physx/joints/PhysXGenericJoint.cpp
@@ -107,9 +107,10 @@ void PhysXGenericJoint::setLinearLimit(uint32_t index, float lower, float upper)
 }
 
 void PhysXGenericJoint::setAngularExtent(float twist, float swing1, float swing2) {
-    _angularLimit.twistExtent = mathutils::toRadian(twist);
-    _angularLimit.swing1Extent = mathutils::toRadian(swing1);
-    _angularLimit.swing2Extent = mathutils::toRadian(swing2);
+    _angularLimit.twistExtent = mathutils::toRadian(std::fmax(twist, 1e-9));
+    _angularLimit.swing1Extent = mathutils::toRadian(std::fmax(swing1, 1e-9));
+    _angularLimit.swing2Extent = mathutils::toRadian(std::fmax(swing2, 1e-9));
+    
     updateTwistLimit();
     updateSwingLimit();
 }
@@ -325,7 +326,7 @@ void PhysXGenericJoint::updateLinearLimit() {
     if (_linearLimit.z == physx::PxD6Motion::Enum::eLIMITED) {
         limitz.upper = upper[2];
         limitz.lower = lower[2];
-        joint->setLinearLimit(physx::PxD6Axis::Enum::eZ, limity);
+        joint->setLinearLimit(physx::PxD6Axis::Enum::eZ, limitz);
     }
 }
 


### PR DESCRIPTION
Re: #

### Changelog

* swing range cant be 0 (> 0)
* twist's upper boundary must be larger than the lower

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
