### PR TITLE
Marionette/Stash: fix error if reenter() the stash but updated in later

### DIFF
--- a/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
+++ b/cocos/animation/marionette/pose-graph/stash/runtime-stash.ts
@@ -20,37 +20,51 @@ interface RuntimeStash {
  *
   ```mermaid
     stateDiagram-v2
-      [*] --> Uninitialized
-      Uninitialized --> Unsettled: `set`
+      [*] --> Preparation
 
-      Unsettled --> Settled: `settle()`
-      Settled --> Unsettled: `rebind()`(not supported yet)
+      state Preparation {
+        [*] --> Uninitialized
 
-      Settled --> Pending: `reenter()`
-      Pending --> Pending: Repeatedly renter through `reenter()`, no effect
+        Uninitialized --> Unsettled: `set`
 
-      Pending --> Update: `update()`
-      state Update {
-        [*] --> Updating
-        Updating --> Updating: `update()`, circular dependency formed, no effect
-        Updating --> Updated: The `update()` returned
-        Updated --> Updated: `update()`, no effect
-        Updated --> [*]
+        Unsettled --> Settled: `settle()`
+
+        Settled --> [*]
       }
 
-      Update --> Evaluate: `evaluate()`
-      state Evaluate {
-        [*] --> Evaluating
-        Evaluating --> Evaluating: `evaluate()`, circular dependency formed, return the default pose
-        Evaluating --> Evaluated: The `evaluate()` returned
-        Evaluated --> Evaluated: `evaluate()`, cache is returned
-        Evaluated --> [*]
+      Preparation --> Up_to_date: `reenter()`
+      Up_to_date --> Up_to_date: Repeatedly renter through `reenter()`, no effect
+      Outdated --> Up_to_date: `reenter()`
+
+      Up_to_date --> Ticking: `update()`
+      Outdated --> Ticking: `update()`
+
+      state Ticking {
+        [*] --> Update
+
+        state Update {
+            [*] --> Updating
+            Updating --> Updating: `update()`, circular dependency formed, no effect
+            Updating --> Updated: The `update()` returned
+            Updated --> Updated: `update()`, no effect
+            Updated --> [*]
+        }
+
+        Update --> Evaluate: `evaluate()`
+        state Evaluate {
+            [*] --> Evaluating
+            Evaluating --> Evaluating: `evaluate()`, circular dependency formed, return the default pose
+            Evaluating --> Evaluated: The `evaluate()` returned
+            Evaluated --> Evaluated: `evaluate()`, cache is returned
+            Evaluated --> [*]
+        }
+
+        Update --> [*]
+        Evaluate --> [*]
       }
 
-      Settled --> Settled: At the end of tick
-      Pending --> Settled: At the end of tick
-      Update --> Pending: At the end of tick
-      Evaluate --> Pending: At the end of tick
+      Ticking --> Up_to_date: At the end of tick
+      Up_to_date --> Outdated: At the end of tick
   ```
  *
  * - Stash records are created at the beginning of layer instantiation, before instantiation of any other things.
@@ -62,11 +76,9 @@ interface RuntimeStash {
  * - After all things in animation graph completed their bind stage, each stash would be settled.
  *   Then the stash was put in `SETTLED` state.
  *
- * - For each animation graph tick:
+ * - Next, at least one `reenter` should be called on the stash, to put the stash into `Up-to-date` to participate loop.
  *
- *   - If the stash was not accessed in last tick(asserts its state would be `SETTLED`),
- *     but should be accessed in this tick. The stash would call `reenter()` of its graph.
- *     Then the stash was put in `PENDING` state.
+ * - For each animation graph tick:
  *
  *   - Then, the stash will run into `UPDATING` and then `UPDATED` stage in animation graph update stage.
  *     The stash only updates once, if there're multiple update threads, the later update takes no effect.
@@ -79,9 +91,7 @@ interface RuntimeStash {
  *
  *   - At the end of tick,
  *
- *      - If the stash is not updated and is not evaluated in this tick, it will be put back into `SETTLED` stage.
- *
- *      - Otherwise, it will be put in `PENDING` state.
+ *      - If the stash is not updated and is not evaluated in this tick, it will be put back into `Outdated` .
  */
 enum StashRecordState {
     /**
@@ -102,9 +112,14 @@ enum StashRecordState {
     SETTLED,
 
     /**
-     * The stash is not activated but have not been updated or evaluated in last frame.
+     * The stash was updated in last frame or has been reentered this frame.
      */
-    PENDING,
+    UP_TO_DATE,
+
+    /**
+     * The stash had not been updated at least one frames at past.
+     */
+    OUTDATED,
 
     /**
      * The stash is being updated.
@@ -153,12 +168,11 @@ class RuntimeStashRecord implements RuntimeStash {
 
     public reset () {
         switch (this._state) {
-        case StashRecordState.SETTLED:
-            // The stash was not touched in last tick and still not been touched in this tick.
+        case StashRecordState.SETTLED: // Happen when the stash was not reentered till now.
+        case StashRecordState.OUTDATED:  // Happen when the stash keeps outdated.
             break;
-        case StashRecordState.PENDING:
-            // The stash was touched in last tick but does not being touched in this tick.
-            this._state = StashRecordState.SETTLED;
+        case StashRecordState.UP_TO_DATE: // Happen when the stash was not updated in this frame.
+            this._state = StashRecordState.OUTDATED; // It's then outdated.
             break;
         case StashRecordState.UPDATED:
             // Note: shall this means the stash is updated but not evaluated.
@@ -169,7 +183,7 @@ class RuntimeStashRecord implements RuntimeStash {
                 this._evaluationCache = null;
             }
             this._maxRequestedUpdateTime = 0.0;
-            this._state = StashRecordState.PENDING;
+            this._state = StashRecordState.UP_TO_DATE;
             break;
         case StashRecordState.UNINITIALIZED:
         default:
@@ -178,22 +192,28 @@ class RuntimeStashRecord implements RuntimeStash {
     }
 
     public reenter () {
-        assertIsTrue(
-            this._state === StashRecordState.SETTLED
-            || this._state === StashRecordState.PENDING
-            || this._state === StashRecordState.UPDATED, // The stash has been updated in other place, but here again reenters.
-        );
-        assertIsTrue(this._instantiatedPoseGraph);
-        if (this._state === StashRecordState.SETTLED) {
-            this._state = StashRecordState.PENDING;
+        switch (this._state) {
+        default:
+            assertIsTrue(false as boolean, `Unexpected state ${this._state} when reenter().`);
+            break;
+        case StashRecordState.UP_TO_DATE: // Happen when the state was updated in last frame but received a reenter() request this frame.
+        case StashRecordState.UPDATED: // Happen when the state has been update() in this frame at one place but request reenter() at another place.
+            break;
+        case StashRecordState.SETTLED: // Happen when the state is first reenter().
+        case StashRecordState.OUTDATED: { // Happen when the state has been outdated.
+            this._state = StashRecordState.UP_TO_DATE;
+            assertIsTrue(this._instantiatedPoseGraph);
             this._instantiatedPoseGraph.reenter();
+            break;
+        }
         }
     }
 
     public requestUpdate (context: AnimationGraphUpdateContext) {
         const { deltaTime } = context;
         assertIsTrue(
-            this._state === StashRecordState.PENDING
+            this._state === StashRecordState.OUTDATED
+            || this._state === StashRecordState.UP_TO_DATE
             || this._state === StashRecordState.UPDATING
             || this._state === StashRecordState.UPDATED,
         );

--- a/tests/animation/new-gen-anim/pose-graph/utils/misc.ts
+++ b/tests/animation/new-gen-anim/pose-graph/utils/misc.ts
@@ -7,7 +7,7 @@ import { assertIsTrue, Quat, Vec3 } from "../../../../../exports/base";
 import { PoseNode } from "../../../../../cocos/animation/marionette/pose-graph/pose-node";
 import { PureValueNode } from "../../../../../cocos/animation/marionette/pose-graph/pure-value-node";
 import { PoseGraphType } from "../../../../../cocos/animation/marionette/pose-graph/foundation/type-system";
-import { PVNodeGetVariableFloat } from "../../../../../cocos/animation/marionette/pose-graph/pure-value-nodes/get-variable";
+import { PVNodeGetVariableBoolean, PVNodeGetVariableFloat } from "../../../../../cocos/animation/marionette/pose-graph/pure-value-nodes/get-variable";
 import { AnimationGraphEvalMock } from "../../utils/eval-mock";
 
 export function normalizeNodeInputMetadata(nodeInputMetadata?: poseGraphOp.InputMetadata) {
@@ -92,10 +92,13 @@ export class UnimplementedPVNode extends PureValueNode {
 }
 
 export function createVariableGettingNode(type: PoseGraphType, varName: string) {
-    let result: PVNodeGetVariableFloat;
+    let result: PVNodeGetVariableFloat | PVNodeGetVariableBoolean;
     switch (type) {
         case PoseGraphType.FLOAT:
             result = new PVNodeGetVariableFloat();
+            break;
+        case PoseGraphType.BOOLEAN:
+            result = new PVNodeGetVariableBoolean();
             break;
         default:
             throw new Error(`Unrecognized pose graph type: ${type}`);


### PR DESCRIPTION
Re: #

### Changelog

* Fixes error if a pose node re-entered a stash but don't update that stash for at least one frame, then if it in later update the pose node, error would be thrown.

### Detail

Before, each stash has a "pending" state, means it has been re-entered, and if the stash is not updated in this frame, the stash will be put back into "settled" state, means a `reenter()` call is needed to re-initialize the stash.

This PR removed the pending state, but instead introduced two new states: "outdated" and "up-to-date":

- A stash is **up-to-date** if it was re-entered in current frame, or it was updated in **last frame**.

- A stash is **outdated** if it was not updated in last frame.

- Stash can update in both **up-to-date** or **outdated**, and both results that stash to be **update-to-date**.

- When the stash received a `reenter()` request, it only perform the re-initialization if it's outdated and ignore the request if it has been up-to-date.

The stash's life time can be represented by such a state diagram:

```mermaid
stateDiagram-v2
      [*] --> Preparation

      state Preparation {
        [*] --> Uninitialized

        Uninitialized --> Unsettled: `set`

        Unsettled --> Settled: `settle()`

        Settled --> [*]
      }

      Preparation --> Up_to_date: `reenter()`
      Up_to_date --> Up_to_date: Repeatedly renter through `reenter()`, no effect
      Outdated --> Up_to_date: `reenter()`

      Up_to_date --> Ticking: `update()`
      Outdated --> Ticking: `update()`

      state Ticking {
        [*] --> Update

        state Update {
            [*] --> Updating
            Updating --> Updating: `update()`, circular dependency formed, no effect
            Updating --> Updated: The `update()` returned
            Updated --> Updated: `update()`, no effect
            Updated --> [*]
        }

        Update --> Evaluate: `evaluate()`
        state Evaluate {
            [*] --> Evaluating
            Evaluating --> Evaluating: `evaluate()`, circular dependency formed, return the default pose
            Evaluating --> Evaluated: The `evaluate()` returned
            Evaluated --> Evaluated: `evaluate()`, cache is returned
            Evaluated --> [*]
        }

        Update --> [*]
        Evaluate --> [*]
      }

      Ticking --> Up_to_date: At the end of tick
      Up_to_date --> Outdated: At the end of tick
```

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
