### PR TITLE
Vulkan is no longer supported on Android with API level lower than 28

### DIFF
--- a/native/cocos/renderer/GFXDeviceManager.h
+++ b/native/cocos/renderer/GFXDeviceManager.h
@@ -28,6 +28,7 @@
 
 #include "gfx-agent/DeviceAgent.h"
 #include "gfx-validator/DeviceValidator.h"
+#include "platform/BasePlatform.h"
 
 // #undef CC_USE_NVN
 // #undef CC_USE_VULKAN
@@ -90,7 +91,13 @@ public:
     #if XR_OEM_PICO
         Device::isSupportDetachDeviceThread = false;
     #endif
-        if (tryCreate<CCVKDevice>(info, &device)) return device;
+
+        bool skipVulkan = false;
+#if CC_PLATFORM == CC_PLATFORM_ANDROID
+        auto sdkVersion = BasePlatform::getPlatform()->getSdkVersion();
+        skipVulkan = sdkVersion <= 27; // Android 8
+#endif
+        if (!skipVulkan && tryCreate<CCVKDevice>(info, &device)) return device;
 #endif
 
 #ifdef CC_USE_METAL


### PR DESCRIPTION
Re: #

https://github.com/cocos/3d-tasks/issues/16368
https://github.com/cocos/3d-tasks/issues/16468

### Changelog

* Using the Vulkan backend is prohibited on Android devices running versions below Android 8 (API Level <= 27).

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [x] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
