### PR TITLE
[3.8.0] fix arengine limit on gles3

### DIFF
--- a/native/cocos/renderer/GFXDeviceManager.h
+++ b/native/cocos/renderer/GFXDeviceManager.h
@@ -35,12 +35,6 @@
 // #undef CC_USE_GLES3
 // #undef CC_USE_GLES2
 
-// arengine only supports gles2, arcore supports gles2 and gles3
-// setting the CC_USE_GLES3 off is needed while using CC_USE_AR_AUTO or CC_USE_AR_ENGINE
-#if CC_USE_AR_MODULE && (CC_USE_AR_AUTO || CC_USE_AR_ENGINE)
-    #undef CC_USE_GLES3
-#endif
-
 #ifdef CC_USE_NVN
     #include "gfx-nvn/NVNDevice.h"
 #endif

--- a/native/cocos/renderer/pipeline/xr/ar/ARBackground.cpp
+++ b/native/cocos/renderer/pipeline/xr/ar/ARBackground.cpp
@@ -282,7 +282,15 @@ void ARBackground::render(cc::scene::Camera *camera, gfx::RenderPass *renderPass
 
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
     if (armodule->getTexInitFlag()) {
-        gfx::SamplerInfo samplerInfo;
+        gfx::SamplerInfo samplerInfo = {
+                gfx::Filter::LINEAR,
+                gfx::Filter::LINEAR,
+                gfx::Filter::NONE,
+                gfx::Address::CLAMP,
+                gfx::Address::CLAMP,
+                gfx::Address::CLAMP,
+        };
+
         auto *sampler = _device->getSampler(samplerInfo);
         armodule->setCameraTextureName(static_cast<int>(_glTex));
 


### PR DESCRIPTION
- adjust ar background binded texture sampler to fix AREngine limit on GLES3

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
