### PR TITLE
Revert changes of hasChangeFlags

### DIFF
--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -39,7 +39,7 @@ namespace cc {
 uint32_t Node::clearFrame{0};
 uint32_t Node::clearRound{1000};
 const uint32_t Node::TRANSFORM_ON{1 << 0};
-uint32_t Node::globalFlagChangeVersion{1};
+uint32_t Node::globalFlagChangeVersion{0};
 
 namespace {
 const ccstd::string EMPTY_NODE_NAME;
@@ -773,6 +773,10 @@ void Node::setRTSInternal(Quaternion *rot, Vec3 *pos, Vec3 *scale, bool calledFr
             emit<TransformChanged>(static_cast<TransformBit>(dirtyBit));
         }
     }
+}
+
+void Node::resetChangedFlags() {
+    globalFlagChangeVersion++;
 }
 
 void Node::clearNodeArray() {

--- a/native/cocos/core/scene-graph/Node.h
+++ b/native/cocos/core/scene-graph/Node.h
@@ -127,11 +127,7 @@ public:
     template <typename T>
     static bool isNode(T *obj);
 
-    inline static void resetChangedFlags() {
-        // Using 26 bits for the flags is sufficient.
-        globalFlagChangeVersion = (globalFlagChangeVersion + 1) & 0x3FFFFFF;
-    }
-
+    static void resetChangedFlags();
     static void clearNodeArray();
 
     Node();
@@ -468,17 +464,18 @@ public:
      * @zh 这个节点的空间变换信息在当前帧内是否有变过？
      */
     inline uint32_t getChangedFlags() const {
-        return (_changedVersionAndRTS >> 3) == globalFlagChangeVersion ? (_changedVersionAndRTS & 0x7) : 0;
+        return _hasChangedFlagsVersion == globalFlagChangeVersion ? _hasChangedFlags : 0;
     }
     inline void setChangedFlags(uint32_t value) {
-        _changedVersionAndRTS = (globalFlagChangeVersion << 3) | value;
+        _hasChangedFlagsVersion = globalFlagChangeVersion;
+        _hasChangedFlags = value;
     }
     /**
      * @zh 节点的变换改动版本号。
      * @en The transformation change version number of the node.
      */
     inline uint32_t getFlagChangedVersion() const {
-        return _changedVersionAndRTS >> 3;
+        return _hasChangedFlagsVersion;
     }
 
     inline bool isTransformDirty() const { return _transformFlags != static_cast<uint32_t>(TransformBit::NONE); }
@@ -667,12 +664,11 @@ private:
     uint8_t _isStatic{0};                                               // Uint8: 2
     uint8_t _padding{0};                                                // Uint8: 3
 
-    /**
-     * The high bits are used to store the version number of the changeflag, and the low 3 bits represent its specific value
-     *
-     * | 31 - 29 reserved | 28 - 3 version number | 2  - 0 : Scale Rotation Translation|
-    */
-    uint32_t _changedVersionAndRTS{0};
+    /* set _hasChangedFlagsVersion to globalFlagChangeVersion when `_hasChangedFlags` updated.
+     * `globalFlagChangeVersion == _hasChangedFlagsVersion` means that "_hasChangedFlags is dirty in current frametime".
+     */
+    uint32_t _hasChangedFlagsVersion{0};
+    uint32_t _hasChangedFlags{0};
 
     bool _eulerDirty{false};
 


### PR DESCRIPTION
Resolve: https://github.com/cocos/3d-tasks/issues/16795

Reverting the relevant [changes](https://github.com/cocos/cocos-engine/pull/14454) may lead to performance degradation on WeChat. Here we roll back the related modifications. 


Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
