### PR TITLE
[AOT] fix type in node-activator.ts && component-scheduler.ts

### DIFF
--- a/cocos/core/utils/misc.ts
+++ b/cocos/core/utils/misc.ts
@@ -31,6 +31,7 @@ import { legacyCC } from '../global-exports';
 import { warnID } from '../platform/debug';
 import { macro } from '../platform/macro';
 import { setTimeoutRAF } from '../../../pal/utils';
+import type { Component } from '../../scene-graph';
 
 export const BUILTIN_CLASSID_RE = /^(?:cc|dragonBones|sp|ccsg)\..+/;
 
@@ -179,7 +180,7 @@ export function callInNextTick (callback, p1?: any, p2?: any): void {
  * @returns @en A new function that will invoke `functionName` with try catch.
  * @zh 使用 try catch 机制调用 `functionName` 的新函数.
  */
-export function tryCatchFunctor_EDITOR (funcName): AnyFunction {
+export function tryCatchFunctor_EDITOR (funcName: string): (comp: Component) => void {
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     return Function('target',
         `${'try {\n'
@@ -187,7 +188,7 @@ export function tryCatchFunctor_EDITOR (funcName): AnyFunction {
         + `}\n`
         + `catch (e) {\n`
         + `  cc._throw(e);\n`
-        + `}`);
+        + `}`) as (comp: Component) => void;
 }
 
 /**

--- a/cocos/scene-graph/component-scheduler.ts
+++ b/cocos/scene-graph/component-scheduler.ts
@@ -548,9 +548,10 @@ export class ComponentScheduler {
 
 if (EDITOR) {
     ComponentScheduler.prototype.enableComp = function (comp, invoker): void {
-        if (legacyCC.GAME_VIEW || comp.constructor._executeInEditMode) {
+        // NOTE: _executeInEditMode is dynamically injected on Editor environment
+        if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (!(comp._objFlags & IsOnEnableCalled)) {
-                if (comp.onEnable) {
+                if (comp._internal_onEnable) {
                     if (invoker) {
                         invoker.add(comp);
                         enableInEditor(comp);
@@ -558,7 +559,7 @@ if (EDITOR) {
                     } else {
                         callOnEnableInTryCatch(comp);
 
-                        const deactivatedDuringOnEnable = !comp.node._activeInHierarchy;
+                        const deactivatedDuringOnEnable = !comp.node.activeInHierarchy;
                         if (deactivatedDuringOnEnable) {
                             return;
                         }
@@ -571,9 +572,10 @@ if (EDITOR) {
     };
 
     ComponentScheduler.prototype.disableComp = function (comp): void {
-        if (legacyCC.GAME_VIEW || comp.constructor._executeInEditMode) {
+        // NOTE: _executeInEditMode is dynamically injected on Editor environment
+        if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (comp._objFlags & IsOnEnableCalled) {
-                if (comp.onDisable) {
+                if (comp._internal_onDisable) {
                     callOnDisableInTryCatch(comp);
                 }
                 this._onDisabled(comp);

--- a/cocos/scene-graph/component-scheduler.ts
+++ b/cocos/scene-graph/component-scheduler.ts
@@ -92,34 +92,34 @@ export class LifeCycleInvoker {
     public static stableRemoveInactive = stableRemoveInactive;
 
     /**
-     * @engineInternal please access `_zero` instead.
+     * @engineInternal `_zero` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_zero (): js.array.MutableForwardIterator<any> {
         return this._zero;
     }
     /**
-     * @engineInternal please access `_neg` instead.
+     * @engineInternal `_neg` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_neg (): js.array.MutableForwardIterator<any> {
         return this._neg;
     }
     /**
-     * @engineInternal please access `_pos` instead.
+     * @engineInternal `_pos` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_pos (): js.array.MutableForwardIterator<any> {
         return this._pos;
     }
+    // components which priority === 0 (default)
     protected _zero: js.array.MutableForwardIterator<any>;
+    // components which priority < 0
     protected _neg: js.array.MutableForwardIterator<any>;
+    // components which priority > 0
     protected _pos: js.array.MutableForwardIterator<any>;
     protected _invoke: InvokeFunc;
     constructor (invokeFunc: InvokeFunc) {
         const Iterator = js.array.MutableForwardIterator;
-        // components which priority === 0 (default)
         this._zero = new Iterator([]);
-        // components which priority < 0
         this._neg = new Iterator([]);
-        // components which priority > 0
         this._pos = new Iterator([]);
 
         if (TEST) {

--- a/cocos/scene-graph/component-scheduler.ts
+++ b/cocos/scene-graph/component-scheduler.ts
@@ -94,19 +94,19 @@ export class LifeCycleInvoker {
     /**
      * @engineInternal `_zero` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalZero (): js.array.MutableForwardIterator<any> {
+    public get zero (): js.array.MutableForwardIterator<any> {
         return this._zero;
     }
     /**
      * @engineInternal `_neg` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalNeg (): js.array.MutableForwardIterator<any> {
+    public get neg (): js.array.MutableForwardIterator<any> {
         return this._neg;
     }
     /**
      * @engineInternal `_pos` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalPos (): js.array.MutableForwardIterator<any> {
+    public get pos (): js.array.MutableForwardIterator<any> {
         return this._pos;
     }
     // components which priority === 0 (default)
@@ -412,13 +412,13 @@ export class ComponentScheduler {
         }
 
         // unschedule
-        if (comp._internalStart && !(comp._objFlags & IsStartCalled)) {
+        if (comp.internalStart && !(comp._objFlags & IsStartCalled)) {
             this.startInvoker.remove(comp);
         }
-        if (comp._internalUpdate) {
+        if (comp.internalUpdate) {
             this.updateInvoker.remove(comp);
         }
-        if (comp._internalLateUpdate) {
+        if (comp.internalLateUpdate) {
             this.lateUpdateInvoker.remove(comp);
         }
     }
@@ -431,12 +431,12 @@ export class ComponentScheduler {
      */
     public enableComp (comp: Component, invoker?: OneOffInvoker): void {
         if (!(comp._objFlags & IsOnEnableCalled)) {
-            if (comp._internalOnEnable) {
+            if (comp.internalOnEnable) {
                 if (invoker) {
                     invoker.add(comp);
                     return;
                 } else {
-                    comp._internalOnEnable();
+                    comp.internalOnEnable();
 
                     const deactivatedDuringOnEnable = !comp.node.activeInHierarchy;
                     if (deactivatedDuringOnEnable) {
@@ -455,8 +455,8 @@ export class ComponentScheduler {
      */
     public disableComp (comp: Component): void {
         if (comp._objFlags & IsOnEnableCalled) {
-            if (comp._internalOnDisable) {
-                comp._internalOnDisable();
+            if (comp.internalOnDisable) {
+                comp.internalOnDisable();
             }
             this._onDisabled(comp);
         }
@@ -526,13 +526,13 @@ export class ComponentScheduler {
     }
 
     private _scheduleImmediate (comp: Component): void {
-        if (typeof comp._internalStart === 'function' && !(comp._objFlags & IsStartCalled)) {
+        if (typeof comp.internalStart === 'function' && !(comp._objFlags & IsStartCalled)) {
             this.startInvoker.add(comp);
         }
-        if (typeof comp._internalUpdate === 'function') {
+        if (typeof comp.internalUpdate === 'function') {
             this.updateInvoker.add(comp);
         }
-        if (typeof comp._internalLateUpdate === 'function') {
+        if (typeof comp.internalLateUpdate === 'function') {
             this.lateUpdateInvoker.add(comp);
         }
     }
@@ -551,7 +551,7 @@ if (EDITOR) {
         // NOTE: _executeInEditMode is dynamically injected on Editor environment
         if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (!(comp._objFlags & IsOnEnableCalled)) {
-                if (comp._internalOnEnable) {
+                if (comp.internalOnEnable) {
                     if (invoker) {
                         invoker.add(comp);
                         enableInEditor(comp);
@@ -575,7 +575,7 @@ if (EDITOR) {
         // NOTE: _executeInEditMode is dynamically injected on Editor environment
         if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (comp._objFlags & IsOnEnableCalled) {
-                if (comp._internalOnDisable) {
+                if (comp.internalOnDisable) {
                     callOnDisableInTryCatch(comp);
                 }
                 this._onDisabled(comp);

--- a/cocos/scene-graph/component-scheduler.ts
+++ b/cocos/scene-graph/component-scheduler.ts
@@ -94,19 +94,19 @@ export class LifeCycleInvoker {
     /**
      * @engineInternal `_zero` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_zero (): js.array.MutableForwardIterator<any> {
+    public get _internalZero (): js.array.MutableForwardIterator<any> {
         return this._zero;
     }
     /**
      * @engineInternal `_neg` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_neg (): js.array.MutableForwardIterator<any> {
+    public get _internalNeg (): js.array.MutableForwardIterator<any> {
         return this._neg;
     }
     /**
      * @engineInternal `_pos` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_pos (): js.array.MutableForwardIterator<any> {
+    public get _internalPos (): js.array.MutableForwardIterator<any> {
         return this._pos;
     }
     // components which priority === 0 (default)
@@ -412,13 +412,13 @@ export class ComponentScheduler {
         }
 
         // unschedule
-        if (comp._internal_start && !(comp._objFlags & IsStartCalled)) {
+        if (comp._internalStart && !(comp._objFlags & IsStartCalled)) {
             this.startInvoker.remove(comp);
         }
-        if (comp._internal_update) {
+        if (comp._internalUpdate) {
             this.updateInvoker.remove(comp);
         }
-        if (comp._internal_lateUpdate) {
+        if (comp._internalLateUpdate) {
             this.lateUpdateInvoker.remove(comp);
         }
     }
@@ -431,12 +431,12 @@ export class ComponentScheduler {
      */
     public enableComp (comp: Component, invoker?: OneOffInvoker): void {
         if (!(comp._objFlags & IsOnEnableCalled)) {
-            if (comp._internal_onEnable) {
+            if (comp._internalOnEnable) {
                 if (invoker) {
                     invoker.add(comp);
                     return;
                 } else {
-                    comp._internal_onEnable();
+                    comp._internalOnEnable();
 
                     const deactivatedDuringOnEnable = !comp.node.activeInHierarchy;
                     if (deactivatedDuringOnEnable) {
@@ -455,8 +455,8 @@ export class ComponentScheduler {
      */
     public disableComp (comp: Component): void {
         if (comp._objFlags & IsOnEnableCalled) {
-            if (comp._internal_onDisable) {
-                comp._internal_onDisable();
+            if (comp._internalOnDisable) {
+                comp._internalOnDisable();
             }
             this._onDisabled(comp);
         }
@@ -496,7 +496,7 @@ export class ComponentScheduler {
      * @zh 为当前注册的组件执行 update 阶段任务
      * @param dt @en Time passed after the last frame in seconds @zh 距离上一帧的时间，以秒计算
      */
-    public updatePhase (dt:number): void {
+    public updatePhase (dt: number): void {
         this.updateInvoker.invoke(dt);
     }
 
@@ -505,7 +505,7 @@ export class ComponentScheduler {
      * @zh 为当前注册的组件执行 late update 阶段任务
      * @param dt @en Time passed after the last frame in seconds @zh 距离上一帧的时间，以秒计算
      */
-    public lateUpdatePhase (dt:number): void {
+    public lateUpdatePhase (dt: number): void {
         this.lateUpdateInvoker.invoke(dt);
 
         // End of this frame
@@ -526,13 +526,13 @@ export class ComponentScheduler {
     }
 
     private _scheduleImmediate (comp: Component): void {
-        if (typeof comp._internal_start === 'function' && !(comp._objFlags & IsStartCalled)) {
+        if (typeof comp._internalStart === 'function' && !(comp._objFlags & IsStartCalled)) {
             this.startInvoker.add(comp);
         }
-        if (typeof comp._internal_update === 'function') {
+        if (typeof comp._internalUpdate === 'function') {
             this.updateInvoker.add(comp);
         }
-        if (typeof comp._internal_lateUpdate === 'function') {
+        if (typeof comp._internalLateUpdate === 'function') {
             this.lateUpdateInvoker.add(comp);
         }
     }
@@ -551,7 +551,7 @@ if (EDITOR) {
         // NOTE: _executeInEditMode is dynamically injected on Editor environment
         if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (!(comp._objFlags & IsOnEnableCalled)) {
-                if (comp._internal_onEnable) {
+                if (comp._internalOnEnable) {
                     if (invoker) {
                         invoker.add(comp);
                         enableInEditor(comp);
@@ -575,7 +575,7 @@ if (EDITOR) {
         // NOTE: _executeInEditMode is dynamically injected on Editor environment
         if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (comp._objFlags & IsOnEnableCalled) {
-                if (comp._internal_onDisable) {
+                if (comp._internalOnDisable) {
                     callOnDisableInTryCatch(comp);
                 }
                 this._onDisabled(comp);

--- a/cocos/scene-graph/component.ts
+++ b/cocos/scene-graph/component.ts
@@ -519,7 +519,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `update` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_update (): ((dt: number) => void) | undefined {
+    public get _internalUpdate (): ((dt: number) => void) | undefined {
         return this.update;
     }
 
@@ -536,7 +536,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `lateUpdate` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_lateUpdate (): ((dt: number) => void) | undefined {
+    public get _internalLateUpdate (): ((dt: number) => void) | undefined {
         return this.lateUpdate;
     }
 
@@ -556,7 +556,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `__preload` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_preload (): (() => void) | undefined {
+    public get _internalPreload (): (() => void) | undefined {
         return this.__preload;
     }
 
@@ -575,7 +575,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `onLoad` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_onLoad (): (() => void) | undefined {
+    public get _internalOnLoad (): (() => void) | undefined {
         return this.onLoad;
     }
 
@@ -594,7 +594,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `start` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_start(): (() => void) | undefined {
+    public get _internalStart (): (() => void) | undefined {
         return this.start;
     }
 
@@ -610,7 +610,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `onEnable` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_onEnable (): (() => void) | undefined {
+    public get _internalOnEnable (): (() => void) | undefined {
         return this.onEnable;
     }
 
@@ -626,7 +626,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `onDisable` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_onDisable (): (() => void) | undefined {
+    public get _internalOnDisable (): (() => void) | undefined {
         return this.onDisable;
     }
 
@@ -642,7 +642,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `onDestroy` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internal_onDestroy (): (() => void) | undefined {
+    public get _internalOnDestroy (): (() => void) | undefined {
         return this.onDestroy;
     }
 

--- a/cocos/scene-graph/component.ts
+++ b/cocos/scene-graph/component.ts
@@ -58,6 +58,16 @@ const NullNode = null as unknown as Node;
 class Component extends CCObject {
     public static EventHandler = EventHandler;
 
+    /**
+     * @engineInternal
+     */
+    public static _executionOrder: number = 0;
+
+    /**
+     * @engineInternal
+     */
+    public static _requireComponent: Constructor<Component> | null = null;
+
     get name (): string {
         if (this._name) {
             return this._name;
@@ -507,6 +517,13 @@ class Component extends CCObject {
     protected update? (dt: number): void;
 
     /**
+     * @engineInternal please access `update` instead.
+     */
+    public get _internal_update (): ((dt: number) => void) | undefined {
+        return this.update;
+    }
+
+    /**
      * @en LateUpdate is called every frame, if the Component is enabled.<br/>
      * This is a lifecycle method. It may not be implemented in the super class.<br/>
      * You can only call its super class method inside it. It should not be called manually elsewhere.
@@ -515,6 +532,13 @@ class Component extends CCObject {
      * @param dt - the delta time in seconds it took to complete the last frame
      */
     protected lateUpdate? (dt: number): void;
+
+    /**
+     * @engineInternal please access `lateUpdate` instead.
+     */
+    public get _internal_lateUpdate (): ((dt: number) => void) | undefined {
+        return this.lateUpdate;
+    }
 
     /**
      * @en `__preload` is called before every onLoad.<br/>
@@ -530,6 +554,13 @@ class Component extends CCObject {
     protected __preload? (): void;
 
     /**
+     * @engineInternal please access `__preload` instead.
+     */
+    public get _internal_preload (): (() => void) | undefined {
+        return this.__preload;
+    }
+
+    /**
      * @en
      * When attaching to an active node or its node first activated.<br/>
      * onLoad is always called before any start functions, this allows you to order initialization of scripts.<br/>
@@ -540,6 +571,13 @@ class Component extends CCObject {
      * 该方法为生命周期方法，父类未必会有实现。并且你只能在该方法内部调用父类的实现，不可在其它地方直接调用该方法。
      */
     protected onLoad? (): void;
+
+    /**
+     * @engineInternal please access `onLoad` instead.
+     */
+    public get _internal_onLoad (): (() => void) | undefined {
+        return this.onLoad;
+    }
 
     /**
      * @en
@@ -554,6 +592,13 @@ class Component extends CCObject {
     protected start? (): void;
 
     /**
+     * @engineInternal please access `start` instead.
+     */
+    public get _internal_start(): (() => void) | undefined {
+        return this.start;
+    }
+
+    /**
      * @en Called when this component becomes enabled and its node is active.<br/>
      * This is a lifecycle method. It may not be implemented in the super class.
      * You can only call its super class method inside it. It should not be called manually elsewhere.
@@ -561,6 +606,13 @@ class Component extends CCObject {
      * 该方法为生命周期方法，父类未必会有实现。并且你只能在该方法内部调用父类的实现，不可在其它地方直接调用该方法。
      */
     protected onEnable? (): void;
+
+    /**
+     * @engineInternal please access `onEnable` instead.
+     */
+    public get _internal_onEnable (): (() => void) | undefined {
+        return this.onEnable;
+    }
 
     /**
      * @en Called when this component becomes disabled or its node becomes inactive.<br/>
@@ -572,6 +624,13 @@ class Component extends CCObject {
     protected onDisable? (): void;
 
     /**
+     * @engineInternal please access `onDisable` instead.
+     */
+    public get _internal_onDisable (): (() => void) | undefined {
+        return this.onDisable;
+    }
+
+    /**
      * @en Called when this component will be destroyed.<br/>
      * This is a lifecycle method. It may not be implemented in the super class.<br/>
      * You can only call its super class method inside it. It should not be called manually elsewhere.
@@ -579,6 +638,13 @@ class Component extends CCObject {
      * 该方法为生命周期方法，父类未必会有实现。并且你只能在该方法内部调用父类的实现，不可在其它地方直接调用该方法。
      */
     protected onDestroy? (): void;
+
+    /**
+     * @engineInternal please access `onDestroy` instead.
+     */
+    public get _internal_onDestroy (): (() => void) | undefined {
+        return this.onDestroy;
+    }
 
     public onFocusInEditor? (): void;
 
@@ -589,7 +655,7 @@ class Component extends CCObject {
      * This function is only called in editor.<br/>
      * @zh 用来初始化组件或节点的一些属性，当该组件被第一次添加到节点上或用户点击了它的 Reset 菜单时调用。这个回调只会在编辑器下调用。
      */
-    public resetInEditor? (): void;
+    public resetInEditor? (didResetToDefault?: boolean): void;
 
     // VIRTUAL
 
@@ -648,25 +714,7 @@ class Component extends CCObject {
     protected onRestore? (): void;
 }
 
-// NOTE: here we access the protected properties in Component, so we need to mark it as type of any.
-const proto = Component.prototype as any;
-proto.update = undefined;
-proto.lateUpdate = undefined;
-proto.__preload = undefined;
-proto.onLoad = undefined;
-proto.start = undefined;
-proto.onEnable = undefined;
-proto.onDisable = undefined;
-proto.onDestroy = undefined;
-proto.onFocusInEditor = undefined;
-proto.onLostFocusInEditor = undefined;
-proto.resetInEditor = undefined;
-proto._getLocalBounds = undefined;
-proto.onRestore = undefined;
 // NOTE: these are all injected properties
-(Component as any)._requireComponent = null;
-(Component as any)._executionOrder = 0;
-
 if (EDITOR || TEST) {
     // INHERITABLE STATIC MEMBERS
     (Component as any)._executeInEditMode = false;

--- a/cocos/scene-graph/component.ts
+++ b/cocos/scene-graph/component.ts
@@ -517,7 +517,7 @@ class Component extends CCObject {
     protected update? (dt: number): void;
 
     /**
-     * @engineInternal please access `update` instead.
+     * @engineInternal `update` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_update (): ((dt: number) => void) | undefined {
         return this.update;
@@ -534,7 +534,7 @@ class Component extends CCObject {
     protected lateUpdate? (dt: number): void;
 
     /**
-     * @engineInternal please access `lateUpdate` instead.
+     * @engineInternal `lateUpdate` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_lateUpdate (): ((dt: number) => void) | undefined {
         return this.lateUpdate;
@@ -554,7 +554,7 @@ class Component extends CCObject {
     protected __preload? (): void;
 
     /**
-     * @engineInternal please access `__preload` instead.
+     * @engineInternal `__preload` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_preload (): (() => void) | undefined {
         return this.__preload;
@@ -573,7 +573,7 @@ class Component extends CCObject {
     protected onLoad? (): void;
 
     /**
-     * @engineInternal please access `onLoad` instead.
+     * @engineInternal `onLoad` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_onLoad (): (() => void) | undefined {
         return this.onLoad;
@@ -592,7 +592,7 @@ class Component extends CCObject {
     protected start? (): void;
 
     /**
-     * @engineInternal please access `start` instead.
+     * @engineInternal `start` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_start(): (() => void) | undefined {
         return this.start;
@@ -608,7 +608,7 @@ class Component extends CCObject {
     protected onEnable? (): void;
 
     /**
-     * @engineInternal please access `onEnable` instead.
+     * @engineInternal `onEnable` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_onEnable (): (() => void) | undefined {
         return this.onEnable;
@@ -624,7 +624,7 @@ class Component extends CCObject {
     protected onDisable? (): void;
 
     /**
-     * @engineInternal please access `onDisable` instead.
+     * @engineInternal `onDisable` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_onDisable (): (() => void) | undefined {
         return this.onDisable;
@@ -640,7 +640,7 @@ class Component extends CCObject {
     protected onDestroy? (): void;
 
     /**
-     * @engineInternal please access `onDestroy` instead.
+     * @engineInternal `onDestroy` is a protected property, we provide this public property for engine internal usage.
      */
     public get _internal_onDestroy (): (() => void) | undefined {
         return this.onDestroy;

--- a/cocos/scene-graph/component.ts
+++ b/cocos/scene-graph/component.ts
@@ -519,7 +519,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `update` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalUpdate (): ((dt: number) => void) | undefined {
+    public get internalUpdate (): ((dt: number) => void) | undefined {
         return this.update;
     }
 
@@ -536,7 +536,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `lateUpdate` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalLateUpdate (): ((dt: number) => void) | undefined {
+    public get internalLateUpdate (): ((dt: number) => void) | undefined {
         return this.lateUpdate;
     }
 
@@ -556,7 +556,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `__preload` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalPreload (): (() => void) | undefined {
+    public get internalPreload (): (() => void) | undefined {
         return this.__preload;
     }
 
@@ -575,7 +575,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `onLoad` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalOnLoad (): (() => void) | undefined {
+    public get internalOnLoad (): (() => void) | undefined {
         return this.onLoad;
     }
 
@@ -594,7 +594,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `start` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalStart (): (() => void) | undefined {
+    public get internalStart (): (() => void) | undefined {
         return this.start;
     }
 
@@ -610,7 +610,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `onEnable` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalOnEnable (): (() => void) | undefined {
+    public get internalOnEnable (): (() => void) | undefined {
         return this.onEnable;
     }
 
@@ -626,7 +626,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `onDisable` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalOnDisable (): (() => void) | undefined {
+    public get internalOnDisable (): (() => void) | undefined {
         return this.onDisable;
     }
 
@@ -642,7 +642,7 @@ class Component extends CCObject {
     /**
      * @engineInternal `onDestroy` is a protected property, we provide this public property for engine internal usage.
      */
-    public get _internalOnDestroy (): (() => void) | undefined {
+    public get internalOnDestroy (): (() => void) | undefined {
         return this.onDestroy;
     }
 

--- a/cocos/scene-graph/node-activator.ts
+++ b/cocos/scene-graph/node-activator.ts
@@ -356,7 +356,8 @@ if (EDITOR) {
             // destroyed before activating
             return;
         }
-        if (legacyCC.GAME_VIEW || comp.constructor._executeInEditMode) {
+        // NOTE: _executeInEditMode is dynamically injected on Editor environment
+        if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (!(comp._objFlags & IsPreloadStarted)) {
                 comp._objFlags |= IsPreloadStarted;
                 if (comp._internal_preload) {
@@ -398,7 +399,8 @@ if (EDITOR) {
         legacyCC.director._compScheduler.disableComp(comp);
 
         if (comp._internal_onDestroy && (comp._objFlags & IsOnLoadCalled)) {
-            if (legacyCC.GAME_VIEW || comp.constructor._executeInEditMode) {
+            // NOTE: _executeInEditMode is dynamically injected on Editor environment
+            if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
                 callOnDestroyInTryCatch && callOnDestroyInTryCatch(comp);
             }
         }

--- a/cocos/scene-graph/node-activator.ts
+++ b/cocos/scene-graph/node-activator.ts
@@ -61,25 +61,25 @@ class UnsortedInvoker extends LifeCycleInvoker {
 
 const invokePreload = SUPPORT_JIT ? createInvokeImplJit('c.__preload();')
     : createInvokeImpl(
-        (c: Component): void => { c._internalPreload?.(); },
+        (c: Component): void => { c.internalPreload?.(); },
         (iterator: array.MutableForwardIterator<Component>): void => {
             const array = iterator.array;
             for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
-                array[iterator.i]._internalPreload?.();
+                array[iterator.i].internalPreload?.();
             }
         },
     );
 const invokeOnLoad = SUPPORT_JIT ? createInvokeImplJit(`c.onLoad();c._objFlags|=${IsOnLoadCalled}`, false, IsOnLoadCalled)
     : createInvokeImpl(
         (c: Component): void => {
-            c._internalOnLoad?.();
+            c.internalOnLoad?.();
             c._objFlags |= IsOnLoadCalled;
         },
         (iterator: array.MutableForwardIterator<Component>): void => {
             const array = iterator.array;
             for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
                 const comp: Component = array[iterator.i];
-                comp._internalOnLoad?.();
+                comp.internalOnLoad?.();
                 comp._objFlags |= IsOnLoadCalled;
             }
         },
@@ -101,15 +101,15 @@ activateTasksPool.get = function getActivateTask (): ActivateTask {
     };
 
     // reset index to -1 so we can skip invoked component in cancelInactive
-    task.preload._internalZero.i = -1;
+    task.preload.zero.i = -1;
     let invoker = task.onLoad;
-    invoker._internalZero.i = -1;
-    invoker._internalNeg.i = -1;
-    invoker._internalPos.i = -1;
+    invoker.zero.i = -1;
+    invoker.neg.i = -1;
+    invoker.pos.i = -1;
     invoker = task.onEnable;
-    invoker._internalZero.i = -1;
-    invoker._internalNeg.i = -1;
-    invoker._internalPos.i = -1;
+    invoker.zero.i = -1;
+    invoker.neg.i = -1;
+    invoker.pos.i = -1;
 
     return task;
 };
@@ -195,21 +195,21 @@ export default class NodeActivator {
         }
         if (!(comp._objFlags & IsPreloadStarted)) {
             comp._objFlags |= IsPreloadStarted;
-            if (comp._internalPreload) {
+            if (comp.internalPreload) {
                 if (preloadInvoker) {
                     preloadInvoker.add(comp);
                 } else {
-                    comp._internalPreload();
+                    comp.internalPreload();
                 }
             }
         }
         if (!(comp._objFlags & IsOnLoadStarted)) {
             comp._objFlags |= IsOnLoadStarted;
-            if (comp._internalOnLoad) {
+            if (comp.internalOnLoad) {
                 if (onLoadInvoker) {
                     onLoadInvoker.add(comp);
                 } else {
-                    comp._internalOnLoad();
+                    comp.internalOnLoad();
                     comp._objFlags |= IsOnLoadCalled;
                 }
             } else {
@@ -237,8 +237,8 @@ export default class NodeActivator {
         // ensure onDisable called
         legacyCC.director._compScheduler.disableComp(comp);
 
-        if (comp._internalOnDestroy && (comp._objFlags & IsOnLoadCalled)) {
-            comp._internalOnDestroy();
+        if (comp.internalOnDestroy && (comp._objFlags & IsOnLoadCalled)) {
+            comp.internalOnDestroy();
         }
     }
 
@@ -327,7 +327,7 @@ if (EDITOR) {
     const callPreloadInTryCatch = tryCatchFunctor_EDITOR('__preload');
     const callOnLoadInTryCatch = function (c: Component): void {
         try {
-            c._internalOnLoad?.();
+            c.internalOnLoad?.();
         } catch (e) {
             legacyCC._throw(e);
         }
@@ -339,7 +339,7 @@ if (EDITOR) {
     const callOnLostFocusInTryCatch = tryCatchFunctor_EDITOR('onLostFocusInEditor');
 
     const _onLoadInEditor = (comp: Component): void => {
-        if (comp._internalOnLoad && !legacyCC.GAME_VIEW) {
+        if (comp.internalOnLoad && !legacyCC.GAME_VIEW) {
             const focused = Editor.Selection.getLastSelected('node') === comp.node.uuid;
             if (focused) {
                 if (comp.onFocusInEditor && callOnFocusInTryCatch) {
@@ -360,7 +360,7 @@ if (EDITOR) {
         if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (!(comp._objFlags & IsPreloadStarted)) {
                 comp._objFlags |= IsPreloadStarted;
-                if (comp._internalPreload) {
+                if (comp.internalPreload) {
                     if (preloadInvoker) {
                         preloadInvoker.add(comp);
                     } else if (callPreloadInTryCatch) {
@@ -370,7 +370,7 @@ if (EDITOR) {
             }
             if (!(comp._objFlags & IsOnLoadStarted)) {
                 comp._objFlags |= IsOnLoadStarted;
-                if (comp._internalOnLoad) {
+                if (comp.internalOnLoad) {
                     if (onLoadInvoker) {
                         onLoadInvoker.add(comp);
                     } else if (callOnLoadInTryCatch) {
@@ -398,7 +398,7 @@ if (EDITOR) {
         // ensure onDisable called
         legacyCC.director._compScheduler.disableComp(comp);
 
-        if (comp._internalOnDestroy && (comp._objFlags & IsOnLoadCalled)) {
+        if (comp.internalOnDestroy && (comp._objFlags & IsOnLoadCalled)) {
             // NOTE: _executeInEditMode is dynamically injected on Editor environment
             if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
                 callOnDestroyInTryCatch && callOnDestroyInTryCatch(comp);

--- a/cocos/scene-graph/node-activator.ts
+++ b/cocos/scene-graph/node-activator.ts
@@ -31,37 +31,26 @@ import { legacyCC } from '../core/global-exports';
 import { assert, errorID, getError } from '../core/platform/debug';
 import { NodeEventType } from './node-event';
 import { assertIsTrue } from '../core/data/utils/asserts';
+import type { Component } from './component';
+import type { Node } from './node';
 
 const MAX_POOL_SIZE = 4;
 
 const IsPreloadStarted = CCObject.Flags.IsPreloadStarted;
 const IsOnLoadStarted = CCObject.Flags.IsOnLoadStarted;
 const IsOnLoadCalled = CCObject.Flags.IsOnLoadCalled;
+const IsOnEnableCalled = CCObject.Flags.IsOnEnableCalled;
 const Deactivating = CCObject.Flags.Deactivating;
-
-const callPreloadInTryCatch: any = EDITOR && tryCatchFunctor_EDITOR('__preload');
-const callOnLoadInTryCatch: any = EDITOR && function (c): void {
-    try {
-        c.onLoad();
-    } catch (e) {
-        legacyCC._throw(e);
-    }
-    c._objFlags |= IsOnLoadCalled;
-    _onLoadInEditor(c);
-};
-const callOnDestroyInTryCatch: any = EDITOR && tryCatchFunctor_EDITOR('onDestroy');
-const callOnFocusInTryCatch: any = EDITOR && tryCatchFunctor_EDITOR('onFocusInEditor');
-const callOnLostFocusInTryCatch: any = EDITOR && tryCatchFunctor_EDITOR('onLostFocusInEditor');
 
 // for __preload: used internally, no sort
 class UnsortedInvoker extends LifeCycleInvoker {
-    public add (comp): void {
+    public add (comp: Component): void {
         this._zero.array.push(comp);
     }
-    public remove (comp): void {
+    public remove (comp: Component): void {
         this._zero.fastRemove(comp);
     }
-    public cancelInactive (flagToClear): void {
+    public cancelInactive (flagToClear: number): void {
         LifeCycleInvoker.stableRemoveInactive(this._zero, flagToClear);
     }
     public invoke (): void {
@@ -72,73 +61,66 @@ class UnsortedInvoker extends LifeCycleInvoker {
 
 const invokePreload = SUPPORT_JIT ? createInvokeImplJit('c.__preload();')
     : createInvokeImpl(
-        (c): void => { c.__preload(); },
-        (iterator): void => {
+        (c: Component): void => { c._internal_preload?.(); },
+        (iterator: array.MutableForwardIterator<Component>): void => {
             const array = iterator.array;
             for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
-                array[iterator.i].__preload();
+                array[iterator.i]._internal_preload?.();
             }
         },
     );
 const invokeOnLoad = SUPPORT_JIT ? createInvokeImplJit(`c.onLoad();c._objFlags|=${IsOnLoadCalled}`, false, IsOnLoadCalled)
     : createInvokeImpl(
-        (c): void => {
-            c.onLoad();
+        (c: Component): void => {
+            c._internal_onLoad?.();
             c._objFlags |= IsOnLoadCalled;
         },
-        (iterator): void => {
+        (iterator: array.MutableForwardIterator<Component>): void => {
             const array = iterator.array;
             for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
-                const comp = array[iterator.i];
-                comp.onLoad();
+                const comp: Component = array[iterator.i];
+                comp._internal_onLoad?.();
                 comp._objFlags |= IsOnLoadCalled;
             }
         },
         IsOnLoadCalled,
     );
 
-const activateTasksPool = new Pool(MAX_POOL_SIZE);
-activateTasksPool.get = function getActivateTask (): any {
-    const task: any = this._get() || {
+interface ActivateTask {
+    preload: UnsortedInvoker;
+    onLoad: OneOffInvoker;
+    onEnable: OneOffInvoker;
+}
+
+const activateTasksPool = new Pool<ActivateTask>(MAX_POOL_SIZE);
+activateTasksPool.get = function getActivateTask (): ActivateTask {
+    const task = this._get() || {
         preload: new UnsortedInvoker(invokePreload),
         onLoad: new OneOffInvoker(invokeOnLoad),
         onEnable: new OneOffInvoker(invokeOnEnable),
     };
 
     // reset index to -1 so we can skip invoked component in cancelInactive
-    task.preload._zero.i = -1;
+    task.preload._internal_zero.i = -1;
     let invoker = task.onLoad;
-    invoker._zero.i = -1;
-    invoker._neg.i = -1;
-    invoker._pos.i = -1;
+    invoker._internal_zero.i = -1;
+    invoker._internal_neg.i = -1;
+    invoker._internal_pos.i = -1;
     invoker = task.onEnable;
-    invoker._zero.i = -1;
-    invoker._neg.i = -1;
-    invoker._pos.i = -1;
+    invoker._internal_zero.i = -1;
+    invoker._internal_neg.i = -1;
+    invoker._internal_pos.i = -1;
 
     return task;
 };
 
-function _componentCorrupted (node, comp, index): void {
+function _componentCorrupted (node: Node, comp: Component, index: number): void {
     errorID(3817, node.name, index);
     console.log('Corrupted component value:', comp);
     if (comp) {
         node._removeComponent(comp);
     } else {
-        array.removeAt(node._components, index);
-    }
-}
-
-function _onLoadInEditor (comp): void {
-    if (comp.onLoad && !legacyCC.GAME_VIEW) {
-        const focused = Editor.Selection.getLastSelected('node') === comp.node.uuid;
-        if (focused) {
-            if (comp.onFocusInEditor && callOnFocusInTryCatch) {
-                callOnFocusInTryCatch(comp);
-            }
-        } else if (comp.onLostFocusInEditor && callOnLostFocusInTryCatch) {
-            callOnLostFocusInTryCatch(comp);
-        }
+        array.removeAt(node.getWritableComponents(), index);
     }
 }
 
@@ -147,8 +129,8 @@ function _onLoadInEditor (comp): void {
  * @zh 用于执行节点和组件的激活和停用操作的管理器。
  */
 export default class NodeActivator {
-    public resetComp: any;
-    protected _activatingStack!: any[];
+    public resetComp?: ((comp: Component, didResetToDefault: boolean) => void);
+    protected _activatingStack!: ActivateTask[];
 
     constructor () {
         this.reset();
@@ -169,18 +151,20 @@ export default class NodeActivator {
      * @param node Target node
      * @param active Which state to set the node to
      */
-    public activateNode (node, active): void {
+    public activateNode (node: Node, active: boolean): void {
         if (active) {
-            const task: any = activateTasksPool.get();
-            this._activatingStack.push(task);
+            const task = activateTasksPool.get();
+            if (task) {
+                this._activatingStack.push(task);
 
-            this._activateNodeRecursively(node, task.preload, task.onLoad, task.onEnable);
-            task.preload.invoke();
-            task.onLoad.invoke();
-            task.onEnable.invoke();
+                this._activateNodeRecursively(node, task.preload, task.onLoad, task.onEnable);
+                task.preload.invoke();
+                task.onLoad.invoke();
+                task.onEnable.invoke();
 
-            this._activatingStack.pop();
-            activateTasksPool.put(task);
+                this._activatingStack.pop();
+                activateTasksPool.put(task);
+            }
         } else {
             this._deactivateNodeRecursively(node);
 
@@ -190,7 +174,7 @@ export default class NodeActivator {
             for (const lastTask of stack) {
                 lastTask.preload.cancelInactive(IsPreloadStarted);
                 lastTask.onLoad.cancelInactive(IsOnLoadStarted);
-                lastTask.onEnable.cancelInactive();
+                lastTask.onEnable.cancelInactive(IsOnEnableCalled);
             }
         }
         node.emit(NodeEventType.ACTIVE_IN_HIERARCHY_CHANGED, node);
@@ -204,28 +188,28 @@ export default class NodeActivator {
      * @param onLoadInvoker The invoker for `onLoad` method, normally from [[ComponentScheduler]]
      * @param onEnableInvoker The invoker for `onEnable` method, normally from [[ComponentScheduler]]
      */
-    public activateComp (comp, preloadInvoker?, onLoadInvoker?, onEnableInvoker?): void {
+    public activateComp (comp: Component, preloadInvoker?: UnsortedInvoker, onLoadInvoker?: OneOffInvoker, onEnableInvoker?: OneOffInvoker): void {
         if (!isValid(comp, true)) {
             // destroyed before activating
             return;
         }
         if (!(comp._objFlags & IsPreloadStarted)) {
             comp._objFlags |= IsPreloadStarted;
-            if (comp.__preload) {
+            if (comp._internal_preload) {
                 if (preloadInvoker) {
                     preloadInvoker.add(comp);
                 } else {
-                    comp.__preload();
+                    comp._internal_preload();
                 }
             }
         }
         if (!(comp._objFlags & IsOnLoadStarted)) {
             comp._objFlags |= IsOnLoadStarted;
-            if (comp.onLoad) {
+            if (comp._internal_onLoad) {
                 if (onLoadInvoker) {
                     onLoadInvoker.add(comp);
                 } else {
-                    comp.onLoad();
+                    comp._internal_onLoad();
                     comp._objFlags |= IsOnLoadCalled;
                 }
             } else {
@@ -236,7 +220,7 @@ export default class NodeActivator {
             if (DEBUG) {
                 assertIsTrue(comp.node, getError(3823, comp.uuid, comp.name));
             }
-            const deactivatedOnLoading = !comp.node._activeInHierarchy;
+            const deactivatedOnLoading = !comp.node.activeInHierarchy;
             if (deactivatedOnLoading) {
                 return;
             }
@@ -249,16 +233,16 @@ export default class NodeActivator {
      * @zh 销毁一个组件
      * @param comp Target component
      */
-    public destroyComp (comp): void {
+    public destroyComp (comp: Component): void {
         // ensure onDisable called
         legacyCC.director._compScheduler.disableComp(comp);
 
-        if (comp.onDestroy && (comp._objFlags & IsOnLoadCalled)) {
-            comp.onDestroy();
+        if (comp._internal_onDestroy && (comp._objFlags & IsOnLoadCalled)) {
+            comp._internal_onDestroy();
         }
     }
 
-    protected _activateNodeRecursively (node, preloadInvoker, onLoadInvoker, onEnableInvoker): void {
+    protected _activateNodeRecursively (node: Node, preloadInvoker: UnsortedInvoker, onLoadInvoker: OneOffInvoker, onEnableInvoker: OneOffInvoker): void {
         if (node._objFlags & Deactivating) {
             // en:
             // Forbid reactive the same node during its deactivating procedure
@@ -270,14 +254,14 @@ export default class NodeActivator {
             return;
         }
 
-        node._activeInHierarchy = true;
+        node._setActiveInHierarchy(true);
 
         // component maybe added during onEnable, and the onEnable of new component is already called
         // so we should record the origin length
-        let originCount = node._components.length;
+        let originCount = node.components.length;
         // activate components
         for (let i = 0; i < originCount; ++i) {
-            const component = node._components[i];
+            const component = node.components[i];
             if (component instanceof legacyCC.Component) {
                 this.activateComp(component, preloadInvoker, onLoadInvoker, onEnableInvoker);
             } else {
@@ -288,45 +272,45 @@ export default class NodeActivator {
         }
 
         // activate children recursively
-        for (let i = 0, len = node._children.length; i < len; ++i) {
-            const child = node._children[i];
-            if (child._active) {
+        for (let i = 0, len = node.children.length; i < len; ++i) {
+            const child = node.children[i];
+            if (child.active) {
                 this._activateNodeRecursively(child, preloadInvoker, onLoadInvoker, onEnableInvoker);
             }
         }
         node._onPostActivated(true);
     }
 
-    protected _deactivateNodeRecursively (node): void {
+    protected _deactivateNodeRecursively (node: Node): void {
         if (DEV) {
             assert(!(node._objFlags & Deactivating), 'node should not deactivating');
             // ensures _activeInHierarchy is always changing when Deactivating flagged
-            assert(node._activeInHierarchy, 'node should not deactivated');
+            assert(node.activeInHierarchy, 'node should not deactivated');
         }
         node._objFlags |= Deactivating;
-        node._activeInHierarchy = false;
+        node._setActiveInHierarchy(false);
 
         // component maybe added during onEnable, and the onEnable of new component is already called
         // so we should record the origin length
-        const originCount = node._components.length;
+        const originCount = node.components.length;
         for (let c = 0; c < originCount; ++c) {
-            const component = node._components[c];
+            const component = node.components[c];
             if (component._enabled) {
                 legacyCC.director._compScheduler.disableComp(component);
 
-                if (node._activeInHierarchy) {
+                if (node.activeInHierarchy) {
                     // reactivated from root
                     node._objFlags &= ~Deactivating;
                     return;
                 }
             }
         }
-        for (let i = 0, len = node._children.length; i < len; ++i) {
-            const child = node._children[i];
-            if (child._activeInHierarchy) {
+        for (let i = 0, len = node.children.length; i < len; ++i) {
+            const child = node.children[i];
+            if (child.activeInHierarchy) {
                 this._deactivateNodeRecursively(child);
 
-                if (node._activeInHierarchy) {
+                if (node.activeInHierarchy) {
                     // reactivated from root
                     node._objFlags &= ~Deactivating;
                     return;
@@ -340,7 +324,34 @@ export default class NodeActivator {
 }
 
 if (EDITOR) {
-    NodeActivator.prototype.activateComp = (comp, preloadInvoker, onLoadInvoker, onEnableInvoker): void => {
+    const callPreloadInTryCatch = tryCatchFunctor_EDITOR('__preload');
+    const callOnLoadInTryCatch = function (c: Component): void {
+        try {
+            c._internal_onLoad?.();
+        } catch (e) {
+            legacyCC._throw(e);
+        }
+        c._objFlags |= IsOnLoadCalled;
+        _onLoadInEditor(c);
+    };
+    const callOnDestroyInTryCatch = tryCatchFunctor_EDITOR('onDestroy');
+    const callOnFocusInTryCatch = tryCatchFunctor_EDITOR('onFocusInEditor');
+    const callOnLostFocusInTryCatch = tryCatchFunctor_EDITOR('onLostFocusInEditor');
+
+    const _onLoadInEditor = (comp: Component): void => {
+        if (comp._internal_onLoad && !legacyCC.GAME_VIEW) {
+            const focused = Editor.Selection.getLastSelected('node') === comp.node.uuid;
+            if (focused) {
+                if (comp.onFocusInEditor && callOnFocusInTryCatch) {
+                    callOnFocusInTryCatch(comp);
+                }
+            } else if (comp.onLostFocusInEditor && callOnLostFocusInTryCatch) {
+                callOnLostFocusInTryCatch(comp);
+            }
+        }
+    };
+
+    NodeActivator.prototype.activateComp = (comp: Component, preloadInvoker: UnsortedInvoker, onLoadInvoker: OneOffInvoker, onEnableInvoker: OneOffInvoker): void => {
         if (!isValid(comp, true)) {
             // destroyed before activating
             return;
@@ -348,7 +359,7 @@ if (EDITOR) {
         if (legacyCC.GAME_VIEW || comp.constructor._executeInEditMode) {
             if (!(comp._objFlags & IsPreloadStarted)) {
                 comp._objFlags |= IsPreloadStarted;
-                if (comp.__preload) {
+                if (comp._internal_preload) {
                     if (preloadInvoker) {
                         preloadInvoker.add(comp);
                     } else if (callPreloadInTryCatch) {
@@ -358,7 +369,7 @@ if (EDITOR) {
             }
             if (!(comp._objFlags & IsOnLoadStarted)) {
                 comp._objFlags |= IsOnLoadStarted;
-                if (comp.onLoad) {
+                if (comp._internal_onLoad) {
                     if (onLoadInvoker) {
                         onLoadInvoker.add(comp);
                     } else if (callOnLoadInTryCatch) {
@@ -374,7 +385,7 @@ if (EDITOR) {
             if (DEBUG) {
                 assertIsTrue(comp.node, getError(3823, comp.uuid, comp.name));
             }
-            const deactivatedOnLoading = !comp.node._activeInHierarchy;
+            const deactivatedOnLoading = !comp.node.activeInHierarchy;
             if (deactivatedOnLoading) {
                 return;
             }
@@ -382,18 +393,18 @@ if (EDITOR) {
         }
     };
 
-    NodeActivator.prototype.destroyComp = (comp): void => {
+    NodeActivator.prototype.destroyComp = (comp: Component): void => {
         // ensure onDisable called
         legacyCC.director._compScheduler.disableComp(comp);
 
-        if (comp.onDestroy && (comp._objFlags & IsOnLoadCalled)) {
+        if (comp._internal_onDestroy && (comp._objFlags & IsOnLoadCalled)) {
             if (legacyCC.GAME_VIEW || comp.constructor._executeInEditMode) {
                 callOnDestroyInTryCatch && callOnDestroyInTryCatch(comp);
             }
         }
     };
 
-    NodeActivator.prototype.resetComp = (comp, didResetToDefault: boolean): void => {
+    NodeActivator.prototype.resetComp = (comp: Component, didResetToDefault: boolean): void => {
         if (comp.resetInEditor) {
             try {
                 comp.resetInEditor(didResetToDefault);

--- a/cocos/scene-graph/node-activator.ts
+++ b/cocos/scene-graph/node-activator.ts
@@ -61,25 +61,25 @@ class UnsortedInvoker extends LifeCycleInvoker {
 
 const invokePreload = SUPPORT_JIT ? createInvokeImplJit('c.__preload();')
     : createInvokeImpl(
-        (c: Component): void => { c._internal_preload?.(); },
+        (c: Component): void => { c._internalPreload?.(); },
         (iterator: array.MutableForwardIterator<Component>): void => {
             const array = iterator.array;
             for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
-                array[iterator.i]._internal_preload?.();
+                array[iterator.i]._internalPreload?.();
             }
         },
     );
 const invokeOnLoad = SUPPORT_JIT ? createInvokeImplJit(`c.onLoad();c._objFlags|=${IsOnLoadCalled}`, false, IsOnLoadCalled)
     : createInvokeImpl(
         (c: Component): void => {
-            c._internal_onLoad?.();
+            c._internalOnLoad?.();
             c._objFlags |= IsOnLoadCalled;
         },
         (iterator: array.MutableForwardIterator<Component>): void => {
             const array = iterator.array;
             for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
                 const comp: Component = array[iterator.i];
-                comp._internal_onLoad?.();
+                comp._internalOnLoad?.();
                 comp._objFlags |= IsOnLoadCalled;
             }
         },
@@ -101,15 +101,15 @@ activateTasksPool.get = function getActivateTask (): ActivateTask {
     };
 
     // reset index to -1 so we can skip invoked component in cancelInactive
-    task.preload._internal_zero.i = -1;
+    task.preload._internalZero.i = -1;
     let invoker = task.onLoad;
-    invoker._internal_zero.i = -1;
-    invoker._internal_neg.i = -1;
-    invoker._internal_pos.i = -1;
+    invoker._internalZero.i = -1;
+    invoker._internalNeg.i = -1;
+    invoker._internalPos.i = -1;
     invoker = task.onEnable;
-    invoker._internal_zero.i = -1;
-    invoker._internal_neg.i = -1;
-    invoker._internal_pos.i = -1;
+    invoker._internalZero.i = -1;
+    invoker._internalNeg.i = -1;
+    invoker._internalPos.i = -1;
 
     return task;
 };
@@ -195,21 +195,21 @@ export default class NodeActivator {
         }
         if (!(comp._objFlags & IsPreloadStarted)) {
             comp._objFlags |= IsPreloadStarted;
-            if (comp._internal_preload) {
+            if (comp._internalPreload) {
                 if (preloadInvoker) {
                     preloadInvoker.add(comp);
                 } else {
-                    comp._internal_preload();
+                    comp._internalPreload();
                 }
             }
         }
         if (!(comp._objFlags & IsOnLoadStarted)) {
             comp._objFlags |= IsOnLoadStarted;
-            if (comp._internal_onLoad) {
+            if (comp._internalOnLoad) {
                 if (onLoadInvoker) {
                     onLoadInvoker.add(comp);
                 } else {
-                    comp._internal_onLoad();
+                    comp._internalOnLoad();
                     comp._objFlags |= IsOnLoadCalled;
                 }
             } else {
@@ -237,8 +237,8 @@ export default class NodeActivator {
         // ensure onDisable called
         legacyCC.director._compScheduler.disableComp(comp);
 
-        if (comp._internal_onDestroy && (comp._objFlags & IsOnLoadCalled)) {
-            comp._internal_onDestroy();
+        if (comp._internalOnDestroy && (comp._objFlags & IsOnLoadCalled)) {
+            comp._internalOnDestroy();
         }
     }
 
@@ -327,7 +327,7 @@ if (EDITOR) {
     const callPreloadInTryCatch = tryCatchFunctor_EDITOR('__preload');
     const callOnLoadInTryCatch = function (c: Component): void {
         try {
-            c._internal_onLoad?.();
+            c._internalOnLoad?.();
         } catch (e) {
             legacyCC._throw(e);
         }
@@ -339,7 +339,7 @@ if (EDITOR) {
     const callOnLostFocusInTryCatch = tryCatchFunctor_EDITOR('onLostFocusInEditor');
 
     const _onLoadInEditor = (comp: Component): void => {
-        if (comp._internal_onLoad && !legacyCC.GAME_VIEW) {
+        if (comp._internalOnLoad && !legacyCC.GAME_VIEW) {
             const focused = Editor.Selection.getLastSelected('node') === comp.node.uuid;
             if (focused) {
                 if (comp.onFocusInEditor && callOnFocusInTryCatch) {
@@ -360,7 +360,7 @@ if (EDITOR) {
         if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
             if (!(comp._objFlags & IsPreloadStarted)) {
                 comp._objFlags |= IsPreloadStarted;
-                if (comp._internal_preload) {
+                if (comp._internalPreload) {
                     if (preloadInvoker) {
                         preloadInvoker.add(comp);
                     } else if (callPreloadInTryCatch) {
@@ -370,7 +370,7 @@ if (EDITOR) {
             }
             if (!(comp._objFlags & IsOnLoadStarted)) {
                 comp._objFlags |= IsOnLoadStarted;
-                if (comp._internal_onLoad) {
+                if (comp._internalOnLoad) {
                     if (onLoadInvoker) {
                         onLoadInvoker.add(comp);
                     } else if (callOnLoadInTryCatch) {
@@ -398,7 +398,7 @@ if (EDITOR) {
         // ensure onDisable called
         legacyCC.director._compScheduler.disableComp(comp);
 
-        if (comp._internal_onDestroy && (comp._objFlags & IsOnLoadCalled)) {
+        if (comp._internalOnDestroy && (comp._objFlags & IsOnLoadCalled)) {
             // NOTE: _executeInEditMode is dynamically injected on Editor environment
             if (legacyCC.GAME_VIEW || (comp.constructor as any)._executeInEditMode) {
                 callOnDestroyInTryCatch && callOnDestroyInTryCatch(comp);

--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -346,7 +346,9 @@ nodeProto.resumeSystemEvents = function resumeSystemEvents(recursive: boolean): 
     this._eventProcessor.setEnabled(true, recursive);
 };
 
-nodeProto.getWritableComponents = function (this: JsbNode) { return this._components; }
+nodeProto.getWritableComponents = function (this: JsbNode) { return this._components; };
+
+nodeProto._setActiveInHierarchy = function (this: JsbNode, v: boolean) { return this._activeInHierarchy = v; };
 
 nodeProto._removeComponent = function (component: Component) {
     if (!component) {

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -197,6 +197,13 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
     }
 
     /**
+     * @engineInternal please don't use this method.
+     */
+    public _setActiveInHierarchy (v: boolean): void {
+        this._activeInHierarchy = v;
+    }
+
+    /**
      * @en Indicates whether this node is active in the scene.
      * @zh 表示此节点是否在场景中激活。
      */


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16413

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
