### PR TITLE
[3.8.0] improve: rendering logic of effect select options

### DIFF
--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -8,49 +8,61 @@ const effectGroupNameRE = /^db:\/\/(\w+)\//i; // match root DB name
 const effectDirRE = /^effects\//i;
 
 /**
+ * @param {string} label
+ */
+function formatOptionLabel(label) {
+    // 1. remove group name if matched
+    // 2. remove prefix 'effects'(after 'db://' prefix removed)
+    return label.replace(effectGroupNameRE, '').replace(effectDirRE, '');
+}
+
+/**
  * 
- * @param {{name: string; uuid: string; assetPath: string}[]} sortedEffects 
+ * @param {{name: string; uuid: string; assetPath: string}[]} effects 
  * @returns html template
  */
-function renderGroupEffectOptions(sortedEffects) {
-    const groupNames = new Set();
+function renderGroupEffectOptions(effects) {
+    // group effects by group name, and no longer rely on the ordering of the input `effects`.
+    const groups = {};
 
-    let htmlTemplate = '';
-    let currGroup = '';
+    /**
+     * ungrouped options. html template string.
+     * @type {string[]} 
+     */
+    const extras = [];
 
-    for (const effect of sortedEffects) {
+    for (const effect of effects) {
         const groupName = effectGroupNameRE.exec(effect.assetPath)?.[1] ?? '';
-        let optionLabel = effect.assetPath;
 
         if (groupName !== '') {
-            // complete prev group
-            if (currGroup !== '' && currGroup !== groupName) {
-                htmlTemplate += '</optgroup>';
+            let group = groups[groupName];
+            // group not found yet, init it
+            if (!Array.isArray(group)) {
+                group = [];
+                groups[groupName] = group;
             }
 
-            if (!groupNames.has(groupName)) {
-                groupNames.add(groupName);
+            const label = formatOptionLabel(effect.assetPath);
 
-                currGroup = groupName;
+            group.push(`<option value="${effect.name}" data-uuid="${effect.uuid}">${label}</option>`);
 
-                htmlTemplate += `<optgroup label="${groupName}">`;
-            }
-
-            // for option label, remove group name if matched
-            optionLabel = optionLabel.replace(effectGroupNameRE, '');
+            continue;
         }
 
-        // remove prefix 'effects'(after 'db://' prefix removed)
-        if (effectDirRE.test(optionLabel)) {
-            optionLabel = optionLabel.replace(effectDirRE, '');
-        }
-
-        // use full name as option value
-        htmlTemplate += `<option value="${effect.name}" data-uuid="${effect.uuid}">${optionLabel}</option>`;
+        // no group name, add to extras and render as ungrouped(before grouped options)
+        const label = formatOptionLabel(effect.name);
+        extras.push(`<option value="${effect.name}" data-uuid="${effect.uuid}">${label}</option>`);
     }
 
-    if (currGroup !== '') {
-        htmlTemplate += '</optgroup>';
+    let htmlTemplate = '';
+
+    for (const extra of extras) {
+        htmlTemplate += extra;
+    }
+
+    for (const name in groups) {
+        const options = groups[name];
+        htmlTemplate += `<optgroup label="${name}">${options.join('')}</optgroup>`;
     }
 
     return htmlTemplate;

--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -3,6 +3,7 @@
 const { materialTechniquePolyfill } = require('../utils/material');
 const { setDisabled, setReadonly, setHidden, loopSetAssetDumpDataReadonly } = require('../utils/prop');
 const { join, sep, normalize } = require('path');
+const { escape } = require('lodash');
 
 const effectGroupNameRE = /^db:\/\/(\w+)\//i; // match root DB name
 const effectDirRE = /^effects\//i;
@@ -13,7 +14,8 @@ const effectDirRE = /^effects\//i;
 function formatOptionLabel(label) {
     // 1. remove group name if matched
     // 2. remove prefix 'effects'(after 'db://' prefix removed)
-    return label.replace(effectGroupNameRE, '').replace(effectDirRE, '');
+    // 3. escape label string because it will be used as html template string
+    return escape(label.replace(effectGroupNameRE, '').replace(effectDirRE, ''));
 }
 
 /**


### PR DESCRIPTION
Re: 
- https://github.com/cocos/cocos-editor/pull/2166
- https://github.com/cocos/3d-tasks/issues/14323

### Changelog

* no longer rely on the ordering of input `effects` data while rendering select options
* enable to show effect options that doesn't have a valid `assetPath`(maybe get errors on fetching asset info or some other reasons)

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
