### PR TITLE
add character controller doc links; replace onGround with isGrounded

### DIFF
--- a/cocos/physics/framework/components/character-controllers/box-character-controller.ts
+++ b/cocos/physics/framework/components/character-controllers/box-character-controller.ts
@@ -43,10 +43,9 @@ const v3_0 = new Vec3(0, 0, 0);
  * 角色控制器组件。
  */
 @ccclass('cc.BoxCharacterController')
-//@help('i18n:cc.BoxCharacterController')
+@help('i18n:cc.BoxCharacterController')
 @menu('Physics/BoxCharacterController')
 @executeInEditMode
-@disallowMultiple
 @executionOrder(-1)
 export class BoxCharacterController extends CharacterController {
     constructor () {

--- a/cocos/physics/framework/components/character-controllers/capsule-character-controller.ts
+++ b/cocos/physics/framework/components/character-controllers/capsule-character-controller.ts
@@ -43,10 +43,9 @@ const v3_0 = new Vec3(0, 0, 0);
  * 角色控制器组件。
  */
 @ccclass('cc.CapsuleCharacterController')
-//@help('i18n:cc.CapsuleCharacterController')
+@help('i18n:cc.CapsuleCharacterController')
 @menu('Physics/CapsuleCharacterController')
 @executeInEditMode
-@disallowMultiple
 @executionOrder(-1)
 export class CapsuleCharacterController extends CharacterController {
     constructor () {

--- a/cocos/physics/framework/components/character-controllers/character-controller.ts
+++ b/cocos/physics/framework/components/character-controllers/character-controller.ts
@@ -46,6 +46,7 @@ const scaledCenter = new Vec3(0, 0, 0);
  * 角色控制器组件基类。
  */
 @ccclass('cc.CharacterController')
+@disallowMultiple
 export class CharacterController extends Eventify(Component) {
     /// PUBLIC PROPERTY GETTER\SETTER ///
 
@@ -332,7 +333,7 @@ export class CharacterController extends Eventify(Component) {
      * @zh
      * 获取是否在地面上。
      */
-    public get onGround (): boolean {
+    public get isGrounded (): boolean {
         return this._cct!.onGround();
     }
 

--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -117,6 +117,8 @@ module.exports = link(mixin({
             HingeConstraint: `${url}/${version}/manual/en/physics/physics-constraint.html`,
             PointToPointConstraint: `${url}/${version}/manual/en/physics/physics-constraint.html`,
             RigidBody: `${url}/${version}/manual/en/physics/physics-rigidbody.html`,
+            BoxCharacterController: `${url}/${version}/manual/en/physics/character-controller/index.html`,
+            CapsuleCharacterController: `${url}/${version}/manual/en/physics/character-controller/index.html`,
             PhysicsMaterial: `${url}/${version}/manual/en/physics/physics-material.html`,
             ConstantForce: `${url}/${version}/manual/en/physics/physics-component.html`,
             VideoPlayer: `${url}/${version}/manual/en/ui-system/components/editor/videoplayer.html`,

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -117,6 +117,8 @@ module.exports = link(mixin({
             HingeConstraint: `${url}/${version}/manual/zh/physics/physics-constraint.html`,
             PointToPointConstraint: `${url}/${version}/manual/zh/physics/physics-constraint.html`,
             RigidBody: `${url}/${version}/manual/zh/physics/physics-rigidbody.html`,
+            BoxCharacterController: `${url}/${version}/manual/zh/physics/character-controller/index.html`,
+            CapsuleCharacterController: `${url}/${version}/manual/zh/physics/character-controller/index.html`,
             PhysicsMaterial: `${url}/${version}/manual/zh/physics/physics-material.html`,
             ConstantForce: `${url}/${version}/manual/zh/physics/physics-component.html`,
             VideoPlayer: `${url}/${version}/manual/zh/ui-system/components/editor/videoplayer.html`,


### PR DESCRIPTION

Re: #https://github.com/cocos/3d-tasks/issues/16713

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
