### PR TITLE
support fetchBuffer in pal/wasm module

### DIFF
--- a/@types/pal/wasm.d.ts
+++ b/@types/pal/wasm.d.ts
@@ -8,4 +8,14 @@ declare module 'pal/wasm' {
      * @param importObject the standard `WebAssembly.Imports` instance
      */
     export function instantiateWasm (wasmUrl: string, importObject: WebAssembly.Imports): Promise<any>;
+
+    /**
+     * Fetch binary data from wasm url or js mem url.
+     * NOTE: This method should only use to instantiate asm.js compiled with `-O2` options,
+     * because not all platforms support instantiate wasm by wasm binary.
+     * eg. WeChat can only instantiate wasm by wasm url.
+     *
+     * @param binaryUrl the url of wasm or js mem, this should be a url relative from build output chunk.
+     */
+    export function fetchBuffer (binaryUrl: string): Promise<ArrayBuffer>;
 }

--- a/pal/wasm/wasm-minigame.ts
+++ b/pal/wasm/wasm-minigame.ts
@@ -22,7 +22,22 @@
  THE SOFTWARE.
 */
 
+// fsUtils is defined in engine-adapter
+declare const fsUtils: any;
+
 export function instantiateWasm (wasmUrl: string, importObject: WebAssembly.Imports): Promise<any> {
     wasmUrl = `cocos-js/${wasmUrl}`;
     return WebAssembly.instantiate(wasmUrl, importObject);
+}
+
+export function fetchBuffer (binaryUrl: string): Promise<ArrayBuffer> {
+    return new Promise<ArrayBuffer>((resolve, reject) => {
+        fsUtils.readArrayBuffer(`cocos-js/${binaryUrl}`, (err, arrayBuffer) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(arrayBuffer);
+        });
+    });
 }


### PR DESCRIPTION
Re: 
https://github.com/cocos/3d-tasks/issues/16867
https://github.com/cocos/3d-tasks/issues/16865

### Changelog

* support `fetchBuffer` interface in `pal/wasm` module
* load spine asm.js module with js.mem

### Dep PR

- https://github.com/cocos/cocos-engine-external/pull/364
- https://github.com/cocos/cocos-editor/pull/2191

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
