### PR TITLE
Fix/physx submesh

### DIFF
--- a/cocos/physics/physx/shapes/physx-trimesh-shape.ts
+++ b/cocos/physics/physx/shapes/physx-trimesh-shape.ts
@@ -27,7 +27,8 @@ import { IVec3Like, Quat, Vec3 } from '../../../core';
 import { Mesh } from '../../../3d/assets';
 import { MeshCollider, PhysicsMaterial } from '../../framework';
 import { ITrimeshShape } from '../../spec/i-physics-shape';
-import { createConvexMesh, createMeshGeometryFlags, createTriangleMesh, PX, _trans, removeReference } from '../physx-adapter';
+import { createConvexMesh, createMeshGeometryFlags, createTriangleMesh, PX,
+    _trans, removeReference, createTriangleMeshShape, createConvexMeshShape } from '../physx-adapter';
 import { EPhysXShapeType, PhysXShape } from './physx-shape';
 import { AttributeName } from '../../../gfx';
 import { PhysXInstance } from '../physx-instance';
@@ -49,24 +50,21 @@ export class PhysXTrimeshShape extends PhysXShape implements ITrimeshShape {
 
             const physics = PhysXInstance.physics;
             const collider = this.collider;
-            const pxmat = this.getSharedMaterial(collider.sharedMaterial!);
+            const pxmat = this.getSharedMaterial(collider.sharedMaterial);
             const meshScale = PhysXShape.MESH_SCALE;
             meshScale.setScale(Vec3.ONE);
             meshScale.setRotation(Quat.IDENTITY);
             if (collider.convex) {
                 if (PX.MESH_CONVEX[v._uuid] == null) {
                     const cooking = PhysXInstance.cooking;
-                    const posBuf = v.readAttribute(0, AttributeName.ATTR_POSITION)! as unknown as Float32Array;
-                    PX.MESH_CONVEX[v._uuid] = createConvexMesh(posBuf, cooking, physics);
+                    PX.MESH_CONVEX[v._uuid] = createConvexMeshShape(v, cooking, physics);
                 }
                 const convexMesh = PX.MESH_CONVEX[v._uuid];
                 this.geometry = new PX.ConvexMeshGeometry(convexMesh, meshScale, createMeshGeometryFlags(0, true));
             } else {
                 if (PX.MESH_STATIC[v._uuid] == null) {
                     const cooking = PhysXInstance.cooking;
-                    const posBuf = v.readAttribute(0, AttributeName.ATTR_POSITION)! as unknown as Float32Array;
-                    const indBuf = v.readIndices(0)! as unknown as Uint32Array; // Uint16Array ?
-                    PX.MESH_STATIC[v._uuid] = createTriangleMesh(posBuf, indBuf, cooking, physics);
+                    PX.MESH_STATIC[v._uuid] = createTriangleMeshShape(v, cooking, physics);
                 }
                 const trimesh = PX.MESH_STATIC[v._uuid];
                 this.geometry = new PX.TriangleMeshGeometry(trimesh, meshScale, createMeshGeometryFlags(0, false));


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/15424

### Changelog

* physx will use vertex data from all submeshes

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
