### PR TITLE
avoid unexpected glslang behavior

### DIFF
--- a/native/cocos/renderer/gfx-base/SPIRVUtils.cpp
+++ b/native/cocos/renderer/gfx-base/SPIRVUtils.cpp
@@ -143,12 +143,14 @@ void SPIRVUtils::compileGLSL(ShaderStageFlagBit type, const ccstd::string &sourc
     _output.clear();
     spv::SpvBuildLogger logger;
     glslang::SpvOptions spvOptions;
-#if CC_DEBUG > 0
-    // spvOptions.validate = true;
-#else
+
     spvOptions.disableOptimizer = false;
     spvOptions.optimizeSize = true;
     spvOptions.stripDebugInfo = true;
+#if CC_DEBUG > 0
+    // spvOptions.validate = true;
+#else
+    //
 #endif
     glslang::GlslangToSpv(*_program->getIntermediate(stage), _output, &logger, &spvOptions);
 }


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16426 #https://github.com/cocos/3d-tasks/issues/17015

### Changelog

* Sith different options vulkan backend consumes different spirv binary, which comes from glslang. In some *debug* cases shader linking failed while in release it doesn't.
* TODO: update glslang needed.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
