### PR TITLE
[Target 390]Serialize BufferAsset as CCON

### DIFF
--- a/cocos/asset/assets/buffer-asset.jsb.ts
+++ b/cocos/asset/assets/buffer-asset.jsb.ts
@@ -31,6 +31,13 @@ declare const jsb: any;
 export type BufferAsset = JsbBufferAsset;
 export const BufferAsset: typeof JsbBufferAsset = jsb.BufferAsset;
 
+BufferAsset.prototype.buffer = function() {
+    if (!this._bufferLegacy) {
+        this._bufferLegacy = new Uint8Array(this.view);
+    }
+    return this._bufferLegacy;
+};
+
 cclegacy.BufferAsset = jsb.BufferAsset;
 
 // handle meta data, it is generated automatically

--- a/cocos/asset/assets/buffer-asset.ts
+++ b/cocos/asset/assets/buffer-asset.ts
@@ -29,9 +29,9 @@ import { Asset } from './asset';
 /**
  * @en
  * `BufferAsset` is a kind of assets whose internal data is a section of memory buffer
- * that you can access through the [[BufferAsset.buffer]] function.
+ * that you can access through `BufferAsset.view`.
  * @zh
- * `BufferAsset` 是一类资产，其内部数据是一段内存缓冲，你可以通过 [[BufferAsset.buffer]] 函数获取其内部数据。
+ * `BufferAsset` 是一类资产，其内部数据是一段内存缓冲，你可以通过 `BufferAsset.view` 获取其内部数据。
  */
 @ccclass('cc.BufferAsset')
 export class BufferAsset extends Asset {

--- a/cocos/asset/assets/buffer-asset.ts
+++ b/cocos/asset/assets/buffer-asset.ts
@@ -40,33 +40,33 @@ export class BufferAsset extends Asset {
      * @en Byte view of the buffered data.
      */
     @serializable
-    public bytes = new Uint8Array();
+    public view = new Uint8Array();
 
     /**
-     * @zh 首次调用将 **复制** 此时的`this.bytes`，并返回副本的 `ArrayBuffer`；该副本会在后续调用中直接返回。
-     * @en The first invocation on this method will **clone** `this.bytes` and returns `ArrayBuffer` of the copy.
+     * @zh 首次调用将 **复制** 此时的`this.view`，并返回副本的 `ArrayBuffer`；该副本会在后续调用中直接返回。
+     * @en The first invocation on this method will **clone** `this.view` and returns `ArrayBuffer` of the copy.
      * The copy will be directly returned in following invocations.
      *
      * @returns @en The `ArrayBuffer`. @zh `ArrayBuffer`。
      *
-     * @deprecated @zh 自 3.9.0，此方法废弃，调用此方法将带来可观的性能开销；请转而使用 `this.bytes`。
+     * @deprecated @zh 自 3.9.0，此方法废弃，调用此方法将带来可观的性能开销；请转而使用 `this.view`。
      * @en Since 3.9.0, this method is deprecated.
-     * Invocation on this method leads to significate cost. Use `this.bytes` instead.
+     * Invocation on this method leads to significate cost. Use `this.view` instead.
      */
     public buffer () {
-        if (!this._bytesLegacy) {
-            this._bytesLegacy = new Uint8Array(this.bytes);
+        if (!this._bufferLegacy) {
+            this._bufferLegacy = new Uint8Array(this.view);
         }
-        return this._bytesLegacy.buffer;
+        return this._bufferLegacy.buffer;
     }
 
     /**
      * This field is preserved here for compatibility purpose:
      * prior to 3.9.0, `buffer()` returns `ArrayBuffer`.
-     * We can't directly returns `this._bytes` in `this.buffer()`
-     * since `this._bytes` does not view entire underlying buffer.
+     * We can't directly returns `this.view` in `this.buffer()`
+     * since `this.view` does not view entire underlying buffer.
      */
-    private _bytesLegacy: undefined | Uint8Array = undefined;
+    private _bufferLegacy: undefined | Uint8Array = undefined;
 }
 
 cclegacy.BufferAsset = BufferAsset;

--- a/cocos/asset/assets/buffer-asset.ts
+++ b/cocos/asset/assets/buffer-asset.ts
@@ -53,7 +53,7 @@ export class BufferAsset extends Asset {
      * @en Since 3.9.0, this method is deprecated.
      * Invocation on this method leads to significate cost. Use `this.view` instead.
      */
-    public buffer () {
+    public buffer (): ArrayBufferLike {
         if (!this._bufferLegacy) {
             this._bufferLegacy = new Uint8Array(this.view);
         }

--- a/cocos/asset/assets/deprecated-3.9.0.ts
+++ b/cocos/asset/assets/deprecated-3.9.0.ts
@@ -6,7 +6,7 @@ replaceProperty(
     'BufferAsset',
     [{
         name: 'buffer',
-        newName: 'bytes',
+        newName: 'view',
         target: BufferAsset.prototype,
         targetName: 'BufferAsset',
         customFunction: BufferAsset.prototype.buffer,

--- a/cocos/asset/assets/deprecated-3.9.0.ts
+++ b/cocos/asset/assets/deprecated-3.9.0.ts
@@ -1,0 +1,15 @@
+import { replaceProperty } from '../../core/utils/x-deprecated';
+import { BufferAsset } from './buffer-asset';
+
+replaceProperty(
+    BufferAsset.prototype,
+    'BufferAsset',
+    [{
+        name: 'buffer',
+        newName: 'bytes',
+        target: BufferAsset.prototype,
+        targetName: 'BufferAsset',
+        customFunction: BufferAsset.prototype.buffer,
+        logTimes: 1,
+    }],
+);

--- a/cocos/asset/assets/index.ts
+++ b/cocos/asset/assets/index.ts
@@ -24,6 +24,7 @@
 */
 
 import './deprecation';
+import './deprecated-3.9.0';
 
 export { Asset } from './asset';
 export { BufferAsset } from './buffer-asset';

--- a/cocos/native-binding/decorators.ts
+++ b/cocos/native-binding/decorators.ts
@@ -99,8 +99,7 @@ interface cc_BufferAsset_Context_Args {
 }
 export function patch_cc_BufferAsset(ctx: cc_BufferAsset_Context_Args, apply = defaultExec) {
   const { BufferAsset } = { ...ctx };
-  const _nativeAssetDescriptor = Object.getOwnPropertyDescriptor(BufferAsset.prototype, '_nativeAsset');
-  apply(() => { $.override(BufferAsset.prototype, '_nativeAsset',  _nativeAssetDescriptor); }, 'override', '_nativeAsset');
+  apply(() => { $.serializable(BufferAsset.prototype, 'view',  () => { return new Uint8Array(); }); }, 'serializable', 'view');
   apply(() => { $.ccclass('cc.BufferAsset')(BufferAsset); }, 'ccclass', null);
 } // end of patch_cc_BufferAsset
 

--- a/native/cocos/core/assets/BufferAsset.cpp
+++ b/native/cocos/core/assets/BufferAsset.cpp
@@ -26,12 +26,5 @@
 
 namespace cc {
 
-ccstd::any BufferAsset::getNativeAsset() const {
-    return _buffer;
-}
-
-void BufferAsset::setNativeAsset(const ccstd::any &obj) {
-    _buffer = ccstd::any_cast<ArrayBuffer *>(obj);
-}
 
 } // namespace cc

--- a/native/cocos/core/assets/BufferAsset.h
+++ b/native/cocos/core/assets/BufferAsset.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "core/ArrayBuffer.h"
+#include "core/TypedArray.h"
 #include "core/assets/Asset.h"
 
 namespace cc {
@@ -34,17 +34,11 @@ public:
     BufferAsset() = default;
     ~BufferAsset() override = default;
 
-    inline ArrayBuffer *getBuffer() const { return _buffer; }
-
-    inline void setNativeAssetForJS(ArrayBuffer *buffer) { _buffer = buffer; }
-    inline ArrayBuffer *getNativeAssetForJS() const { return _buffer; }
-
-    ccstd::any getNativeAsset() const override;
-    void setNativeAsset(const ccstd::any &obj) override;
-    bool validate() const override { return _buffer != nullptr; }
+    const Uint8Array &getView() { return _view; }
+    void setView(const Uint8Array &view) { _view = view; }
 
 private:
-    ArrayBuffer::Ptr _buffer;
+    Uint8Array _view;
 
     CC_DISALLOW_COPY_MOVE_ASSIGN(BufferAsset);
 };

--- a/native/tools/swig-config/assets.i
+++ b/native/tools/swig-config/assets.i
@@ -92,8 +92,6 @@
 %rename(_getBindposes) cc::Skeleton::getBindposes;
 %rename(_setBindposes) cc::Skeleton::setBindposes;
 
-%rename(buffer) cc::BufferAsset::getBuffer;
-
 
 
 // ----- Module Macro Section ------
@@ -134,7 +132,7 @@
 %attribute(cc::ImageAsset, cc::PixelFormat, format, getFormat, setFormat);
 %attribute(cc::ImageAsset, ccstd::string&, url, getUrl, setUrl);
 
-%attribute(cc::BufferAsset, cc::ArrayBuffer*, _nativeAsset, getNativeAssetForJS, setNativeAssetForJS);
+%attribute(cc::BufferAsset, cc::Uint8Array&, view, getView, setView);
 
 %attribute(cc::TextureBase, bool, isCompressed, isCompressed);
 %attribute(cc::TextureBase, uint32_t, _width, getWidth, setWidth);

--- a/tests/assets/buffer-asset.test.ts
+++ b/tests/assets/buffer-asset.test.ts
@@ -4,35 +4,35 @@ import { captureWarns } from '../utils/log-capture';
 test(`Deprecation warning`, () => {
     const bufferAsset = new BufferAsset();
 
-    bufferAsset.bytes = new Uint8Array([3, 1, 8, 8]);
+    bufferAsset.view = new Uint8Array([3, 1, 8, 8]);
     
     const warns = captureWarns();
 
     // Deprecation message should be given at first invocation.
     const bytesFirstInvocationResult = bufferAsset.buffer();
     expect(warns.captured).toStrictEqual([
-        [`'%s' is deprecated, please use '%s' instead. `, `BufferAsset.buffer`, `BufferAsset.bytes`],
+        [`'%s' is deprecated, please use '%s' instead. `, `BufferAsset.buffer`, `BufferAsset.view`],
     ]);
     warns.clear();
 
-    // The first invocation returns a copy of `.bytes`.
-    expect(bytesFirstInvocationResult).not.toBe(bufferAsset.bytes.buffer);
-    expect(new Uint8Array(bytesFirstInvocationResult)).toStrictEqual(bufferAsset.bytes);
+    // The first invocation returns a copy of `.view`.
+    expect(bytesFirstInvocationResult).not.toBe(bufferAsset.view.buffer);
+    expect(new Uint8Array(bytesFirstInvocationResult)).toStrictEqual(bufferAsset.view);
 
     // Repeatedly invocations on `buffer()` should return the same result.
     const check = () => { expect(bufferAsset.buffer()).toBe(bytesFirstInvocationResult); };
 
     check();
 
-    // The copy won't change event the `.bytes` has changed.
-    ++bufferAsset.bytes[0];
+    // The copy won't change event the `.view` has changed.
+    ++bufferAsset.view[0];
     check();
-    bufferAsset.bytes = new Uint8Array([7, 4, 5, 6]);
+    bufferAsset.view = new Uint8Array([7, 4, 5, 6]);
     check();
     // Verse vice.
     {
-        const v = bufferAsset.bytes[0];
+        const v = bufferAsset.view[0];
         new Uint8Array(bufferAsset.buffer())[0] = v + 1;
-        expect(bufferAsset.bytes[0]).toBe(v);
+        expect(bufferAsset.view[0]).toBe(v);
     }
 });

--- a/tests/assets/buffer-asset.test.ts
+++ b/tests/assets/buffer-asset.test.ts
@@ -1,0 +1,38 @@
+import { BufferAsset } from "../../exports/base";
+import { captureWarns } from '../utils/log-capture';
+
+test(`Deprecation warning`, () => {
+    const bufferAsset = new BufferAsset();
+
+    bufferAsset.bytes = new Uint8Array([3, 1, 8, 8]);
+    
+    const warns = captureWarns();
+
+    // Deprecation message should be given at first invocation.
+    const bytesFirstInvocationResult = bufferAsset.buffer();
+    expect(warns.captured).toStrictEqual([
+        [`'%s' is deprecated, please use '%s' instead. `, `BufferAsset.buffer`, `BufferAsset.bytes`],
+    ]);
+    warns.clear();
+
+    // The first invocation returns a copy of `.bytes`.
+    expect(bytesFirstInvocationResult).not.toBe(bufferAsset.bytes.buffer);
+    expect(new Uint8Array(bytesFirstInvocationResult)).toStrictEqual(bufferAsset.bytes);
+
+    // Repeatedly invocations on `buffer()` should return the same result.
+    const check = () => { expect(bufferAsset.buffer()).toBe(bytesFirstInvocationResult); };
+
+    check();
+
+    // The copy won't change event the `.bytes` has changed.
+    ++bufferAsset.bytes[0];
+    check();
+    bufferAsset.bytes = new Uint8Array([7, 4, 5, 6]);
+    check();
+    // Verse vice.
+    {
+        const v = bufferAsset.bytes[0];
+        new Uint8Array(bufferAsset.buffer())[0] = v + 1;
+        expect(bufferAsset.bytes[0]).toBe(v);
+    }
+});


### PR DESCRIPTION
Re: #

### Changelog

* Adjust `BufferAsset` so that it can be serialized as CCON format.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
