### PR TITLE
V3.8.0 fix edit material cache editing data bug in inspector

### DIFF
--- a/editor/inspector/assets/animation-graph.js
+++ b/editor/inspector/assets/animation-graph.js
@@ -29,6 +29,7 @@ exports.style = /* css */`
     display: none;
     text-align: center;
     color: var(--color-focus-contrast-weakest);
+    margin-top: 8px;
 }
 `;
 

--- a/editor/inspector/assets/animation-mask.js
+++ b/editor/inspector/assets/animation-mask.js
@@ -40,6 +40,7 @@ exports.style = /* css */`
     display: none;
     text-align: center;
     color: var(--color-focus-contrast-weakest);
+    margin-top: 8px;
 }
 
 .asset-animation-mask > .header {

--- a/editor/inspector/assets/effect-header.js
+++ b/editor/inspector/assets/effect-header.js
@@ -35,6 +35,7 @@ exports.style = /* css */`
     display: none;
     text-align: center;
     color: var(--color-focus-contrast-weakest);
+    margin-top: 8px;
 }
 
 .asset-effect-header > ui-code {

--- a/editor/inspector/assets/effect.js
+++ b/editor/inspector/assets/effect.js
@@ -42,6 +42,7 @@ exports.style = /* css */`
         display: none;
         text-align: center;
         color: var(--color-focus-contrast-weakest);
+        margin-top: 8px;
     }
 
     .asset-effect > .section > .description {

--- a/editor/inspector/assets/fbx/animation.js
+++ b/editor/inspector/assets/fbx/animation.js
@@ -113,6 +113,7 @@ exports.style = /* css */`
     display: none;
     text-align: center;
     color: var(--color-focus-contrast-weakest);
+    margin-top: 8px;
 }
 .container > .show-type-wrap {
     text-align: center;

--- a/editor/inspector/assets/json.js
+++ b/editor/inspector/assets/json.js
@@ -33,6 +33,7 @@ exports.style = /* css */`
     display: none;
     text-align: center;
     color: var(--color-focus-contrast-weakest);
+    margin-top: 8px;
 }
 .asset-json > ui-code {
     flex: 1;

--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -73,7 +73,7 @@ function renderGroupEffectOptions(effects) {
 }
 
 exports.style = `
-.invalid { display: none; }
+.invalid { display: none; text-align: center; margin-top: 8px; }
 .invalid[active] { display: block; }
 .invalid[active] ~ * { display: none; }
 

--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -319,7 +319,7 @@ exports.methods = {
                 $container.$children[i].querySelectorAll('ui-prop').forEach(($prop) => {
                     const dump = $prop.dump;
                     if (dump && dump.childMap && dump.children.length) {
-                        if (!$prop.$section) {
+                        if (!$prop.$childMap) {
                             $prop.$childMap = document.createElement('section');
                             $prop.$childMap.setAttribute(
                                 'style',

--- a/editor/inspector/assets/material.js
+++ b/editor/inspector/assets/material.js
@@ -319,12 +319,13 @@ exports.methods = {
                 $container.$children[i].querySelectorAll('ui-prop').forEach(($prop) => {
                     const dump = $prop.dump;
                     if (dump && dump.childMap && dump.children.length) {
-                        if (!$prop.$children) {
-                            $prop.$children = document.createElement('section');
-                            $prop.$children.setAttribute(
+                        if (!$prop.$section) {
+                            $prop.$childMap = document.createElement('section');
+                            $prop.$childMap.setAttribute(
                                 'style',
                                 'margin-left: var(--ui-prop-margin-left, unset);',
                             );
+                            $prop.$childMap.$props = {};
 
                             for (const childName in dump.childMap) {
                                 if (dump.childMap[childName].value === undefined) {
@@ -335,29 +336,29 @@ exports.methods = {
                                     loopSetAssetDumpDataReadonly(dump.childMap[childName]);
                                 }
 
-                                $prop.$children[childName] = document.createElement('ui-prop');
-                                $prop.$children[childName].setAttribute('type', 'dump');
-                                $prop.$children[childName].render(dump.childMap[childName]);
-                                $prop.$children.appendChild($prop.$children[childName]);
+                                $prop.$childMap.$props[childName] = document.createElement('ui-prop');
+                                $prop.$childMap.$props[childName].setAttribute('type', 'dump');
+                                $prop.$childMap.$props[childName].render(dump.childMap[childName]);
+                                $prop.$childMap.appendChild($prop.$childMap.$props[childName]);
                             }
 
-                            if (Array.from($prop.$children.children).length) {
-                                $prop.after($prop.$children);
+                            if (Array.from($prop.$childMap.children).length) {
+                                $prop.after($prop.$childMap);
                             }
 
                             $prop.addEventListener('change-dump', (e) => {
                                 if (e.target.dump.value) {
-                                    $prop.$children.removeAttribute('hidden');
+                                    $prop.$childMap.removeAttribute('hidden');
                                 } else {
-                                    $prop.$children.setAttribute('hidden', '');
+                                    $prop.$childMap.setAttribute('hidden', '');
                                 }
                             });
                         }
 
                         if (dump.value) {
-                            $prop.$children.removeAttribute('hidden');
+                            $prop.$childMap.removeAttribute('hidden');
                         } else {
-                            $prop.$children.setAttribute('hidden', '');
+                            $prop.$childMap.setAttribute('hidden', '');
                         }
                     }
                 });
@@ -366,7 +367,11 @@ exports.methods = {
             // when passes length more than one, the ui-section of pipeline state collapse
             if (technique.passes.length > 1) {
                 $container.querySelectorAll('[cache-expand$="PassStates"]').forEach(($pipelineState) => {
-                    $pipelineState.removeAttribute('expand');
+                    const cacheExpand = $pipelineState.getAttribute('cache-expand');
+                    if (!this.defaultCollapsePasses[cacheExpand]) {
+                        $pipelineState.expand = false;
+                        this.defaultCollapsePasses[cacheExpand] = true;
+                    }
                 });
             }
         }
@@ -410,7 +415,6 @@ exports.methods = {
             'children',
             'defines',
             'extends',
-            'pipelineStates',
         ];
 
         const cacheData = this.cacheData;
@@ -434,7 +438,7 @@ exports.methods = {
                         cacheData[name] = {};
                     }
 
-                    const { type, value } = prop[name];
+                    const { type, value, isObject } = prop[name];
                     if (type && value !== undefined) {
                         if (!cacheData[name][passIndex]) {
                             if (name === 'USE_INSTANCING' && passIndex !== 0) {
@@ -449,7 +453,9 @@ exports.methods = {
                         }
                     }
 
-                    if (prop[name].childMap && typeof prop[name].childMap === 'object') {
+                    if (isObject) {
+                        cacheProperty(value, passIndex);
+                    } else if (prop[name].childMap && typeof prop[name].childMap === 'object') {
                         cacheProperty(prop[name].childMap, passIndex);
                     }
                 }
@@ -503,7 +509,9 @@ exports.methods = {
                         }
                     }
 
-                    if (prop[name].childMap && typeof prop[name].childMap === 'object') {
+                    if (prop[name].isObject) {
+                        updateProperty(prop[name].value, passIndex);
+                    } else if (prop[name].childMap && typeof prop[name].childMap === 'object') {
                         updateProperty(prop[name].childMap, passIndex);
                     }
                 }
@@ -578,6 +586,7 @@ exports.update = async function(assetList, metaList) {
  * Method of initializing the panel
  */
 exports.ready = function() {
+    this.defaultCollapsePasses = {};
     this.canUpdatePreview = false;
     // Used to determine whether the material has been modified in isDirty()
     this.dirtyData = {

--- a/editor/inspector/assets/particle.js
+++ b/editor/inspector/assets/particle.js
@@ -34,6 +34,7 @@ exports.style = /* css */`
     display: none;
     text-align: center;
     color: var(--color-focus-contrast-weakest);
+    margin-top: 8px;
 }
 `;
 

--- a/editor/inspector/assets/physics-material.js
+++ b/editor/inspector/assets/physics-material.js
@@ -23,6 +23,7 @@ exports.style = /* css */`
     display: none;
     text-align: center;
     color: var(--color-focus-contrast-weakest);
+    margin-top: 8px;
 }
 `;
 

--- a/editor/inspector/assets/render-pipeline.js
+++ b/editor/inspector/assets/render-pipeline.js
@@ -24,6 +24,7 @@ exports.style = /* css */`
     display: none;
     text-align: center;
     color: var(--color-focus-contrast-weakest);
+    margin-top: 8px;
 }
 `;
 


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/15531

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
