### PR TITLE
Revert "[fix] refactor physics2d contact listener (#14026)"

### DIFF
--- a/cocos/physics-2d/box2d/physics-world.ts
+++ b/cocos/physics-2d/box2d/physics-world.ts
@@ -35,7 +35,8 @@ import { b2RigidBody2D } from './rigid-body';
 import { PhysicsContactListener } from './platform/physics-contact-listener';
 import { PhysicsAABBQueryCallback } from './platform/physics-aabb-query-callback';
 import { PhysicsRayCastCallback } from './platform/physics-ray-cast-callback';
-import { Collider2D, RaycastResult2D } from '../framework';
+import { PhysicsContact, b2ContactExtends } from './physics-contact';
+import { Contact2DType, Collider2D, RaycastResult2D } from '../framework';
 import { b2Shape2D } from './shapes/shape-2d';
 import { PhysicsDebugDraw } from './platform/physics-debug-draw';
 import { Node, find, Layers } from '../../scene-graph';
@@ -75,7 +76,12 @@ export class b2PhysicsWorld implements IPhysicsWorld {
         //tempBodyDef.position.Set(480 / PHYSICS_2D_PTM_RATIO, 320 / PHYSICS_2D_PTM_RATIO);//temporary
         this._physicsGroundBody = this._world.CreateBody(tempBodyDef);
         const listener = new PhysicsContactListener();
+        listener.setBeginContact(this._onBeginContact);
+        listener.setEndContact(this._onEndContact);
+        listener.setPreSolve(this._onPreSolve);
+        listener.setPostSolve(this._onPostSolve);
         this._world.SetContactListener(listener);
+
         this._contactListener = listener;
 
         this._aabbQueryCallback = new PhysicsAABBQueryCallback();
@@ -322,6 +328,13 @@ export class b2PhysicsWorld implements IPhysicsWorld {
         }
     }
 
+    registerContactFixture (fixture: b2.Fixture) {
+        this._contactListener.registerContactFixture(fixture);
+    }
+    unregisterContactFixture (fixture: b2.Fixture) {
+        this._contactListener.unregisterContactFixture(fixture);
+    }
+
     testPoint (point: Vec2): readonly Collider2D[] {
         const x = tempVec2_1.x = point.x / PHYSICS_2D_PTM_RATIO;
         const y = tempVec2_1.y = point.y / PHYSICS_2D_PTM_RATIO;
@@ -378,7 +391,39 @@ export class b2PhysicsWorld implements IPhysicsWorld {
         this._world.DrawDebugData();
     }
 
-    finalizeContactEvent () {
-        this._contactListener.finalizeContactEvent();
+    _onBeginContact (b2contact: b2ContactExtends) {
+        const c = PhysicsContact.get(b2contact);
+        c.emit(Contact2DType.BEGIN_CONTACT);
+    }
+
+    _onEndContact (b2contact: b2ContactExtends) {
+        const c = b2contact.m_userData as PhysicsContact;
+        if (!c) {
+            return;
+        }
+        c.emit(Contact2DType.END_CONTACT);
+
+        PhysicsContact.put(b2contact);
+    }
+
+    _onPreSolve (b2contact: b2ContactExtends) {
+        const c = b2contact.m_userData as PhysicsContact;
+        if (!c) {
+            return;
+        }
+
+        c.emit(Contact2DType.PRE_SOLVE);
+    }
+
+    _onPostSolve (b2contact: b2ContactExtends, impulse: b2.ContactImpulse) {
+        const c: PhysicsContact = b2contact.m_userData as PhysicsContact;
+        if (!c) {
+            return;
+        }
+
+        // impulse only survive during post sole callback
+        c._setImpulse(impulse);
+        c.emit(Contact2DType.POST_SOLVE);
+        c._setImpulse(null);
     }
 }

--- a/cocos/physics-2d/box2d/platform/physics-contact-listener.ts
+++ b/cocos/physics-2d/box2d/platform/physics-contact-listener.ts
@@ -23,118 +23,71 @@
 */
 
 import b2 from '@cocos/box2d';
-import { assert, js } from '../../../core';
-import { fastRemove } from '../../../core/utils/array';
-import { Contact2DType, PhysicsSystem2D } from '../../framework';
-import { PhysicsContact } from '../physics-contact';
-import { b2Shape2D } from '../shapes/shape-2d';
+import { js } from '../../../core';
 
-/**
- * @en
- * The contact listener responsible for all contact events between colliders.
- * @zh
- * 负责处理所有碰撞体之间的触发事件。
- * @class PhysicsContactListener
- * @extends b2.ContactListener
- */
 export class PhysicsContactListener extends b2.ContactListener {
-    static readonly _contactMap = new Map<string, PhysicsContact>();
+    _contactFixtures: b2.Fixture[] = [];
 
-    private getContactKey (contact: b2.Contact) {
-        const colliderA = (contact.m_fixtureA.m_userData as b2Shape2D).collider;
-        const colliderB = (contact.m_fixtureB.m_userData as b2Shape2D).collider;
-        let key = colliderA.uuid + colliderB.uuid;
-        if (colliderA.uuid > colliderB.uuid) {
-            key = colliderB.uuid + colliderA.uuid;
-        }
-        return key;
+    _BeginContact: Function | null = null;
+    _EndContact: Function | null = null;
+    _PreSolve: Function | null = null;
+    _PostSolve: Function | null = null;
+
+    setBeginContact (cb) {
+        this._BeginContact = cb;
+    }
+
+    setEndContact (cb) {
+        this._EndContact = cb;
+    }
+
+    setPreSolve (cb) {
+        this._PreSolve = cb;
+    }
+
+    setPostSolve (cb) {
+        this._PostSolve = cb;
     }
 
     BeginContact (contact: b2.Contact) {
-        const key = this.getContactKey(contact);
+        if (!this._BeginContact) return;
 
-        if (PhysicsContactListener._contactMap.has(key)) {
-            const retContact = PhysicsContactListener._contactMap.get(key)!;
-            retContact.ref++;
-            if (retContact.status === Contact2DType.END_CONTACT) {
-                retContact.status = Contact2DType.STAY_CONTACT;
-            } else if (retContact.status !== Contact2DType.STAY_CONTACT) {
-                retContact.status = Contact2DType.BEGIN_CONTACT;
-            }
-        } else {
-            const retCollision = new PhysicsContact(contact);
-            PhysicsContactListener._contactMap.set(key, retCollision);
-            retCollision.status = Contact2DType.BEGIN_CONTACT;
+        const fixtureA = contact.GetFixtureA();
+        const fixtureB = contact.GetFixtureB();
+        const fixtures = this._contactFixtures;
+
+        (contact as any)._shouldReport = false;
+
+        if (fixtures.indexOf(fixtureA) !== -1 || fixtures.indexOf(fixtureB) !== -1) {
+            (contact as any)._shouldReport = true; // for quick check whether this contact should report
+            this._BeginContact(contact);
         }
     }
 
     EndContact (contact: b2.Contact) {
-        const key = this.getContactKey(contact);
-
-        const retContact = PhysicsContactListener._contactMap.get(key);
-        assert(retContact);
-
-        retContact.ref--;
-        if (retContact.ref <= 0) {
-            retContact.status = Contact2DType.END_CONTACT;
+        if (this._EndContact && (contact as any)._shouldReport) {
+            (contact as any)._shouldReport = false;
+            this._EndContact(contact);
         }
     }
 
     PreSolve (contact: b2.Contact, oldManifold: b2.Manifold) {
+        if (this._PreSolve && (contact as any)._shouldReport) {
+            this._PreSolve(contact, oldManifold);
+        }
     }
 
     PostSolve (contact: b2.Contact, impulse: b2.ContactImpulse) {
+        if (this._PostSolve && (contact as any)._shouldReport) {
+            this._PostSolve(contact, impulse);
+        }
     }
 
-    public finalizeContactEvent () {
-        PhysicsContactListener._contactMap.forEach((contact: PhysicsContact, key: string) => {
-            // emit collision event
-            if (!contact.disabled || contact.status === Contact2DType.BEGIN_CONTACT) { //BEGIN_CONTACT always emits
-                if (contact.status === Contact2DType.END_CONTACT) {
-                    this.emit(Contact2DType.END_CONTACT, contact);
-                } else if (contact.status === Contact2DType.BEGIN_CONTACT) {
-                    this.emit(Contact2DType.BEGIN_CONTACT, contact);
-                } else if (contact.status === Contact2DType.STAY_CONTACT) {
-                    this.emit(Contact2DType.STAY_CONTACT, contact);
-                }
-            }
-
-            // extra processing
-            if (contact.status === Contact2DType.END_CONTACT) {
-                PhysicsContactListener._contactMap.delete(key);
-            } else if (contact.status === Contact2DType.BEGIN_CONTACT) {
-                contact.status = Contact2DType.STAY_CONTACT;
-            }
-        });
+    registerContactFixture (fixture) {
+        this._contactFixtures.push(fixture);
     }
 
-    private emit (contactType, contact: PhysicsContact) {
-        const colliderA = contact.colliderA;
-        const colliderB = contact.colliderB;
-        if (!colliderA || !colliderB) {
-            return;
-        }
-
-        const bodyA = colliderA.body;
-        const bodyB = colliderB.body;
-        //if rigid body doesn't exist, collider will be added to groundRigidbody automatically,
-        //hence it should emit event
-        if ((bodyA && !bodyA.enabledInHierarchy) || (bodyB && !bodyB.enabledInHierarchy) || (!bodyA && !bodyB)) {
-            return;
-        }
-
-        //bodyA exists and enabledContactListner, or bodyA doesn't exist
-        if ((bodyA && bodyA.enabledContactListener) || (!bodyA)) {
-            colliderA?.emit(contactType, colliderA, colliderB, contact);
-        }
-
-        //bodyB exists and enabledContactListner, or bodyB doesn't exist
-        if ((bodyB && bodyB.enabledContactListener) || (!bodyB)) {
-            colliderB?.emit(contactType, colliderB, colliderA, contact);
-        }
-
-        if ((bodyA && bodyA.enabledContactListener) || (bodyB && bodyB.enabledContactListener) || !bodyA || !bodyB) {
-            PhysicsSystem2D.instance.emit(contactType, colliderA, colliderB, contact);
-        }
+    unregisterContactFixture (fixture) {
+        js.array.remove(this._contactFixtures, fixture);
     }
 }

--- a/cocos/physics-2d/box2d/shapes/shape-2d.ts
+++ b/cocos/physics-2d/box2d/shapes/shape-2d.ts
@@ -180,6 +180,10 @@ export class b2Shape2D implements IBaseShape {
             const fixture = this._body.CreateFixture(fixDef);
             fixture.m_userData = this;
 
+            if (body.enabledContactListener) {
+                (PhysicsSystem2D.instance.physicsWorld as b2PhysicsWorld).registerContactFixture(fixture);
+            }
+
             this._shapes.push(shape);
             this._fixtures.push(fixture);
         }
@@ -195,6 +199,9 @@ export class b2Shape2D implements IBaseShape {
 
         for (let i = fixtures.length - 1; i >= 0; i--) {
             const fixture = fixtures[i];
+            fixture.m_userData = null;
+
+            (PhysicsSystem2D.instance.physicsWorld as b2PhysicsWorld).unregisterContactFixture(fixture);
 
             if (body) {
                 body.DestroyFixture(fixture);

--- a/cocos/physics-2d/box2d/shapes/shape-2d.ts
+++ b/cocos/physics-2d/box2d/shapes/shape-2d.ts
@@ -180,7 +180,7 @@ export class b2Shape2D implements IBaseShape {
             const fixture = this._body.CreateFixture(fixDef);
             fixture.m_userData = this;
 
-            if (body.enabledContactListener) {
+            if (body?.enabledContactListener) {
                 (PhysicsSystem2D.instance.physicsWorld as b2PhysicsWorld).registerContactFixture(fixture);
             }
 

--- a/cocos/physics-2d/builtin/builtin-world.ts
+++ b/cocos/physics-2d/builtin/builtin-world.ts
@@ -267,7 +267,4 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
     raycast (p1: IVec2Like, p2: IVec2Like, type: ERaycast2DType): RaycastResult2D[] {
         return [];
     }
-    finalizeContactEvent () {
-
-    }
 }

--- a/cocos/physics-2d/framework/components/colliders/collider-2d.ts
+++ b/cocos/physics-2d/framework/components/colliders/collider-2d.ts
@@ -24,12 +24,12 @@
 
 import { EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
 
-import { Vec2, Rect, _decorator, Eventify, tooltip, serializable, CCFloat, CCBoolean, warnID } from '../../../../core';
+import { Vec2, Rect, _decorator, Eventify, cclegacy, tooltip, CCInteger, serializable, CCFloat, CCBoolean } from '../../../../core';
 import { PhysicsGroup } from '../../../../physics/framework/physics-enum';
 
 import { RigidBody2D } from '../rigid-body-2d';
 import { createShape } from '../../physics-selector';
-import { Contact2DType, ECollider2DType } from '../../physics-types';
+import { ECollider2DType } from '../../physics-types';
 import { IBaseShape } from '../../../spec/i-physics-shape';
 import { Component } from '../../../../scene-graph';
 
@@ -210,13 +210,6 @@ export class Collider2D extends Eventify(Component) {
         }
 
         return new Rect();
-    }
-
-    public on<TFunction extends (...any) => void>(type: string, callback: TFunction, thisArg?: any, once?: boolean): typeof callback {
-        if (type === Contact2DType.PRE_SOLVE || type === Contact2DType.POST_SOLVE) {
-            warnID(16002, type, '3.7.1');
-        }
-        return super.on(type, callback, thisArg, once);
     }
 
     // protected properties

--- a/cocos/physics-2d/framework/physics-selector.ts
+++ b/cocos/physics-2d/framework/physics-selector.ts
@@ -164,7 +164,6 @@ const ENTIRE_WORLD: IPhysicsWorld = {
     testPoint: FUNC,
     testAABB: FUNC,
     drawDebug: FUNC,
-    finalizeContactEvent: FUNC,
 };
 
 export function checkPhysicsModule (obj: any) {

--- a/cocos/physics-2d/framework/physics-system.ts
+++ b/cocos/physics-2d/framework/physics-system.ts
@@ -23,13 +23,13 @@
 */
 
 import { EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
-import { System, Vec2, IVec2Like, Rect, Eventify, Enum, Settings, settings, cclegacy, warnID } from '../../core';
+import { System, Vec2, IVec2Like, Rect, Eventify, Enum, Settings, settings, cclegacy } from '../../core';
 import { createPhysicsWorld, selector, IPhysicsSelector } from './physics-selector';
 
 import { DelayEvent } from './physics-internal-types';
 import { ICollisionMatrix } from '../../physics/framework/physics-config';
 import { CollisionMatrix } from '../../physics/framework/collision-matrix';
-import { ERaycast2DType, RaycastResult2D, PHYSICS_2D_PTM_RATIO, PhysicsGroup, Contact2DType } from './physics-types';
+import { ERaycast2DType, RaycastResult2D, PHYSICS_2D_PTM_RATIO, PhysicsGroup } from './physics-types';
 import { Collider2D } from './components/colliders/collider-2d';
 import { director, Director } from '../../game';
 
@@ -300,8 +300,6 @@ export class PhysicsSystem2D extends Eventify(System) {
 
         this.physicsWorld.syncPhysicsToScene();
 
-        this.physicsWorld.finalizeContactEvent();
-
         if (this.debugDrawFlags) {
             this.physicsWorld.drawDebug();
         }
@@ -374,13 +372,6 @@ export class PhysicsSystem2D extends Eventify(System) {
      */
     testAABB (rect: Rect): readonly Collider2D[] {
         return this.physicsWorld.testAABB(rect);
-    }
-
-    public on<TFunction extends (...any) => void>(type: string, callback: TFunction, thisArg?: any, once?: boolean): typeof callback {
-        if (type === Contact2DType.PRE_SOLVE || type === Contact2DType.POST_SOLVE) {
-            warnID(16002, type, '3.7.1');
-        }
-        return super.on(type, callback, thisArg, once);
     }
 }
 

--- a/cocos/physics-2d/framework/physics-types.ts
+++ b/cocos/physics-2d/framework/physics-types.ts
@@ -127,55 +127,11 @@ export enum ERaycast2DType {
     All
 }
 
-/**
- * @en
- * Physics2D contact event types.
- * @zh
- * 2D物理接触事件类型。
- */
 export const Contact2DType = {
-    /**
-     * @en
-     * The event type of non contact.
-     * @zh
-     * 无接触的事件类型。
-     */
     None: 'none-contact',
-
-    /**
-     * @en
-     * The event type of the contact start.
-     * @zh
-     * 开始接触的事件类型。
-     */
     BEGIN_CONTACT: 'begin-contact',
-
-    /**
-     * @en
-     * The event type of the contact stay.
-     * @zh
-     * 保持接触的事件类型。
-     */
-    STAY_CONTACT: 'stay-contact',
-
-    /**
-     * @en
-     * The event type of the contact end.
-     * @zh
-     * 结束接触的事件类型。
-     */
     END_CONTACT: 'end-contact',
-
-    /**
-    * @deprecated Since v3.7.1, PhysicsSystem2D doesn't directly emit the contact events emitted by box2d.
-    * If you need this event, try to modify the relevant engine code(mainly PhysicsContactListener).
-    */
     PRE_SOLVE: 'pre-solve',
-
-    /**
-    * @deprecated Since v3.7.1, PhysicsSystem2D doesn't directly emit the contact events emitted by box2d.
-    * If you need this event, try to modify the relevant engine code(mainly PhysicsContactListener).
-    */
     POST_SOLVE: 'post-solve',
 };
 

--- a/cocos/physics-2d/spec/i-physics-contact.ts
+++ b/cocos/physics-2d/spec/i-physics-contact.ts
@@ -204,17 +204,17 @@ export interface IPhysics2DContact {
     /**
      * @en
      * If set disabled to true, the contact will be ignored until contact end.
+     * If you just want to disabled contact for current time step or sub-step, please use disabledOnce.
      * @zh
      * 如果 disabled 被设置为 true，那么直到接触结束此接触都将被忽略。
+     * 如果只是希望在当前时间步或子步中忽略此接触，请使用 disabledOnce 。
      */
     disabled: boolean;
-
     /**
      * @en
      * Disabled contact for current time step or sub-step.
      * @zh
      * 在当前时间步或子步中忽略此接触。
-     * @deprecated Since v3.8.0, disabledOnce is no longer supported.
      */
     disabledOnce: boolean;
 

--- a/cocos/physics-2d/spec/i-physics-world.ts
+++ b/cocos/physics-2d/spec/i-physics-world.ts
@@ -38,5 +38,4 @@ export interface IPhysicsWorld {
     testPoint (p: Vec2): readonly Collider2D[];
     testAABB (rect: Rect): readonly Collider2D[];
     drawDebug (): void;
-    finalizeContactEvent(): void
 }


### PR DESCRIPTION
Re: #https://github.com/cocos/cocos-engine/issues/15530

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
