### PR TITLE
fix dependency on camera component

### DIFF
--- a/cocos/rendering/post-process/post-process-builder.ts
+++ b/cocos/rendering/post-process/post-process-builder.ts
@@ -18,7 +18,6 @@ import { HBAOPass } from './passes/hbao-pass';
 import { PostProcess } from './components/post-process';
 import { director } from '../../game';
 
-import { CameraComponent } from '../../misc';
 import { BloomPass, ColorGradingPass, ForwardTransparencyPass, ForwardTransparencySimplePass, FxaaPass, SkinPass, ToneMappingPass } from './passes';
 import { PipelineEventType } from '../pipeline-event';
 
@@ -103,7 +102,7 @@ export class PostProcessBuilder implements PipelineBuilder  {
     }
     private applyPreviewCamera (camera: Camera) {
         if (!camera.node.parent) return;
-        const camComp = camera.node.parent.getComponent(CameraComponent);
+        const camComp = camera.node.parent.getComponent('cc.Camera') as any;
         const oriCamera = camComp && camComp.camera;
         if (oriCamera) {
             camera.postProcess = oriCamera.postProcess;

--- a/cocos/rendering/post-process/post-process-builder.ts
+++ b/cocos/rendering/post-process/post-process-builder.ts
@@ -18,6 +18,7 @@ import { HBAOPass } from './passes/hbao-pass';
 import { PostProcess } from './components/post-process';
 import { director } from '../../game';
 
+import { Camera as CameraComponent } from '../../misc';
 import { BloomPass, ColorGradingPass, ForwardTransparencyPass, ForwardTransparencySimplePass, FxaaPass, SkinPass, ToneMappingPass } from './passes';
 import { PipelineEventType } from '../pipeline-event';
 
@@ -102,7 +103,7 @@ export class PostProcessBuilder implements PipelineBuilder  {
     }
     private applyPreviewCamera (camera: Camera) {
         if (!camera.node.parent) return;
-        const camComp = camera.node.parent.getComponent('cc.Camera') as any;
+        const camComp = camera.node.parent.getComponent(CameraComponent);
         const oriCamera = camComp && camComp.camera;
         if (oriCamera) {
             camera.postProcess = oriCamera.postProcess;


### PR DESCRIPTION
New forward pipeline uses `PostProcessBuilder` which will import `CameraComponent` from `misc/camera-component.ts`.
It will result in some dependency issue. See https://forum.cocos.org/t/topic/149932/318?u=jare
This pr uses `getComponent('cc.Camera')` to find the component and erased the type info.
As a result, forward pipeline is now decoupled from camera-component.ts

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
