### PR TITLE
勾选use baked animation时的用户警告优化

### DIFF
--- a/editor/i18n/en/components.js
+++ b/editor/i18n/en/components.js
@@ -3,7 +3,7 @@ module.exports = {
         add_component: 'Add Component',
 
         animation: {
-            use_baked_animation_tips: 'When a skeleton animation is pre-baked, its bones do not move in real-time. If you need to attach external nodes to specific bone joints, it is recommended to use Sockets System.',
+            use_baked_animation_tips: 'When a skeleton animation is pre-baked, its bones do not move in real-time. If you need to attach external nodes to specific bone joints, it is recommended to use <ui-link value="https://docs.cocos.com/creator/manual/en/animation/skeletal-animation.html#socket-system"> Sockets System </ui-link>.',
         },
 
         safe_area: {

--- a/editor/i18n/en/components.js
+++ b/editor/i18n/en/components.js
@@ -1,6 +1,11 @@
 module.exports = {
     components: {
         add_component: 'Add Component',
+
+        animation: {
+            use_baked_animation_tips: 'When a skeleton animation is pre-baked, its bones do not move in real-time. If you need to attach external nodes to specific bone joints, it is recommended to use Sockets System.',
+        },
+
         safe_area: {
             brief_help:
                 'This component is used to adjust the layout of current node to respect the safe area of a notched mobile device such as the iPhone X.' +

--- a/editor/i18n/zh/components.js
+++ b/editor/i18n/zh/components.js
@@ -1,6 +1,11 @@
 module.exports = {
     components: {
         add_component: '添加组件',
+
+        animation: {
+            use_baked_animation_tips: '使用预烘焙动画，骨骼在运行时不会实时移动，如需将某些外部节点挂到指定的骨骼关节上，请使用 Sockets 挂点系统',
+        },
+
         safe_area: {
             brief_help:
                 '该组件会将所在节点的布局适配到 iPhone X 等异形屏手机的安全区域内，通常用于 UI 交互区域的顶层节点。该组件将在真机上将自动生效，在编辑器下没有效果。',

--- a/editor/i18n/zh/components.js
+++ b/editor/i18n/zh/components.js
@@ -3,7 +3,7 @@ module.exports = {
         add_component: '添加组件',
 
         animation: {
-            use_baked_animation_tips: '使用预烘焙动画，骨骼在运行时不会实时移动，如需将某些外部节点挂到指定的骨骼关节上，请使用 Sockets 挂点系统',
+            use_baked_animation_tips: '使用预烘焙动画，骨骼在运行时不会实时移动，如需将某些外部节点挂到指定的骨骼关节上，请使用 <ui-link value="https://docs.cocos.com/creator/manual/zh/animation/skeletal-animation.html#socket-system">Sockets 挂点系统</ui-link>。',
         },
 
         safe_area: {

--- a/editor/inspector/components.js
+++ b/editor/inspector/components.js
@@ -12,6 +12,7 @@ module.exports = {
     'cc.SafeArea': join(__dirname, './components/safe-area.js'),
     'cc.ScrollView': join(__dirname, './components/scroll-view.js'),
     'cc.SkinnedMeshBatchRenderer': join(__dirname, './components/batched-skinning-model.js'),
+    'cc.SkeletalAnimation': join(__dirname, './components/skeletal-animation.js'),
     'cc.SphereLight': join(__dirname, './components/sphere-light.js'),
     'cc.SpotLight': join(__dirname, './components/spot-light.js'),
     'cc.PointLight': join(__dirname, './components/point-light.js'),

--- a/editor/inspector/components/skeletal-animation.js
+++ b/editor/inspector/components/skeletal-animation.js
@@ -1,0 +1,44 @@
+const { template, $, update } = require('./base');
+
+exports.template = template;
+exports.$ = $;
+exports.update = update;
+
+exports.style = `
+    .use_baked_animation_tips {
+        color: #707070;
+    }
+    .use_baked_animation_tips_hidden {
+        display: none;
+    }
+`;
+
+function updateTipsState(parent, hidden) {
+    let tips = parent.getElementsByClassName('use_baked_animation_tips')[0];
+    if (!tips) {
+        tips = document.createElement('ui-label');
+        tips.value = `i18n:ENGINE.components.animation.use_baked_animation_tips`;
+        tips.classList.add('use_baked_animation_tips', 'use_baked_animation_tips_hidden');
+        parent.appendChild(tips);
+    }
+    if (hidden) {
+        tips.classList.add('use_baked_animation_tips_hidden');
+    } else {
+        tips.classList.remove('use_baked_animation_tips_hidden');
+    }
+    return tips;
+}
+
+exports.elements = {
+    useBakedAnimation: {
+        update(element, dump) {
+            updateTipsState(element, !dump.useBakedAnimation.value);
+        }
+    }
+};
+
+exports.ready = function() {
+    this.elements = exports.elements;
+};
+
+exports.close = function() {}


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/13604

### Changelog

* 勾选use baked animation时的用户警告优化

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
