### PR TITLE
Optimize unit test; support overriding constants in per-test-suite

### DIFF
--- a/tests/init.ts
+++ b/tests/init.ts
@@ -2,14 +2,15 @@ jest.mock(
     'internal:constants',
     () => {
         const actual = jest.requireActual('./constants-for-test');
-        const { getCurrentTestSuiteConfig } = jest.requireActual('./utils/test-suite-config');
+        const { getCurrentTestSuiteConfig } = jest.requireActual('./utils/test-suite-config') as
+            typeof import('./utils/test-suite-config');
         const config = getCurrentTestSuiteConfig();
-        if (!config.constantsOverride) {
+        if (!config.constantOverrides) {
             return actual;
         }
         return {
             ...actual,
-            ...config.constantsOverride,
+            ...config.constantOverrides,
         };
     },
     { virtual: true, },

--- a/tests/init.ts
+++ b/tests/init.ts
@@ -1,6 +1,17 @@
 jest.mock(
     'internal:constants',
-    () => jest.requireActual('./constants-for-test'),
+    () => {
+        const actual = jest.requireActual('./constants-for-test');
+        const { getCurrentTestSuiteConfig } = jest.requireActual('./utils/test-suite-config');
+        const config = getCurrentTestSuiteConfig();
+        if (!config.constantsOverride) {
+            return actual;
+        }
+        return {
+            ...actual,
+            ...config.constantsOverride,
+        };
+    },
     { virtual: true, },
 );
 
@@ -171,7 +182,8 @@ const config: IGameConfig = {
         }
     }
 }
-globalThis.waitThis((async () => {
+
+async function bootstrap() {
     game.on(Game.EVENT_POST_SUBSYSTEM_INIT, () => {
         effects.forEach((e, effectIndex) => {
             const effect = Object.assign(new EffectAsset(), e);
@@ -190,4 +202,6 @@ globalThis.waitThis((async () => {
     initBuiltinPhysicsMaterial();
     await game.init(config);
     await game.run();
-})());
+}
+
+module.exports = bootstrap;

--- a/tests/test-environment.ts
+++ b/tests/test-environment.ts
@@ -1,25 +1,36 @@
 import JSDOMEnvironment from 'jest-environment-jsdom';
+import fs from 'fs-extra';
+import type { TestSuiteConfig } from './utils/test-suite-config';
 
 class Environment extends JSDOMEnvironment {
     constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
         super(...args);
 
-        const promises = this._promises;
-        Object.defineProperty(this.global, 'waitThis', {
-            get: () => {
-                return (promise: Promise<unknown>) => {
-                    promises.push(promise);
-                };
-            },
-        });
+        const [_, context] = args;
+        this._testPath = context.testPath;
+
+        this.global.__cc_test__ = {
+            currentTestSuiteConfig: {},
+        };
+        this._readTestSuiteConfig();
     }
 
     async setup(...args: Parameters<JSDOMEnvironment['setup']>) {
         await super.setup(...args);
-        await Promise.all(this._promises);
     }
 
-    private _promises: Promise<unknown>[] = [];
+    private _testPath: string;
+
+    private _readTestSuiteConfig() {
+        const configPath = `${this._testPath}.config.json`;
+        if (!fs.pathExistsSync(configPath)) {
+            return;
+        }
+        const config = fs.readJsonSync(configPath) as TestSuiteConfig;
+        this.global.__cc_test__ = {
+            currentTestSuiteConfig: config,
+        };
+    }
 }
 
 export default Environment;

--- a/tests/utils/test-suite-config.test.ts
+++ b/tests/utils/test-suite-config.test.ts
@@ -1,10 +1,8 @@
-import { getCurrentTestSuiteConfig, TestSuiteConfig } from "./test-suite-config";
+/// <reference path="../../@types/consts.d.ts"/>
 
-test(`Test suite config`, () => {
-    expect(getCurrentTestSuiteConfig()).toEqual<TestSuiteConfig>({
-        constantOverrides: {
-            SUPPORT_JIT: true,
-            BUILD: true,
-        },
-    });
+import { SUPPORT_JIT, BUILD } from 'internal:constants';
+
+test(`Constant overrides`, () => {
+    expect(SUPPORT_JIT).toBe(true);
+    expect(BUILD).toBe(true);
 });

--- a/tests/utils/test-suite-config.test.ts
+++ b/tests/utils/test-suite-config.test.ts
@@ -1,0 +1,10 @@
+import { getCurrentTestSuiteConfig, TestSuiteConfig } from "./test-suite-config";
+
+test(`Test suite config`, () => {
+    expect(getCurrentTestSuiteConfig()).toEqual<TestSuiteConfig>({
+        constantOverrides: {
+            SUPPORT_JIT: true,
+            BUILD: true,
+        },
+    });
+});

--- a/tests/utils/test-suite-config.test.ts.config.json
+++ b/tests/utils/test-suite-config.test.ts.config.json
@@ -1,0 +1,6 @@
+{
+    "constantOverrides": {
+        "SUPPORT_JIT": true,
+        "BUILD": true
+    }
+}

--- a/tests/utils/test-suite-config.ts
+++ b/tests/utils/test-suite-config.ts
@@ -1,6 +1,6 @@
 
 export interface TestSuiteConfig {
-    constantsOverride?: Record<string, boolean>;
+    constantOverrides?: Record<string, boolean>;
 }
 
 declare global {

--- a/tests/utils/test-suite-config.ts
+++ b/tests/utils/test-suite-config.ts
@@ -1,0 +1,14 @@
+
+export interface TestSuiteConfig {
+    constantsOverride?: Record<string, boolean>;
+}
+
+declare global {
+    namespace __cc_test__ {
+        let currentTestSuiteConfig: TestSuiteConfig;
+    }
+}
+
+export function getCurrentTestSuiteConfig() {
+    return __cc_test__.currentTestSuiteConfig;
+}


### PR DESCRIPTION
Re: #

### Changelog

* Optimize unit test.

  We have the requirement to await for an initialization function before some tests. Before, we implement this by expose a [waitThis](https://github.com/cocos/cocos-engine/blob/08d9a344571b6e2995242f3a8f31cf2a06c30a6b/tests/test-environment.ts#L8) in global within test environment. However in jest 28.x, they make a change so we can directly export an async function in [**setupFiles**](https://jestjs.io/docs/configuration#setupfiles-array). So here I adjusted to use this mechanism.

* Support overriding constants in per test suite.

  Sometimes we need to test a feature under different "constants". For example, we need to test the deserialization behaviour under both `SUPPORT_JIT` is true or false.

  If a test suite(ie. a test file) needs to override the default constant value. One may create a JSON config file at `<dir-of-test-file>/<name-of-the-test-file-including-extension>.config.json`, called as "test suite config". Within that config, one can specify the constant overrides. The config's content can be configured according to [`TestSuiteConfig`](https://github.com/cocos/cocos-engine/pull/15628/files#diff-d2c64ef8176f957584f6f863c240883afe45fe2695556e756c4e0aa62d34119dR2-R4).

  Note, this PR also includes a [test](https://github.com/cocos/cocos-engine/pull/15628/files#diff-86c3f0dcf4501d40cf0107971dfce64298753972cba07e3bca6fdbfa3a686932R5) for the constant overriding. It can as well be referenced as example.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
