### PR TITLE
Fix deserialization of engine class in certain circumstance

### DIFF
--- a/cocos/serialization/deserialize-dynamic.ts
+++ b/cocos/serialization/deserialize-dynamic.ts
@@ -235,7 +235,7 @@ function compileDeserializeNative (_self: _Deserializer, klass: CCClassConstruct
             if (prop === undefined) {
                 continue;
             }
-            if (!fastMode && typeof prop !== 'object') {
+            if (typeof prop !== 'object') {
                 o[propName] = prop;
             } else {
                 // fastMode (so will not simpleProp) or object

--- a/tests/core/deserialize.test.ts
+++ b/tests/core/deserialize.test.ts
@@ -3,6 +3,7 @@ import { property } from '../../cocos/core/data/class-decorator';
 import { ccclass, type } from '../../cocos/core/data/decorators';
 import { deserialize } from '../../cocos/serialization/deserialize';
 import { BitMask } from '../../cocos/core/value-types/bitmask';
+import './serialization/deserialize-common-tests';
 
 describe('Deserialize', () => {
     test('Object array element', () => {

--- a/tests/core/serialization/deserialize-common-tests.ts
+++ b/tests/core/serialization/deserialize-common-tests.ts
@@ -1,0 +1,43 @@
+import { CCClass, ccenum } from '../../../cocos/core';
+import { property } from '../../../cocos/core/data/class-decorator';
+import { ccclass, type } from '../../../cocos/core/data/decorators';
+import { deserialize } from '../../../cocos/serialization/deserialize';
+import { getClassId, unregisterClass } from '../../../cocos/core/utils/js-typed';
+
+test.only('Fast mode', () => {
+    @ccclass('cc.MeDoNotBelieveThisExists')
+    class Cls {
+        @property
+        n: number;
+
+        @property
+        b: boolean;
+
+        @property
+        s: string;
+
+        @property
+        nil: null;
+    }
+
+    const serialized = {
+        __type__: getClassId(Cls),
+        n: 3.14,
+        b: true,
+        s: '321',
+        nil: null,
+    };
+
+    const deserialized = deserialize(serialized, undefined, undefined);
+    expect(Object.getPrototypeOf(deserialized)).toStrictEqual(expect.objectContaining({
+        constructor: Cls,
+    }));
+    expect(deserialized).toStrictEqual(expect.objectContaining<Cls>({
+        n: 3.14,
+        b: true,
+        s: '321',
+        nil: null,
+    }));
+
+    unregisterClass(Cls);
+});

--- a/tests/core/serialization/deserialize-common-tests.ts
+++ b/tests/core/serialization/deserialize-common-tests.ts
@@ -4,7 +4,7 @@ import { ccclass, type } from '../../../cocos/core/data/decorators';
 import { deserialize } from '../../../cocos/serialization/deserialize';
 import { getClassId, unregisterClass } from '../../../cocos/core/utils/js-typed';
 
-test.only('Fast mode', () => {
+test('Fast mode', () => {
     @ccclass('cc.MeDoNotBelieveThisExists')
     class Cls {
         @property

--- a/tests/core/serialization/deserialize-jit.test.ts
+++ b/tests/core/serialization/deserialize-jit.test.ts
@@ -1,0 +1,3 @@
+import './deserialize-common-tests';
+
+export {};

--- a/tests/core/serialization/deserialize-jit.test.ts.config.json
+++ b/tests/core/serialization/deserialize-jit.test.ts.config.json
@@ -1,0 +1,5 @@
+{
+    "constantOverrides": {
+        "SUPPORT_JIT": true
+    }
+}


### PR DESCRIPTION
This closes https://github.com/cocos/3d-tasks/issues/7909

### Changelog

* Previously, if a class have cc name "cc.", and it has a property with primitive type but has neither default value nor `@type`, the property will be incorrectly deserialized. For example:

  ```ts
  @ccclass('cc.Whatever')
  class Cls { @serializable x: number; }
  
  const o = new Cls();
  o.x = 1;
  ```

 Serialize then deserialize `o` results the deserialized `o.x ` being empty object literal `{}` instead of `1`. Note, this error only appears in "non-JIT" branch of deserialization.

  This PR fixes it.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
