### PR TITLE
Fix the enumeration order of event types in Wasm (native) and TypeScript interfaces.

### DIFF
--- a/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
@@ -98,8 +98,8 @@ EMSCRIPTEN_BINDINGS(spine) {
         .value("start", EventType_Start)
         .value("interrupt", EventType_Interrupt)
         .value("end", EventType_End)
-        .value("dispose", EventType_Complete)
         .value("complete", EventType_Dispose)
+        .value("dispose", EventType_Complete)
         .value("event", EventType_Event);
 
     enum_<TransformMode>("TransformMode")

--- a/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
@@ -98,8 +98,8 @@ EMSCRIPTEN_BINDINGS(spine) {
         .value("start", EventType_Start)
         .value("interrupt", EventType_Interrupt)
         .value("end", EventType_End)
-        .value("complete", EventType_Dispose)
-        .value("dispose", EventType_Complete)
+        .value("dispose", EventType_Dispose)
+        .value("complete", EventType_Complete)
         .value("event", EventType_Event);
 
     enum_<TransformMode>("TransformMode")

--- a/native/cocos/editor-support/spine/AnimationState.h
+++ b/native/cocos/editor-support/spine/AnimationState.h
@@ -46,8 +46,8 @@ enum EventType {
     EventType_Start,
     EventType_Interrupt,
     EventType_End,
-    EventType_Complete,
     EventType_Dispose,
+    EventType_Complete,
     EventType_Event
 };
 


### PR DESCRIPTION


Re: #

### Changelog

*Fix the issue of aligning the enumeration order of event types in Wasm (native) and TypeScript interfaces.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
