### PR TITLE
fixed #15688: [JSB] Assertion was triggered if bind an inner class whose parent is also an inner class

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/Class.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Class.cpp
@@ -79,14 +79,14 @@ Class *Class::create(const ccstd::string &clsName, Object *parent, Object *paren
 
 Class *Class::create(const std::initializer_list<const char *> &classPath, Object *parent, Object *parentProto, v8::FunctionCallback ctor, void *data) {
     se::AutoHandleScope scope;
-    se::Object *currentParent = parent;
-    se::Value tmp;
+    se::Value currentParent{parent};
     for (auto i = 0; i < classPath.size() - 1; i++) {
-        bool ok = currentParent->getProperty(*(classPath.begin() + i), &tmp);
+        se::Value tmp;
+        bool ok = currentParent.toObject()->getProperty(*(classPath.begin() + i), &tmp);
         CC_ASSERT(ok); // class or namespace in path is not defined
-        currentParent = tmp.toObject();
+        currentParent = tmp;
     }
-    return create(*(classPath.end() - 1), currentParent, parentProto, ctor, data);
+    return create(*(classPath.end() - 1), currentParent.toObject(), parentProto, ctor, data);
 }
 
 bool Class::init(const ccstd::string &clsName, Object *parent, Object *parentProto, v8::FunctionCallback ctor, void *data) {


### PR DESCRIPTION
Re: #15688

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
