### PR TITLE
[AOT] fix ts engine compile

### DIFF
--- a/cocos/physics/framework/physics-selector.ts
+++ b/cocos/physics/framework/physics-selector.ts
@@ -64,7 +64,7 @@ interface IPhysicsWrapperObject {
 
 interface IPhysicsBackend { [key: string]: IPhysicsWrapperObject; }
 
-interface IPhysicsSelector {
+export interface IPhysicsSelector {
     /**
      * @en
      * The id of the physics engine being used by the physics system.

--- a/cocos/physics/physx/instantiate.jsb.ts
+++ b/cocos/physics/physx/instantiate.jsb.ts
@@ -26,6 +26,6 @@
  * hack for jsb, shoule be refactor in futrue
  */
 
-import { selector } from '../framework/physics-selector';
+import { selector, IPhysicsSelector } from '../framework/physics-selector';
 
-selector.id = 'physx';
+(selector as Mutable<IPhysicsSelector>).id = 'physx';

--- a/templates/openharmony/entry/src/main/ets/cocos/game.ts
+++ b/templates/openharmony/entry/src/main/ets/cocos/game.ts
@@ -80,7 +80,7 @@ export function launchEngine (): Promise<void> {
         return systemReady().then(() => {
             // @ts-ignore
             window.oh.loadModule = loadModule;
-            import('./jsb-adapter/web-adapter.js').then(() => {
+            return import('./jsb-adapter/web-adapter.js').then(() => {
                 return import('./src/<%= systemBundleUrl%>').then(() => {
                     System.warmup({
                         importMap,


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/16149

### Changelog

* fix ts engine compile issue in DevEco Studio

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
