### PR TITLE
Fix videoplayer status after pause&finish

### DIFF
--- a/cocos/video/video-player-impl.ts
+++ b/cocos/video/video-player-impl.ts
@@ -178,6 +178,7 @@ export abstract class VideoPlayerImpl {
     }
 
     public onEnded (e: Event): void {
+        this._playing = false;
         this.dispatchEvent(EventType.COMPLETED);
     }
 
@@ -193,7 +194,6 @@ export abstract class VideoPlayerImpl {
         }
     }
 
-    //
     public play (): void {
         if (this._loadedMeta || this._loaded) {
             this.canPlay();

--- a/cocos/video/video-player-impl.ts
+++ b/cocos/video/video-player-impl.ts
@@ -163,11 +163,11 @@ export abstract class VideoPlayerImpl {
     }
 
     public onPause (e: Event): void {
+        this._playing = false;
         if (this._ignorePause) {
             this._ignorePause = false;
             return;
         }
-        this._playing = false;
         this.dispatchEvent(EventType.PAUSED);
     }
 


### PR DESCRIPTION
Re: # related PR: https://github.com/cocos/cocos-test-projects/pull/824

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
