### PR TITLE
Workflow: fix interface check workflow comment

### DIFF
--- a/.github/workflows/web-interface-check-pr-comment.yml
+++ b/.github/workflows/web-interface-check-pr-comment.yml
@@ -14,14 +14,29 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifacts  
+      - name: 'Get source run informations'
+        uses: potiuk/get-workflow-origin@v1_1
+        id: source_run_info
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+
+      - name: 'Debug'
+        run: |
+            Write-Host "Source PR Number: ${{ github.event.workflow_run.pull_requests[0].number }}"
+        shell: pwsh
+
+      - name: Download artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
-          gh run download -R "${{ github.repository }}" --name "interface-diff.txt" "$RUN_ID"       
+          gh run download -R "${{ github.repository }}" --name "interface-diff.txt" "$RUN_ID"
+          
       - name: Post interface-diff.txt as comment 
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          path: interface-diff.txt          
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          path: interface-diff.txt
+          number: ${{ steps.source_run_info.outputs.pullRequestNumber }}
+          # The following matters, see: https://github.com/orgs/community/discussions/25220
+          # number: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
Re: #

### Changelog

* Fix that interface check workflow comment was invalidated due to #15451.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
