### PR TITLE
remove _fitDesignResolution function call in EVENT_AFTER_UPDATE

### DIFF
--- a/cocos/2d/framework/canvas.ts
+++ b/cocos/2d/framework/canvas.ts
@@ -138,12 +138,12 @@ export class Canvas extends RenderRoot2D {
                 // TODO: support paddings of locked widget
                 this.node.getPosition(this._pos);
                 const nodeSize = view.getDesignResolutionSize();
-                Vec3.set(_worldPos, nodeSize.width * 0.5, nodeSize.height * 0.5, 0);
+                const trans = this.node._uiProps.uiTransformComp!;
+                Vec3.set(_worldPos, nodeSize.width * trans.anchorX, nodeSize.height * trans.anchorY, 0);
 
                 if (!this._pos.equals(_worldPos)) {
                     this.node.setPosition(_worldPos);
                 }
-                const trans = this.node._uiProps.uiTransformComp!;
                 if (trans.width !== nodeSize.width) {
                     trans.width = nodeSize.width;
                 }

--- a/cocos/2d/framework/canvas.ts
+++ b/cocos/2d/framework/canvas.ts
@@ -28,7 +28,7 @@ import { ccclass, help, disallowMultiple, executeInEditMode,
 import { EDITOR } from 'internal:constants';
 import { Camera } from '../../misc/camera-component';
 import { Widget } from '../../ui/widget';
-import { Vec3, screen, Enum, cclegacy, visibleRect, approx, EPSILON } from '../../core';
+import { Vec3, screen, Enum, cclegacy, visibleRect } from '../../core';
 import { view } from '../../ui/view';
 import { RenderRoot2D } from './render-root-2d';
 import { NodeEventType } from '../../scene-graph/node-event';

--- a/cocos/2d/framework/canvas.ts
+++ b/cocos/2d/framework/canvas.ts
@@ -139,7 +139,24 @@ export class Canvas extends RenderRoot2D {
                 this.node.getPosition(this._pos);
                 const nodeSize = view.getDesignResolutionSize();
                 const trans = this.node._uiProps.uiTransformComp!;
-                Vec3.set(_worldPos, nodeSize.width * trans.anchorX, nodeSize.height * trans.anchorY, 0);
+
+                let scaleX = this.node.scale.x;
+                let anchorX = trans.anchorX;
+                if (scaleX < 0) {
+                    anchorX = 1.0 - anchorX;
+                    scaleX = -scaleX;
+                }
+                nodeSize.width = scaleX === 0 ? nodeSize.width : nodeSize.width / scaleX;
+
+                let scaleY = this.node.scale.y;
+                let anchorY = trans.anchorY;
+                if (scaleY < 0) {
+                    anchorY = 1.0 - anchorY;
+                    scaleY = -scaleY;
+                }
+                nodeSize.height = scaleY === 0 ? nodeSize.height : nodeSize.height / scaleY;
+
+                Vec3.set(_worldPos, nodeSize.width * anchorX, nodeSize.height * anchorY, 0);
 
                 if (!this._pos.equals(_worldPos)) {
                     this.node.setPosition(_worldPos);

--- a/cocos/2d/framework/canvas.ts
+++ b/cocos/2d/framework/canvas.ts
@@ -28,7 +28,7 @@ import { ccclass, help, disallowMultiple, executeInEditMode,
 import { EDITOR } from 'internal:constants';
 import { Camera } from '../../misc/camera-component';
 import { Widget } from '../../ui/widget';
-import { Vec3, screen, Enum, cclegacy, visibleRect } from '../../core';
+import { Vec3, screen, Enum, cclegacy, visibleRect, approx, EPSILON } from '../../core';
 import { view } from '../../ui/view';
 import { RenderRoot2D } from './render-root-2d';
 import { NodeEventType } from '../../scene-graph/node-event';
@@ -124,7 +124,7 @@ export class Canvas extends RenderRoot2D {
 
     protected _thisOnCameraResized: () => void;
     // fit canvas node to design resolution
-    protected _fitDesignResolution: (() => void) | undefined;
+    protected fitDesignResolution_EDITOR: (() => void) | undefined;
 
     private _pos = new Vec3();
     private _renderMode = RenderMode.OVERLAY;
@@ -134,7 +134,7 @@ export class Canvas extends RenderRoot2D {
         this._thisOnCameraResized = this._onResizeCamera.bind(this);
 
         if (EDITOR) {
-            this._fitDesignResolution = (): void => {
+            this.fitDesignResolution_EDITOR = (): void => {
                 // TODO: support paddings of locked widget
                 this.node.getPosition(this._pos);
                 const nodeSize = view.getDesignResolutionSize();
@@ -160,7 +160,7 @@ export class Canvas extends RenderRoot2D {
         if (widget) {
             widget.updateAlignment();
         } else if (EDITOR) {
-            this._fitDesignResolution!();
+            this.fitDesignResolution_EDITOR!();
         }
 
         if (!EDITOR) {


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/17320
https://github.com/cocos/3d-tasks/issues/17320

### Changelog

* Canvas switched to using Widgets, but forgot to clean up the previous alignment logic, resulting in duplicates. Cleanup required.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
