### PR TITLE
Fix the problem of noise when playing web audio for more than 5 minutes.

### DIFF
--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -83,7 +83,6 @@ export class OneShotAudioWeb {
         this._bufferSourceNode.stop();
         this._bufferSourceNode.disconnect();
         this._bufferSourceNode.buffer = null;
-        this._bufferSourceNode = null as any;
     }
 }
 
@@ -282,7 +281,7 @@ export class AudioPlayerWeb implements OperationQueueable {
                 this._sourceNode.stop();
                 this._sourceNode.disconnect();
                 this._sourceNode.buffer = null;
-                this._sourceNode = null as any;
+                this._sourceNode = undefined;
             }
         } catch (e) {
             // sourceNode can't be stopped twice, especially on Safari.

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -81,7 +81,9 @@ export class OneShotAudioWeb {
         this._bufferSourceNode.onended = null;  // stop will call ended callback
         audioBufferManager.tryReleasingCache(this._url);
         this._bufferSourceNode.stop();
+        this._bufferSourceNode.disconnect();
         this._bufferSourceNode.buffer = null;
+        this._bufferSourceNode = null as any;
     }
 }
 
@@ -278,7 +280,9 @@ export class AudioPlayerWeb implements OperationQueueable {
             if (this._sourceNode) {
                 this._sourceNode.onended = null;  // stop will call ended callback
                 this._sourceNode.stop();
+                this._sourceNode.disconnect();
                 this._sourceNode.buffer = null;
+                this._sourceNode = null as any;
             }
         } catch (e) {
             // sourceNode can't be stopped twice, especially on Safari.

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -208,7 +208,6 @@ export class OneShotAudioWeb {
         this._bufferSourceNode.stop();
         this._bufferSourceNode.disconnect();
         this._bufferSourceNode.buffer = null;
-        this._bufferSourceNode = null as any;
     }
 }
 
@@ -442,7 +441,7 @@ export class AudioPlayerWeb implements OperationQueueable {
                 this._sourceNode.stop();
                 this._sourceNode.disconnect();
                 this._sourceNode.buffer = null;
-                this._sourceNode = null as any;
+                this._sourceNode = undefined;
             }
         } catch (e) {
             // sourceNode can't be stopped twice, especially on Safari.

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -206,7 +206,9 @@ export class OneShotAudioWeb {
         clearTimeout(this._currentTimer);
         audioBufferManager.tryReleasingCache(this._url);
         this._bufferSourceNode.stop();
+        this._bufferSourceNode.disconnect();
         this._bufferSourceNode.buffer = null;
+        this._bufferSourceNode = null as any;
     }
 }
 
@@ -438,7 +440,9 @@ export class AudioPlayerWeb implements OperationQueueable {
         try {
             if (this._sourceNode) {
                 this._sourceNode.stop();
+                this._sourceNode.disconnect();
                 this._sourceNode.buffer = null;
+                this._sourceNode = null as any;
             }
         } catch (e) {
             // sourceNode can't be stopped twice, especially on Safari.


### PR DESCRIPTION
Re:  https://github.com/cocos/cocos-engine/issues/10977

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
