### PR TITLE
Re-support non-transform animation in animation graph

### DIFF
--- a/cocos/animation/marionette/animation-graph-animation-clip-binding.ts
+++ b/cocos/animation/marionette/animation-graph-animation-clip-binding.ts
@@ -8,7 +8,7 @@ import { AuxiliaryCurveHandle, TransformHandle } from '../core/animation-handle'
 import { calculateDeltaPose, Pose } from '../core/pose';
 import { createEvalSymbol } from '../define';
 import { ExoticTrsAGEvaluation } from '../exotic-animation/exotic-animation';
-import { isTrsPropertyName, normalizedFollowTag, Track, TrackBinding, trackBindingTag, TrackEval } from '../tracks/track';
+import { isTrsPropertyName, normalizedFollowTag, RuntimeBinding, Track, TrackBinding, trackBindingTag, TrackEval } from '../tracks/track';
 import { UntypedTrack } from '../tracks/untyped-track';
 import { AnimationGraphEvaluationContext } from './animation-graph-context';
 
@@ -204,6 +204,26 @@ function bindPoseTransform (
     }
 }
 
+class NonTransformPoseBinding implements PoseBinding<any> {
+    constructor (
+        public readonly binding: RuntimeBinding,
+    ) {
+
+    }
+
+    destroy (): void {
+        // Needs no destroy.
+    }
+
+    setValue (value: any, _pose: Pose): void {
+        this.binding.setValue(value);
+    }
+
+    getValue (pose: Pose): any {
+        return this.binding.getValue?.() ?? undefined;
+    }
+}
+
 /**
  * Describes the evaluation of a animation clip track in sense of animation graph.
  */
@@ -230,7 +250,11 @@ class AGTrackEvaluation<TValue> {
     private _trackSampler: TrackEval<TValue>;
 }
 
-function bindTrackAG (animationClip: AnimationClip, track: Track, bindContext: AnimationClipGraphBindingContext): PoseBinding<unknown> | undefined {
+function bindTrackAG (
+    animationClip: AnimationClip,
+    track: Track,
+    bindContext: AnimationClipGraphBindingContext,
+): PoseBinding<unknown> | undefined {
     const trackBinding = track[trackBindingTag];
     const trackTarget = createRuntimeBindingAG(trackBinding, bindContext);
     if (DEBUG && !trackTarget) {
@@ -247,7 +271,10 @@ function bindTrackAG (animationClip: AnimationClip, track: Track, bindContext: A
     return trackTarget ?? undefined;
 }
 
-function createRuntimeBindingAG (track: TrackBinding, bindContext: AnimationClipGraphBindingContext): PoseBinding<unknown> | null | undefined {
+function createRuntimeBindingAG (
+    track: TrackBinding,
+    bindContext: AnimationClipGraphBindingContext,
+): PoseBinding<unknown> | null | undefined {
     const {
         origin,
     } = bindContext;
@@ -288,10 +315,16 @@ function createRuntimeBindingAG (track: TrackBinding, bindContext: AnimationClip
         }
     }
 
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    // TODO: here should be resolved before this can be landed.
-    error(`Animation graph currently only supports (bone) transform animations.`);
-    return undefined;
+    // If this path does not aim a transform target,
+    // we create `NonTransformPoseBinding` using default binding.
+    {
+        const nonTransformBinding = track.createRuntimeBinding(bindContext.origin, undefined, false);
+        if (!nonTransformBinding) {
+            return null;
+        }
+
+        return new NonTransformPoseBinding(nonTransformBinding);
+    }
 }
 
 class AuxiliaryCurveEvaluation {
@@ -361,7 +394,7 @@ class AnimationClipAGEvaluationRegular implements AnimationClipAGEvaluation {
 
         for (const track of tracks) {
             if (track instanceof UntypedTrack) {
-            // Untyped track is not supported in AG.
+                // Untyped track is not supported in AG.
                 continue;
             }
             if (Array.from(track.channels()).every(({ curve }) => curve.keyFramesCount === 0)) {


### PR DESCRIPTION
Re: #

### Changelog

* Re-support non-transform animation in animation graph.

### Detail

Prior to v3.8.0, non-transform animation is "unexpectedly" supported in animation. Word "unexpectedly" here means: the animation graph in original does not intend to support non-transform animation, but due to the old implementation and mistake in editor, it's actually supported. In v3.8.0, non-transform animation gets no longer worked. The "breaking change" has been reported by user(s), which can be tracked in [here](https://forum.cocos.org/t/topic/149932/664?u=shrinktofit). As a result, it's added back.

The behaviour of using non-transform in animation graph should be same as prior: only state switching, no blending.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
