### PR TITLE
refactor : prefab code optimization and protection

### DIFF
--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -1214,11 +1214,25 @@ nodeProto[serializeTag] = function (serializationOutput: SerializationOutput, co
         // discard props disallow to synchronize
         const isRoot = this._prefab?.root === this;
         if (isRoot) {
-            serializationOutput.writeProperty('_objFlags', this._objFlags);
-            serializationOutput.writeProperty('_parent', this._parent);
-            serializationOutput.writeProperty('_prefab', this._prefab);
-            if (context.customArguments.keepNodeUuid) {
-                serializationOutput.writeProperty('_id', this._id);
+            // if B prefab is in A prefab,B can be referenced by component.We should discard it.because B is not the root of prefab
+            let isNestedPrefab = false;
+            let parent = this.getParent();
+            while (parent) {
+                const nestedRoots = parent?._prefab?.nestedPrefabInstanceRoots;
+                if (nestedRoots && nestedRoots.length > 0) {
+                    // if this node is not in nestedPrefabInstanceRoots,it means this node is not the root of prefab,so it should be discarded.
+                    isNestedPrefab = !nestedRoots.some((root) => root === this);
+                    break;
+                }
+                parent = parent.getParent();
+            }
+            if (!isNestedPrefab) {
+                serializationOutput.writeProperty('_objFlags', this._objFlags);
+                serializationOutput.writeProperty('_parent', this._parent);
+                serializationOutput.writeProperty('_prefab', this._prefab);
+                if (context.customArguments.keepNodeUuid) {
+                    serializationOutput.writeProperty('_id', this._id);
+                }
             }
             // TODO: editorExtrasTag may be a symbol in the future
             serializationOutput.writeProperty(editorExtrasTag, this[editorExtrasTag]);

--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -1016,6 +1016,14 @@ Object.defineProperty(nodeProto, '_siblingIndex', {
     },
 });
 
+Object.defineProperty(nodeProto, 'prefab', {
+    configurable: true,
+    enumerable: true,
+    get() {
+        return this._prefab;
+    },
+});
+
 // External classes need to access it through getter/setter
 Object.defineProperty(nodeProto, 'siblingIndex', {
     configurable: true,

--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -1218,7 +1218,7 @@ nodeProto[serializeTag] = function (serializationOutput: SerializationOutput, co
             let isNestedPrefab = false;
             let parent = this.getParent();
             while (parent) {
-                const nestedRoots = parent?._prefab?.nestedPrefabInstanceRoots;
+                const nestedRoots = parent._prefab?.nestedPrefabInstanceRoots;
                 if (nestedRoots && nestedRoots.length > 0) {
                     // if this node is not in nestedPrefabInstanceRoots,it means this node is not the root of prefab,so it should be discarded.
                     isNestedPrefab = !nestedRoots.some((root) => root === this);

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -1810,7 +1810,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
                 let isNestedPrefab = false;
                 let parent = this.getParent();
                 while (parent) {
-                    const nestedRoots = parent?._prefab?.nestedPrefabInstanceRoots;
+                    const nestedRoots = parent._prefab?.nestedPrefabInstanceRoots;
                     if (nestedRoots && nestedRoots.length > 0) {
                         // if this node is not in nestedPrefabInstanceRoots,it means this node is not the root of prefab,so it should be discarded.
                         isNestedPrefab = !nestedRoots.some((root) => root === this);

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -363,6 +363,10 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      */
     @serializable
     protected _prefab: PrefabInfo | null = null;
+    /**
+     * @engineInternal
+     */
+    public get prefab (): PrefabInfo | null { return this._prefab; }
 
     protected _scene: Scene = null!;
 

--- a/cocos/scene-graph/prefab/prefab-info.ts
+++ b/cocos/scene-graph/prefab/prefab-info.ts
@@ -167,7 +167,7 @@ export class PrefabInstance {
     @type([TargetInfo])
     public removedComponents: TargetInfo[] = [];
 
-    public targetMap: Record<string, any | Node | Component> = {};
+    public targetMap: TargetMap = new TargetMap();
 
     /**
      * make sure prefab instance expand only once
@@ -199,6 +199,10 @@ export class PrefabInstance {
             }
         }
     }
+}
+
+export class TargetMap {
+    [key: string]: TargetMap | Node | Component;
 }
 
 @ccclass('cc.PrefabInfo')

--- a/cocos/scene-graph/prefab/prefab-info.ts
+++ b/cocos/scene-graph/prefab/prefab-info.ts
@@ -167,7 +167,7 @@ export class PrefabInstance {
     @type([TargetInfo])
     public removedComponents: TargetInfo[] = [];
 
-    public targetMap: TargetMap = new TargetMap();
+    public targetMap: TargetMap = {};
 
     /**
      * make sure prefab instance expand only once
@@ -201,9 +201,7 @@ export class PrefabInstance {
     }
 }
 
-export class TargetMap {
-    [key: string]: TargetMap | Node | Component;
-}
+export interface TargetMap { [k: string]: TargetMap | Node | Component }
 
 @ccclass('cc.PrefabInfo')
 export class PrefabInfo {

--- a/cocos/scene-graph/prefab/utils.ts
+++ b/cocos/scene-graph/prefab/utils.ts
@@ -120,7 +120,7 @@ export function generateTargetMap (node: Node, targetMap: TargetMap, isRoot: boo
     // Tracking issue: https://github.com/cocos/cocos-engine/issues/14613
     const prefabInstance = node.prefab?.instance;
     if (!isRoot && prefabInstance) {
-        targetMap[prefabInstance.fileId] = new TargetMap();
+        targetMap[prefabInstance.fileId] = {};
         curTargetMap = targetMap[prefabInstance.fileId] as TargetMap;
     }
 
@@ -405,7 +405,7 @@ export function expandPrefabInstanceNode (node: Node, recursively = false): void
             }
         }
 
-        const targetMap = new TargetMap();
+        const targetMap = {};
         prefabInstance.targetMap = targetMap;
         generateTargetMap(node, targetMap, true);
         applyMountedChildren(node, prefabInstance.mountedChildren, targetMap);

--- a/cocos/scene-graph/prefab/utils.ts
+++ b/cocos/scene-graph/prefab/utils.ts
@@ -429,7 +429,7 @@ export function expandNestedPrefabInstanceNode (node: Node): void {
 
     if (prefabInfo && prefabInfo.nestedPrefabInstanceRoots) {
         prefabInfo.nestedPrefabInstanceRoots.forEach((instanceNode: Node) => {
-            expandPrefabInstanceNode(instanceNode, true);
+            expandPrefabInstanceNode(instanceNode);
             // when expanding the prefab,it's children will be change,so need to apply after expanded
             // if (!EDITOR) {
             //     applyNodeAndComponentId(instanceNode, (instanceNode as any)._prefab?.instance?.fileId ?? '');

--- a/cocos/scene-graph/prefab/utils.ts
+++ b/cocos/scene-graph/prefab/utils.ts
@@ -400,9 +400,7 @@ export function expandPrefabInstanceNode (node: Node, recursively = false): void
         if (recursively) {
             if (node && node.children) {
                 node.children.forEach((child) => {
-                    if (child) {
-                        expandPrefabInstanceNode(child, true);
-                    }
+                    expandPrefabInstanceNode(child, true);
                 });
             }
         }
@@ -418,9 +416,7 @@ export function expandPrefabInstanceNode (node: Node, recursively = false): void
     } else if (recursively) {
         if (node && node.children) {
             node.children.forEach((child) => {
-                if (child) {
-                    expandPrefabInstanceNode(child, true);
-                }
+                expandPrefabInstanceNode(child, true);
             });
         }
     }

--- a/cocos/scene-graph/prefab/utils.ts
+++ b/cocos/scene-graph/prefab/utils.ts
@@ -40,8 +40,6 @@ import { ValueType } from '../../core/value-types';
 export * from './prefab-info';
 
 export function createNodeWithPrefab (node: Node): void {
-    // TODO(PP_Pro): after we support editorOnly tag, we could remove this any type assertion.
-    // Tracking issue: https://github.com/cocos/cocos-engine/issues/14613
     const prefabInfo = node?.prefab;
     if (!prefabInfo) {
         return;
@@ -96,8 +94,6 @@ export function createNodeWithPrefab (node: Node): void {
         node[editorExtrasTag] = editorExtras;
     }
 
-    // TODO(PP_Pro): after we support editorOnly tag, we could remove this any type assertion.
-    // Tracking issue: https://github.com/cocos/cocos-engine/issues/14613
     if (node.prefab) {
         // just keep the instance
         node.prefab.instance = prefabInfo.instance;
@@ -116,16 +112,12 @@ export function generateTargetMap (node: Node, targetMap: TargetMap, isRoot: boo
 
     let curTargetMap = targetMap;
 
-    // TODO(PP_Pro): after we support editorOnly tag, we could remove this any type assertion.
-    // Tracking issue: https://github.com/cocos/cocos-engine/issues/14613
     const prefabInstance = node.prefab?.instance;
     if (!isRoot && prefabInstance) {
         targetMap[prefabInstance.fileId] = {};
         curTargetMap = targetMap[prefabInstance.fileId] as TargetMap;
     }
 
-    // TODO(PP_Pro): after we support editorOnly tag, we could remove this any type assertion.
-    // Tracking issue: https://github.com/cocos/cocos-engine/issues/14613
     const prefabInfo = node.prefab;
     if (prefabInfo) {
         curTargetMap[prefabInfo.fileId] = node;
@@ -326,8 +318,6 @@ export function applyPropertyOverrides (node: Node, propertyOverrides: PropertyO
 }
 
 export function applyTargetOverrides (node: Node): void {
-    // TODO(PP_Pro): after we support editorOnly tag, we could remove this any type assertion.
-    // Tracking issue: https://github.com/cocos/cocos-engine/issues/14613
     const targetOverrides = node.prefab?.targetOverrides as TargetOverrideInfo[];
     if (targetOverrides) {
         for (let i = 0; i < targetOverrides.length; i++) {
@@ -391,8 +381,6 @@ export function applyTargetOverrides (node: Node): void {
 }
 
 export function expandPrefabInstanceNode (node: Node, recursively = false): void {
-    // TODO(PP_Pro): after we support editorOnly tag, we could remove this any type assertion.
-    // Tracking issue: https://github.com/cocos/cocos-engine/issues/14613
     const prefabInstance = node?.prefab?.instance as PrefabInstance;
     if (prefabInstance && !prefabInstance.expanded) {
         createNodeWithPrefab(node);
@@ -423,8 +411,6 @@ export function expandPrefabInstanceNode (node: Node, recursively = false): void
 }
 
 export function expandNestedPrefabInstanceNode (node: Node): void {
-    // TODO(PP_Pro): after we support editorOnly tag, we could remove this any type assertion.
-    // Tracking issue: https://github.com/cocos/cocos-engine/issues/14613
     const prefabInfo = node.prefab;
 
     if (prefabInfo && prefabInfo.nestedPrefabInstanceRoots) {

--- a/cocos/scene-graph/prefab/utils.ts
+++ b/cocos/scene-graph/prefab/utils.ts
@@ -336,7 +336,7 @@ export function applyTargetOverrides (node: Node): void {
             let source: Node | Component | null = targetOverride.source;
             const sourceInfo = targetOverride.sourceInfo;
             if (sourceInfo) {
-                const src  = targetOverride.source as Node;
+                const src = targetOverride.source as Node;
                 const sourceInstance = src?.prefab?.instance;
                 if (sourceInstance && sourceInstance.targetMap) {
                     source = getTarget(sourceInfo.localID, sourceInstance.targetMap);


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/17058

### Changelog

* node.jsb.ts code  synchronization with node.ts
* add node.prefab getter to avoid any
* add targetMap type and remove any
* add protection when access node.prefab when expanding prefab
* remove applyNodeAndComponentId called(it's add for onlineX which is abandon now)

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
