### PR TITLE
export downloadJson and downloadArraybuffer

### DIFF
--- a/cocos/asset/asset-manager/download-file.ts
+++ b/cocos/asset/asset-manager/download-file.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-type FileProgressCallback = (loaded: number, total: number) => void;
+export type FileProgressCallback = (loaded: number, total: number) => void;
 
 export default function downloadFile (
     url: string,

--- a/cocos/asset/asset-manager/download-file.ts
+++ b/cocos/asset/asset-manager/download-file.ts
@@ -28,21 +28,21 @@ export default function downloadFile (
     url: string,
     options: Record<string, any>,
     onProgress: FileProgressCallback | null | undefined,
-    onComplete: ((err: Error | null, data?: any | null) => void),
+    onComplete: ((err: Error | null, data?: any) => void),
 ): XMLHttpRequest {
     const xhr = new XMLHttpRequest();
     const errInfo = `download failed: ${url}, status: `;
 
     xhr.open('GET', url, true);
 
-    if (options.xhrResponseType !== undefined) { xhr.responseType = options.xhrResponseType; }
-    if (options.xhrWithCredentials !== undefined) { xhr.withCredentials = options.xhrWithCredentials; }
-    if (options.xhrMimeType !== undefined && xhr.overrideMimeType) { xhr.overrideMimeType(options.xhrMimeType); }
-    if (options.xhrTimeout !== undefined) { xhr.timeout = options.xhrTimeout; }
+    if (options.xhrResponseType !== undefined) { xhr.responseType = options.xhrResponseType as XMLHttpRequestResponseType; }
+    if (options.xhrWithCredentials !== undefined) { xhr.withCredentials = options.xhrWithCredentials as boolean; }
+    if (options.xhrMimeType !== undefined && xhr.overrideMimeType) { xhr.overrideMimeType(options.xhrMimeType as string); }
+    if (options.xhrTimeout !== undefined) { xhr.timeout = options.xhrTimeout as number; }
 
     if (options.xhrHeader) {
         for (const header in options.xhrHeader) {
-            xhr.setRequestHeader(header, options.xhrHeader[header]);
+            xhr.setRequestHeader(header, options.xhrHeader[header] as string);
         }
     }
 

--- a/cocos/asset/asset-manager/downloader.ts
+++ b/cocos/asset/asset-manager/downloader.ts
@@ -262,6 +262,18 @@ export class Downloader {
      */
     public downloadScript = downloadScript;
 
+    /**
+     * @engineInternal
+     * @internal
+     */
+    public _downloadArrayBuffer = downloadArrayBuffer;
+
+    /**
+     * @engineInternal
+     * @internal
+     */
+    public _downloadJson = downloadJson;
+
     // default handler map
     private _downloaders: Record<string, DownloadHandler> = {
         // Images

--- a/cocos/asset/asset-manager/downloader.ts
+++ b/cocos/asset/asset-manager/downloader.ts
@@ -269,7 +269,6 @@ export class Downloader {
 
     /**
      * @engineInternal
-     * @internal
      */
     public _downloadJson = downloadJson;
 

--- a/cocos/asset/asset-manager/downloader.ts
+++ b/cocos/asset/asset-manager/downloader.ts
@@ -264,7 +264,6 @@ export class Downloader {
 
     /**
      * @engineInternal
-     * @internal
      */
     public _downloadArrayBuffer = downloadArrayBuffer;
 

--- a/cocos/asset/asset-manager/downloader.ts
+++ b/cocos/asset/asset-manager/downloader.ts
@@ -320,7 +320,7 @@ export class Downloader {
         default: downloadText,
     };
 
-    private _downloading = new Cache<((err: Error | null, data?: any | null) => void)[]>();
+    private _downloading = new Cache<((err: Error | null, data?: any) => void)[]>();
     private _queue: IDownloadRequest[] = [];
     private _queueDirty = false;
     // the number of loading thread
@@ -429,9 +429,9 @@ export class Downloader {
         }
 
         // if download fail, should retry
-        const maxRetryCount = typeof options.maxRetryCount !== 'undefined' ? options.maxRetryCount : this.maxRetryCount;
-        const maxConcurrency = typeof options.maxConcurrency !== 'undefined' ? options.maxConcurrency : this.maxConcurrency;
-        const maxRequestsPerFrame = typeof options.maxRequestsPerFrame !== 'undefined' ? options.maxRequestsPerFrame : this.maxRequestsPerFrame;
+        const maxRetryCount = typeof options.maxRetryCount !== 'undefined' ? options.maxRetryCount as number : this.maxRetryCount;
+        const maxConcurrency = typeof options.maxConcurrency !== 'undefined' ? options.maxConcurrency as number : this.maxConcurrency;
+        const maxRequestsPerFrame = typeof options.maxRequestsPerFrame !== 'undefined' ? options.maxRequestsPerFrame as number : this.maxRequestsPerFrame;
         const handler = this._downloaders[type] || this._downloaders.default;
 
         const process: RetryFunction = (index, callback): void => {
@@ -447,7 +447,7 @@ export class Downloader {
             // refresh
             this._updateTime();
 
-            const done: ((err: Error | null, data?: any | null) => void) = (err, data): void => {
+            const done: ((err: Error | null, data?: any) => void) = (err, data): void => {
                 // when finish downloading, update _totalNum
                 this._totalNum--;
                 this._handleQueueInNextFrame(maxConcurrency, maxRequestsPerFrame);
@@ -468,9 +468,9 @@ export class Downloader {
         };
 
         // when retry finished, invoke callbacks
-        const finale = (err, result): void => {
+        const finale = (err: Error | null, result : any): void => {
             if (!err) { files.add(id, result); }
-            const callbacks = this._downloading.remove(id) as ((err: Error | null, data?: any | null) => void)[];
+            const callbacks = this._downloading.remove(id) as ((err: Error | null, data?: any) => void)[];
             for (let i = 0, l = callbacks.length; i < l; i++) {
                 callbacks[i](err, result);
             }

--- a/cocos/asset/asset-manager/downloader.ts
+++ b/cocos/asset/asset-manager/downloader.ts
@@ -26,45 +26,45 @@ import { BUILD, EDITOR, EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
 import { sys, js, misc, path, cclegacy } from '../../core';
 import Cache from './cache';
 import downloadDomImage from './download-dom-image';
-import downloadFile from './download-file';
+import downloadFile, { FileProgressCallback } from './download-file';
 import downloadScript from './download-script';
 import { files } from './shared';
 import { retry, RetryFunction, urlAppendTimestamp } from './utilities';
 import { IConfigOption } from './config';
 import { CCON, parseCCONJson, decodeCCONBinary } from '../../serialization/ccon';
 
-export type DownloadHandler = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)) => void;
+export type DownloadHandler = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)) => void;
 
 interface IDownloadRequest {
     id: string;
     priority: number;
     url: string;
     options: Record<string, any>;
-    done: ((err: Error | null, data?: any | null) => void);
+    done: ((err: Error | null, data?: any) => void);
     handler: DownloadHandler;
 }
 
 const REGEX = /^(?:\w+:\/\/|\.+\/).+/;
 
-const downloadImage = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)): void => {
+const downloadImage = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)): void => {
     // if createImageBitmap is valid, we can transform blob to ImageBitmap. Otherwise, just use HTMLImageElement to load
     const func = sys.hasFeature(sys.Feature.IMAGE_BITMAP) && cclegacy.assetManager.allowImageBitmap ? downloadBlob : downloadDomImage;
     func(url, options, onComplete);
 };
 
-const downloadBlob = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)): void => {
+const downloadBlob = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)): void => {
     options.xhrResponseType = 'blob';
-    downloadFile(url, options, options.onFileProgress, onComplete);
+    downloadFile(url, options, options.onFileProgress as FileProgressCallback, onComplete);
 };
 
 const downloadJson = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: Record<string, any> | null) => void)): void => {
     options.xhrResponseType = 'json';
-    downloadFile(url, options, options.onFileProgress, onComplete);
+    downloadFile(url, options, options.onFileProgress as FileProgressCallback, onComplete);
 };
 
-const downloadArrayBuffer = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)): void => {
+const downloadArrayBuffer = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)): void => {
     options.xhrResponseType = 'arraybuffer';
-    downloadFile(url, options, options.onFileProgress, onComplete);
+    downloadFile(url, options, options.onFileProgress as FileProgressCallback, onComplete);
 };
 
 const downloadCCON = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: CCON | null) => void)): void => {
@@ -75,7 +75,7 @@ const downloadCCON = (url: string, options: Record<string, any>, onComplete: ((e
         }
         const cconPreface = parseCCONJson(json);
         const chunkPromises = Promise.all(cconPreface.chunks.map((chunk): Promise<Uint8Array> => new Promise<Uint8Array>((resolve, reject): void => {
-            downloadArrayBuffer(`${path.mainFileName(url)}${chunk}`, {}, (errChunk, chunkBuffer): void => {
+            downloadArrayBuffer(`${path.mainFileName(url)}${chunk}`, {}, (errChunk, chunkBuffer: ArrayBuffer): void => {
                 if (err) {
                     reject(err);
                 } else {
@@ -86,7 +86,7 @@ const downloadCCON = (url: string, options: Record<string, any>, onComplete: ((e
         chunkPromises.then((chunks): void => {
             const ccon = new CCON(cconPreface.document, chunks);
             onComplete(null, ccon);
-        }).catch((err): void => {
+        }).catch((err: Error): void => {
             onComplete(err);
         });
     });
@@ -107,12 +107,12 @@ const downloadCCONB = (url: string, options: Record<string, any>, onComplete: ((
     });
 };
 
-const downloadText = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)): void => {
+const downloadText = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)): void => {
     options.xhrResponseType = 'text';
-    downloadFile(url, options, options.onFileProgress, onComplete);
+    downloadFile(url, options, options.onFileProgress as FileProgressCallback, onComplete);
 };
 
-const downloadBundle = (nameOrUrl: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)): void => {
+const downloadBundle = (nameOrUrl: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)): void => {
     const bundleName = path.basename(nameOrUrl);
     let url = nameOrUrl;
     if (!REGEX.test(url)) {
@@ -372,11 +372,11 @@ export class Downloader {
      *                      '.ext': (url, options, onComplete) => onComplete(null, null)});
      *
      */
-    public register (type: string, handler: (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)) => void): void;
-    public register (map: Record<string, (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)) => void>): void;
+    public register (type: string, handler: (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)) => void): void;
+    public register (map: Record<string, (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)) => void>): void;
     public register (
-        type: string | Record<string, (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)) => void>,
-        handler?: (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)) => void,
+        type: string | Record<string, (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)) => void>,
+        handler?: (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)) => void,
     ): void {
         if (typeof type === 'object') {
             js.mixin(this._downloaders, type);
@@ -409,7 +409,7 @@ export class Downloader {
      * download('http://example.com/test.tga', '.tga', { onFileProgress: (loaded, total) => console.log(loaded/total) },
      *      onComplete: (err) => console.log(err));
      */
-    public download (id: string, url: string, type: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any | null) => void)): void {
+    public download (id: string, url: string, type: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)): void {
         // if it is downloaded, don't download again
         const file = files.get(id);
         if (file) {

--- a/platforms/minigame/common/engine/AssetManager.js
+++ b/platforms/minigame/common/engine/AssetManager.js
@@ -325,6 +325,8 @@ const parsePlist = function (url, options, onComplete) {
 };
 
 downloader.downloadScript = downloadScript;
+downloader._downloadArrayBuffer = downloadArrayBuffer;
+downloader._downloadJson = downloadJson;
 parser.parsePVRTex = parsePVRTex;
 parser.parsePKMTex = parsePKMTex;
 parser.parseASTCTex = parseASTCTex;

--- a/platforms/native/engine/jsb-loader.js
+++ b/platforms/native/engine/jsb-loader.js
@@ -291,6 +291,8 @@ parser.parsePKMTex = downloader.downloadDomImage;
 parser.parseASTCTex = downloader.downloadDomImage;
 parser.parsePlist = parsePlist;
 downloader.downloadScript = downloadScript;
+downloader._downloadArrayBuffer = downloadArrayBuffer;
+downloader._downloadJson = downloadJson;
 
 function loadAudioPlayer (url, options, onComplete) {
     cc.AudioPlayer.load(url).then((player) => {

--- a/platforms/runtime/common/engine/asset-manager.js
+++ b/platforms/runtime/common/engine/asset-manager.js
@@ -288,6 +288,8 @@ const parsePlist = function (url, options, onComplete) {
 };
 
 downloader.downloadScript = downloadScript;
+downloader._downloadArrayBuffer = downloadArrayBuffer;
+downloader._downloadJson = downloadJson;
 parser.parsePVRTex = parsePVRTex;
 parser.parsePKMTex = parsePKMTex;
 parser.parseASTCTex = parseASTCTex;


### PR DESCRIPTION
Re: #

### Changelog

* export downloadJson and downloadArrayBuffer for internal usage

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
