### PR TITLE
Restore the model when the UImeshRenderer is destroyed.

### DIFF
--- a/cocos/2d/components/graphics.ts
+++ b/cocos/2d/components/graphics.ts
@@ -267,7 +267,6 @@ export class Graphics extends UIRenderer {
     }
 
     public onDestroy (): void {
-        this._sceneGetter = null;
         if (JSB) {
             this._graphicsNativeProxy.destroy();
             this.model = null;

--- a/cocos/2d/components/ui-mesh-renderer.ts
+++ b/cocos/2d/components/ui-mesh-renderer.ts
@@ -118,7 +118,9 @@ export class UIMeshRenderer extends Component {
             return;
         }
 
-        this._modelComponent._sceneGetter = null;
+        if (this._modelComponent.enabledInHierarchy) {
+            this._modelComponent._attachToScene();
+        }
     }
 
     /**

--- a/cocos/3d/framework/mesh-renderer.ts
+++ b/cocos/3d/framework/mesh-renderer.ts
@@ -961,7 +961,10 @@ export class MeshRenderer extends ModelRenderer {
         }
     }
 
-    protected _attachToScene (): void {
+    /**
+     * @engineInternal
+     */
+    public _attachToScene (): void {
         if (!this.node.scene || !this._model) {
             return;
         }

--- a/cocos/misc/model-renderer.ts
+++ b/cocos/misc/model-renderer.ts
@@ -99,7 +99,10 @@ export class ModelRenderer extends Renderer {
         this._updatePriority();
     }
 
-    protected _attachToScene (): void {
+    /**
+     * @engineInternal
+     */
+    public _attachToScene (): void {
     }
 
     /**


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/14156

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
