### PR TITLE
deprecate cone twsit constraint

### DIFF
--- a/cocos/physics/framework/deprecated.ts
+++ b/cocos/physics/framework/deprecated.ts
@@ -33,6 +33,7 @@ import { RigidBody } from './components/rigid-body';
 import { Collider } from './components/colliders/collider';
 import { PhysicsMaterial } from './assets/physics-material';
 import { Constraint } from './components/constraints/constraint';
+import { EConstraintType } from './physics-enum';
 
 replaceProperty(PhysicsSystem, 'PhysicsSystem', [
     {
@@ -144,6 +145,12 @@ replaceProperty(RigidBody, 'RigidBody', [
 removeProperty(RigidBody.prototype, 'RigidBody.prototype', [
     {
         name: 'fixedRotation',
+    },
+]);
+
+removeProperty(EConstraintType, 'EConstraintType.prototype', [
+    {
+        name: 'CONE_TWIST',  
     },
 ]);
 

--- a/cocos/physics/framework/physics-enum.ts
+++ b/cocos/physics/framework/physics-enum.ts
@@ -275,6 +275,7 @@ export enum EConstraintType {
      * Cone twist constraint.
      * @zh
      * 锥形扭转约束。
+     * @deprecated coneTwist is deprecated, please use configurable instead
      */
     CONE_TWIST,
     /**

--- a/cocos/physics/framework/physics-selector.ts
+++ b/cocos/physics/framework/physics-selector.ts
@@ -57,6 +57,9 @@ interface IPhysicsWrapperObject {
     PlaneShape?: Constructor<IPlaneShape>,
     PointToPointConstraint?: Constructor<IPointToPointConstraint>,
     HingeConstraint?: Constructor<IHingeConstraint>,
+    /**
+     * @deprecated cone twist constraint is deprecated, please use configurable instead
+     */
     ConeTwistConstraint?: Constructor<IConeTwistConstraint>,
     FixedConstraint?: Constructor<IFixedConstraint>,
     ConfigurableConstraint?: Constructor<IConfigurableConstraint>,
@@ -232,6 +235,9 @@ enum ECheckType {
     // JOINT //
     PointToPointConstraint,
     HingeConstraint,
+    /**
+     * @deprecated cone twist constraint is deprecated, please use configurable instead
+     */
     ConeTwistConstraint,
     FixedConstraint,
     ConfigurableConstraint,

--- a/cocos/physics/physx/instantiate.ts
+++ b/cocos/physics/physx/instantiate.ts
@@ -58,17 +58,14 @@ game.once(Game.EVENT_PRE_SUBSYSTEM_INIT, () => {
         CylinderShape: PhysXCylinderShape,
         ConeShape: PhysXConeShape,
         TerrainShape: PhysXTerrainShape,
-        // SimplexShape: PhysXSimplexShape,
         PlaneShape: PhysXPlaneShape,
 
         PointToPointConstraint: PhysXSphericalJoint,
-        // PointToPointConstraint: PhysXFixedJoint,
         HingeConstraint: PhysXRevoluteJoint,
         FixedConstraint: PhysXFixedJoint,
         ConfigurableConstraint: PhysXConfigurableJoint,
 
         BoxCharacterController: PhysXBoxCharacterController,
         CapsuleCharacterController: PhysXCapsuleCharacterController,
-
     });
 });

--- a/cocos/physics/spec/i-physics-constraint.ts
+++ b/cocos/physics/spec/i-physics-constraint.ts
@@ -97,4 +97,7 @@ export interface IConfigurableConstraint extends IBaseConstraint {
     setBreakTorque(v: number): void;
 }
 
+/**
+ * @deprecated ConeTwistConstraint is deprecated, please use ConfigurableConstraint instead
+ */
 export type IConeTwistConstraint = IBaseConstraint


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/16407

### Changelog

* deprecate cone twist constraint

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
