### PR TITLE
Set JAVA_HOME in build process

### DIFF
--- a/scripts/native-pack-tool/source/base/default.ts
+++ b/scripts/native-pack-tool/source/base/default.ts
@@ -370,7 +370,7 @@ export abstract class NativePackTool {
 
     protected getExcutableNameOrDefault(): string {
         const en = this.params.executableName;
-        return en ? en : this.projectNameASCII(); 
+        return en ? en : this.projectNameASCII();
     }
 
     protected async excuteTemplateTask(tasks: CocosProjectTasks) {
@@ -422,7 +422,7 @@ export abstract class NativePackTool {
                 replaceFilesDelay[fp] = replaceFilesDelay[fp] || [];
                 replaceFilesDelay[fp].push({
                     reg: name,
-                    content: this.params.platformParams.packageName!,
+                    content: (this.params.platformParams as any).packageName!,
                 });
             });
             delete tasks.projectReplacePackageName;
@@ -454,7 +454,7 @@ export abstract class NativePackTool {
             }
         });
         Object.keys(config).forEach((key: string) => {
-            if(typeof config[key] !== 'string')  {
+            if (typeof config[key] !== 'string') {
                 console.error(`cMakeConfig.${key} is not a string, "${config[key]}"`);
             } else {
                 content += config[key] + '\n';
@@ -468,7 +468,7 @@ export abstract class NativePackTool {
         args.push(`-DRES_DIR="${cchelper.fixPath(this.paths.buildDir)}"`);
         args.push(`-DAPP_NAME="${this.params.projectName}"`);
         args.push(`-DLAUNCH_TYPE="${this.buildType}"`);
-        if (this.params.platformParams?.skipUpdateXcodeProject) {
+        if ((this.params.platformParams as any).skipUpdateXcodeProject) {
             args.push(`-DCMAKE_SUPPRESS_REGENERATION=ON`);
         }
     }
@@ -543,7 +543,7 @@ export abstract class NativePackTool {
 
 // cocos.compile.json 
 export class CocosParams<T> {
-    platformParams!: T | any;
+    platformParams: T;
     public debug: boolean;
     public projectName: string;
     public cmakePath: string;
@@ -602,7 +602,7 @@ export class CocosParams<T> {
         CC_ENABLE_SWAPPY: false,
     }
 
-    constructor(params: CocosParams<Object>) {
+    constructor(params: CocosParams<T>) {
         this.buildAssetsDir = params.buildAssetsDir;
         this.projectName = params.projectName;
         this.debug = params.debug;

--- a/scripts/native-pack-tool/source/platforms/openharmony.ts
+++ b/scripts/native-pack-tool/source/platforms/openharmony.ts
@@ -20,6 +20,8 @@ export interface OHOSParam {
     ndkPath: string;
     orientation: IOrientation;
     packageName: string;
+    appABIs: string[];
+    apiLevel: number;
 }
 
 export class OpenHarmonyPackTool extends NativePackTool {
@@ -143,7 +145,7 @@ export class OpenHarmonyPackTool extends NativePackTool {
             hdcExe, ['uninstall', packageName], false, hdcCwd);
         console.debug(`${hdc} install -r ${hapFile}`);
         await cchelper.runCmd(
-            hdcExe,['install', '-r', hapFile], false, hdcCwd);
+            hdcExe, ['install', '-r', hapFile], false, hdcCwd);
         console.debug(`${hdc} shell aa start -a ${ability} -b ${packageName}`);
         await cchelper.runCmd(
             hdcExe, ['shell', 'aa', 'start', '-a', ability, '-b', packageName, '-m', moduleName], false, hdcCwd);

--- a/scripts/native-pack-tool/source/utils.ts
+++ b/scripts/native-pack-tool/source/utils.ts
@@ -557,7 +557,7 @@ export class Paths {
         this.buildDir = params.buildDir;
         this.buildAssetsDir = params.buildAssetsDir;
         if (params.platform === 'windows') {
-            this.platformTemplateDirName = params.platformParams.targetPlatform === "win32" ? "win32" : "win64";
+            this.platformTemplateDirName = (params.platformParams as any).targetPlatform === "win32" ? "win32" : "win64";
         } else {
             this.platformTemplateDirName = params.platformName ? params.platformName : this.platform;
         }


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/15731

### Changelog

* Set JAVA_HOME in build process

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
