### PR TITLE
improve:adjust xr begin/end render frame call's position

### DIFF
--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -206,6 +206,7 @@ void Engine::destroy() {
 
 int32_t Engine::run() {
     BasePlatform *platform = BasePlatform::getPlatform();
+    _xr = CC_GET_XR_INTERFACE();
     platform->runInPlatformThread([&]() {
         tick();
     });
@@ -284,7 +285,7 @@ void Engine::tick() {
 #endif
 
         prevTime = std::chrono::steady_clock::now();
-
+        if (_xr) _xr->beginRenderFrame();
         _scheduler->update(dt);
 
         se::ScriptEngine::getInstance()->handlePromiseExceptions();
@@ -292,7 +293,7 @@ void Engine::tick() {
         se::ScriptEngine::getInstance()->mainLoopUpdate();
 
         cc::DeferredReleasePool::clear();
-
+        if (_xr) _xr->endRenderFrame();
         now = std::chrono::steady_clock::now();
         dtNS = dtNS * 0.1 + 0.9 * static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(now - prevTime).count());
         dt = static_cast<float>(dtNS) / NANOSECONDS_PER_SECOND;

--- a/native/cocos/engine/Engine.h
+++ b/native/cocos/engine/Engine.h
@@ -48,6 +48,7 @@ class DebugRenderer;
 class Profiler;
 class BuiltinResMgr;
 class ProgramLib;
+class IXRInterface;
 
 #define NANOSECONDS_PER_SECOND 1000000000
 #define NANOSECONDS_60FPS      16666667L
@@ -132,6 +133,8 @@ private:
     events::WindowEvent::Listener _windowEventListener;
 
     CC_DISALLOW_COPY_MOVE_ASSIGN(Engine);
+
+    IXRInterface *_xr{nullptr};
 };
 
 } // namespace cc

--- a/native/cocos/platform/android/AndroidPlatform.cpp
+++ b/native/cocos/platform/android/AndroidPlatform.cpp
@@ -843,9 +843,7 @@ int32_t AndroidPlatform::loop() {
         if (xr && !xr->platformLoopStart()) continue;
         _inputProxy->handleInput();
         if (_inputProxy->isAnimating() && (xr ? xr->getXRConfig(xr::XRConfigKey::SESSION_RUNNING).getBool() : true)) {
-            if (xr) xr->beginRenderFrame();
             runTask();
-            if (xr) xr->endRenderFrame();
             if (_inputProxy->isActive()) {
                 flushTasksOnGameThreadAtForegroundJNI();
             }


### PR DESCRIPTION
(Calculate the correct delta time)
Reduce xr mtp latency
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
