### PR TITLE
Disallow using image bitmap by default

### DIFF
--- a/cocos/asset/asset-manager/asset-manager.ts
+++ b/cocos/asset/asset-manager/asset-manager.ts
@@ -429,7 +429,7 @@ export class AssetManager {
         this._projectBundles = settings.querySettings(Settings.Category.ASSETS, 'projectBundles') || [];
         const assetsOverride = settings.querySettings(Settings.Category.ASSETS, 'assetsOverrides') || {};
         for (const key in assetsOverride) {
-            this.assetsOverrideMap.set(key, assetsOverride[key]);
+            this.assetsOverrideMap.set(key, assetsOverride[key] as string);
         }
     }
 
@@ -632,9 +632,9 @@ export class AssetManager {
         this.loadAny({ url }, opts, null, (err, data): void => {
             if (err) {
                 error(err.message, err.stack);
-                if (onComp) { onComp(err, data); }
+                if (onComp) { onComp(err, data as T); }
             } else {
-                factory.create(url, data, opts.ext || path.extname(url), opts, (p1, p2): void => {
+                factory.create(url, data, (opts.ext as string) || path.extname(url), opts, (p1, p2): void => {
                     if (onComp) { onComp(p1, p2 as T); }
                 });
             }
@@ -693,7 +693,7 @@ export class AssetManager {
         this.loadAny({ url: nameOrUrl }, opts, null, (err, data): void => {
             if (err) {
                 error(err.message, err.stack);
-                if (onComp) { onComp(err, data); }
+                if (onComp) { onComp(err, data as Bundle); }
             } else {
                 factory.create(nameOrUrl, data, 'bundle', opts, (p1, p2): void => {
                     if (onComp) { onComp(p1, p2 as Bundle); }
@@ -791,7 +791,7 @@ export class AssetManager {
             input: [item],
             onProgress: onProg,
             options: opts,
-            onComplete: asyncify((err, data: T): void => {
+            onComplete: asyncify((err: Error | null, data: T): void => {
                 if (!err) {
                     if (!opts.assetId) {
                         data._uuid = '';

--- a/cocos/asset/asset-manager/asset-manager.ts
+++ b/cocos/asset/asset-manager/asset-manager.ts
@@ -201,7 +201,7 @@ export class AssetManager {
      * 是否优先使用 image bitmap 来加载图片，启用之后，图片加载速度会更快, 但内存占用会变高。
      *
      */
-    public allowImageBitmap = !EDITOR && !sys.isMobile;
+    public allowImageBitmap = false;
 
     /**
      * @en


### PR DESCRIPTION
Re: #

### Changelog

* ImageBitmap will cause a huge memory allocation when parsing high res image. 

------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
