### PR TITLE
A better eslint rules config

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -235,7 +235,10 @@ rules:
         objects: always-multiline,
         imports: never,
         exports: never,
-        functions: never
+        functions: never,
+        enums: always-multiline,
+        generics: never,
+        tuples: never,
     }]
     '@stylistic/quote-props': [error, consistent-as-needed]
     '@stylistic/function-paren-newline': off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -201,7 +201,6 @@ rules:
 
     ##### eslint-stylistic rules #####
 
-    '@stylistic/eol-last': error
     '@stylistic/no-trailing-spaces': error
     '@stylistic/space-before-blocks': error
     '@stylistic/space-before-function-paren': [warn, always] # we require this explicitl
@@ -303,3 +302,4 @@ rules:
         enforceForFunctionPrototypeMethods: false,
         ignoreJSX: all
     }]
+    '@stylistic/eol-last': error

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -85,35 +85,43 @@ rules:
     prefer-destructuring: off # auto-fix is not smart enough to merge different instances
     default-case-last: off # Place default case clause to first make it more clear that this switch statement has handled all cases
 
-    prefer-template: off
-
     func-names: off
     default-param-last: off
     one-var: [error, never]
     arrow-body-style: [error, as-needed]
-    id-denylist: [error, any, unknown, Number, number, Boolean, boolean, String, Undefined]
+    id-denylist: [error,
+        any,
+        unknown,
+        Number, number,
+        Boolean, boolean,
+        String, # string,
+        Undefined, undefined,
+    ]
     id-match: off
     no-cond-assign: off
     no-constant-condition: off
     no-prototype-builtins: off
 
-    # constructor-super: error
-    # curly: [error, all]
-    # no-debugger: error
-    # no-duplicate-case: error
-    # no-eval: error
-    # no-sparse-arrays: error
-    # no-trailing-spaces: error
-    # no-var: error
-    # prefer-const: error
-    # prefer-numeric-literals: off
+    constructor-super: error
+    curly: [error, all]
+    no-debugger: error
+    no-duplicate-case: error
+    no-eval: error
+    no-new-wrappers: error
+    no-sparse-arrays: error
+    no-trailing-spaces: error
+    no-var: error
+    prefer-const: error
+    prefer-numeric-literals: off
+    prefer-template: off
+    eol-last: error
 
     ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####
 
     '@typescript-eslint/no-unused-expressions': [error, {
         allowShortCircuit: true,
         allowTernary: true,
-        allowTaggedTemplates: false
+        allowTaggedTemplates: false,
     }]
     '@typescript-eslint/no-empty-function': [off, {
       allow: [
@@ -125,7 +133,7 @@ rules:
     }]
 
     '@typescript-eslint/ban-ts-comment': [error, {
-        'ts-expect-error': true,
+        'ts-expect-error': false,
         'ts-ignore': true,
         'ts-nocheck': true,
         'ts-check': false,
@@ -155,11 +163,11 @@ rules:
     '@typescript-eslint/no-non-null-assertion': off # sometimes we just know better than the compiler
     '@typescript-eslint/no-namespace': [warn, { # we need to declare static properties
         allowDeclarations: true,
-        allowDefinitionFiles: true
+        allowDefinitionFiles: true,
     }]
     '@typescript-eslint/restrict-template-expressions': [warn, { # concatenations of different types are common, e.g. hash calculations
         allowNumber: true,
-        allowBoolean: true
+        allowBoolean: true,
     }]
 
 
@@ -168,7 +176,7 @@ rules:
     # For example, https://babeljs.io/docs/en/babel-plugin-transform-typescript#istsx
     # forbids angle bracket style if `isTSX` is enabled.
     '@typescript-eslint/consistent-type-assertions': [error, {
-        assertionStyle: 'as'
+        assertionStyle: 'as',
     }]
 
     # Prefer the interface style.
@@ -177,8 +185,14 @@ rules:
     '@typescript-eslint/no-this-alias': off
     '@typescript-eslint/no-duplicate-type-constituents': [error, {
         ignoreIntersections: false,
-        ignoreUnions: true
+        ignoreUnions: true,
     }]
+    '@typescript-eslint/explicit-member-accessibility': [error, {
+         accessibility: 'no-public',
+    }]
+    '@typescript-eslint/member-ordering': off
+    '@typescript-eslint/naming-convention': off
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': off
 
 
     # '@stylistic/key-spacing': [error, {

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -204,6 +204,7 @@ rules:
     '@stylistic/no-trailing-spaces': error
     '@stylistic/eol-last': error
     '@stylistic/space-before-blocks': error
+    '@stylistic/semi-spacing': [error, {before: false, after: true}]
 
     '@stylistic/key-spacing': [error, {
         singleLine: {

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -115,6 +115,7 @@ rules:
     prefer-numeric-literals: off
     prefer-template: off
     eol-last: error
+    no-case-declarations: error
 
     ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####
 

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -252,6 +252,7 @@ rules:
     }]
     '@typescript-eslint/keyword-spacing': [error]
     '@typescript-eslint/space-infix-ops': [error]
+    '@typescript-eslint/member-delimiter-style': [error]
     '@typescript-eslint/type-annotation-spacing': [error, {
         'before': false,
         'after': true,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -202,15 +202,16 @@ rules:
     ##### eslint-stylistic rules #####
 
     '@stylistic/no-trailing-spaces': error
-    '@stylistic/space-before-blocks': error
-    '@stylistic/space-before-function-paren': [warn, always] # we require this explicitl
     '@stylistic/space-unary-ops': error
     '@stylistic/space-infix-ops': error
     '@stylistic/space-in-parens': [error, never, { exceptions: [] }]
+    '@stylistic/block-spacing': error
+    '@stylistic/space-before-blocks': error
+    '@stylistic/space-before-function-paren': [warn, always] # we require this explicitl
+    '@stylistic/function-call-spacing': [error, never]
     '@stylistic/semi-spacing': [error, {before: false, after: true}]
     '@stylistic/comma-spacing': [error, {before: false, after: true}]
     '@stylistic/arrow-spacing': [error, {before: true, after: true}]
-    '@stylistic/block-spacing': error
     '@stylistic/array-bracket-spacing': error
     '@stylistic/object-curly-spacing': off
     '@stylistic/key-spacing': [error, {

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -205,6 +205,7 @@ rules:
     '@stylistic/eol-last': error
     '@stylistic/space-before-blocks': error
     '@stylistic/semi-spacing': [error, {before: false, after: true}]
+    '@stylistic/arrow-spacing': [error, {before: true, after: true}]
 
     '@stylistic/key-spacing': [error, {
         singleLine: {

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -75,17 +75,10 @@ rules:
       ignoredNodes: [ # https://stackoverflow.com/a/72897089
           'FunctionExpression > .params[decorators.length > 0]',
           'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
       ]
     }]
-    '@typescript-eslint/indent': [error, 4, {
-      SwitchCase: 0,
-      ignoredNodes: [ # https://stackoverflow.com/a/72897089
-          'FunctionExpression > .params[decorators.length > 0]',
-          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
-      ]
-    }]
+
     lines-between-class-members: off # be more lenient on member declarations
     max-classes-per-file: off # helper classes are common
 
@@ -132,7 +125,7 @@ rules:
     '@typescript-eslint/unbound-method': off # we exploit prototype methods sometimes to acheive better performace
     '@typescript-eslint/no-explicit-any': off # still relevant for some heavily templated usages
 
-    '@typescript-eslint/no-empty-function': [error, {
+    '@typescript-eslint/no-empty-function': [off, {
       allow: [
         private-constructors,
         protected-constructors,
@@ -162,7 +155,7 @@ rules:
 
     # Prefer the interface style.
     '@typescript-eslint/consistent-type-definitions': [error, interface]
-    '@typescript-eslint/explicit-function-return-type': [error, {
+    '@typescript-eslint/explicit-function-return-type': [off, {
       allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
     }]
 
@@ -177,12 +170,13 @@ rules:
     # no-var: error
     # prefer-const: error
     # prefer-numeric-literals: off
+    # prefer-template: error
 
-    prefer-template: off
+
     '@typescript-eslint/no-unsafe-argument': warn
 
     max-len: [warn, 250] # more lenient on max length per line
-    no-console: warn # prefer the uniform logging methods
+    no-console: off # prefer the uniform logging methods
     no-multi-spaces: [warn, {
         'ignoreEOLComments': true,
         'exceptions': {
@@ -191,7 +185,7 @@ rules:
         }
     }]
     no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
-    no-multi-assign: [error, { 'ignoreNonDeclaration': true }]
+    no-multi-assign: [off, { 'ignoreNonDeclaration': true }]
     max-statements-per-line: [error, { max: 1 }]
 
     comma-dangle: [error, {
@@ -211,11 +205,10 @@ rules:
         },
         'multiLine': {
             'beforeColon': false,
-            'afterColon': true
-            # 'align': colon
+            'afterColon': true,
+            'align': colon
         }
     }]
-
     func-names: off
     default-param-last: off
     one-var: [error, never]
@@ -232,14 +225,22 @@ rules:
         'classes': always
     }]
 
+    semi: off
+    no-extra-semi: ["error"]
+    "@typescript-eslint/semi": ["error", "always"]
+    "@typescript-eslint/member-delimiter-style": ["error", {
+        "multiline": { "delimiter": "semi" },
+        "singleline": { "delimiter": "semi" },
+    }]
+
     '@typescript-eslint/no-this-alias': [off]
     '@typescript-eslint/no-extra-parens': [error, all, {
-      'conditionalAssign': false,
-      'returnAssign': false,
-      'nestedBinaryExpressions': false,
-      'enforceForArrowConditionals': false,
-      'enforceForFunctionPrototypeMethods': false,
-      'ignoreJSX': all
+        'conditionalAssign': false,
+        'returnAssign': false,
+        'nestedBinaryExpressions': false,
+        'enforceForArrowConditionals': false,
+        'enforceForFunctionPrototypeMethods': false,
+        'ignoreJSX': all
     }]
     '@typescript-eslint/no-unused-expressions': [error, {
         'allowShortCircuit': true,
@@ -252,7 +253,6 @@ rules:
     }]
     '@typescript-eslint/keyword-spacing': [error]
     '@typescript-eslint/space-infix-ops': [error]
-    '@typescript-eslint/member-delimiter-style': [error]
     '@typescript-eslint/type-annotation-spacing': [error, {
         'before': false,
         'after': true,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -205,6 +205,7 @@ rules:
     '@stylistic/eol-last': error
     '@stylistic/space-before-blocks': error
     '@stylistic/semi-spacing': [error, {before: false, after: true}]
+    '@stylistic/comma-spacing': [error, {before: false, after: true}]
     '@stylistic/arrow-spacing': [error, {before: true, after: true}]
 
     '@stylistic/key-spacing': [error, {

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -95,6 +95,7 @@ rules:
     id-match: off
     no-cond-assign: off
     no-constant-condition: off
+    no-prototype-builtins: off
 
     # constructor-super: error
     # curly: [error, all]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -127,10 +127,10 @@ rules:
     }]
     '@typescript-eslint/no-empty-function': [off, {
       allow: [
-        private-constructors,
-        protected-constructors,
-        decoratedFunctions,
-        overrideMethods,
+        'private-constructors',
+        'protected-constructors',
+        'decoratedFunctions',
+        'overrideMethods',
       ]
     }]
 
@@ -201,13 +201,19 @@ rules:
 
     ##### eslint-stylistic rules #####
 
-    '@stylistic/no-trailing-spaces': error
     '@stylistic/eol-last': error
+    '@stylistic/no-trailing-spaces': error
     '@stylistic/space-before-blocks': error
+    '@stylistic/space-before-function-paren': [warn, always] # we require this explicitl
+    '@stylistic/space-unary-ops': error
+    '@stylistic/space-infix-ops': error
+    '@stylistic/space-in-parens': [error, never, { exceptions: [] }]
     '@stylistic/semi-spacing': [error, {before: false, after: true}]
     '@stylistic/comma-spacing': [error, {before: false, after: true}]
     '@stylistic/arrow-spacing': [error, {before: true, after: true}]
-
+    '@stylistic/block-spacing': error
+    '@stylistic/array-bracket-spacing': error
+    '@stylistic/object-curly-spacing': off
     '@stylistic/key-spacing': [error, {
         singleLine: {
             beforeColon: false,
@@ -220,14 +226,32 @@ rules:
         }
     }]
     '@stylistic/keyword-spacing': error # we require this explicitly
+    '@stylistic/type-annotation-spacing': [error, {
+        before: false,
+        after: true,
+        overrides : {
+            arrow: {
+                before: true,
+                after: true,
+            }
+        }
+     }]
+    '@stylistic/rest-spread-spacing': [error, never]
+    '@stylistic/switch-colon-spacing': error
+    '@stylistic/template-curly-spacing': [error, never]
+    '@stylistic/template-tag-spacing': [error, always]
+    '@stylistic/yield-star-spacing': [error, both]
     '@stylistic/no-multi-spaces': [warn, {
         ignoreEOLComments: true,
         exceptions: {
-            'Property': true,
-            'VariableDeclarator': false
+            Property: true,
+            VariableDeclarator: false
         }
     }]
-    '@stylistic/space-before-function-paren': [warn, always] # we require this explicitly
+    '@stylistic/spaced-comment': off # for license declarations
+    '@stylistic/no-whitespace-before-property': error
+
+
     '@stylistic/quotes': [warn, single, { allowTemplateLiterals: true }] # force single, but allow template literal
     '@stylistic/indent': [error, 4, {
       SwitchCase: 1,
@@ -243,17 +267,7 @@ rules:
     '@stylistic/object-curly-newline': off # we want manual control over this
     '@stylistic/one-var-declaration-per-line': off # auto-fix has order issues with `one-var`
     '@stylistic/linebreak-style': off # we don't enforce this on everyone's dev environment for now
-    '@stylistic/spaced-comment': off # for license declarations
-    '@stylistic/type-annotation-spacing': [error, {
-        before: false,
-        after: true,
-        overrides : {
-            'arrow': {
-                'before': true,
-                'after': true,
-            }
-        }
-     }]
+
 
     '@stylistic/no-multiple-empty-lines': [warn, {max: 2, maxEOF: 1}]
     '@stylistic/max-statements-per-line': [error, { max: 1 }]
@@ -269,7 +283,6 @@ rules:
     }]
     '@stylistic/quote-props': [error, consistent-as-needed]
     '@stylistic/function-paren-newline': off
-    '@stylistic/space-unary-ops': error
     '@stylistic/arrow-parens': [error, always]
     '@stylistic/brace-style': [error, 1tbs]
     '@stylistic/nonblock-statement-body-position': [error, below]
@@ -279,8 +292,8 @@ rules:
     '@stylistic/no-extra-semi': error
     '@stylistic/semi': [error, always]
     '@stylistic/member-delimiter-style': [error, {
-        multiline: { 'delimiter': 'semi' },
-        singleline: { 'delimiter': 'semi' },
+        multiline: { delimiter: 'semi' },
+        singleline: { delimiter: 'semi' },
     }]
     '@stylistic/no-extra-parens': [error, all, {
         conditionalAssign: false,
@@ -290,4 +303,3 @@ rules:
         enforceForFunctionPrototypeMethods: false,
         ignoreJSX: all
     }]
-    '@stylistic/space-infix-ops': [error]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -116,6 +116,7 @@ rules:
     default-case-last: error
     no-case-declarations: error
     no-irregular-whitespace: error
+    no-inner-declarations: off
 
 
     ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -72,7 +72,7 @@ rules:
     no-console: warn # prefer the uniform logging methods
     no-plusplus: off # allow increment/decrement operators
     no-continue: off # allow unlabeled continues
-    no-multi-assign: [warn, { ignoreNonDeclaration: true }] # it is handy sometimes
+    no-multi-assign: [off, { ignoreNonDeclaration: true }] # it is handy sometimes
     no-nested-ternary: off # it is handy sometimes
     no-param-reassign: off # the output object is passed as parameters all the time
     no-restricted-syntax: off # for-in is a efficient choice for plain objects
@@ -109,14 +109,13 @@ rules:
     no-eval: error
     no-new-wrappers: error
     no-sparse-arrays: error
-    no-trailing-spaces: error
     no-var: error
     prefer-const: error
     prefer-numeric-literals: off
     prefer-template: off
-    eol-last: error
     default-case-last: error
     no-case-declarations: error
+    no-irregular-whitespace: error
 
 
     ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####
@@ -200,303 +199,23 @@ rules:
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': off
 
 
-    # '@stylistic/key-spacing': [error, {
-    #     singleLine: {
-    #         beforeColon: false,
-    #         afterColon: true
-    #     },
-    #     multiLine: {
-    #         beforeColon: false,
-    #         afterColon: true,
-    #         align: colon
-    #     }
-    # }]
-    '@stylistic/keyword-spacing': error # we require this explicitly
-    '@stylistic/no-multi-spaces': [warn, {
-        ignoreEOLComments: true,
-        exceptions: {
-            'Property': true,
-            'VariableDeclarator': false
+    ##### eslint-stylistic rules #####
+
+    '@stylistic/no-trailing-spaces': error
+    '@stylistic/eol-last': error
+    '@stylistic/space-before-blocks': error
+
+    '@stylistic/key-spacing': [error, {
+        singleLine: {
+            beforeColon: false,
+            afterColon: true
+        },
+        multiLine: {
+            beforeColon: false,
+            afterColon: true,
+            # align: colon
         }
     }]
-    '@stylistic/space-before-function-paren': [warn, always] # we require this explicitly
-    '@stylistic/quotes': [warn, single, { allowTemplateLiterals: true }] # force single, but allow template literal
-    '@stylistic/indent': [error, 4, {
-      SwitchCase: 1,
-      ignoredNodes: [ # https://stackoverflow.com/a/72897089
-          'FunctionExpression > .params[decorators.length > 0]',
-          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
-      ]
-    }]
-    '@stylistic/lines-between-class-members': off # be more lenient on member declarations
-    '@stylistic/max-len': [warn, 250] # more lenient on max length per line
-    '@stylistic/no-mixed-operators': off # this is just cumbersome
-    '@stylistic/object-curly-newline': off # we want manual control over this
-    '@stylistic/one-var-declaration-per-line': off # auto-fix has order issues with `one-var`
-    '@stylistic/linebreak-style': off # we don't enforce this on everyone's dev environment for now
-    '@stylistic/spaced-comment': off # for license declarations
-    '@stylistic/type-annotation-spacing': [error, {
-        before: false,
-        after: true,
-        overrides : {
-            'arrow': {
-                'before': true,
-                'after': true,
-            }
-        }
-     }]
-
-    '@stylistic/no-multiple-empty-lines': [warn, {max: 2, maxEOF: 1}]
-    '@stylistic/max-statements-per-line': [error, { max: 1 }]
-    '@stylistic/comma-dangle': [error, {
-        arrays: always-multiline,
-        objects: always-multiline,
-        imports: never,
-        exports: never,
-        functions: never,
-        enums: always-multiline,
-        generics: never,
-        tuples: never,
-    }]
-    '@stylistic/quote-props': [error, consistent-as-needed]
-    '@stylistic/function-paren-newline': off
-    '@stylistic/space-unary-ops': error
-    '@stylistic/arrow-parens': [error, always]
-    '@stylistic/brace-style': [error, 1tbs]
-    '@stylistic/nonblock-statement-body-position': [error, below]
-    '@stylistic/padded-blocks': [error, {
-        classes: always
-    }]
-    '@stylistic/no-extra-semi': error
-    '@stylistic/semi': [error, always]
-    '@stylistic/member-delimiter-style': [error, {
-        multiline: { 'delimiter': 'semi' },
-        singleline: { 'delimiter': 'semi' },
-    }]
-    '@stylistic/no-extra-parens': [error, all, {
-        conditionalAssign: false,
-        returnAssign: false,
-        nestedBinaryExpressions: false,
-        enforceForArrowConditionals: false,
-        enforceForFunctionPrototypeMethods: false,
-        ignoreJSX: all
-    }]
-    '@stylistic/space-infix-ops': [error]
-
-root: true
-
-parser: '@typescript-eslint/parser'
-
-parserOptions:
-    project:
-        - ./tsconfig.json
-
-extends:
-    - eslint:recommended
-    - plugin:@typescript-eslint/recommended
-    - plugin:@typescript-eslint/recommended-requiring-type-checking
-
-plugins: ['@stylistic', '@stylistic/migrate', '@typescript-eslint']
-
-settings:
-    import/resolver:
-        node:
-            extensions:
-                - .js
-                - .jsx
-                - .ts
-                - .tsx
-                - .d.ts
-
-env:
-    browser: true
-    node: true
-    es6: true
-    jest: true
-
-globals:
-    cc: false
-    wx: false
-    Editor: false
-    _Scene: false
-    _ccsg: false
-
-rules:
-
-    # https://eslint.org/docs/rules/
-    # https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin
-
-    # !!!!!!!!!!!!!!!!!!!!!!!!!
-    # BEFORE ADDING ANY RULES
-    # PLEASE EXPLAIN THE REASON IN THE COMMENT.
-
-    ##### RECOMMENDED RULE OVERRIDES #####
-
-    camelcase: off # underscores may come in handy in some cases
-    eqeqeq: [error, always, {null: ignore}] # important check missing from recommended
-    prefer-rest-params: off # we need ES5 to be fast too
-    prefer-spread: off # we need ES5 to be fast too
-    radix: off # we sometimes do not need to pass a second parameter
-    # allow underscores, we still widely use pre-dangle naming in our naming convention
-    # e.g. private properties, private functions, module scope shared variables etc.
-    no-underscore-dangle: off
-    no-else-return: off # else-return is a common pattern which clearly expresses the control flow
-    no-unused-expressions: off # taken over by '@typescript-eslint/no-unused-expressions'
-    no-empty-function: off # taken over by '@typescript-eslint/no-empty-function'
-
-    ##### AIRBNB-SPECIFIC RULE OVERRIDES #####
-
-    class-methods-use-this: off # so empty functions could work
-    guard-for-in: off # for-in is a efficient choice for plain objects
-    import/export: off # so export declare namespace could work
-    import/extensions: off # typescript doesn't support this
-    import/no-unresolved: off # TODO: fix internal modules
-    import/prefer-default-export: off # prefer named exports
-
-    max-classes-per-file: off # helper classes are common
-    no-console: warn # prefer the uniform logging methods
-    no-plusplus: off # allow increment/decrement operators
-    no-continue: off # allow unlabeled continues
-    no-multi-assign: [warn, { ignoreNonDeclaration: true }] # it is handy sometimes
-    no-nested-ternary: off # it is handy sometimes
-    no-param-reassign: off # the output object is passed as parameters all the time
-    no-restricted-syntax: off # for-in is a efficient choice for plain objects
-    no-return-assign: off # it is handy sometimes
-    no-shadow: off # TODO: this throws false-positives?
-    no-sequences: off # it is handy sometimes
-    no-bitwise: off # we use this extensively
-    no-use-before-define: off # just too much work
-    no-useless-constructor: off # gives false-positives for empty constructor with parameter properties
-    prefer-destructuring: off # auto-fix is not smart enough to merge different instances
-
-
-    func-names: off
-    default-param-last: off
-    one-var: [error, never]
-    arrow-body-style: [error, as-needed]
-    id-denylist: [error,
-        any,
-        unknown,
-        Number, number,
-        Boolean, boolean,
-        String, # string,
-        Undefined, undefined,
-    ]
-    id-match: off
-    no-cond-assign: off
-    no-constant-condition: off
-    no-prototype-builtins: off
-
-    constructor-super: error
-    curly: [error, all]
-    no-debugger: error
-    no-duplicate-case: error
-    no-eval: error
-    no-new-wrappers: error
-    no-sparse-arrays: error
-    no-trailing-spaces: error
-    no-var: error
-    prefer-const: error
-    prefer-numeric-literals: off
-    prefer-template: off
-    eol-last: error
-    default-case-last: error
-    no-case-declarations: error
-
-
-    ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####
-
-    '@typescript-eslint/no-unused-expressions': [error, {
-        allowShortCircuit: true,
-        allowTernary: true,
-        allowTaggedTemplates: false,
-    }]
-    '@typescript-eslint/no-empty-function': [off, {
-      allow: [
-        private-constructors,
-        protected-constructors,
-        decoratedFunctions,
-        overrideMethods,
-      ]
-    }]
-
-    '@typescript-eslint/ban-ts-comment': [error, {
-        'ts-expect-error': false,
-        'ts-ignore': true,
-        'ts-nocheck': true,
-        'ts-check': false,
-    }]
-
-    '@typescript-eslint/explicit-function-return-type': [error, {
-      allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
-    }]
-    '@typescript-eslint/no-unsafe-argument': warn
-    '@typescript-eslint/no-unsafe-return': error
-    '@typescript-eslint/no-var-requires': error
-    '@typescript-eslint/ban-types': error
-
-    # TODO: this is just too much work
-    '@typescript-eslint/explicit-module-boundary-types': off
-
-    # NOTE: We don't want to rely on TS automatic type inference
-    '@typescript-eslint/no-inferrable-types': off
-
-    # TODO: sadly we still rely heavily on legacyCC
-    '@typescript-eslint/no-unsafe-assignment': off
-    '@typescript-eslint/no-unsafe-call': off
-    '@typescript-eslint/no-unsafe-member-access': off
-
-    '@typescript-eslint/unbound-method': off # we exploit prototype methods sometimes to acheive better performace
-    '@typescript-eslint/no-explicit-any': off # still relevant for some heavily templated usages
-
-    '@typescript-eslint/no-unused-vars': off # may become useful in some parent classes
-    '@typescript-eslint/no-non-null-assertion': off # sometimes we just know better than the compiler
-    '@typescript-eslint/no-namespace': [warn, { # we need to declare static properties
-        allowDeclarations: true,
-        allowDefinitionFiles: true,
-    }]
-    '@typescript-eslint/restrict-template-expressions': [warn, { # concatenations of different types are common, e.g. hash calculations
-        allowNumber: true,
-        allowBoolean: true,
-    }]
-
-
-    # We choose to use style `... as foo` since it's more common.
-    # In the other hand, angle bracket style can be ambiguous with j/tsx syntax.
-    # For example, https://babeljs.io/docs/en/babel-plugin-transform-typescript#istsx
-    # forbids angle bracket style if `isTSX` is enabled.
-    '@typescript-eslint/consistent-type-assertions': [error, {
-        assertionStyle: 'as',
-    }]
-
-    # Prefer the interface style.
-    '@typescript-eslint/consistent-type-definitions': [error, interface]
-
-    '@typescript-eslint/no-this-alias': off
-    '@typescript-eslint/no-duplicate-type-constituents': [error, {
-        ignoreIntersections: false,
-        ignoreUnions: true,
-    }]
-    '@typescript-eslint/explicit-member-accessibility': [error, {
-         accessibility: 'no-public',
-    }]
-    '@typescript-eslint/member-ordering': off
-    '@typescript-eslint/naming-convention': off
-    '@typescript-eslint/no-unnecessary-boolean-literal-compare': off
-
-
-    # '@stylistic/key-spacing': [error, {
-    #     singleLine: {
-    #         beforeColon: false,
-    #         afterColon: true
-    #     },
-    #     multiLine: {
-    #         beforeColon: false,
-    #         afterColon: true,
-    #         align: colon
-    #     }
-    # }]
     '@stylistic/keyword-spacing': error # we require this explicitly
     '@stylistic/no-multi-spaces': [warn, {
         ignoreEOLComments: true,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -83,7 +83,7 @@ rules:
     no-use-before-define: off # just too much work
     no-useless-constructor: off # gives false-positives for empty constructor with parameter properties
     prefer-destructuring: off # auto-fix is not smart enough to merge different instances
-    default-case-last: off # Place default case clause to first make it more clear that this switch statement has handled all cases
+
 
     func-names: off
     default-param-last: off
@@ -115,7 +115,9 @@ rules:
     prefer-numeric-literals: off
     prefer-template: off
     eol-last: error
+    default-case-last: error
     no-case-declarations: error
+
 
     ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####
 
@@ -282,3 +284,288 @@ rules:
     }]
     '@stylistic/space-infix-ops': [error]
 
+root: true
+
+parser: '@typescript-eslint/parser'
+
+parserOptions:
+    project:
+        - ./tsconfig.json
+
+extends:
+    - eslint:recommended
+    - plugin:@typescript-eslint/recommended
+    - plugin:@typescript-eslint/recommended-requiring-type-checking
+
+plugins: ['@stylistic', '@stylistic/migrate', '@typescript-eslint']
+
+settings:
+    import/resolver:
+        node:
+            extensions:
+                - .js
+                - .jsx
+                - .ts
+                - .tsx
+                - .d.ts
+
+env:
+    browser: true
+    node: true
+    es6: true
+    jest: true
+
+globals:
+    cc: false
+    wx: false
+    Editor: false
+    _Scene: false
+    _ccsg: false
+
+rules:
+
+    # https://eslint.org/docs/rules/
+    # https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin
+
+    # !!!!!!!!!!!!!!!!!!!!!!!!!
+    # BEFORE ADDING ANY RULES
+    # PLEASE EXPLAIN THE REASON IN THE COMMENT.
+
+    ##### RECOMMENDED RULE OVERRIDES #####
+
+    camelcase: off # underscores may come in handy in some cases
+    eqeqeq: [error, always, {null: ignore}] # important check missing from recommended
+    prefer-rest-params: off # we need ES5 to be fast too
+    prefer-spread: off # we need ES5 to be fast too
+    radix: off # we sometimes do not need to pass a second parameter
+    # allow underscores, we still widely use pre-dangle naming in our naming convention
+    # e.g. private properties, private functions, module scope shared variables etc.
+    no-underscore-dangle: off
+    no-else-return: off # else-return is a common pattern which clearly expresses the control flow
+    no-unused-expressions: off # taken over by '@typescript-eslint/no-unused-expressions'
+    no-empty-function: off # taken over by '@typescript-eslint/no-empty-function'
+
+    ##### AIRBNB-SPECIFIC RULE OVERRIDES #####
+
+    class-methods-use-this: off # so empty functions could work
+    guard-for-in: off # for-in is a efficient choice for plain objects
+    import/export: off # so export declare namespace could work
+    import/extensions: off # typescript doesn't support this
+    import/no-unresolved: off # TODO: fix internal modules
+    import/prefer-default-export: off # prefer named exports
+
+    max-classes-per-file: off # helper classes are common
+    no-console: warn # prefer the uniform logging methods
+    no-plusplus: off # allow increment/decrement operators
+    no-continue: off # allow unlabeled continues
+    no-multi-assign: [warn, { ignoreNonDeclaration: true }] # it is handy sometimes
+    no-nested-ternary: off # it is handy sometimes
+    no-param-reassign: off # the output object is passed as parameters all the time
+    no-restricted-syntax: off # for-in is a efficient choice for plain objects
+    no-return-assign: off # it is handy sometimes
+    no-shadow: off # TODO: this throws false-positives?
+    no-sequences: off # it is handy sometimes
+    no-bitwise: off # we use this extensively
+    no-use-before-define: off # just too much work
+    no-useless-constructor: off # gives false-positives for empty constructor with parameter properties
+    prefer-destructuring: off # auto-fix is not smart enough to merge different instances
+
+
+    func-names: off
+    default-param-last: off
+    one-var: [error, never]
+    arrow-body-style: [error, as-needed]
+    id-denylist: [error,
+        any,
+        unknown,
+        Number, number,
+        Boolean, boolean,
+        String, # string,
+        Undefined, undefined,
+    ]
+    id-match: off
+    no-cond-assign: off
+    no-constant-condition: off
+    no-prototype-builtins: off
+
+    constructor-super: error
+    curly: [error, all]
+    no-debugger: error
+    no-duplicate-case: error
+    no-eval: error
+    no-new-wrappers: error
+    no-sparse-arrays: error
+    no-trailing-spaces: error
+    no-var: error
+    prefer-const: error
+    prefer-numeric-literals: off
+    prefer-template: off
+    eol-last: error
+    default-case-last: error
+    no-case-declarations: error
+
+
+    ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####
+
+    '@typescript-eslint/no-unused-expressions': [error, {
+        allowShortCircuit: true,
+        allowTernary: true,
+        allowTaggedTemplates: false,
+    }]
+    '@typescript-eslint/no-empty-function': [off, {
+      allow: [
+        private-constructors,
+        protected-constructors,
+        decoratedFunctions,
+        overrideMethods,
+      ]
+    }]
+
+    '@typescript-eslint/ban-ts-comment': [error, {
+        'ts-expect-error': false,
+        'ts-ignore': true,
+        'ts-nocheck': true,
+        'ts-check': false,
+    }]
+
+    '@typescript-eslint/explicit-function-return-type': [error, {
+      allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
+    }]
+    '@typescript-eslint/no-unsafe-argument': warn
+    '@typescript-eslint/no-unsafe-return': error
+    '@typescript-eslint/no-var-requires': error
+    '@typescript-eslint/ban-types': error
+
+    # TODO: this is just too much work
+    '@typescript-eslint/explicit-module-boundary-types': off
+
+    # NOTE: We don't want to rely on TS automatic type inference
+    '@typescript-eslint/no-inferrable-types': off
+
+    # TODO: sadly we still rely heavily on legacyCC
+    '@typescript-eslint/no-unsafe-assignment': off
+    '@typescript-eslint/no-unsafe-call': off
+    '@typescript-eslint/no-unsafe-member-access': off
+
+    '@typescript-eslint/unbound-method': off # we exploit prototype methods sometimes to acheive better performace
+    '@typescript-eslint/no-explicit-any': off # still relevant for some heavily templated usages
+
+    '@typescript-eslint/no-unused-vars': off # may become useful in some parent classes
+    '@typescript-eslint/no-non-null-assertion': off # sometimes we just know better than the compiler
+    '@typescript-eslint/no-namespace': [warn, { # we need to declare static properties
+        allowDeclarations: true,
+        allowDefinitionFiles: true,
+    }]
+    '@typescript-eslint/restrict-template-expressions': [warn, { # concatenations of different types are common, e.g. hash calculations
+        allowNumber: true,
+        allowBoolean: true,
+    }]
+
+
+    # We choose to use style `... as foo` since it's more common.
+    # In the other hand, angle bracket style can be ambiguous with j/tsx syntax.
+    # For example, https://babeljs.io/docs/en/babel-plugin-transform-typescript#istsx
+    # forbids angle bracket style if `isTSX` is enabled.
+    '@typescript-eslint/consistent-type-assertions': [error, {
+        assertionStyle: 'as',
+    }]
+
+    # Prefer the interface style.
+    '@typescript-eslint/consistent-type-definitions': [error, interface]
+
+    '@typescript-eslint/no-this-alias': off
+    '@typescript-eslint/no-duplicate-type-constituents': [error, {
+        ignoreIntersections: false,
+        ignoreUnions: true,
+    }]
+    '@typescript-eslint/explicit-member-accessibility': [error, {
+         accessibility: 'no-public',
+    }]
+    '@typescript-eslint/member-ordering': off
+    '@typescript-eslint/naming-convention': off
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': off
+
+
+    # '@stylistic/key-spacing': [error, {
+    #     singleLine: {
+    #         beforeColon: false,
+    #         afterColon: true
+    #     },
+    #     multiLine: {
+    #         beforeColon: false,
+    #         afterColon: true,
+    #         align: colon
+    #     }
+    # }]
+    '@stylistic/keyword-spacing': error # we require this explicitly
+    '@stylistic/no-multi-spaces': [warn, {
+        ignoreEOLComments: true,
+        exceptions: {
+            'Property': true,
+            'VariableDeclarator': false
+        }
+    }]
+    '@stylistic/space-before-function-paren': [warn, always] # we require this explicitly
+    '@stylistic/quotes': [warn, single, { allowTemplateLiterals: true }] # force single, but allow template literal
+    '@stylistic/indent': [error, 4, {
+      SwitchCase: 1,
+      ignoredNodes: [ # https://stackoverflow.com/a/72897089
+          'FunctionExpression > .params[decorators.length > 0]',
+          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
+      ]
+    }]
+    '@stylistic/lines-between-class-members': off # be more lenient on member declarations
+    '@stylistic/max-len': [warn, 250] # more lenient on max length per line
+    '@stylistic/no-mixed-operators': off # this is just cumbersome
+    '@stylistic/object-curly-newline': off # we want manual control over this
+    '@stylistic/one-var-declaration-per-line': off # auto-fix has order issues with `one-var`
+    '@stylistic/linebreak-style': off # we don't enforce this on everyone's dev environment for now
+    '@stylistic/spaced-comment': off # for license declarations
+    '@stylistic/type-annotation-spacing': [error, {
+        before: false,
+        after: true,
+        overrides : {
+            'arrow': {
+                'before': true,
+                'after': true,
+            }
+        }
+     }]
+
+    '@stylistic/no-multiple-empty-lines': [warn, {max: 2, maxEOF: 1}]
+    '@stylistic/max-statements-per-line': [error, { max: 1 }]
+    '@stylistic/comma-dangle': [error, {
+        arrays: always-multiline,
+        objects: always-multiline,
+        imports: never,
+        exports: never,
+        functions: never,
+        enums: always-multiline,
+        generics: never,
+        tuples: never,
+    }]
+    '@stylistic/quote-props': [error, consistent-as-needed]
+    '@stylistic/function-paren-newline': off
+    '@stylistic/space-unary-ops': error
+    '@stylistic/arrow-parens': [error, always]
+    '@stylistic/brace-style': [error, 1tbs]
+    '@stylistic/nonblock-statement-body-position': [error, below]
+    '@stylistic/padded-blocks': [error, {
+        classes: always
+    }]
+    '@stylistic/no-extra-semi': error
+    '@stylistic/semi': [error, always]
+    '@stylistic/member-delimiter-style': [error, {
+        multiline: { 'delimiter': 'semi' },
+        singleline: { 'delimiter': 'semi' },
+    }]
+    '@stylistic/no-extra-parens': [error, all, {
+        conditionalAssign: false,
+        returnAssign: false,
+        nestedBinaryExpressions: false,
+        enforceForArrowConditionals: false,
+        enforceForFunctionPrototypeMethods: false,
+        ignoreJSX: all
+    }]
+    '@stylistic/space-infix-ops': [error]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -3,15 +3,15 @@ root: true
 parser: '@typescript-eslint/parser'
 
 parserOptions:
-    project: ./tsconfig.json
+    project:
+        - ./tsconfig.json
 
 extends:
     - eslint:recommended
-    - airbnb-base
     - plugin:@typescript-eslint/recommended
     - plugin:@typescript-eslint/recommended-requiring-type-checking
 
-plugins: ['@typescript-eslint']
+plugins: ['@stylistic', '@stylistic/migrate', '@typescript-eslint']
 
 settings:
     import/resolver:
@@ -48,16 +48,13 @@ rules:
     ##### RECOMMENDED RULE OVERRIDES #####
 
     camelcase: off # underscores may come in handy in some cases
-
-    keyword-spacing: warn # we require this explicitly
+    eqeqeq: [error, always, {null: ignore}] # important check missing from recommended
     prefer-rest-params: off # we need ES5 to be fast too
     prefer-spread: off # we need ES5 to be fast too
-    space-before-function-paren: [warn, always] # we require this explicitly
     radix: off # we sometimes do not need to pass a second parameter
     # allow underscores, we still widely use pre-dangle naming in our naming convention
     # e.g. private properties, private functions, module scope shared variables etc.
     no-underscore-dangle: off
-    quotes: [warn, single, { allowTemplateLiterals: true }] # force single, but allow template literal
     no-else-return: off # else-return is a common pattern which clearly expresses the control flow
     no-unused-expressions: off # taken over by '@typescript-eslint/no-unused-expressions'
     no-empty-function: off # taken over by '@typescript-eslint/no-empty-function'
@@ -70,29 +67,12 @@ rules:
     import/extensions: off # typescript doesn't support this
     import/no-unresolved: off # TODO: fix internal modules
     import/prefer-default-export: off # prefer named exports
-    indent: [error, 4, {
-      SwitchCase: 0,
-      ignoredNodes: [ # https://stackoverflow.com/a/72897089
-          'FunctionExpression > .params[decorators.length > 0]',
-          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
-      ]
-    }]
-    '@typescript-eslint/indent': [error, 4, {
-      SwitchCase: 0,
-      ignoredNodes: [ # https://stackoverflow.com/a/72897089
-          'FunctionExpression > .params[decorators.length > 0]',
-          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
-      ]
-    }]
-    lines-between-class-members: off # be more lenient on member declarations
-    max-classes-per-file: off # helper classes are common
 
+    max-classes-per-file: off # helper classes are common
+    no-console: warn # prefer the uniform logging methods
     no-plusplus: off # allow increment/decrement operators
     no-continue: off # allow unlabeled continues
-    no-mixed-operators: off # this is just cumbersome
-
+    no-multi-assign: [warn, { ignoreNonDeclaration: true }] # it is handy sometimes
     no-nested-ternary: off # it is handy sometimes
     no-param-reassign: off # the output object is passed as parameters all the time
     no-restricted-syntax: off # for-in is a efficient choice for plain objects
@@ -102,14 +82,46 @@ rules:
     no-bitwise: off # we use this extensively
     no-use-before-define: off # just too much work
     no-useless-constructor: off # gives false-positives for empty constructor with parameter properties
-    object-curly-newline: off # we want manual control over this
-    one-var-declaration-per-line: off # auto-fix has order issues with `one-var`
     prefer-destructuring: off # auto-fix is not smart enough to merge different instances
-    linebreak-style: off # we don't enforce this on everyone's dev environment for now
-    spaced-comment: off # for license declarations
     default-case-last: off # Place default case clause to first make it more clear that this switch statement has handled all cases
 
+    prefer-template: off
+
+    func-names: off
+    default-param-last: off
+    one-var: [error, never]
+    arrow-body-style: [error, as-needed]
+    id-denylist: [error, any, unknown, Number, number, Boolean, boolean, String, Undefined]
+    id-match: off
+    no-cond-assign: off
+    no-constant-condition: off
+
+    # constructor-super: error
+    # curly: [error, all]
+    # no-debugger: error
+    # no-duplicate-case: error
+    # no-eval: error
+    # no-sparse-arrays: error
+    # no-trailing-spaces: error
+    # no-var: error
+    # prefer-const: error
+    # prefer-numeric-literals: off
+
     ##### TYPESCRIPT-SPECIFIC RULE OVERRIDES #####
+
+    '@typescript-eslint/no-unused-expressions': [error, {
+        allowShortCircuit: true,
+        allowTernary: true,
+        allowTaggedTemplates: false
+    }]
+    '@typescript-eslint/no-empty-function': [off, {
+      allow: [
+        private-constructors,
+        protected-constructors,
+        decoratedFunctions,
+        overrideMethods,
+      ]
+    }]
 
     '@typescript-eslint/ban-ts-comment': [error, {
         'ts-expect-error': true,
@@ -117,6 +129,12 @@ rules:
         'ts-nocheck': true,
         'ts-check': false,
     }]
+
+    '@typescript-eslint/explicit-function-return-type': [error, {
+      allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
+    }]
+    '@typescript-eslint/no-unsafe-argument': warn
+
 
     # TODO: this is just too much work
     '@typescript-eslint/explicit-module-boundary-types': off
@@ -132,15 +150,6 @@ rules:
     '@typescript-eslint/unbound-method': off # we exploit prototype methods sometimes to acheive better performace
     '@typescript-eslint/no-explicit-any': off # still relevant for some heavily templated usages
 
-    '@typescript-eslint/no-empty-function': [error, {
-      allow: [
-        private-constructors,
-        protected-constructors,
-        decoratedFunctions,
-        overrideMethods,
-      ]
-    }]
-
     '@typescript-eslint/no-unused-vars': off # may become useful in some parent classes
     '@typescript-eslint/no-non-null-assertion': off # sometimes we just know better than the compiler
     '@typescript-eslint/no-namespace': [warn, { # we need to declare static properties
@@ -152,6 +161,7 @@ rules:
         allowBoolean: true
     }]
 
+
     # We choose to use style `... as foo` since it's more common.
     # In the other hand, angle bracket style can be ambiguous with j/tsx syntax.
     # For example, https://babeljs.io/docs/en/babel-plugin-transform-typescript#istsx
@@ -162,111 +172,91 @@ rules:
 
     # Prefer the interface style.
     '@typescript-eslint/consistent-type-definitions': [error, interface]
-    '@typescript-eslint/explicit-function-return-type': [error, {
-      allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
+
+    '@typescript-eslint/no-this-alias': off
+    '@typescript-eslint/no-duplicate-type-constituents': [error, {
+        ignoreIntersections: false,
+        ignoreUnions: true
     }]
 
 
-    # constructor-super: error
-    # curly: [error, all]
-    # no-debugger: error
-    # no-duplicate-case: error
-    # no-eval: error
-    # no-sparse-arrays: error
-    # no-trailing-spaces: error
-    # no-var: error
-    # prefer-const: error
-    # prefer-numeric-literals: off
-
-    prefer-template: off
-
-    '@typescript-eslint/no-unsafe-argument': warn
-
-    max-len: [warn, 250] # more lenient on max length per line
-    no-console: warn # prefer the uniform logging methods
-    no-multi-spaces: [warn, {
-        'ignoreEOLComments': true,
-        'exceptions': {
+    # '@stylistic/key-spacing': [error, {
+    #     singleLine: {
+    #         beforeColon: false,
+    #         afterColon: true
+    #     },
+    #     multiLine: {
+    #         beforeColon: false,
+    #         afterColon: true,
+    #         align: colon
+    #     }
+    # }]
+    '@stylistic/keyword-spacing': error # we require this explicitly
+    '@stylistic/no-multi-spaces': [warn, {
+        ignoreEOLComments: true,
+        exceptions: {
             'Property': true,
             'VariableDeclarator': false
         }
     }]
-    no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
-    no-multi-assign: [error, { 'ignoreNonDeclaration': true }]
-    max-statements-per-line: [error, { max: 1 }]
-
-    comma-dangle: [error, {
-        'arrays': always-multiline,
-        'objects': always-multiline,
-        'imports': never,
-        'exports': never,
-        'functions': never
+    '@stylistic/space-before-function-paren': [warn, always] # we require this explicitly
+    '@stylistic/quotes': [warn, single, { allowTemplateLiterals: true }] # force single, but allow template literal
+    '@stylistic/indent': [error, 4, {
+      SwitchCase: 1,
+      ignoredNodes: [ # https://stackoverflow.com/a/72897089
+          'FunctionExpression > .params[decorators.length > 0]',
+          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
+      ]
     }]
-    quote-props: [error, consistent-as-needed]
-    function-paren-newline: off
-    space-unary-ops: error
-    # key-spacing: [error, {
-    #     'singleLine': {
-    #         'beforeColon': false,
-    #         'afterColon': true
-    #     },
-    #     'multiLine': {
-    #         'beforeColon': false,
-    #         'afterColon': true,
-    #         'align': colon
-    #     }
-    # }]
-    func-names: off
-    default-param-last: off
-    one-var: [error, never]
-    eqeqeq: [error, always, {'null': ignore}]
-    arrow-body-style: [error, as-needed]
-    arrow-parens: [error, always]
-    brace-style: [error, 1tbs]
-    id-denylist: [error, any, unknown, Number, number, Boolean, boolean, String, Undefined]
-    id-match: off
-    no-cond-assign: off
-    no-constant-condition: off
-    nonblock-statement-body-position: [error, below]
-    padded-blocks: [error, {
-        'classes': always
-    }]
-
-    semi: off
-    no-extra-semi: ["error"]
-    "@typescript-eslint/semi": ["error", "always"]
-    "@typescript-eslint/member-delimiter-style": ["error", {
-        "multiline": { "delimiter": "semi" },
-        "singleline": { "delimiter": "semi" },
-    }]
-
-    '@typescript-eslint/no-this-alias': [off]
-    '@typescript-eslint/no-extra-parens': [error, all, {
-        'conditionalAssign': false,
-        'returnAssign': false,
-        'nestedBinaryExpressions': false,
-        'enforceForArrowConditionals': false,
-        'enforceForFunctionPrototypeMethods': false,
-        'ignoreJSX': all
-    }]
-    '@typescript-eslint/no-unused-expressions': [error, {
-        'allowShortCircuit': true,
-        'allowTernary': true,
-        'allowTaggedTemplates': false
-    }]
-    '@typescript-eslint/no-duplicate-type-constituents': [error, {
-        'ignoreIntersections': false,
-        'ignoreUnions': true
-    }]
-    '@typescript-eslint/keyword-spacing': [error]
-    '@typescript-eslint/space-infix-ops': [error]
-    '@typescript-eslint/type-annotation-spacing': [error, {
-        'before': false,
-        'after': true,
-        'overrides' : {
+    '@stylistic/lines-between-class-members': off # be more lenient on member declarations
+    '@stylistic/max-len': [warn, 250] # more lenient on max length per line
+    '@stylistic/no-mixed-operators': off # this is just cumbersome
+    '@stylistic/object-curly-newline': off # we want manual control over this
+    '@stylistic/one-var-declaration-per-line': off # auto-fix has order issues with `one-var`
+    '@stylistic/linebreak-style': off # we don't enforce this on everyone's dev environment for now
+    '@stylistic/spaced-comment': off # for license declarations
+    '@stylistic/type-annotation-spacing': [error, {
+        before: false,
+        after: true,
+        overrides : {
             'arrow': {
                 'before': true,
                 'after': true,
             }
         }
      }]
+
+    '@stylistic/no-multiple-empty-lines': [warn, {max: 2, maxEOF: 1}]
+    '@stylistic/max-statements-per-line': [error, { max: 1 }]
+    '@stylistic/comma-dangle': [error, {
+        arrays: always-multiline,
+        objects: always-multiline,
+        imports: never,
+        exports: never,
+        functions: never
+    }]
+    '@stylistic/quote-props': [error, consistent-as-needed]
+    '@stylistic/function-paren-newline': off
+    '@stylistic/space-unary-ops': error
+    '@stylistic/arrow-parens': [error, always]
+    '@stylistic/brace-style': [error, 1tbs]
+    '@stylistic/nonblock-statement-body-position': [error, below]
+    '@stylistic/padded-blocks': [error, {
+        classes: always
+    }]
+    '@stylistic/no-extra-semi': error
+    '@stylistic/semi': [error, always]
+    '@stylistic/member-delimiter-style': [error, {
+        multiline: { 'delimiter': 'semi' },
+        singleline: { 'delimiter': 'semi' },
+    }]
+    '@stylistic/no-extra-parens': [error, all, {
+        conditionalAssign: false,
+        returnAssign: false,
+        nestedBinaryExpressions: false,
+        enforceForArrowConditionals: false,
+        enforceForFunctionPrototypeMethods: false,
+        ignoreJSX: all
+    }]
+    '@stylistic/space-infix-ops': [error]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -75,10 +75,17 @@ rules:
       ignoredNodes: [ # https://stackoverflow.com/a/72897089
           'FunctionExpression > .params[decorators.length > 0]',
           'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
       ]
     }]
-
+    '@typescript-eslint/indent': [error, 4, {
+      SwitchCase: 0,
+      ignoredNodes: [ # https://stackoverflow.com/a/72897089
+          'FunctionExpression > .params[decorators.length > 0]',
+          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
+      ]
+    }]
     lines-between-class-members: off # be more lenient on member declarations
     max-classes-per-file: off # helper classes are common
 
@@ -125,7 +132,7 @@ rules:
     '@typescript-eslint/unbound-method': off # we exploit prototype methods sometimes to acheive better performace
     '@typescript-eslint/no-explicit-any': off # still relevant for some heavily templated usages
 
-    '@typescript-eslint/no-empty-function': [off, {
+    '@typescript-eslint/no-empty-function': [error, {
       allow: [
         private-constructors,
         protected-constructors,
@@ -155,7 +162,7 @@ rules:
 
     # Prefer the interface style.
     '@typescript-eslint/consistent-type-definitions': [error, interface]
-    '@typescript-eslint/explicit-function-return-type': [off, {
+    '@typescript-eslint/explicit-function-return-type': [error, {
       allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
     }]
 
@@ -170,13 +177,13 @@ rules:
     # no-var: error
     # prefer-const: error
     # prefer-numeric-literals: off
-    # prefer-template: error
 
+    prefer-template: off
 
     '@typescript-eslint/no-unsafe-argument': warn
 
     max-len: [warn, 250] # more lenient on max length per line
-    no-console: off # prefer the uniform logging methods
+    no-console: warn # prefer the uniform logging methods
     no-multi-spaces: [warn, {
         'ignoreEOLComments': true,
         'exceptions': {
@@ -185,7 +192,7 @@ rules:
         }
     }]
     no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
-    no-multi-assign: [off, { 'ignoreNonDeclaration': true }]
+    no-multi-assign: [error, { 'ignoreNonDeclaration': true }]
     max-statements-per-line: [error, { max: 1 }]
 
     comma-dangle: [error, {
@@ -198,17 +205,17 @@ rules:
     quote-props: [error, consistent-as-needed]
     function-paren-newline: off
     space-unary-ops: error
-    key-spacing: [error, {
-        'singleLine': {
-            'beforeColon': false,
-            'afterColon': true
-        },
-        'multiLine': {
-            'beforeColon': false,
-            'afterColon': true,
-            'align': colon
-        }
-    }]
+    # key-spacing: [error, {
+    #     'singleLine': {
+    #         'beforeColon': false,
+    #         'afterColon': true
+    #     },
+    #     'multiLine': {
+    #         'beforeColon': false,
+    #         'afterColon': true,
+    #         'align': colon
+    #     }
+    # }]
     func-names: off
     default-param-last: off
     one-var: [error, never]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -144,7 +144,9 @@ rules:
       allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
     }]
     '@typescript-eslint/no-unsafe-argument': warn
-
+    '@typescript-eslint/no-unsafe-return': error
+    '@typescript-eslint/no-var-requires': error
+    '@typescript-eslint/ban-types': error
 
     # TODO: this is just too much work
     '@typescript-eslint/explicit-module-boundary-types': off
@@ -279,3 +281,4 @@ rules:
         ignoreJSX: all
     }]
     '@stylistic/space-infix-ops': [error]
+

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -50,7 +50,6 @@ rules:
     camelcase: off # underscores may come in handy in some cases
     eqeqeq: warn # important check missing from recommended
     keyword-spacing: warn # we require this explicitly
-    no-multi-spaces: off # useful for manually align some expression across lines
     prefer-rest-params: off # we need ES5 to be fast too
     prefer-spread: off # we need ES5 to be fast too
     space-before-function-paren: [warn, always] # we require this explicitly
@@ -82,8 +81,7 @@ rules:
 
     lines-between-class-members: off # be more lenient on member declarations
     max-classes-per-file: off # helper classes are common
-    max-len: [warn, 150] # more lenient on max length per line
-    no-console: error # prefer the uniform logging methods
+
     no-plusplus: off # allow increment/decrement operators
     no-continue: off # allow unlabeled continues
     no-mixed-operators: off # this is just cumbersome
@@ -112,7 +110,6 @@ rules:
         'ts-nocheck': true,
         'ts-check': false,
     }]
-    '@typescript-eslint/no-unused-expressions': warn
 
     # TODO: this is just too much work
     '@typescript-eslint/explicit-module-boundary-types': off
@@ -127,15 +124,6 @@ rules:
 
     '@typescript-eslint/unbound-method': off # we exploit prototype methods sometimes to acheive better performace
     '@typescript-eslint/no-explicit-any': off # still relevant for some heavily templated usages
-
-    '@typescript-eslint/no-empty-function': [error, {
-      allow: [
-        private-constructors,
-        protected-constructors,
-        decoratedFunctions,
-        overrideMethods,
-      ]
-    }]
 
     '@typescript-eslint/no-unused-vars': off # may become useful in some parent classes
     '@typescript-eslint/no-non-null-assertion': off # sometimes we just know better than the compiler
@@ -163,3 +151,34 @@ rules:
     '@typescript-eslint/explicit-function-return-type': [error, {
       allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
     }]
+
+    max-len: [warn, 250] # more lenient on max length per line
+    no-console: warn # prefer the uniform logging methods
+    '@typescript-eslint/no-unused-expressions': off
+    '@typescript-eslint/no-empty-function': off
+    no-multi-spaces: [warn, {'ignoreEOLComments': true, 'exceptions': {'Property': true, 'VariableDeclarator': false } }]
+
+    comma-dangle: ['error', {
+        "arrays": "only-multiline",
+        "objects": "only-multiline",
+        "imports": "never",
+        "exports": "never",
+        "functions": "never"
+    }]
+    function-paren-newline: off
+    space-infix-ops: warn
+    key-spacing: [warn, {
+        'singleLine':{
+            'beforeColon': false,
+            'afterColon': true
+        },
+        'multiLine' :{
+            'beforeColon': true,
+            'afterColon': true,
+            'align': 'colon'
+        }
+    }]
+    no-multiple-empty-lines: [warn, {'max': 2, 'maxEOF': 1}]
+    '@typescript-eslint/no-unsafe-argument': off
+    '@typescript-eslint/no-unsafe-enum-comparison': off
+    '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -196,7 +196,7 @@ rules:
     eqeqeq: ['error', 'smart']
     no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
     '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]
-    arrow-body-style: [off, as-needed]
+    arrow-body-style: [error, as-needed]
     arrow-parens: [ error, as-needed ]
     brace-style: [ error, 1tbs ]
     id-denylist: [ error, any, unknown, Number, number, String, string, Boolean, boolean, Undefined, undefined ]
@@ -205,4 +205,13 @@ rules:
     no-constant-condition: off
     # padded-blocks: ['error', { 'classes': 'always' }]
     "@typescript-eslint/space-infix-ops": ["error"]
-    '@typescript-eslint/type-annotation-spacing': [error, { "before": false, "after": true }]
+    '@typescript-eslint/type-annotation-spacing': [error, {
+        before: false,
+        after: true,
+        overrides : {
+            arrow: {
+                before: true,
+                after: true,
+            }
+        }
+     }]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -214,7 +214,7 @@ rules:
     arrow-body-style: [error, as-needed]
     arrow-parens: [error, always]
     brace-style: [error, 1tbs]
-    id-denylist: [error, any, unknown, Number, number, String, string, Boolean, boolean, Undefined, undefined]
+    id-denylist: [error, any, unknown, Number, number, String, Boolean, boolean, Undefined, undefined]
     id-match: off
     no-cond-assign: off
     no-constant-condition: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -70,14 +70,6 @@ rules:
     import/extensions: off # typescript doesn't support this
     import/no-unresolved: off # TODO: fix internal modules
     import/prefer-default-export: off # prefer named exports
-    indent: [error, 4, {
-      SwitchCase: 0,
-      ignoredNodes: [ # https://stackoverflow.com/a/72897089
-          'FunctionExpression > .params[decorators.length > 0]',
-          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
-      ]
-    }]
 
     lines-between-class-members: off # be more lenient on member declarations
     max-classes-per-file: off # helper classes are common
@@ -255,3 +247,11 @@ rules:
             }
         }
      }]
+    '@typescript-eslint/indent': [error, 4, {
+      SwitchCase: 0,
+      ignoredNodes: [ # https://stackoverflow.com/a/72897089
+          'FunctionExpression > .params[decorators.length > 0]',
+          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
+      ]
+    }]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -180,5 +180,4 @@ rules:
     }]
     no-multiple-empty-lines: [warn, {'max': 2, 'maxEOF': 1}]
     '@typescript-eslint/no-unsafe-argument': off
-    '@typescript-eslint/no-unsafe-enum-comparison': off
     '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -85,7 +85,7 @@ rules:
     no-plusplus: off # allow increment/decrement operators
     no-continue: off # allow unlabeled continues
     no-mixed-operators: off # this is just cumbersome
-    no-multi-assign: off # it is handy sometimes
+
     no-nested-ternary: off # it is handy sometimes
     no-param-reassign: off # the output object is passed as parameters all the time
     no-restricted-syntax: off # for-in is a efficient choice for plain objects
@@ -177,8 +177,16 @@ rules:
 
     max-len: [warn, 250] # more lenient on max length per line
     no-console: warn # prefer the uniform logging methods
-    no-multi-spaces: [warn, {'ignoreEOLComments': true, 'exceptions': {'Property': true, 'VariableDeclarator': false } }]
+    no-multi-spaces: [warn, {
+        'ignoreEOLComments': true,
+        'exceptions': {
+            'Property': true,
+            'VariableDeclarator': false
+        }
+    }]
     no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
+    no-multi-assign: [error, { 'ignoreNonDeclaration': true }]
+    max-statements-per-line: [error, { max: 1 }]
 
     comma-dangle: [error, {
         'arrays': always-multiline,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -188,14 +188,6 @@ rules:
         'functions': never
     }]
     quote-props: [error, consistent-as-needed]
-    no-extra-parens: [error, all, {
-      'conditionalAssign': false,
-      'returnAssign': false,
-      'nestedBinaryExpressions': false,
-      'enforceForArrowConditionals': false,
-      'enforceForFunctionPrototypeMethods': false,
-      'ignoreJSX': all
-    }]
     function-paren-newline: off
     space-unary-ops: error
     key-spacing: [error, {
@@ -222,6 +214,14 @@ rules:
     # padded-blocks: [error, {
     #     'classes': always
     # }]
+    '@typescript-eslint/no-extra-parens': [error, all, {
+      'conditionalAssign': false,
+      'returnAssign': false,
+      'nestedBinaryExpressions': false,
+      'enforceForArrowConditionals': false,
+      'enforceForFunctionPrototypeMethods': false,
+      'ignoreJSX': all
+    }]
     '@typescript-eslint/no-unused-expressions': [error, {
         'allowShortCircuit': true,
         'allowTernary': true,
@@ -231,6 +231,7 @@ rules:
         'ignoreIntersections': false,
         'ignoreUnions': true
     }]
+    '@typescript-eslint/keyword-spacing': [error]
     '@typescript-eslint/space-infix-ops': [error]
     '@typescript-eslint/type-annotation-spacing': [error, {
         'before': false,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -210,6 +210,7 @@ rules:
         }
     }]
     func-names: off
+    default-param-last: off
     one-var: [error, never]
     eqeqeq: [error, always, {'null': ignore}]
     arrow-body-style: [error, as-needed]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -11,7 +11,7 @@ extends:
     - plugin:@typescript-eslint/recommended
     - plugin:@typescript-eslint/recommended-requiring-type-checking
 
-plugins: ["@typescript-eslint"]
+plugins: ['@typescript-eslint']
 
 settings:
     import/resolver:
@@ -48,7 +48,7 @@ rules:
     ##### RECOMMENDED RULE OVERRIDES #####
 
     camelcase: off # underscores may come in handy in some cases
-    eqeqeq: warn # important check missing from recommended
+
     keyword-spacing: warn # we require this explicitly
     prefer-rest-params: off # we need ES5 to be fast too
     prefer-spread: off # we need ES5 to be fast too
@@ -73,9 +73,9 @@ rules:
     indent: [error, 4, {
       SwitchCase: 0,
       ignoredNodes: [ # https://stackoverflow.com/a/72897089
-          "FunctionExpression > .params[decorators.length > 0]",
-          "FunctionExpression > .params > :matches(Decorator, :not(:first-child))",
-          "ClassBody.body > PropertyDefinition[decorators.length > 0] > .key",
+          'FunctionExpression > .params[decorators.length > 0]',
+          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
       ]
     }]
 
@@ -136,8 +136,6 @@ rules:
         allowBoolean: true
     }]
 
-    '@typescript-eslint/type-annotation-spacing': warn
-
     # We choose to use style `... as foo` since it's more common.
     # In the other hand, angle bracket style can be ambiguous with j/tsx syntax.
     # For example, https://babeljs.io/docs/en/babel-plugin-transform-typescript#istsx
@@ -152,22 +150,37 @@ rules:
       allowIIFEs: true, # IIFEs are widely used, writing their signature twice is painful
     }]
 
+
+    # constructor-super: error
+    # curly: [ error, all ]
+    # no-debugger: error
+    # no-duplicate-case: error
+    # no-eval: error
+    # no-sparse-arrays: error
+    # no-trailing-spaces: error
+    # no-var: error
+    # prefer-const: error
+    # prefer-numeric-literals: off
+    # prefer-template: error
+
+
+    # '@typescript-eslint/no-unsafe-argument': off
+
     max-len: [warn, 250] # more lenient on max length per line
     no-console: warn # prefer the uniform logging methods
-    '@typescript-eslint/no-unused-expressions': off
     '@typescript-eslint/no-empty-function': off
     no-multi-spaces: [warn, {'ignoreEOLComments': true, 'exceptions': {'Property': true, 'VariableDeclarator': false } }]
 
     comma-dangle: ['error', {
-        'arrays': 'only-multiline',
-        'objects': 'only-multiline',
+        'arrays': 'never',
+        'objects': 'always-multiline',
         'imports': 'never',
         'exports': 'never',
         'functions': 'never'
     }]
     quote-props: ['error', 'consistent-as-needed']
     function-paren-newline: off
-    space-infix-ops: warn
+    space-unary-ops: error
     key-spacing: [warn, {
         'singleLine':{
             'beforeColon': false,
@@ -179,6 +192,17 @@ rules:
             'align': 'colon'
         }
     }]
-    no-multiple-empty-lines: [warn, {'max': 2, 'maxEOF': 1}]
-    '@typescript-eslint/no-unsafe-argument': off
+    one-var: [error, never]
+    eqeqeq: ['error', 'smart']
+    no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
     '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]
+    arrow-body-style: [off, as-needed]
+    arrow-parens: [ error, as-needed ]
+    brace-style: [ error, 1tbs ]
+    id-denylist: [ error, any, unknown, Number, number, String, string, Boolean, boolean, Undefined, undefined ]
+    id-match: off
+    no-cond-assign: off
+    no-constant-condition: off
+    # padded-blocks: ['error', { 'classes': 'always' }]
+    "@typescript-eslint/space-infix-ops": ["error"]
+    '@typescript-eslint/type-annotation-spacing': [error, { "before": false, "after": true }]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -70,7 +70,17 @@ rules:
     import/extensions: off # typescript doesn't support this
     import/no-unresolved: off # TODO: fix internal modules
     import/prefer-default-export: off # prefer named exports
-
+    indent: [error, 4, {
+        SwitchCase: 0
+    }]
+    '@typescript-eslint/indent': [error, 4, {
+      SwitchCase: 0,
+      ignoredNodes: [ # https://stackoverflow.com/a/72897089
+          'FunctionExpression > .params[decorators.length > 0]',
+          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
+      ]
+    }]
     lines-between-class-members: off # be more lenient on member declarations
     max-classes-per-file: off # helper classes are common
 
@@ -247,11 +257,3 @@ rules:
             }
         }
      }]
-    '@typescript-eslint/indent': [error, 4, {
-      SwitchCase: 0,
-      ignoredNodes: [ # https://stackoverflow.com/a/72897089
-          'FunctionExpression > .params[decorators.length > 0]',
-          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
-      ]
-    }]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -210,7 +210,7 @@ rules:
         }
     }]
     one-var: [error, never]
-    eqeqeq: [error, smart]
+    eqeqeq: [error, always, {'null': ignore}]
     arrow-body-style: [error, as-needed]
     arrow-parens: [error, always]
     brace-style: [error, 1tbs]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -180,7 +180,7 @@ rules:
     no-multi-spaces: [warn, {'ignoreEOLComments': true, 'exceptions': {'Property': true, 'VariableDeclarator': false } }]
 
     comma-dangle: [error, {
-        'arrays': 'never',
+        'arrays': 'always-multiline',
         'objects': 'always-multiline',
         'imports': 'never',
         'exports': 'never',

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -172,9 +172,8 @@ rules:
     # no-var: error
     # prefer-const: error
     # prefer-numeric-literals: off
-    # prefer-template: error
 
-
+    prefer-template: off
     '@typescript-eslint/no-unsafe-argument': warn
 
     max-len: [warn, 250] # more lenient on max length per line
@@ -211,6 +210,7 @@ rules:
             'align': colon
         }
     }]
+
     func-names: off
     default-param-last: off
     one-var: [error, never]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -214,7 +214,7 @@ rules:
     arrow-body-style: [error, as-needed]
     arrow-parens: [error, always]
     brace-style: [error, 1tbs]
-    id-denylist: [error, any, unknown, Number, number, String, Boolean, boolean, Undefined, undefined]
+    id-denylist: [error, any, unknown, Number, number, Boolean, boolean, String, Undefined]
     id-match: off
     no-cond-assign: off
     no-constant-condition: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -173,11 +173,12 @@ rules:
     # prefer-template: error
 
 
-    # '@typescript-eslint/no-unsafe-argument': off
+    '@typescript-eslint/no-unsafe-argument': warn
 
     max-len: [warn, 250] # more lenient on max length per line
     no-console: warn # prefer the uniform logging methods
     no-multi-spaces: [warn, {'ignoreEOLComments': true, 'exceptions': {'Property': true, 'VariableDeclarator': false } }]
+    no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
 
     comma-dangle: [error, {
         'arrays': 'always-multiline',
@@ -197,7 +198,7 @@ rules:
     }]
     function-paren-newline: off
     space-unary-ops: error
-    key-spacing: [warn, {
+    key-spacing: [error, {
         'singleLine':{
             'beforeColon': false,
             'afterColon': true
@@ -210,7 +211,6 @@ rules:
     }]
     one-var: [error, never]
     eqeqeq: [error, smart]
-    no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
     arrow-body-style: [error, as-needed]
     arrow-parens: [ error, as-needed ]
     brace-style: [ error, 1tbs ]
@@ -229,7 +229,7 @@ rules:
     ]
     '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]
     "@typescript-eslint/space-infix-ops": [error]
-    '@typescript-eslint/type-annotation-spacing': [warn, {
+    '@typescript-eslint/type-annotation-spacing': [error, {
         before: false,
         after: true,
         overrides : {

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -171,14 +171,22 @@ rules:
     '@typescript-eslint/no-empty-function': off
     no-multi-spaces: [warn, {'ignoreEOLComments': true, 'exceptions': {'Property': true, 'VariableDeclarator': false } }]
 
-    comma-dangle: ['error', {
+    comma-dangle: [error, {
         'arrays': 'never',
         'objects': 'always-multiline',
         'imports': 'never',
         'exports': 'never',
         'functions': 'never'
     }]
-    quote-props: ['error', 'consistent-as-needed']
+    quote-props: [error, 'consistent-as-needed']
+    no-extra-parens: [error, 'all', {
+      conditionalAssign: false,
+      returnAssign: false,
+      nestedBinaryExpressions: false,
+      enforceForArrowConditionals: false,
+      enforceForFunctionPrototypeMethods: false,
+      ignoreJSX: 'all'
+    }]
     function-paren-newline: off
     space-unary-ops: error
     key-spacing: [warn, {
@@ -193,9 +201,8 @@ rules:
         }
     }]
     one-var: [error, never]
-    eqeqeq: ['error', 'smart']
+    eqeqeq: [error, smart]
     no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
-    '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]
     arrow-body-style: [error, as-needed]
     arrow-parens: [ error, as-needed ]
     brace-style: [ error, 1tbs ]
@@ -203,8 +210,10 @@ rules:
     id-match: off
     no-cond-assign: off
     no-constant-condition: off
-    # padded-blocks: ['error', { 'classes': 'always' }]
-    "@typescript-eslint/space-infix-ops": ["error"]
+    nonblock-statement-body-position: [error, below]
+    # padded-blocks: [error, { 'classes': 'always' }]
+    '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]
+    "@typescript-eslint/space-infix-ops": [error]
     '@typescript-eslint/type-annotation-spacing': [error, {
         before: false,
         after: true,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -219,10 +219,13 @@ rules:
     no-cond-assign: off
     no-constant-condition: off
     nonblock-statement-body-position: [error, below]
+
     func-names: off
+
     padded-blocks: [error, {
         'classes': always
     }]
+    '@typescript-eslint/no-this-alias': [off]
     '@typescript-eslint/no-extra-parens': [error, all, {
       'conditionalAssign': false,
       'returnAssign': false,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -209,6 +209,7 @@ rules:
             'align': colon
         }
     }]
+    func-names: off
     one-var: [error, never]
     eqeqeq: [error, always, {'null': ignore}]
     arrow-body-style: [error, as-needed]
@@ -219,12 +220,10 @@ rules:
     no-cond-assign: off
     no-constant-condition: off
     nonblock-statement-body-position: [error, below]
-
-    func-names: off
-
     padded-blocks: [error, {
         'classes': always
     }]
+
     '@typescript-eslint/no-this-alias': [off]
     '@typescript-eslint/no-extra-parens': [error, all, {
       'conditionalAssign': false,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -71,14 +71,19 @@ rules:
     import/no-unresolved: off # TODO: fix internal modules
     import/prefer-default-export: off # prefer named exports
     indent: [error, 4, {
-        SwitchCase: 0
+      SwitchCase: 0,
+      ignoredNodes: [ # https://stackoverflow.com/a/72897089
+          'FunctionExpression > .params[decorators.length > 0]',
+          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
+      ]
     }]
     '@typescript-eslint/indent': [error, 4, {
       SwitchCase: 0,
       ignoredNodes: [ # https://stackoverflow.com/a/72897089
           'FunctionExpression > .params[decorators.length > 0]',
           'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
+          'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
       ]
     }]
     lines-between-class-members: off # be more lenient on member declarations
@@ -206,8 +211,8 @@ rules:
         },
         'multiLine': {
             'beforeColon': false,
-            'afterColon': true,
-            'align': colon
+            'afterColon': true
+            # 'align': colon
         }
     }]
 

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -165,6 +165,7 @@ rules:
         'exports': 'never',
         'functions': 'never'
     }]
+    quote-props: ['error', 'consistent-as-needed']
     function-paren-newline: off
     space-infix-ops: warn
     key-spacing: [warn, {

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -124,6 +124,7 @@ rules:
 
     '@typescript-eslint/unbound-method': off # we exploit prototype methods sometimes to acheive better performace
     '@typescript-eslint/no-explicit-any': off # still relevant for some heavily templated usages
+
     '@typescript-eslint/no-empty-function': [error, {
       allow: [
         private-constructors,
@@ -132,6 +133,7 @@ rules:
         overrideMethods,
       ]
     }]
+
     '@typescript-eslint/no-unused-vars': off # may become useful in some parent classes
     '@typescript-eslint/no-non-null-assertion': off # sometimes we just know better than the compiler
     '@typescript-eslint/no-namespace': [warn, { # we need to declare static properties

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -124,7 +124,14 @@ rules:
 
     '@typescript-eslint/unbound-method': off # we exploit prototype methods sometimes to acheive better performace
     '@typescript-eslint/no-explicit-any': off # still relevant for some heavily templated usages
-
+    '@typescript-eslint/no-empty-function': [error, {
+      allow: [
+        private-constructors,
+        protected-constructors,
+        decoratedFunctions,
+        overrideMethods,
+      ]
+    }]
     '@typescript-eslint/no-unused-vars': off # may become useful in some parent classes
     '@typescript-eslint/no-non-null-assertion': off # sometimes we just know better than the compiler
     '@typescript-eslint/no-namespace': [warn, { # we need to declare static properties
@@ -168,7 +175,6 @@ rules:
 
     max-len: [warn, 250] # more lenient on max length per line
     no-console: warn # prefer the uniform logging methods
-    '@typescript-eslint/no-empty-function': off
     no-multi-spaces: [warn, {'ignoreEOLComments': true, 'exceptions': {'Property': true, 'VariableDeclarator': false } }]
 
     comma-dangle: [error, {
@@ -212,9 +218,16 @@ rules:
     no-constant-condition: off
     nonblock-statement-body-position: [error, below]
     # padded-blocks: [error, { 'classes': 'always' }]
+    '@typescript-eslint/no-unused-expressions': [error,
+        {
+            "allowShortCircuit": true,
+            "allowTernary": true,
+            "allowTaggedTemplates": false
+        }
+    ]
     '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]
     "@typescript-eslint/space-infix-ops": [error]
-    '@typescript-eslint/type-annotation-spacing': [error, {
+    '@typescript-eslint/type-annotation-spacing': [warn, {
         before: false,
         after: true,
         overrides : {

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -219,9 +219,10 @@ rules:
     no-cond-assign: off
     no-constant-condition: off
     nonblock-statement-body-position: [error, below]
-    # padded-blocks: [error, {
-    #     'classes': always
-    # }]
+    func-names: off
+    padded-blocks: [error, {
+        'classes': always
+    }]
     '@typescript-eslint/no-extra-parens': [error, all, {
       'conditionalAssign': false,
       'returnAssign': false,

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -161,7 +161,7 @@ rules:
 
 
     # constructor-super: error
-    # curly: [ error, all ]
+    # curly: [error, all]
     # no-debugger: error
     # no-duplicate-case: error
     # no-eval: error
@@ -181,61 +181,64 @@ rules:
     no-multiple-empty-lines: [warn, {max: 2, maxEOF: 1}]
 
     comma-dangle: [error, {
-        'arrays': 'always-multiline',
-        'objects': 'always-multiline',
-        'imports': 'never',
-        'exports': 'never',
-        'functions': 'never'
+        'arrays': always-multiline,
+        'objects': always-multiline,
+        'imports': never,
+        'exports': never,
+        'functions': never
     }]
-    quote-props: [error, 'consistent-as-needed']
-    no-extra-parens: [error, 'all', {
-      conditionalAssign: false,
-      returnAssign: false,
-      nestedBinaryExpressions: false,
-      enforceForArrowConditionals: false,
-      enforceForFunctionPrototypeMethods: false,
-      ignoreJSX: 'all'
+    quote-props: [error, consistent-as-needed]
+    no-extra-parens: [error, all, {
+      'conditionalAssign': false,
+      'returnAssign': false,
+      'nestedBinaryExpressions': false,
+      'enforceForArrowConditionals': false,
+      'enforceForFunctionPrototypeMethods': false,
+      'ignoreJSX': all
     }]
     function-paren-newline: off
     space-unary-ops: error
     key-spacing: [error, {
-        'singleLine':{
+        'singleLine': {
             'beforeColon': false,
             'afterColon': true
         },
-        'multiLine' :{
+        'multiLine': {
             'beforeColon': false,
             'afterColon': true,
-            'align': 'colon'
+            'align': colon
         }
     }]
     one-var: [error, never]
     eqeqeq: [error, smart]
     arrow-body-style: [error, as-needed]
-    arrow-parens: [ error, as-needed ]
-    brace-style: [ error, 1tbs ]
-    id-denylist: [ error, any, unknown, Number, number, String, string, Boolean, boolean, Undefined, undefined ]
+    arrow-parens: [error, always]
+    brace-style: [error, 1tbs]
+    id-denylist: [error, any, unknown, Number, number, String, string, Boolean, boolean, Undefined, undefined]
     id-match: off
     no-cond-assign: off
     no-constant-condition: off
     nonblock-statement-body-position: [error, below]
-    # padded-blocks: [error, { 'classes': 'always' }]
-    '@typescript-eslint/no-unused-expressions': [error,
-        {
-            "allowShortCircuit": true,
-            "allowTernary": true,
-            "allowTaggedTemplates": false
-        }
-    ]
-    '@typescript-eslint/no-duplicate-type-constituents': [error, { ignoreIntersections: false, ignoreUnions: true }]
-    "@typescript-eslint/space-infix-ops": [error]
+    # padded-blocks: [error, {
+    #     'classes': always
+    # }]
+    '@typescript-eslint/no-unused-expressions': [error, {
+        'allowShortCircuit': true,
+        'allowTernary': true,
+        'allowTaggedTemplates': false
+    }]
+    '@typescript-eslint/no-duplicate-type-constituents': [error, {
+        'ignoreIntersections': false,
+        'ignoreUnions': true
+    }]
+    '@typescript-eslint/space-infix-ops': [error]
     '@typescript-eslint/type-annotation-spacing': [error, {
-        before: false,
-        after: true,
-        overrides : {
-            arrow: {
-                before: true,
-                after: true,
+        'before': false,
+        'after': true,
+        'overrides' : {
+            'arrow': {
+                'before': true,
+                'after': true,
             }
         }
      }]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -159,11 +159,11 @@ rules:
     no-multi-spaces: [warn, {'ignoreEOLComments': true, 'exceptions': {'Property': true, 'VariableDeclarator': false } }]
 
     comma-dangle: ['error', {
-        "arrays": "only-multiline",
-        "objects": "only-multiline",
-        "imports": "never",
-        "exports": "never",
-        "functions": "never"
+        'arrays': 'only-multiline',
+        'objects': 'only-multiline',
+        'imports': 'never',
+        'exports': 'never',
+        'functions': 'never'
     }]
     function-paren-newline: off
     space-infix-ops: warn
@@ -173,7 +173,7 @@ rules:
             'afterColon': true
         },
         'multiLine' :{
-            'beforeColon': true,
+            'beforeColon': false,
             'afterColon': true,
             'align': 'colon'
         }


### PR DESCRIPTION
A better eslint rules config    (maybe).


需要在 package.json里加入下列依赖项: 
```
  "devDependencies": {
    "@eslint-stylistic/metadata": "^1.4.1",
    "@stylistic/eslint-plugin": "^1.4.1",
    "@stylistic/eslint-plugin-migrate": "^1.4.1",
    "@typescript-eslint/eslint-plugin": "^6.12.0",
    "@typescript-eslint/parser": "^6.12.0",
    "eslint": "^8.54.0",
    "eslint-plugin-import": "^2.29.0"
  },
```
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
