### PR TITLE
fix audio can not reset to position 0 after call stop operation on web platform

### DIFF
--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -25,6 +25,7 @@
 import { minigame } from 'pal/minigame';
 import { systemInfo } from 'pal/system-info';
 import { clamp01 } from '../../../cocos/core';
+import * as debug from '../../../cocos/core/platform/debug';
 import { EventTarget } from '../../../cocos/core/event';
 import { audioBufferManager } from '../audio-buffer-manager';
 import AudioTimer from '../audio-timer';
@@ -133,8 +134,7 @@ export class AudioPlayerWeb implements OperationQueueable {
                 this._state = AudioState.INTERRUPTED;
                 this._readyToHandleOnShow = true;
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_BEGIN);
-            // eslint-disable-next-line no-console
-            }).catch((e) => { console.warn('_onInterruptedBegin error', e); });
+            }).catch((e) => { debug.warn('_onInterruptedBegin error', e); });
         }
     }
     private _onInterruptedEnd (): void {
@@ -146,8 +146,7 @@ export class AudioPlayerWeb implements OperationQueueable {
         if (this._state === AudioState.INTERRUPTED) {
             this.play().then(() => {
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_END);
-            // eslint-disable-next-line no-console
-            }).catch((e) => { console.warn('_onInterruptedEnd error', e); });
+            }).catch((e) => { debug.warn('_onInterruptedEnd error', e); });
         }
         this._readyToHandleOnShow = false;
     }
@@ -155,8 +154,7 @@ export class AudioPlayerWeb implements OperationQueueable {
         return new Promise((resolve) => {
             AudioPlayerWeb.loadNative(url).then((audioBuffer) => {
                 resolve(new AudioPlayerWeb(audioBuffer, url));
-            // eslint-disable-next-line no-console
-            }).catch((e) => { console.warn('load error', url, e); });
+            }).catch((e) => { debug.warn('load error', url, e); });
         });
     }
     static loadNative (url: string): Promise<AudioBuffer> {
@@ -178,8 +176,7 @@ export class AudioPlayerWeb implements OperationQueueable {
                 audioContext!.decodeAudioData(arrayBuffer).then((decodedAudioBuffer) => {
                     audioBufferManager.addCache(url, decodedAudioBuffer);
                     resolve(decodedAudioBuffer);
-                // eslint-disable-next-line no-console
-                }).catch((e) => { console.warn('loadNative error', url, e); });
+                }).catch((e) => { debug.warn('loadNative error', url, e); });
             });
         });
     }
@@ -243,8 +240,7 @@ export class AudioPlayerWeb implements OperationQueueable {
             if (this._state === AudioState.PLAYING) {
                 // one AudioBufferSourceNode can't start twice
                 // need to create a new one to start from the offset
-                // eslint-disable-next-line no-console
-                this._doPlay().then(resolve).catch((e) => { console.warn('seek error', e); });
+                this._doPlay().then(resolve).catch((e) => { debug.warn('seek error', e); });
             } else {
                 resolve();
             }

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -133,7 +133,8 @@ export class AudioPlayerWeb implements OperationQueueable {
                 this._state = AudioState.INTERRUPTED;
                 this._readyToHandleOnShow = true;
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_BEGIN);
-            }).catch((e) => {});
+            // eslint-disable-next-line no-console
+            }).catch((e) => { console.warn('_onInterruptedBegin error', e); });
         }
     }
     private _onInterruptedEnd (): void {
@@ -145,7 +146,8 @@ export class AudioPlayerWeb implements OperationQueueable {
         if (this._state === AudioState.INTERRUPTED) {
             this.play().then(() => {
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_END);
-            }).catch((e) => {});
+            // eslint-disable-next-line no-console
+            }).catch((e) => { console.warn('_onInterruptedEnd error', e); });
         }
         this._readyToHandleOnShow = false;
     }
@@ -153,7 +155,8 @@ export class AudioPlayerWeb implements OperationQueueable {
         return new Promise((resolve) => {
             AudioPlayerWeb.loadNative(url).then((audioBuffer) => {
                 resolve(new AudioPlayerWeb(audioBuffer, url));
-            }).catch((e) => {});
+            // eslint-disable-next-line no-console
+            }).catch((e) => { console.warn('load error', url, e); });
         });
     }
     static loadNative (url: string): Promise<AudioBuffer> {
@@ -175,7 +178,8 @@ export class AudioPlayerWeb implements OperationQueueable {
                 audioContext!.decodeAudioData(arrayBuffer).then((decodedAudioBuffer) => {
                     audioBufferManager.addCache(url, decodedAudioBuffer);
                     resolve(decodedAudioBuffer);
-                }).catch((e) => {});
+                // eslint-disable-next-line no-console
+                }).catch((e) => { console.warn('loadNative error', url, e); });
             });
         });
     }
@@ -185,6 +189,7 @@ export class AudioPlayerWeb implements OperationQueueable {
             AudioPlayerWeb.loadNative(url).then((audioBuffer) => {
                 // HACK: AudioPlayer should be a friend class in OneShotAudio
                 const oneShotAudio = new (OneShotAudioWeb as any)(audioBuffer, volume, url);
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 resolve(oneShotAudio);
             }).catch(reject);
         });
@@ -238,7 +243,8 @@ export class AudioPlayerWeb implements OperationQueueable {
             if (this._state === AudioState.PLAYING) {
                 // one AudioBufferSourceNode can't start twice
                 // need to create a new one to start from the offset
-                this._doPlay().then(resolve).catch((e) => {});
+                // eslint-disable-next-line no-console
+                this._doPlay().then(resolve).catch((e) => { console.warn('seek error', e); });
             } else {
                 resolve();
             }

--- a/pal/audio/minigame/player-web.ts
+++ b/pal/audio/minigame/player-web.ts
@@ -302,6 +302,8 @@ export class AudioPlayerWeb implements OperationQueueable {
     @enqueueOperation
     stop (): Promise<void> {
         if (!this._sourceNode) {
+            this._audioTimer.stop();
+            this._state = AudioState.STOPPED;
             return Promise.resolve();
         }
         this._audioTimer.stop();

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -76,9 +76,11 @@ export class AudioContextAgent {
                 resolve(audioBuffer);
             }, (err) => {
                 // TODO: need to reject the error.
+                // eslint-disable-next-line no-console
                 console.error('failed to load Web Audio', err);
             });
-            promise?.catch((e) => {});  // Safari doesn't support the promise based decodeAudioData
+            // eslint-disable-next-line no-console
+            promise?.catch((e) => { console.warn('decodeAudioData error', e); });  // Safari doesn't support the promise based decodeAudioData
         });
     }
 
@@ -93,7 +95,8 @@ export class AudioContextAgent {
                 resolve();
                 return;
             }
-            context.resume().catch((e) => {});
+            // eslint-disable-next-line no-console
+            context.resume().catch((e) => { console.warn('runContext error', e); });
             if (context.state === 'running') {
                 resolve();
                 return;
@@ -106,7 +109,8 @@ export class AudioContextAgent {
                     canvas?.removeEventListener('touchend', onGesture, { capture: true });
                     canvas?.removeEventListener('mouseup', onGesture, { capture: true });
                     resolve();
-                }).catch((e) => {});
+                // eslint-disable-next-line no-console
+                }).catch((e) => { console.warn('onGesture resume error', e); });
             };
             canvas?.addEventListener('touchend', onGesture, { capture: true });
             canvas?.addEventListener('mouseup', onGesture, { capture: true });
@@ -199,7 +203,8 @@ export class OneShotAudioWeb {
                 audioBufferManager.tryReleasingCache(this._url);
                 this.onEnd?.();
             }, this._duration * 1000);
-        }).catch((e) => {});
+        // eslint-disable-next-line no-console
+        }).catch((e) => { console.warn('play error', e); });
     }
 
     public stop (): void {
@@ -257,7 +262,8 @@ export class AudioPlayerWeb implements OperationQueueable {
         return new Promise((resolve) => {
             AudioPlayerWeb.loadNative(url).then((audioBuffer) => {
                 resolve(new AudioPlayerWeb(audioBuffer, url));
-            }).catch((e) => {});
+            // eslint-disable-next-line no-console
+            }).catch((e) => { console.warn('load error', url, e); });
         });
     }
     static loadNative (url: string): Promise<AudioBuffer> {
@@ -275,10 +281,12 @@ export class AudioPlayerWeb implements OperationQueueable {
 
             xhr.onload = (): void => {
                 if (xhr.status === 200 || xhr.status === 0) {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     audioContextAgent!.decodeAudioData(xhr.response).then((decodedAudioBuffer) => {
                         audioBufferManager.addCache(url, decodedAudioBuffer);
                         resolve(decodedAudioBuffer);
-                    }).catch((e) => {});
+                    // eslint-disable-next-line no-console
+                    }).catch((e) => { console.warn('loadNative error', url, e); });
                 } else {
                     reject(new Error(`${errInfo}${xhr.status}(no response)`));
                 }
@@ -295,6 +303,7 @@ export class AudioPlayerWeb implements OperationQueueable {
             AudioPlayerWeb.loadNative(url).then((audioBuffer) => {
                 // HACK: AudioPlayer should be a friend class in OneShotAudio
                 const oneShotAudio = new (OneShotAudioWeb as any)(audioBuffer, volume, url);
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 resolve(oneShotAudio);
             }).catch(reject);
         });
@@ -313,14 +322,16 @@ export class AudioPlayerWeb implements OperationQueueable {
             this.pause().then(() => {
                 this._state = AudioState.INTERRUPTED;
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_BEGIN);
-            }).catch((e) => {});
+            // eslint-disable-next-line no-console
+            }).catch((e) => { console.warn('_onInterruptedBegin error', e); });
         }
     }
     private _onInterruptedEnd (): void {
         if (this._state === AudioState.INTERRUPTED) {
             this.play().then(() => {
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_END);
-            }).catch((e) => {});
+            // eslint-disable-next-line no-console
+            }).catch((e) => { console.warn('_onInterruptedEnd error', e); });
         }
     }
 
@@ -371,7 +382,8 @@ export class AudioPlayerWeb implements OperationQueueable {
             if (this._state === AudioState.PLAYING) {
                 // one AudioBufferSourceNode can't start twice
                 // need to create a new one to start from the offset
-                this._doPlay().then(resolve).catch((e) => {});
+                // eslint-disable-next-line no-console
+                this._doPlay().then(resolve).catch((e) => { console.warn('seek error', e); });
             } else {
                 resolve();
             }
@@ -405,7 +417,8 @@ export class AudioPlayerWeb implements OperationQueueable {
                 // - system automatically resume audio context when enter foreground from background.
                 audioContextAgent!.onceRunning(this._runningCallback);
                 // Ensure resume context.
-                audioContextAgent!.runContext().catch((e) => {});
+                // eslint-disable-next-line no-console
+                audioContextAgent!.runContext().catch((e) => { console.warn('doPlay error', e); });
             }
         });
     }

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -26,6 +26,7 @@ import { EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
 import { AudioPCMDataView, AudioEvent, AudioState, AudioType } from '../type';
 import { EventTarget } from '../../../cocos/core/event';
 import { clamp01 } from '../../../cocos/core';
+import * as debug from '../../../cocos/core/platform/debug';
 import { enqueueOperation, OperationInfo, OperationQueueable } from '../operation-queue';
 import AudioTimer from '../audio-timer';
 import { audioBufferManager } from '../audio-buffer-manager';
@@ -79,8 +80,7 @@ export class AudioContextAgent {
                 // eslint-disable-next-line no-console
                 console.error('failed to load Web Audio', err);
             });
-            // eslint-disable-next-line no-console
-            promise?.catch((e) => { console.warn('decodeAudioData error', e); });  // Safari doesn't support the promise based decodeAudioData
+            promise?.catch((e) => { debug.warn('decodeAudioData error', e); });  // Safari doesn't support the promise based decodeAudioData
         });
     }
 
@@ -95,8 +95,7 @@ export class AudioContextAgent {
                 resolve();
                 return;
             }
-            // eslint-disable-next-line no-console
-            context.resume().catch((e) => { console.warn('runContext error', e); });
+            context.resume().catch((e) => { debug.warn('runContext error', e); });
             if (context.state === 'running') {
                 resolve();
                 return;
@@ -109,8 +108,7 @@ export class AudioContextAgent {
                     canvas?.removeEventListener('touchend', onGesture, { capture: true });
                     canvas?.removeEventListener('mouseup', onGesture, { capture: true });
                     resolve();
-                // eslint-disable-next-line no-console
-                }).catch((e) => { console.warn('onGesture resume error', e); });
+                }).catch((e) => { debug.warn('onGesture resume error', e); });
             };
             canvas?.addEventListener('touchend', onGesture, { capture: true });
             canvas?.addEventListener('mouseup', onGesture, { capture: true });
@@ -203,8 +201,7 @@ export class OneShotAudioWeb {
                 audioBufferManager.tryReleasingCache(this._url);
                 this.onEnd?.();
             }, this._duration * 1000);
-        // eslint-disable-next-line no-console
-        }).catch((e) => { console.warn('play error', e); });
+        }).catch((e) => { debug.warn('play error', e); });
     }
 
     public stop (): void {
@@ -262,8 +259,7 @@ export class AudioPlayerWeb implements OperationQueueable {
         return new Promise((resolve) => {
             AudioPlayerWeb.loadNative(url).then((audioBuffer) => {
                 resolve(new AudioPlayerWeb(audioBuffer, url));
-            // eslint-disable-next-line no-console
-            }).catch((e) => { console.warn('load error', url, e); });
+            }).catch((e) => { debug.warn('load error', url, e); });
         });
     }
     static loadNative (url: string): Promise<AudioBuffer> {
@@ -285,8 +281,7 @@ export class AudioPlayerWeb implements OperationQueueable {
                     audioContextAgent!.decodeAudioData(xhr.response).then((decodedAudioBuffer) => {
                         audioBufferManager.addCache(url, decodedAudioBuffer);
                         resolve(decodedAudioBuffer);
-                    // eslint-disable-next-line no-console
-                    }).catch((e) => { console.warn('loadNative error', url, e); });
+                    }).catch((e) => { debug.warn('loadNative error', url, e); });
                 } else {
                     reject(new Error(`${errInfo}${xhr.status}(no response)`));
                 }
@@ -322,16 +317,14 @@ export class AudioPlayerWeb implements OperationQueueable {
             this.pause().then(() => {
                 this._state = AudioState.INTERRUPTED;
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_BEGIN);
-            // eslint-disable-next-line no-console
-            }).catch((e) => { console.warn('_onInterruptedBegin error', e); });
+            }).catch((e) => { debug.warn('_onInterruptedBegin error', e); });
         }
     }
     private _onInterruptedEnd (): void {
         if (this._state === AudioState.INTERRUPTED) {
             this.play().then(() => {
                 this._eventTarget.emit(AudioEvent.INTERRUPTION_END);
-            // eslint-disable-next-line no-console
-            }).catch((e) => { console.warn('_onInterruptedEnd error', e); });
+            }).catch((e) => { debug.warn('_onInterruptedEnd error', e); });
         }
     }
 
@@ -382,8 +375,7 @@ export class AudioPlayerWeb implements OperationQueueable {
             if (this._state === AudioState.PLAYING) {
                 // one AudioBufferSourceNode can't start twice
                 // need to create a new one to start from the offset
-                // eslint-disable-next-line no-console
-                this._doPlay().then(resolve).catch((e) => { console.warn('seek error', e); });
+                this._doPlay().then(resolve).catch((e) => { debug.warn('seek error', e); });
             } else {
                 resolve();
             }
@@ -417,8 +409,7 @@ export class AudioPlayerWeb implements OperationQueueable {
                 // - system automatically resume audio context when enter foreground from background.
                 audioContextAgent!.onceRunning(this._runningCallback);
                 // Ensure resume context.
-                // eslint-disable-next-line no-console
-                audioContextAgent!.runContext().catch((e) => { console.warn('doPlay error', e); });
+                audioContextAgent!.runContext().catch((e) => { debug.warn('doPlay error', e); });
             }
         });
     }

--- a/pal/audio/web/player-web.ts
+++ b/pal/audio/web/player-web.ts
@@ -415,6 +415,7 @@ export class AudioPlayerWeb implements OperationQueueable {
         this._stopSourceNode();
         this._sourceNode = audioContextAgent!.createBufferSource(this._audioBuffer, this.loop);
         this._sourceNode.connect(this._gainNode);
+        this._sourceNode.loop = this._loop;
         this._sourceNode.start(0, this._audioTimer.currentTime);
         this._state = AudioState.PLAYING;
         this._audioTimer.start();
@@ -465,6 +466,8 @@ export class AudioPlayerWeb implements OperationQueueable {
     stop (): Promise<void> {
         this.offRunning();
         if (!this._sourceNode) {
+            this._audioTimer.stop();
+            this._state = AudioState.STOPPED;
             return Promise.resolve();
         }
         this._audioTimer.stop();


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/17478

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
