### PR TITLE
support taobaoMinigamePlugin in render-config.json

### DIFF
--- a/editor/engine-features/render-config.json
+++ b/editor/engine-features/render-config.json
@@ -6,7 +6,8 @@
             "description": "i18n:ENGINE.features.core.description",
             "required": true,
             "default": ["base"],
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "graphcis": {
             "label": "i18n:ENGINE.features.graphics.label",
@@ -18,12 +19,14 @@
                     "required": true,
                     "label": "i18n:ENGINE.features.gfx_webgl.label",
                     "description": "i18n:ENGINE.features.gfx_webgl.description",
-                    "wechatPlugin": true
+                    "wechatPlugin": true,
+                    "taobaoMinigamePlugin": true
                 },
                 "gfx-webgl2": {
                     "label": "i18n:ENGINE.features.gfx_webgl2.label",
                     "description": "i18n:ENGINE.features.gfx_webgl2.description",
-                    "wechatPlugin": true
+                    "wechatPlugin": true,
+                    "taobaoMinigamePlugin": true
                 }
             }
         },
@@ -44,6 +47,7 @@
             "label": "i18n:ENGINE.features.base_3d.label",
             "description": "i18n:ENGINE.features.base_3d.description",
             "wechatPlugin": true,
+            "taobaoMinigamePlugin": true,
             "category": "3d"
         },
         "2d": {
@@ -51,27 +55,31 @@
             "label": "i18n:ENGINE.features.base_2d.label",
             "description": "i18n:ENGINE.features.base_2d.description",
             "category": "2d",
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "xr": {
             "default": [],
             "label": "i18n:ENGINE.features.xr.label",
             "description": "i18n:ENGINE.features.xr.description",
-            "wechatPlugin": false
+            "wechatPlugin": false,
+            "taobaoMinigamePlugin": false
         },
         "ui": {
             "default": ["ui"],
             "label": "i18n:ENGINE.features.ui.label",
             "description": "i18n:ENGINE.features.ui.description",
             "category": "2d",
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "particle": {
             "default": ["particle"],
             "label": "i18n:ENGINE.features.particle.label",
             "description": "i18n:ENGINE.features.particle.description",
             "category": "3d",
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "physics": {
             "label": "i18n:ENGINE.features.physics.label",
@@ -119,6 +127,7 @@
             "label": "i18n:ENGINE.features.intersection_2d.label",
             "description": "i18n:ENGINE.features.intersection_2d.description",
             "wechatPlugin": true,
+            "taobaoMinigamePlugin": true,
             "category": "2d"
         },
         "primitive": {
@@ -126,13 +135,15 @@
             "label": "i18n:ENGINE.features.primitives.label",
             "description": "i18n:ENGINE.features.primitives.description",
             "wechatPlugin": true,
+            "taobaoMinigamePlugin": true,
             "category": "3d"
         },
         "profiler": {
             "default": ["profiler"],
             "label": "i18n:ENGINE.features.profiler.label",
             "description": "i18n:ENGINE.features.profiler.description",
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "occlusion-query": {
             "default": [],
@@ -140,6 +151,7 @@
             "description": "i18n:ENGINE.features.occlusion_query.description",
             "native": "USE_OCCLUSION_QUERY",
             "wechatPlugin": false,
+            "taobaoMinigamePlugin": false,
             "category": "3d"
         },
         "geometry-renderer": {
@@ -148,6 +160,7 @@
             "description": "i18n:ENGINE.features.geometry_renderer.description",
             "native": "USE_GEOMETRY_RENDERER",
             "wechatPlugin": true,
+            "taobaoMinigamePlugin": true,
             "category": "3d"
         },
         "debug-renderer": {
@@ -156,6 +169,7 @@
             "description": "i18n:ENGINE.features.debug_renderer.description",
             "native": "USE_DEBUG_RENDERER",
             "wechatPlugin": false,
+            "taobaoMinigamePlugin": false,
             "category": "3d"
         },
         "particle-2d": {
@@ -163,6 +177,7 @@
             "label": "i18n:ENGINE.features.particle_2d.label",
             "description": "i18n:ENGINE.features.particle_2d.description",
             "wechatPlugin": true,
+            "taobaoMinigamePlugin": true,
             "category": "2d"
         },
         "audio": {
@@ -170,27 +185,31 @@
             "label": "i18n:ENGINE.features.audio.label",
             "description": "i18n:ENGINE.features.audio.description",
             "native": "USE_AUDIO",
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "video": {
             "default": ["video"],
             "label": "i18n:ENGINE.features.video.label",
             "description": "i18n:ENGINE.features.video.description",
             "native": "USE_VIDEO",
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "webview": {
             "default": ["webview"],
             "label": "i18n:ENGINE.features.webview.label",
             "description": "i18n:ENGINE.features.webview.description",
             "native": "USE_WEBVIEW",
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "tween": {
             "default": ["tween"],
             "label": "i18n:ENGINE.features.tween.label",
             "description": "i18n:ENGINE.features.tween.description",
-            "wechatPlugin": true
+            "wechatPlugin": true,
+            "taobaoMinigamePlugin": true
         },
         "websocket": {
             "default": ["websocket"],
@@ -198,6 +217,7 @@
             "description": "i18n:ENGINE.features.websocket.description",
             "native": "USE_SOCKET",
             "wechatPlugin": false,
+            "taobaoMinigamePlugin": false,
             "category": "network"
         },
         "websocket-server": {
@@ -206,6 +226,7 @@
             "description": "i18n:ENGINE.features.websocket_server.description",
             "native": "USE_WEBSOCKET_SERVER",
             "wechatPlugin": false,
+            "taobaoMinigamePlugin": false,
             "category": "network"
         },
         "terrain": {
@@ -213,6 +234,7 @@
             "label": "i18n:ENGINE.features.terrain.label",
             "description": "i18n:ENGINE.features.terrain.description",
             "wechatPlugin": true,
+            "taobaoMinigamePlugin": true,
             "category": "3d"
         },
         "light-probe": {
@@ -220,6 +242,7 @@
             "label": "i18n:ENGINE.features.light_probe.label",
             "description": "i18n:ENGINE.features.light_probe.description",
             "wechatPlugin": true,
+            "taobaoMinigamePlugin": true,
             "category": "3d"
         },
         "tiled-map": {
@@ -227,6 +250,7 @@
             "label": "i18n:ENGINE.features.tiled_map.label",
             "description": "i18n:ENGINE.features.tiled_map.description",
             "wechatPlugin": true,
+            "taobaoMinigamePlugin": true,
             "category": "2d"
         },
         "spine": {
@@ -235,6 +259,7 @@
             "description": "i18n:ENGINE.features.spine.description",
             "native": "USE_SPINE",
 	        "wechatPlugin": true,
+	        "taobaoMinigamePlugin": false,
             "category": "2d"
         },
         "dragon-bones": {
@@ -243,6 +268,7 @@
             "description": "i18n:ENGINE.features.dragon_bones.description",
             "native": "USE_DRAGONBONES",
 	        "wechatPlugin": true,
+	        "taobaoMinigamePlugin": true,
             "category": "2d"
         },
         "marionette": {
@@ -250,6 +276,7 @@
             "label": "i18n:ENGINE.features.marionette.label",
             "description": "i18n:ENGINE.features.marionette.description",
             "wechatPlugin": false,
+            "taobaoMinigamePlugin": false,
             "category": "animation"
         },
         "procedural-animation": {
@@ -257,13 +284,15 @@
             "label": "i18n:ENGINE.features.procedural_animation.label",
             "description": "i18n:ENGINE.features.procedural_animation.description",
             "wechatPlugin": false,
+            "taobaoMinigamePlugin": false,
             "category": "animation"
         },
         "custom-pipeline": {
             "default": [],
             "label": "i18n:ENGINE.features.custom_pipeline.label",
             "description": "i18n:ENGINE.features.custom_pipeline.description",
-            "wechatPlugin": false
+            "wechatPlugin": false,
+            "taobaoMinigamePlugin": false
         }
     },
     "categories": {

--- a/editor/engine-features/schema.json
+++ b/editor/engine-features/schema.json
@@ -33,6 +33,9 @@
                 },
                 "wechatPlugin": {
                     "type": "boolean"
+                },
+                "taobaoMinigamePlugin": {
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -194,6 +197,9 @@
                     "type": "boolean"
                 },
                 "wechatPlugin": {
+                    "type": "boolean"
+                },
+                "taobaoMinigamePlugin": {
                     "type": "boolean"
                 }
             },

--- a/editor/engine-features/types.ts
+++ b/editor/engine-features/types.ts
@@ -66,6 +66,12 @@ export interface FlagBaseItem {
 
     wechatPlugin?: boolean;
 
+    /**
+     * Different with wechat plugin, taobao plugin can't read buffer from local wasm.
+     * So we need another config item for taobao minigame plugin.
+     */
+    taobaoMinigamePlugin?: boolean;
+
     default?: string[];
 }
 
@@ -85,6 +91,12 @@ export interface BaseItem {
     native?: string;
 
     wechatPlugin?: boolean;
+
+    /**
+     * Different with wechat plugin, taobao plugin can't read buffer from local wasm.
+     * So we need another config item for taobao minigame plugin.
+     */
+    taobaoMinigamePlugin?: boolean;
 
     default?: string[];
 


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/17066

### Changelog

* add taobaoMinigamePlugin in render-config.json，we need to set spine as not plugin on taobao minigame platform. becuase plugin script can't read buffer from local wasm on taobao minigame platform

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
