### PR TITLE
macos 10.x -> 11+ api change

### DIFF
--- a/native/cocos/renderer/gfx-metal/MTLTexture.mm
+++ b/native/cocos/renderer/gfx-metal/MTLTexture.mm
@@ -235,6 +235,7 @@ bool CCMTLTexture::createMTLTexture() {
     descriptor.arrayLength = _info.type == TextureType::CUBE ? 1 : _info.layerCount;
 
     bool memoryless = false;
+#if !(CC_PLATFORM == CC_PLATFORM_MACOS && __MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
     if (@available(macos 11.0, ios 10.0, *)) {
         memoryless = hasFlag(_info.flags, TextureFlagBit::LAZILY_ALLOCATED) &&
             hasAllFlags(TextureUsageBit::COLOR_ATTACHMENT | TextureUsageBit::DEPTH_STENCIL_ATTACHMENT | TextureUsageBit::INPUT_ATTACHMENT, _info.usage);
@@ -243,7 +244,7 @@ bool CCMTLTexture::createMTLTexture() {
             _allocateMemory = false;
         }
     }
-
+#endif
     if (!memoryless && !_isPVRTC) {
         // pvrtc can not use blit encoder to upload data.
         descriptor.storageMode = MTLStorageModePrivate;


### PR DESCRIPTION
Re: #

### Changelog

* MTLSTorageModeMemoryless is not available(compile time) on macOS bellow 11.0.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
