### PR TITLE
add dirty flag to edit box

### DIFF
--- a/cocos/ui/editbox/edit-box-impl-base.ts
+++ b/cocos/ui/editbox/edit-box-impl-base.ts
@@ -37,6 +37,11 @@ export class EditBoxImplBase {
      */
     public _delegate: EditBox | null = null;
 
+    /**
+     *  dirty flag to update the matrix
+     * */
+    public _dirtyFlag: boolean | null = false;
+
     public init (delegate: EditBox): void {}
 
     public onEnable (): void {}

--- a/cocos/ui/editbox/edit-box-impl.ts
+++ b/cocos/ui/editbox/edit-box-impl.ts
@@ -137,6 +137,7 @@ export class EditBoxImpl extends EditBoxImplBase {
     }
 
     public update (): void {
+        if(!this._dirtyFlag) return;
         this._updateMatrix();
     }
 

--- a/cocos/ui/editbox/edit-box.ts
+++ b/cocos/ui/editbox/edit-box.ts
@@ -492,6 +492,9 @@ export class EditBox extends Component {
     public _editBoxEditingDidBegan (): void {
         ComponentEventHandler.emitEvents(this.editingDidBegan, this);
         this.node.emit(EventType.EDITING_DID_BEGAN, this);
+        if (this._impl) {
+            this._impl._dirtyFlag = true;
+        }
     }
 
     /**
@@ -503,6 +506,9 @@ export class EditBox extends Component {
     public _editBoxEditingDidEnded (text?: string): void {
         ComponentEventHandler.emitEvents(this.editingDidEnded, this);
         this.node.emit(EventType.EDITING_DID_ENDED, this, text);
+        if (this._impl) {
+            this._impl._dirtyFlag = false;
+        }
     }
 
     /**


### PR DESCRIPTION
Add dirty flag to edit-box-impl in order to save matrix cost while not been focused

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
