### PR TITLE
webgpu update

### DIFF
--- a/native/cocos/renderer/gfx-agent/DescriptorSetAgent.cpp
+++ b/native/cocos/renderer/gfx-agent/DescriptorSetAgent.cpp
@@ -98,16 +98,17 @@ void DescriptorSetAgent::forceUpdate() {
         });
 }
 
-void DescriptorSetAgent::bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index) {
+void DescriptorSetAgent::bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index, AccessFlags flags) {
     DescriptorSet::bindBuffer(binding, buffer, index);
 
-    ENQUEUE_MESSAGE_4(
+    ENQUEUE_MESSAGE_5(
         DeviceAgent::getInstance()->getMessageQueue(),
         DescriptorSetBindBuffer,
         actor, getActor(),
         binding, binding,
         buffer, static_cast<BufferAgent *>(buffer)->getActor(),
         index, index,
+        flags, flags,
         {
             actor->bindBuffer(binding, buffer, index);
         });

--- a/native/cocos/renderer/gfx-agent/DescriptorSetAgent.h
+++ b/native/cocos/renderer/gfx-agent/DescriptorSetAgent.h
@@ -38,7 +38,7 @@ public:
     void update() override;
     void forceUpdate() override;
 
-    void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index) override;
+    void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index, AccessFlags flags) override;
     void bindTexture(uint32_t binding, Texture *texture, uint32_t index, AccessFlags flags) override;
     void bindSampler(uint32_t binding, Sampler *sampler, uint32_t index) override;
 

--- a/native/cocos/renderer/gfx-base/GFXDescriptorSet.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDescriptorSet.cpp
@@ -85,6 +85,17 @@ void DescriptorSet::bindTexture(uint32_t binding, Texture *texture, uint32_t ind
     }
 }
 
+void DescriptorSet::bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index, AccessFlags flags) {
+    const uint32_t descriptorIndex = _layout->getDescriptorIndices()[binding] + index;
+    const uint32_t newId = getObjectID(buffer);
+    if (_buffers[descriptorIndex].id != newId) {
+        _buffers[descriptorIndex].ptr = buffer;
+        _buffers[descriptorIndex].id = newId;
+        _buffers[descriptorIndex].flags = flags;
+        _isDirty = true;
+    }
+}
+
 void DescriptorSet::bindSampler(uint32_t binding, Sampler *sampler, uint32_t index) {
     const uint32_t descriptorIndex = _layout->getDescriptorIndices()[binding] + index;
     const uint32_t newId = getObjectID(sampler);

--- a/native/cocos/renderer/gfx-base/GFXDescriptorSet.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDescriptorSet.cpp
@@ -61,13 +61,7 @@ void DescriptorSet::destroy() {
 }
 
 void DescriptorSet::bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index) {
-    const uint32_t descriptorIndex = _layout->getDescriptorIndices()[binding] + index;
-    const uint32_t newId = getObjectID(buffer);
-    if (_buffers[descriptorIndex].id != newId) {
-        _buffers[descriptorIndex].ptr = buffer;
-        _buffers[descriptorIndex].id = newId;
-        _isDirty = true;
-    }
+    bindBuffer(binding, buffer, index, AccessFlagBit::NONE);
 }
 
 void DescriptorSet::bindTexture(uint32_t binding, Texture *texture, uint32_t index) {

--- a/native/cocos/renderer/gfx-base/GFXDescriptorSet.h
+++ b/native/cocos/renderer/gfx-base/GFXDescriptorSet.h
@@ -41,10 +41,11 @@ public:
     virtual void update() = 0;
     virtual void forceUpdate() = 0;
 
-    virtual void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index);
+    virtual void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index, AccessFlags flags);
     virtual void bindSampler(uint32_t binding, Sampler *sampler, uint32_t index);
     virtual void bindTexture(uint32_t binding, Texture *texture, uint32_t index, AccessFlags flags);
 
+    void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index);
     void bindTexture(uint32_t binding, Texture *texture, uint32_t index);
 
     // Functions invoked by JSB adapter

--- a/native/cocos/renderer/gfx-validator/DescriptorSetValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/DescriptorSetValidator.cpp
@@ -113,7 +113,7 @@ void DescriptorSetValidator::updateReferenceStamp() {
     _referenceStamp = DeviceValidator::getInstance()->currentFrame();
 }
 
-void DescriptorSetValidator::bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index) {
+void DescriptorSetValidator::bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index, AccessFlags flags) {
     CC_ASSERT(isInited());
     auto *vBuffer = static_cast<BufferValidator *>(buffer);
     CC_ASSERT(buffer && vBuffer->isInited());
@@ -139,9 +139,9 @@ void DescriptorSetValidator::bindBuffer(uint32_t binding, Buffer *buffer, uint32
 
     /////////// execute ///////////
 
-    DescriptorSet::bindBuffer(binding, buffer, index);
+    DescriptorSet::bindBuffer(binding, buffer, index, flags);
 
-    _actor->bindBuffer(binding, vBuffer->getActor(), index);
+    _actor->bindBuffer(binding, vBuffer->getActor(), index, flags);
 }
 
 void DescriptorSetValidator::bindTexture(uint32_t binding, Texture *texture, uint32_t index, AccessFlags flags) {

--- a/native/cocos/renderer/gfx-validator/DescriptorSetValidator.h
+++ b/native/cocos/renderer/gfx-validator/DescriptorSetValidator.h
@@ -38,7 +38,7 @@ public:
     void update() override;
     void forceUpdate() override;
 
-    void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index) override;
+    void bindBuffer(uint32_t binding, Buffer *buffer, uint32_t index, AccessFlags flags) override;
     void bindTexture(uint32_t binding, Texture *texture, uint32_t index, AccessFlags flags) override;
     void bindSampler(uint32_t binding, Sampler *sampler, uint32_t index) override;
 

--- a/native/cocos/renderer/gfx-wgpu/CMakeLists.txt
+++ b/native/cocos/renderer/gfx-wgpu/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 set(APP_NAME "webgpu" CACHE STRING "Project Name")
 project(${APP_NAME}_wasm)
 
+message(${CMAKE_BUILD_TYPE})
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
@@ -11,11 +12,13 @@ set(ENGINE_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../..)
 
 include(${ENGINE_ROOT_DIR}/cmake/predefine.cmake)
 
-# include (${ENGINE_ROOT_DIR}/external/CMakeLists.txt)
+include (${ENGINE_ROOT_DIR}/external/CMakeLists.txt)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17  -Wextra -Wno-nonportable-include-path -fno-exceptions -v")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g3 -D_DEBUG=1 -Wno-unused -O0 -std=c++17")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -w -DNDEBUG=1 -O3 -std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17  -Wextra -Wno-nonportable-include-path -fno-exceptions -v -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g3 -D_DEBUG=1 -Wno-unused -O0 -std=c++17 -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -w -DNDEBUG=1 -O3 -std=c++17 -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES")
+
+message(${CMAKE_BUILD_TYPE})
 
 AUX_SOURCE_DIRECTORY(
     ./states
@@ -100,7 +103,7 @@ AUX_SOURCE_DIRECTORY(
 add_executable(${APP_NAME}_wasm ${WASM_EXPORTS} ${NATIVE_SRC})
 
 target_include_directories(
-	${APP_NAME}_wasm PRIVATE "${CMAKE_CURRENT_LIST_DIR}/inc"
+	${APP_NAME}_wasm PRIVATE "${CMAKE_CURRENT_LIST_DIR}/include"
 	${CC_EXTERNAL_INCLUDES}
     ${CMAKE_CURRENT_LIST_DIR}
 	${ENGINE_ROOT_DIR}
@@ -121,5 +124,11 @@ target_link_libraries(
 set(EMS_LINK_FLAGS
 "-flto --bind --no-entry -O3 -s USE_ES6_IMPORT_META=0 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORT_NAME='wasmDevice' -s ENVIRONMENT=web -s WASM=1 -s USE_WEBGPU=1 -s NO_EXIT_RUNTIME=1 -s LLD_REPORT_UNDEFINED -s ALLOW_MEMORY_GROWTH=1"
 )
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    string(APPEND EMS_LINK_FLAGS " -s ASSERTIONS=2")
+endif()
+
+set_target_properties(${APP_NAME}_wasm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ENGINE_ROOT_DIR}/external/emscripten/webgpu)
 
 set_target_properties(${APP_NAME}_wasm PROPERTIES CXX_STANDARD 17 LINK_FLAGS ${EMS_LINK_FLAGS})

--- a/native/cocos/renderer/gfx-wgpu/WGPUBuffer.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUBuffer.cpp
@@ -54,7 +54,7 @@ void CCWGPUBuffer::doInit(const BufferInfo &info) {
         _gpuBufferObject->indirectObjs.resize(drawInfoCount);
     }
 
-    _size = ceil(info.size / 4.0) * 4;
+    _size = ceil(info.size / 16.0) * 16;
 
     WGPUBufferDescriptor descriptor = {
         .nextInChain = nullptr,
@@ -113,7 +113,7 @@ void CCWGPUBuffer::doResize(uint32_t size, uint32_t count) {
         _gpuBufferObject->indirectObjs.resize(drawInfoCount);
     }
 
-    _size = ceil(size / 4.0) * 4;
+    _size = ceil(size / 16.0) * 16;
 
     WGPUBufferDescriptor descriptor = {
         .nextInChain = nullptr,
@@ -172,7 +172,7 @@ void CCWGPUBuffer::update(const void *buffer, uint32_t size) {
         update(drawInfo, drawInfoCount);
     } else {
         size_t offset = _isBufferView ? _offset : 0;
-        uint32_t alignedSize = ceil(size / 4.0) * 4;
+        uint32_t alignedSize = ceil(size / 16.0) * 16;
         size_t buffSize = alignedSize;
         wgpuQueueWriteBuffer(CCWGPUDevice::getInstance()->gpuDeviceObject()->wgpuQueue, _gpuBufferObject->wgpuBuffer, offset, buffer, buffSize);
     }

--- a/native/cocos/renderer/gfx-wgpu/WGPUBuffer.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUBuffer.cpp
@@ -115,7 +115,7 @@ void CCWGPUBuffer::doResize(uint32_t size, uint32_t count) {
         _gpuBufferObject->indirectObjs.resize(drawInfoCount);
     }
 
-    _size = boost::alignment::align_up(_size, BUFFER_ALIGNMENT);
+    _size = boost::alignment::align_up(size, BUFFER_ALIGNMENT);
 
     WGPUBufferDescriptor descriptor = {
         .nextInChain = nullptr,

--- a/native/cocos/renderer/gfx-wgpu/WGPUBuffer.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUBuffer.cpp
@@ -27,6 +27,7 @@
 #include "WGPUDevice.h"
 #include "WGPUObject.h"
 #include "WGPUUtils.h"
+#include <boost/align/align_up.hpp>
 
 namespace cc {
 namespace gfx {
@@ -34,6 +35,7 @@ namespace gfx {
 namespace {
 CCWGPUBuffer *dftUniformBuffer = nullptr;
 CCWGPUBuffer *dftStorageBuffer = nullptr;
+static uint32_t BUFFER_ALIGNMENT = 16;
 } // namespace
 
 using namespace emscripten;
@@ -54,7 +56,7 @@ void CCWGPUBuffer::doInit(const BufferInfo &info) {
         _gpuBufferObject->indirectObjs.resize(drawInfoCount);
     }
 
-    _size = ceil(info.size / 16.0) * 16;
+    _size = boost::alignment::align_up(_size, BUFFER_ALIGNMENT);
 
     WGPUBufferDescriptor descriptor = {
         .nextInChain = nullptr,
@@ -113,7 +115,7 @@ void CCWGPUBuffer::doResize(uint32_t size, uint32_t count) {
         _gpuBufferObject->indirectObjs.resize(drawInfoCount);
     }
 
-    _size = ceil(size / 16.0) * 16;
+    _size = boost::alignment::align_up(_size, BUFFER_ALIGNMENT);
 
     WGPUBufferDescriptor descriptor = {
         .nextInChain = nullptr,
@@ -172,7 +174,7 @@ void CCWGPUBuffer::update(const void *buffer, uint32_t size) {
         update(drawInfo, drawInfoCount);
     } else {
         size_t offset = _isBufferView ? _offset : 0;
-        uint32_t alignedSize = ceil(size / 16.0) * 16;
+        uint32_t alignedSize = boost::alignment::align_up(size, BUFFER_ALIGNMENT);
         size_t buffSize = alignedSize;
         wgpuQueueWriteBuffer(CCWGPUDevice::getInstance()->gpuDeviceObject()->wgpuQueue, _gpuBufferObject->wgpuBuffer, offset, buffer, buffSize);
     }

--- a/native/cocos/renderer/gfx-wgpu/WGPUCommandBuffer.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUCommandBuffer.cpp
@@ -157,7 +157,9 @@ void CCWGPUCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *f
     }
 
     ccstd::vector<WGPURenderPassDepthStencilAttachment> depthStencils;
-    if (dsTexture) {
+    if(renderPass->getDepthStencilAttachment().format == Format::UNKNOWN) {
+        renderPassDesc.depthStencilAttachment = nullptr;
+    } else if(dsTexture) {
         WGPURenderPassDepthStencilAttachment depthStencil = {
             .view = static_cast<CCWGPUTexture *>(dsTexture)->gpuTextureObject()->selfView,
             .depthLoadOp = toWGPULoadOp(depthStencilConfig.depthLoadOp),
@@ -171,10 +173,7 @@ void CCWGPUCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *f
         };
         depthStencils.emplace_back(depthStencil);
     } else {
-        if (depthStencilConfig.format == Format::UNKNOWN) {
-            renderPassDesc.depthStencilAttachment = nullptr;
-        } else {
-            WGPURenderPassDepthStencilAttachment depthStencil = {
+        WGPURenderPassDepthStencilAttachment depthStencil = {
                 .view = swapchain->gpuSwapchainObject()->swapchainDepthStencil->gpuTextureObject()->selfView,
                 .depthLoadOp = toWGPULoadOp(depthStencilConfig.depthLoadOp),
                 .depthStoreOp = toWGPUStoreOp(depthStencilConfig.depthStoreOp),
@@ -186,7 +185,6 @@ void CCWGPUCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *f
                 .stencilReadOnly = false,
             };
             depthStencils.emplace_back(depthStencil);
-        }
     }
 
     setViewport({renderArea.x, renderArea.y, renderArea.width, renderArea.height, 0.0F, 1.0F});

--- a/native/cocos/renderer/gfx-wgpu/WGPUCommandBuffer.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUCommandBuffer.cpp
@@ -435,9 +435,10 @@ void CCWGPUCommandBuffer::bindStates() {
 #endif
         const auto *indexBuffer = static_cast<CCWGPUBuffer *>(ia->getIndexBuffer());
         if (indexBuffer) {
+            CC_ASSERT(indexBuffer->getStride() >= 2);
             wgpuRenderPassEncoderSetIndexBuffer(_gpuCommandBufferObj->wgpuRenderPassEncoder,
                                                 indexBuffer->gpuBufferObject()->wgpuBuffer,
-                                                indexBuffer->getStride() <= 2 ? WGPUIndexFormat::WGPUIndexFormat_Uint16 : WGPUIndexFormat_Uint32,
+                                                indexBuffer->getStride() == 2 ? WGPUIndexFormat::WGPUIndexFormat_Uint16 : WGPUIndexFormat_Uint32,
                                                 indexBuffer->getOffset(),
                                                 indexBuffer->getSize());
         }

--- a/native/cocos/renderer/gfx-wgpu/WGPUCommandBuffer.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUCommandBuffer.cpp
@@ -25,6 +25,7 @@
 #include "WGPUCommandBuffer.h"
 #include <webgpu/webgpu.h>
 #include <limits>
+#include <string>
 #include "WGPUBuffer.h"
 #include "WGPUDescriptorSet.h"
 #include "WGPUDescriptorSetLayout.h"
@@ -55,7 +56,7 @@ CCWGPUCommandBuffer::~CCWGPUCommandBuffer() {
     doDestroy();
 }
 void CCWGPUCommandBuffer::doInit(const CommandBufferInfo &info) {
-    _gpuCommandBufferObj = ccnew CCWGPUCommandBufferObject;
+    _gpuCommandBufferObj = ccnew CCWGPUCommandBufferObject{};
     _gpuCommandBufferObj->type = info.type;
     _gpuCommandBufferObj->queue = static_cast<CCWGPUQueue *>(info.queue);
     _gpuCommandBufferObj->stateCache.descriptorSets.resize(4); //(info.queue->getDevice()->getMaxDescriptorSetLayoutBindings());
@@ -77,8 +78,6 @@ void CCWGPUCommandBuffer::doDestroy() {
 }
 
 void CCWGPUCommandBuffer::begin(RenderPass * /*renderPass*/, uint32_t /*subpass*/, Framebuffer * /*frameBuffer*/) {
-    // TODO_Zeqiang: subpass support
-    //    printf("begin\n");
     reset();
 
     _numTriangles = 0;
@@ -93,19 +92,7 @@ void CCWGPUCommandBuffer::begin(RenderPass * /*renderPass*/, uint32_t /*subpass*
 void CCWGPUCommandBuffer::end() {
     auto *pipelineState = _gpuCommandBufferObj->stateCache.pipelineState;
     if (pipelineState) {
-        if (pipelineState->getBindPoint() == PipelineBindPoint::GRAPHICS) {
-            auto *queue = _gpuCommandBufferObj->queue;
-            _gpuCommandBufferObj->wgpuCommandBuffer = wgpuCommandEncoderFinish(_gpuCommandBufferObj->wgpuCommandEncoder, nullptr);
-            wgpuCommandEncoderRelease(_gpuCommandBufferObj->wgpuCommandEncoder);
-            _gpuCommandBufferObj->wgpuCommandEncoder = wgpuDefaultHandle;
-        } else {
-            wgpuComputePassEncoderEnd(_gpuCommandBufferObj->wgpuComputeEncoder);
-            wgpuComputePassEncoderRelease(_gpuCommandBufferObj->wgpuComputeEncoder);
-            _gpuCommandBufferObj->wgpuCommandBuffer = wgpuCommandEncoderFinish(_gpuCommandBufferObj->wgpuCommandEncoder, nullptr);
-            wgpuCommandEncoderRelease(_gpuCommandBufferObj->wgpuCommandEncoder);
-            _gpuCommandBufferObj->wgpuComputeEncoder = wgpuDefaultHandle;
-            _gpuCommandBufferObj->wgpuCommandEncoder = wgpuDefaultHandle;
-        }
+        _gpuCommandBufferObj->wgpuCommandBuffer = wgpuCommandEncoderFinish(_gpuCommandBufferObj->wgpuCommandEncoder, nullptr);
     }
 }
 
@@ -225,7 +212,6 @@ void CCWGPUCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *f
 } // namespace gfx
 
 void CCWGPUCommandBuffer::endRenderPass() {
-    //  printf("endr\n");
     wgpuRenderPassEncoderEnd(_gpuCommandBufferObj->wgpuRenderPassEncoder);
     wgpuRenderPassEncoderRelease(_gpuCommandBufferObj->wgpuRenderPassEncoder);
     _gpuCommandBufferObj->wgpuRenderPassEncoder = wgpuDefaultHandle;
@@ -322,7 +308,6 @@ void CCWGPUCommandBuffer::bindStates() {
     if (!pipelineState) {
         return;
     }
-
     ccstd::set<uint8_t> setInUse;
 
     auto *pipelineLayout = static_cast<CCWGPUPipelineLayout *>(pipelineState->layout());
@@ -334,14 +319,28 @@ void CCWGPUCommandBuffer::bindStates() {
         const auto &descriptorSets = _gpuCommandBufferObj->stateCache.descriptorSets;
         for (size_t i = 0; i < setLayouts.size(); i++) {
             if (descriptorSets[i].descriptorSet) {
+                // optional: prune descriptor set for redundant resources
+                {
+                    auto *ccShader = static_cast<CCWGPUShader *>(pipelineState->getShader());
+                    const auto &bindingInshader = ccShader->gpuShaderObject()->bindings;
+                    if (bindingInshader.size() > i) {
+                        descriptorSets[i].descriptorSet->prune(bindingInshader[i]);
+                    } else {
+                        descriptorSets[i].descriptorSet->prune({});
+                    }
+                    descriptorSets[i].descriptorSet->forceUpdate();
+                }
+
                 descriptorSets[i].descriptorSet->prepare();
 
                 if (descriptorSets[i].descriptorSet->dynamicOffsetCount() != descriptorSets[i].dynamicOffsetCount) {
+                    std::string str = "force " + std::to_string(i);
+                    wgpuRenderPassEncoderSetLabel(_gpuCommandBufferObj->wgpuRenderPassEncoder, str.c_str());
                     uint32_t *dynOffsets = dynamicOffsetBuffer;
-                    const Pairs &dynamicOffsets = descriptorSets[i].descriptorSet->dynamicOffsets();
+                    const auto &dynamicOffsets = descriptorSets[i].descriptorSet->dynamicOffsets();
                     uint32_t givenOffsetIndex = 0;
                     for (size_t j = 0; j < descriptorSets[i].descriptorSet->dynamicOffsetCount(); ++j) {
-                        if (j >= descriptorSets[i].dynamicOffsetCount || dynamicOffsets[j].second == 0) {
+                        if (j >= descriptorSets[i].dynamicOffsetCount) {
                             dynOffsets[j] = 0;
                         } else {
                             dynOffsets[j] = descriptorSets[i].dynamicOffsets[givenOffsetIndex++];
@@ -352,11 +351,9 @@ void CCWGPUCommandBuffer::bindStates() {
                                                       descriptorSets[i].descriptorSet->gpuBindGroupObject()->bindgroup,
                                                       descriptorSets[i].descriptorSet->dynamicOffsetCount(),
                                                       dynOffsets);
-                    setInUse.insert(i);
-                    if (setLayouts[i] != descriptorSets[i].descriptorSet->getLayout()) {
-                        pipelineLayoutChanged = true;
-                    }
                 } else {
+                    std::string str = "same " + std::to_string(i);
+                    wgpuRenderPassEncoderSetLabel(_gpuCommandBufferObj->wgpuRenderPassEncoder, str.c_str());
                     wgpuRenderPassEncoderSetBindGroup(_gpuCommandBufferObj->wgpuRenderPassEncoder,
                                                       i,
                                                       descriptorSets[i].descriptorSet->gpuBindGroupObject()->bindgroup,
@@ -364,32 +361,26 @@ void CCWGPUCommandBuffer::bindStates() {
                                                       descriptorSets[i].dynamicOffsets);
                 }
                 setInUse.insert(i);
+                pipelineLayoutChanged |= (setLayouts[i] != descriptorSets[i].descriptorSet->getLayout());
             } else {
                 // missing
+                std::string str = "missing " + std::to_string(i);
+                wgpuRenderPassEncoderSetLabel(_gpuCommandBufferObj->wgpuRenderPassEncoder, str.c_str());
                 wgpuRenderPassEncoderSetBindGroup(_gpuCommandBufferObj->wgpuRenderPassEncoder,
                                                   i,
                                                   static_cast<WGPUBindGroup>(CCWGPUDescriptorSet::defaultBindGroup()),
                                                   0,
                                                   nullptr);
+                pipelineLayoutChanged = true;
             }
         }
 
-        for (size_t i = 0; i < setLayouts.size(); i++) {
-            if (setInUse.find(i) == setInUse.end()) {
-                wgpuRenderPassEncoderSetBindGroup(_gpuCommandBufferObj->wgpuRenderPassEncoder,
-                                                  i,
-                                                  static_cast<WGPUBindGroup>(CCWGPUDescriptorSet::defaultBindGroup()),
-                                                  0,
-                                                  nullptr);
-            }
-        }
-
-        if (1) {
+        if (pipelineLayoutChanged && setLayouts.size()) {
             ccstd::vector<DescriptorSet *> dsSets;
             for (size_t i = 0; i < setLayouts.size(); i++) {
                 dsSets.push_back(descriptorSets[i].descriptorSet);
             }
-            createPipelineLayoutFallback(dsSets, pipelineLayout);
+            createPipelineLayoutFallback(dsSets, pipelineLayout, false);
         } else {
             pipelineLayout->prepare(setInUse);
         }
@@ -446,7 +437,7 @@ void CCWGPUCommandBuffer::bindStates() {
         if (indexBuffer) {
             wgpuRenderPassEncoderSetIndexBuffer(_gpuCommandBufferObj->wgpuRenderPassEncoder,
                                                 indexBuffer->gpuBufferObject()->wgpuBuffer,
-                                                indexBuffer->getStride() == 2 ? WGPUIndexFormat::WGPUIndexFormat_Uint16 : WGPUIndexFormat_Uint32,
+                                                indexBuffer->getStride() <= 2 ? WGPUIndexFormat::WGPUIndexFormat_Uint16 : WGPUIndexFormat_Uint32,
                                                 indexBuffer->getOffset(),
                                                 indexBuffer->getSize());
         }
@@ -487,17 +478,45 @@ void CCWGPUCommandBuffer::bindStates() {
         wgpuRenderPassEncoderSetStencilReference(_gpuCommandBufferObj->wgpuRenderPassEncoder, pipelineState->getDepthStencilState().stencilRefFront);
     } else if (pipelineState->getBindPoint() == PipelineBindPoint::COMPUTE) {
         auto *pipelineState = _gpuCommandBufferObj->stateCache.pipelineState;
-
+        const auto &setLayouts = pipelineLayout->getSetLayouts();
         // bindgroup & descriptorset
         const auto &descriptorSets = _gpuCommandBufferObj->stateCache.descriptorSets;
+        bool pipelineLayoutChanged = false;
         for (size_t i = 0; i < descriptorSets.size(); i++) {
-            if (descriptorSets[i].descriptorSet->gpuBindGroupObject()->bindgroup) {
+            if (descriptorSets[i].descriptorSet) {
+                // optional: prune descriptor set for redundant resources
+                {
+                    auto *ccShader = static_cast<CCWGPUShader *>(pipelineState->getShader());
+                    const auto &bindingInshader = ccShader->gpuShaderObject()->bindings;
+                    if (bindingInshader.size() > i) {
+                        descriptorSets[i].descriptorSet->prune(bindingInshader[i]);
+                    } else {
+                        descriptorSets[i].descriptorSet->prune({});
+                    }
+                    descriptorSets[i].descriptorSet->forceUpdate();
+                }
+
+                descriptorSets[i].descriptorSet->prepare();
                 wgpuComputePassEncoderSetBindGroup(_gpuCommandBufferObj->wgpuComputeEncoder,
                                                    i,
                                                    descriptorSets[i].descriptorSet->gpuBindGroupObject()->bindgroup,
                                                    descriptorSets[i].dynamicOffsetCount,
                                                    descriptorSets[i].dynamicOffsets);
+                pipelineLayoutChanged |= (setLayouts[i] != descriptorSets[i].descriptorSet->getLayout());
+                setInUse.insert(i);
+            } else {
+                pipelineLayoutChanged = true;
             }
+        }
+
+        if (pipelineLayoutChanged && setLayouts.size()) {
+            ccstd::vector<DescriptorSet *> dsSets;
+            for (size_t i = 0; i < setLayouts.size(); i++) {
+                dsSets.push_back(descriptorSets[i].descriptorSet);
+            }
+            createPipelineLayoutFallback(dsSets, pipelineLayout, true);
+        } else {
+            pipelineLayout->prepare(setInUse);
         }
 
         pipelineState->prepare(setInUse);
@@ -777,6 +796,10 @@ void CCWGPUCommandBuffer::copyBuffersToTexture(const uint8_t *const *buffers, Te
     }
 }
 
+void CCWGPUCommandBuffer::copyTexture(Texture *srcTexture, Texture *dstTexture, const TextureCopy *regions, uint32_t count) {
+    // blitTexture(srcTexture, dstTexture, regions, count, Filter::POINT);
+}
+
 void CCWGPUCommandBuffer::blitTexture(Texture *srcTexture, Texture *dstTexture, const TextureBlit *regions, uint32_t count, Filter filter) {
     for (size_t i = 0; i < count; i++) {
         auto *srcTex = static_cast<CCWGPUTexture *>(srcTexture);
@@ -824,9 +847,11 @@ void CCWGPUCommandBuffer::execute(CommandBuffer *const * /*cmdBuffs*/, uint32_t 
 
 void CCWGPUCommandBuffer::dispatch(const DispatchInfo &info) {
     WGPUComputePassDescriptor cmoputeDesc = {};
-    if (!_gpuCommandBufferObj->wgpuComputeEncoder) {
-        _gpuCommandBufferObj->wgpuComputeEncoder = wgpuCommandEncoderBeginComputePass(_gpuCommandBufferObj->wgpuCommandEncoder, &cmoputeDesc);
-    }
+    // if (!_gpuCommandBufferObj->wgpuComputeEncoder) {
+    _gpuCommandBufferObj->wgpuComputeEncoder = wgpuCommandEncoderBeginComputePass(_gpuCommandBufferObj->wgpuCommandEncoder, &cmoputeDesc);
+    // }
+
+    bindStates();
 
     if (info.indirectBuffer) {
         auto *indirectBuffer = static_cast<CCWGPUBuffer *>(info.indirectBuffer);
@@ -840,6 +865,8 @@ void CCWGPUCommandBuffer::dispatch(const DispatchInfo &info) {
                                                  info.groupCountY,
                                                  info.groupCountZ);
     }
+    wgpuComputePassEncoderEnd(_gpuCommandBufferObj->wgpuComputeEncoder);
+    wgpuComputePassEncoderRelease(_gpuCommandBufferObj->wgpuComputeEncoder);
 }
 
 void CCWGPUCommandBuffer::pipelineBarrier(const GeneralBarrier *barrier, const BufferBarrier *const *bufferBarriers, const Buffer *const *buffers, uint32_t bufferBarrierCount, const TextureBarrier *const *textureBarriers, const Texture *const *textures, uint32_t textureBarrierCount) {
@@ -850,6 +877,7 @@ void CCWGPUCommandBuffer::reset() {
     _gpuCommandBufferObj->wgpuCommandEncoder = wgpuDefaultHandle;
     _gpuCommandBufferObj->wgpuRenderPassEncoder = wgpuDefaultHandle;
     _gpuCommandBufferObj->wgpuComputeEncoder = wgpuDefaultHandle;
+    _gpuCommandBufferObj->computeCmdBuffs.clear();
 
     CCWGPUStateCache stateCache = {};
 }

--- a/native/cocos/renderer/gfx-wgpu/WGPUCommandBuffer.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUCommandBuffer.h
@@ -68,8 +68,10 @@ public:
     void execute(CommandBuffer *const *cmdBuffs, uint32_t count) override;
     void dispatch(const DispatchInfo &info) override;
     void pipelineBarrier(const GeneralBarrier *barrier, const BufferBarrier *const *bufferBarriers, const Buffer *const *buffers, uint32_t bufferBarrierCount, const TextureBarrier *const *textureBarriers, const Texture *const *textures, uint32_t textureBarrierCount) override;
+    void copyTexture(Texture *srcTexture, Texture *dstTexture, const TextureCopy *regions, uint32_t count) override;
 
     void updateIndirectBuffer(Buffer *buff, const DrawInfoList &info);
+    void resolveTexture(Texture *srcTexture, Texture *dstTexture, const TextureCopy *regions, uint32_t count) override{};
 
     // TODO_Zeqiang: wgpu query pool
     void beginQuery(QueryPool *queryPool, uint32_t id) override{};

--- a/native/cocos/renderer/gfx-wgpu/WGPUDescriptorSet.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUDescriptorSet.cpp
@@ -65,107 +65,49 @@ void CCWGPUDescriptorSet::clearCache() {
 }
 
 void CCWGPUDescriptorSet::doInit(const DescriptorSetInfo &info) {
-    _gpuBindGroupObj = ccnew CCWGPUBindGroupObject;
+    _gpuBindGroupObj = ccnew CCWGPUBindGroupObject{};
+    _gpuDescriptorObj = ccnew CCWGPUGPUDescriptorSetObject{};
 
-    auto *dsLayout = static_cast<CCWGPUDescriptorSetLayout *>(_layout);
-    CCWGPUBindGroupLayoutObject *layoutEntries = dsLayout->gpuLayoutEntryObject();
+    auto *tLayout = const_cast<DescriptorSetLayout *>(_layout);
+    auto *dsLayout = static_cast<CCWGPUDescriptorSetLayout *>(tLayout);
     const auto &bindings = dsLayout->getBindings();
     CCWGPUDeviceObject *deviceObj = CCWGPUDevice::getInstance()->gpuDeviceObject();
     for (size_t i = 0; i < bindings.size(); i++) {
         // effect.ts: INPUT_ATTACHMENT as combined texture but no sampler_texture desc type.
         if (hasFlag(COMBINED_ST_IN_USE, bindings[i].descriptorType)) {
-            // 1. texture
-            CCWGPUTexture *texture = deviceObj->defaultResources.commonTexture;
-            WGPUBindGroupEntry texEntry = {
-                .binding = bindings[i].binding,
-                .textureView = texture->gpuTextureObject()->selfView,
-            };
-            _gpuBindGroupObj->bindGroupEntries.push_back(texEntry);
-            _textureIdxMap.insert(std::make_pair<uint8_t, uint8_t>(bindings[i].binding, _gpuBindGroupObj->bindGroupEntries.size() - 1));
-            dsLayout->updateTextureLayout(texEntry.binding, texture);
-
-            // 2. sampler
-            CCWGPUSampler *sampler = deviceObj->defaultResources.unfilterableSampler;
-            WGPUBindGroupEntry smpEntry = {
-                .binding = bindings[i].binding + CC_WGPU_MAX_ATTACHMENTS,
-                .sampler = sampler->gpuSampler(),
-            };
-            _gpuBindGroupObj->bindGroupEntries.push_back(smpEntry);
-            _samplerIdxMap.insert(std::make_pair<uint8_t, uint8_t>(bindings[i].binding, _gpuBindGroupObj->bindGroupEntries.size() - 1));
-            dsLayout->updateSamplerLayout(smpEntry.binding, sampler);
         } else if (hasFlag(DESCRIPTOR_BUFFER_TYPE, bindings[i].descriptorType)) {
-            CCWGPUBuffer *buffer = hasFlag(DescriptorType::DYNAMIC_STORAGE_BUFFER | DescriptorType::STORAGE_BUFFER, bindings[i].descriptorType)
-                                       ? deviceObj->defaultResources.storageBuffer
-                                       : deviceObj->defaultResources.uniformBuffer;
-            WGPUBindGroupEntry bufferEntry = {
-                .binding = bindings[i].binding,
-                .buffer = buffer->gpuBufferObject()->wgpuBuffer,
-                .size = buffer->getSize(),
-                .offset = buffer->getOffset(),
-            };
-
             if (hasAnyFlags(bindings[i].descriptorType, DescriptorType::DYNAMIC_STORAGE_BUFFER | DescriptorType::DYNAMIC_UNIFORM_BUFFER)) {
-                _dynamicOffsets.push_back({bindings[i].binding, 0});
+                _dynamicOffsets.emplace(i, bindings[i].binding);
             }
-            _gpuBindGroupObj->bindGroupEntries.push_back(bufferEntry);
-        } else if (bindings[i].descriptorType == DescriptorType::STORAGE_IMAGE) {
-            CCWGPUTexture *texture = deviceObj->defaultResources.storageTexture;
-            WGPUBindGroupEntry texEntry = {
-                .binding = bindings[i].binding,
-                .textureView = texture->gpuTextureObject()->selfView,
-            };
-            _gpuBindGroupObj->bindGroupEntries.push_back(texEntry);
-            dsLayout->updateTextureLayout(texEntry.binding, texture);
-        } else if (bindings[i].descriptorType == DescriptorType::TEXTURE) {
-            CCWGPUTexture *texture = deviceObj->defaultResources.commonTexture;
-            WGPUBindGroupEntry texEntry = {
-                .binding = bindings[i].binding,
-                .textureView = texture->gpuTextureObject()->selfView,
-            };
-            _gpuBindGroupObj->bindGroupEntries.push_back(texEntry);
-            dsLayout->updateTextureLayout(texEntry.binding, texture);
-        } else if (bindings[i].descriptorType == DescriptorType::SAMPLER) {
-            CCWGPUSampler *sampler = deviceObj->defaultResources.unfilterableSampler;
-            WGPUBindGroupEntry smpEntry = {
-                .binding = bindings[i].binding,
-                .sampler = sampler->gpuSampler(),
-            };
-            _gpuBindGroupObj->bindGroupEntries.push_back(smpEntry);
-            dsLayout->updateSamplerLayout(smpEntry.binding, sampler);
-        } else {
-            WGPUBindGroupEntry texEntry = {
-                .binding = bindings[i].binding,
-            };
-            _gpuBindGroupObj->bindGroupEntries.push_back(texEntry);
         }
     }
+
+    _gpuDescriptorObj->gpuDescriptors.resize(bindings.size());
+    _gpuDescriptorObj->descriptorIndices = info.layout->getBindingIndices();
+
+    _bindingSatisfied = [](uint32_t) { return true; };
 
     (void)defaultBindGroup();
 }
 
 ccstd::hash_t CCWGPUDescriptorSet::hash() const {
-    ccstd::hash_t hash = 9527;
-    for (const auto &bufferWrapper : _buffers) {
-        auto *buffer = bufferWrapper.ptr;
-        if (buffer) {
-            auto *wgpuBuffer = static_cast<CCWGPUBuffer *>(buffer)->gpuBufferObject()->wgpuBuffer;
-            ccstd::hash_combine(hash, wgpuBuffer);
+    ccstd::hash_t hash = _gpuBindGroupObj->bindGroupEntries.size();
+
+    for (const auto &entry : _gpuBindGroupObj->bindGroupEntries) {
+        ccstd::hash_combine(hash, entry.binding);
+        if (entry.buffer) {
+            ccstd::hash_combine(hash, entry.buffer);
+            ccstd::hash_combine(hash, entry.offset);
+            ccstd::hash_combine(hash, entry.size);
+        }
+        if (entry.sampler) {
+            ccstd::hash_combine(hash, entry.sampler);
+        }
+        if (entry.textureView) {
+            ccstd::hash_combine(hash, entry.textureView);
         }
     }
-    for (const auto &textureWrapper : _textures) {
-        auto *texture = textureWrapper.ptr;
-        if (texture) {
-            auto *wgpuTextureView = static_cast<CCWGPUTexture *>(texture)->gpuTextureObject()->selfView;
-            ccstd::hash_combine(hash, wgpuTextureView);
-        }
-    }
-    for (const auto &samplerWrapper : _samplers) {
-        auto *sampler = samplerWrapper.ptr;
-        if (sampler) {
-            auto *wgpuSampler = static_cast<CCWGPUSampler *>(sampler)->gpuSampler();
-            ccstd::hash_combine(hash, wgpuSampler);
-        }
-    }
+
     return hash;
 }
 
@@ -174,74 +116,106 @@ void CCWGPUDescriptorSet::doDestroy() {
         delete _gpuBindGroupObj;
         _gpuBindGroupObj = nullptr;
     }
+    if (_gpuDescriptorObj) {
+        delete _gpuDescriptorObj;
+        _gpuDescriptorObj = nullptr;
+    }
+}
+
+void CCWGPUDescriptorSet::setGpuDescriptors(DescriptorSet *set) {
+    auto *ccDesc = static_cast<CCWGPUDescriptorSet *>(set);
+    const auto &descs = ccDesc->gpuDescriptors();
+
+    auto *tLayout = const_cast<DescriptorSetLayout *>(_layout);
+    auto *dsLayout = static_cast<CCWGPUDescriptorSetLayout *>(tLayout);
+    auto *srcTmpLayout = set->getLayout();
+
+    dsLayout->setBindings(srcTmpLayout->getBindings());
+    dsLayout->setBindingIndices(srcTmpLayout->getBindingIndices());
+    dsLayout->setDescriptorIndices(srcTmpLayout->getDescriptorIndices());
+
+    _gpuDescriptorObj->gpuDescriptors = descs.gpuDescriptors;
+    _gpuDescriptorObj->descriptorIndices = descs.descriptorIndices;
+
+    _buffers = ccDesc->_buffers;
+    _textures = ccDesc->_textures;
+    _samplers = ccDesc->_samplers;
+
+    _isDirty = true;
+}
+
+void CCWGPUDescriptorSet::prune(ccstd::vector<uint8_t> bindings) {
+    _gpuBindGroupObj->bindingInShader = std::set<uint8_t>(bindings.begin(), bindings.end());
+
+    _bindingSatisfied = [&](uint32_t binding) {
+        return (!_gpuBindGroupObj->bindingInShader.empty()) && (_gpuBindGroupObj->bindingInShader.find(binding) != _gpuBindGroupObj->bindingInShader.end());
+    };
 }
 
 void CCWGPUDescriptorSet::update() {
     if (!_isDirty) {
         return;
     }
-    auto *dsLayout = static_cast<CCWGPUDescriptorSetLayout *>(_layout);
+    auto *tLayout = const_cast<DescriptorSetLayout *>(_layout);
+    auto *dsLayout = static_cast<CCWGPUDescriptorSetLayout *>(tLayout);
     const auto &bindings = dsLayout->getBindings();
 
-    for (size_t i = 0; i < bindings.size(); i++) {
+    _gpuBindGroupObj->bindGroupEntries.clear();
+    _dynamicOffsetNum = 0;
+
+    for (size_t i = 0; i < _gpuDescriptorObj->gpuDescriptors.size(); i++) {
+        if (!_bindingSatisfied(bindings[i].binding)) {
+            continue;
+        }
+        _gpuDescriptorObj->gpuDescriptors[i].type = bindings[i].descriptorType;
         const auto &binding = bindings[i];
         uint8_t resourceIndex = _layout->getDescriptorIndices()[i];
         if (hasFlag(DESCRIPTOR_BUFFER_TYPE, bindings[i].descriptorType)) {
-            if (_buffers[resourceIndex].ptr) {
-                auto *buffer = static_cast<CCWGPUBuffer *>(_buffers[resourceIndex].ptr);
-                auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries[i];
-                buffer->check();
-                bindGroupEntry.binding = binding.binding;
-                bindGroupEntry.buffer = buffer->gpuBufferObject()->wgpuBuffer;
-                bindGroupEntry.offset = buffer->getOffset();
-                bindGroupEntry.size = buffer->getSize();
-                dsLayout->updateBufferLayout(bindGroupEntry.binding, buffer);
-                uint8_t bindIndex = binding.binding;
-                if (hasAnyFlags(binding.descriptorType, DescriptorType::DYNAMIC_STORAGE_BUFFER | DescriptorType::DYNAMIC_UNIFORM_BUFFER)) {
-                    auto iter = std::find_if(_dynamicOffsets.begin(), _dynamicOffsets.end(), [bindIndex](const std::pair<uint8_t, uint8_t> dynIndex) {
-                        return dynIndex.first == bindIndex;
-                    });
-                    // assert(iter != _dynamicOffsets.end()); //can't happen
-                    (*iter).second = 1;
-                }
-            }
-        } else if (hasFlag(COMBINED_ST_IN_USE, bindings[i].descriptorType)) {
-            auto texIter = _textureIdxMap.find(binding.binding);
-            auto smpIter = _samplerIdxMap.find(binding.binding);
-            // assert((texIter != _textureIdxMap.end()) + (smpIter != _samplerIdxMap.end()) == 1);
-            uint8_t textureIdx = texIter != _textureIdxMap.end() ? texIter->second : 255;
-            uint8_t samplerIdx = smpIter != _samplerIdxMap.end() ? smpIter->second : 255;
-
-            if (textureIdx != 255 && _textures[resourceIndex].ptr) {
-                auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries[textureIdx];
-                auto *texture = static_cast<CCWGPUTexture *>(_textures[resourceIndex].ptr);
-                bindGroupEntry.binding = binding.binding;
-                bindGroupEntry.textureView = texture->gpuTextureObject()->selfView;
-                dsLayout->updateTextureLayout(bindGroupEntry.binding, texture);
-                _gpuBindGroupObj->bindingSet.insert(binding.binding);
-            }
-            if (samplerIdx != 255 && _samplers[resourceIndex].ptr) {
-                auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries[samplerIdx];
-                auto *sampler = static_cast<CCWGPUSampler *>(_samplers[resourceIndex].ptr);
-                bindGroupEntry.binding = binding.binding + CC_WGPU_MAX_ATTACHMENTS;
-                bindGroupEntry.sampler = sampler->gpuSampler();
-                dsLayout->updateSamplerLayout(bindGroupEntry.binding, sampler);
-                _gpuBindGroupObj->bindingSet.insert(binding.binding + CC_WGPU_MAX_ATTACHMENTS);
-            }
-        } else if (DescriptorType::STORAGE_IMAGE == bindings[i].descriptorType || DescriptorType::TEXTURE == bindings[i].descriptorType) {
-            if (_textures[resourceIndex].ptr) {
-                auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries[resourceIndex];
-                auto *texture = static_cast<CCWGPUTexture *>(_textures[resourceIndex].ptr);
-                bindGroupEntry.binding = binding.binding;
-                bindGroupEntry.textureView = texture->gpuTextureObject()->selfView;
-                dsLayout->updateTextureLayout(bindGroupEntry.binding, texture);
-            }
-        } else if (DescriptorType::SAMPLER == bindings[i].descriptorType) {
-            auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries[resourceIndex];
-            auto *sampler = static_cast<CCWGPUSampler *>(_samplers[resourceIndex].ptr);
+            auto *ccBuffer = _buffers[resourceIndex].ptr ? static_cast<CCWGPUBuffer *>(_buffers[resourceIndex].ptr) : CCWGPUBuffer::defaultUniformBuffer();
+            auto *buffer = static_cast<CCWGPUBuffer *>(ccBuffer);
+            auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries.emplace_back();
+            buffer->check();
             bindGroupEntry.binding = binding.binding;
-            bindGroupEntry.sampler = sampler->gpuSampler();
-            dsLayout->updateSamplerLayout(bindGroupEntry.binding, sampler);
+            bindGroupEntry.buffer = buffer->gpuBufferObject()->wgpuBuffer;
+            bindGroupEntry.offset = buffer->getOffset();
+            bindGroupEntry.size = buffer->getSize();
+            dsLayout->updateBufferLayout(i, buffer, _buffers[resourceIndex].flags);
+            uint8_t bindIndex = binding.binding;
+            if (hasAnyFlags(binding.descriptorType, DescriptorType::DYNAMIC_STORAGE_BUFFER | DescriptorType::DYNAMIC_UNIFORM_BUFFER)) {
+                _dynamicOffsets[i] = bindIndex;
+                _dynamicOffsetNum++;
+            }
+
+            _gpuDescriptorObj->gpuDescriptors[i].buffer = ccBuffer;
+        } else if (hasFlag(COMBINED_ST_IN_USE, bindings[i].descriptorType)) {
+            // printf("texture update %d %d %p\n", i, resourceIndex, _textures[resourceIndex].ptr);
+            auto *ccTexture = _textures[resourceIndex].ptr ? static_cast<CCWGPUTexture *>(_textures[resourceIndex].ptr) : CCWGPUTexture::defaultCommonTexture();
+            auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries.emplace_back();
+            bindGroupEntry.binding = binding.binding;
+            bindGroupEntry.textureView = static_cast<WGPUTextureView>(ccTexture->getPlaneView(0));
+            dsLayout->updateTextureLayout(i, ccTexture);
+            _gpuDescriptorObj->gpuDescriptors[i].texture = ccTexture;
+
+            auto &sBindGroupEntry = _gpuBindGroupObj->bindGroupEntries.emplace_back();
+            auto *ccSampler = _samplers[resourceIndex].ptr ? static_cast<CCWGPUSampler *>(_samplers[resourceIndex].ptr) : CCWGPUSampler::defaultFilterableSampler();
+            sBindGroupEntry.binding = binding.binding + CC_WGPU_MAX_ATTACHMENTS;
+            sBindGroupEntry.sampler = ccSampler->gpuSampler();
+            dsLayout->updateSamplerLayout(i, ccSampler);
+            _gpuDescriptorObj->gpuDescriptors[i].sampler = ccSampler;
+        } else if (DescriptorType::STORAGE_IMAGE == bindings[i].descriptorType || DescriptorType::TEXTURE == bindings[i].descriptorType) {
+            auto *ccTexture = _textures[resourceIndex].ptr ? static_cast<CCWGPUTexture *>(_textures[resourceIndex].ptr) : CCWGPUTexture::defaultCommonTexture();
+            auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries[resourceIndex];
+            bindGroupEntry.binding = binding.binding;
+            bindGroupEntry.textureView = static_cast<WGPUTextureView>(ccTexture->getPlaneView(0));
+            dsLayout->updateTextureLayout(i, ccTexture);
+            _gpuDescriptorObj->gpuDescriptors[i].texture = ccTexture;
+        } else if (DescriptorType::SAMPLER == bindings[i].descriptorType) {
+            auto *ccSampler = _samplers[resourceIndex].ptr ? static_cast<CCWGPUSampler *>(_samplers[resourceIndex].ptr) : CCWGPUSampler::defaultFilterableSampler();
+            auto &bindGroupEntry = _gpuBindGroupObj->bindGroupEntries[resourceIndex];
+            bindGroupEntry.binding = binding.binding;
+            bindGroupEntry.sampler = ccSampler->gpuSampler();
+            dsLayout->updateSamplerLayout(i, ccSampler);
+            _gpuDescriptorObj->gpuDescriptors[i].sampler = ccSampler;
         } else {
             printf("*******unexpected binding type detected!\n");
         }
@@ -263,20 +237,15 @@ void CCWGPUDescriptorSet::prepare() {
         update();
     }
 
-    const auto &entries = _gpuBindGroupObj->bindGroupEntries;
-
     if (_isDirty || forceUpdate || !_gpuBindGroupObj->bindgroup) {
-        auto *dsLayout = static_cast<CCWGPUDescriptorSetLayout *>(_layout);
-        dsLayout->prepare(_gpuBindGroupObj->bindingSet, forceUpdate);
+        // TODDO(Zeqiang): no const cast
+        auto *tLayout = const_cast<DescriptorSetLayout *>(_layout);
+        auto *dsLayout = static_cast<CCWGPUDescriptorSetLayout *>(tLayout);
 
-        // ccstd::vector<WGPUBindGroupEntry> bindGroupEntries;
-        // bindGroupEntries.assign(_gpuBindGroupObj->bindGroupEntries.begin(), _gpuBindGroupObj->bindGroupEntries.end());
-        // bindGroupEntries.erase(std::remove_if(
-        //                            bindGroupEntries.begin(), bindGroupEntries.end(), [this, &bindGroupEntries](const WGPUBindGroupEntry &entry) {
-        //                                return _gpuBindGroupObj->bindingSet.find(entry.binding) == _gpuBindGroupObj->bindingSet.end();
-        //                            }),
-        //                        bindGroupEntries.end());
-        if (entries.empty()) {
+        dsLayout->prepare(_gpuBindGroupObj->bindingInShader, forceUpdate);
+
+        const auto &entries = _gpuBindGroupObj->bindGroupEntries;
+        if (_gpuBindGroupObj->bindingInShader.empty()) {
             _gpuBindGroupObj->bindgroup = dftBindGroup;
             _bornHash = 0;
         } else {
@@ -286,9 +255,7 @@ void CCWGPUDescriptorSet::prepare() {
                 // layout might be changed later.
                 _bornHash = dsLayout->getHash();
                 CCWGPUDeviceObject *deviceObj = CCWGPUDevice::getInstance()->gpuDeviceObject();
-                // if (_gpuBindGroupObj->bindgroup && _gpuBindGroupObj->bindgroup != dftBindGroup) {
-                //     wgpuBindGroupRelease(_gpuBindGroupObj->bindgroup);
-                // }
+
                 label = std::to_string(_bornHash);
                 WGPUBindGroupDescriptor bindGroupDesc = {
                     .nextInChain = nullptr,
@@ -299,7 +266,6 @@ void CCWGPUDescriptorSet::prepare() {
                 };
 
                 _gpuBindGroupObj->bindgroup = wgpuDeviceCreateBindGroup(CCWGPUDevice::getInstance()->gpuDeviceObject()->wgpuDevice, &bindGroupDesc);
-                // printf("create new bg\n");
 
                 _isDirty = false;
                 if (buffIter != _buffers.end())
@@ -318,14 +284,13 @@ void CCWGPUDescriptorSet::prepare() {
             } else {
                 _gpuBindGroupObj->bindgroup = static_cast<WGPUBindGroup>(iter->second.bindGroup);
                 _bornHash = iter->second.bornHash;
-                // printf("reuse bg\n");
             }
         }
     }
 }
 
 uint8_t CCWGPUDescriptorSet::dynamicOffsetCount() const {
-    return _dynamicOffsets.size();
+    return _dynamicOffsetNum;
 }
 
 void *CCWGPUDescriptorSet::defaultBindGroup() {

--- a/native/cocos/renderer/gfx-wgpu/WGPUDescriptorSetLayout.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUDescriptorSetLayout.cpp
@@ -32,6 +32,7 @@
 #include "WGPUSampler.h"
 #include "WGPUTexture.h"
 #include "WGPUUtils.h"
+#include "base/Assertf.h"
 
 namespace cc {
 namespace gfx {
@@ -40,174 +41,8 @@ namespace {
 WGPUBindGroupLayout dftBindgroupLayout = wgpuDefaultHandle;
 
 ccstd::unordered_map<ccstd::hash_t, WGPUBindGroupLayout> layoutPool;
-} // namespace
 
-using namespace emscripten;
-
-CCWGPUDescriptorSetLayout::CCWGPUDescriptorSetLayout() : DescriptorSetLayout() {
-}
-
-CCWGPUDescriptorSetLayout::~CCWGPUDescriptorSetLayout() {
-    doDestroy();
-}
-
-void CCWGPUDescriptorSetLayout::doInit(const DescriptorSetLayoutInfo &info) {
-    _gpuLayoutEntryObj = ccnew CCWGPUBindGroupLayoutObject;
-    for (size_t i = 0; i < _bindings.size(); i++) {
-        if (_bindings[i].descriptorType == DescriptorType::UNKNOWN)
-            continue;
-        if (hasFlag(COMBINED_ST_IN_USE, _bindings[i].descriptorType)) {
-            // 1. texture
-            WGPUBindGroupLayoutEntry textureLayout = {
-                .nextInChain = nullptr,
-                .binding = _bindings[i].binding,
-                .visibility = toWGPUShaderStageFlag(_bindings[i].stageFlags),
-                .texture.sampleType = WGPUTextureSampleType_Float,
-                .texture.viewDimension = WGPUTextureViewDimension_2D,
-            };
-            _gpuLayoutEntryObj->bindGroupLayoutEntries.push_back(textureLayout);
-
-            // 2. sampler
-            WGPUBindGroupLayoutEntry samplerLayout = {
-                .nextInChain = nullptr,
-                .binding = _bindings[i].binding + CC_WGPU_MAX_ATTACHMENTS,
-                .visibility = toWGPUShaderStageFlag(_bindings[i].stageFlags),
-                .sampler.type = WGPUSamplerBindingType_NonFiltering,
-            };
-            _gpuLayoutEntryObj->bindGroupLayoutEntries.push_back(samplerLayout);
-        } else if (hasFlag(DESCRIPTOR_BUFFER_TYPE, _bindings[i].descriptorType)) {
-            bool hasDynamicOffset = hasAnyFlags(_bindings[i].descriptorType, DescriptorType::DYNAMIC_STORAGE_BUFFER | DescriptorType::DYNAMIC_UNIFORM_BUFFER);
-            _dynamicOffsetCount += (hasDynamicOffset);
-            if (hasFlag(_bindings[i].descriptorType, DescriptorType::STORAGE_BUFFER | DescriptorType::DYNAMIC_STORAGE_BUFFER)) {
-                WGPUBindGroupLayoutEntry layout = {
-                    .nextInChain = nullptr,
-                    .binding = _bindings[i].binding,
-                    .visibility = toWGPUShaderStageFlag(_bindings[i].stageFlags),
-                    .buffer = {nullptr, WGPUBufferBindingType::WGPUBufferBindingType_Storage, hasDynamicOffset, 0},
-                };
-                _gpuLayoutEntryObj->bindGroupLayoutEntries.push_back(layout);
-            } else if (hasFlag(_bindings[i].descriptorType, DescriptorType::UNIFORM_BUFFER | DescriptorType::DYNAMIC_UNIFORM_BUFFER)) {
-                WGPUBindGroupLayoutEntry layout = {
-                    .nextInChain = nullptr,
-                    .binding = _bindings[i].binding,
-                    .visibility = toWGPUShaderStageFlag(_bindings[i].stageFlags),
-                    .buffer = {nullptr, WGPUBufferBindingType::WGPUBufferBindingType_Uniform, hasDynamicOffset, 0},
-                };
-                _gpuLayoutEntryObj->bindGroupLayoutEntries.push_back(layout);
-            } else {
-                printf("unsupport buffer descriptor type.");
-            }
-        } else if (_bindings[i].descriptorType == DescriptorType::SAMPLER) {
-            WGPUBindGroupLayoutEntry layout = {
-                .nextInChain = nullptr,
-                .binding = _bindings[i].binding,
-                .visibility = toWGPUShaderStageFlag(_bindings[i].stageFlags),
-                .sampler = {nullptr, WGPUSamplerBindingType::WGPUSamplerBindingType_NonFiltering},
-            };
-            _gpuLayoutEntryObj->bindGroupLayoutEntries.push_back(layout);
-        } else if (_bindings[i].descriptorType == DescriptorType::STORAGE_IMAGE) {
-            WGPUBindGroupLayoutEntry layout = {
-                .nextInChain = nullptr,
-                .binding = _bindings[i].binding,
-                .visibility = toWGPUShaderStageFlag(_bindings[i].stageFlags),
-                .storageTexture = {
-                    nullptr,
-                    WGPUStorageTextureAccess::WGPUStorageTextureAccess_WriteOnly,
-                    WGPUTextureFormat::WGPUTextureFormat_RGBA8Unorm,
-                    WGPUTextureViewDimension::WGPUTextureViewDimension_2D,
-                },
-            };
-            _gpuLayoutEntryObj->bindGroupLayoutEntries.push_back(layout);
-        } else {
-            WGPUBindGroupLayoutEntry layout = {
-                .nextInChain = nullptr,
-                .binding = _bindings[i].binding,
-                .visibility = toWGPUShaderStageFlag(_bindings[i].stageFlags),
-            };
-            _gpuLayoutEntryObj->bindGroupLayoutEntries.push_back(layout);
-        }
-    }
-
-    (void)defaultBindGroupLayout();
-
-    _hash = hash();
-}
-
-void CCWGPUDescriptorSetLayout::updateBufferLayout(uint8_t binding, const CCWGPUBuffer *buffer) {
-    // auto iter = std::find_if(_gpuLayoutEntryObj->bindGroupLayoutEntries.begin(), _gpuLayoutEntryObj->bindGroupLayoutEntries.end(), [binding](const WGPUBindGroupLayoutEntry &entry) {
-    //     return entry.binding == binding;
-    // });
-
-    // if (iter != _gpuLayoutEntryObj->bindGroupLayoutEntries.end()) {
-    //     auto bindingIter = std::find_if(_bindings.begin(), _bindings.end(), [binding](const auto &binding) {
-    //         return binding.binding == binding;
-    //     });
-    // }
-
-    // _internalChanged = true;
-}
-
-void CCWGPUDescriptorSetLayout::updateTextureLayout(uint8_t binding, const CCWGPUTexture *texture) {
-    auto iter = std::find_if(_gpuLayoutEntryObj->bindGroupLayoutEntries.begin(), _gpuLayoutEntryObj->bindGroupLayoutEntries.end(), [binding](const WGPUBindGroupLayoutEntry &entry) {
-        return entry.binding == binding;
-    });
-
-    if (iter != _gpuLayoutEntryObj->bindGroupLayoutEntries.end()) {
-        auto bindingIter = std::find_if(_bindings.begin(), _bindings.end(), [binding](const auto &bindingElem) {
-            return bindingElem.binding == binding;
-        });
-        if (texture) {
-            if (texture->getInfo().usage == TextureUsageBit::STORAGE) {
-                (*iter).storageTexture.nextInChain = nullptr;
-                (*iter).storageTexture.access = WGPUStorageTextureAccess::WGPUStorageTextureAccess_WriteOnly;
-                (*iter).storageTexture.format = toWGPUTextureFormat(texture->getFormat());
-                TextureType type = texture->isTextureView() ? texture->getViewInfo().type : texture->getInfo().type;
-                (*iter).storageTexture.viewDimension = toWGPUTextureViewDimension(type);
-            } else {
-                (*iter).texture.nextInChain = nullptr;
-                (*iter).texture.sampleType = textureSampleTypeTrait(texture->getFormat());
-                const CCWGPUTexture *ccTex = static_cast<const CCWGPUTexture *>(texture->isTextureView() ? texture->getViewInfo().texture : texture);
-                TextureType type = ccTex->getViewInfo().type;
-                (*iter).texture.viewDimension = toWGPUTextureViewDimension(type);
-                (*iter).texture.multisampled = ccTex->getInfo().samples != SampleCount::X1;
-            }
-        } else {
-            (*iter).texture.nextInChain = nullptr;
-            (*iter).texture.sampleType = WGPUTextureSampleType::WGPUTextureSampleType_Float;
-            (*iter).texture.viewDimension = WGPUTextureViewDimension::WGPUTextureViewDimension_2D;
-            (*iter).texture.multisampled = false;
-        }
-        _internalChanged = true;
-    }
-}
-
-void CCWGPUDescriptorSetLayout::updateSamplerLayout(uint8_t binding, const CCWGPUSampler *sampler) {
-    auto iter = std::find_if(_gpuLayoutEntryObj->bindGroupLayoutEntries.begin(), _gpuLayoutEntryObj->bindGroupLayoutEntries.end(), [binding](const WGPUBindGroupLayoutEntry &entry) {
-        return entry.binding == binding;
-    });
-
-    if (iter != _gpuLayoutEntryObj->bindGroupLayoutEntries.end()) {
-        auto bindingIter = std::find_if(_bindings.begin(), _bindings.end(), [binding](const auto &bindingElem) {
-            return bindingElem.binding == binding;
-        });
-        if (sampler) {
-            const SamplerInfo &info = sampler->getInfo();
-            if ((info.minFilter == Filter::POINT || info.minFilter == Filter::NONE) &&
-                (info.magFilter == Filter::POINT || info.magFilter == Filter::NONE) &&
-                (info.mipFilter == Filter::POINT || info.mipFilter == Filter::NONE)) {
-                (*iter).sampler.type = WGPUSamplerBindingType::WGPUSamplerBindingType_NonFiltering;
-            } else {
-                (*iter).sampler.type = WGPUSamplerBindingType::WGPUSamplerBindingType_Filtering;
-            }
-        } else {
-            (*iter).sampler.type = WGPUSamplerBindingType::WGPUSamplerBindingType_NonFiltering;
-        }
-        _internalChanged = true;
-    }
-}
-
-ccstd::hash_t CCWGPUDescriptorSetLayout::hash() const {
-    const auto &entries = _gpuLayoutEntryObj->bindGroupLayoutEntries;
+ccstd::hash_t hash(const ccstd::vector<WGPUBindGroupLayoutEntry> &entries) {
     ccstd::hash_t hash = 9527;
     ccstd::hash_combine(hash, entries.size());
     for (size_t i = 0; i < entries.size(); i++) {
@@ -236,12 +71,110 @@ ccstd::hash_t CCWGPUDescriptorSetLayout::hash() const {
     return hash;
 }
 
+} // namespace
+
+using namespace emscripten;
+
+CCWGPUDescriptorSetLayout::CCWGPUDescriptorSetLayout() : DescriptorSetLayout() {
+}
+
+CCWGPUDescriptorSetLayout::~CCWGPUDescriptorSetLayout() {
+    doDestroy();
+}
+
+void CCWGPUDescriptorSetLayout::doInit(const DescriptorSetLayoutInfo &info) {
+    _gpuLayoutEntryObj = ccnew CCWGPUBindGroupLayoutObject;
+    (void)defaultBindGroupLayout();
+}
+
+void CCWGPUDescriptorSetLayout::updateBufferLayout(uint8_t index, const CCWGPUBuffer *buffer, AccessFlags flags) {
+    WGPUBindGroupLayoutEntry bufferEntry{};
+    bufferEntry.binding = _bindings[index].binding;
+    bufferEntry.visibility = toWGPUShaderStageFlag(_bindings[index].stageFlags);
+
+    CC_ASSERT(buffer);
+
+    WGPUBufferBindingLayout bufferLayout{};
+    bool storageFlag = hasFlag(_bindings[index].descriptorType, DescriptorType::STORAGE_BUFFER | DescriptorType::DYNAMIC_STORAGE_BUFFER);
+    if (storageFlag) {
+        bufferLayout.type = flags > AccessFlagBit::PRESENT ? WGPUBufferBindingType_Storage : WGPUBufferBindingType_ReadOnlyStorage;
+    } else {
+        bufferLayout.type = WGPUBufferBindingType_Uniform;
+    }
+    bufferLayout.hasDynamicOffset = hasAnyFlags(_bindings[index].descriptorType, DescriptorType::DYNAMIC_STORAGE_BUFFER | DescriptorType::DYNAMIC_UNIFORM_BUFFER);
+
+    bufferEntry.buffer = bufferLayout;
+    _gpuLayoutEntryObj->bindGroupLayoutEntries[bufferEntry.binding] = bufferEntry;
+}
+
+namespace {
+WGPUTextureFormat formatTraits(const CCWGPUTexture *texture, uint32_t plane) {
+    if (texture->getFormat() == Format::DEPTH_STENCIL) {
+        return plane ? WGPUTextureFormat_Stencil8 : WGPUTextureFormat_Depth24Plus;
+    }
+    return toWGPUTextureFormat(texture->getFormat());
+}
+
+WGPUTextureSampleType sampletypeTraits(const CCWGPUTexture *texture, uint32_t plane) {
+    if (texture->getFormat() == Format::DEPTH_STENCIL) {
+        return plane ? WGPUTextureSampleType_Uint : WGPUTextureSampleType_UnfilterableFloat;
+    }
+    return textureSampleTypeTrait(texture->getFormat());
+}
+} // namespace
+
+void CCWGPUDescriptorSetLayout::updateTextureLayout(uint8_t index, const CCWGPUTexture *texture, uint32_t plane) {
+    WGPUBindGroupLayoutEntry textureEntry{};
+    textureEntry.binding = _bindings[index].binding;
+    textureEntry.visibility = toWGPUShaderStageFlag(_bindings[index].stageFlags);
+
+    CC_ASSERT(texture);
+
+    if (texture->getInfo().usage == TextureUsageBit::STORAGE) {
+        WGPUStorageTextureBindingLayout storageTextureLayout{};
+        storageTextureLayout.access = WGPUStorageTextureAccess::WGPUStorageTextureAccess_WriteOnly;
+        storageTextureLayout.format = formatTraits(texture, plane);
+        TextureType type = texture->isTextureView() ? texture->getViewInfo().type : texture->getInfo().type;
+        storageTextureLayout.viewDimension = toWGPUTextureViewDimension(type);
+        textureEntry.storageTexture = storageTextureLayout;
+    } else {
+        WGPUTextureBindingLayout textureLayout{};
+        textureLayout.sampleType = sampletypeTraits(texture, plane); // textureSampleTypeTrait(texture->getFormat());
+        const CCWGPUTexture *ccTex = static_cast<const CCWGPUTexture *>(texture->isTextureView() ? texture->getViewInfo().texture : texture);
+        TextureType type = ccTex->getViewInfo().type;
+        textureLayout.viewDimension = toWGPUTextureViewDimension(type);
+        textureLayout.multisampled = ccTex->getInfo().samples != SampleCount::X1;
+        textureEntry.texture = textureLayout;
+    }
+    _gpuLayoutEntryObj->bindGroupLayoutEntries[textureEntry.binding] = textureEntry;
+}
+
+void CCWGPUDescriptorSetLayout::updateSamplerLayout(uint8_t index, const CCWGPUSampler *sampler) {
+    WGPUBindGroupLayoutEntry samplerEntry{};
+    samplerEntry.binding = _bindings[index].binding + CC_WGPU_MAX_ATTACHMENTS;
+    samplerEntry.visibility = toWGPUShaderStageFlag(_bindings[index].stageFlags);
+
+    CC_ASSERT(sampler);
+
+    WGPUSamplerBindingLayout samplerLayout{};
+    const SamplerInfo &info = sampler->getInfo();
+    if ((info.minFilter == Filter::POINT || info.minFilter == Filter::NONE) &&
+        (info.magFilter == Filter::POINT || info.magFilter == Filter::NONE) &&
+        (info.mipFilter == Filter::POINT || info.mipFilter == Filter::NONE)) {
+        samplerLayout.type = WGPUSamplerBindingType::WGPUSamplerBindingType_NonFiltering;
+    } else {
+        samplerLayout.type = WGPUSamplerBindingType::WGPUSamplerBindingType_Filtering;
+    }
+    samplerEntry.sampler = samplerLayout;
+
+    _gpuLayoutEntryObj->bindGroupLayoutEntries[samplerEntry.binding] = samplerEntry;
+}
+
 void CCWGPUDescriptorSetLayout::print() const {
     size_t hashVal = _hash;
     printf("\npr this %p %p %zu\n", _gpuLayoutEntryObj, this, hashVal);
     const auto &entries = _gpuLayoutEntryObj->bindGroupLayoutEntries;
-    for (size_t j = 0; j < entries.size(); j++) {
-        const auto &entry = entries[j];
+    for (const auto &[bd, entry] : entries) {
         if ((entry.buffer.type != WGPUBufferBindingType_Undefined) +
                 (entry.sampler.type != WGPUSamplerBindingType_Undefined) +
                 (entry.texture.sampleType != WGPUTextureSampleType_Undefined) +
@@ -249,7 +182,7 @@ void CCWGPUDescriptorSetLayout::print() const {
             1) {
             printf("******missing %d, %d, %d, %d, %d\n", entry.binding, entry.buffer.type, entry.sampler.type, entry.texture.sampleType, entry.storageTexture.access);
         }
-        printf("%d, %d\n", entry.binding, entry.visibility);
+        printf("%d, %d, %d\n", entry.binding, entry.visibility, entries.size());
         if (entry.buffer.type != WGPUBufferBindingType_Undefined) {
             printf("b %d %d %d\n", entry.buffer.type, entry.buffer.hasDynamicOffset ? 1 : 0, entry.buffer.minBindingSize);
         }
@@ -266,44 +199,28 @@ void CCWGPUDescriptorSetLayout::print() const {
 }
 
 void CCWGPUDescriptorSetLayout::prepare(ccstd::set<uint8_t> &bindingInUse, bool forceUpdate) {
-    // if (_gpuLayoutEntryObj->bindGroupLayout && !forceUpdate) {
-    //     return;
-    // }
-    // ccstd::vector<WGPUBindGroupLayoutEntry> bindGroupLayoutEntries;
-    // bindGroupLayoutEntries.assign(_gpuLayoutEntryObj->bindGroupLayoutEntries.begin(), _gpuLayoutEntryObj->bindGroupLayoutEntries.end());
-    // bindGroupLayoutEntries.erase(std::remove_if(
-    //                                  bindGroupLayoutEntries.begin(), bindGroupLayoutEntries.end(), [&bindingInUse, &bindGroupLayoutEntries](const WGPUBindGroupLayoutEntry &entry) {
-    //                                      return bindingInUse.find(entry.binding) == bindingInUse.end();
-    //                                  }),
-    //                              bindGroupLayoutEntries.end());
+    ccstd::vector<WGPUBindGroupLayoutEntry> bindGroupLayoutEntries{};
+    bindGroupLayoutEntries.reserve(_gpuLayoutEntryObj->bindGroupLayoutEntries.size());
+    for (const auto &[bd, layoutEntry] : _gpuLayoutEntryObj->bindGroupLayoutEntries) {
+        if (bindingInUse.find(static_cast<uint8_t>(bd)) != bindingInUse.end()) {
+            bindGroupLayoutEntries.emplace_back(layoutEntry);
+        }
+    }
 
-    _hash = hash();
+    _hash = hash(bindGroupLayoutEntries);
     auto iter = layoutPool.find(_hash);
-    // printf("dsl upd %zu\n", _hash);
     if (iter != layoutPool.end()) {
         _gpuLayoutEntryObj->bindGroupLayout = iter->second;
         return;
     }
-    const auto &entries = _gpuLayoutEntryObj->bindGroupLayoutEntries;
 
-    // for (size_t j = 0; j < entries.size(); j++) {
-    //     const auto& entry = entries[j];
-    //     if ((entry.buffer.type != WGPUBufferBindingType_Undefined) +
-    //             (entry.sampler.type != WGPUSamplerBindingType_Undefined) +
-    //             (entry.texture.sampleType != WGPUTextureSampleType_Undefined) +
-    //             (entry.storageTexture.access != WGPUStorageTextureAccess_Undefined) !=
-    //         1) {
-    //         printf("******missing %d, %d, %d, %d, %d\n", entry.binding, entry.buffer.type, entry.sampler.type, entry.texture.sampleType, entry.storageTexture.access);
-    //     }
-    //     // printf("l binding, b, t, s  %d, %d, %d, %d, %d\n", entry.binding, entry.buffer.type, entry.sampler.type, entry.texture.sampleType, entry.storageTexture.access);
-    // }
-
+    const auto &entries = bindGroupLayoutEntries;
     if (entries.empty()) {
         _gpuLayoutEntryObj->bindGroupLayout = dftBindgroupLayout;
     } else {
         WGPUBindGroupLayoutDescriptor descriptor = {
             .nextInChain = nullptr,
-            .label = std::to_string(_hash).c_str(),
+            .label = "",//std::to_string(_hash).c_str(),
             .entryCount = entries.size(),
             .entries = entries.data(),
         };

--- a/native/cocos/renderer/gfx-wgpu/WGPUDescriptorSetLayout.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUDescriptorSetLayout.cpp
@@ -71,6 +71,14 @@ ccstd::hash_t hash(const ccstd::vector<WGPUBindGroupLayoutEntry> &entries) {
     return hash;
 }
 
+bool checkInUse(uint8_t binding, const ccstd::set<uint8_t> &bindingInUse, bool samplerBinding) {
+    bool res = bindingInUse.find(binding) != bindingInUse.end();
+    if (!res && samplerBinding) {
+        res |= bindingInUse.find(binding - CC_WGPU_MAX_ATTACHMENTS) != bindingInUse.end();
+    }
+    return res;
+}
+
 } // namespace
 
 using namespace emscripten;
@@ -202,7 +210,7 @@ void CCWGPUDescriptorSetLayout::prepare(ccstd::set<uint8_t> &bindingInUse, bool 
     ccstd::vector<WGPUBindGroupLayoutEntry> bindGroupLayoutEntries{};
     bindGroupLayoutEntries.reserve(_gpuLayoutEntryObj->bindGroupLayoutEntries.size());
     for (const auto &[bd, layoutEntry] : _gpuLayoutEntryObj->bindGroupLayoutEntries) {
-        if (bindingInUse.find(static_cast<uint8_t>(bd)) != bindingInUse.end()) {
+        if(checkInUse(static_cast<uint8_t>(bd), bindingInUse, layoutEntry.sampler.type != WGPUSamplerBindingType_Undefined)) {
             bindGroupLayoutEntries.emplace_back(layoutEntry);
         }
     }

--- a/native/cocos/renderer/gfx-wgpu/WGPUDescriptorSetLayout.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUDescriptorSetLayout.h
@@ -44,13 +44,15 @@ public:
 
     inline CCWGPUBindGroupLayoutObject *gpuLayoutEntryObject() { return _gpuLayoutEntryObj; }
 
-    void updateBufferLayout(uint8_t binding, const CCWGPUBuffer *buffer);
-    void updateTextureLayout(uint8_t binding, const CCWGPUTexture *texture);
-    void updateSamplerLayout(uint8_t binding, const CCWGPUSampler *sampler);
+    void updateBufferLayout(uint8_t index, const CCWGPUBuffer *buffer, AccessFlags flags);
+    void updateTextureLayout(uint8_t index, const CCWGPUTexture *texture, uint32_t plane = 0);
+    void updateSamplerLayout(uint8_t index, const CCWGPUSampler *sampler);
+
+    inline void setBindings(const DescriptorSetLayoutBindingList &list) { _bindings.assign(list.begin(), list.end()); }
+    inline void setBindingIndices(const ccstd::vector<uint32_t> &list) { _bindingIndices.assign(list.begin(), list.end()); }
+    inline void setDescriptorIndices(const ccstd::vector<uint32_t> &indices) { _descriptorIndices.assign(indices.begin(), indices.end()); }
 
     void prepare(ccstd::set<uint8_t> &bindingInUse, bool forceUpdate = false);
-
-    inline uint8_t dynamicOffsetCount() { return _dynamicOffsetCount; }
 
     static void *defaultBindGroupLayout();
     static void *getBindGroupLayoutByHash(ccstd::hash_t hash);
@@ -65,13 +67,9 @@ protected:
     void doInit(const DescriptorSetLayoutInfo &info) override;
     void doDestroy() override;
 
-    ccstd::hash_t hash() const;
     ccstd::hash_t _hash{0};
-    bool _internalChanged{false};
 
     CCWGPUBindGroupLayoutObject *_gpuLayoutEntryObj = nullptr;
-
-    uint8_t _dynamicOffsetCount = 0;
 };
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-wgpu/WGPUDevice.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUDevice.cpp
@@ -132,8 +132,7 @@ bool CCWGPUDevice::doInit(const DeviceInfo &info) {
         .type = CommandBufferType::PRIMARY,
     };
     _cmdBuff = this->Device::createCommandBuffer(cmdInfo);
-    // Sept 6th 2022: not implemented by emscripten
-    // _gpuDeviceObj->instance.wgpuInstance = wgpuCreateInstance({});
+    _gpuDeviceObj->instance.wgpuInstance = wgpuCreateInstance({});
 
 #ifdef CC_WGPU_WASM
     WGPUSurfaceDescriptorFromCanvasHTMLSelector canvDesc = {};
@@ -142,7 +141,7 @@ bool CCWGPUDevice::doInit(const DeviceInfo &info) {
 
     WGPUSurfaceDescriptor surfDesc = {};
     surfDesc.nextInChain = reinterpret_cast<WGPUChainedStruct *>(&canvDesc);
-    _gpuDeviceObj->instance.wgpuSurface = wgpuInstanceCreateSurface(nullptr, &surfDesc);
+    _gpuDeviceObj->instance.wgpuSurface = wgpuInstanceCreateSurface(_gpuDeviceObj->instance.wgpuInstance, &surfDesc);
 
 #elif defined(CC_WGPU_DAWN)
     _gpuDeviceObj->instance.wgpuInstance = wgpuCreateInstance({});
@@ -486,7 +485,7 @@ void CCWGPUDevice::debug() {
 }
 
 void CCWGPUDevice::initConfigs() {
-    WGPUAdapterProperties props;
+    WGPUAdapterProperties props{};
     wgpuAdapterGetProperties(_gpuDeviceObj->instance.wgpuAdapter, &props);
     // _deviceName = props.name;
     // _vendor = props.driverDescription;

--- a/native/cocos/renderer/gfx-wgpu/WGPUDevice.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUDevice.h
@@ -91,6 +91,8 @@ public:
     using Device::getSampler;
     using Device::initialize;
 
+    void frameSync() override {};
+
     Shader *createShader(const ShaderInfo &, const std::vector<std::vector<uint32_t>> &);
 
     void copyBuffersToTexture(const std::vector<std::vector<uint8_t>> &buffers, Texture *dst, const std::vector<BufferTextureCopy> &regions) {
@@ -117,7 +119,6 @@ public:
     EXPORT_EMS(
         void copyTextureToBuffers(Texture *src, const emscripten::val &buffers, const emscripten::val &regions);
         emscripten::val copyTextureToBuffers(Texture * src, const BufferTextureCopyList &regions);
-        Shader * createShader(const ShaderInfo &info, const emscripten::val &spirvVal);
         void copyBuffersToTexture(const emscripten::val &v, Texture *dst, const std::vector<BufferTextureCopy> &regions);)
 
     void initFeatures();

--- a/native/cocos/renderer/gfx-wgpu/WGPUEMSImpl.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUEMSImpl.cpp
@@ -29,6 +29,7 @@
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/preprocessor/variadic/to_seq.hpp>
+#include <vector>
 #include "WGPUBuffer.h"
 #include "WGPUCommandBuffer.h"
 #include "WGPUDef.h"
@@ -153,21 +154,6 @@ void CCWGPUDevice::copyTextureToBuffers(Texture* src, const emscripten::val& buf
     // @hana-alice
 }
 
-Shader* CCWGPUDevice::createShader(const ShaderInfo& info, const emscripten::val& spirvVal) {
-    CHECK_PTR(spirvVal);
-
-    auto len = spirvVal[length_val].as<uint32_t>();
-    std::vector<std::vector<uint32_t>> spvData;
-    for (size_t i = 0; i < len; ++i) {
-        spvData.emplace_back(std::move(convertJSArrayToNumberVector_local<uint32_t>(spirvVal[i])));
-    }
-
-    auto* shader = new CCWGPUShader();
-    // shader->initialize(shaderInfo);
-    shader->initialize(info, spvData);
-    return shader;
-}
-
 void CCWGPUDevice::copyBuffersToTexture(const emscripten::val& v, Texture* dst, const std::vector<BufferTextureCopy>& regions) {
     CHECK_VOID(v);
     auto len = v[length_val].as<unsigned>();
@@ -180,6 +166,11 @@ void CCWGPUDevice::copyBuffersToTexture(const emscripten::val& v, Texture* dst, 
     }
 
     return copyBuffersToTexture(buffers.data(), dst, regions.data(), regions.size());
+}
+
+void CCWGPUShader::reflectBinding(const emscripten::val &vals) {
+    const std::vector<uint8_t>& bindings = convertJSArrayToNumberVector<uint8_t>(vals);
+    _gpuShaderObject->bindings.emplace_back(bindings);
 }
 
 } // namespace cc::gfx

--- a/native/cocos/renderer/gfx-wgpu/WGPUExports.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUExports.h
@@ -45,7 +45,7 @@
 #include "states/WGPUGeneralBarrier.h"
 #include "states/WGPUTextureBarrier.h"
 
-REGISTER_GFX_PTRS_FOR_STRUCT(Device, Buffer, Texture, GeneralBarrier, Queue, RenderPass, Shader, PipelineLayout, DescriptorSetLayout, CommandBuffer, DescriptorSet);
+REGISTER_GFX_PTRS_FOR_STRUCT(Device, Buffer, Texture, GeneralBarrier, Queue, RenderPass, Shader, PipelineLayout, DescriptorSetLayout, CommandBuffer, DescriptorSet, Sampler, CCWGPUGPUDescriptorSetObject);
 
 namespace cc::gfx {
 
@@ -106,17 +106,20 @@ EMSCRIPTEN_BINDINGS(WEBGPU_DEVICE_WASM_EXPORT) {
     EXPORT_STRUCT_POD(Attribute, name, format, isNormalized, stream, isInstanced, location);
     EXPORT_STRUCT_POD(ShaderInfo, name, stages, attributes, blocks, buffers, samplerTextures, samplers, textures, images, subpassInputs);
     EXPORT_STRUCT_NPOD(InputAssemblerInfo, attributes, vertexBuffers, indexBuffer, indirectBuffer);
-    EXPORT_STRUCT_NPOD(ColorAttachment, format, sampleCount, loadOp, storeOp, barrier, isGeneralLayout);
-    EXPORT_STRUCT_NPOD(DepthStencilAttachment, format, sampleCount, depthLoadOp, depthStoreOp, stencilLoadOp, stencilStoreOp, barrier, isGeneralLayout);
+    EXPORT_STRUCT_NPOD(ColorAttachment, format, sampleCount, loadOp, storeOp, barrier);
+    EXPORT_STRUCT_NPOD(DepthStencilAttachment, format, sampleCount, depthLoadOp, depthStoreOp, stencilLoadOp, stencilStoreOp, barrier);
     EXPORT_STRUCT_POD(SubpassInfo, inputs, colors, resolves, preserves, depthStencil, depthStencilResolve, depthResolveMode, stencilResolveMode);
 
     // MAYBE TODO(Zeqiang): all ts related backend no need to care about barriers.
-    EXPORT_STRUCT_POD(SubpassDependency, srcSubpass, dstSubpass, bufferBarrierCount, textureBarrierCount);
+    EXPORT_STRUCT_POD(SubpassDependency, srcSubpass, dstSubpass, prevAccesses, nextAccesses);
     EXPORT_STRUCT_POD(RenderPassInfo, colorAttachments, depthStencilAttachment, subpasses, dependencies);
     EXPORT_STRUCT_POD(GeneralBarrierInfo, prevAccesses, nextAccesses, type);
-    EXPORT_STRUCT_NPOD(TextureBarrierInfo, prevAccesses, nextAccesses, type, baseMipLevel, levelCount, baseSlice, sliceCount, discardContents, srcQueue, dstQueue);
+    EXPORT_STRUCT_POD(ResourceRange, width, height, depthOrArraySize, firstSlice, numSlices, mipLevel, levelCount, basePlane, planeCount);
+    EXPORT_STRUCT_NPOD(TextureBarrierInfo, prevAccesses, nextAccesses, type, range, discardContents, srcQueue, dstQueue);
     EXPORT_STRUCT_NPOD(BufferBarrierInfo, prevAccesses, nextAccesses, type, offset, size, discardContents, srcQueue, dstQueue);
     EXPORT_STRUCT_NPOD(FramebufferInfo, renderPass, colorTextures, depthStencilTexture);
+    EXPORT_STRUCT_NPOD(WGPUGPUDescriptor, type, buffer, texture, sampler);
+    EXPORT_STRUCT_NPOD(CCWGPUGPUDescriptorSetObject, gpuDescriptors, descriptorIndices);
     EXPORT_STRUCT_NPOD(DescriptorSetLayoutBinding, binding, descriptorType, count, stageFlags, immutableSamplers);
     EXPORT_STRUCT_POD(DescriptorSetLayoutInfo, bindings);
     EXPORT_STRUCT_NPOD(DescriptorSetInfo, layout);
@@ -174,6 +177,7 @@ EMSCRIPTEN_BINDINGS(WEBGPU_DEVICE_WASM_EXPORT) {
         //           /* pure_virtual(), */ allow_raw_pointer<arg<0>>())
         // .function("flushCommands", &Device::flushCommands, allow_raw_pointers())
         .function("present", select_overload<void(void)>(&Device::present))
+        .function("enableAutoBarrier", &Device::enableAutoBarrier)
         .property("queue", &Device::getQueue)
         .property("commandBuffer", &Device::getCommandBuffer)
         .property("capabilities", &Device::getCapabilities)
@@ -190,8 +194,7 @@ EMSCRIPTEN_BINDINGS(WEBGPU_DEVICE_WASM_EXPORT) {
 
         .function("acquire", select_overload<void(const std::vector<Swapchain *> &)>(&CCWGPUDevice::acquire),
                   /* pure_virtual(), */ allow_raw_pointer<arg<0>>())
-        .function("createShaderNative", select_overload<Shader *(const ShaderInfo &, const emscripten::val &)>(&CCWGPUDevice::createShader),
-                  /* pure_virtual(), */ allow_raw_pointer<arg<0>>())
+        .function("createShaderNative", select_overload<Shader *(const ShaderInfo &)>(&CCWGPUDevice::createShader))
         .function("copyTextureToBuffers", select_overload<void(Texture * src, const emscripten::val &, const emscripten::val &)>(&CCWGPUDevice::copyTextureToBuffers),
                   /* pure_virtual(), */ allow_raw_pointers())
         .function("copyBuffersToTexture", select_overload<void(const emscripten::val &, Texture *dst, const std::vector<BufferTextureCopy> &)>(&CCWGPUDevice::copyBuffersToTexture),
@@ -288,6 +291,7 @@ EMSCRIPTEN_BINDINGS(WEBGPU_DEVICE_WASM_EXPORT) {
         .function("update", &DescriptorSet::update)
         .function("bindBuffer", select_overload<void(uint32_t, Buffer *)>(&DescriptorSet::bindBuffer), allow_raw_pointer<arg<1>>())
         .function("bindBuffer", select_overload<void(uint32_t, Buffer *, uint32_t)>(&DescriptorSet::bindBuffer), allow_raw_pointer<arg<1>>())
+        .function("bindBuffer", select_overload<void(uint32_t, Buffer *, uint32_t, AccessFlags)>(&DescriptorSet::bindBuffer), allow_raw_pointer<arg<1>>())
         .function("bindTexture", select_overload<void(uint32_t, Texture *)>(&DescriptorSet::bindTexture), allow_raw_pointer<arg<1>>())
         .function("bindTexture", select_overload<void(uint32_t, Texture *, uint32_t)>(&DescriptorSet::bindTexture), allow_raw_pointer<arg<1>>())
         .function("bindSampler", select_overload<void(uint32_t, Sampler *)>(&DescriptorSet::bindSampler), allow_raw_pointer<arg<1>>())
@@ -301,6 +305,8 @@ EMSCRIPTEN_BINDINGS(WEBGPU_DEVICE_WASM_EXPORT) {
         .property("layout", &DescriptorSet::getLayout)
         .property("objectID", select_overload<uint32_t(void) const>(&DescriptorSet::getObjectID));
     class_<CCWGPUDescriptorSet, base<DescriptorSet>>("CCWGPUDescriptorSet")
+        // .property("gpuDescriptorSet", &CCWGPUDescriptorSet::gpuDescriptors)
+        .function("updateFrom", &CCWGPUDescriptorSet::setGpuDescriptors)
         .constructor<>();
 
     class_<PipelineLayout>("PipelineLayout")
@@ -312,7 +318,6 @@ EMSCRIPTEN_BINDINGS(WEBGPU_DEVICE_WASM_EXPORT) {
         .constructor<>();
 
     class_<Shader>("Shader")
-        .function("initialize", &Shader::initialize)
         .function("destroy", &Shader::destroy)
         .property("name", &Shader::getName)
         .property("attributes", &Shader::getAttributes)
@@ -326,6 +331,8 @@ EMSCRIPTEN_BINDINGS(WEBGPU_DEVICE_WASM_EXPORT) {
         .property("subpassInputs", &Shader::getSubpassInputs)
         .property("objectID", select_overload<uint32_t(void) const>(&Shader::getObjectID));
     class_<CCWGPUShader, base<Shader>>("CCWGPUShader")
+        .function("initialize", &CCWGPUShader::initWithWGSL)
+        .function("reflectBinding", &CCWGPUShader::reflectBinding)
         .constructor<>();
 
     class_<InputAssembler>("InputAssembler")

--- a/native/cocos/renderer/gfx-wgpu/WGPUObject.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUObject.h
@@ -101,6 +101,7 @@ struct CCWGPUTextureObject {
     WGPUTexture wgpuTexture = wgpuDefaultHandle;
     WGPUTextureView wgpuTextureView = wgpuDefaultHandle;
     WGPUTextureView selfView = wgpuDefaultHandle;
+    std::vector<WGPUTextureView> planeViews;
 };
 
 // The indirect drawIndexed parameters encoded in the buffer must be a tightly packed block
@@ -161,13 +162,14 @@ struct CCWGPUSamplerObject {
 
 struct CCWGPUBindGroupLayoutObject {
     WGPUBindGroupLayout bindGroupLayout = wgpuDefaultHandle;
-    ccstd::vector<WGPUBindGroupLayoutEntry> bindGroupLayoutEntries;
+    ccstd::map<uint32_t, WGPUBindGroupLayoutEntry> bindGroupLayoutEntries;
 };
 
 struct CCWGPUBindGroupObject {
     WGPUBindGroup bindgroup = wgpuDefaultHandle;
     ccstd::vector<WGPUBindGroupEntry> bindGroupEntries;
-    ccstd::set<uint8_t> bindingSet;
+    ccstd::set<uint8_t> bindingSet;      // bindingInDesc
+    ccstd::set<uint8_t> bindingInShader; // bindingInShader
 };
 
 struct CCWGPUPipelineLayoutObject {
@@ -182,11 +184,14 @@ struct CCWGPUPipelineStateObject {
     uint32_t maxAttrLength = 0;
 };
 
+using BindingList = ccstd::vector<uint8_t>;
 struct CCWGPUShaderObject {
     ccstd::string name;
     WGPUShaderModule wgpuShaderVertexModule = wgpuDefaultHandle;
     WGPUShaderModule wgpuShaderFragmentModule = wgpuDefaultHandle;
     WGPUShaderModule wgpuShaderComputeModule = wgpuDefaultHandle;
+
+    ccstd::vector<BindingList> bindings;
 };
 
 struct CCWGPUInputAssemblerObject {
@@ -244,6 +249,7 @@ struct CCWGPUCommandBufferObject {
     WGPURenderPassDescriptor renderPassDescriptor;
     CCWGPUStateCache stateCache;
 
+    ccstd::vector<WGPUCommandBuffer> computeCmdBuffs;
     ccstd::unordered_map<uint32_t, CCWGPUBuffer *> redundantVertexBufferMap;
 };
 

--- a/native/cocos/renderer/gfx-wgpu/WGPUObject.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUObject.h
@@ -42,7 +42,6 @@ namespace cc {
 namespace gfx {
 
 constexpr uint8_t CC_WGPU_MAX_ATTACHMENTS = 16;
-constexpr uint8_t CC_WGPU_MAX_STREAM = 256; // not sure
 constexpr decltype(nullptr) wgpuDefaultHandle = nullptr;
 constexpr ccstd::hash_t WGPU_HASH_SEED = 0x811C9DC5;
 constexpr uint8_t CC_WGPU_MAX_FRAME_COUNT = 3;

--- a/native/cocos/renderer/gfx-wgpu/WGPUPipelineLayout.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUPipelineLayout.h
@@ -64,7 +64,7 @@ protected:
 
     ccstd::hash_t _hash{0};
 
-    friend void createPipelineLayoutFallback(const ccstd::vector<DescriptorSet *> &descriptorSets, PipelineLayout *pipelineLayout);
+    friend void createPipelineLayoutFallback(const ccstd::vector<DescriptorSet *> &descriptorSets, PipelineLayout *pipelineLayout, bool skipEmpty);
 };
 
 } // namespace gfx

--- a/native/cocos/renderer/gfx-wgpu/WGPUPipelineState.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUPipelineState.cpp
@@ -24,6 +24,7 @@
 
 #include "WGPUPipelineState.h"
 #include <emscripten/html5_webgpu.h>
+#include <algorithm>
 #include <numeric>
 #include "WGPUDescriptorSetLayout.h"
 #include "WGPUDevice.h"
@@ -101,10 +102,10 @@ ccstd::hash_t hash(const WGPURenderPipelineDescriptor &desc) {
             hash_combine(hash, desc.fragment->constants[i].key);
             hash_combine(hash, desc.fragment->constants[i].value);
         }
+
         hash_combine(hash, desc.fragment->targetCount);
         for (uint32_t i = 0; i < desc.fragment->targetCount; ++i) {
             hash_combine(hash, desc.fragment->targets[i].format);
-            hash_combine(hash, desc.fragment->targets[i].blend);
             if (desc.fragment->targets[i].blend) {
                 hash_combine(hash, desc.fragment->targets[i].blend->color.operation);
                 hash_combine(hash, desc.fragment->targets[i].blend->color.srcFactor);
@@ -115,8 +116,6 @@ ccstd::hash_t hash(const WGPURenderPipelineDescriptor &desc) {
             }
             hash_combine(hash, desc.fragment->targets[i].writeMask);
         }
-    } else {
-        hash_combine(hash, 0);
     }
     return hash;
 }
@@ -295,7 +294,7 @@ void CCWGPUPipelineState::prepare(const ccstd::set<uint8_t> &setInUse) {
             .nextInChain = nullptr,
             .format = toWGPUTextureFormat(dsAttachment.format),
             .depthWriteEnabled = _depthStencilState.depthWrite != 0,
-            .depthCompare = _depthStencilState.depthTest ? toWGPUCompareFunction(_depthStencilState.depthFunc) : WGPUCompareFunction_Undefined,
+            .depthCompare = _depthStencilState.depthTest ? toWGPUCompareFunction(_depthStencilState.depthFunc) : WGPUCompareFunction_Always,
             .stencilFront = stencilFront,
             .stencilBack = stencilBack,
             .stencilReadMask = _depthStencilState.stencilReadMaskFront,

--- a/native/cocos/renderer/gfx-wgpu/WGPUQueue.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUQueue.cpp
@@ -82,17 +82,26 @@ void CCWGPUQueue::submit(CommandBuffer *const *cmdBuffs, uint32_t count) {
     // CCWGPUDevice::getInstance()->stagingBuffer()->unmap();
 
     ccstd::vector<WGPUCommandBuffer> wgpuCmdBuffs(count);
+    ccstd::vector<WGPUCommandEncoder> wgpuCmdEncoders(count);
     for (size_t i = 0; i < count; ++i) {
         const auto *cmdBuff = static_cast<CCWGPUCommandBuffer *>(cmdBuffs[i]);
         wgpuCmdBuffs[i] = cmdBuff->gpuCommandBufferObject()->wgpuCommandBuffer;
+        wgpuCmdEncoders[i] = cmdBuff->gpuCommandBufferObject()->wgpuCommandEncoder;
 
         _numDrawCalls += cmdBuff->getNumDrawCalls();
         _numInstances += cmdBuff->getNumInstances();
         _numTriangles += cmdBuff->getNumTris();
+
+        const_cast<CCWGPUCommandBuffer*>(cmdBuff)->reset();
     }
 
     wgpuQueueSubmit(_gpuQueueObject->wgpuQueue, count, wgpuCmdBuffs.data());
-    std::for_each(wgpuCmdBuffs.begin(), wgpuCmdBuffs.end(), [](auto wgpuCmdBuffer) { wgpuCommandBufferRelease(wgpuCmdBuffer); });
+    std::for_each(wgpuCmdBuffs.begin(), wgpuCmdBuffs.end(), [](auto wgpuCmdBuffer) {
+        wgpuCommandBufferRelease(wgpuCmdBuffer);
+    });
+    std::for_each(wgpuCmdEncoders.begin(), wgpuCmdEncoders.end(), [](auto wgpuCmdEncoder) {
+        wgpuCommandEncoderRelease(wgpuCmdEncoder);
+    });
 
     auto *recycleBin = CCWGPUDevice::getInstance()->recycleBin();
     wgpuQueueOnSubmittedWorkDone(_gpuQueueObject->wgpuQueue, 0, wgpuQueueSubmitCallback, recycleBin);

--- a/native/cocos/renderer/gfx-wgpu/WGPUSampler.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUSampler.cpp
@@ -47,7 +47,7 @@ CCWGPUSampler::CCWGPUSampler(const SamplerInfo &info) : Sampler(info) {
         .addressModeW = toWGPUAddressMode(info.addressW),
         .magFilter = toWGPUFilterMode(info.magFilter),
         .minFilter = toWGPUFilterMode(info.minFilter),
-        .mipmapFilter = toWGPUFilterMode(info.mipFilter),
+        .mipmapFilter = toWGPUMipmapFilterMode(info.mipFilter),
         .lodMinClamp = 0.0f,
         .lodMaxClamp = std::numeric_limits<float>::max(),
         .compare = WGPUCompareFunction_Undefined, // toWGPUCompareFunction(info.cmpFunc),

--- a/native/cocos/renderer/gfx-wgpu/WGPUSampler.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUSampler.cpp
@@ -39,9 +39,10 @@ CCWGPUSampler *dftUnfilterableSampler = nullptr;
 using namespace emscripten;
 
 CCWGPUSampler::CCWGPUSampler(const SamplerInfo &info) : Sampler(info) {
+    ccstd::string tag = std::to_string(static_cast<uint32_t>(info.minFilter)) + " " + std::to_string(static_cast<uint32_t>(info.magFilter)) + " " + std::to_string(static_cast<uint32_t>(info.mipFilter));
     WGPUSamplerDescriptor descriptor = {
         .nextInChain = nullptr,
-        .label = (std::to_string(static_cast<uint32_t>(info.minFilter)) + " " + std::to_string(static_cast<uint32_t>(info.magFilter)) + " " + std::to_string(static_cast<uint32_t>(info.mipFilter))).c_str(),
+        .label = tag.c_str(),
         .addressModeU = toWGPUAddressMode(info.addressU),
         .addressModeV = toWGPUAddressMode(info.addressV),
         .addressModeW = toWGPUAddressMode(info.addressW),

--- a/native/cocos/renderer/gfx-wgpu/WGPUShader.cpp
+++ b/native/cocos/renderer/gfx-wgpu/WGPUShader.cpp
@@ -27,6 +27,7 @@
 #include "WGPUDevice.h"
 #include "WGPUObject.h"
 #include "WGPUUtils.h"
+#include "gfx-base/GFXDef-common.h"
 #define USE_NATIVE_SPIRV 0
 #if USE_NATIVE_SPIRV
     #include "gfx-base/SPIRVUtils.h"
@@ -74,6 +75,41 @@ void CCWGPUShader::initialize(const ShaderInfo &info, const std::vector<std::vec
         spv.code = spvData;
         WGPUShaderModuleDescriptor desc = {};
         desc.nextInChain = reinterpret_cast<WGPUChainedStruct *>(&spv);
+        desc.label = _name.c_str();
+        if (stage.stage == ShaderStageFlagBit::VERTEX) {
+            _gpuShaderObject->wgpuShaderVertexModule = wgpuDeviceCreateShaderModule(CCWGPUDevice::getInstance()->gpuDeviceObject()->wgpuDevice, &desc);
+        } else if (stage.stage == ShaderStageFlagBit::FRAGMENT) {
+            _gpuShaderObject->wgpuShaderFragmentModule = wgpuDeviceCreateShaderModule(CCWGPUDevice::getInstance()->gpuDeviceObject()->wgpuDevice, &desc);
+        } else if (stage.stage == ShaderStageFlagBit::COMPUTE) {
+            _gpuShaderObject->wgpuShaderComputeModule = wgpuDeviceCreateShaderModule(CCWGPUDevice::getInstance()->gpuDeviceObject()->wgpuDevice, &desc);
+        } else {
+            printf("unsupport shader stage.");
+        }
+    }
+}
+
+void CCWGPUShader::initWithWGSL(const ShaderInfo& info) {
+     _gpuShaderObject = ccnew CCWGPUShaderObject;
+
+    _name = info.name;
+    _stages = info.stages;
+    _attributes = info.attributes;
+    _blocks = info.blocks;
+    _buffers = info.buffers;
+    _samplerTextures = info.samplerTextures;
+    _samplers = info.samplers;
+    _textures = info.textures;
+    _images = info.images;
+    _subpassInputs = info.subpassInputs;
+
+    _gpuShaderObject->name = info.name;
+    for (size_t i = 0; i < info.stages.size(); i++) {
+        const auto &stage = info.stages[i];
+        WGPUShaderModuleWGSLDescriptor wgslDesc = {};
+        wgslDesc.chain.sType = WGPUSType_ShaderModuleWGSLDescriptor;
+        wgslDesc.code = stage.source.c_str();
+        WGPUShaderModuleDescriptor desc = {};
+        desc.nextInChain = reinterpret_cast<WGPUChainedStruct *>(&wgslDesc);
         desc.label = _name.c_str();
         if (stage.stage == ShaderStageFlagBit::VERTEX) {
             _gpuShaderObject->wgpuShaderVertexModule = wgpuDeviceCreateShaderModule(CCWGPUDevice::getInstance()->gpuDeviceObject()->wgpuDevice, &desc);
@@ -140,6 +176,7 @@ const std::string spirvProcess(const uint32_t *data, size_t size, const UniformS
 }
 
 void CCWGPUShader::doInit(const ShaderInfo &info) {
+    initWithWGSL(info);
 #if USE_NATIVE_SPIRV
     _gpuShaderObject = ccnew CCWGPUShaderObject;
     if (!spirv) {

--- a/native/cocos/renderer/gfx-wgpu/WGPUShader.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUShader.h
@@ -23,6 +23,7 @@
 ****************************************************************************/
 
 #pragma once
+#include "gfx-base/GFXDef-common.h"
 #ifdef CC_WGPU_WASM
     #include "WGPUDef.h"
 #endif
@@ -45,8 +46,12 @@ public:
 
     // ems export
     EXPORT_EMS(
-        void initialize(const ShaderInfo &info, emscripten::val &spirvs);)
+        void initialize(const ShaderInfo &info, emscripten::val &spirvs);
+        void reflectBinding(const emscripten::val& bindings);
+        )
+
     void initialize(const ShaderInfo &info, const std::vector<std::vector<uint32_t>> &spirvs);
+    void initWithWGSL(const ShaderInfo& info);
 
 protected:
     void doInit(const ShaderInfo &info) override;

--- a/native/cocos/renderer/gfx-wgpu/WGPUTexture.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUTexture.h
@@ -63,6 +63,8 @@ public:
     inline auto getTextureSamples() const { return _info.samples; };
     inline auto getTextureFlags() const { return _info.flags; };
 
+    void* getPlaneView(uint32_t plane);
+
 protected:
     void doInit(const TextureInfo &info) override;
     void doInit(const TextureViewInfo &info) override;

--- a/native/cocos/renderer/gfx-wgpu/WGPUUtils.h
+++ b/native/cocos/renderer/gfx-wgpu/WGPUUtils.h
@@ -309,6 +309,19 @@ static WGPUAddressMode toWGPUAddressMode(Address addrMode) {
     }
 }
 
+static WGPUMipmapFilterMode toWGPUMipmapFilterMode(Filter filter) {
+    switch (filter) {
+        case Filter::NONE:
+            return WGPUMipmapFilterMode::WGPUMipmapFilterMode_Nearest;
+        case Filter::POINT:
+            return WGPUMipmapFilterMode::WGPUMipmapFilterMode_Nearest;
+        case Filter::LINEAR:
+            return WGPUMipmapFilterMode::WGPUMipmapFilterMode_Linear;
+        case Filter::ANISOTROPIC:
+            return WGPUMipmapFilterMode::WGPUMipmapFilterMode_Linear;
+    }
+}
+
 static WGPUFilterMode toWGPUFilterMode(Filter filter) {
     switch (filter) {
         case Filter::NONE:
@@ -644,7 +657,7 @@ void genMipMap(Texture* texture, uint8_t fromLevel, uint8_t levelCount, uint32_t
 class DescriptorSet;
 class PipelineLayout;
 // descriptor set layout in descriptor set not consistent with the binding in pipeline layout.
-void createPipelineLayoutFallback(const ccstd::vector<DescriptorSet*>& descriptorSets, PipelineLayout* pipelineLayout);
+void createPipelineLayoutFallback(const ccstd::vector<DescriptorSet*>& descriptorSets, PipelineLayout* pipelineLayout, bool skipEmpty = false);
 
 class Texture;
 class CommandBuffer;


### PR DESCRIPTION
Re: # https://github.com/cocos/cocos-engine-external/pull/417

### Changelog

webgpu update:
* several const cast exist for lazy instantiation of descriptor set layout;
* add access flag for storage buffer distinguishing read-only access and write read-write access
* update emscripten sdk to latest(3.1.45)

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
