### PR TITLE
add CULL_MESHOPT constant

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -682,7 +682,7 @@
         "CULL_MESHOPT": {
             "comment": "An internal constant to indicate whether we cull the meshopt wasm module and asm.js module.",
             "type": "boolean",
-            "value": false,
+            "value": true,
             "internal": true
         }
     },

--- a/cc.config.json
+++ b/cc.config.json
@@ -678,6 +678,12 @@
             "type": "boolean",
             "value": false,
             "internal": true
+        },
+        "CULL_MESHOPT": {
+            "comment": "An internal constant to indicate whether we cull the meshopt wasm module and asm.js module.",
+            "type": "boolean",
+            "value": false,
+            "internal": true
         }
     },
 

--- a/cocos/3d/misc/mesh-codec.ts
+++ b/cocos/3d/misc/mesh-codec.ts
@@ -21,7 +21,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
 */
-import { WASM_SUPPORT_MODE } from 'internal:constants';
+import { CULL_MESHOPT, WASM_SUPPORT_MODE } from 'internal:constants';
 import { ensureWasmModuleReady, instantiateWasm } from 'pal/wasm';
 
 import { sys, logID } from '../../core';
@@ -90,4 +90,6 @@ export function InitDecoder (): Promise<void> {
     }));
 }
 
-game.onPostInfrastructureInitDelegate.add(InitDecoder);
+if (!CULL_MESHOPT) {
+    game.onPostInfrastructureInitDelegate.add(InitDecoder);
+}


### PR DESCRIPTION
Re: #

### Changelog

* add CULL_MESHOPT constant

### Rely on PR
https://github.com/cocos/cocos-editor/pull/2518

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
