### PR TITLE
Add workflow_dispatch for oh sdk & vulkan sdk, workflow_dispatch only could be shown when the yml files are merged to default branch

### DIFF
--- a/.github/workflows/generate-oh-sdk-cache.yml
+++ b/.github/workflows/generate-oh-sdk-cache.yml
@@ -1,0 +1,80 @@
+name: <Native> Generate OH SDK Cache
+
+on:
+  workflow_dispatch:
+    inputs:
+      oh_sdk_version:
+        description: 'Openharmony SDK version'
+        type: string
+        default: '9'
+        required: true
+
+jobs:
+  generate_oh_sdk_cache:
+    name: "Generate OH SDK cache"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-java@v3
+        id: setup-jdk
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      
+      - name: Get oh sdk cache directory path
+        id: oh-sdk-cache-dir-path
+        run: |
+          echo "cache dir: "
+          echo "dir=$HOME/openharmony" >> $GITHUB_OUTPUT
+
+      - name: Output cache dir
+        run: |
+          echo "Output cache dir: ${{ steps.oh-sdk-cache-dir-path.outputs.dir }}"
+
+      - name: Cache OH SDK
+        id: cache-oh-sdk
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-oh-sdk-${{ github.event.inputs.oh_sdk_version }}
+        with:
+          path: ${{ steps.oh-sdk-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+      - name: Add package.json
+        run: |
+          echo "{}" > package.json
+          echo "{\"name\": \"tests\",\"lockfileVersion\": 3,\"requires\": true,\"packages\": {}}" > package-lock.json
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'npm'
+
+      - if: ${{ steps.cache-oh-sdk.outputs.cache-hit != 'true' }}
+        name: No Cache found, install oh sdk
+        continue-on-error: false
+        run: |
+          if [ ! -d "$HOME/openharmony" ]; then
+            mkdir -p $HOME/openharmony
+            echo "Download commandline-tools-linux.zip ..."
+            curl -o commandline-tools-linux.zip "https://contentcenter-vali-drcn.dbankcdn.cn/pvt_2/DeveloperAlliance_package_901_9/b1/v3/E6zhv5UFQ2-inIwNJhTN6Q/commandline-tools-linux-2.0.0.2.zip?HW-CC-KV=V1&HW-CC-Date=20230621T074401Z&HW-CC-Expire=315360000&HW-CC-Sign=621224257B02079B1E76C0A56FDF21483400B1E3556213F88DC79BC9BE7D595D"
+            echo "Unzip commandline-tools-linux.zip ..."
+            unzip commandline-tools-linux.zip -d $HOME/openharmony > /dev/null
+            cd $HOME/openharmony
+            ls -l
+            cd command-line-tools
+            echo "=============== PATCHING sdkmanager/bin/sdkmgr file ==============="
+            sed -i "s@-Dfile.encoding=UTF-8@-Dfile.encoding=UTF-8 -Duser.country=CN@g" ./sdkmanager/bin/sdkmgr
+            cd bin
+            ./sdkmgr list
+            echo "=============== INSTALL HOS toolchains:${{ github.event.inputs.oh_sdk_version }} ==============="
+            ./sdkmgr install toolchains:${{ github.event.inputs.oh_sdk_version }} --accept-license > /dev/null
+            echo "=============== INSTALL OH SDK ets:${{ github.event.inputs.oh_sdk_version }} ==============="
+            ./sdkmgr install OpenHarmony/ets:${{ github.event.inputs.oh_sdk_version }} --accept-license > /dev/null
+            echo "=============== INSTALL OH SDK js:${{ github.event.inputs.oh_sdk_version }} ==============="
+            ./sdkmgr install OpenHarmony/js:${{ github.event.inputs.oh_sdk_version }} --accept-license > /dev/null
+            echo "=============== INSTALL OH SDK native:${{ github.event.inputs.oh_sdk_version }} ==============="
+            ./sdkmgr install OpenHarmony/native:${{ github.event.inputs.oh_sdk_version }} --accept-license > /dev/null
+            echo "=============== INSTALL OH SDK toolchains:${{ github.event.inputs.oh_sdk_version }} ==============="
+            ./sdkmgr install OpenHarmony/toolchains:${{ github.event.inputs.oh_sdk_version }} --accept-license > /dev/null
+            echo "=============== INSTALL OH SDK DONE ==============="
+            ./sdkmgr list
+          fi

--- a/.github/workflows/generate-vulkan-sdk-cache.yml
+++ b/.github/workflows/generate-vulkan-sdk-cache.yml
@@ -1,0 +1,22 @@
+name: <Native> Generate Vulkan SDK Cache
+
+on:
+  workflow_dispatch:
+    inputs:
+      vulkan_sdk_version:
+        description: 'Vulkan SDK version'
+        type: string
+        default: '1.2.189.0'
+        required: true
+
+jobs:
+  generate_vulkan_sdk_cache:
+    name: "Generate Vulkan SDK cache"
+    runs-on: windows-2019
+    steps:
+      - name: Setup Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: ${{ github.event.inputs.vulkan_sdk_version }}
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/67523882/workflow-is-not-shown-so-i-cannot-run-it-manually-github-actions

> Some workflows, such as those, based on workflow_dispatch event, the workflow will not even show until the code is on the main (or default branch).

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
