### PR TITLE
Fix sprite not checking for validate render when onEnable

### DIFF
--- a/cocos2d/core/components/CCSprite.js
+++ b/cocos2d/core/components/CCSprite.js
@@ -426,6 +426,7 @@ var Sprite = cc.Class({
 
     onEnable () {
         this._super();
+        this._validateRender();
         this._spriteFrame && this._spriteFrame.isValid && this._spriteFrame.ensureLoadTexture();
 
         this.node.on(cc.Node.EventType.SIZE_CHANGED, this.setVertsDirty, this);

--- a/cocos2d/core/renderer/assembler-2d.js
+++ b/cocos2d/core/renderer/assembler-2d.js
@@ -131,8 +131,8 @@ export default class Assembler2D extends Assembler {
     }
 
     packToDynamicAtlas (comp, frame) {
-        if (CC_TEST || !frame) return;
-
+        if (CC_TEST) return;
+        
         if (!frame._original && dynamicAtlasManager && frame._texture.packable && frame._texture.loaded) {
             let packedFrame = dynamicAtlasManager.insertSpriteFrame(frame);
             if (packedFrame) {


### PR DESCRIPTION
… (#14456)"

This reverts commit 31cfc457b4ca61bce8ac0fbc49cd6b3bb6877596.

Re: #
https://github.com/cocos/2d-tasks/issues/3781
https://github.com/cocos/cocos-engine/issues/14045

### Changelog

* Fix sprite not checking for validate render when onEnable

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
