### PR TITLE
[opt] physx mesh collider shrinkPositions() performance x50

### DIFF
--- a/cocos/physics/utils/util.ts
+++ b/cocos/physics/utils/util.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { equals, Vec3, IVec3Like } from '../../core';
+import { equals, Vec3, IVec3Like, murmurhash2_32_gc } from '../../core';
 import { CharacterController, CharacterTriggerEventType, Collider, CollisionEventType, IContactEquation, TriggerEventType } from '../framework';
 
 export { cylinder } from '../../primitive';
@@ -69,23 +69,21 @@ export const CollisionEventObject = {
 
 export function shrinkPositions (buffer: Float32Array | number[]): number[] {
     const pos: number[] = [];
+    const posHashMap = {};
     if (buffer.length >= 3) {
-        // eslint-disable-next-line no-unused-expressions
-        pos[0] = buffer[0], pos[1] = buffer[1], pos[2] = buffer[2];
+        pos[0] = buffer[0];
+        pos[1] = buffer[1];
+        pos[2] = buffer[2];
         const len = buffer.length;
         for (let i = 3; i < len; i += 3) {
             const p0 = buffer[i];
             const p1 = buffer[i + 1];
             const p2 = buffer[i + 2];
-            const len2 = pos.length;
-            let isNew = true;
-            for (let j = 0; j < len2; j += 3) {
-                if (equals(p0, pos[j]) && equals(p1, pos[j + 1]) && equals(p2, pos[j + 2])) {
-                    isNew = false;
-                    break;
-                }
-            }
-            if (isNew) {
+            const str = String(p0) +  String(p1) + String(p2);
+            //todo: directly use buffer as input
+            const hash = murmurhash2_32_gc(str, 666);
+            if (posHashMap[hash] !== str) {
+                posHashMap[hash] = str;
                 pos.push(p0); pos.push(p1); pos.push(p2);
             }
         }


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/17719

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
