### PR TITLE
remove useless cone twist joint

### DIFF
--- a/cocos/physics/framework/deprecated.ts
+++ b/cocos/physics/framework/deprecated.ts
@@ -148,12 +148,6 @@ removeProperty(RigidBody.prototype, 'RigidBody.prototype', [
     },
 ]);
 
-removeProperty(EConstraintType, 'EConstraintType.prototype', [
-    {
-        name: 'CONE_TWIST',  
-    },
-]);
-
 /**
  * Alias of [[RigidBody]]
  * @deprecated Since v1.2

--- a/cocos/physics/framework/physics-enum.ts
+++ b/cocos/physics/framework/physics-enum.ts
@@ -272,14 +272,6 @@ export enum EConstraintType {
     HINGE,
     /**
      * @en
-     * Cone twist constraint.
-     * @zh
-     * 锥形扭转约束。
-     * @deprecated coneTwist is deprecated, please use configurable instead
-     */
-    CONE_TWIST,
-    /**
-     * @en
      * Fixed constraint.
      * @zh
      * 固定约束。

--- a/cocos/physics/framework/physics-selector.ts
+++ b/cocos/physics/framework/physics-selector.ts
@@ -26,7 +26,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import { EDITOR, TEST } from 'internal:constants';
-import { IBaseConstraint, IPointToPointConstraint, IHingeConstraint, IConeTwistConstraint, IFixedConstraint,
+import { IBaseConstraint, IPointToPointConstraint, IHingeConstraint, IFixedConstraint,
     IConfigurableConstraint } from '../spec/i-physics-constraint';
 import {
     IBoxShape, ISphereShape, ICapsuleShape, ITrimeshShape, ICylinderShape,
@@ -58,10 +58,6 @@ interface IPhysicsWrapperObject {
     PlaneShape?: Constructor<IPlaneShape>,
     PointToPointConstraint?: Constructor<IPointToPointConstraint>,
     HingeConstraint?: Constructor<IHingeConstraint>,
-    /**
-     * @deprecated cone twist constraint is deprecated, please use configurable instead
-     */
-    ConeTwistConstraint?: Constructor<IConeTwistConstraint>,
     FixedConstraint?: Constructor<IFixedConstraint>,
     ConfigurableConstraint?: Constructor<IConfigurableConstraint>,
 }
@@ -236,10 +232,6 @@ enum ECheckType {
     // JOINT //
     PointToPointConstraint,
     HingeConstraint,
-    /**
-     * @deprecated cone twist constraint is deprecated, please use configurable instead
-     */
-    ConeTwistConstraint,
     FixedConstraint,
     ConfigurableConstraint,
     // CHARACTER CONTROLLER //
@@ -422,7 +414,7 @@ function initColliderProxy (): void {
 
 const CREATE_CONSTRAINT_PROXY = { INITED: false };
 
-interface IEntireConstraint extends IPointToPointConstraint, IHingeConstraint, IConeTwistConstraint, IFixedConstraint, IConfigurableConstraint { }
+interface IEntireConstraint extends IPointToPointConstraint, IHingeConstraint, IFixedConstraint, IConfigurableConstraint { }
 const ENTIRE_CONSTRAINT: IEntireConstraint = {
     impl: null,
     initialize: FUNC,
@@ -486,11 +478,6 @@ function initConstraintProxy (): void {
     CREATE_CONSTRAINT_PROXY[EConstraintType.HINGE] = function createHingeConstraint (): IHingeConstraint {
         if (check(selector.wrapper.HingeConstraint, ECheckType.HingeConstraint)) { return ENTIRE_CONSTRAINT; }
         return new selector.wrapper.HingeConstraint!();
-    };
-
-    CREATE_CONSTRAINT_PROXY[EConstraintType.CONE_TWIST] = function createConeTwistConstraint (): IConeTwistConstraint {
-        if (check(selector.wrapper.ConeTwistConstraint, ECheckType.ConeTwistConstraint)) { return ENTIRE_CONSTRAINT; }
-        return new selector.wrapper.ConeTwistConstraint!();
     };
 
     CREATE_CONSTRAINT_PROXY[EConstraintType.FIXED] = function createFixedConstraint (): IFixedConstraint {

--- a/cocos/physics/spec/i-physics-constraint.ts
+++ b/cocos/physics/spec/i-physics-constraint.ts
@@ -96,8 +96,3 @@ export interface IConfigurableConstraint extends IBaseConstraint {
     setBreakForce(v: number): void;
     setBreakTorque(v: number): void;
 }
-
-/**
- * @deprecated ConeTwistConstraint is deprecated, please use ConfigurableConstraint instead
- */
-export type IConeTwistConstraint = IBaseConstraint


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/17708

### Changelog

* rm cone twist joint directly, since it's not implemented and not planned

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
