### PR TITLE
subpass output sort logic

### DIFF
--- a/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
+++ b/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
@@ -791,12 +791,15 @@ struct AttachmentSortKey {
     gfx::SampleCount samples;
     AccessType accessType;
     uint32_t attachmentWeight;
-    const ccstd::pmr::string name;
+    uint32_t slotID;
+    const ccstd::pmr::string &slotName;
+    const ccstd::pmr::string &name;
 };
 
 struct AttachmentComparator {
     bool operator()(const AttachmentSortKey &lhs, const AttachmentSortKey &rhs) const {
-        return std::tie(rhs.samples, lhs.accessType, lhs.attachmentWeight, lhs.name) < std::tie(lhs.samples, rhs.accessType, rhs.attachmentWeight, rhs.name);
+        return std::tie(rhs.samples, lhs.accessType, lhs.attachmentWeight, lhs.slotID, lhs.slotName, lhs.name) <
+               std::tie(lhs.samples, rhs.accessType, rhs.attachmentWeight, rhs.slotID, rhs.slotName, rhs.name);
     }
 };
 
@@ -956,6 +959,8 @@ auto checkRasterViews(const Graphs &graphs,
         colorMap.emplace(AttachmentSortKey{desc.sampleCount,
                                            rasterView.accessType,
                                            ATTACHMENT_TYPE_WEIGHT[static_cast<uint32_t>(rasterView.attachmentType)],
+                                           rasterView.slotID,
+                                           rasterView.slotName1.empty() ? rasterView.slotName : rasterView.slotName1,
                                            resName},
                          ViewInfo{desc.format,
                                   LayoutAccess{lastAccess, accessFlag},
@@ -1051,6 +1056,8 @@ bool checkResolveResource(const Graphs &graphs,
         colorMap.emplace(AttachmentSortKey{desc.sampleCount,
                                            AccessType::WRITE,
                                            ATTACHMENT_TYPE_WEIGHT[static_cast<uint32_t>(attachmentType)],
+                                           INVALID_ID,
+                                           "",
                                            resolveTargetName},
                          ViewInfo{desc.format,
                                   LayoutAccess{lastAccess, accessFlag},

--- a/native/cocos/renderer/pipeline/custom/NativeRenderGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeRenderGraph.cpp
@@ -296,7 +296,7 @@ void addRasterViewImpl(
     auto &pass = get(RasterPassTag{}, passID, renderGraph);
     CC_EXPECTS(subpass.subpassID < num_vertices(pass.subpassGraph));
     auto &subpassData = get(SubpassGraph::SubpassTag{}, pass.subpassGraph, subpass.subpassID);
-    const auto slotID = subpass.rasterViews.size();
+    const auto slotID = static_cast<uint32_t>(subpass.rasterViews.size());
     CC_EXPECTS(subpass.rasterViews.size() == subpassData.rasterViews.size());
     auto nameIter = subpassData.rasterViews.find(name);
 

--- a/native/cocos/renderer/pipeline/custom/NativeRenderGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeRenderGraph.cpp
@@ -296,7 +296,7 @@ void addRasterViewImpl(
     auto &pass = get(RasterPassTag{}, passID, renderGraph);
     CC_EXPECTS(subpass.subpassID < num_vertices(pass.subpassGraph));
     auto &subpassData = get(SubpassGraph::SubpassTag{}, pass.subpassGraph, subpass.subpassID);
-    const auto slotID = getSlotID(pass, name, attachmentType);
+    const auto slotID = subpass.rasterViews.size();
     CC_EXPECTS(subpass.rasterViews.size() == subpassData.rasterViews.size());
     auto nameIter = subpassData.rasterViews.find(name);
 


### PR DESCRIPTION
Re: # https://github.com/cocos/engine-extensions/pull/374

### Changelog

* correct output attachment logic, since output in shader has been fixed,  no need to distinguish pass or subpass outputs.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
