### PR TITLE
deprecate `misc.tryCatchFunctor_EDITOR`

### DIFF
--- a/cocos/core/utils/misc.ts
+++ b/cocos/core/utils/misc.ts
@@ -25,13 +25,12 @@
 
 /* eslint-disable no-new-func */
 
-import { DEV } from 'internal:constants';
+import { DEBUG, DEV } from 'internal:constants';
 import { setTimeoutRAF } from '@pal/utils';
 import { cclegacy } from '@base/global';
 import { warnID } from '@base/debug';
 import { js } from '@base/utils';
 import { macro } from '../platform/macro';
-import type { Component } from '../../scene-graph';
 
 const { getClassName, getset, isEmptyObject } = js;
 
@@ -181,8 +180,13 @@ export function callInNextTick (callback, p1?: any, p2?: any): void {
  * @zh 被 try catch 包裹的函数名。
  * @returns @en A new function that will invoke `functionName` with try catch.
  * @zh 使用 try catch 机制调用 `functionName` 的新函数.
+ *
+ * @deprecated `misc.tryCatchFunctor_EDITOR` is deprecated since v3.9.0.
  */
-export function tryCatchFunctor_EDITOR (funcName: string): (comp: Component) => void {
+export function tryCatchFunctor_EDITOR (funcName: string): (comp: unknown) => void {
+    if (DEBUG) {
+        warnID(16000, 'misc.tryCatchFunctor_EDITOR', '3.9.0');
+    }
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     return Function(
         'target',
@@ -192,7 +196,7 @@ export function tryCatchFunctor_EDITOR (funcName: string): (comp: Component) => 
         + `catch (e) {\n`
         + `  cc._throw(e);\n`
         + `}`,
-    ) as (comp: Component) => void;
+    ) as (comp: unknown) => void;
 }
 
 /**

--- a/cocos/scene-graph/component-scheduler.ts
+++ b/cocos/scene-graph/component-scheduler.ts
@@ -237,7 +237,9 @@ export function createInvokeImplJit (code: string, useDt?, ensureFlag?): (iterat
                 + 'var c=a[it.i];'}${
         code
     }}`;
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
     const fastPath = useDt ? Function('it', 'dt', body) : Function('it', body);
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
     const singleInvoke = Function('c', 'dt', code);
     return createInvokeImpl(singleInvoke, fastPath, ensureFlag);
 }
@@ -361,7 +363,7 @@ export class ComponentScheduler {
      */
     public lateUpdateInvoker!: ReusableInvoker;
     // components deferred to schedule
-    private _deferredComps: any[] = [];
+    private _deferredComps: Component[] = [];
     private _updating!: boolean;
 
     constructor () {

--- a/cocos/scene-graph/component-scheduler.ts
+++ b/cocos/scene-graph/component-scheduler.ts
@@ -27,7 +27,7 @@ import { cclegacy } from '@base/global';
 import { error, assert } from '@base/debug';
 import { js } from '@base/utils';
 import { CCObject } from '../core/data/object';
-import { tryCatchFunctor_EDITOR } from '../core/utils/misc';
+import { tryCatchFunctor_EDITOR } from './utils';
 import type { Component } from './component';
 
 const fastRemoveAt = js.array.fastRemoveAt;

--- a/cocos/scene-graph/node-activator.ts
+++ b/cocos/scene-graph/node-activator.ts
@@ -28,7 +28,7 @@ import { assert, errorID, getError, log } from '@base/debug';
 import { assertIsTrue } from '@base/debug/internal';
 import { js } from '@base/utils';
 import { CCObject, isValid } from '../core/data/object';
-import { tryCatchFunctor_EDITOR } from '../core/utils/misc';
+import { tryCatchFunctor_EDITOR } from './utils';
 import { invokeOnEnable, createInvokeImpl, createInvokeImplJit, OneOffInvoker, LifeCycleInvoker } from './component-scheduler';
 import { NodeEventType } from './node-event';
 import type { Component } from './component';

--- a/cocos/scene-graph/utils.ts
+++ b/cocos/scene-graph/utils.ts
@@ -1,6 +1,5 @@
 /*
- Copyright (c) 2013-2016 Chukong Technologies Inc.
- Copyright (c) 2017-2023 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
 
  http://www.cocos.com
 

--- a/cocos/scene-graph/utils.ts
+++ b/cocos/scene-graph/utils.ts
@@ -1,0 +1,48 @@
+/*
+ Copyright (c) 2013-2016 Chukong Technologies Inc.
+ Copyright (c) 2017-2023 Xiamen Yaji Software Co., Ltd.
+
+ http://www.cocos.com
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+
+import type { Component } from './component';
+
+/**
+ * @en Create a new function that will invoke `functionName` with try catch.
+ * @zh 创建一个新函数，该函数会使用 try catch 机制调用 `functionName`.
+ * @param funcName @en The function name to be invoked with try catch.
+ * @zh 被 try catch 包裹的函数名。
+ * @returns @en A new function that will invoke `functionName` with try catch.
+ * @zh 使用 try catch 机制调用 `functionName` 的新函数.
+ */
+export function tryCatchFunctor_EDITOR (funcName: string): (comp: Component) => void {
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    return Function(
+        'target',
+        `${'try {\n'
+        + '  target.'}${funcName}();\n`
+        + `}\n`
+        + `catch (e) {\n`
+        + `  cc._throw(e);\n`
+        + `}`,
+    ) as (comp: Component) => void;
+}

--- a/cocos/scene-graph/utils.ts
+++ b/cocos/scene-graph/utils.ts
@@ -22,7 +22,6 @@
  THE SOFTWARE.
 */
 
-
 import type { Component } from './component';
 
 /**
@@ -34,7 +33,7 @@ import type { Component } from './component';
  * @zh 使用 try catch 机制调用 `functionName` 的新函数.
  */
 export function tryCatchFunctor_EDITOR (funcName: string): (comp: Component) => void {
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
     return Function(
         'target',
         `${'try {\n'


### PR DESCRIPTION
Re: 
https://github.com/cocos/cocos-engine/issues/14293
https://github.com/cocos/cocos-engine/issues/12647
https://github.com/cocos/3d-tasks/issues/17767

### Changelog

* deprecate `misc.tryCatchFunctor_EDITOR`
* this interface introduces the dependency from `misc` to `scene-graph`, which is incorrect
* `tryCatchFunctor_EDITOR` should be engine internal in `scene-graph` module

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
