### PR TITLE
deprecate `misc.isPlainEmptyObj_DEV`, use `js.isEmptyObject` instead

### DIFF
--- a/cocos/base/utils/src/internal-index.ts
+++ b/cocos/base/utils/src/internal-index.ts
@@ -1,1 +1,10 @@
+import { js } from './js';
+
 export { ScalableContainer, scalableContainerManager } from './memop/scalable-container';
+
+export function isPlainEmptyObj (obj): boolean {
+    if (!obj || obj.constructor !== Object) {
+        return false;
+    }
+    return js.isEmptyObject(obj);
+}

--- a/cocos/core/data/utils/attribute.ts
+++ b/cocos/core/data/utils/attribute.ts
@@ -27,7 +27,7 @@ import { EDITOR } from 'internal:constants';
 import { log, warnID } from '@base/debug';
 import { cclegacy } from '@base/global';
 import { js } from '@base/utils';
-import { isPlainEmptyObj_DEV } from '../../utils/misc';
+import { isPlainEmptyObj } from '@base/utils/internal';
 
 const { formatStr, get, getClassName, isChildClassOf, value } = js;
 
@@ -228,7 +228,7 @@ export function getTypeChecker_ET (type: string, attributeName: string) {
         if (typeof defaultVal === 'undefined') {
             return;
         }
-        const isContainer = Array.isArray(defaultVal) || isPlainEmptyObj_DEV(defaultVal);
+        const isContainer = Array.isArray(defaultVal) || isPlainEmptyObj(defaultVal);
         if (isContainer) {
             return;
         }

--- a/cocos/core/utils/misc.ts
+++ b/cocos/core/utils/misc.ts
@@ -207,11 +207,11 @@ export function tryCatchFunctor_EDITOR (funcName: string): (comp: unknown) => vo
  * @returns @en True if it is an empty object. False if it is not an empty object, not Object type, null or undefined.
  * @ 如果是空对象，返回 true。如果不是空对象，不是Object类型，空或未定义，则为假。
  *
- * @deprecated `misc.isPlainEmptyObj_DEV` is deprecated since v3.9.0.
+ * @deprecated `misc.isPlainEmptyObj_DEV` is deprecated since v3.9.0, please use `js.isEmptyObject` instead.
  */
 export function isPlainEmptyObj_DEV (obj): boolean {
     if (DEBUG) {
-        warnID(16000, 'misc.isPlainEmptyObj_DEV', '3.9.0');
+        warnID(16001, 'misc.isPlainEmptyObj_DEV', '3.9.0', 'js.isEmptyObject');
     }
     return isPlainEmptyObj(obj);
 }

--- a/cocos/core/utils/misc.ts
+++ b/cocos/core/utils/misc.ts
@@ -30,6 +30,7 @@ import { setTimeoutRAF } from '@pal/utils';
 import { cclegacy } from '@base/global';
 import { warnID } from '@base/debug';
 import { js } from '@base/utils';
+import { isPlainEmptyObj } from '@base/utils/internal';
 import { macro } from '../platform/macro';
 
 const { getClassName, getset, isEmptyObject } = js;
@@ -205,12 +206,14 @@ export function tryCatchFunctor_EDITOR (funcName: string): (comp: unknown) => vo
  * @param obj @en The object to check. @zh 要检查的对象。
  * @returns @en True if it is an empty object. False if it is not an empty object, not Object type, null or undefined.
  * @ 如果是空对象，返回 true。如果不是空对象，不是Object类型，空或未定义，则为假。
+ *
+ * @deprecated `misc.isPlainEmptyObj_DEV` is deprecated since v3.9.0.
  */
 export function isPlainEmptyObj_DEV (obj): boolean {
-    if (!obj || obj.constructor !== Object) {
-        return false;
+    if (DEBUG) {
+        warnID(16000, 'misc.isPlainEmptyObj_DEV', '3.9.0');
     }
-    return isEmptyObject(obj);
+    return isPlainEmptyObj(obj);
 }
 
 /**


### PR DESCRIPTION
Re: 
https://github.com/cocos/cocos-engine/issues/14293
https://github.com/cocos/cocos-engine/issues/12647
https://github.com/cocos/3d-tasks/issues/17767

### Changelog

* deprecate `isPlainEmptyObj_DEV`, migrate as an internal interface
* remove dep from `attribute.ts` to `misc.ts`

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
