### PR TITLE
Turning off textinput when using SDL

### DIFF
--- a/native/cocos/platform/SDLHelper.cpp
+++ b/native/cocos/platform/SDLHelper.cpp
@@ -158,6 +158,12 @@ int SDLHelper::init() {
         CC_LOG_ERROR("SDL could not initialize! SDL_Error: %s\n", SDL_GetError());
         return -1;
     }
+    // (1) Disable IDE on windows platform.
+    // (2) On mac platform, SDL has an internal implementation of textinput ,
+    // which internally sends the SDL_TEXTINPUT event. Causing two events to be sent.
+    // So we need to stop the implementation of TextInput.
+	// (3) Other platforms do not use textinput in sdl.
+    stopTextInput();
     return 0;
 }
 

--- a/native/cocos/ui/edit-box/EditBox-mac.mm
+++ b/native/cocos/ui/edit-box/EditBox-mac.mm
@@ -242,10 +242,6 @@ void initTextField(const cc::EditBox::ShowInfo &showInfo) {
 }
 
 void init(const cc::EditBox::ShowInfo &showInfo) {
-    // SDL has an internal implementation of textinput ,
-    // which internally sends the SDL_TEXTINPUT event. Causing two events to be sent.
-    // So we need to stop the implementation of TextInput.
-    cc::SDLHelper::stopTextInput();
     if (showInfo.isMultiline)
         initTextView(showInfo);
     else


### PR DESCRIPTION
Re: #

### Changelog

https://github.com/cocos/3d-tasks/issues/17471#issuecomment-1736835755

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
