### PR TITLE
+ fix mask display bug when mask has opacity = 0

### DIFF
--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -840,7 +840,8 @@ export class Batcher2D implements IBatcher {
         // ATTENTION: Will also reset colorDirty inside postUpdateAssembler
         if (render && render.enabledInHierarchy) {
             render.postUpdateAssembler(this);
-            if ((render.stencilStage === Stage.ENTER_LEVEL || render.stencilStage === Stage.ENTER_LEVEL_INVERTED)
+            if (!approx(opacity, 0, EPSILON) 
+            && (render.stencilStage === Stage.ENTER_LEVEL || render.stencilStage === Stage.ENTER_LEVEL_INVERTED)
             && (StencilManager.sharedManager!.getMaskStackSize() > 0)) {
                 this.autoMergeBatches(this._currComponent!);
                 this.resetRenderStates();

--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -840,7 +840,7 @@ export class Batcher2D implements IBatcher {
         // ATTENTION: Will also reset colorDirty inside postUpdateAssembler
         if (render && render.enabledInHierarchy) {
             render.postUpdateAssembler(this);
-            if (!approx(opacity, 0, EPSILON) 
+            if (!approx(opacity, 0, EPSILON)
             && (render.stencilStage === Stage.ENTER_LEVEL || render.stencilStage === Stage.ENTER_LEVEL_INVERTED)
             && (StencilManager.sharedManager!.getMaskStackSize() > 0)) {
                 this.autoMergeBatches(this._currComponent!);

--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -148,7 +148,7 @@ void Batcher2d::walk(Node* node, float parentOpacity) { // NOLINT(misc-no-recurs
     }
 
     // post assembler
-    if (_stencilManager->getMaskStackSize() > 0 && entity && entity->isEnabled()) {
+    if (_stencilManager->getMaskStackSize() > 0 && entity && entity->isEnabled() && !breakWalk) {
         handlePostRender(entity);
     }
 }


### PR DESCRIPTION
Re: #

Problem: When mask have opacity = 0, it skip the pushMask, but handlePostRender still call exitMask, which create a display problem
Solution: Add a check for opacity before handlePostRender

### Changelog

* 

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
