### PR TITLE
Fix rollup visualizer plugin not working in build-engine and add publish-build-engine.yml ci action.

### DIFF
--- a/.github/workflows/publish-build-engine.yml
+++ b/.github/workflows/publish-build-engine.yml
@@ -1,0 +1,25 @@
+name: Publish build-engine module to NPM
+
+on: workflow_dispatch
+
+jobs:
+  publish_to_npm:
+    name: "Publish build-engine to NPM"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.17.0'
+
+      - run: |
+        cd scripts/build-engine
+        npm ci
+        npm run build
+        npm run test
+
+      - uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+          registry: "https://registry.npmjs.org"
+          package: scripts/build-engine

--- a/.github/workflows/run-build-engine.yml
+++ b/.github/workflows/run-build-engine.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run_build_engine:
-    name: "Run build-engine to NPM"
+    name: "Run build-engine"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-build-engine.yml
+++ b/.github/workflows/run-build-engine.yml
@@ -1,10 +1,15 @@
-name: Publish build-engine module to NPM
+name: Run build-engine
 
-on: workflow_dispatch
+on: 
+  pull_request:
+    paths:
+    - 'scripts/build-engine/**'
+    - '.github/workflows/run-build-engine.yml'
+  workflow_dispatch:
 
 jobs:
-  publish_to_npm:
-    name: "Publish build-engine to NPM"
+  run_build_engine:
+    name: "Run build-engine to NPM"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,6 +24,7 @@ jobs:
         npm run test
 
       - uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
+        if: github.event_name == 'workflow_dispatch'
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           registry: "https://registry.npmjs.org"

--- a/.github/workflows/run-build-engine.yml
+++ b/.github/workflows/run-build-engine.yml
@@ -17,11 +17,12 @@ jobs:
         with:
           node-version: '18.17.0'
 
-      - run: |
-        cd scripts/build-engine
-        npm ci
-        npm run build
-        npm run test
+      - name: Run build-engine
+        run: |
+          cd scripts/build-engine
+          npm ci
+          npm run build
+          npm run test
 
       - uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         if: github.event_name == 'workflow_dispatch'

--- a/scripts/build-engine/package-lock.json
+++ b/scripts/build-engine/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.4.1",
+  "version": "4.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cocos/build-engine",
-      "version": "4.4.1",
+      "version": "4.4.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.13.10",
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-for-of": "^7.9.0",
         "@babel/preset-env": "^7.8.7",
         "@cocos/babel-plugin-dynamic-import-vars": "^1.0.2",
-        "@cocos/creator-programming-babel-preset-cc": "1.0.1-alpha.2",
+        "@cocos/creator-programming-babel-preset-cc": "1.0.1-alpha.5",
         "@rollup/plugin-babel": "^5.2.2",
         "@rollup/plugin-commonjs": "^11.0.2",
         "@rollup/plugin-json": "^4.0.2",
@@ -49,10 +49,7 @@
         "ts-json-schema-generator": "~1.0.0"
       },
       "optionalDependencies": {
-        "rollup-plugin-visualizer": "^4.2.0"
-      },
-      "peerDependencies": {
-        "typescript": "^3.7.2"
+        "rollup-plugin-visualizer": "^5.9.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -527,11 +524,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz",
-      "integrity": "sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.18.9.tgz",
+      "integrity": "sha512-128YbMpjCrP35IOExw2Fq+x55LMP42DzhOhX2aNNIdI9avSWl2PI0yuBWarr3RYpZBSPtabfadkH2yeRiMD61Q==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.18.9",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       },
       "engines": {
@@ -557,12 +555,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz",
-      "integrity": "sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.18.9.tgz",
+      "integrity": "sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.18.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.18.9",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       },
       "engines": {
@@ -632,11 +631,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.22.10.tgz",
-      "integrity": "sha512-z1KTVemBjnz+kSEilAsI4lbkPOl5TvJH7YDSY1CTIzvLWJ+KHXp+mRe8VPmfnyvqOPqar1V2gid2PleKzRUstQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.19.0.tgz",
+      "integrity": "sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1506,14 +1505,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.11.tgz",
-      "integrity": "sha512-0E4/L+7gfvHub7wsbTv03oRtD69X31LByy44fGmFzbZScpupFByMcgCJ0VbBTkzyjSJKuRoGN8tcijOWKTmqOA==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.6.tgz",
+      "integrity": "sha512-XlTdBq7Awr4FYIzqhmYY80WN0V0azF74DMPyFqVHBvf81ZUgc4X7ZOpx6O8eLDK6iM5cCQzeyJw0ynTaefixRA==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.22.11",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-syntax-typescript": "^7.22.5"
+        "@babel/helper-create-class-features-plugin": "^7.14.6",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1775,27 +1773,139 @@
       }
     },
     "node_modules/@cocos/creator-programming-babel-preset-cc": {
-      "version": "1.0.1-alpha.2",
-      "resolved": "https://registry.npmjs.org/@cocos/creator-programming-babel-preset-cc/-/creator-programming-babel-preset-cc-1.0.1-alpha.2.tgz",
-      "integrity": "sha512-zZ9oP+YvuzQXaCeeWgcbcrdTcwtTn6TjmB6VUBsqFc4ZRQFcYz3wU6dlYDkc/v93iaQl638qOKCW4/dTCzUVRQ==",
+      "version": "1.0.1-alpha.5",
+      "resolved": "https://registry.npmjs.org/@cocos/creator-programming-babel-preset-cc/-/creator-programming-babel-preset-cc-1.0.1-alpha.5.tgz",
+      "integrity": "sha512-XSS5N3/8w1u3WD5qolRmhdYpLfo9nbiqNl1nMNO/PybXhIArn9e1cGOcg51tkLTwCxdonxHsOIJEzGY8Vj+CJw==",
       "dependencies": {
-        "@babel/core": "^7.19.6",
+        "@babel/core": "7.19.6",
+        "@babel/generator": "7.20.1",
+        "@babel/helper-module-imports": "7.18.6",
+        "@babel/helper-plugin-utils": "7.14.5",
+        "@babel/plugin-proposal-class-properties": "7.18.6",
+        "@babel/plugin-proposal-logical-assignment-operators": "7.18.9",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "7.18.6",
+        "@babel/plugin-proposal-optional-chaining": "7.18.9",
+        "@babel/plugin-syntax-decorators": "7.19.0",
+        "@babel/plugin-transform-typescript": "7.14.6",
+        "@babel/template": "7.18.10",
+        "@babel/traverse": "7.20.1",
+        "@babel/types": "7.20.0",
+        "babel-plugin-const-enum": "1.1.0"
+      }
+    },
+    "node_modules/@cocos/creator-programming-babel-preset-cc/node_modules/@babel/core": {
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
+      "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+      "dependencies": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.19.6",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-proposal-class-properties": "^7.18.6",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
-        "@babel/plugin-proposal-optional-chaining": "^7.18.9",
-        "@babel/plugin-syntax-decorators": "^7.19.0",
-        "@babel/plugin-transform-typescript": "^7.9.4",
+        "@babel/helper-compilation-targets": "^7.19.3",
+        "@babel/helper-module-transforms": "^7.19.6",
+        "@babel/helpers": "^7.19.4",
+        "@babel/parser": "^7.19.6",
         "@babel/template": "^7.18.10",
         "@babel/traverse": "^7.19.6",
         "@babel/types": "^7.19.4",
-        "babel-plugin-const-enum": "^1.0.1"
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
       },
-      "peerDependencies": {
-        "@babel/core": "^7.9.0"
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@cocos/creator-programming-babel-preset-cc/node_modules/@babel/generator": {
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.1.tgz",
+      "integrity": "sha512-u1dMdBUmA7Z0rBB97xh8pIhviK7oItYOkjbsCxTWMknyvbQRBwX7/gn4JXurRdirWMFh+ZtYARqkA6ydogVZpg==",
+      "dependencies": {
+        "@babel/types": "^7.20.0",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cocos/creator-programming-babel-preset-cc/node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cocos/creator-programming-babel-preset-cc/node_modules/@babel/helper-plugin-utils": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cocos/creator-programming-babel-preset-cc/node_modules/@babel/template": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
+      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.10",
+        "@babel/types": "^7.18.10"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cocos/creator-programming-babel-preset-cc/node_modules/@babel/traverse": {
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.1",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.20.1",
+        "@babel/types": "^7.20.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cocos/creator-programming-babel-preset-cc/node_modules/@babel/types": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
+      "integrity": "sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cocos/creator-programming-babel-preset-cc/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -3093,13 +3203,13 @@
       }
     },
     "node_modules/babel-plugin-const-enum": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-const-enum/-/babel-plugin-const-enum-1.2.0.tgz",
-      "integrity": "sha512-o1m/6iyyFnp9MRsK1dHF3bneqyf3AlM2q3A/YbgQr2pCat6B6XJVDv2TXqzfY2RYUi4mak6WAksSBPlyYGx9dg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-const-enum/-/babel-plugin-const-enum-1.1.0.tgz",
+      "integrity": "sha512-HcqyEOv8IUXY/pEe/4b/6yW2SfilxlII+2Ok4l5vkE8UrN4gFgGqhhSPFbVuX0dIyG8TSHvt+7qccOI1kjynUw==",
       "dependencies": {
+        "@babel/generator": "^7.5.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-typescript": "^7.3.3",
-        "@babel/traverse": "^7.16.0"
+        "@babel/plugin-syntax-typescript": "^7.3.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -3512,6 +3622,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -5958,24 +6077,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "optional": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6038,16 +6139,17 @@
       }
     },
     "node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "optional": true,
       "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6484,24 +6586,29 @@
       }
     },
     "node_modules/rollup-plugin-visualizer": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-4.2.2.tgz",
-      "integrity": "sha512-10/TsugsaQL5rdynl0lrklBngTtkRBESZdxUJy+3fN+xKqNdg5cr7JQU1OoPx4p5mhQ+nspa6EvX3qc8SsBvnA==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.9.2.tgz",
+      "integrity": "sha512-waHktD5mlWrYFrhOLbti4YgQCn1uR24nYsNuXxg7LkPH8KdTXVWR9DNY1WU0QqokyMixVXJS4J04HNrVTMP01A==",
       "optional": true,
       "dependencies": {
-        "nanoid": "^3.1.22",
-        "open": "^7.4.2",
-        "source-map": "^0.7.3",
-        "yargs": "^16.2.0"
+        "open": "^8.4.0",
+        "picomatch": "^2.3.1",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
       },
       "bin": {
-        "rollup-plugin-visualizer": "bin/cli.js"
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "rollup": ">=1.20.0"
+        "rollup": "2.x || 3.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/ansi-styles": {
@@ -6520,14 +6627,17 @@
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/color-convert": {
@@ -6584,30 +6694,21 @@
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "optional": true,
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/rollup/node_modules/fsevents": {
@@ -7516,7 +7617,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       }

--- a/scripts/build-engine/package.json
+++ b/scripts/build-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/build-engine",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "",
   "repository": {
     "type": "git",
@@ -52,9 +52,6 @@
     "ts-jest": "^28.0.4",
     "ts-json-schema-generator": "~1.0.0"
   },
-  "peerDependencies": {
-    "typescript": "^3.7.2"
-  },
   "scripts": {
     "build": "npx tsc",
     "clear": "node ./scripts/clear.mjs",
@@ -65,6 +62,6 @@
   "author": "",
   "license": "MIT",
   "optionalDependencies": {
-    "rollup-plugin-visualizer": "^4.2.0"
+    "rollup-plugin-visualizer": "^5.9.2"
   }
 }

--- a/scripts/build-engine/src/index.ts
+++ b/scripts/build-engine/src/index.ts
@@ -539,14 +539,13 @@ async function doBuild({
     if (visualizeOptions) {
         let rpVisualizer;
         try {
-            // @ts-expect-error: No typing
             rpVisualizer = await import('rollup-plugin-visualizer');
         } catch {
             console.warn('Visualizing needs \'rollup-plugin-visualizer\' to be installed. It\'s installed as dev-dependency.');
         }
         if (rpVisualizer) {
             const visualizeFile = visualizeOptions.file ?? ps.join(options.out, 'visualize.html');
-            rollupPlugins.push(rpVisualizer({
+            rollupPlugins.push(rpVisualizer.default({
                 filename: visualizeFile,
                 title: 'Cocos Creator build visualizer',
                 template: 'treemap',


### PR DESCRIPTION
Re: #14801

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
