### PR TITLE
fix skeleton's setTrackXXXListener doesn't work on web platform

### DIFF
--- a/cocos/spine/lib/spine-core.d.ts
+++ b/cocos/spine/lib/spine-core.d.ts
@@ -1189,6 +1189,7 @@ declare namespace spine {
         isCache: boolean;
         isDelete: boolean;
         enable: boolean;
+        setTrackListener: any;
         initSkeleton(data: SkeletonData);
         getAnimationState();
         setAnimation(trackIndex: number, name: string, loop: boolean): spine.TrackEntry | null;

--- a/cocos/spine/lib/spine-core.d.ts
+++ b/cocos/spine/lib/spine-core.d.ts
@@ -1189,7 +1189,7 @@ declare namespace spine {
         isCache: boolean;
         isDelete: boolean;
         enable: boolean;
-        setTrackListener: any;
+        setTrackEntryListener: any;
         initSkeleton(data: SkeletonData);
         getAnimationState();
         setAnimation(trackIndex: number, name: string, loop: boolean): spine.TrackEntry | null;

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -1744,7 +1744,7 @@ export class Skeleton extends UIRenderer {
      * @param listener @en Listener for registering callback functions. @zh 监听器对象，可注册回调方法。
      */
     public setTrackStartListener (entry: spine.TrackEntry, listener: TrackListener): void {
-        TrackEntryListeners.getListeners(entry).start = listener;
+        TrackEntryListeners.getListeners(entry, this._instance).start = listener;
     }
 
     /**
@@ -1754,7 +1754,7 @@ export class Skeleton extends UIRenderer {
      * @param listener @en Listener for registering callback functions. @zh 监听器对象，可注册回调方法。
      */
     public setTrackInterruptListener (entry: spine.TrackEntry, listener: TrackListener): void {
-        TrackEntryListeners.getListeners(entry).interrupt = listener;
+        TrackEntryListeners.getListeners(entry, this._instance).interrupt = listener;
     }
 
     /**
@@ -1764,7 +1764,7 @@ export class Skeleton extends UIRenderer {
      * @param listener @en Listener for registering callback functions. @zh 监听器对象，可注册回调方法。
      */
     public setTrackEndListener (entry: spine.TrackEntry, listener: TrackListener): void {
-        TrackEntryListeners.getListeners(entry).end = listener;
+        TrackEntryListeners.getListeners(entry, this._instance).end = listener;
     }
 
     /**
@@ -1774,7 +1774,7 @@ export class Skeleton extends UIRenderer {
      * @param listener @en Listener for registering callback functions. @zh 监听器对象，可注册回调方法。
      */
     public setTrackDisposeListener (entry: spine.TrackEntry, listener: TrackListener): void {
-        TrackEntryListeners.getListeners(entry).dispose = listener;
+        TrackEntryListeners.getListeners(entry, this._instance).dispose = listener;
     }
 
     /**
@@ -1788,10 +1788,10 @@ export class Skeleton extends UIRenderer {
             const loopCount = Math.floor(trackEntry.trackTime / trackEntry.animationEnd);
             const listenerID = TrackEntryListeners.addListener(listener);
             listener(trackEntry, loopCount);
-            this._instance.setListener(listenerID, spine.EventType.event);
-            this._listener!.event = listener;
+            // this._instance.setListener(listenerID, spine.EventType.event);
+            // this._listener!.event = listener;
         };
-        TrackEntryListeners.getListeners(entry).complete = onComplete;
+        TrackEntryListeners.getListeners(entry, this._instance).complete = onComplete;
     }
 
     /**
@@ -1801,7 +1801,7 @@ export class Skeleton extends UIRenderer {
      * @param listener @en Listener for registering callback functions. @zh 监听器对象，可注册回调方法。
      */
     public setTrackEventListener (entry: spine.TrackEntry, listener: TrackListener|TrackListener2): void {
-        TrackEntryListeners.getListeners(entry).event = listener;
+        TrackEntryListeners.getListeners(entry, this._instance).event = listener;
     }
 
     /**

--- a/cocos/spine/track-entry-listeners.ts
+++ b/cocos/spine/track-entry-listeners.ts
@@ -23,6 +23,7 @@
 */
 
 import spine from './lib/spine-core.js';
+import { warn } from '../core';
 
 let _listener_ID = 0;
 let _track_ID = 0;
@@ -43,7 +44,7 @@ export class TrackEntryListeners {
         if (!entry.listener) {
             entry.listener = new TrackEntryListeners() as any;
             const id = ++_track_ID;
-            instance.setTrackListener(id, entry);
+            instance.setTrackEntryListener(id, entry);
             TrackEntryListeners._trackSet.set(id, entry);
         }
         return entry.listener;
@@ -58,11 +59,10 @@ export class TrackEntryListeners {
         }
     }
 
-    static emitTrackListener (id: number, entry: spine.TrackEntry, event: spine.Event, eventType: spine.EventType): void {
+    static emitTrackEntryListener (id: number, entry: spine.TrackEntry, event: spine.Event, eventType: spine.EventType): void {
         const curTrack = this._trackSet.get(id);
         if (!curTrack) return;
-        // eslint-disable-next-line default-case
-        switch (eventType as number) {
+        switch (eventType) {
         case spine.EventType.start:
             if (curTrack.listener.start) {
                 curTrack.listener.start(entry);
@@ -83,6 +83,7 @@ export class TrackEntryListeners {
                 curTrack.listener.dispose(entry);
             }
             this._trackSet.delete(id);
+            curTrack.listener = null as any;
             break;
         case spine.EventType.complete:
             if (curTrack.listener.complete) {
@@ -93,6 +94,9 @@ export class TrackEntryListeners {
             if (curTrack.listener.event) {
                 curTrack.listener.event(entry, event);
             }
+            break;
+        default:
+            warn('TrackEntry doesn\'t handled', eventType);
             break;
         }
     }

--- a/cocos/spine/track-entry-listeners.ts
+++ b/cocos/spine/track-entry-listeners.ts
@@ -25,6 +25,7 @@
 import spine from './lib/spine-core.js';
 
 let _listener_ID = 0;
+let _track_ID = 0;
 
 type TrackListener = (x: spine.TrackEntry) => void;
 type TrackListener2 = (x: spine.TrackEntry, ev: spine.Event) => void;
@@ -38,9 +39,12 @@ export class TrackEntryListeners {
     complete?: ((entry: spine.TrackEntry) => void);
     event?: ((entry: spine.TrackEntry, event: spine.Event) => void);
 
-    static getListeners (entry: spine.TrackEntry): spine.AnimationStateListener {
+    static getListeners (entry: spine.TrackEntry, instance: spine.SkeletonInstance): spine.AnimationStateListener {
         if (!entry.listener) {
             entry.listener = new TrackEntryListeners() as any;
+            const id = ++_track_ID;
+            instance.setTrackListener(id, entry);
+            TrackEntryListeners._trackSet.set(id, entry);
         }
         return entry.listener;
     }
@@ -54,6 +58,45 @@ export class TrackEntryListeners {
         }
     }
 
+    static emitTrackListener (id: number, entry: spine.TrackEntry, event: spine.Event, eventType: spine.EventType): void {
+        const curTrack = this._trackSet.get(id);
+        if (!curTrack) return;
+        // eslint-disable-next-line default-case
+        switch (eventType as number) {
+        case spine.EventType.start:
+            if (curTrack.listener.start) {
+                curTrack.listener.start(entry);
+            }
+            break;
+        case spine.EventType.interrupt:
+            if (curTrack.listener.interrupt) {
+                curTrack.listener.interrupt(entry);
+            }
+            break;
+        case spine.EventType.end:
+            if (curTrack.listener.end) {
+                curTrack.listener.end(entry);
+            }
+            break;
+        case spine.EventType.dispose:
+            if (curTrack.listener.dispose) {
+                curTrack.listener.dispose(entry);
+            }
+            this._trackSet.delete(id);
+            break;
+        case spine.EventType.complete:
+            if (curTrack.listener.complete) {
+                curTrack.listener.complete(entry);
+            }
+            break;
+        case spine.EventType.event:
+            if (curTrack.listener.event) {
+                curTrack.listener.event(entry, event);
+            }
+            break;
+        }
+    }
+
     static addListener (listener: CommonTrackEntryListener): number {
         const id = ++_listener_ID;
         TrackEntryListeners._listenerSet.set(id, listener);
@@ -61,6 +104,7 @@ export class TrackEntryListeners {
     }
 
     private static _listenerSet = new Map<number, CommonTrackEntryListener>();
+    private static _trackSet = new Map<number, spine.TrackEntry>();
 }
 
 globalThis.TrackEntryListeners = TrackEntryListeners;

--- a/native/cocos/editor-support/spine-wasm/library_spine.js
+++ b/native/cocos/editor-support/spine-wasm/library_spine.js
@@ -5,5 +5,14 @@ mergeInto(LibraryManager.library, {
         var trackEntry = wasmUtil.getCurrentTrackEntry();
         var event = wasmUtil.getCurrentEvent();
         globalThis.TrackEntryListeners.emitListener(listenerID, trackEntry, event);
+    },
+
+    spineTrackListenerCallback: function() {
+        var wasmUtil = Module['SpineWasmUtil'];
+        var listenerID = wasmUtil.getCurrentListenerID();
+        var eventType = wasmUtil.getCurrentEventType();
+        var trackEntry = wasmUtil.getCurrentTrackEntry();
+        var event = wasmUtil.getCurrentEvent();
+        globalThis.TrackEntryListeners.emitTrackListener(listenerID, trackEntry, event, eventType.value);
     }
 });

--- a/native/cocos/editor-support/spine-wasm/library_spine.js
+++ b/native/cocos/editor-support/spine-wasm/library_spine.js
@@ -13,6 +13,6 @@ mergeInto(LibraryManager.library, {
         var eventType = wasmUtil.getCurrentEventType();
         var trackEntry = wasmUtil.getCurrentTrackEntry();
         var event = wasmUtil.getCurrentEvent();
-        globalThis.TrackEntryListeners.emitTrackListener(listenerID, trackEntry, event, eventType.value);
+        globalThis.TrackEntryListeners.emitTrackEntryListener(listenerID, trackEntry, event, eventType.value);
     }
 });

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -433,9 +433,9 @@ void SpineSkeletonInstance::setListener(uint32_t listenerID, uint32_t type) {
     }
 }
 
-void SpineSkeletonInstance::setTrackListener(uint32_t trackId, TrackEntry *entry) {
+void SpineSkeletonInstance::setTrackEntryListener(uint32_t trackId, TrackEntry *entry) {
     if (!entry->getRendererObject()) {
-        _trackListenerID = trackId;
+        _trackEntryListenerID = trackId;
         entry->setRendererObject(this);
         entry->setListener(trackEntryCallback);
     }
@@ -451,7 +451,7 @@ void SpineSkeletonInstance::setDebugMode(bool debug) {
 
 void SpineSkeletonInstance::onTrackEntryEvent(TrackEntry *entry, EventType type, Event *event) {
     if (!entry->getRendererObject()) return;
-    SpineWasmUtil::s_listenerID = _trackListenerID;
+    SpineWasmUtil::s_listenerID = _trackEntryListenerID;
     SpineWasmUtil::s_currentType = type;
     SpineWasmUtil::s_currentEntry = entry;
     SpineWasmUtil::s_currentEvent = event;

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -20,11 +20,14 @@ static void animationCallback(AnimationState *state, EventType type, TrackEntry 
     instance->onAnimationStateEvent(entry, type, event);
 }
 
-void trackEntryCallback(AnimationState *state, EventType type, TrackEntry *entry, Event *event) {
-    (static_cast<SpineSkeletonInstance *>(state->getRendererObject()))->onTrackEntryEvent(entry, type, event);
-    if (type == EventType_Dispose) {
-        if (entry->getRendererObject()) {
-            entry->setRendererObject(nullptr);
+static void trackEntryCallback(AnimationState *state, EventType type, TrackEntry *entry, Event *event) {
+    void* renderObj = state->getRendererObject();
+    if (renderObj) {
+        (static_cast<SpineSkeletonInstance *>(renderObj))->onTrackEntryEvent(entry, type, event);
+        if (type == EventType_Dispose) {
+            if (entry->getRendererObject()) {
+                entry->setRendererObject(nullptr);
+            }
         }
     }
 }

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
@@ -52,7 +52,7 @@ public:
     AnimationState *getAnimationState();
     void setMix(const std::string &from, const std::string &to, float duration);
     void setListener(uint32_t listenerID, uint32_t type);
-    void setTrackListener(uint32_t trackId, TrackEntry *entry);
+    void setTrackEntryListener(uint32_t trackId, TrackEntry *entry);
     void onAnimationStateEvent(TrackEntry *entry, EventType type, Event *event);
     void onTrackEntryEvent(TrackEntry *entry, EventType type, Event *event);
     std::vector<SpineDebugShape> &getDebugShapes();
@@ -79,7 +79,7 @@ private:
     uint32_t _disposeListenerID = 0;
     uint32_t _completeListenerID = 0;
     uint32_t _eventListenerID = 0;
-    uint32_t _trackListenerID = 0;
+    uint32_t _trackEntryListenerID = 0;
     UserData _userData;
     std::vector<SpineDebugShape> _debugShapes{};
     std::map<Slot *, uint32_t> slotTextureSet{};

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
@@ -9,12 +9,6 @@
 #include "spine-model.h"
 using namespace spine;
 
-typedef std::function<void(TrackEntry *entry)> StartListener;
-typedef std::function<void(TrackEntry *entry)> InterruptListener;
-typedef std::function<void(TrackEntry *entry)> EndListener;
-typedef std::function<void(TrackEntry *entry)> DisposeListener;
-typedef std::function<void(TrackEntry *entry)> CompleteListener;
-typedef std::function<void(TrackEntry *entry, Event *event)> EventListener;
 
 enum DEBUG_SHAPE_TYPE {
     DEBUG_REGION = 0,
@@ -58,7 +52,9 @@ public:
     AnimationState *getAnimationState();
     void setMix(const std::string &from, const std::string &to, float duration);
     void setListener(uint32_t listenerID, uint32_t type);
+    void setTrackListener(uint32_t trackId, TrackEntry *entry);
     void onAnimationStateEvent(TrackEntry *entry, EventType type, Event *event);
+    void onTrackEntryEvent(TrackEntry *entry, EventType type, Event *event);
     std::vector<SpineDebugShape> &getDebugShapes();
     void resizeSlotRegion(const std::string &slotName, uint32_t width, uint32_t height, bool createNew = false);
     void setSlotTexture(const std::string &slotName, uint32_t index);
@@ -83,6 +79,7 @@ private:
     uint32_t _disposeListenerID = 0;
     uint32_t _completeListenerID = 0;
     uint32_t _eventListenerID = 0;
+    uint32_t _trackListenerID = 0;
     UserData _userData;
     std::vector<SpineDebugShape> _debugShapes{};
     std::map<Slot *, uint32_t> slotTextureSet{};

--- a/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
@@ -1604,7 +1604,7 @@ EMSCRIPTEN_BINDINGS(spine) {
         .function("getAnimationState", &SpineSkeletonInstance::getAnimationState, allow_raw_pointer<AnimationState>())
         .function("setMix", &SpineSkeletonInstance::setMix)
         .function("setListener", &SpineSkeletonInstance::setListener)
-        .function("setTrackListener", &SpineSkeletonInstance::setTrackListener, allow_raw_pointer<TrackEntry *>())
+        .function("setTrackEntryListener", &SpineSkeletonInstance::setTrackEntryListener, allow_raw_pointer<TrackEntry *>())
         .function("setDebugMode", &SpineSkeletonInstance::setDebugMode)
         .function("getDebugShapes", &SpineSkeletonInstance::getDebugShapes)
         .function("resizeSlotRegion", &SpineSkeletonInstance::resizeSlotRegion)

--- a/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
@@ -1604,6 +1604,7 @@ EMSCRIPTEN_BINDINGS(spine) {
         .function("getAnimationState", &SpineSkeletonInstance::getAnimationState, allow_raw_pointer<AnimationState>())
         .function("setMix", &SpineSkeletonInstance::setMix)
         .function("setListener", &SpineSkeletonInstance::setListener)
+        .function("setTrackListener", &SpineSkeletonInstance::setTrackListener, allow_raw_pointer<TrackEntry *>())
         .function("setDebugMode", &SpineSkeletonInstance::setDebugMode)
         .function("getDebugShapes", &SpineSkeletonInstance::getDebugShapes)
         .function("resizeSlotRegion", &SpineSkeletonInstance::resizeSlotRegion)

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos-creator",
         "name": "engine-native-external",
-        "checkout": "v3.8.2-16"
+        "checkout": "v3.8.2-17"
     }
 }


### PR DESCRIPTION
Re: # https://github.com/cocos/cocos-engine/issues/16493

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
