### PR TITLE
refine & fix spine can not show normally while work on cache mode

### DIFF
--- a/cocos/spine/assembler/simple.ts
+++ b/cocos/spine/assembler/simple.ts
@@ -267,12 +267,12 @@ function cacheTraverse (comp: Skeleton): void {
 
     const vc = model.vCount as number;
     const ic = model.iCount as number;
+    if (vc < 1 || ic < 1) return;
     const rd = comp.renderData!;
     if (rd.vertexCount !== vc || rd.indexCount !== ic) {
         rd.resize(vc, ic);
         rd.indices = new Uint16Array(ic);
     }
-    if (vc < 1 || ic < 1) return;
 
     const vbuf = rd.chunk.vb;
     const vUint8Buf = new Uint8Array(vbuf.buffer, vbuf.byteOffset, Float32Array.BYTES_PER_ELEMENT * vbuf.length);

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -742,21 +742,15 @@ export class Skeleton extends UIRenderer {
         //const data = this.skeletonData?.getRuntimeData();
         //if (!data) return;
         //this.setSkeletonData(data);
+        this.setAnimationCacheMode(this._cacheMode);
         this._runtimeData = skeletonData.getRuntimeData();
         if (!this._runtimeData) return;
         this.setSkeletonData(this._runtimeData);
-
-        if (this.defaultSkin) this.setSkin(this.defaultSkin);
         this._textures = skeletonData.textures;
 
         this._refreshInspector();
         if (this.defaultAnimation) this.animation = this.defaultAnimation.toString();
-        //if (this.defaultSkin) this.setSkin(this.defaultSkin);
-        this._updateUseTint();
-        this._indexBoneSockets();
-        this._updateSocketBindings();
-        this.attachUtil.init(this);
-        this._preCacheMode = this._cacheMode;
+        if (this.defaultSkin && this.defaultSkin !== '') this.setSkin(this.defaultSkin);
     }
 
     /**
@@ -786,7 +780,7 @@ export class Skeleton extends UIRenderer {
             }
             if (this.skeletonData) {
                 const skeletonInfo = this._skeletonCache!.getSkeletonCache(this.skeletonData.uuid, skeletonData);
-                if (skeletonInfo.skeleton == null) {
+                if (!skeletonInfo.skeleton) {
                     skeletonInfo.skeleton = this._instance.initSkeleton(skeletonData);
                 }
                 this._skeleton = skeletonInfo.skeleton!;
@@ -1028,7 +1022,7 @@ export class Skeleton extends UIRenderer {
                 return;
             }
             this._updateCache(dt);
-        } else if (EDITOR_NOT_IN_PREVIEW) {
+        } else {
             this._instance.updateAnimation(dt);
         }
     }
@@ -1308,15 +1302,16 @@ export class Skeleton extends UIRenderer {
     public setAnimationCacheMode (cacheMode: AnimationCacheMode): void {
         if (this._preCacheMode  !== cacheMode) {
             this._cacheMode = cacheMode;
+            this._preCacheMode = cacheMode;
             //this.setSkin(this.defaultSkin);
             if (this._instance) {
                 this._instance.isCache = this.isAnimationCached();
             }
-            //this.attachUtil.init(this);
             this._updateSkeletonData();
-            //this.setSkin(this.defaultSkin);
-            //this._updateUseTint();
-            //this._updateSocketBindings();
+            this.setSkin(this.defaultSkin);
+            this._updateUseTint();
+            this._updateSocketBindings();
+            this.attachUtil.init(this);
             this.markForUpdateRenderData();
         }
     }


### PR DESCRIPTION
Re: #  https://github.com/cocos/3d-tasks/issues/17853

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
