### PR TITLE
Fixed the issue of OpenHarmony compilation failure on Windows

### DIFF
--- a/native/cocos/platform/openharmony/modules/Accelerometer.cpp
+++ b/native/cocos/platform/openharmony/modules/Accelerometer.cpp
@@ -46,16 +46,16 @@ const Accelerometer::MotionValue &Accelerometer::getDeviceMotionValue() {
     auto v = ret.As<Napi::Array>();
     if (v.Length() == 9) {
         motionValue.accelerationIncludingGravityX = static_cast<Napi::Value>(v[(uint32_t)0]).As<Napi::Number>().FloatValue();
-        motionValue.accelerationIncludingGravityY = static_cast<Napi::Value>(v[1]).As<Napi::Number>().FloatValue();
-        motionValue.accelerationIncludingGravityZ = static_cast<Napi::Value>(v[2]).As<Napi::Number>().FloatValue();
+        motionValue.accelerationIncludingGravityY = static_cast<Napi::Value>(v[(uint32_t)1]).As<Napi::Number>().FloatValue();
+        motionValue.accelerationIncludingGravityZ = static_cast<Napi::Value>(v[(uint32_t)2]).As<Napi::Number>().FloatValue();
 
-        motionValue.accelerationX = static_cast<Napi::Value>(v[3]).As<Napi::Number>().FloatValue();
-        motionValue.accelerationY = static_cast<Napi::Value>(v[4]).As<Napi::Number>().FloatValue();
-        motionValue.accelerationZ = static_cast<Napi::Value>(v[5]).As<Napi::Number>().FloatValue();
+        motionValue.accelerationX = static_cast<Napi::Value>(v[(uint32_t)3]).As<Napi::Number>().FloatValue();
+        motionValue.accelerationY = static_cast<Napi::Value>(v[(uint32_t)4]).As<Napi::Number>().FloatValue();
+        motionValue.accelerationZ = static_cast<Napi::Value>(v[(uint32_t)5]).As<Napi::Number>().FloatValue();
 
-        motionValue.rotationRateAlpha = static_cast<Napi::Value>(v[6]).As<Napi::Number>().FloatValue();
-        motionValue.rotationRateBeta = static_cast<Napi::Value>(v[7]).As<Napi::Number>().FloatValue();
-        motionValue.rotationRateGamma = static_cast<Napi::Value>(v[8]).As<Napi::Number>().FloatValue();
+        motionValue.rotationRateAlpha = static_cast<Napi::Value>(v[(uint32_t)6]).As<Napi::Number>().FloatValue();
+        motionValue.rotationRateBeta = static_cast<Napi::Value>(v[(uint32_t)7]).As<Napi::Number>().FloatValue();
+        motionValue.rotationRateGamma = static_cast<Napi::Value>(v[(uint32_t)8]).As<Napi::Number>().FloatValue();
     } else {
         memset(&motionValue, 0, sizeof(motionValue));
     }


### PR DESCRIPTION
Re: #

https://github.com/cocos/3d-tasks/issues/17893

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
