### PR TITLE
A better tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es6",
     "lib": ["es2015", "es2017", "es2020", "dom"],
     "module": "es2020",
+    "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "./bin/.ts",
     "rootDir": "./",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,14 +6,24 @@
     "sourceMap": true,
     "outDir": "./bin/.ts",
     "rootDir": "./",
-    "noEmit": true,
+
     "strict": true,
     "noImplicitAny": false,
+    "strictNullChecks": false,
+    "strictPropertyInitialization": false,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+
+    "noEmit": true,
     "downlevelIteration": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+
     "baseUrl": "./",
     "paths": {
         "cc.decorator": [
@@ -51,6 +61,7 @@
     ]
   },
   "include": [
+      "cocos/**/*.ts",
       "exports/**/*.ts",
       "typedoc-index.ts",
       "pal/**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": ["es2015", "es2017", "dom"],
+    "lib": ["es2015", "es2017", "es2020", "dom"],
     "module": "commonjs",
     "sourceMap": true,
     "outDir": "./bin/.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2015", "es2017", "es2020", "dom"],
     "target": "es2017",
-    "module": "es2020",
+    "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "./bin/.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
     "lib": ["es2015", "es2017", "es2020", "dom"],
+    "target": "es2017",
     "module": "es2020",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "lib": ["es2015", "es2017", "es2020", "dom"],
-    "module": "commonjs",
+    "module": "es2020",
     "sourceMap": true,
     "outDir": "./bin/.ts",
     "rootDir": "./",


### PR DESCRIPTION
一个更合理的 tsconfig配置.
建议与 https://github.com/cocos/cocos-engine/pull/16118/ 配合使用

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
