### PR TITLE
Fix cc.assetManager.downloader.maxConcurrency is overrode by mistake on mini-game platforms.

### DIFF
--- a/platforms/minigame/common/engine/index.js
+++ b/platforms/minigame/common/engine/index.js
@@ -1,3 +1,2 @@
 require('./Editbox');
 require('./AssetManager');
-require('./misc');

--- a/platforms/minigame/common/engine/misc.js
+++ b/platforms/minigame/common/engine/misc.js
@@ -1,1 +1,0 @@
-cc.macro.DOWNLOAD_MAX_CONCURRENT = 10;


### PR DESCRIPTION
The value has already been set here https://github.com/cocos/cocos-engine/blob/v3.8.2/platforms/minigame/common/engine/AssetManager.js#L10

No need to override it in misc.js

The Pull Request ( https://github.com/cocos/cocos-engine/pull/14307/files#diff-74fceea3a4d92d46eb24eca9cd5eb9f16d761f8b37cd5473796eaf5c6b145a41 ) sets the value to `12`, but misc.js will override it to `10` again.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
