### PR TITLE
Fix the socket target in Spine is not functioning correctly

### DIFF
--- a/cocos/spine/attach-util.ts
+++ b/cocos/spine/attach-util.ts
@@ -48,13 +48,16 @@ export class AttachUtil {
     init (skeletonComp: Skeleton): void {
         this._isInitialized = false;
         if (!skeletonComp || skeletonComp.socketNodes?.size === 0) return;
-        const isCached = skeletonComp.isAnimationCached();
-        this._skeletonBones = isCached && skeletonComp._curFrame ? skeletonComp._curFrame.boneInfos : skeletonComp._skeleton.bones;
+        this._skeletonBones = skeletonComp._skeleton.bones;
         if (!this._skeletonBones || this._skeletonBones.length < 1) return;
         this._socketNodes = skeletonComp.socketNodes;
         if (!this._socketNodes || this._socketNodes.size <= 0) return;
         this._isInitialized = true;
         this._syncAttachedNode();
+    }
+
+    updateSkeletonBones (bones: FrameBoneInfo[]): void {
+        this._skeletonBones = bones;
     }
 
     reset (): void {

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -1051,6 +1051,9 @@ export class Skeleton extends UIRenderer {
             frameCache.updateToFrame(frameIdx);
         }
         this._curFrame = frames[frameIdx];
+        if (this._curFrame !== undefined) {
+            this.attachUtil.updateSkeletonBones(this._curFrame.boneInfos);
+        }
         if (frameCache.isCompleted && frameIdx >= frames.length) {
             this._playCount++;
             if (this._playTimes > 0 && this._playCount >= this._playTimes) {

--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -844,6 +844,7 @@ const cacheManager = require('./jsb-cache-manager');
 
     assembler.updateRenderData = function (comp) {
         comp._render();
+        comp.syncAttachedNode();
     };
 
     // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Re: #
https://github.com/cocos/3d-tasks/issues/17879
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
