### PR TITLE
[ADPF] PerformanceHintAPI - include core threads + use NDK API

### DIFF
--- a/native/cocos/application/BaseGame.cpp
+++ b/native/cocos/application/BaseGame.cpp
@@ -40,7 +40,7 @@ int BaseGame::init() {
     cc_load_all_plugins();
 
 #if (CC_PLATFORM == CC_PLATFORM_ANDROID) && CC_SUPPORT_ADPF
-    ADPFManager::getInstance().Initialize();
+    ADPFManager::getInstance().initialize();
 #endif
 
 #if CC_PLATFORM == CC_PLATFORM_WINDOWS || CC_PLATFORM == CC_PLATFORM_LINUX || CC_PLATFORM == CC_PLATFORM_QNX || CC_PLATFORM == CC_PLATFORM_MACOS

--- a/native/cocos/base/threading/MessageQueue.cpp
+++ b/native/cocos/base/threading/MessageQueue.cpp
@@ -281,7 +281,7 @@ void MessageQueue::consumerThreadLoop() noexcept {
 #if CC_PLATFORM == CC_PLATFORM_ANDROID && CC_SUPPORT_ADPF == 1
     // add tid to PerformanceHintManager
     int32_t tid = gettid();
-    ADPFManager::getInstance().AddThreadIdToHintSession(tid);
+    ADPFManager::getInstance().addThreadIdToHintSession(tid);
 #endif
     while (!_reader.terminateConsumerThread) {
         AutoReleasePool autoReleasePool;

--- a/native/cocos/base/threading/MessageQueue.cpp
+++ b/native/cocos/base/threading/MessageQueue.cpp
@@ -22,13 +22,13 @@
  THE SOFTWARE.
 ****************************************************************************/
 
-#include <unistd.h>
 #include "MessageQueue.h"
 #include "AutoReleasePool.h"
 #include "base/Utils.h"
 #include "base/Log.h"
 
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
+    #include <unistd.h>
     #include "platform/android/adpf_manager.h"
 #endif
 
@@ -278,9 +278,11 @@ MessageQueue::~MessageQueue() {
 }
 
 void MessageQueue::consumerThreadLoop() noexcept {
+#if CC_PLATFORM == CC_PLATFORM_ANDROID
     // add tid to PerformanceHintManager
     int32_t tid = gettid();
     ADPFManager::getInstance().AddThreadIdToHintSession(tid);
+#endif
     while (!_reader.terminateConsumerThread) {
         AutoReleasePool autoReleasePool;
         flushMessages();

--- a/native/cocos/base/threading/MessageQueue.cpp
+++ b/native/cocos/base/threading/MessageQueue.cpp
@@ -278,7 +278,7 @@ MessageQueue::~MessageQueue() {
 }
 
 void MessageQueue::consumerThreadLoop() noexcept {
-#if CC_PLATFORM == CC_PLATFORM_ANDROID
+#if CC_PLATFORM == CC_PLATFORM_ANDROID && CC_SUPPORT_ADPF == 1
     // add tid to PerformanceHintManager
     int32_t tid = gettid();
     ADPFManager::getInstance().AddThreadIdToHintSession(tid);

--- a/native/cocos/base/threading/MessageQueue.cpp
+++ b/native/cocos/base/threading/MessageQueue.cpp
@@ -22,9 +22,15 @@
  THE SOFTWARE.
 ****************************************************************************/
 
+#include <unistd.h>
 #include "MessageQueue.h"
 #include "AutoReleasePool.h"
 #include "base/Utils.h"
+#include "base/Log.h"
+
+#if CC_PLATFORM == CC_PLATFORM_ANDROID
+    #include "platform/android/adpf_manager.h"
+#endif
 
 namespace cc {
 
@@ -272,6 +278,9 @@ MessageQueue::~MessageQueue() {
 }
 
 void MessageQueue::consumerThreadLoop() noexcept {
+    // add tid to PerformanceHintManager
+    int32_t tid = gettid();
+    ADPFManager::getInstance().AddThreadIdToHintSession(tid);
     while (!_reader.terminateConsumerThread) {
         AutoReleasePool autoReleasePool;
         flushMessages();

--- a/native/cocos/bindings/manual/jsb_adpf.cpp
+++ b/native/cocos/bindings/manual/jsb_adpf.cpp
@@ -59,7 +59,7 @@ static bool jsb_adpf_onThermalStatusChanged_set(se::State &state) { // NOLINT
 
     vmCallback.cbFn = new se::Value(fn.toObject(), true);
     // NOLINTNEXTLINE
-    ADPFManager::getInstance().SetThermalListener(+[](int prevStatus, int currentStatus) {
+    ADPFManager::getInstance().setThermalListener(+[](int prevStatus, int currentStatus) {
         CC_CURRENT_ENGINE()->getScheduler()->performFunctionInCocosThread([=]() {
             se::AutoHandleScope scope;
             se::ValueArray args;
@@ -88,7 +88,7 @@ static bool jsb_adpf_onThermalStatusChanged_get(se::State &state) { // NOLINT
 SE_BIND_PROP_GET(jsb_adpf_onThermalStatusChanged_get)
 
 static bool jsb_adpf_getThermalStatus(se::State &state) { // NOLINT
-    int statusInt = ADPFManager::getInstance().GetThermalStatus();
+    int statusInt = ADPFManager::getInstance().getThermalStatus();
     state.rval().setUint32(statusInt);
     return true;
 }
@@ -106,14 +106,13 @@ static bool jsb_adpf_getThermalStatusMax(se::State &state) { // NOLINT
 SE_BIND_PROP_GET(jsb_adpf_getThermalStatusMax)
 
 static bool jsb_adpf_getThermalStatusNormalized(se::State &state) { // NOLINT
-    float statusNormalized = ADPFManager::getInstance().GetThermalStatusNormalized();
+    float statusNormalized = ADPFManager::getInstance().getThermalStatusNormalized();
     state.rval().setFloat(statusNormalized);
     return true;
 }
 SE_BIND_PROP_GET(jsb_adpf_getThermalStatusNormalized)
-
 static bool jsb_adpf_getThermalHeadroom(se::State &state) { // NOLINT
-    float headroom = ADPFManager::getInstance().GetThermalHeadroom();
+    float headroom = ADPFManager::getInstance().getThermalHeadroom();
     state.rval().setFloat(headroom);
     return true;
 }

--- a/native/cocos/platform/android/adpf_manager.cpp
+++ b/native/cocos/platform/android/adpf_manager.cpp
@@ -19,6 +19,7 @@
 
 #if CC_PLATFORM == CC_PLATFORM_ANDROID && __ANDROID_API__ >= 30
 
+    #include <algorithm>
     #include <unistd.h>
     #include <chrono>
     #include <cstdio>
@@ -157,12 +158,30 @@ float ADPFManager::UpdateThermalStatusHeadRoom() {
     thermal_headroom_ =
         env->CallFloatMethod(obj_power_service_, get_thermal_headroom_,
                              kThermalHeadroomUpdateThreshold);
+
+    if (!std::isnan(thermal_headroom_)) {
+        thermal_headroom_valid_ = thermal_headroom_;
+    }
+
     ALOGE("Current thermal Headroom %f", thermal_headroom_);
     return thermal_headroom_;
 }
 
 // Initialize JNI calls for the PowerHintManager.
 bool ADPFManager::InitializePerformanceHintManager() {
+#if __ANDROID_API__ >= 33
+    if ( hint_manager_ == nullptr ) {
+        hint_manager_ = APerformanceHint_getManager();
+    }
+    if ( hint_session_ == nullptr && hint_manager_ != nullptr ) {
+        int32_t tid = gettid();
+        thread_ids_.push_back(tid);
+        int32_t tids[1];
+        tids[0] = tid;
+        hint_session_ = APerformanceHint_createSession(hint_manager_, tids, 1, last_target_);
+    }
+    return true;
+#else
     JNIEnv *env = cc::JniHelper::getEnv();
     auto *javaGameActivity = cc::JniHelper::getActivity();
 
@@ -185,7 +204,7 @@ bool ADPFManager::InitializePerformanceHintManager() {
 
     // Retrieve methods IDs for the APIs.
     jclass cls_perfhint_service = env->GetObjectClass(obj_perfhint_service_);
-    jmethodID mid_createhintsession =
+    create_hint_session_ =
         env->GetMethodID(cls_perfhint_service, "createHintSession",
                          "([IJ)Landroid/os/PerformanceHintManager$Session;");
     jmethodID mid_preferedupdaterate = env->GetMethodID(
@@ -193,15 +212,18 @@ bool ADPFManager::InitializePerformanceHintManager() {
 
     // Create int array which contain current tid.
     jintArray array = env->NewIntArray(1);
-    int32_t tid = getpid();
+    int32_t tid = gettid();
+    thread_ids_.push_back(tid);
     env->SetIntArrayRegion(array, 0, 1, &tid);
     const jlong DEFAULT_TARGET_NS = 16666666;
 
     // Create Hint session for the thread.
     jobject obj_hintsession = env->CallObjectMethod(
-        obj_perfhint_service_, mid_createhintsession, array, DEFAULT_TARGET_NS);
+        obj_perfhint_service_, create_hint_session_, array, DEFAULT_TARGET_NS);
+    jboolean check = env->ExceptionCheck();
+    CC_LOG_DEBUG("ADPFManager::InitializePerformanceHintManager threadId: %ld gettid: %d getpid: %ld  %d %x", std::this_thread::get_id(), gettid(), getpid(), check, obj_hintsession);
     if (obj_hintsession == nullptr) {
-        ALOGI("Failed to create a perf hint session.");
+        CC_LOG_DEBUG("Failed First to create a perf hint session.");
     } else {
         obj_perfhint_session_ = env->NewGlobalRef(obj_hintsession);
         preferred_update_rate_ =
@@ -213,6 +235,14 @@ bool ADPFManager::InitializePerformanceHintManager() {
             cls_perfhint_session, "reportActualWorkDuration", "(J)V");
         update_target_work_duration_ = env->GetMethodID(
             cls_perfhint_session, "updateTargetWorkDuration", "(J)V");
+        set_threads_ = env->GetMethodID(
+            cls_perfhint_session, "setThreads", "([I)V");
+        check = env->ExceptionCheck();
+        if ( check ) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            set_threads_ = nullptr;
+        }
     }
 
     // Free local references
@@ -229,6 +259,7 @@ bool ADPFManager::InitializePerformanceHintManager() {
     }
 
     return true;
+#endif
 }
 
 thermalStateChangeListener ADPFManager::thermalListener = NULL;
@@ -249,24 +280,88 @@ void ADPFManager::SetThermalListener(thermalStateChangeListener listener) {
 // Indicates the start and end of the performance intensive task.
 // The methods call performance hint API to tell the performance
 // hint to the system.
-void ADPFManager::BeginPerfHintSession() { perfhintsession_start_ = std::chrono::high_resolution_clock::now(); }
+void ADPFManager::BeginPerfHintSession() {
+    perf_start_ = std::chrono::steady_clock::now();
+}
 
 void ADPFManager::EndPerfHintSession(jlong target_duration_ns) {
-    auto current_clock = std::chrono::high_resolution_clock::now();
-    auto duration = current_clock - perfhintsession_start_;
-    frame_time_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+#if __ANDROID_API__ >= 33
+    auto perf_end = std::chrono::steady_clock::now();
+    auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(perf_end - perf_start_).count();
+    int64_t actual_duration_ns = static_cast<int64_t>(dur);
+    APerformanceHint_reportActualWorkDuration(hint_session_, actual_duration_ns);
+    APerformanceHint_updateTargetWorkDuration(hint_session_, target_duration_ns);
+#else
+    auto perf_end = std::chrono::steady_clock::now();
+    auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(perf_end - perf_start_).count();
+    jlong actual_duration_ns = static_cast<jlong>(dur);
     if (obj_perfhint_session_) {
-        jlong duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                duration * 100000000)
-                                .count();
         auto *env = cc::JniHelper::getEnv();
 
         // Report and update the target work duration using JNI calls.
         env->CallVoidMethod(obj_perfhint_session_, report_actual_work_duration_,
-                            duration_ns);
+                            actual_duration_ns);
         env->CallVoidMethod(obj_perfhint_session_, update_target_work_duration_,
                             target_duration_ns);
     }
+#endif
+}
+void ADPFManager::AddThreadIdToHintSession(int32_t tid)
+{
+    thread_ids_.push_back(tid);
+    auto data = thread_ids_.data();
+
+    registerThreadIdsToHintSession();
+}
+
+void ADPFManager::RemoveThreadIdFromHintSession(int32_t tid)
+{
+    thread_ids_.erase(std::remove(thread_ids_.begin(), thread_ids_.end(), tid), thread_ids_.end());
+    auto data = thread_ids_.data();
+
+    registerThreadIdsToHintSession();
+}
+
+void ADPFManager::registerThreadIdsToHintSession()
+{
+#if __ANDROID_API__ >= 34
+    auto data = thread_ids_.data();
+    std::size_t size = thread_ids_.size();
+    int result = APerformanceHint_setThreads(hint_session_, data, size);
+    CC_LOG_INFO("ADPFManager::registerThreadIdsToHintSession result: %d", result);
+#elif __ANDROID_API__ >= 33
+    auto data = thread_ids_.data();
+    std::size_t size = thread_ids_.size();
+    int result = 0;
+    if ( hint_session_ != nullptr ) {
+        APerformanceHint_closeSession(hint_session_);
+    }
+    hint_session_ = APerformanceHint_createSession(hint_manager_, data, size, last_target_);
+    CC_LOG_INFO("ADPFManager::registerThreadIdsToHintSession result: %d newHint: %x", result, hint_session_);
+#else
+    JNIEnv *env = cc::JniHelper::getEnv();
+    std::size_t size = thread_ids_.size();
+    jintArray array = env->NewIntArray(size);
+    auto data = thread_ids_.data();
+    env->SetIntArrayRegion(array, 0, size, data);
+    if ( set_threads_ == nullptr ) {
+        // we have to recreate the hint session
+        if ( obj_perfhint_session_ ) {
+            env->DeleteGlobalRef(obj_perfhint_session_ );
+        }
+        const jlong DEFAULT_TARGET_NS = 16666666;
+        jobject obj_hintsession = env->CallObjectMethod(obj_perfhint_service_, create_hint_session_, array, DEFAULT_TARGET_NS);
+        obj_perfhint_session_ = env->NewGlobalRef(obj_hintsession);
+    } else {
+        // API Level 34
+        env->CallVoidMethod(obj_perfhint_session_, set_threads_, array);
+        jboolean check = env->ExceptionCheck();
+        if ( check ) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+#endif
 }
 
 #endif

--- a/native/cocos/platform/android/adpf_manager.cpp
+++ b/native/cocos/platform/android/adpf_manager.cpp
@@ -218,8 +218,7 @@ bool ADPFManager::InitializePerformanceHintManager() {
     const jlong DEFAULT_TARGET_NS = 16666666;
 
     // Create Hint session for the thread.
-    jobject obj_hintsession = env->CallObjectMethod(
-        obj_perfhint_service_, create_hint_session_, array, DEFAULT_TARGET_NS);
+    jobject obj_hintsession = env->CallObjectMethod(obj_perfhint_service_, create_hint_session_, array, DEFAULT_TARGET_NS);
     jboolean check = env->ExceptionCheck();
     CC_LOG_DEBUG("ADPFManager::InitializePerformanceHintManager threadId: %ld gettid: %d getpid: %ld  %d %x", std::this_thread::get_id(), gettid(), getpid(), check, obj_hintsession);
     if (obj_hintsession == nullptr) {
@@ -310,22 +309,22 @@ void ADPFManager::AddThreadIdToHintSession(int32_t tid) {
     thread_ids_.push_back(tid);
     auto data = thread_ids_.data();
 
-    registerThreadIdsToHintSession();
+    RegisterThreadIdsToHintSession();
 }
 
 void ADPFManager::RemoveThreadIdFromHintSession(int32_t tid) {
     thread_ids_.erase(std::remove(thread_ids_.begin(), thread_ids_.end(), tid), thread_ids_.end());
     auto data = thread_ids_.data();
 
-    registerThreadIdsToHintSession();
+    RegisterThreadIdsToHintSession();
 }
 
-void ADPFManager::registerThreadIdsToHintSession() {
+void ADPFManager::RegisterThreadIdsToHintSession() {
 #if __ANDROID_API__ >= 34
     auto data = thread_ids_.data();
     std::size_t size = thread_ids_.size();
     int result = APerformanceHint_setThreads(hint_session_, data, size);
-    CC_LOG_INFO("ADPFManager::registerThreadIdsToHintSession result: %d", result);
+    CC_LOG_INFO("ADPFManager::RegisterThreadIdsToHintSession result: %d", result);
 #elif __ANDROID_API__ >= 33
     auto data = thread_ids_.data();
     std::size_t size = thread_ids_.size();
@@ -334,7 +333,7 @@ void ADPFManager::registerThreadIdsToHintSession() {
         APerformanceHint_closeSession(hint_session_);
     }
     hint_session_ = APerformanceHint_createSession(hint_manager_, data, size, last_target_);
-    CC_LOG_INFO("ADPFManager::registerThreadIdsToHintSession result: %d newHint: %x", result, hint_session_);
+    CC_LOG_INFO("ADPFManager::RegisterThreadIdsToHintSession result: %d newHint: %x", result, hint_session_);
 #else
     JNIEnv *env = cc::JniHelper::getEnv();
     std::size_t size = thread_ids_.size();

--- a/native/cocos/platform/android/adpf_manager.cpp
+++ b/native/cocos/platform/android/adpf_manager.cpp
@@ -306,24 +306,21 @@ void ADPFManager::EndPerfHintSession(jlong target_duration_ns) {
     }
 #endif
 }
-void ADPFManager::AddThreadIdToHintSession(int32_t tid)
-{
+void ADPFManager::AddThreadIdToHintSession(int32_t tid) {
     thread_ids_.push_back(tid);
     auto data = thread_ids_.data();
 
     registerThreadIdsToHintSession();
 }
 
-void ADPFManager::RemoveThreadIdFromHintSession(int32_t tid)
-{
+void ADPFManager::RemoveThreadIdFromHintSession(int32_t tid) {
     thread_ids_.erase(std::remove(thread_ids_.begin(), thread_ids_.end(), tid), thread_ids_.end());
     auto data = thread_ids_.data();
 
     registerThreadIdsToHintSession();
 }
 
-void ADPFManager::registerThreadIdsToHintSession()
-{
+void ADPFManager::registerThreadIdsToHintSession() {
 #if __ANDROID_API__ >= 34
     auto data = thread_ids_.data();
     std::size_t size = thread_ids_.size();

--- a/native/cocos/platform/android/adpf_manager.cpp
+++ b/native/cocos/platform/android/adpf_manager.cpp
@@ -307,14 +307,12 @@ void ADPFManager::endPerfHintSession(jlong target_duration_ns) {
 }
 void ADPFManager::addThreadIdToHintSession(int32_t tid) {
     thread_ids_.push_back(tid);
-    auto data = thread_ids_.data();
 
     registerThreadIdsToHintSession();
 }
 
 void ADPFManager::removeThreadIdFromHintSession(int32_t tid) {
     thread_ids_.erase(std::remove(thread_ids_.begin(), thread_ids_.end(), tid), thread_ids_.end());
-    auto data = thread_ids_.data();
 
     registerThreadIdsToHintSession();
 }
@@ -323,17 +321,14 @@ void ADPFManager::registerThreadIdsToHintSession() {
 #if __ANDROID_API__ >= 34
     auto data = thread_ids_.data();
     std::size_t size = thread_ids_.size();
-    int result = APerformanceHint_setThreads(hint_session_, data, size);
-    CC_LOG_INFO("ADPFManager::registerThreadIdsToHintSession result: %d", result);
+    APerformanceHint_setThreads(hint_session_, data, size);
 #elif __ANDROID_API__ >= 33
     auto data = thread_ids_.data();
     std::size_t size = thread_ids_.size();
-    int result = 0;
     if ( hint_session_ != nullptr ) {
         APerformanceHint_closeSession(hint_session_);
     }
     hint_session_ = APerformanceHint_createSession(hint_manager_, data, size, last_target_);
-    CC_LOG_INFO("ADPFManager::registerThreadIdsToHintSession result: %d newHint: %x", result, hint_session_);
 #else
     JNIEnv *env = cc::JniHelper::getEnv();
     std::size_t size = thread_ids_.size();

--- a/native/cocos/platform/android/adpf_manager.h
+++ b/native/cocos/platform/android/adpf_manager.h
@@ -155,7 +155,7 @@ private:
     jobject obj_power_service_;
     jmethodID get_thermal_headroom_;
 
-    std::map<std::string, jobject> map_hint_sessions;
+    std::unordered_map<std::string, jobject> map_hint_sessions;
 
     jobject obj_perfhint_service_;
     jobject obj_perfhint_session_;

--- a/native/cocos/platform/android/adpf_manager.h
+++ b/native/cocos/platform/android/adpf_manager.h
@@ -145,7 +145,7 @@ private:
 
     bool InitializePerformanceHintManager();
 
-    void registerThreadIdsToHintSession();
+    void RegisterThreadIdsToHintSession();
 
     AThermalManager *thermal_manager_ = nullptr;
     int32_t thermal_status_;

--- a/native/cocos/platform/android/adpf_manager.h
+++ b/native/cocos/platform/android/adpf_manager.h
@@ -82,39 +82,39 @@ public:
 
     // Invoke the method periodically (once a frame) to monitor
     // the device's thermal throttling status.
-    void Monitor();
+    void monitor();
 
     // Invoke the API first to set the android_app instance.
 
     // Method to set thermal status. Need to be public since the method
     // is called from C native listener.
-    void SetThermalStatus(int32_t i);
+    void setThermalStatus(int32_t i);
 
     // Get current thermal status and headroom.
-    int32_t GetThermalStatus() { return thermal_status_; }
-    float GetThermalStatusNormalized() const;
+    int32_t getThermalStatus() { return thermal_status_; }
+    float getThermalStatusNormalized() const;
 
-    float GetFrameTimeMS() const { return frame_time_ns_ / 1000000.0F; }
+    float getFrameTimeMS() const { return frame_time_ns_ / 1000000.0F; }
 
-    float GetThermalHeadroom() { return thermal_headroom_; }
+    float getThermalHeadroom() { return thermal_headroom_; }
 
-    void SetThermalListener(thermalStateChangeListener listener);
+    void setThermalListener(thermalStateChangeListener listener);
 
     // Indicates the start and end of the performance intensive task.
     // The methods call performance hint API to tell the performance
     // hint to the system.
-    void BeginPerfHintSession();
+    void beginPerfHintSession();
 
-    void EndPerfHintSession(jlong target_duration_ns);
+    void endPerfHintSession(jlong target_duration_ns);
 
-    void AddThreadIdToHintSession(int32_t tid);
-    void RemoveThreadIdFromHintSession(int32_t tid);
+    void addThreadIdToHintSession(int32_t tid);
+    void removeThreadIdFromHintSession(int32_t tid);
 
     // Method to retrieve thermal manager. The API is used to register/unregister
     // callbacks from C API.
-    AThermalManager *GetThermalManager() { return thermal_manager_; }
+    AThermalManager *getThermalManager() { return thermal_manager_; }
 
-    void Initialize();
+    void initialize();
 
 private:
     // Update thermal headroom each sec.
@@ -139,13 +139,13 @@ private:
     }
 
     // Functions to initialize ADPF API's calls.
-    bool InitializePowerManager();
+    bool initializePowerManager();
 
-    float UpdateThermalStatusHeadRoom();
+    float updateThermalStatusHeadRoom();
 
-    bool InitializePerformanceHintManager();
+    bool initializePerformanceHintManager();
 
-    void RegisterThreadIdsToHintSession();
+    void registerThreadIdsToHintSession();
 
     AThermalManager *thermal_manager_ = nullptr;
     int32_t thermal_status_;


### PR DESCRIPTION
Re: #

adapt PerformanceHintAPI to include main thread & render thread and optionally use the NDK API when available

### Changelog

* Add call to ADPF Performance Hint Manager in MessageQueue
* Adapt ADPFManager to be able to dynamically add/remove thread-ids

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ V] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [V ] Your pull request title is using English, it's precise and appropriate.
- [ V] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ V] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ V] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
