### PR TITLE
V3.8.3 webp broswer support improvements

### DIFF
--- a/pal/system-info/web/system-info.ts
+++ b/pal/system-info/web/system-info.ts
@@ -195,7 +195,7 @@ class SystemInfo extends EventTarget {
                     supportWebp = true;
                 }
             }
-        } else if (this.browserType == BrowserType.SAFARI) {
+        } else if (this.browserType === BrowserType.SAFARI) {
             //non-ios safari (desktop)
             const result = / version\/(\d+)/.exec(ua)?.[1];
             if (typeof result === "string") {

--- a/pal/system-info/web/system-info.ts
+++ b/pal/system-info/web/system-info.ts
@@ -194,6 +194,15 @@ class SystemInfo extends EventTarget {
                     supportWebp = true;
                 }
             }
+        } else if (this.browserType == BrowserType.SAFARI) {
+            //non-ios safari (desktop)
+            const result = / version\/(\d+)/.exec(ua)?.[1];
+            if (typeof result === "string") {
+                if (Number.parseInt(result) >= 14) {
+                    // safari 14+ support webp, but canvas.toDataURL is not supported by default
+                    supportWebp = true;
+                }
+            }
         }
 
         const supportTouch = (document.documentElement.ontouchstart !== undefined || document.ontouchstart !== undefined || EDITOR);

--- a/pal/system-info/web/system-info.ts
+++ b/pal/system-info/web/system-info.ts
@@ -184,7 +184,7 @@ class SystemInfo extends EventTarget {
         } catch (e) {
             supportWebp  = false;
         }
-        if (this.browserType === BrowserType.SAFARI) {
+        if (this.os === OS.IOS) {
             // if we're on iOS all major browsers will identify as BrowserType.SAFARI but Chrome and Firefox DO NOT have the
             // version in the browser identifier, using "applewebkit" solves this issue for all browsers on iOS
             const result = / applewebkit\/(\d+)/.exec(ua)?.[1];

--- a/pal/system-info/web/system-info.ts
+++ b/pal/system-info/web/system-info.ts
@@ -198,7 +198,7 @@ class SystemInfo extends EventTarget {
         } else if (this.browserType === BrowserType.SAFARI) {
             //non-ios safari (desktop)
             const result = / version\/(\d+)/.exec(ua)?.[1];
-            if (typeof result === "string") {
+            if (typeof result === 'string') {
                 if (Number.parseInt(result) >= 14) {
                     // safari 14+ support webp, but canvas.toDataURL is not supported by default
                     supportWebp = true;

--- a/pal/system-info/web/system-info.ts
+++ b/pal/system-info/web/system-info.ts
@@ -185,9 +185,11 @@ class SystemInfo extends EventTarget {
             supportWebp  = false;
         }
         if (this.browserType === BrowserType.SAFARI) {
-            const result = / version\/(\d+)/.exec(ua)?.[1];
+            // if we're on iOS all major browsers will identify as BrowserType.SAFARI but Chrome and Firefox DO NOT have the
+            // version in the browser identifier, using "applewebkit" solves this issue for all browsers on iOS
+            const result = / applewebkit\/(\d+)/.exec(ua)?.[1];
             if (typeof result === 'string') {
-                if (Number.parseInt(result) >= 14) {
+                if (Number.parseInt(result) >= 604) {
                     // safari 14+ support webp, but canvas.toDataURL is not supported by default
                     supportWebp = true;
                 }


### PR DESCRIPTION
Re: # Further work improving webp support on mobile and desktop browsers

### Changelog

* Fixed a bug where the browser type may not be set as Safari on certain iOS devices
* Because of this change we've had to add a case that supports Safari, specifically when using webp files on the desktop.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [x] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
