### PR TITLE
bug fixed  label Problems with using stroke and shadow

### DIFF
--- a/cocos/2d/assembler/label/text-processing.ts
+++ b/cocos/2d/assembler/label/text-processing.ts
@@ -77,8 +77,14 @@ export class TextProcessing {
         this._lettersInfo.length = 0;
     }
 
-    public processingString (isBmFont: boolean, style: TextStyle, layout: TextLayout,
-        outputLayoutData: TextOutputLayoutData, inputString: string, out?: string[]): void {
+    public processingString (
+        isBmFont: boolean,
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        inputString: string,
+        out?: string[],
+    ): void {
         if (!isBmFont) {
             let loopTime = 0;
             this._fontScale = this._getStyleFontScale(style.fontSize, style.fontScale);
@@ -117,8 +123,15 @@ export class TextProcessing {
         }
     }
 
-    public generateRenderInfo (isBmFont: boolean, style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-        outputRenderData: TextOutputRenderData, inputString: string, callback: AnyFunction): void {
+    public generateRenderInfo (
+        isBmFont: boolean,
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        outputRenderData: TextOutputRenderData,
+        inputString: string,
+        callback: AnyFunction,
+    ): void {
         if (!isBmFont) {
             this._updateLabelDimensions(style, layout, outputLayoutData);
             this._updateTexture(style, layout, outputLayoutData, outputRenderData);
@@ -157,8 +170,12 @@ export class TextProcessing {
         return scale;
     }
 
-    private _calculateLabelFont (style: TextStyle, layout: TextLayout,
-        outputLayoutData: TextOutputLayoutData, inputString: string): void {
+    private _calculateLabelFont (
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        inputString: string,
+    ): void {
         if (!this._context) {
             return;
         }
@@ -291,10 +308,12 @@ export class TextProcessing {
                 totalHeight = 0;
                 for (i = 0; i < paragraphedStrings.length; ++i) {
                     const allWidth = safeMeasureText(this._context, paragraphedStrings[i], _fontDesc);
-                    textFragment = fragmentText(paragraphedStrings[i],
+                    textFragment = fragmentText(
+                        paragraphedStrings[i],
                         allWidth,
                         canvasWidthNoMargin,
-                        this._measureText(this._context, _fontDesc));
+                        this._measureText(this._context, _fontDesc),
+                    );
                     totalHeight += textFragment.length * lineHeight;
                 }
 
@@ -341,10 +360,12 @@ export class TextProcessing {
         this._context.font = _fontDesc;
         for (let i = 0; i < paragraphedStrings.length; ++i) {
             const allWidth = safeMeasureText(this._context, paragraphedStrings[i], _fontDesc);
-            const textFragment = fragmentText(paragraphedStrings[i],
+            const textFragment = fragmentText(
+                paragraphedStrings[i],
                 allWidth,
                 canvasWidthNoMargin,
-                this._measureText(this._context, _fontDesc));
+                this._measureText(this._context, _fontDesc),
+            );
             _splitStrings = _splitStrings.concat(textFragment);
         }
         outputLayoutData.parsedString = _splitStrings;
@@ -470,14 +491,23 @@ export class TextProcessing {
         const tempPos = new Vec2(outputLayoutData.startPosition.x, outputLayoutData.startPosition.y);
         const drawTextPosX = tempPos.x;
         let drawTextPosY = 0;
+        const tempFillStyle = this._context.fillStyle;
         // draw shadow and underline
         this._drawTextEffect(tempPos, lineHeight, style, layout, outputLayoutData);
         // draw text and outline
         for (let i = 0; i < outputLayoutData.parsedString.length; ++i) {
             drawTextPosY = tempPos.y + i * lineHeight;
+            //draw shadow
+            if (style.hasShadow) {
+                this._setupShadow(style);
+                this._context.fillText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
+            }
+            //draw outline
             if (style.isOutlined) {
+                this._setupOutline(style);
                 this._context.strokeText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
             }
+            //draw text
             this._context.fillText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
         }
 
@@ -530,24 +560,23 @@ export class TextProcessing {
         let drawTextPosX = 0;
         let drawTextPosY = 0;
 
-        // only one set shadow and outline
-        if (style.hasShadow) {
-            this._setupShadow(style);
-        }
-
-        if (style.isOutlined) {
-            this._setupOutline(style);
-        }
-
         // draw shadow and (outline or text)
         for (let i = 0; i < outputLayoutData.parsedString.length; ++i) {
             drawTextPosX = startPosition.x;
             drawTextPosY = startPosition.y + i * lineHeight;
             // multiple lines need to be drawn outline and fill text
             if (isMultiple) {
+                //draw shadow
+                if (style.hasShadow) {
+                    this._setupShadow(style);
+                    this._context!.fillText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
+                }
+                // draw outline
                 if (style.isOutlined) {
+                    this._setupOutline(style);
                     this._context!.strokeText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
                 }
+                //draw text
                 this._context!.fillText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
             }
 
@@ -573,6 +602,10 @@ export class TextProcessing {
     }
 
     private _setupOutline (style: TextStyle): void {
+        this._context!.shadowBlur = 0;
+        this._context!.shadowOffsetX = 0;
+        this._context!.shadowOffsetY = 0;
+        this._context!.miterLimit = 2;
         this._context!.strokeStyle = `rgba(${style.outlineColor.r}, ${style.outlineColor.g}, ${style.outlineColor.b}, ${style.outlineColor.a / 255})`;
         this._context!.lineWidth = style.outlineWidth * 2 * this._fontScale;
     }
@@ -587,8 +620,15 @@ export class TextProcessing {
 
     // -------------------- Render Processing Part --------------------------
 
-    private generateVertexData (isBmFont: boolean, style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-        outputRenderData: TextOutputRenderData, inputString: string, callback: AnyFunction): void {
+    private generateVertexData (
+        isBmFont: boolean,
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        outputRenderData: TextOutputRenderData,
+        inputString: string,
+        callback: AnyFunction,
+    ): void {
         if (!isBmFont) {
             this.updateQuatCount(outputRenderData); // update vbBuffer count
             callback(style, outputLayoutData, outputRenderData);
@@ -702,8 +742,13 @@ export class TextProcessing {
         outputLayoutData.parsedString = _splitStrings;
     }
 
-    private _multilineTextWrap (style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-        inputString: string, nextTokenFunc: (arg0: TextStyle, arg1: TextLayout, arg2: string, arg3: number, arg4: number) => number): boolean {
+    private _multilineTextWrap (
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        inputString: string,
+        nextTokenFunc: (arg0: TextStyle, arg1: TextLayout, arg2: string, arg3: number, arg4: number) => number,
+    ): boolean {
         layout.linesWidth.length = 0;
 
         const _string = inputString;
@@ -957,8 +1002,13 @@ export class TextProcessing {
         return layout.overFlow === Overflow.SHRINK ? style.bmfontScale : 1;
     }
 
-    private _isVerticalClamp (style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-        inputString: string, process: TextProcessing): boolean {
+    private _isVerticalClamp (
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        inputString: string,
+        process: TextProcessing,
+    ): boolean {
         if (layout.textDesiredHeight > outputLayoutData.nodeContentSize.height) {
             return true;
         } else {
@@ -966,8 +1016,13 @@ export class TextProcessing {
         }
     }
 
-    private _isHorizontalClamp (style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-        inputString: string, process: TextProcessing): boolean {
+    private _isHorizontalClamp (
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        inputString: string,
+        process: TextProcessing,
+    ): boolean {
         let letterClamp = false;
         const _string = inputString;
         for (let ctr = 0, l = _string.length; ctr < l; ++ctr) {
@@ -1009,9 +1064,14 @@ export class TextProcessing {
         return false;
     }
 
-    private _shrinkLabelToContentSize (style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData, inputString: string,
+    private _shrinkLabelToContentSize (
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        inputString: string,
         lambda: (style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-            inputString: string, process: TextProcessing) => boolean): void {
+            inputString: string, process: TextProcessing) => boolean,
+    ): void {
         const fontSize = style.actualFontSize;
 
         let left = 0;
@@ -1057,8 +1117,14 @@ export class TextProcessing {
         }
     }
 
-    private _updateQuads (style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-        outputRenderData: TextOutputRenderData, inputString: string, callback): boolean {
+    private _updateQuads (
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        outputRenderData: TextOutputRenderData,
+        inputString: string,
+        callback,
+    ): boolean {
         const texture =  style.spriteFrame ? style.spriteFrame.texture : shareLabelInfo.fontAtlas!.getTexture();
 
         const appX = outputRenderData.uiTransAnchorX * outputLayoutData.nodeContentSize.width;

--- a/cocos/2d/assembler/label/text-processing.ts
+++ b/cocos/2d/assembler/label/text-processing.ts
@@ -491,7 +491,6 @@ export class TextProcessing {
         const tempPos = new Vec2(outputLayoutData.startPosition.x, outputLayoutData.startPosition.y);
         const drawTextPosX = tempPos.x;
         let drawTextPosY = 0;
-        const tempFillStyle = this._context.fillStyle;
         // draw shadow and underline
         this._drawTextEffect(tempPos, lineHeight, style, layout, outputLayoutData);
         // draw text and outline
@@ -607,10 +606,10 @@ export class TextProcessing {
     }
 
     private _setupOutline (style: TextStyle): void {
+        // draw outline need clear shadow
         this._context!.shadowBlur = 0;
         this._context!.shadowOffsetX = 0;
         this._context!.shadowOffsetY = 0;
-        this._context!.miterLimit = 2;
         this._context!.strokeStyle = `rgba(${style.outlineColor.r}, ${style.outlineColor.g}, ${style.outlineColor.b}, ${style.outlineColor.a / 255})`;
         this._context!.lineWidth = style.outlineWidth * 2 * this._fontScale;
     }

--- a/cocos/2d/assembler/label/text-processing.ts
+++ b/cocos/2d/assembler/label/text-processing.ts
@@ -508,7 +508,9 @@ export class TextProcessing {
                 this._context.strokeText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
             }
             //draw text
-            this._context.fillText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
+            if (!style.hasShadow || style.isOutlined) {
+                this._context.fillText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
+            }
         }
 
         if (style.hasShadow) {
@@ -576,8 +578,11 @@ export class TextProcessing {
                     this._setupOutline(style);
                     this._context!.strokeText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
                 }
+
                 //draw text
-                this._context!.fillText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
+                if (!style.hasShadow || style.isOutlined) {
+                    this._context!.fillText(outputLayoutData.parsedString[i], drawTextPosX, drawTextPosY);
+                }
             }
 
             // draw underline


### PR DESCRIPTION
https://github.com/cocos/cocos-engine/issues/16666

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
