### PR TITLE
support char mode emoji and multibyte emoji like 👨‍👩‍👧‍👦

### DIFF
--- a/cocos/2d/assembler/label/font-utils.ts
+++ b/cocos/2d/assembler/label/font-utils.ts
@@ -27,7 +27,7 @@ import { Color, macro, warnID } from '../../../core';
 import { ImageAsset, Texture2D } from '../../../asset/assets';
 import { PixelFormat } from '../../../asset/assets/asset-enum';
 import { BufferTextureCopy } from '../../../gfx';
-import { safeMeasureText, BASELINE_RATIO, MIDDLE_RATIO, getBaselineOffset } from '../../utils/text-utils';
+import { safeMeasureText, BASELINE_RATIO, MIDDLE_RATIO, getBaselineOffset, getSymbolCodeAt } from '../../utils/text-utils';
 import { director, Director } from '../../../game/director';
 import { ccwindow } from '../../../core/global-exports';
 
@@ -133,7 +133,7 @@ class LetterTexture {
     constructor (char: string, labelInfo: ILabelInfo) {
         this.char = char;
         this.labelInfo = labelInfo;
-        this.hash = `${char.charCodeAt(0)}${labelInfo.hash}`;
+        this.hash = `${getSymbolCodeAt(char, 0)}${labelInfo.hash}`;
     }
 
     public updateRenderData (): void {
@@ -400,7 +400,7 @@ export class LetterAtlas {
     }
 
     public getLetterDefinitionForChar (char: string, labelInfo: ILabelInfo): any {
-        const hash = char.charCodeAt(0) + labelInfo.hash;
+        const hash = getSymbolCodeAt(char, 0) + labelInfo.hash;
         let letter = this.fontDefDictionary.letterDefinitions[hash];
         if (!letter) {
             const temp = new LetterTexture(char, labelInfo);

--- a/cocos/2d/assembler/label/text-processing.ts
+++ b/cocos/2d/assembler/label/text-processing.ts
@@ -29,7 +29,7 @@ import { log, logID, warn } from '../../../core/platform';
 import { SpriteFrame } from '../../assets';
 import { FontLetterDefinition } from '../../assets/bitmap-font';
 import { HorizontalTextAlignment, Overflow, VerticalTextAlignment } from '../../components/label';
-import { BASELINE_RATIO, fragmentText, getBaselineOffset, isUnicodeCJK, isUnicodeSpace, safeMeasureText } from '../../utils/text-utils';
+import { BASELINE_RATIO, fragmentText, getBaselineOffset, getSymbolAt, getSymbolCodeAt, getSymbolLength, isUnicodeCJK, isUnicodeSpace, safeMeasureText } from '../../utils/text-utils';
 import { CanvasPool, ISharedLabelData, shareLabelInfo } from './font-utils';
 import { TextOutputLayoutData, TextOutputRenderData } from './text-output-data';
 import { TextStyle } from './text-style';
@@ -686,8 +686,8 @@ export class TextProcessing {
     private _parsedString (outputLayoutData: TextOutputLayoutData, inputString: string): void {
         let _splitStrings: string[] = [];
         let textFragment = '';
-
-        for (let i = 0, line = 0, l = inputString.length; i < l; ++i) {
+        const length = getSymbolLength(inputString);
+        for (let i = 0, line = 0, l = length; i < l; ++i) {
             const letterInfo = this._lettersInfo[i];
             if (!letterInfo.valid) { continue; }
             if (line === letterInfo.line) {
@@ -722,7 +722,7 @@ export class TextProcessing {
         const _lineSpacing = 0; // use less?
 
         for (let index = 0; index < textLen;) {
-            let character = _string.charAt(index);
+            let character = getSymbolAt(_string, index);
             if (character === '\n') {
                 layout.linesWidth.push(letterRight);
                 letterRight = 0;
@@ -744,7 +744,7 @@ export class TextProcessing {
 
             for (let tmp = 0; tmp < tokenLen; ++tmp) {
                 const letterIndex = index + tmp;
-                character = _string.charAt(letterIndex);
+                character = getSymbolAt(_string, letterIndex);
                 if (character === '\r') {
                     this._recordPlaceholderInfo(letterIndex, character);
                     continue;
@@ -852,7 +852,7 @@ export class TextProcessing {
         }
 
         this._lettersInfo[letterIndex].char = char;
-        this._lettersInfo[letterIndex].hash = `${char.charCodeAt(0)}${shareLabelInfo.hash}`;
+        this._lettersInfo[letterIndex].hash = `${getSymbolCodeAt(char, 0)}${shareLabelInfo.hash}`;
         this._lettersInfo[letterIndex].valid = false;
     }
 
@@ -862,7 +862,7 @@ export class TextProcessing {
             this._lettersInfo.push(tmpInfo);
         }
 
-        const char = character.charCodeAt(0);
+        const char = getSymbolCodeAt(character, 0);
         const key = `${char}${shareLabelInfo.hash}`;
 
         this._lettersInfo[letterIndex].line = lineIndex;
@@ -874,7 +874,7 @@ export class TextProcessing {
     }
 
     private _getFirstWordLen (style: TextStyle, layout: TextLayout, text: string, startIndex: number, textLen: number): number {
-        let character = text.charAt(startIndex);
+        let character = getSymbolAt(text, startIndex);
         if (isUnicodeCJK(character)
             || character === '\n'
             || isUnicodeSpace(character)) {
@@ -889,7 +889,7 @@ export class TextProcessing {
         let nextLetterX = letterDef.xAdvance * style.bmfontScale + layout.spacingX;
         let letterX = 0;
         for (let index = startIndex + 1; index < textLen; ++index) {
-            character = text.charAt(index);
+            character = getSymbolAt(text, index);
 
             letterDef = shareLabelInfo.fontAtlas!.getLetterDefinitionForChar(character, shareLabelInfo);
             if (!letterDef) {
@@ -966,11 +966,17 @@ export class TextProcessing {
         }
     }
 
-    private _isHorizontalClamp (style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-        inputString: string, process: TextProcessing): boolean {
+    private _isHorizontalClamp (
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        inputString: string,
+        process: TextProcessing,
+    ): boolean {
         let letterClamp = false;
         const _string = inputString;
-        for (let ctr = 0, l = _string.length; ctr < l; ++ctr) {
+        const _length = getSymbolLength(_string);
+        for (let ctr = 0, l = _length; ctr < l; ++ctr) {
             const letterInfo = process._lettersInfo[ctr];
             if (letterInfo.valid) {
                 const letterDef = shareLabelInfo.fontAtlas!.getLetterDefinitionForChar(letterInfo.char, shareLabelInfo);
@@ -1057,15 +1063,22 @@ export class TextProcessing {
         }
     }
 
-    private _updateQuads (style: TextStyle, layout: TextLayout, outputLayoutData: TextOutputLayoutData,
-        outputRenderData: TextOutputRenderData, inputString: string, callback): boolean {
+    private _updateQuads (
+        style: TextStyle,
+        layout: TextLayout,
+        outputLayoutData: TextOutputLayoutData,
+        outputRenderData: TextOutputRenderData,
+        inputString: string,
+        callback,
+    ): boolean {
         const texture =  style.spriteFrame ? style.spriteFrame.texture : shareLabelInfo.fontAtlas!.getTexture();
 
         const appX = outputRenderData.uiTransAnchorX * outputLayoutData.nodeContentSize.width;
         const appY = outputRenderData.uiTransAnchorY * outputLayoutData.nodeContentSize.height;
 
         const ret = true;
-        for (let ctr = 0, l = inputString.length; ctr < l; ++ctr) {
+        const _length = getSymbolLength(inputString);
+        for (let ctr = 0, l = _length; ctr < l; ++ctr) {
             const letterInfo = this._lettersInfo[ctr];
             if (!letterInfo.valid) { continue; }
             const letterDef = shareLabelInfo.fontAtlas!.getLetter(letterInfo.hash);

--- a/cocos/2d/assets/bitmap-font.ts
+++ b/cocos/2d/assets/bitmap-font.ts
@@ -27,6 +27,7 @@ import { ccclass, type, serializable, editable } from 'cc.decorator';
 import { Font } from './font';
 import { SpriteFrame } from './sprite-frame';
 import { cclegacy, js, warn } from '../../core';
+import { getSymbolCodeAt } from '../utils';
 
 export interface IConfig {
     [key: string]: any;
@@ -80,7 +81,7 @@ export class FontAtlas {
     }
 
     public getLetterDefinitionForChar (char, labelInfo?): any {
-        const key = char.charCodeAt(0);
+        const key = getSymbolCodeAt(char as string, 0);
         const hasKey = this.letterDefinitions.hasOwnProperty(key);
         let letter;
         if (hasKey) {

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -28,7 +28,7 @@ import { DEBUG, DEV, EDITOR } from 'internal:constants';
 import { Font, SpriteAtlas, TTFFont, SpriteFrame } from '../assets';
 import { EventTouch } from '../../input/types';
 import { assert, warnID, Color, Vec2, CCObject, cclegacy, js, Size } from '../../core';
-import { BASELINE_RATIO, fragmentText, isUnicodeCJK, isUnicodeSpace, getEnglishWordPartAtFirst, getEnglishWordPartAtLast } from '../utils/text-utils';
+import { BASELINE_RATIO, fragmentText, isUnicodeCJK, isUnicodeSpace, getEnglishWordPartAtFirst, getEnglishWordPartAtLast, getSymbolAt } from '../utils/text-utils';
 import { HtmlTextParser, IHtmlTextParserResultObj, IHtmlTextParserStack } from '../utils/html-text-parser';
 import { Node } from '../../scene-graph';
 import { CacheMode, HorizontalTextAlignment, Label, VerticalTextAlignment } from './label';
@@ -1153,14 +1153,14 @@ export class RichText extends Component {
     }
 
     protected _getFirstWordLen (text: string, startIndex: number, textLen: number): number {
-        let character = text.charAt(startIndex);
+        let character = getSymbolAt(text, startIndex);
         if (isUnicodeCJK(character) || isUnicodeSpace(character)) {
             return 1;
         }
 
         let len = 1;
         for (let index = startIndex + 1; index < textLen; ++index) {
-            character = text.charAt(index);
+            character = getSymbolAt(text, index);
             if (isUnicodeSpace(character) || isUnicodeCJK(character)) {
                 break;
             }

--- a/cocos/2d/utils/text-utils.ts
+++ b/cocos/2d/utils/text-utils.ts
@@ -214,6 +214,192 @@ export function safeMeasureText (ctx: CanvasRenderingContext2D, string: string, 
     return width;
 }
 
+export function getSymbolLength (str: string): number {
+    const length = str.length;
+    let len = 0;
+    let count = 0;
+    let start = 0;
+    let charCode = 0;
+    for (let i = 0; i < length; i++) {
+        charCode = str.charCodeAt(i);
+        if (charCode === 0x200d) {
+            len++;
+            continue;
+        }
+        if (charCode >= 0xd800 && charCode <= 0xdbff) {
+            len++;
+            charCode = str.charCodeAt(i + 1);
+            if (charCode >= 0xdc00 && charCode <= 0xdfff) {
+                if (i + 2 < length && str.charCodeAt(i + 2) === 0x200d) {
+                    len++;
+                } else {
+                    len++;
+                    start += len;
+                    count++;
+                    len = 0;
+                }
+                i++;
+                continue;
+            }
+        }
+        start = i + 1;
+        count++;
+        len = 0;
+    }
+    return count;
+}
+
+export function getSymbolAt (str: string, index: number): string  {
+    const length = str.length;
+    let len = 0;
+    let count = 0;
+    let start = 0;
+    let charCode = 0;
+    for (let i = 0; i < length; i++) {
+        charCode = str.charCodeAt(i);
+        if (charCode === 0x200d) {
+            len++;
+            continue;
+        }
+        if (charCode >= 0xd800 && charCode <= 0xdbff) {
+            len++;
+            charCode = str.charCodeAt(i + 1);
+            if (charCode >= 0xdc00 && charCode <= 0xdfff) {
+                if (i + 2 < length && str.charCodeAt(i + 2) === 0x200d) {
+                    len++;
+                } else {
+                    len++;
+                    if (index === count) {
+                        return str.slice(start, start + len);
+                    }
+                    start += len;
+                    count++;
+                    len = 0;
+                }
+                i++;
+                continue;
+            }
+        }
+        if (index === count) {
+            return str.charAt(i);
+        }
+        start = i + 1;
+        count++;
+        len = 0;
+    }
+    return '';
+}
+
+export function getSymbolCodeAt (str: string, index: number): string  {
+    const length = str.length;
+    let len = 0;
+    let count = 0;
+    let start = 0;
+    let charCode = 0;
+    for (let i = 0; i < length; i++) {
+        charCode = str.charCodeAt(i);
+        if (charCode === 0x200d) {
+            len++;
+            continue;
+        }
+        if (charCode >= 0xd800 && charCode <= 0xdbff) {
+            len++;
+            charCode = str.charCodeAt(i + 1);
+            if (charCode >= 0xdc00 && charCode <= 0xdfff) {
+                if (i + 2 < length && str.charCodeAt(i + 2) === 0x200d) {
+                    len++;
+                } else {
+                    len++;
+                    if (index === count) {
+                        return str.slice(start, start + len);
+                    }
+                    start += len;
+                    count++;
+                    len = 0;
+                }
+                i++;
+                continue;
+            }
+        }
+        if (index === count) {
+            return `${str.charCodeAt(i)}`;
+        }
+        start = i + 1;
+        count++;
+        len = 0;
+    }
+    return '';
+}
+
+function getSymbolStartIndex (targetString, index): number {
+    if (index >= targetString.length) {
+        return targetString.length;
+    }
+    let startCheckIndex = index;
+    let startChar = targetString[startCheckIndex];
+    while (startCheckIndex >= 0) {
+        if (startChar === '\u200d') {
+            startCheckIndex--;
+        }
+        startChar = targetString[startCheckIndex];
+        if (startChar >= '\uDC00' && startChar <= '\uDFFF') {
+            // lowSurrogateRex
+            if (startCheckIndex - 1 >= 0) {
+                startCheckIndex--;
+                startChar = targetString[startCheckIndex];
+            }
+        }
+        if (startChar >= '\uD800' && startChar <= '\uDBFF') {
+            // highSurrogateRex
+            if (startCheckIndex - 1 >= 0 && targetString[startCheckIndex - 1] === '\u200d') {
+                startCheckIndex--;
+                startChar = targetString[startCheckIndex];
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return startCheckIndex;
+}
+
+function getSymbolEndIndex (targetString, index): number {
+    let newEndIndex = index;
+    let endCheckIndex = index;
+    let endChar = targetString[endCheckIndex];
+    while (endCheckIndex < targetString.length) {
+        if (endChar === '\u200d') {
+            endCheckIndex++;
+            newEndIndex++;
+            endChar = targetString[endCheckIndex];
+            if (endChar >= '\uD800' && endChar <= '\uDBFF') {
+                // highSurrogateRex
+                endCheckIndex++;
+                newEndIndex++;
+            }
+        }
+        endChar = targetString[endCheckIndex];
+        if (endChar >= '\uD800' && endChar <= '\uDBFF') {
+            // highSurrogateRex
+            endCheckIndex++;
+            newEndIndex++;
+            endChar = targetString[endCheckIndex];
+        } else if (endChar >= '\uDC00' && endChar <= '\uDFFF') {
+            // lowSurrogateRex
+            endCheckIndex++;
+            if (endCheckIndex < targetString.length && targetString[endCheckIndex] === '\u200d') {
+                newEndIndex++;
+                endChar = targetString[endCheckIndex];
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return newEndIndex;
+}
 // in case truncate a character on the Supplementary Multilingual Plane
 // test case: a = '😉🚗'
 // _safeSubstring(a, 1) === '😉🚗'
@@ -224,27 +410,25 @@ export function safeMeasureText (ctx: CanvasRenderingContext2D, string: string, 
 // _safeSubstring(a, 1, 2) === _safeSubstring(a, 1, 3) === '😉'
 // _safeSubstring(a, 2, 3) === _safeSubstring(a, 2, 4) === '🚗'
 function _safeSubstring (targetString, startIndex, endIndex?): string {
-    let newStartIndex = startIndex;
-    let newEndIndex = endIndex;
-    const startChar = targetString[startIndex];
-    // lowSurrogateRex
-    if (startChar >= '\uDC00' && startChar <= '\uDFFF') {
-        newStartIndex--;
+    let newStartIndex = getSymbolStartIndex(targetString, startIndex);
+    if (newStartIndex < startIndex) {
+        newStartIndex = getSymbolEndIndex(targetString, startIndex) + 1;
     }
+    let newEndIndex = endIndex;
+
     if (endIndex !== undefined) {
-        if (endIndex - 1 !== startIndex) {
-            const endChar = targetString[endIndex - 1];
-            // highSurrogateRex
-            if (endChar >= '\uD800' && endChar <= '\uDBFF') {
-                newEndIndex--;
-            }
-        } else if (startChar >= '\uD800' && startChar <= '\uDBFF') {
-            // highSurrogateRex
-            newEndIndex++;
+        endIndex = Math.max(0, endIndex - 1);
+        newEndIndex = getSymbolEndIndex(targetString, endIndex);
+        const newStartEndIndex = getSymbolStartIndex(targetString, endIndex);
+        if (newStartEndIndex < newStartIndex || (newStartEndIndex == newStartIndex && startIndex > newStartIndex)) {
+            newEndIndex = newStartIndex;
+        } else {
+            newEndIndex += 1;
         }
     }
     return targetString.substring(newStartIndex, newEndIndex) as string;
 }
+
 /**
 * @engineInternal
 */


### PR DESCRIPTION
https://github.com/cocos/cocos-engine/issues/15192

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
