### PR TITLE
fix minigames failed to read files after executing clearLRU

### DIFF
--- a/platforms/minigame/common/engine/cache-manager.js
+++ b/platforms/minigame/common/engine/cache-manager.js
@@ -186,6 +186,8 @@ var cacheManager = {
         caches.length = Math.floor(caches.length / 3);
         if (caches.length === 0) return;
         for (var i = 0, l = caches.length; i < l; i++) {
+            var cacheKey = cc.assetManager.utils.getUuidFromURL(caches[i].originUrl) + "@native";
+            cc.assetManager._files.remove(cacheKey);
             this.cachedFiles.remove(caches[i].originUrl);
         }
         


### PR DESCRIPTION
当清除微信小游戏适配层的缓存资源时需要同步清除引擎资源管理系统中的缓存数据。

When clearing the cache resources of the WeChat mini-game adaptation layer, it is necessary to synchronously clear the cache data in the engine resource management system.


发生错误时的日志表现：
Log behavior when errors occur:

![d7d255360cc476c4ca632aa6e28af40](https://github.com/cocos/cocos-engine/assets/35944775/a16c7935-9bfa-412a-951d-3f54e8114091)

由于微信小游戏适配层会因为用户目录储存空间不足触发自动清除资源，如果没有同步删除资源系统中的缓存数据，会导致下一次加载相同资源时，资源系统会认为缓存资源存在并加载已经被删除的缓存资源路径，导致资源加载失败。在测试中只有原生资源会触发此问题，在 assetManager._file 中原生资源会记录资源缓存路径，而 json 数据则缓存序列化后的 js 数据，所以只有当使用路径加载缓存资源（原生资源）时会有此问题。

Due to the fact that the WeChat mini-game adaptation layer automatically clears resources when the user's storage space is insufficient, if the cache data in the resource management system is not synchronized and deleted, it can cause the next time the same resource is loaded, the resource system will think that the cached resource exists and load the path of the deleted cached resource, leading to resource loading failure. In testing, only native resources trigger this issue. In `assetManager._file`, native resources record the path of the resource cache, while JSON data caches the serialized JavaScript data. Therefore, this issue only occurs when loading cached resources (native resources) using paths.


