### PR TITLE
fix a few errors in VKCommands.cpp

### DIFF
--- a/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -157,10 +157,8 @@ void cmdFuncCCVKCreateTexture(CCVKDevice *device, CCVKGPUTexture *gpuTexture) {
             allocInfo.usage = VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED;
             VkResult result = vmaCreateImage(device->gpuDevice()->memoryAllocator, &createInfo, &allocInfo,
                                              pVkImage, pVmaAllocation, &res);
-            if (!result) {
+            if (!result)
                 gpuTexture->memoryAllocated = false;
-                return;
-            }
 
             // feature not present, fallback to device memory
             allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
@@ -360,8 +358,8 @@ private:
     ccstd::unordered_set<VkSubpassDependency2, DependencyHasher, DependencyComparer> _hashes;
 };
 
-std::pair<VkImageLayout, VkImageLayout> getInitialFinalLayout(CCVKDevice *device, CCVKGeneralBarrier *barrier, bool depthSetncil) {
-    const auto *gpuBarrier = barrier ? barrier->gpuBarrier() : (depthSetncil ? &device->gpuDevice()->defaultDepthStencilBarrier : &device->gpuDevice()->defaultColorBarrier);
+std::pair<VkImageLayout, VkImageLayout> getInitialFinalLayout(CCVKDevice *device, CCVKGeneralBarrier *barrier, bool depthStencil) {
+    const auto *gpuBarrier = barrier ? barrier->gpuBarrier() : (depthStencil ? &device->gpuDevice()->defaultDepthStencilBarrier : &device->gpuDevice()->defaultColorBarrier);
 
     ThsvsImageBarrier imageBarrier = {};
     imageBarrier.prevAccessCount = utils::toUint(gpuBarrier->prevAccesses.size());
@@ -593,8 +591,6 @@ void cmdFuncCCVKCreateRenderPass(CCVKDevice *device, CCVKGPURenderPass *gpuRende
         manuallyDeduce = dependencyCount == 0;
     }
     if (!manuallyDeduce) {
-        // offset = 0U;
-        ccstd::unordered_set<const GFXObject *> subpassExternalFilter;
         for (uint32_t i = 0U; i < dependencyCount; ++i) {
             const auto &dependency{gpuRenderPass->dependencies[i]};
             VkSubpassDependency2 vkDependency{VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2};

--- a/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -159,6 +159,7 @@ void cmdFuncCCVKCreateTexture(CCVKDevice *device, CCVKGPUTexture *gpuTexture) {
                                              pVkImage, pVmaAllocation, &res);
             if (!result) {
                 gpuTexture->memoryAllocated = false;
+                return;
             }
 
             // feature not present, fallback to device memory

--- a/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -157,8 +157,9 @@ void cmdFuncCCVKCreateTexture(CCVKDevice *device, CCVKGPUTexture *gpuTexture) {
             allocInfo.usage = VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED;
             VkResult result = vmaCreateImage(device->gpuDevice()->memoryAllocator, &createInfo, &allocInfo,
                                              pVkImage, pVmaAllocation, &res);
-            if (!result)
+            if (!result) {
                 gpuTexture->memoryAllocated = false;
+            }
 
             // feature not present, fallback to device memory
             allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;


### PR DESCRIPTION
1, removed the wrong `return`, because we still need to retry with the default way to allocate
2, just typo: `depthSetncil` -> `depthStencil`
3, clear: useless line
