### PR TITLE
Fix label inactivation without calling destroy to release resources

### DIFF
--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -39,10 +39,8 @@ import { BlendFactor } from '../../gfx';
 import { TextStyle } from '../assembler/label/text-style';
 import { TextLayout } from '../assembler/label/text-layout';
 import { TextOutputLayoutData, TextOutputRenderData } from '../assembler/label/text-output-data';
-import { CCObject } from '../../core/data/object';
 
 const tempColor = Color.WHITE.clone();
-const IsOnLoadCalled = CCObject.Flags.IsOnLoadCalled;
 /**
  * @en Enum for horizontal text alignment.
  *
@@ -913,7 +911,7 @@ export class Label extends UIRenderer {
     }
 
     public _onPreDestroy (): void {
-        if (this._objFlags & IsOnLoadCalled) {
+        if (this._isOnLoadCalled) {
             super._onPreDestroy();
             return;
         }

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -911,7 +911,7 @@ export class Label extends UIRenderer {
     }
 
     // Override
-    protected _onPreDestroy (): void {
+    public _onPreDestroy (): void {
         if (this._isOnLoadCalled) {
             super._onPreDestroy();
             return;

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -910,6 +910,7 @@ export class Label extends UIRenderer {
         this._ttfSpriteFrame = null;
     }
 
+    // Override
     protected _onPreDestroy (): void {
         if (this._isOnLoadCalled) {
             super._onPreDestroy();

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -910,7 +910,7 @@ export class Label extends UIRenderer {
         this._ttfSpriteFrame = null;
     }
 
-    public _onPreDestroy (): void {
+    protected _onPreDestroy (): void {
         if (this._isOnLoadCalled) {
             super._onPreDestroy();
             return;


### PR DESCRIPTION
Re: #

### Changelog

https://github.com/cocos/cocos-engine/issues/16721

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
