### PR TITLE
修改小游戏平台加载远程资源之后，会在一段时间内间隔2秒左右出现一次卡顿掉帧的问题

### DIFF
--- a/platforms/minigame/common/engine/cache-manager.js
+++ b/platforms/minigame/common/engine/cache-manager.js
@@ -22,7 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
-const { getUserDataPath, readJsonSync, makeDirSync, writeFileSync, copyFile, downloadFile, deleteFile, rmdirSync, unzip, isOutOfStorage } = window.fsUtils;
+const { getUserDataPath, readJsonSync, makeDirSync, writeFile, writeFileSync, copyFile, downloadFile, deleteFile, rmdirSync, unzip, isOutOfStorage } = window.fsUtils;
 
 var checkNextPeriod = false;
 var writeCacheFileList = null;
@@ -93,7 +93,7 @@ var cacheManager = {
 
     _write () {
         writeCacheFileList = null;
-        writeFileSync(this.cacheDir + '/' + this.cachedFileName, JSON.stringify({ files: this.cachedFiles._map, version: this.version }), 'utf8');
+        writeFile(this.cacheDir + '/' + this.cachedFileName, JSON.stringify({ files: this.cachedFiles._map, version: this.version }), 'utf8');
     },
 
     writeCacheFile () {


### PR DESCRIPTION

https://forum.cocos.org/t/topic/156157
在小游戏平台远程加载资源之后，会在一段时间内间隔2秒左右出现一次卡顿掉帧。测试是在字节小游戏使用iphone11和iPhone13.
定位到问题是在加载远程资源以后，引擎会间隔2秒从临时目录保存到缓存，这里用的是writeFileSync同步方法，打印时间70ms左右，writeFileSync会导致游戏主线程卡主，应该改为writeFile方法异步写入