### PR TITLE
fix spine cache animation delete material cache bug

### DIFF
--- a/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
@@ -440,10 +440,7 @@ void SkeletonCacheAnimation::setColor(float r, float g, float b, float a) {
 
 void SkeletonCacheAnimation::setBatchEnabled(bool enabled) {
     if (_enableBatch != enabled) {
-        for (auto &item : _materialCaches) {
-            CC_SAFE_DELETE(item.second);
-        }
-        _materialCaches.clear();
+        _needClerMaterialCaches = true;
         _enableBatch = enabled;
     }
 }
@@ -558,10 +555,7 @@ void SkeletonCacheAnimation::setRenderEntity(cc::RenderEntity *entity) {
 
 void SkeletonCacheAnimation::setMaterial(cc::Material *material) {
     _material = material;
-    for (auto &item : _materialCaches) {
-        CC_SAFE_DELETE(item.second);
-    }
-    _materialCaches.clear();
+    _needClerMaterialCaches = true;
 }
 
 cc::RenderDrawInfo *SkeletonCacheAnimation::requestDrawInfo(int idx) {
@@ -574,6 +568,13 @@ cc::RenderDrawInfo *SkeletonCacheAnimation::requestDrawInfo(int idx) {
 }
 
 cc::Material *SkeletonCacheAnimation::requestMaterial(uint16_t blendSrc, uint16_t blendDst) {
+    if (_needClerMaterialCaches) {
+        for (auto &item : _materialCaches) {
+            CC_SAFE_DELETE(item.second);
+        }
+        _materialCaches.clear();
+        _needClerMaterialCaches = false;
+    }
     uint32_t key = static_cast<uint32_t>(blendSrc) << 16 | static_cast<uint32_t>(blendDst);
     if (_materialCaches.find(key) == _materialCaches.end()) {
         const IMaterialInstanceInfo info{

--- a/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.h
@@ -141,5 +141,6 @@ private:
     cc::Material *_material = nullptr;
     ccstd::vector<cc::RenderDrawInfo *> _drawInfoArray;
     ccstd::unordered_map<uint32_t, cc::Material*> _materialCaches;
+    bool _needClerMaterialCaches = false;
 };
 } // namespace spine


### PR DESCRIPTION
原生平台spine使用缓存时，在组件update时候进行操作可能会导致删除正在使用的材质信息，导致绘制访问异常内存而崩溃。

例如：
```
import { _decorator, Component, director, math, Node, sp } from 'cc';
const { ccclass, property } = _decorator;

@ccclass('Tester')
export class Tester extends Component {

    @property(sp.Skeleton)
    private skeleton: sp.Skeleton;

    update(deltaTime: number) {
        if (director.getTotalFrames() == 3) {
            this.skeleton.enabled = false;
            this.skeleton.setSkin("e yu");
            this.skeleton.enabled = true;
        }
    }
}
```
除update阶段，还存在其他一些阶段有问题，不列举了。