### PR TITLE
check max mipmap level for texture creation

### DIFF
--- a/native/cocos/renderer/gfx-validator/TextureValidator.cpp
+++ b/native/cocos/renderer/gfx-validator/TextureValidator.cpp
@@ -104,7 +104,8 @@ void TextureValidator::doInit(const TextureInfo &info) {
     }
 
     if (hasFlag(info.flags, TextureFlagBit::GEN_MIPMAP)) {
-        CC_ASSERT(info.levelCount > 1);
+        auto maxLevelCount = std::floor(std::log2(std::max({ info.width, info.height, info.depth }))) + 1;
+        CC_ASSERT(info.levelCount > 1 && info.levelCount <= maxLevelCount);
 
         bool isCompressed = GFX_FORMAT_INFOS[static_cast<int>(info.format)].isCompressed;
         CC_ASSERT(!isCompressed);


### PR DESCRIPTION
check max level count
actually there is already a function `getLevelCount` in the `GFXTexture.cpp` to calculate the max count, but i didn't move this function to somewhere for common use because not sure where should i put it.