### PR TITLE
fix: use gltf-scene as a fillter, when open a asset dialog

### DIFF
--- a/editor/i18n/en/assets.js
+++ b/editor/i18n/en/assets.js
@@ -485,7 +485,6 @@ module.exports = {
             importSkeleton: 'Import Skeleton',
             clearAllNodes: 'Clear',
             clearAllNodesWarn: 'Are you sure to clear all data of this Animation Mask?',
-            illegalFbx: 'Import Skeleton Failed: this fbx asset has not contained sub prefab asset.',
             nodeEnableTip: 'Whether to enable this joint and its descendants.;<br>Alt + Click only toggle the state of itself.',
         },
         multipleWarning: 'Multi-select editing of this type of asset is not supported.',

--- a/editor/i18n/zh/assets.js
+++ b/editor/i18n/zh/assets.js
@@ -469,7 +469,6 @@ module.exports = {
             importSkeleton: '导入骨骼',
             clearAllNodes: '清空',
             clearAllNodesWarn: '确定清空所有遮罩数据吗？',
-            illegalFbx: '导入骨骼失败：此 FBX 文件不含有 Prefab 子资源。',
             nodeEnableTip: '是否启用该节点及其子孙节点<br>按住 Alt + 点击，只切换自身的状态。',
         },
         multipleWarning: '不支持此类型资源的多选编辑',

--- a/editor/inspector/assets/animation-mask.js
+++ b/editor/inspector/assets/animation-mask.js
@@ -119,10 +119,10 @@ exports.methods = {
 
         this.changed();
     },
-    async import(info) {
+    async import(uuid) {
         this.queryData = await Editor.Message.request('scene', 'change-animation-mask', {
             method: 'import-skeleton',
-            uuid: info.redirect.uuid,
+            uuid: uuid,
         });
 
         this.changed();
@@ -275,27 +275,20 @@ exports.ready = function() {
     const panel = this;
 
     panel.$.import.addEventListener('change', (event) => {
-        const rawTimestamp = Date.now();
         Editor.Panel.__protected__.openKit('ui-kit.searcher', {
             elem: event.target,
             params: [
                 {
                     type: 'asset',
                     assetFilter: {
-                        importer: ['fbx', 'gltf'],
+                        importer: ['gltf-scene'],
                     },
                 },
             ],
             listeners: {
                 async confirm(detail) {
                     if (!detail) { return; }
-                    const info = await Editor.Message.request('asset-db', 'query-asset-info', detail.value);
-                    if (!info || !info.redirect || info.redirect.type !== 'cc.Prefab') {
-                        console.error(Editor.I18n.t('ENGINE.assets.animationMask.illegalFbx') + ` {asset(${detail.value})}`);
-                        return;
-                    }
-
-                    await panel.import(info);
+                    await panel.import(detail.value);
                 },
             },
         });


### PR DESCRIPTION
Re: #

### Changelog

*fix: use gltf-scene as a fillter, when open a asset dialog

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
