### PR TITLE
Fix terrain asset unsynchronized data

### DIFF
--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -2478,6 +2478,10 @@ export class Terrain extends Component {
                 this._normals[i * 3 + 1] = 1;
                 this._normals[i * 3 + 2] = 0;
             }
+            if (terrainAsset) {
+                terrainAsset.heights = this._heights;
+                terrainAsset.normals = this._normals;
+            }
         }
 
         if (this._normals === null || this._normals.length !== vertexCount * 3) {
@@ -2492,6 +2496,9 @@ export class Terrain extends Component {
             for (let i = 0; i < layerBufferSize; ++i) {
                 this._layerBuffer[i] = -1;
             }
+            if (terrainAsset) {
+                terrainAsset.layerBuffer = this._layerBuffer;
+            }
         }
 
         // build weights
@@ -2504,6 +2511,9 @@ export class Terrain extends Component {
                 this._weights[i * 4 + 1] = 0;
                 this._weights[i * 4 + 2] = 0;
                 this._weights[i * 4 + 3] = 0;
+            }
+            if (terrainAsset) {
+                terrainAsset.weights = this._weights;
             }
         }
 


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/17902

### Changelog

* Fixed the issue of unsynchronized Terrain Asset data, which caused terrain height data to be lost when entering prefab editing mode after setting terrain height in the editor.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
