### PR TITLE
Fix the issue of screen.orientation being undefined on Safari.

### DIFF
--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -383,32 +383,34 @@ class ScreenAdapter extends EventTarget {
             this._resizeFrame();
         });
 
-        const adapter = this;
         const notifyOrientationChange = (orientation): void => {
-            if (orientation === adapter._orientation) {
+            if (orientation === this._orientation) {
                 return;
             }
-            adapter._orientation = orientation;
-            adapter.emit('orientation-change', orientation);
+            this._orientation = orientation;
+            this.emit('orientation-change', orientation);
         };
 
         const getOrientation = (rotateAngle: number): Orientation => {
             let tmpOrientation = Orientation.PORTRAIT;
             switch (window.orientation) {
-                case 0:
-                    tmpOrientation = Orientation.PORTRAIT;
-                    break;
-                case 90:
-                    // Handle landscape orientation, top side facing to the right
-                    tmpOrientation = Orientation.LANDSCAPE_RIGHT;
-                    break;
-                case -90:
-                    // Handle landscape orientation, top side facing to the left
-                    tmpOrientation = Orientation.LANDSCAPE_LEFT;
-                    break;
-                case 180:
-                    tmpOrientation = Orientation.PORTRAIT_UPSIDE_DOWN;
-                    break;
+            case 0:
+                tmpOrientation = Orientation.PORTRAIT;
+                break;
+            case 90:
+                // Handle landscape orientation, top side facing to the right
+                tmpOrientation = Orientation.LANDSCAPE_RIGHT;
+                break;
+            case -90:
+                // Handle landscape orientation, top side facing to the left
+                tmpOrientation = Orientation.LANDSCAPE_LEFT;
+                break;
+            case 180:
+                tmpOrientation = Orientation.PORTRAIT_UPSIDE_DOWN;
+                break;
+            default:
+                tmpOrientation = this._orientation;
+                break;
             }
             return tmpOrientation;
         };
@@ -426,7 +428,7 @@ class ScreenAdapter extends EventTarget {
             const mediaQueryPortrait = window.matchMedia('(orientation: portrait)');
             const mediaQueryLandscape = window.matchMedia('(orientation: landscape)');
             const handleOrientationChange = (): void => {
-                let tmpOrientation = adapter._orientation;
+                let tmpOrientation: Orientation = this._orientation;
                 if (!screen.orientation) {
                     tmpOrientation = getOrientation(window.orientation);
                 } else {

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -427,11 +427,12 @@ class ScreenAdapter extends EventTarget {
                 }, { once: true });
             };
             updateDPRChangeListener();
-            
+
             const mediaQueryPortrait = window.matchMedia('(orientation: portrait)');
             const mediaQueryLandscape = window.matchMedia('(orientation: landscape)');
             const handleOrientationChange = (): void => {
                 let tmpOrientation: Orientation = this._orientation;
+                // eslint-disable-next-line no-restricted-globals
                 if (!screen.orientation) {
                     tmpOrientation = getOrientation(window.orientation);
                 } else {
@@ -455,7 +456,7 @@ class ScreenAdapter extends EventTarget {
             mediaQueryLandscape.addEventListener('change', handleOrientationChange);
         } else {
             const handleOrientationChange = (): void => {
-                const tmpOrientation = getOrientation(window.orientation); 
+                const tmpOrientation = getOrientation(window.orientation);
                 notifyOrientationChange(tmpOrientation);
             };
             window.addEventListener('orientationchange', handleOrientationChange);

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -391,7 +391,10 @@ class ScreenAdapter extends EventTarget {
             this.emit('orientation-change', orientation);
         };
 
-        const getOrientation = (rotateAngle: number): Orientation => {
+        const getOrientation = (rotateAngle: number | string): Orientation => {
+            if (typeof rotateAngle === 'string') {
+                rotateAngle = parseInt(rotateAngle, 10);
+            }
             let tmpOrientation = Orientation.PORTRAIT;
             switch (window.orientation) {
             case 0:
@@ -432,6 +435,7 @@ class ScreenAdapter extends EventTarget {
                 if (!screen.orientation) {
                     tmpOrientation = getOrientation(window.orientation);
                 } else {
+                    // eslint-disable-next-line no-restricted-globals
                     const orientationType = screen.orientation.type;
                     if (mediaQueryPortrait.matches) {
                         if (orientationType === 'portrait-primary') {
@@ -439,12 +443,10 @@ class ScreenAdapter extends EventTarget {
                         } else {
                             tmpOrientation = Orientation.PORTRAIT_UPSIDE_DOWN;
                         }
-                    } else {
-                        if (orientationType === 'landscape-primary') {
-                            tmpOrientation = Orientation.LANDSCAPE_LEFT;
-                        } else if (orientationType === 'landscape-secondary') {
-                            tmpOrientation = Orientation.LANDSCAPE_RIGHT;
-                        }
+                    } else if (orientationType === 'landscape-primary') {
+                        tmpOrientation = Orientation.LANDSCAPE_LEFT;
+                    } else if (orientationType === 'landscape-secondary') {
+                        tmpOrientation = Orientation.LANDSCAPE_RIGHT;
                     }
                 }
                 notifyOrientationChange(tmpOrientation);
@@ -453,7 +455,7 @@ class ScreenAdapter extends EventTarget {
             mediaQueryLandscape.addEventListener('change', handleOrientationChange);
         } else {
             const handleOrientationChange = (): void => {
-                let tmpOrientation = getOrientation(window.orientation); 
+                const tmpOrientation = getOrientation(window.orientation); 
                 notifyOrientationChange(tmpOrientation);
             };
             window.addEventListener('orientationchange', handleOrientationChange);
@@ -561,10 +563,8 @@ class ScreenAdapter extends EventTarget {
         const height = window.innerHeight;
         const isBrowserLandscape = width > height;
         this.isFrameRotated = systemInfo.isMobile
-            && ((isBrowserLandscape && orientation === Orientation.PORTRAIT) ||
-                (!isBrowserLandscape && (orientation === Orientation.LANDSCAPE ||
-                    orientation === Orientation.LANDSCAPE_LEFT ||
-                    orientation === Orientation.LANDSCAPE_RIGHT)));
+            && ((isBrowserLandscape && orientation === Orientation.PORTRAIT)
+             || (!isBrowserLandscape && orientation === Orientation.LANDSCAPE));
     }
     private _updateContainer (): void {
         if (!this._gameContainer) {

--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -392,6 +392,26 @@ class ScreenAdapter extends EventTarget {
             adapter.emit('orientation-change', orientation);
         };
 
+        const getOrientation = (rotateAngle: number): Orientation => {
+            let tmpOrientation = Orientation.PORTRAIT;
+            switch (window.orientation) {
+                case 0:
+                    tmpOrientation = Orientation.PORTRAIT;
+                    break;
+                case 90:
+                    // Handle landscape orientation, top side facing to the right
+                    tmpOrientation = Orientation.LANDSCAPE_RIGHT;
+                    break;
+                case -90:
+                    // Handle landscape orientation, top side facing to the left
+                    tmpOrientation = Orientation.LANDSCAPE_LEFT;
+                    break;
+                case 180:
+                    tmpOrientation = Orientation.PORTRAIT_UPSIDE_DOWN;
+                    break;
+            }
+            return tmpOrientation;
+        };
         if (typeof window.matchMedia === 'function') {
             const updateDPRChangeListener = (): void => {
                 const dpr = window.devicePixelRatio;
@@ -407,18 +427,22 @@ class ScreenAdapter extends EventTarget {
             const mediaQueryLandscape = window.matchMedia('(orientation: landscape)');
             const handleOrientationChange = (): void => {
                 let tmpOrientation = adapter._orientation;
-                const orientationType = screen.orientation.type;
-                if (mediaQueryPortrait.matches) {
-                    if (orientationType === 'portrait-primary') {
-                        tmpOrientation = Orientation.PORTRAIT;
-                    } else {
-                        tmpOrientation = Orientation.PORTRAIT_UPSIDE_DOWN;
-                    }
+                if (!screen.orientation) {
+                    tmpOrientation = getOrientation(window.orientation);
                 } else {
-                    if (orientationType === 'landscape-primary') {
-                        tmpOrientation = Orientation.LANDSCAPE_LEFT;
-                    } else if (orientationType === 'landscape-secondary') {
-                        tmpOrientation = Orientation.LANDSCAPE_RIGHT;
+                    const orientationType = screen.orientation.type;
+                    if (mediaQueryPortrait.matches) {
+                        if (orientationType === 'portrait-primary') {
+                            tmpOrientation = Orientation.PORTRAIT;
+                        } else {
+                            tmpOrientation = Orientation.PORTRAIT_UPSIDE_DOWN;
+                        }
+                    } else {
+                        if (orientationType === 'landscape-primary') {
+                            tmpOrientation = Orientation.LANDSCAPE_LEFT;
+                        } else if (orientationType === 'landscape-secondary') {
+                            tmpOrientation = Orientation.LANDSCAPE_RIGHT;
+                        }
                     }
                 }
                 notifyOrientationChange(tmpOrientation);
@@ -426,25 +450,8 @@ class ScreenAdapter extends EventTarget {
             mediaQueryPortrait.addEventListener('change', handleOrientationChange);
             mediaQueryLandscape.addEventListener('change', handleOrientationChange);
         } else {
-            const adapter = this;
             const handleOrientationChange = (): void => {
-                let tmpOrientation = adapter._orientation;
-                switch (window.orientation) {
-                    case 0:
-                        tmpOrientation = Orientation.PORTRAIT;
-                        break;
-                    case 90:
-                        // Handle landscape orientation, top side facing to the right
-                        tmpOrientation = Orientation.LANDSCAPE_RIGHT;
-                        break;
-                    case -90:
-                        // Handle landscape orientation, top side facing to the left
-                        tmpOrientation = Orientation.LANDSCAPE_LEFT;
-                        break;
-                    case 180:
-                        tmpOrientation = Orientation.PORTRAIT_UPSIDE_DOWN;
-                        break;
-                }
+                let tmpOrientation = getOrientation(window.orientation); 
                 notifyOrientationChange(tmpOrientation);
             };
             window.addEventListener('orientationchange', handleOrientationChange);


### PR DESCRIPTION
Re: #
https://github.com/cocos/3d-tasks/issues/18177

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
