### PR TITLE
Resolve Transparent Rendering Breaking when changing screen Resolution

### DIFF
--- a/cocos/gfx/base/framebuffer.ts
+++ b/cocos/gfx/base/framebuffer.ts
@@ -73,6 +73,10 @@ export abstract class Framebuffer extends GFXObject {
         return this._height;
     }
 
+    public get needsRebuild(): boolean {
+        return false;
+    }
+
     protected _renderPass: RenderPass | null = null;
     protected _colorTextures: (Texture | null)[] = [];
     protected _depthStencilTexture: Texture | null = null;

--- a/cocos/gfx/webgl2/webgl2-framebuffer.ts
+++ b/cocos/gfx/webgl2/webgl2-framebuffer.ts
@@ -36,7 +36,16 @@ export class WebGL2Framebuffer extends Framebuffer {
     }
 
     private _gpuFramebuffer: IWebGL2GPUFramebuffer | null = null;
+    private _gpuColorTexture: WebGLTexture | null = null;
 
+    get needsRebuild(): boolean {
+        if (this._gpuFramebuffer && this._gpuColorTexture && this._gpuFramebuffer.gpuColorViews.length > 0) {
+            return this._gpuFramebuffer.gpuColorViews[0].gpuTexture.glTexture != this._gpuColorTexture;
+        }
+
+        return false;
+    }
+    
     public initialize (info: Readonly<FramebufferInfo>): void {
         this._renderPass = info.renderPass;
         this._colorTextures = info.colorTextures || [];
@@ -88,6 +97,9 @@ export class WebGL2Framebuffer extends Framebuffer {
         };
 
         WebGL2CmdFuncCreateFramebuffer(WebGL2DeviceManager.instance, this._gpuFramebuffer);
+        this._gpuColorTexture = this._gpuFramebuffer.gpuColorViews.length
+            ? this._gpuFramebuffer.gpuColorViews[0]?.gpuTexture?.glTexture
+            : null;
         this._width = this._gpuFramebuffer.width;
         this._height = this._gpuFramebuffer.height;
     }
@@ -96,6 +108,7 @@ export class WebGL2Framebuffer extends Framebuffer {
         if (this._gpuFramebuffer) {
             WebGL2CmdFuncDestroyFramebuffer(WebGL2DeviceManager.instance, this._gpuFramebuffer);
             this._gpuFramebuffer = null;
+            this._gpuColorTexture = null;
         }
     }
 }

--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -1076,7 +1076,7 @@ class DeviceRenderPass implements RecordingInterface {
             height = resDesc.height;
             break;
         }
-        const needRebuild = (width !== currentWidth) || (height !== currentHeight);
+        const needRebuild = (width !== currentWidth) || (height !== currentHeight) || this._framebuffer.needsRebuild;
 
         for (const [resName, rasterV] of this._rasterInfo.pass.rasterViews) {
             let deviceTex = context.deviceTextures.get(resName)!;


### PR DESCRIPTION
Resolves this issue: https://github.com/cocos/cocos-engine/issues/16266

The above issue was partially fixed by detecting that the screen size changed indicating the frame buffer resources needed to be rebuilt. However the specific issue of Transparency breaking is due to the fact that the Transparent Render Pass for the Post Process pipeline references the same Texture resources used by the Opaque Render Pass. Each Render Pass owns its own Framebuffer but the underlying Texture resources are shared. When the above issue occurs it is a result of the Transparent Render Pass frame buffer no longer referencing the same Texture resources as the Opaque Render Pass.

1. Initial screen resolution set and Render Pass objects initialized
2. Transparent Frame Buffer is initialized and points to the same Texture resource as the Opaque Render Pass
3. Change screen resolution
4. New Render Pass objects are created keyed off the render params used to generate the hashId
5. Everything works fine
6. Change screen resolution back to the original size
7. The Render Pass objects already exist so call resetResrouces
8. Opaque Render Pass `resetResources` called and detects the screen resolution has changed so it rebuilds it's frame buffer object
9. This triggers calls to `Texture.resize` on the color and depth textures associated with the Render Pass
10. Calling `resize` destroys the old webgl textures and creates new ones that the Opaque frame buffer binds to when it is recreated
11. Transparent Render Pass `resetResources` called but because it shares the same Textures with the Opaque Render Pass it does not detect that any resolution changes have been made so it does not rebuild it's frame buffer, resulting in the Transparent Render Pass frame buffer still binding to old webgl texture handles that are different than the ones bound to the Opaque Render Pass.

I am not certain that my solution here is the best way to solve this problem but it has resolved the issue for my project and does properly showcase what the issue is.

### Changelog

* 

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
