### PR TITLE
Fix for particle system render bounds center getting out of sync

### DIFF
--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -1108,9 +1108,9 @@ export class ParticleSystem extends ModelRenderer {
         this.processor.onDisable();
         if (this._trailModule) this._trailModule.onDisable();
         if (this._boundingBox) {
-            this._boundingBox = null;
-            this._oldPos = null;
+            this._boundingBox = null;            
         }
+        this._oldPos = null;
         if (this._culler) {
             this._culler.clear();
             this._culler.destroy();

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -1108,7 +1108,7 @@ export class ParticleSystem extends ModelRenderer {
         this.processor.onDisable();
         if (this._trailModule) this._trailModule.onDisable();
         if (this._boundingBox) {
-            this._boundingBox = null;            
+            this._boundingBox = null;
         }
         this._oldPos = null;
         if (this._culler) {

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -1109,6 +1109,7 @@ export class ParticleSystem extends ModelRenderer {
         if (this._trailModule) this._trailModule.onDisable();
         if (this._boundingBox) {
             this._boundingBox = null;
+            this._oldPos = null;
         }
         if (this._culler) {
             this._culler.clear();


### PR DESCRIPTION
I discovered this issue when trying to enable render culling for Particle Systems in our game to improve performance. I noticed that Particle Systems were being culled while they were clearly visible on screen. It turns out the issue is that the Particle System render culling bounding box center is not recomputed every frame, it merely has a movement offset applied to the current bounding box center. This can result in the bounding box center being drastically offset from the actually location of the particle system if the particle system is moved while the Node is disabled. For our situation this was due to us  making use of a Pooling system to re-use one shot particle effects.

This change clears the _oldPos value used when computing the offset delta to be applied to the bounding box so that it is reset to the current position of the particle system when it is re-enabled and the bounding box is re-computed.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
