### PR TITLE
fix the issue of material release bug for spine & dragonbone

### DIFF
--- a/native/cmake/predefine.cmake
+++ b/native/cmake/predefine.cmake
@@ -126,6 +126,8 @@ if("$ENV{COCOS_ENGINE_DEV}" EQUAL "1")
     set(WERROR_FLAGS "-Werror -Werror=return-type") # -Wshorten-64-to-32 -Werror=return-type
     
     if(APPLE)
+        set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations")
+    elseif(MACOSX)
         set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations -Wno-deprecated-builtins")
     elseif(LINUX)
         set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-nullability-completeness -Wno-deprecated-declarations")

--- a/native/cmake/predefine.cmake
+++ b/native/cmake/predefine.cmake
@@ -126,7 +126,7 @@ if("$ENV{COCOS_ENGINE_DEV}" EQUAL "1")
     set(WERROR_FLAGS "-Werror -Werror=return-type") # -Wshorten-64-to-32 -Werror=return-type
     
     if(APPLE)
-        set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations")
+        set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations -Wno-deprecated-builtins")
     elseif(LINUX)
         set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-nullability-completeness -Wno-deprecated-declarations")
     elseif(ANDROID)

--- a/native/cmake/predefine.cmake
+++ b/native/cmake/predefine.cmake
@@ -126,7 +126,7 @@ if("$ENV{COCOS_ENGINE_DEV}" EQUAL "1")
     set(WERROR_FLAGS "-Werror -Werror=return-type") # -Wshorten-64-to-32 -Werror=return-type
     
     if(MACOSX)
-        set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations -Wno-deprecated-builtins")
+        set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations -Wno-deprecated-builtins -Wno-unqualified-std-cast-call")
     elseif(APPLE)
         set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations")
     elseif(LINUX)

--- a/native/cmake/predefine.cmake
+++ b/native/cmake/predefine.cmake
@@ -125,10 +125,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if("$ENV{COCOS_ENGINE_DEV}" EQUAL "1")
     set(WERROR_FLAGS "-Werror -Werror=return-type") # -Wshorten-64-to-32 -Werror=return-type
     
-    if(APPLE)
-        set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations")
-    elseif(MACOSX)
+    if(MACOSX)
         set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations -Wno-deprecated-builtins")
+    elseif(APPLE)
+        set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-deprecated-declarations")
     elseif(LINUX)
         set(WERROR_FLAGS " ${WERROR_FLAGS} -Wno-nullability-completeness -Wno-deprecated-declarations")
     elseif(ANDROID)

--- a/native/cocos/editor-support/dragonbones-creator-support/CCArmatureCacheDisplay.cpp
+++ b/native/cocos/editor-support/dragonbones-creator-support/CCArmatureCacheDisplay.cpp
@@ -397,10 +397,7 @@ void CCArmatureCacheDisplay::setAttachEnabled(bool enabled) {
 
 void CCArmatureCacheDisplay::setBatchEnabled(bool enabled) {
     if (enabled != _enableBatch) {
-        for (auto &item : _materialCaches) {
-            CC_SAFE_DELETE(item.second);
-        }
-        _materialCaches.clear();
+        _needClerMaterialCaches = true;
         _enableBatch = enabled;
     }
 }
@@ -418,10 +415,7 @@ void CCArmatureCacheDisplay::setRenderEntity(cc::RenderEntity *entity) {
 
 void CCArmatureCacheDisplay::setMaterial(cc::Material *material) {
     _material = material;
-    for (auto &item : _materialCaches) {
-        CC_SAFE_DELETE(item.second);
-    }
-    _materialCaches.clear();
+    _needClerMaterialCaches = true;
 }
 
 cc::RenderDrawInfo *CCArmatureCacheDisplay::requestDrawInfo(int idx) {
@@ -434,6 +428,13 @@ cc::RenderDrawInfo *CCArmatureCacheDisplay::requestDrawInfo(int idx) {
 }
 
 cc::Material *CCArmatureCacheDisplay::requestMaterial(uint16_t blendSrc, uint16_t blendDst) {
+    if (_needClerMaterialCaches) {
+        _needClerMaterialCaches = false;
+        for (auto &item : _materialCaches) {
+            CC_SAFE_DELETE(item.second);
+        }
+        _materialCaches.clear();
+    }
     uint32_t key = static_cast<uint32_t>(blendSrc) << 16 | static_cast<uint32_t>(blendDst);
     if (_materialCaches.find(key) == _materialCaches.end()) {
         const IMaterialInstanceInfo info{

--- a/native/cocos/editor-support/dragonbones-creator-support/CCArmatureCacheDisplay.h
+++ b/native/cocos/editor-support/dragonbones-creator-support/CCArmatureCacheDisplay.h
@@ -124,6 +124,7 @@ private:
     cc::Material *_material = nullptr;
     ccstd::vector<cc::RenderDrawInfo *> _drawInfoArray;
     ccstd::unordered_map<uint32_t, cc::Material *> _materialCaches;
+    bool _needClerMaterialCaches = false;
 };
 
 DRAGONBONES_NAMESPACE_END

--- a/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -406,10 +406,7 @@ se_object_ptr CCArmatureDisplay::getSharedBufferOffset() const {
 
 void CCArmatureDisplay::setBatchEnabled(bool enabled) {
     if (enabled != _enableBatch) {
-        for (auto &item : _materialCaches) {
-            CC_SAFE_DELETE(item.second);
-        }
-        _materialCaches.clear();
+        _needClerMaterialCaches = true;
         _enableBatch = enabled;
     }
 }
@@ -420,10 +417,7 @@ void CCArmatureDisplay::setRenderEntity(cc::RenderEntity *entity) {
 
 void CCArmatureDisplay::setMaterial(cc::Material *material) {
     _material = material;
-    for (auto &item : _materialCaches) {
-        CC_SAFE_DELETE(item.second);
-    }
-    _materialCaches.clear();
+    _needClerMaterialCaches = true;
 }
 
 cc::RenderDrawInfo *CCArmatureDisplay::requestDrawInfo(int idx) {
@@ -436,6 +430,13 @@ cc::RenderDrawInfo *CCArmatureDisplay::requestDrawInfo(int idx) {
 }
 
 cc::Material *CCArmatureDisplay::requestMaterial(uint16_t blendSrc, uint16_t blendDst) {
+    if (_needClerMaterialCaches) {
+        _needClerMaterialCaches = false;
+        for (auto &item : _materialCaches) {
+            CC_SAFE_DELETE(item.second);
+        }
+        _materialCaches.clear();
+    }
     uint32_t key = static_cast<uint32_t>(blendSrc) << 16 | static_cast<uint32_t>(blendDst);
     if (_materialCaches.find(key) == _materialCaches.end()) {
         const IMaterialInstanceInfo info{

--- a/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.h
+++ b/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.h
@@ -204,6 +204,7 @@ private:
     cc::Material *_material = nullptr;
     ccstd::vector<cc::RenderDrawInfo *> _drawInfoArray;
     ccstd::unordered_map<uint32_t, cc::Material *> _materialCaches;
+    bool _needClerMaterialCaches = false;
 };
 
 DRAGONBONES_NAMESPACE_END

--- a/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
@@ -440,10 +440,7 @@ void SkeletonCacheAnimation::setColor(float r, float g, float b, float a) {
 
 void SkeletonCacheAnimation::setBatchEnabled(bool enabled) {
     if (_enableBatch != enabled) {
-        for (auto &item : _materialCaches) {
-            CC_SAFE_DELETE(item.second);
-        }
-        _materialCaches.clear();
+        _needClerMaterialCaches = true;
         _enableBatch = enabled;
     }
 }
@@ -558,10 +555,7 @@ void SkeletonCacheAnimation::setRenderEntity(cc::RenderEntity *entity) {
 
 void SkeletonCacheAnimation::setMaterial(cc::Material *material) {
     _material = material;
-    for (auto &item : _materialCaches) {
-        CC_SAFE_DELETE(item.second);
-    }
-    _materialCaches.clear();
+    _needClerMaterialCaches = true;
 }
 
 cc::RenderDrawInfo *SkeletonCacheAnimation::requestDrawInfo(int idx) {
@@ -574,6 +568,13 @@ cc::RenderDrawInfo *SkeletonCacheAnimation::requestDrawInfo(int idx) {
 }
 
 cc::Material *SkeletonCacheAnimation::requestMaterial(uint16_t blendSrc, uint16_t blendDst) {
+    if (_needClerMaterialCaches) {
+        for (auto &item : _materialCaches) {
+            CC_SAFE_DELETE(item.second);
+        }
+        _materialCaches.clear();
+        _needClerMaterialCaches = false;
+    }
     uint32_t key = static_cast<uint32_t>(blendSrc) << 16 | static_cast<uint32_t>(blendDst);
     if (_materialCaches.find(key) == _materialCaches.end()) {
         const IMaterialInstanceInfo info{

--- a/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.h
@@ -141,5 +141,6 @@ private:
     cc::Material *_material = nullptr;
     ccstd::vector<cc::RenderDrawInfo *> _drawInfoArray;
     ccstd::unordered_map<uint32_t, cc::Material*> _materialCaches;
+    bool _needClerMaterialCaches = false;
 };
 } // namespace spine

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -952,10 +952,7 @@ void SkeletonRenderer::setColor(float r, float g, float b, float a) {
 
 void SkeletonRenderer::setBatchEnabled(bool enabled) {
     if (enabled != _enableBatch) {
-        for (auto &item : _materialCaches) {
-            CC_SAFE_DELETE(item.second);
-        }
-        _materialCaches.clear();
+        _needClerMaterialCaches = true;
         _enableBatch = enabled;
     }
 }
@@ -1000,10 +997,7 @@ void SkeletonRenderer::setRenderEntity(cc::RenderEntity *entity) {
 
 void SkeletonRenderer::setMaterial(cc::Material *material) {
     _material = material;
-    for (auto &item : _materialCaches) {
-        CC_SAFE_DELETE(item.second);
-    }
-    _materialCaches.clear();
+    _needClerMaterialCaches = true;
 }
 
 cc::RenderDrawInfo *SkeletonRenderer::requestDrawInfo(int idx) {
@@ -1016,6 +1010,13 @@ cc::RenderDrawInfo *SkeletonRenderer::requestDrawInfo(int idx) {
 }
 
 cc::Material *SkeletonRenderer::requestMaterial(uint16_t blendSrc, uint16_t blendDst) {
+    if (_needClerMaterialCaches) {
+        _needClerMaterialCaches = false;
+        for (auto &item : _materialCaches) {
+            CC_SAFE_DELETE(item.second);
+        }
+        _materialCaches.clear();
+    }
     uint32_t key = static_cast<uint32_t>(blendSrc) << 16 | static_cast<uint32_t>(blendDst);
     if (_materialCaches.find(key) == _materialCaches.end()) {
         const IMaterialInstanceInfo info{

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.h
@@ -187,6 +187,7 @@ protected:
     cc::Material *_material = nullptr;
     ccstd::vector<cc::RenderDrawInfo *> _drawInfoArray;
     ccstd::unordered_map<uint32_t, cc::Material *> _materialCaches;
+    bool _needClerMaterialCaches = false;
 };
 
 } // namespace spine


### PR DESCRIPTION
Re: #
https://github.com/cocos/cocos-engine/pull/16782
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
