### PR TITLE
Fix divide zero issue in mat4.toSRT which causes node._lrot with NaN values.

### DIFF
--- a/cocos/core/math/mat4.ts
+++ b/cocos/core/math/mat4.ts
@@ -897,44 +897,48 @@ export class Mat4 extends ValueType {
      * @param s The corresponding scaling vector
      */
     public static toSRT<InType extends IMat4Like, VecLike extends IVec3Like> (m: InType, q: Quat | null, v: VecLike | null, s: VecLike | null): void {
+        // Translation
+        if (v) {
+            Vec3.set(v, m.m12, m.m13, m.m14);
+        }
+
+        // Scale
         const sx = Vec3.set(v3_1, m.m00, m.m01, m.m02).length();
         const sy = Vec3.set(v3_1, m.m04, m.m05, m.m06).length();
         const sz = Vec3.set(v3_1, m.m08, m.m09, m.m10).length();
-
-        if (sx !== 0) {
-            m3_1.m00 = m.m00 / sx;
-            m3_1.m01 = m.m01 / sx;
-            m3_1.m02 = m.m02 / sx;
-        } else {
-            m3_1.m00 = m3_1.m01 = m3_1.m02 = 0;
-        }
-        if (sy !== 0) {
-            m3_1.m03 = m.m04 / sy;
-            m3_1.m04 = m.m05 / sy;
-            m3_1.m05 = m.m06 / sy;
-        } else {
-            m3_1.m03 = m3_1.m04 = m3_1.m05 = 0;
-        }
-        if (sz !== 0) {
-            m3_1.m06 = m.m08 / sz;
-            m3_1.m07 = m.m09 / sz;
-            m3_1.m08 = m.m10 / sz;
-        } else {
-            m3_1.m06 = m3_1.m07 = m3_1.m08 = 0;
-        }
-
-        const det = Mat3.determinant(m3_1);
         if (s) {
             s.x = sx;
             s.y = sy;
             s.z = sz;
+        }
+
+        // Scale too close to zero, can't decompose rotation.
+        if (sx === 0 || sy === 0 || sz === 0) {
+            if (q) {
+                Quat.identity(q);
+            }
+            return;
+        }
+
+        m3_1.m00 = m.m00 / sx;
+        m3_1.m01 = m.m01 / sx;
+        m3_1.m02 = m.m02 / sx;
+
+        m3_1.m03 = m.m04 / sy;
+        m3_1.m04 = m.m05 / sy;
+        m3_1.m05 = m.m06 / sy;
+
+        m3_1.m06 = m.m08 / sz;
+        m3_1.m07 = m.m09 / sz;
+        m3_1.m08 = m.m10 / sz;
+
+        const det = Mat3.determinant(m3_1);
+        if (s) {
             if (det < 0) {
                 s.x *= -1;
             }
         }
-        if (v) {
-            Vec3.set(v, m.m12, m.m13, m.m14);
-        }
+
         if (q) {
             if (det < 0) {
                 m3_1.m00 *= -1;

--- a/cocos/core/math/mat4.ts
+++ b/cocos/core/math/mat4.ts
@@ -884,37 +884,7 @@ export class Mat4 extends ValueType {
      * @deprecated Since 3.8.0, please use toSRT instead
      */
     public static toRTS<InType extends IMat4Like, VecLike extends IVec3Like> (m: InType, q: Quat | null, v: VecLike | null, s: VecLike | null): void {
-        const sx = Vec3.set(v3_1, m.m00, m.m01, m.m02).length();
-        const sy = Vec3.set(v3_1, m.m04, m.m05, m.m06).length();
-        const sz = Vec3.set(v3_1, m.m08, m.m09, m.m10).length();
-        m3_1.m00 = m.m00 / sx;
-        m3_1.m01 = m.m01 / sx;
-        m3_1.m02 = m.m02 / sx;
-        m3_1.m03 = m.m04 / sy;
-        m3_1.m04 = m.m05 / sy;
-        m3_1.m05 = m.m06 / sy;
-        m3_1.m06 = m.m08 / sz;
-        m3_1.m07 = m.m09 / sz;
-        m3_1.m08 = m.m10 / sz;
-        const det = Mat3.determinant(m3_1);
-
-        if (s) {
-            Vec3.set(s, sx, sy, sz);
-            if (det < 0) {
-                s.x *= -1;
-            }
-        }
-        if (v) {
-            Vec3.set(v, m.m12, m.m13, m.m14);
-        }
-        if (q) {
-            if (det < 0) {
-                m3_1.m00 *= -1;
-                m3_1.m01 *= -1;
-                m3_1.m02 *= -1;
-            }
-            Quat.fromMat3(q, m3_1);
-        }
+        Mat4.toSRT(m, q, v, s);
     }
 
     /**
@@ -930,27 +900,43 @@ export class Mat4 extends ValueType {
         const sx = Vec3.set(v3_1, m.m00, m.m01, m.m02).length();
         const sy = Vec3.set(v3_1, m.m04, m.m05, m.m06).length();
         const sz = Vec3.set(v3_1, m.m08, m.m09, m.m10).length();
+
+        if (sx !== 0) {
+            m3_1.m00 = m.m00 / sx;
+            m3_1.m01 = m.m01 / sx;
+            m3_1.m02 = m.m02 / sx;
+        } else {
+            m3_1.m00 = m3_1.m01 = m3_1.m02 = 0;
+        }
+        if (sy !== 0) {
+            m3_1.m03 = m.m04 / sy;
+            m3_1.m04 = m.m05 / sy;
+            m3_1.m05 = m.m06 / sy;
+        } else {
+            m3_1.m03 = m3_1.m04 = m3_1.m05 = 0;
+        }
+        if (sz !== 0) {
+            m3_1.m06 = m.m08 / sz;
+            m3_1.m07 = m.m09 / sz;
+            m3_1.m08 = m.m10 / sz;
+        } else {
+            m3_1.m06 = m3_1.m07 = m3_1.m08 = 0;
+        }
+
+        const det = Mat3.determinant(m3_1);
         if (s) {
             s.x = sx;
             s.y = sy;
             s.z = sz;
+            if (det < 0) {
+                s.x *= -1;
+            }
         }
         if (v) {
             Vec3.set(v, m.m12, m.m13, m.m14);
         }
         if (q) {
-            m3_1.m00 = m.m00 / sx;
-            m3_1.m01 = m.m01 / sx;
-            m3_1.m02 = m.m02 / sx;
-            m3_1.m03 = m.m04 / sy;
-            m3_1.m04 = m.m05 / sy;
-            m3_1.m05 = m.m06 / sy;
-            m3_1.m06 = m.m08 / sz;
-            m3_1.m07 = m.m09 / sz;
-            m3_1.m08 = m.m10 / sz;
-            const det = Mat3.determinant(m3_1);
             if (det < 0) {
-                if (s) s.x *= -1;
                 m3_1.m00 *= -1;
                 m3_1.m01 *= -1;
                 m3_1.m02 *= -1;
@@ -980,42 +966,7 @@ export class Mat4 extends ValueType {
      * @deprecated Since 3.8.0, please use [[fromSRT]] instead.
      */
     public static fromRTS<Out extends IMat4Like, VecLike extends IVec3Like> (out: Out, q: Quat, v: VecLike, s: VecLike): Out {
-        const x = q.x; const y = q.y; const z = q.z; const w = q.w;
-        const x2 = x + x;
-        const y2 = y + y;
-        const z2 = z + z;
-
-        const xx = x * x2;
-        const xy = x * y2;
-        const xz = x * z2;
-        const yy = y * y2;
-        const yz = y * z2;
-        const zz = z * z2;
-        const wx = w * x2;
-        const wy = w * y2;
-        const wz = w * z2;
-        const sx = s.x;
-        const sy = s.y;
-        const sz = s.z;
-
-        out.m00 = (1 - (yy + zz)) * sx;
-        out.m01 = (xy + wz) * sx;
-        out.m02 = (xz - wy) * sx;
-        out.m03 = 0;
-        out.m04 = (xy - wz) * sy;
-        out.m05 = (1 - (xx + zz)) * sy;
-        out.m06 = (yz + wx) * sy;
-        out.m07 = 0;
-        out.m08 = (xz + wy) * sz;
-        out.m09 = (yz - wx) * sz;
-        out.m10 = (1 - (xx + yy)) * sz;
-        out.m11 = 0;
-        out.m12 = v.x;
-        out.m13 = v.y;
-        out.m14 = v.z;
-        out.m15 = 1;
-
-        return out;
+        return Mat4.fromSRT(out, q, v, s);
     }
 
     /**

--- a/native/cocos/math/Mat4.cpp
+++ b/native/cocos/math/Mat4.cpp
@@ -554,6 +554,7 @@ bool Mat4::decompose(Vec3 *scale, Quaternion *rotation, Vec3 *translation) const
 
     // Scale too close to zero, can't decompose rotation.
     if (std::abs(scaleX) < MATH_TOLERANCE || std::abs(scaleY) < MATH_TOLERANCE || std::abs(scaleZ) < MATH_TOLERANCE) {
+        rotation->setIdentity();
         return false;
     }
 

--- a/native/tests/unit-test/src/math_mat4_test.cpp
+++ b/native/tests/unit-test/src/math_mat4_test.cpp
@@ -283,4 +283,20 @@ TEST(mathMat4Test, test5) {
     cc::Mat4 a{1.111223F, 0.123454F, 0.384183F, 1.111222F, 3.123455F, 4.384183F, 5.111223F, 6.123455F, 2.384183F, 3.111224F, 4.123455F, 5.384183F, 6.111224F, 7.123456F, 8.384183F, 9.111224F};
     cc::Mat4 b{1.111224F, 0.123455F, 0.384182F, 1.111223F, 3.123456F, 4.384184F, 5.111224F, 6.123456F, 2.384182F, 3.111223F, 4.123456F, 5.384184F, 6.111223F, 7.123455F, 8.384184F, 9.111223F};
     ExpectEq(a.approxEquals(b), true);
+    
+    // toRTS: zero axis length
+    const cc::Mat4 m(
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 1, 0,
+        0.000002836869271050091, -64.9000015258789, 0, 1
+    );
+    
+    cc::Quaternion q;
+    cc::Vec3 t;
+    cc::Vec3 s;
+    cc::Mat4::toRTS(m, &q, &t, &s);
+    ExpectEq(q.approxEquals(cc::Quaternion(0, 0, 0, 1)), true);
+    ExpectEq(t.approxEquals(cc::Vec3(0.000002836869271050091, -64.9000015258789, 0)), true);
+    ExpectEq(s.approxEquals(cc::Vec3(0, 0, 1)), true);
 }

--- a/tests/core/math/mat4.test.ts
+++ b/tests/core/math/mat4.test.ts
@@ -38,7 +38,7 @@ describe('Test Mat4', () => {
         const t = new Vec3();
         const s = new Vec3();
         Mat4.toSRT(m, q, t, s);
-        expect(Quat.equals(q, new Quat(0, 0, 0, 0.7071067811865476))).toBe(true);
+        expect(Quat.equals(q, new Quat(0, 0, 0, 1))).toBe(true);
         expect(Vec3.equals(t, new Vec3(0.000002836869271050091, -64.9000015258789, 0))).toBe(true);
         expect(Vec3.equals(s, new Vec3(0, 0, 1))).toBe(true);
     });

--- a/tests/core/math/mat4.test.ts
+++ b/tests/core/math/mat4.test.ts
@@ -17,13 +17,30 @@ describe('Test Mat4', () => {
         const t2 = new Vec3();
         const r2 = new Quat();
         const s2 = new Vec3();
-        Mat4.toRTS(mat4, r2, t2, s2);
+        Mat4.toSRT(mat4, r2, t2, s2);
         expect(Vec3.equals(t2, t)).toBe(true);
         expect(Vec3.equals(s2, s)).toBe(true);
         expect(Quat.equals(r2, r)).toBe(true);
         expect(Vec3.equals(mat4.getTranslation(new Vec3()), t)).toBe(true);
         expect(Vec3.equals(mat4.getScale(new Vec3()), s)).toBe(true);
         expect(Quat.equals(mat4.getRotation(new Quat()), r)).toBe(true);
+    });
+
+    test('toSRT: zero axis length', () => {
+        const m = new Mat4(
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 1, 0,
+            0.000002836869271050091, -64.9000015258789, 0, 1
+        );
+        
+        const q = new Quat();
+        const t = new Vec3();
+        const s = new Vec3();
+        Mat4.toSRT(m, q, t, s);
+        expect(Quat.equals(q, new Quat(0, 0, 0, 0.7071067811865476))).toBe(true);
+        expect(Vec3.equals(t, new Vec3(0.000002836869271050091, -64.9000015258789, 0))).toBe(true);
+        expect(Vec3.equals(s, new Vec3(0, 0, 1))).toBe(true);
     });
 
     test('clone', () => {


### PR DESCRIPTION
Re: #16929

If node._lrot.x is NaN, it will be serialized to scene data with `null` value.

![企业微信截图_b5056fb5-4838-440b-9b90-774731779425](https://github.com/cocos/cocos-engine/assets/493372/54489c1c-6e2e-48b2-b8dd-de08f8b9459d)


### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
