### PR TITLE
Fix lots of type issues in Tween system

### DIFF
--- a/.github/workflows/run_test_cases.yml
+++ b/.github/workflows/run_test_cases.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Checkout rebase
         run: |
+          git config user.email
+          git config user.name
           git fetch origin
           git reset --hard   
           git checkout origin/${{ steps.parse_pr.outputs.pr_base_ref }}

--- a/cocos/core/algorithm/easing.ts
+++ b/cocos/core/algorithm/easing.ts
@@ -197,7 +197,7 @@ export function sineInOut (k: number): number {
  * @zh 启动慢，加速快。具体效果可以参考[该文档](https://docs.cocos.com/creator/manual/zh/tween/tween-function.html)。
  */
 export function expoIn (k: number): number {
-    return k === 0 ? 0 : Math.pow(1024, k - 1);
+    return k === 0 ? 0 : 1024 ** (k - 1);
 }
 
 /**
@@ -206,7 +206,7 @@ export function expoIn (k: number): number {
  * @zh 起动迅速，减速慢。具体效果可以参考[该文档](https://docs.cocos.com/creator/manual/zh/tween/tween-function.html)。
  */
 export function expoOut (k: number): number {
-    return k === 1 ? 1 : 1 - Math.pow(2, -10 * k);
+    return k === 1 ? 1 : 1 - (2 ** (-10 * k));
 }
 
 /**
@@ -223,9 +223,9 @@ export function expoInOut (k: number): number {
     }
     k *= 2;
     if (k < 1) {
-        return 0.5 * Math.pow(1024, k - 1);
+        return 0.5 * 1024 ** (k - 1);
     }
-    return 0.5 * (-Math.pow(2, -10 * (k - 1)) + 2);
+    return 0.5 * (-(2 ** (-10 * (k - 1))) + 2);
 }
 
 /**
@@ -278,7 +278,7 @@ export function elasticIn (k: number): number {
     } else {
         s = p * Math.asin(1 / a) / (2 * Math.PI);
     }
-    return -(a * Math.pow(2, 10 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p));
+    return -(a * 2 ** (10 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p));
 }
 
 /**
@@ -301,7 +301,7 @@ export function elasticOut (k: number): number {
     } else {
         s = p * Math.asin(1 / a) / (2 * Math.PI);
     }
-    return (a * Math.pow(2, -10 * k) * Math.sin((k - s) * (2 * Math.PI) / p) + 1);
+    return (a * 2 ** (-10 * k) * Math.sin((k - s) * (2 * Math.PI) / p) + 1);
 }
 
 /**
@@ -327,9 +327,9 @@ export function elasticInOut (k: number): number {
     k *= 2;
     if (k < 1) {
         return -0.5
-            * (a * Math.pow(2, 10 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p));
+            * (a * 2 ** (10 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p));
     }
-    return a * Math.pow(2, -10 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p) * 0.5 + 1;
+    return a * 2 ** (-10 * (k -= 1)) * Math.sin((k - s) * (2 * Math.PI) / p) * 0.5 + 1;
 }
 
 /**

--- a/cocos/misc/renderer.ts
+++ b/cocos/misc/renderer.ts
@@ -244,14 +244,17 @@ export class Renderer extends Component {
     }
 
     protected _onMaterialModified (index: number, material: Material | null): void {
+        /* empty */
     }
 
     /**
      * @engineInternal
      */
     public _onRebuildPSO (index: number, material: Material | null): void {
+        /* empty */
     }
 
     protected _clearMaterials (): void {
+        /* empty */
     }
 }

--- a/cocos/primitive/torus.ts
+++ b/cocos/primitive/torus.ts
@@ -46,7 +46,19 @@ interface ITorusOptions extends IGeometryOptions {
  * @param tube @zh 管形大小。@en The radius of tube
  * @param opts @zh 参数选项。@en The optional creation parameters of the torus
  */
-export default function torus (radius = 0.4, tube = 0.1, opts: RecursivePartial<ITorusOptions> = {}): { positions: number[]; normals: number[]; uvs: number[]; indices: number[]; minPos: Vec3; maxPos: Vec3; boundingRadius: number; } {
+export default function torus (
+    radius = 0.4,
+    tube = 0.1,
+    opts: RecursivePartial<ITorusOptions> = {},
+): {
+    positions: number[];
+    normals: number[];
+    uvs: number[];
+    indices: number[];
+    minPos: Vec3;
+    maxPos: Vec3;
+    boundingRadius: number;
+} {
     const radialSegments = opts.radialSegments || 32;
     const tubularSegments = opts.tubularSegments || 32;
     const arc = opts.arc || 2.0 * Math.PI;

--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -35,7 +35,7 @@ import { Renderer } from '../../misc/renderer';
  * @class ActionInstant
  * @extends FiniteTimeAction
  */
-export class ActionInstant<T> extends FiniteTimeAction<T> {
+export class ActionInstant extends FiniteTimeAction {
     isDone (): boolean {
         return true;
     }
@@ -55,12 +55,12 @@ export class ActionInstant<T> extends FiniteTimeAction<T> {
      * - The reversed action will be x of 100 move to 0.
      * @returns {Action}
      */
-    reverse (): ActionInstant<T> {
+    reverse (): ActionInstant {
         return this.clone();
     }
 
-    clone (): ActionInstant<T> {
-        return new ActionInstant<T>();
+    clone (): ActionInstant {
+        return new ActionInstant();
     }
 }
 
@@ -69,7 +69,7 @@ export class ActionInstant<T> extends FiniteTimeAction<T> {
  * @class Show
  * @extends ActionInstant
  */
-export class Show<T> extends ActionInstant<T> {
+export class Show extends ActionInstant {
     update (_dt: number): void {
         const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
@@ -78,12 +78,12 @@ export class Show<T> extends ActionInstant<T> {
         }
     }
 
-    reverse (): Hide<T> {
-        return new Hide<T>();
+    reverse (): Hide {
+        return new Hide();
     }
 
-    clone (): Show<T> {
-        return new Show<T>();
+    clone (): Show {
+        return new Show();
     }
 }
 
@@ -96,8 +96,8 @@ export class Show<T> extends ActionInstant<T> {
  * // example
  * var showAction = show();
  */
-export function show<T> (): ActionInstant<T> {
-    return new Show<T>();
+export function show (): ActionInstant {
+    return new Show();
 }
 
 /*
@@ -105,7 +105,7 @@ export function show<T> (): ActionInstant<T> {
  * @class Hide
  * @extends ActionInstant
  */
-export class Hide<T> extends ActionInstant<T> {
+export class Hide extends ActionInstant {
     update (_dt: number): void {
         const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
@@ -114,12 +114,12 @@ export class Hide<T> extends ActionInstant<T> {
         }
     }
 
-    reverse (): Show<T> {
-        return new Show<T>();
+    reverse (): Show {
+        return new Show();
     }
 
-    clone (): Hide<T> {
-        return new Hide<T>();
+    clone (): Hide {
+        return new Hide();
     }
 }
 
@@ -132,8 +132,8 @@ export class Hide<T> extends ActionInstant<T> {
  * // example
  * var hideAction = hide();
  */
-export function hide<T> (): ActionInstant<T> {
-    return new Hide<T>();
+export function hide (): ActionInstant {
+    return new Hide();
 }
 
 /*
@@ -141,7 +141,7 @@ export function hide<T> (): ActionInstant<T> {
  * @class ToggleVisibility
  * @extends ActionInstant
  */
-export class ToggleVisibility<T> extends ActionInstant<T> {
+export class ToggleVisibility extends ActionInstant {
     update (_dt: number): void {
         const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
@@ -150,12 +150,12 @@ export class ToggleVisibility<T> extends ActionInstant<T> {
         }
     }
 
-    reverse (): ToggleVisibility<T> {
-        return new ToggleVisibility<T>();
+    reverse (): ToggleVisibility {
+        return new ToggleVisibility();
     }
 
-    clone (): ToggleVisibility<T> {
-        return new ToggleVisibility<T>();
+    clone (): ToggleVisibility {
+        return new ToggleVisibility();
     }
 }
 
@@ -168,8 +168,8 @@ export class ToggleVisibility<T> extends ActionInstant<T> {
  * // example
  * var toggleVisibilityAction = toggleVisibility();
  */
-export function toggleVisibility<T> (): ActionInstant<T> {
-    return new ToggleVisibility<T>();
+export function toggleVisibility (): ActionInstant {
+    return new ToggleVisibility();
 }
 
 /*
@@ -182,7 +182,7 @@ export function toggleVisibility<T> (): ActionInstant<T> {
  * // example
  * var removeSelfAction = new RemoveSelf(false);
  */
-export class RemoveSelf<T> extends ActionInstant<T> {
+export class RemoveSelf extends ActionInstant {
     protected _isNeedCleanUp = true;
 
     constructor (isNeedCleanUp?: boolean) {
@@ -202,11 +202,11 @@ export class RemoveSelf<T> extends ActionInstant<T> {
         return true;
     }
 
-    reverse (): RemoveSelf<T> {
+    reverse (): RemoveSelf {
         return new RemoveSelf(this._isNeedCleanUp);
     }
 
-    clone (): RemoveSelf<T> {
+    clone (): RemoveSelf {
         return new RemoveSelf(this._isNeedCleanUp);
     }
 }
@@ -222,8 +222,8 @@ export class RemoveSelf<T> extends ActionInstant<T> {
  * // example
  * var removeSelfAction = removeSelf();
  */
-export function removeSelf<T> (isNeedCleanUp: boolean): ActionInstant<T> {
-    return new RemoveSelf<T>(isNeedCleanUp);
+export function removeSelf (isNeedCleanUp: boolean): ActionInstant {
+    return new RemoveSelf(isNeedCleanUp);
 }
 
 /*
@@ -241,8 +241,8 @@ export function removeSelf<T> (isNeedCleanUp: boolean): ActionInstant<T> {
  * // CallFunc with data
  * var finish = new CallFunc(this.removeFromParentAndCleanup, this,  true);
  */
-export class CallFunc<T> extends ActionInstant<T> {
-    private _selectorTarget: T | undefined;
+export class CallFunc extends ActionInstant {
+    private _selectorTarget: unknown;
     private _function: Function | undefined;
     private _data = null;
 
@@ -253,7 +253,7 @@ export class CallFunc<T> extends ActionInstant<T> {
      * @param {object} [selectorTarget=null]
      * @param {*} [data=null] data for function, it accepts all data types.
      */
-    constructor (selector?: Function, selectorTarget?: T, data?: any) {
+    constructor (selector?: Function, selectorTarget?: unknown, data?: any) {
         super();
         this.initWithFunction(selector, selectorTarget, data);
     }
@@ -265,7 +265,7 @@ export class CallFunc<T> extends ActionInstant<T> {
      * @param {*|Null} [data] data for function, it accepts all data types.
      * @return {Boolean}
      */
-    initWithFunction (selector?: Function, selectorTarget?: T, data?: any): boolean {
+    initWithFunction<T> (selector?: Function, selectorTarget?: T, data?: any): boolean {
         if (selector) {
             this._function = selector;
         }
@@ -295,23 +295,23 @@ export class CallFunc<T> extends ActionInstant<T> {
      * Get selectorTarget.
      * @return {object}
      */
-    getTargetCallback (): T | undefined {
-        return this._selectorTarget;
+    getTargetCallback<T> (): T | undefined {
+        return this._selectorTarget as T;
     }
 
     /*
      * Set selectorTarget.
      * @param {object} sel
      */
-    setTargetCallback (sel: T): void {
+    setTargetCallback<T> (sel: T): void {
         if (sel !== this._selectorTarget) {
             if (this._selectorTarget) { this._selectorTarget = undefined; }
             this._selectorTarget = sel;
         }
     }
 
-    clone (): CallFunc<T> {
-        const action = new CallFunc<T>();
+    clone (): CallFunc {
+        const action = new CallFunc();
         action.initWithFunction(this._function, this._selectorTarget, this._data);
         return action;
     }
@@ -333,6 +333,6 @@ export class CallFunc<T> extends ActionInstant<T> {
  * // CallFunc with data
  * var finish = callFunc(this.removeFromParentAndCleanup, this._grossini,  true);
  */
-export function callFunc<T> (selector: Function, selectorTarget?: T, data?: any): ActionInstant<T> {
+export function callFunc<T> (selector: Function, selectorTarget?: T, data?: any): ActionInstant {
     return new CallFunc(selector, selectorTarget, data);
 }

--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -26,7 +26,7 @@
 */
 /* eslint-disable @typescript-eslint/ban-types */
 
-import { FiniteTimeAction, Action } from './action';
+import { FiniteTimeAction } from './action';
 import { Renderer } from '../../misc/renderer';
 
 /**
@@ -35,12 +35,12 @@ import { Renderer } from '../../misc/renderer';
  * @class ActionInstant
  * @extends FiniteTimeAction
  */
-export class ActionInstant extends FiniteTimeAction {
+export class ActionInstant<T> extends FiniteTimeAction<T> {
     isDone (): boolean {
         return true;
     }
 
-    step (dt: any): void {
+    step (dt: number): void {
         this.update(1);
     }
 
@@ -55,12 +55,12 @@ export class ActionInstant extends FiniteTimeAction {
      * - The reversed action will be x of 100 move to 0.
      * @returns {Action}
      */
-    reverse (): Action {
+    reverse (): ActionInstant<T> {
         return this.clone();
     }
 
-    clone (): ActionInstant {
-        return new ActionInstant();
+    clone (): ActionInstant<T> {
+        return new ActionInstant<T>();
     }
 }
 
@@ -69,21 +69,21 @@ export class ActionInstant extends FiniteTimeAction {
  * @class Show
  * @extends ActionInstant
  */
-export class Show extends ActionInstant {
-    update (dt: any): void {
-        const _renderComps = this.target!.getComponentsInChildren(Renderer);
+export class Show<T> extends ActionInstant<T> {
+    update (_dt: number): void {
+        const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
             const render = _renderComps[i];
             render.enabled = true;
         }
     }
 
-    reverse (): Hide {
-        return new Hide();
+    reverse (): Hide<T> {
+        return new Hide<T>();
     }
 
-    clone (): Show {
-        return new Show();
+    clone (): Show<T> {
+        return new Show<T>();
     }
 }
 
@@ -96,8 +96,8 @@ export class Show extends ActionInstant {
  * // example
  * var showAction = show();
  */
-export function show (): ActionInstant {
-    return new Show();
+export function show<T> (): ActionInstant<T> {
+    return new Show<T>();
 }
 
 /*
@@ -105,21 +105,21 @@ export function show (): ActionInstant {
  * @class Hide
  * @extends ActionInstant
  */
-export class Hide extends ActionInstant {
-    update (dt: any): void {
-        const _renderComps = this.target!.getComponentsInChildren(Renderer);
+export class Hide<T> extends ActionInstant<T> {
+    update (_dt: number): void {
+        const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
             const render = _renderComps[i];
             render.enabled = false;
         }
     }
 
-    reverse (): Show {
-        return new Show();
+    reverse (): Show<T> {
+        return new Show<T>();
     }
 
-    clone (): Hide {
-        return new Hide();
+    clone (): Hide<T> {
+        return new Hide<T>();
     }
 }
 
@@ -132,8 +132,8 @@ export class Hide extends ActionInstant {
  * // example
  * var hideAction = hide();
  */
-export function hide (): ActionInstant {
-    return new Hide();
+export function hide<T> (): ActionInstant<T> {
+    return new Hide<T>();
 }
 
 /*
@@ -141,21 +141,21 @@ export function hide (): ActionInstant {
  * @class ToggleVisibility
  * @extends ActionInstant
  */
-export class ToggleVisibility extends ActionInstant {
-    update (dt: any): void {
-        const _renderComps = this.target!.getComponentsInChildren(Renderer);
+export class ToggleVisibility<T> extends ActionInstant<T> {
+    update (_dt: number): void {
+        const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
             const render = _renderComps[i];
             render.enabled = !render.enabled;
         }
     }
 
-    reverse (): ToggleVisibility {
-        return new ToggleVisibility();
+    reverse (): ToggleVisibility<T> {
+        return new ToggleVisibility<T>();
     }
 
-    clone (): ToggleVisibility {
-        return new ToggleVisibility();
+    clone (): ToggleVisibility<T> {
+        return new ToggleVisibility<T>();
     }
 }
 
@@ -168,8 +168,8 @@ export class ToggleVisibility extends ActionInstant {
  * // example
  * var toggleVisibilityAction = toggleVisibility();
  */
-export function toggleVisibility (): ActionInstant {
-    return new ToggleVisibility();
+export function toggleVisibility<T> (): ActionInstant<T> {
+    return new ToggleVisibility<T>();
 }
 
 /*
@@ -182,31 +182,31 @@ export function toggleVisibility (): ActionInstant {
  * // example
  * var removeSelfAction = new RemoveSelf(false);
  */
-export class RemoveSelf extends ActionInstant {
+export class RemoveSelf<T> extends ActionInstant<T> {
     protected _isNeedCleanUp = true;
 
     constructor (isNeedCleanUp?: boolean) {
         super();
-        isNeedCleanUp !== undefined && this.init(isNeedCleanUp);
+        if (isNeedCleanUp !== undefined) this.init(isNeedCleanUp);
     }
 
-    update (dt: any): void {
-        this.target!.removeFromParent();
+    update (_dt: number): void {
+        (this.target as any).removeFromParent();
         if (this._isNeedCleanUp) {
-            this.target!.destroy();
+            (this.target as any).destroy();
         }
     }
 
-    init (isNeedCleanUp: any): boolean {
+    init (isNeedCleanUp: boolean): boolean {
         this._isNeedCleanUp = isNeedCleanUp;
         return true;
     }
 
-    reverse (): RemoveSelf {
+    reverse (): RemoveSelf<T> {
         return new RemoveSelf(this._isNeedCleanUp);
     }
 
-    clone (): RemoveSelf {
+    clone (): RemoveSelf<T> {
         return new RemoveSelf(this._isNeedCleanUp);
     }
 }
@@ -222,8 +222,8 @@ export class RemoveSelf extends ActionInstant {
  * // example
  * var removeSelfAction = removeSelf();
  */
-export function removeSelf (isNeedCleanUp: boolean): ActionInstant {
-    return new RemoveSelf(isNeedCleanUp);
+export function removeSelf<T> (isNeedCleanUp: boolean): ActionInstant<T> {
+    return new RemoveSelf<T>(isNeedCleanUp);
 }
 
 /*
@@ -241,9 +241,9 @@ export function removeSelf (isNeedCleanUp: boolean): ActionInstant {
  * // CallFunc with data
  * var finish = new CallFunc(this.removeFromParentAndCleanup, this,  true);
  */
-export class CallFunc extends ActionInstant {
-    private _selectorTarget = null;
-    private _function: Function | null = null;
+export class CallFunc<T> extends ActionInstant<T> {
+    private _selectorTarget: T | undefined;
+    private _function: Function | undefined;
     private _data = null;
 
     /*
@@ -253,7 +253,7 @@ export class CallFunc extends ActionInstant {
      * @param {object} [selectorTarget=null]
      * @param {*} [data=null] data for function, it accepts all data types.
      */
-    constructor (selector?: Function, selectorTarget?: any, data?: any) {
+    constructor (selector?: Function, selectorTarget?: T, data?: any) {
         super();
         this.initWithFunction(selector, selectorTarget, data);
     }
@@ -265,7 +265,7 @@ export class CallFunc extends ActionInstant {
      * @param {*|Null} [data] data for function, it accepts all data types.
      * @return {Boolean}
      */
-    initWithFunction (selector: any, selectorTarget?: any, data?: any): boolean {
+    initWithFunction (selector?: Function, selectorTarget?: T, data?: any): boolean {
         if (selector) {
             this._function = selector;
         }
@@ -287,7 +287,7 @@ export class CallFunc extends ActionInstant {
         }
     }
 
-    update (dt: any): void {
+    update (_dt: number): void {
         this.execute();
     }
 
@@ -295,7 +295,7 @@ export class CallFunc extends ActionInstant {
      * Get selectorTarget.
      * @return {object}
      */
-    getTargetCallback (): null {
+    getTargetCallback (): T | undefined {
         return this._selectorTarget;
     }
 
@@ -303,15 +303,15 @@ export class CallFunc extends ActionInstant {
      * Set selectorTarget.
      * @param {object} sel
      */
-    setTargetCallback (sel: any): void {
+    setTargetCallback (sel: T): void {
         if (sel !== this._selectorTarget) {
-            if (this._selectorTarget) { this._selectorTarget = null; }
+            if (this._selectorTarget) { this._selectorTarget = undefined; }
             this._selectorTarget = sel;
         }
     }
 
-    clone (): CallFunc {
-        const action = new CallFunc();
+    clone (): CallFunc<T> {
+        const action = new CallFunc<T>();
         action.initWithFunction(this._function, this._selectorTarget, this._data);
         return action;
     }
@@ -333,6 +333,6 @@ export class CallFunc extends ActionInstant {
  * // CallFunc with data
  * var finish = callFunc(this.removeFromParentAndCleanup, this._grossini,  true);
  */
-export function callFunc (selector: Function, selectorTarget?: any, data?: any): ActionInstant {
+export function callFunc<T> (selector: Function, selectorTarget?: T, data?: any): ActionInstant<T> {
     return new CallFunc(selector, selectorTarget, data);
 }

--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -35,16 +35,16 @@ import { Renderer } from '../../misc/renderer';
  * @class ActionInstant
  * @extends FiniteTimeAction
  */
-export class ActionInstant extends FiniteTimeAction {
+export abstract class ActionInstant extends FiniteTimeAction {
     isDone (): boolean {
         return true;
     }
 
-    step (dt: number): void {
+    step (_dt: number): void {
         this.update(1);
     }
 
-    update (dt: number): void {
+    update (_dt: number): void {
         // nothing
     }
 
@@ -59,9 +59,7 @@ export class ActionInstant extends FiniteTimeAction {
         return this.clone();
     }
 
-    clone (): ActionInstant {
-        return new ActionInstant();
-    }
+    abstract clone (): ActionInstant;
 }
 
 /*

--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -242,8 +242,8 @@ export function removeSelf (isNeedCleanUp: boolean): ActionInstant {
  * var finish = new CallFunc(this.removeFromParentAndCleanup, this,  true);
  */
 export class CallFunc extends ActionInstant {
-    private _selectorTarget: unknown;
-    private _function: Function | undefined;
+    private _selectorTarget: unknown = null;
+    private _function: Function | null | undefined = null;
     private _data = null;
 
     /*
@@ -253,7 +253,7 @@ export class CallFunc extends ActionInstant {
      * @param {object} [selectorTarget=null]
      * @param {*} [data=null] data for function, it accepts all data types.
      */
-    constructor (selector?: Function, selectorTarget?: unknown, data?: any) {
+    constructor (selector?: Function | null, selectorTarget?: unknown, data?: any) {
         super();
         this.initWithFunction(selector, selectorTarget, data);
     }
@@ -265,7 +265,7 @@ export class CallFunc extends ActionInstant {
      * @param {*|Null} [data] data for function, it accepts all data types.
      * @return {Boolean}
      */
-    initWithFunction<T> (selector?: Function, selectorTarget?: T, data?: any): boolean {
+    initWithFunction<T> (selector?: Function | null, selectorTarget?: T, data?: any): boolean {
         if (selector) {
             this._function = selector;
         }
@@ -295,7 +295,7 @@ export class CallFunc extends ActionInstant {
      * Get selectorTarget.
      * @return {object}
      */
-    getTargetCallback<T> (): T | undefined {
+    getTargetCallback<T> (): T | null {
         return this._selectorTarget as T;
     }
 
@@ -305,7 +305,7 @@ export class CallFunc extends ActionInstant {
      */
     setTargetCallback<T> (sel: T): void {
         if (sel !== this._selectorTarget) {
-            if (this._selectorTarget) { this._selectorTarget = undefined; }
+            if (this._selectorTarget) { this._selectorTarget = null; }
             this._selectorTarget = sel;
         }
     }

--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -26,6 +26,7 @@
 */
 import { FiniteTimeAction } from './action';
 import { Renderer } from '../../misc/renderer';
+import type { Node } from '../../scene-graph';
 
 /**
  * @en Instant actions are immediate actions. They don't have a duration like the ActionInterval actions.
@@ -65,20 +66,21 @@ export abstract class ActionInstant extends FiniteTimeAction {
  * @class Show
  * @extends ActionInstant
  */
-export class Show extends ActionInstant {
+export class Show<T extends Node> extends ActionInstant {
     update (_dt: number): void {
-        const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
+        const target = this.target as T;
+        const _renderComps = target.getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
             const render = _renderComps[i];
             render.enabled = true;
         }
     }
 
-    reverse (): Hide {
+    reverse (): Hide<T> {
         return new Hide();
     }
 
-    clone (): Show {
+    clone (): Show<T> {
         return new Show();
     }
 }
@@ -92,8 +94,8 @@ export class Show extends ActionInstant {
  * // example
  * var showAction = show();
  */
-export function show (): Show {
-    return new Show();
+export function show<T extends Node> (): Show<T> {
+    return new Show<T>();
 }
 
 /*
@@ -101,21 +103,22 @@ export function show (): Show {
  * @class Hide
  * @extends ActionInstant
  */
-export class Hide extends ActionInstant {
+export class Hide<T extends Node> extends ActionInstant {
     update (_dt: number): void {
-        const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
+        const target = this.target as T;
+        const _renderComps = target.getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
             const render = _renderComps[i];
             render.enabled = false;
         }
     }
 
-    reverse (): Show {
-        return new Show();
+    reverse (): Show<T> {
+        return new Show<T>();
     }
 
-    clone (): Hide {
-        return new Hide();
+    clone (): Hide<T> {
+        return new Hide<T>();
     }
 }
 
@@ -128,8 +131,8 @@ export class Hide extends ActionInstant {
  * // example
  * var hideAction = hide();
  */
-export function hide (): Hide {
-    return new Hide();
+export function hide<T extends Node> (): Hide<T> {
+    return new Hide<T>();
 }
 
 /*
@@ -137,21 +140,22 @@ export function hide (): Hide {
  * @class ToggleVisibility
  * @extends ActionInstant
  */
-export class ToggleVisibility extends ActionInstant {
+export class ToggleVisibility<T extends Node> extends ActionInstant {
     update (_dt: number): void {
-        const _renderComps = (this.target as any).getComponentsInChildren(Renderer);
+        const target = this.target as T;
+        const _renderComps = target.getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
             const render = _renderComps[i];
             render.enabled = !render.enabled;
         }
     }
 
-    reverse (): ToggleVisibility {
-        return new ToggleVisibility();
+    reverse (): ToggleVisibility<T> {
+        return new ToggleVisibility<T>();
     }
 
-    clone (): ToggleVisibility {
-        return new ToggleVisibility();
+    clone (): ToggleVisibility<T> {
+        return new ToggleVisibility<T>();
     }
 }
 
@@ -164,8 +168,8 @@ export class ToggleVisibility extends ActionInstant {
  * // example
  * var toggleVisibilityAction = toggleVisibility();
  */
-export function toggleVisibility (): ToggleVisibility {
-    return new ToggleVisibility();
+export function toggleVisibility<T extends Node> (): ToggleVisibility<T> {
+    return new ToggleVisibility<T>();
 }
 
 /*
@@ -178,7 +182,7 @@ export function toggleVisibility (): ToggleVisibility {
  * // example
  * var removeSelfAction = new RemoveSelf(false);
  */
-export class RemoveSelf extends ActionInstant {
+export class RemoveSelf<T extends Node> extends ActionInstant {
     protected _isNeedCleanUp = true;
 
     constructor (isNeedCleanUp?: boolean) {
@@ -187,9 +191,10 @@ export class RemoveSelf extends ActionInstant {
     }
 
     update (_dt: number): void {
-        (this.target as any).removeFromParent();
+        const target = this.target as T;
+        target.removeFromParent();
         if (this._isNeedCleanUp) {
-            (this.target as any).destroy();
+            target.destroy();
         }
     }
 
@@ -198,12 +203,12 @@ export class RemoveSelf extends ActionInstant {
         return true;
     }
 
-    reverse (): RemoveSelf {
-        return new RemoveSelf(this._isNeedCleanUp);
+    reverse (): RemoveSelf<T> {
+        return new RemoveSelf<T>(this._isNeedCleanUp);
     }
 
-    clone (): RemoveSelf {
-        return new RemoveSelf(this._isNeedCleanUp);
+    clone (): RemoveSelf<T> {
+        return new RemoveSelf<T>(this._isNeedCleanUp);
     }
 }
 
@@ -218,8 +223,8 @@ export class RemoveSelf extends ActionInstant {
  * // example
  * var removeSelfAction = removeSelf();
  */
-export function removeSelf (isNeedCleanUp: boolean): RemoveSelf {
-    return new RemoveSelf(isNeedCleanUp);
+export function removeSelf<T extends Node> (isNeedCleanUp: boolean): RemoveSelf<T> {
+    return new RemoveSelf<T>(isNeedCleanUp);
 }
 
 export type TCallFuncCallback<TTarget, TData> = (target?: TTarget, data?: TData) => void;

--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -239,36 +239,36 @@ export type TCallFuncCallback<TTarget, TData> = (target?: TTarget, data?: TData)
  * // CallFunc with data
  * var finish = new CallFunc(this.removeFromParentAndCleanup, this,  true);
  */
-export class CallFunc<TSelectorTarget, TTarget, TData> extends ActionInstant {
-    private _selectorTarget: TSelectorTarget | undefined = undefined;
-    private _function: TCallFuncCallback<TTarget, TData> | undefined = undefined;
+export class CallFunc<TCallbackThis, TTarget, TData> extends ActionInstant {
+    private _callbackThis: TCallbackThis | undefined = undefined;
+    private _callback: TCallFuncCallback<TTarget, TData> | undefined = undefined;
     private _data: TData | undefined = undefined;
 
     /*
      * Constructor function, override it to extend the construction behavior, remember to call "super()". <br />
      * Creates a CallFunc action with the callback.
-     * @param {CallFuncSelector} selector
-     * @param {TSelectorTarget} [selectorTarget=null]
-     * @param {TData} [data=null] data for function, it accepts all data types.
+     * @param {TCallFuncCallback} callback The callback function
+     * @param {TCallbackThis} callbackThis The this object for callback
+     * @param {TData} data The custom data passed to the callback function, it accepts all data types.
      */
-    constructor (selector?: TCallFuncCallback<TTarget, TData>, selectorTarget?: TSelectorTarget, data?: TData) {
+    constructor (selector?: TCallFuncCallback<TTarget, TData>, callbackThis?: TCallbackThis, data?: TData) {
         super();
-        this.initWithFunction(selector, selectorTarget, data);
+        this.initWithFunction(selector, callbackThis, data);
     }
 
     /*
      * Initializes the action with a function or function and its target
-     * @param {function} selector
-     * @param {object|Null} selectorTarget
-     * @param {*|Null} [data] data for function, it accepts all data types.
+     * @param {TCallFuncCallback} callback The callback function
+     * @param {TCallbackThis} callbackThis The this object for callback
+     * @param {TData} data The custom data passed to the callback function, it accepts all data types.
      * @return {Boolean}
      */
-    initWithFunction (selector?: TCallFuncCallback<TTarget, TData>, selectorTarget?: TSelectorTarget, data?: TData): boolean {
-        if (selector) {
-            this._function = selector;
+    initWithFunction (callback?: TCallFuncCallback<TTarget, TData>, callbackThis?: TCallbackThis, data?: TData): boolean {
+        if (callback) {
+            this._callback = callback;
         }
-        if (selectorTarget) {
-            this._selectorTarget = selectorTarget;
+        if (callbackThis) {
+            this._callbackThis = callbackThis;
         }
         if (data !== undefined) {
             this._data = data;
@@ -280,8 +280,8 @@ export class CallFunc<TSelectorTarget, TTarget, TData> extends ActionInstant {
      * execute the function.
      */
     execute (): void {
-        if (this._function) {
-            this._function.call(this._selectorTarget, this.target as TTarget, this._data);
+        if (this._callback) {
+            this._callback.call(this._callbackThis, this.target as TTarget, this._data);
         }
     }
 
@@ -293,23 +293,23 @@ export class CallFunc<TSelectorTarget, TTarget, TData> extends ActionInstant {
      * Get selectorTarget.
      * @return {object}
      */
-    getTargetCallback (): TSelectorTarget | undefined {
-        return this._selectorTarget;
+    getTargetCallback (): TCallbackThis | undefined {
+        return this._callbackThis;
     }
 
     /*
      * Set selectorTarget.
      * @param {object} sel
      */
-    setTargetCallback (sel: TSelectorTarget): void {
-        if (sel !== this._selectorTarget) {
-            this._selectorTarget = sel;
+    setTargetCallback (sel: TCallbackThis): void {
+        if (sel !== this._callbackThis) {
+            this._callbackThis = sel;
         }
     }
 
-    clone (): CallFunc<TSelectorTarget, TTarget, TData> {
-        const action = new CallFunc<TSelectorTarget, TTarget, TData>();
-        if (this._function) action.initWithFunction(this._function, this._selectorTarget, this._data);
+    clone (): CallFunc<TCallbackThis, TTarget, TData> {
+        const action = new CallFunc<TCallbackThis, TTarget, TData>();
+        if (this._callback) action.initWithFunction(this._callback, this._callbackThis, this._data);
         return action;
     }
 }

--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -243,7 +243,7 @@ export function removeSelf (isNeedCleanUp: boolean): ActionInstant {
  */
 export class CallFunc extends ActionInstant {
     private _selectorTarget: unknown = null;
-    private _function: Function | null | undefined = null;
+    private _function: Function | null = null;
     private _data = null;
 
     /*
@@ -253,7 +253,7 @@ export class CallFunc extends ActionInstant {
      * @param {object} [selectorTarget=null]
      * @param {*} [data=null] data for function, it accepts all data types.
      */
-    constructor (selector?: Function | null, selectorTarget?: unknown, data?: any) {
+    constructor (selector?: Function, selectorTarget?: unknown, data?: any) {
         super();
         this.initWithFunction(selector, selectorTarget, data);
     }

--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -89,12 +89,12 @@ export class Show extends ActionInstant {
  * @en Show the Node.
  * @zh 立即显示。
  * @method show
- * @return {ActionInstant}
+ * @return {Show}
  * @example
  * // example
  * var showAction = show();
  */
-export function show (): ActionInstant {
+export function show (): Show {
     return new Show();
 }
 
@@ -125,12 +125,12 @@ export class Hide extends ActionInstant {
  * @en Hide the node.
  * @zh 立即隐藏。
  * @method hide
- * @return {ActionInstant}
+ * @return {Hide}
  * @example
  * // example
  * var hideAction = hide();
  */
-export function hide (): ActionInstant {
+export function hide (): Hide {
     return new Hide();
 }
 
@@ -161,12 +161,12 @@ export class ToggleVisibility extends ActionInstant {
  * @en Toggles the visibility of a node.
  * @zh 显隐状态切换。
  * @method toggleVisibility
- * @return {ActionInstant}
+ * @return {ToggleVisibility}
  * @example
  * // example
  * var toggleVisibilityAction = toggleVisibility();
  */
-export function toggleVisibility (): ActionInstant {
+export function toggleVisibility (): ToggleVisibility {
     return new ToggleVisibility();
 }
 
@@ -214,13 +214,13 @@ export class RemoveSelf extends ActionInstant {
  * @zh 从父节点移除自身。
  * @method removeSelf
  * @param {Boolean} [isNeedCleanUp = true]
- * @return {ActionInstant}
+ * @return {RemoveSelf}
  *
  * @example
  * // example
  * var removeSelfAction = removeSelf();
  */
-export function removeSelf (isNeedCleanUp: boolean): ActionInstant {
+export function removeSelf (isNeedCleanUp: boolean): RemoveSelf {
     return new RemoveSelf(isNeedCleanUp);
 }
 

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -47,7 +47,7 @@ import { ActionInstant } from './action-instant';
  * @extends FiniteTimeAction
  * @param {Number} d duration in seconds
  */
-export class ActionInterval extends FiniteTimeAction {
+export class ActionInterval<T> extends FiniteTimeAction<T> {
     protected MAX_VALUE = 2;
     protected _elapsed = 0;
     protected _firstTick = false;
@@ -92,7 +92,7 @@ export class ActionInterval extends FiniteTimeAction {
         return (this._elapsed >= this._duration);
     }
 
-    _cloneDecoration (action: ActionInterval): void {
+    _cloneDecoration (action: ActionInterval<T>): void {
         action._repeatForever = this._repeatForever;
         action._speed = this._speed;
         action._timesForRepeat = this._timesForRepeat;
@@ -101,7 +101,7 @@ export class ActionInterval extends FiniteTimeAction {
         action._repeatMethod = this._repeatMethod;
     }
 
-    _reverseEaseList (action: ActionInterval): void {
+    _reverseEaseList (action: ActionInterval<T>): void {
         if (this._easeList) {
             action._easeList = [];
             for (let i = 0; i < this._easeList.length; i++) {
@@ -110,8 +110,8 @@ export class ActionInterval extends FiniteTimeAction {
         }
     }
 
-    clone (): ActionInterval {
-        const action = new ActionInterval(this._duration);
+    clone (): ActionInterval<T> {
+        const action = new ActionInterval<T>(this._duration);
         this._cloneDecoration(action);
         return action;
     }
@@ -126,7 +126,7 @@ export class ActionInterval extends FiniteTimeAction {
      * import { easeIn } from 'cc';
      * action.easing(easeIn(3.0));
      */
-    easing (easeObj: any): ActionInterval {
+    easing (easeObj: any): ActionInterval<T> {
         if (this._easeList) this._easeList.length = 0;
         else this._easeList = [];
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -134,7 +134,7 @@ export class ActionInterval extends FiniteTimeAction {
         return this;
     }
 
-    _computeEaseTime (dt: any): any {
+    _computeEaseTime (dt: number): number {
         // var locList = this._easeList;
         // if ((!locList) || (locList.length === 0))
         //     return dt;
@@ -169,13 +169,13 @@ export class ActionInterval extends FiniteTimeAction {
         }
     }
 
-    startWithTarget (target: any): void {
-        Action.prototype.startWithTarget.call(this, target);
+    startWithTarget (target: T | undefined): void {
+        super.startWithTarget(target);
         this._elapsed = 0;
         this._firstTick = true;
     }
 
-    reverse (): ActionInterval {
+    reverse (): ActionInterval<T> {
         logID(1010);
         return this;
     }
@@ -212,7 +212,7 @@ export class ActionInterval extends FiniteTimeAction {
      * @param {Number} speed
      * @returns {Action}
      */
-    speed (speed: number): Action {
+    speed (speed: number): Action<T> {
         if (speed <= 0) {
             logID(1013);
             return this;
@@ -242,7 +242,7 @@ export class ActionInterval extends FiniteTimeAction {
      * @param {Number} speed
      * @returns {ActionInterval}
      */
-    setSpeed (speed: number): ActionInterval {
+    setSpeed (speed: number): ActionInterval<T> {
         this._speed = speed;
         return this;
     }
@@ -256,7 +256,7 @@ export class ActionInterval extends FiniteTimeAction {
      * @param {Number} times
      * @returns {ActionInterval}
      */
-    repeat (times: number): ActionInterval {
+    repeat (times: number): ActionInterval<T> {
         times = Math.round(times);
         if (Number.isNaN(times) || times < 1) {
             logID(1014);
@@ -275,7 +275,7 @@ export class ActionInterval extends FiniteTimeAction {
      * @method repeatForever
      * @returns {ActionInterval}
      */
-    repeatForever (): ActionInterval {
+    repeatForever (): ActionInterval<T> {
         this._repeatMethod = true; // Compatible with repeat class, Discard after can be deleted
         this._timesForRepeat = this.MAX_VALUE;
         this._repeatForever = true;
@@ -286,14 +286,14 @@ export class ActionInterval extends FiniteTimeAction {
 /*
  * Runs actions sequentially, one after another.
  */
-export class Sequence extends ActionInterval {
-    static _actionOneTwo = function (actionOne: ActionInterval, actionTwo: ActionInterval): Sequence {
+export class Sequence<T> extends ActionInterval<T> {
+    static _actionOneTwo (actionOne: FiniteTimeAction<unknown>, actionTwo: FiniteTimeAction<unknown>): Sequence<unknown> {
         const sequence = new Sequence();
         sequence.initWithTwoActions(actionOne, actionTwo);
         return sequence;
-    };
+    }
 
-    private _actions: ActionInterval[] = [];
+    private _actions: FiniteTimeAction<T>[] = [];
     private _split = 0;
     private _last = 0;
     private _reversed = false;
@@ -308,11 +308,12 @@ export class Sequence extends ActionInterval {
      * // create sequence with array
      * const seq = new Sequence(actArray);
      */
-    constructor (...actions: FiniteTimeAction[]);
+    constructor (...actions: FiniteTimeAction<T>[]);
+    constructor (actions: FiniteTimeAction<T>[]);
     constructor (tempArray: any) {
         super();
 
-        const paramArray = (tempArray instanceof Array) ? tempArray : arguments;
+        const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction<T>[];
         if (paramArray.length === 1) {
             errorID(1019);
             return;
@@ -321,11 +322,12 @@ export class Sequence extends ActionInterval {
         if ((last >= 0) && (paramArray[last] == null)) logID(1015);
 
         if (last >= 0) {
-            let prev = paramArray[0]; let action1: any;
+            let prev = paramArray[0];
+            let action1: FiniteTimeAction<T>;
             for (let i = 1; i < last; i++) {
                 if (paramArray[i]) {
                     action1 = prev;
-                    prev = Sequence._actionOneTwo(action1 as ActionInterval, paramArray[i] as ActionInterval);
+                    prev = Sequence._actionOneTwo(action1 as ActionInterval<T>, paramArray[i] as ActionInterval<T>) as FiniteTimeAction<T>;
                 }
             }
             this.initWithTwoActions(prev, paramArray[last]);
@@ -338,49 +340,49 @@ export class Sequence extends ActionInterval {
      * @param {FiniteTimeAction} actionTwo
      * @return {Boolean}
      */
-    initWithTwoActions (actionOne: any, actionTwo: any): boolean {
+    initWithTwoActions (actionOne?: FiniteTimeAction<T>, actionTwo?: FiniteTimeAction<T>): boolean {
         if (!actionOne || !actionTwo) {
             errorID(1025);
             return false;
         }
 
         let durationOne = actionOne._duration; let durationTwo = actionTwo._duration;
-        durationOne *= actionOne._repeatMethod ? actionOne._timesForRepeat : 1;
-        durationTwo *= actionTwo._repeatMethod ? actionTwo._timesForRepeat : 1;
+        durationOne *= (actionOne as any)._repeatMethod ? actionOne._timesForRepeat : 1;
+        durationTwo *= (actionTwo as any)._repeatMethod ? actionTwo._timesForRepeat : 1;
         const d = durationOne + durationTwo;
-        this.initWithDuration(d as number);
+        this.initWithDuration(d);
 
         this._actions[0] = actionOne;
         this._actions[1] = actionTwo;
         return true;
     }
 
-    clone (): any {
-        const action = new Sequence();
-        this._cloneDecoration(action as ActionInterval);
+    clone (): Sequence<T> {
+        const action = new Sequence<T>();
+        this._cloneDecoration(action);
         action.initWithTwoActions(this._actions[0].clone(), this._actions[1].clone());
-        return action as any;
+        return action;
     }
 
-    startWithTarget (target: any): void {
-        ActionInterval.prototype.startWithTarget.call(this, target);
+    startWithTarget (target: T | undefined): void {
+        super.startWithTarget(target);
         this._split = this._actions[0]._duration / this._duration;
-        this._split *= this._actions[0]._repeatMethod ? this._actions[0]._timesForRepeat : 1;
+        this._split *= (this._actions[0] as any)._repeatMethod ? this._actions[0]._timesForRepeat : 1;
         this._last = -1;
     }
 
     stop (): void {
         // Issue #1305
         if (this._last !== -1) this._actions[this._last].stop();
-        Action.prototype.stop.call(this);
+        super.stop();
     }
 
     update (dt: number): void {
-        let new_t: number; let found = 0;
+        let new_t: number = 0;
+        let found = 0;
         const locSplit = this._split;
         const locActions = this._actions;
         const locLast = this._last;
-        let actionFound: ActionInterval;
 
         dt = this._computeEaseTime(dt);
         if (dt < locSplit) {
@@ -413,8 +415,7 @@ export class Sequence extends ActionInterval {
             }
         }
 
-        // eslint-disable-next-line prefer-const
-        actionFound = locActions[found];
+        const actionFound = locActions[found];
         // Last action found and it is done.
         if (locLast === found && actionFound.isDone()) return;
 
@@ -426,12 +427,12 @@ export class Sequence extends ActionInterval {
         this._last = found;
     }
 
-    reverse (): any {
-        const action = Sequence._actionOneTwo(this._actions[1].reverse(), this._actions[0].reverse());
+    reverse (): Sequence<T> {
+        const action: Sequence<T> = Sequence._actionOneTwo(this._actions[1].reverse(), this._actions[0].reverse()) as Sequence<T>;
         this._cloneDecoration(action);
         this._reverseEaseList(action);
         action._reversed = true;
-        return action as any;
+        return action;
     }
 }
 
@@ -454,25 +455,28 @@ export class Sequence extends ActionInterval {
  * const seq = sequence(actArray);
  */
 // todo: It should be use new
-export function sequence (/* Multiple Arguments */tempArray: any): ActionInterval {
-    const paramArray = (tempArray instanceof Array) ? tempArray : arguments;
+export function sequence<T> (...actions: FiniteTimeAction<T>[]): ActionInterval<T> | null;
+export function sequence<T> (actions: FiniteTimeAction<T>[]): ActionInterval<T> | null;
+export function sequence<T> (tempArray: any): ActionInterval<T> | null {
+    const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction<T>[];
+
     if (paramArray.length === 1) {
-        return paramArray[0] as ActionInterval;
+        return paramArray[0] as ActionInterval<T>;
     }
     const last = paramArray.length - 1;
     if ((last >= 0) && (paramArray[last] == null)) logID(1015);
 
-    let result: any = null;
+    let result: ActionInterval<T> | null = null;
     if (last >= 0) {
-        result = paramArray[0];
+        result = paramArray[0] as ActionInterval<T>; //FIXME: remove 'as'
         for (let i = 1; i <= last; i++) {
             if (paramArray[i]) {
-                result = Sequence._actionOneTwo(result as ActionInterval, paramArray[i] as ActionInterval);
+                result = Sequence._actionOneTwo(result, paramArray[i] as ActionInterval<T>) as Sequence<T>;
             }
         }
     }
 
-    return result as ActionInterval;
+    return result;
 }
 
 /*
@@ -486,16 +490,16 @@ export function sequence (/* Multiple Arguments */tempArray: any): ActionInterva
  * import { Repeat, sequence } from 'cc';
  * const rep = new Repeat(sequence(jump2, jump1), 5);
  */
-export class Repeat extends ActionInterval {
+export class Repeat<T> extends ActionInterval<T> {
     private _times = 0;
     private _total = 0;
     private _nextDt = 0;
     private _actionInstant = false;
-    private _innerAction: FiniteTimeAction | null = null;
+    private _innerAction: FiniteTimeAction<T> | null = null;
 
-    constructor (action?: any, times?: any) {
+    constructor (action?: FiniteTimeAction<T>, times?: number) {
         super();
-        times !== undefined && this.initWithAction(action as FiniteTimeAction, times as number);
+        this.initWithAction(action, times);
     }
 
     /*
@@ -503,7 +507,10 @@ export class Repeat extends ActionInterval {
      * @param {Number} times
      * @return {Boolean}
      */
-    initWithAction (action: FiniteTimeAction, times: number): boolean {
+    initWithAction (action?: FiniteTimeAction<T>, times?: number): boolean {
+        if (!action || times === undefined) {
+            return false;
+        }
         const duration = action._duration * times;
 
         if (this.initWithDuration(duration)) {
@@ -519,31 +526,36 @@ export class Repeat extends ActionInterval {
         return false;
     }
 
-    clone (): Repeat {
-        const action = new Repeat();
+    clone (): Repeat<T> {
+        const action = new Repeat<T>();
         this._cloneDecoration(action);
-        action.initWithAction(this._innerAction!.clone(), this._times);
+        if (this._innerAction) {
+            action.initWithAction(this._innerAction.clone(), this._times);
+        }
         return action;
     }
 
-    startWithTarget (target: any): void {
+    startWithTarget (target: T | undefined): void {
         this._total = 0;
-        this._nextDt = this._innerAction!._duration / this._duration;
-        ActionInterval.prototype.startWithTarget.call(this, target);
-        this._innerAction!.startWithTarget(target);
+        this._nextDt = (this._innerAction ? this._innerAction._duration : 0) / this._duration;
+        super.startWithTarget(target);
+        this._innerAction?.startWithTarget(target);
     }
 
     stop (): void {
-        this._innerAction!.stop();
-        Action.prototype.stop.call(this);
+        this._innerAction?.stop();
+        super.stop();
     }
 
     update (dt: number): void {
         dt = this._computeEaseTime(dt);
-        const locInnerAction = this._innerAction!;
+        const locInnerAction = this._innerAction;
         const locDuration = this._duration;
         const locTimes = this._times;
         let locNextDt = this._nextDt;
+        if (!locInnerAction) {
+            return;
+        }
 
         if (dt >= locNextDt) {
             while (dt > locNextDt && this._total < locTimes) {
@@ -580,18 +592,19 @@ export class Repeat extends ActionInterval {
         return this._total === this._times;
     }
 
-    reverse (): any {
-        const action = new Repeat(this._innerAction!.reverse(), this._times);
+    reverse (): Repeat<T> {
+        const actionArg = this._innerAction ? this._innerAction.reverse() : undefined;
+        const action = new Repeat(actionArg, this._times);
         this._cloneDecoration(action);
         this._reverseEaseList(action);
-        return action as any;
+        return action;
     }
 
     /*
      * Set inner Action.
      * @param {FiniteTimeAction} action
      */
-    setInnerAction (action: any): void {
+    setInnerAction (action: FiniteTimeAction<T>): void {
         if (this._innerAction !== action) {
             this._innerAction = action;
         }
@@ -601,7 +614,7 @@ export class Repeat extends ActionInterval {
      * Get inner Action.
      * @return {FiniteTimeAction}
      */
-    getInnerAction (): FiniteTimeAction | null {
+    getInnerAction (): FiniteTimeAction<T> | null {
         return this._innerAction;
     }
 }
@@ -617,8 +630,8 @@ export class Repeat extends ActionInterval {
  * import { repeat, sequence } from 'cc';
  * const rep = repeat(sequence(jump2, jump1), 5);
  */
-export function repeat (action: any, times: any): Action {
-    return new Repeat(action, times);
+export function repeat<T> (action: FiniteTimeAction<T>, times: number): Action<T> {
+    return new Repeat<T>(action, times);
 }
 
 /*
@@ -632,19 +645,19 @@ export function repeat (action: any, times: any): Action {
  * import { sequence, RepeatForever } from 'cc';
  * const rep = new RepeatForever(sequence(jump2, jump1), 5);
  */
-export class RepeatForever extends ActionInterval {
-    private _innerAction: ActionInterval | null = null;
+export class RepeatForever<T> extends ActionInterval<T> {
+    private _innerAction: ActionInterval<T> | null = null;
 
-    constructor (action?: ActionInterval) {
+    constructor (action?: ActionInterval<T>) {
         super();
-        action && this.initWithAction(action);
+        if (action) this.initWithAction(action);
     }
 
     /*
      * @param {ActionInterval} action
      * @return {Boolean}
      */
-    initWithAction (action: ActionInterval): boolean {
+    initWithAction (action: ActionInterval<T>): boolean {
         if (!action) {
             errorID(1026);
             return false;
@@ -654,21 +667,28 @@ export class RepeatForever extends ActionInterval {
         return true;
     }
 
-    clone (): RepeatForever {
-        const action = new RepeatForever();
+    clone (): RepeatForever<T> {
+        const action = new RepeatForever<T>();
         this._cloneDecoration(action);
-        action.initWithAction(this._innerAction!.clone());
+        if (this._innerAction) {
+            action.initWithAction(this._innerAction.clone());
+        }
         return action;
     }
 
-    startWithTarget (target: any): void {
-        ActionInterval.prototype.startWithTarget.call(this, target);
-        this._innerAction!.startWithTarget(target);
+    startWithTarget (target: T | undefined): void {
+        super.startWithTarget(target);
+        if (this._innerAction) {
+            this._innerAction.startWithTarget(target);
+        }
     }
 
-    step (dt: any): void {
-        const locInnerAction = this._innerAction!;
-        locInnerAction.step(dt as number);
+    step (dt: number): void {
+        const locInnerAction = this._innerAction;
+        if (!locInnerAction) {
+            return;
+        }
+        locInnerAction.step(dt);
         if (locInnerAction.isDone()) {
             // var diff = locInnerAction.getElapsed() - locInnerAction._duration;
             locInnerAction.startWithTarget(this.target);
@@ -683,18 +703,21 @@ export class RepeatForever extends ActionInterval {
         return false;
     }
 
-    reverse (): any {
-        const action = new RepeatForever(this._innerAction!.reverse());
-        this._cloneDecoration(action);
-        this._reverseEaseList(action);
-        return action as any;
+    reverse (): RepeatForever<T> {
+        if (this._innerAction) {
+            const action = new RepeatForever(this._innerAction.reverse());
+            this._cloneDecoration(action);
+            this._reverseEaseList(action);
+            return action;
+        }
+        return this;
     }
 
     /*
      * Set inner action.
      * @param {ActionInterval} action
      */
-    setInnerAction (action: any): void {
+    setInnerAction (action: ActionInterval<T> | null): void {
         if (this._innerAction !== action) {
             this._innerAction = action;
         }
@@ -704,7 +727,7 @@ export class RepeatForever extends ActionInterval {
      * Get inner action.
      * @return {ActionInterval}
      */
-    getInnerAction (): ActionInstant | null {
+    getInnerAction (): ActionInstant<T> | null {
         return this._innerAction;
     }
 }
@@ -719,7 +742,7 @@ export class RepeatForever extends ActionInterval {
  * import { repeatForever, rotateBy } from 'cc';
  * var repeat = repeatForever(rotateBy(1.0, 360));
  */
-export function repeatForever (action?: ActionInterval): ActionInterval {
+export function repeatForever<T> (action?: ActionInterval<T>): ActionInterval<T> {
     return new RepeatForever(action);
 }
 
@@ -728,20 +751,23 @@ export function repeatForever (action?: ActionInterval): ActionInterval {
  * @class Spawn
  * @extends ActionInterval
  */
-export class Spawn extends ActionInterval {
-    static _actionOneTwo = function (action1: any, action2: any): Spawn {
+export class Spawn<T> extends ActionInterval<T> {
+    static _actionOneTwo (action1?: FiniteTimeAction<unknown>, action2?: FiniteTimeAction<unknown>): Spawn<unknown> {
         const pSpawn = new Spawn();
         pSpawn.initWithTwoActions(action1, action2);
         return pSpawn;
-    };
+    }
 
-    private _one: ActionInterval | null = null;
-    private _two: ActionInterval | null = null;
+    private _one: FiniteTimeAction<T> | null = null;
+    private _two: FiniteTimeAction<T> | null = null;
 
-    constructor (tempArray?: any) {
+    constructor (...actions: FiniteTimeAction<T>[]);
+    constructor (actions: FiniteTimeAction<T>[]);
+    constructor (tempArray: any) {
         super();
 
-        const paramArray = (tempArray instanceof Array) ? tempArray : arguments;
+        const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction<T>[];
+
         if (paramArray.length === 1) {
             errorID(1020);
             return;
@@ -750,11 +776,12 @@ export class Spawn extends ActionInterval {
         if ((last >= 0) && (paramArray[last] == null)) logID(1015);
 
         if (last >= 0) {
-            let prev = paramArray[0]; let action1: any;
+            let prev: FiniteTimeAction<T> = paramArray[0];
+            let action1: FiniteTimeAction<T>;
             for (let i = 1; i < last; i++) {
                 if (paramArray[i]) {
                     action1 = prev;
-                    prev = Spawn._actionOneTwo(action1, paramArray[i]);
+                    prev = Spawn._actionOneTwo(action1, paramArray[i]) as Spawn<T>;
                 }
             }
             this.initWithTwoActions(prev, paramArray[last]);
@@ -766,7 +793,7 @@ export class Spawn extends ActionInterval {
      * @param {FiniteTimeAction} action2
      * @return {Boolean}
      */
-    initWithTwoActions (action1: any, action2: any): boolean {
+    initWithTwoActions (action1?: FiniteTimeAction<T>, action2?: FiniteTimeAction<T>): boolean {
         if (!action1 || !action2) {
             errorID(1027);
             return false;
@@ -777,14 +804,14 @@ export class Spawn extends ActionInterval {
         const d1 = action1._duration;
         const d2 = action2._duration;
 
-        if (this.initWithDuration(Math.max(d1 as number, d2 as number))) {
+        if (this.initWithDuration(Math.max(d1, d2))) {
             this._one = action1;
             this._two = action2;
 
             if (d1 > d2) {
-                this._two = Sequence._actionOneTwo(action2 as ActionInterval, delayTime(d1 - d2));
+                this._two = Sequence._actionOneTwo(action2 as ActionInterval<T>, delayTime<T>(d1 - d2)) as Sequence<T>;
             } else if (d1 < d2) {
-                this._one = Sequence._actionOneTwo(action1 as ActionInterval, delayTime(d2 - d1));
+                this._one = Sequence._actionOneTwo(action1 as ActionInterval<T>, delayTime<T>(d2 - d1)) as Sequence<T>;
             }
 
             ret = true;
@@ -792,36 +819,41 @@ export class Spawn extends ActionInterval {
         return ret;
     }
 
-    clone (): Spawn {
-        const action = new Spawn();
+    clone (): Spawn<T> {
+        const action = new Spawn<T>();
         this._cloneDecoration(action);
-        action.initWithTwoActions(this._one!.clone(), this._two!.clone());
+        if (this._one && this._two) {
+            action.initWithTwoActions(this._one.clone(), this._two.clone());
+        }
         return action;
     }
 
-    startWithTarget (target: any): void {
-        ActionInterval.prototype.startWithTarget.call(this, target);
-        this._one!.startWithTarget(target);
-        this._two!.startWithTarget(target);
+    startWithTarget (target: T | undefined): void {
+        super.startWithTarget(target);
+        this._one?.startWithTarget(target);
+        this._two?.startWithTarget(target);
     }
 
     stop (): void {
-        this._one!.stop();
-        this._two!.stop();
-        Action.prototype.stop.call(this);
+        this._one?.stop();
+        this._two?.stop();
+        super.stop();
     }
 
-    update (dt: any): void {
+    update (dt: number): void {
         dt = this._computeEaseTime(dt);
-        if (this._one) this._one.update(dt as number);
-        if (this._two) this._two.update(dt as number);
+        if (this._one) this._one.update(dt);
+        if (this._two) this._two.update(dt);
     }
 
-    reverse (): any {
-        const action = Spawn._actionOneTwo(this._one!.reverse(), this._two!.reverse());
-        this._cloneDecoration(action);
-        this._reverseEaseList(action);
-        return action as any;
+    reverse (): Spawn<T> {
+        if (this._one && this._two) {
+            const action = Spawn._actionOneTwo(this._one.reverse(), this._two.reverse()) as Spawn<T>;
+            this._cloneDecoration(action);
+            this._reverseEaseList(action);
+            return action;
+        }
+        return this;
     }
 }
 
@@ -837,8 +869,10 @@ export class Spawn extends ActionInterval {
  * const action = spawn(jumpBy(2, new Vec2(300, 0), 50, 4), rotateBy(2, 720));
  * todo: It should be the direct use new
  */
-export function spawn (/* Multiple Arguments */tempArray: any): FiniteTimeAction {
-    const paramArray = (tempArray instanceof Array) ? tempArray : arguments;
+export function spawn<T> (...actions: FiniteTimeAction<T>[]): FiniteTimeAction<T>;
+export function spawn<T> (actions: FiniteTimeAction<T>[]): FiniteTimeAction<T>;
+export function spawn<T> (tempArray: any): FiniteTimeAction<T> {
+    const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction<T>[];
     if (paramArray.length === 1) {
         errorID(1020);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -847,29 +881,31 @@ export function spawn (/* Multiple Arguments */tempArray: any): FiniteTimeAction
     if ((paramArray.length > 0) && (paramArray[paramArray.length - 1] == null)) logID(1015);
 
     let prev = paramArray[0];
+    let current: FiniteTimeAction<T> | null;
     for (let i = 1; i < paramArray.length; i++) {
-        if (paramArray[i] != null) prev = Spawn._actionOneTwo(prev, paramArray[i]);
+        current = paramArray[i];
+        if (current != null) prev = Spawn._actionOneTwo(prev, current) as Spawn<T>;
     }
-    return prev as FiniteTimeAction;
+    return prev;
 }
 
 /* Delays the action a certain amount of seconds
  * @class DelayTime
  * @extends ActionInterval
  */
-class DelayTime extends ActionInterval {
+class DelayTime<T> extends ActionInterval<T> {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    update (dt: any): void { }
+    update (dt: number): void { }
 
-    reverse (): any {
-        const action = new DelayTime(this._duration);
+    reverse (): DelayTime<T> {
+        const action = new DelayTime<T>(this._duration);
         this._cloneDecoration(action);
         this._reverseEaseList(action);
-        return action as any;
+        return action;
     }
 
-    clone (): DelayTime {
-        const action = new DelayTime();
+    clone (): DelayTime<T> {
+        const action = new DelayTime<T>();
         this._cloneDecoration(action);
         action.initWithDuration(this._duration);
         return action;
@@ -886,8 +922,8 @@ class DelayTime extends ActionInterval {
  * import { delayTime } from 'cc';
  * const delay = delayTime(1);
  */
-export function delayTime (d: number): ActionInterval {
-    return new DelayTime(d);
+export function delayTime<T> (d: number): ActionInterval<T> {
+    return new DelayTime<T>(d);
 }
 
 /**
@@ -904,19 +940,19 @@ export function delayTime (d: number): ActionInterval {
  * import ReverseTime from 'cc';
  * var reverse = new ReverseTime(this);
  */
-export class ReverseTime extends ActionInterval {
-    private _other: ActionInterval | null = null;
+export class ReverseTime<T> extends ActionInterval<T> {
+    private _other: ActionInterval<T> | null = null;
 
-    constructor (action?: any) {
+    constructor (action?: ActionInterval<T>) {
         super();
-        action && this.initWithAction(action as ActionInterval);
+        if (action) this.initWithAction(action);
     }
 
     /*
      * @param {FiniteTimeAction} action
      * @return {Boolean}
      */
-    initWithAction (action: ActionInterval): boolean {
+    initWithAction (action: ActionInterval<T>): boolean {
         if (!action) {
             errorID(1028);
             return false;
@@ -926,7 +962,7 @@ export class ReverseTime extends ActionInterval {
             return false;
         }
 
-        if (ActionInterval.prototype.initWithDuration.call(this, action._duration)) {
+        if (super.initWithDuration(action._duration)) {
             // Don't leak if action is reused
             this._other = action;
             return true;
@@ -934,16 +970,18 @@ export class ReverseTime extends ActionInterval {
         return false;
     }
 
-    clone (): ReverseTime {
-        const action = new ReverseTime();
+    clone (): ReverseTime<T> {
+        const action = new ReverseTime<T>();
         this._cloneDecoration(action);
-        action.initWithAction(this._other!.clone());
+        if (this._other) {
+            action.initWithAction(this._other.clone());
+        }
         return action;
     }
 
-    startWithTarget (target: any): void {
-        ActionInterval.prototype.startWithTarget.call(this, target);
-        this._other!.startWithTarget(target);
+    startWithTarget (target: T | undefined): void {
+        super.startWithTarget(target);
+        this._other?.startWithTarget(target);
     }
 
     update (dt: number): void {
@@ -951,13 +989,16 @@ export class ReverseTime extends ActionInterval {
         if (this._other) this._other.update(1 - dt);
     }
 
-    reverse (): any {
-        return this._other!.clone() as any;
+    reverse (): ActionInterval<T> {
+        if (this._other) {
+            return this._other.clone();
+        }
+        return this;
     }
 
     stop (): void {
-        this._other!.stop();
-        Action.prototype.stop.call(this);
+        this._other?.stop();
+        super.stop();
     }
 }
 
@@ -971,6 +1012,6 @@ export class ReverseTime extends ActionInterval {
  * import { reverseTime } from 'cc';
  * const reverse = reverseTime(this);
  */
-export function reverseTime (action: any): ActionInterval {
+export function reverseTime<T> (action: ActionInterval<T>): ActionInterval<T> {
     return new ReverseTime(action);
 }

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -47,7 +47,7 @@ import { ActionInstant } from './action-instant';
  * @extends FiniteTimeAction
  * @param {Number} d duration in seconds
  */
-export class ActionInterval<T> extends FiniteTimeAction<T> {
+export class ActionInterval extends FiniteTimeAction {
     protected MAX_VALUE = 2;
     protected _elapsed = 0;
     protected _firstTick = false;
@@ -92,7 +92,7 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
         return (this._elapsed >= this._duration);
     }
 
-    _cloneDecoration (action: ActionInterval<T>): void {
+    _cloneDecoration (action: ActionInterval): void {
         action._repeatForever = this._repeatForever;
         action._speed = this._speed;
         action._timesForRepeat = this._timesForRepeat;
@@ -101,7 +101,7 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
         action._repeatMethod = this._repeatMethod;
     }
 
-    _reverseEaseList (action: ActionInterval<T>): void {
+    _reverseEaseList (action: ActionInterval): void {
         if (this._easeList) {
             action._easeList = [];
             for (let i = 0; i < this._easeList.length; i++) {
@@ -110,8 +110,8 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
         }
     }
 
-    clone (): ActionInterval<T> {
-        const action = new ActionInterval<T>(this._duration);
+    clone (): ActionInterval {
+        const action = new ActionInterval(this._duration);
         this._cloneDecoration(action);
         return action;
     }
@@ -126,7 +126,7 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
      * import { easeIn } from 'cc';
      * action.easing(easeIn(3.0));
      */
-    easing (easeObj: any): ActionInterval<T> {
+    easing (easeObj: any): ActionInterval {
         if (this._easeList) this._easeList.length = 0;
         else this._easeList = [];
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -169,13 +169,13 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
         }
     }
 
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<T> (target: T | null): void {
         super.startWithTarget(target);
         this._elapsed = 0;
         this._firstTick = true;
     }
 
-    reverse (): ActionInterval<T> {
+    reverse (): ActionInterval {
         logID(1010);
         return this;
     }
@@ -212,7 +212,7 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
      * @param {Number} speed
      * @returns {Action}
      */
-    speed (speed: number): Action<T> {
+    speed (speed: number): Action {
         if (speed <= 0) {
             logID(1013);
             return this;
@@ -242,7 +242,7 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
      * @param {Number} speed
      * @returns {ActionInterval}
      */
-    setSpeed (speed: number): ActionInterval<T> {
+    setSpeed (speed: number): ActionInterval {
         this._speed = speed;
         return this;
     }
@@ -256,7 +256,7 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
      * @param {Number} times
      * @returns {ActionInterval}
      */
-    repeat (times: number): ActionInterval<T> {
+    repeat (times: number): ActionInterval {
         times = Math.round(times);
         if (Number.isNaN(times) || times < 1) {
             logID(1014);
@@ -275,7 +275,7 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
      * @method repeatForever
      * @returns {ActionInterval}
      */
-    repeatForever (): ActionInterval<T> {
+    repeatForever (): ActionInterval {
         this._repeatMethod = true; // Compatible with repeat class, Discard after can be deleted
         this._timesForRepeat = this.MAX_VALUE;
         this._repeatForever = true;
@@ -286,14 +286,14 @@ export class ActionInterval<T> extends FiniteTimeAction<T> {
 /*
  * Runs actions sequentially, one after another.
  */
-export class Sequence<T> extends ActionInterval<T> {
-    static _actionOneTwo (actionOne: FiniteTimeAction<unknown>, actionTwo: FiniteTimeAction<unknown>): Sequence<unknown> {
+export class Sequence extends ActionInterval {
+    static _actionOneTwo (actionOne: FiniteTimeAction, actionTwo: FiniteTimeAction): Sequence {
         const sequence = new Sequence();
         sequence.initWithTwoActions(actionOne, actionTwo);
         return sequence;
     }
 
-    private _actions: FiniteTimeAction<T>[] = [];
+    private _actions: FiniteTimeAction[] = [];
     private _split = 0;
     private _last = 0;
     private _reversed = false;
@@ -308,12 +308,12 @@ export class Sequence<T> extends ActionInterval<T> {
      * // create sequence with array
      * const seq = new Sequence(actArray);
      */
-    constructor (...actions: FiniteTimeAction<T>[]);
-    constructor (actions: FiniteTimeAction<T>[]);
+    constructor (...actions: FiniteTimeAction[]);
+    constructor (actions: FiniteTimeAction[]);
     constructor (tempArray: any) {
         super();
 
-        const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction<T>[];
+        const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction[];
         if (paramArray.length === 1) {
             errorID(1019);
             return;
@@ -323,11 +323,11 @@ export class Sequence<T> extends ActionInterval<T> {
 
         if (last >= 0) {
             let prev = paramArray[0];
-            let action1: FiniteTimeAction<T>;
+            let action1: FiniteTimeAction;
             for (let i = 1; i < last; i++) {
                 if (paramArray[i]) {
                     action1 = prev;
-                    prev = Sequence._actionOneTwo(action1 as ActionInterval<T>, paramArray[i] as ActionInterval<T>) as FiniteTimeAction<T>;
+                    prev = Sequence._actionOneTwo(action1, paramArray[i]) as FiniteTimeAction;
                 }
             }
             this.initWithTwoActions(prev, paramArray[last]);
@@ -340,7 +340,7 @@ export class Sequence<T> extends ActionInterval<T> {
      * @param {FiniteTimeAction} actionTwo
      * @return {Boolean}
      */
-    initWithTwoActions (actionOne?: FiniteTimeAction<T>, actionTwo?: FiniteTimeAction<T>): boolean {
+    initWithTwoActions (actionOne?: FiniteTimeAction, actionTwo?: FiniteTimeAction): boolean {
         if (!actionOne || !actionTwo) {
             errorID(1025);
             return false;
@@ -357,14 +357,14 @@ export class Sequence<T> extends ActionInterval<T> {
         return true;
     }
 
-    clone (): Sequence<T> {
-        const action = new Sequence<T>();
+    clone (): Sequence {
+        const action = new Sequence();
         this._cloneDecoration(action);
         action.initWithTwoActions(this._actions[0].clone(), this._actions[1].clone());
         return action;
     }
 
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<T> (target: T | null): void {
         super.startWithTarget(target);
         this._split = this._actions[0]._duration / this._duration;
         this._split *= (this._actions[0] as any)._repeatMethod ? this._actions[0]._timesForRepeat : 1;
@@ -427,8 +427,8 @@ export class Sequence<T> extends ActionInterval<T> {
         this._last = found;
     }
 
-    reverse (): Sequence<T> {
-        const action: Sequence<T> = Sequence._actionOneTwo(this._actions[1].reverse(), this._actions[0].reverse()) as Sequence<T>;
+    reverse (): Sequence {
+        const action: Sequence = Sequence._actionOneTwo(this._actions[1].reverse(), this._actions[0].reverse());
         this._cloneDecoration(action);
         this._reverseEaseList(action);
         action._reversed = true;
@@ -455,28 +455,28 @@ export class Sequence<T> extends ActionInterval<T> {
  * const seq = sequence(actArray);
  */
 // todo: It should be use new
-export function sequence<T> (...actions: FiniteTimeAction<T>[]): ActionInterval<T> | null;
-export function sequence<T> (actions: FiniteTimeAction<T>[]): ActionInterval<T> | null;
-export function sequence<T> (tempArray: any): ActionInterval<T> | null {
-    const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction<T>[];
+export function sequence (...actions: FiniteTimeAction[]): ActionInterval | null;
+export function sequence (actions: FiniteTimeAction[]): ActionInterval | null;
+export function sequence (tempArray: any): ActionInterval | null {
+    const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction[];
 
     if (paramArray.length === 1) {
-        return paramArray[0] as ActionInterval<T>;
+        return paramArray[0] as ActionInterval; //FIXME: Remove 'as'
     }
     const last = paramArray.length - 1;
     if ((last >= 0) && (paramArray[last] == null)) logID(1015);
 
-    let result: ActionInterval<T> | null = null;
+    let result: FiniteTimeAction | null = null;
     if (last >= 0) {
-        result = paramArray[0] as ActionInterval<T>; //FIXME: remove 'as'
+        result = paramArray[0];
         for (let i = 1; i <= last; i++) {
             if (paramArray[i]) {
-                result = Sequence._actionOneTwo(result, paramArray[i] as ActionInterval<T>) as Sequence<T>;
+                result = Sequence._actionOneTwo(result, paramArray[i]);
             }
         }
     }
 
-    return result;
+    return result as ActionInterval; //FIXME: remove 'as'
 }
 
 /*
@@ -490,14 +490,14 @@ export function sequence<T> (tempArray: any): ActionInterval<T> | null {
  * import { Repeat, sequence } from 'cc';
  * const rep = new Repeat(sequence(jump2, jump1), 5);
  */
-export class Repeat<T> extends ActionInterval<T> {
+export class Repeat extends ActionInterval {
     private _times = 0;
     private _total = 0;
     private _nextDt = 0;
     private _actionInstant = false;
-    private _innerAction: FiniteTimeAction<T> | null = null;
+    private _innerAction: FiniteTimeAction | null = null;
 
-    constructor (action?: FiniteTimeAction<T>, times?: number) {
+    constructor (action?: FiniteTimeAction, times?: number) {
         super();
         this.initWithAction(action, times);
     }
@@ -507,7 +507,7 @@ export class Repeat<T> extends ActionInterval<T> {
      * @param {Number} times
      * @return {Boolean}
      */
-    initWithAction (action?: FiniteTimeAction<T>, times?: number): boolean {
+    initWithAction (action?: FiniteTimeAction, times?: number): boolean {
         if (!action || times === undefined) {
             return false;
         }
@@ -526,8 +526,8 @@ export class Repeat<T> extends ActionInterval<T> {
         return false;
     }
 
-    clone (): Repeat<T> {
-        const action = new Repeat<T>();
+    clone (): Repeat {
+        const action = new Repeat();
         this._cloneDecoration(action);
         if (this._innerAction) {
             action.initWithAction(this._innerAction.clone(), this._times);
@@ -535,7 +535,7 @@ export class Repeat<T> extends ActionInterval<T> {
         return action;
     }
 
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<T> (target: T | null): void {
         this._total = 0;
         this._nextDt = (this._innerAction ? this._innerAction._duration : 0) / this._duration;
         super.startWithTarget(target);
@@ -592,7 +592,7 @@ export class Repeat<T> extends ActionInterval<T> {
         return this._total === this._times;
     }
 
-    reverse (): Repeat<T> {
+    reverse (): Repeat {
         const actionArg = this._innerAction ? this._innerAction.reverse() : undefined;
         const action = new Repeat(actionArg, this._times);
         this._cloneDecoration(action);
@@ -604,7 +604,7 @@ export class Repeat<T> extends ActionInterval<T> {
      * Set inner Action.
      * @param {FiniteTimeAction} action
      */
-    setInnerAction (action: FiniteTimeAction<T>): void {
+    setInnerAction (action: FiniteTimeAction): void {
         if (this._innerAction !== action) {
             this._innerAction = action;
         }
@@ -614,7 +614,7 @@ export class Repeat<T> extends ActionInterval<T> {
      * Get inner Action.
      * @return {FiniteTimeAction}
      */
-    getInnerAction (): FiniteTimeAction<T> | null {
+    getInnerAction (): FiniteTimeAction | null {
         return this._innerAction;
     }
 }
@@ -630,8 +630,8 @@ export class Repeat<T> extends ActionInterval<T> {
  * import { repeat, sequence } from 'cc';
  * const rep = repeat(sequence(jump2, jump1), 5);
  */
-export function repeat<T> (action: FiniteTimeAction<T>, times: number): Action<T> {
-    return new Repeat<T>(action, times);
+export function repeat (action: FiniteTimeAction, times: number): Action {
+    return new Repeat(action, times);
 }
 
 /*
@@ -645,10 +645,10 @@ export function repeat<T> (action: FiniteTimeAction<T>, times: number): Action<T
  * import { sequence, RepeatForever } from 'cc';
  * const rep = new RepeatForever(sequence(jump2, jump1), 5);
  */
-export class RepeatForever<T> extends ActionInterval<T> {
-    private _innerAction: ActionInterval<T> | null = null;
+export class RepeatForever extends ActionInterval {
+    private _innerAction: ActionInterval | null = null;
 
-    constructor (action?: ActionInterval<T>) {
+    constructor (action?: ActionInterval) {
         super();
         if (action) this.initWithAction(action);
     }
@@ -657,7 +657,7 @@ export class RepeatForever<T> extends ActionInterval<T> {
      * @param {ActionInterval} action
      * @return {Boolean}
      */
-    initWithAction (action: ActionInterval<T>): boolean {
+    initWithAction (action: ActionInterval): boolean {
         if (!action) {
             errorID(1026);
             return false;
@@ -667,8 +667,8 @@ export class RepeatForever<T> extends ActionInterval<T> {
         return true;
     }
 
-    clone (): RepeatForever<T> {
-        const action = new RepeatForever<T>();
+    clone (): RepeatForever {
+        const action = new RepeatForever();
         this._cloneDecoration(action);
         if (this._innerAction) {
             action.initWithAction(this._innerAction.clone());
@@ -676,7 +676,7 @@ export class RepeatForever<T> extends ActionInterval<T> {
         return action;
     }
 
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<T> (target: T | null): void {
         super.startWithTarget(target);
         if (this._innerAction) {
             this._innerAction.startWithTarget(target);
@@ -703,7 +703,7 @@ export class RepeatForever<T> extends ActionInterval<T> {
         return false;
     }
 
-    reverse (): RepeatForever<T> {
+    reverse (): RepeatForever {
         if (this._innerAction) {
             const action = new RepeatForever(this._innerAction.reverse());
             this._cloneDecoration(action);
@@ -717,7 +717,7 @@ export class RepeatForever<T> extends ActionInterval<T> {
      * Set inner action.
      * @param {ActionInterval} action
      */
-    setInnerAction (action: ActionInterval<T> | null): void {
+    setInnerAction (action: ActionInterval | null): void {
         if (this._innerAction !== action) {
             this._innerAction = action;
         }
@@ -727,7 +727,7 @@ export class RepeatForever<T> extends ActionInterval<T> {
      * Get inner action.
      * @return {ActionInterval}
      */
-    getInnerAction (): ActionInstant<T> | null {
+    getInnerAction (): ActionInstant | null {
         return this._innerAction;
     }
 }
@@ -742,7 +742,7 @@ export class RepeatForever<T> extends ActionInterval<T> {
  * import { repeatForever, rotateBy } from 'cc';
  * var repeat = repeatForever(rotateBy(1.0, 360));
  */
-export function repeatForever<T> (action?: ActionInterval<T>): ActionInterval<T> {
+export function repeatForever (action?: ActionInterval): ActionInterval {
     return new RepeatForever(action);
 }
 
@@ -751,22 +751,22 @@ export function repeatForever<T> (action?: ActionInterval<T>): ActionInterval<T>
  * @class Spawn
  * @extends ActionInterval
  */
-export class Spawn<T> extends ActionInterval<T> {
-    static _actionOneTwo (action1?: FiniteTimeAction<unknown>, action2?: FiniteTimeAction<unknown>): Spawn<unknown> {
+export class Spawn extends ActionInterval {
+    static _actionOneTwo (action1?: FiniteTimeAction, action2?: FiniteTimeAction): Spawn {
         const pSpawn = new Spawn();
         pSpawn.initWithTwoActions(action1, action2);
         return pSpawn;
     }
 
-    private _one: FiniteTimeAction<T> | null = null;
-    private _two: FiniteTimeAction<T> | null = null;
+    private _one: FiniteTimeAction | null = null;
+    private _two: FiniteTimeAction | null = null;
 
-    constructor (...actions: FiniteTimeAction<T>[]);
-    constructor (actions: FiniteTimeAction<T>[]);
+    constructor (...actions: FiniteTimeAction[]);
+    constructor (actions: FiniteTimeAction[]);
     constructor (tempArray: any) {
         super();
 
-        const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction<T>[];
+        const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction[];
 
         if (paramArray.length === 1) {
             errorID(1020);
@@ -776,12 +776,12 @@ export class Spawn<T> extends ActionInterval<T> {
         if ((last >= 0) && (paramArray[last] == null)) logID(1015);
 
         if (last >= 0) {
-            let prev: FiniteTimeAction<T> = paramArray[0];
-            let action1: FiniteTimeAction<T>;
+            let prev: FiniteTimeAction = paramArray[0];
+            let action1: FiniteTimeAction;
             for (let i = 1; i < last; i++) {
                 if (paramArray[i]) {
                     action1 = prev;
-                    prev = Spawn._actionOneTwo(action1, paramArray[i]) as Spawn<T>;
+                    prev = Spawn._actionOneTwo(action1, paramArray[i]);
                 }
             }
             this.initWithTwoActions(prev, paramArray[last]);
@@ -793,7 +793,7 @@ export class Spawn<T> extends ActionInterval<T> {
      * @param {FiniteTimeAction} action2
      * @return {Boolean}
      */
-    initWithTwoActions (action1?: FiniteTimeAction<T>, action2?: FiniteTimeAction<T>): boolean {
+    initWithTwoActions (action1?: FiniteTimeAction, action2?: FiniteTimeAction): boolean {
         if (!action1 || !action2) {
             errorID(1027);
             return false;
@@ -809,9 +809,9 @@ export class Spawn<T> extends ActionInterval<T> {
             this._two = action2;
 
             if (d1 > d2) {
-                this._two = Sequence._actionOneTwo(action2 as ActionInterval<T>, delayTime<T>(d1 - d2)) as Sequence<T>;
+                this._two = Sequence._actionOneTwo(action2 as ActionInterval, delayTime(d1 - d2));
             } else if (d1 < d2) {
-                this._one = Sequence._actionOneTwo(action1 as ActionInterval<T>, delayTime<T>(d2 - d1)) as Sequence<T>;
+                this._one = Sequence._actionOneTwo(action1 as ActionInterval, delayTime(d2 - d1));
             }
 
             ret = true;
@@ -819,8 +819,8 @@ export class Spawn<T> extends ActionInterval<T> {
         return ret;
     }
 
-    clone (): Spawn<T> {
-        const action = new Spawn<T>();
+    clone (): Spawn {
+        const action = new Spawn();
         this._cloneDecoration(action);
         if (this._one && this._two) {
             action.initWithTwoActions(this._one.clone(), this._two.clone());
@@ -828,7 +828,7 @@ export class Spawn<T> extends ActionInterval<T> {
         return action;
     }
 
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<T> (target: T | null): void {
         super.startWithTarget(target);
         this._one?.startWithTarget(target);
         this._two?.startWithTarget(target);
@@ -846,9 +846,9 @@ export class Spawn<T> extends ActionInterval<T> {
         if (this._two) this._two.update(dt);
     }
 
-    reverse (): Spawn<T> {
+    reverse (): Spawn {
         if (this._one && this._two) {
-            const action = Spawn._actionOneTwo(this._one.reverse(), this._two.reverse()) as Spawn<T>;
+            const action = Spawn._actionOneTwo(this._one.reverse(), this._two.reverse());
             this._cloneDecoration(action);
             this._reverseEaseList(action);
             return action;
@@ -869,10 +869,10 @@ export class Spawn<T> extends ActionInterval<T> {
  * const action = spawn(jumpBy(2, new Vec2(300, 0), 50, 4), rotateBy(2, 720));
  * todo: It should be the direct use new
  */
-export function spawn<T> (...actions: FiniteTimeAction<T>[]): FiniteTimeAction<T>;
-export function spawn<T> (actions: FiniteTimeAction<T>[]): FiniteTimeAction<T>;
-export function spawn<T> (tempArray: any): FiniteTimeAction<T> {
-    const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction<T>[];
+export function spawn (...actions: FiniteTimeAction[]): FiniteTimeAction;
+export function spawn (actions: FiniteTimeAction[]): FiniteTimeAction;
+export function spawn (tempArray: any): FiniteTimeAction {
+    const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction[];
     if (paramArray.length === 1) {
         errorID(1020);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -881,10 +881,10 @@ export function spawn<T> (tempArray: any): FiniteTimeAction<T> {
     if ((paramArray.length > 0) && (paramArray[paramArray.length - 1] == null)) logID(1015);
 
     let prev = paramArray[0];
-    let current: FiniteTimeAction<T> | null;
+    let current: FiniteTimeAction | null;
     for (let i = 1; i < paramArray.length; i++) {
         current = paramArray[i];
-        if (current != null) prev = Spawn._actionOneTwo(prev, current) as Spawn<T>;
+        if (current != null) prev = Spawn._actionOneTwo(prev, current);
     }
     return prev;
 }
@@ -893,19 +893,19 @@ export function spawn<T> (tempArray: any): FiniteTimeAction<T> {
  * @class DelayTime
  * @extends ActionInterval
  */
-class DelayTime<T> extends ActionInterval<T> {
+class DelayTime extends ActionInterval {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     update (dt: number): void { }
 
-    reverse (): DelayTime<T> {
-        const action = new DelayTime<T>(this._duration);
+    reverse (): DelayTime {
+        const action = new DelayTime(this._duration);
         this._cloneDecoration(action);
         this._reverseEaseList(action);
         return action;
     }
 
-    clone (): DelayTime<T> {
-        const action = new DelayTime<T>();
+    clone (): DelayTime {
+        const action = new DelayTime();
         this._cloneDecoration(action);
         action.initWithDuration(this._duration);
         return action;
@@ -922,8 +922,8 @@ class DelayTime<T> extends ActionInterval<T> {
  * import { delayTime } from 'cc';
  * const delay = delayTime(1);
  */
-export function delayTime<T> (d: number): ActionInterval<T> {
-    return new DelayTime<T>(d);
+export function delayTime (d: number): ActionInterval {
+    return new DelayTime(d);
 }
 
 /**
@@ -940,10 +940,10 @@ export function delayTime<T> (d: number): ActionInterval<T> {
  * import ReverseTime from 'cc';
  * var reverse = new ReverseTime(this);
  */
-export class ReverseTime<T> extends ActionInterval<T> {
-    private _other: ActionInterval<T> | null = null;
+export class ReverseTime extends ActionInterval {
+    private _other: ActionInterval | null = null;
 
-    constructor (action?: ActionInterval<T>) {
+    constructor (action?: ActionInterval) {
         super();
         if (action) this.initWithAction(action);
     }
@@ -952,7 +952,7 @@ export class ReverseTime<T> extends ActionInterval<T> {
      * @param {FiniteTimeAction} action
      * @return {Boolean}
      */
-    initWithAction (action: ActionInterval<T>): boolean {
+    initWithAction (action: ActionInterval): boolean {
         if (!action) {
             errorID(1028);
             return false;
@@ -970,8 +970,8 @@ export class ReverseTime<T> extends ActionInterval<T> {
         return false;
     }
 
-    clone (): ReverseTime<T> {
-        const action = new ReverseTime<T>();
+    clone (): ReverseTime {
+        const action = new ReverseTime();
         this._cloneDecoration(action);
         if (this._other) {
             action.initWithAction(this._other.clone());
@@ -979,7 +979,7 @@ export class ReverseTime<T> extends ActionInterval<T> {
         return action;
     }
 
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<T> (target: T | null): void {
         super.startWithTarget(target);
         this._other?.startWithTarget(target);
     }
@@ -989,7 +989,7 @@ export class ReverseTime<T> extends ActionInterval<T> {
         if (this._other) this._other.update(1 - dt);
     }
 
-    reverse (): ActionInterval<T> {
+    reverse (): ActionInterval {
         if (this._other) {
             return this._other.clone();
         }
@@ -1012,6 +1012,6 @@ export class ReverseTime<T> extends ActionInterval<T> {
  * import { reverseTime } from 'cc';
  * const reverse = reverseTime(this);
  */
-export function reverseTime<T> (action: ActionInterval<T>): ActionInterval<T> {
+export function reverseTime (action: ActionInterval): ActionInterval {
     return new ReverseTime(action);
 }

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -47,7 +47,7 @@ import { ActionInstant } from './action-instant';
  * @extends FiniteTimeAction
  * @param {Number} d duration in seconds
  */
-export class ActionInterval extends FiniteTimeAction {
+export abstract class ActionInterval extends FiniteTimeAction {
     protected MAX_VALUE = 2;
     protected _elapsed = 0;
     protected _firstTick = false;
@@ -98,11 +98,7 @@ export class ActionInterval extends FiniteTimeAction {
         action._repeatMethod = this._repeatMethod;
     }
 
-    clone (): ActionInterval {
-        const action = new ActionInterval(this._duration);
-        this._cloneDecoration(action);
-        return action;
-    }
+    abstract clone (): ActionInterval;
 
     step (dt: number): void {
         if (this._firstTick) {

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -185,7 +185,7 @@ export class ActionInterval extends FiniteTimeAction {
      * @warning It should be overridden in subclass.
      * @param {Number} amp
      */
-    setAmplitudeRate (amp: any): void {
+    setAmplitudeRate (amp: number): void {
         // Abstract class needs implementation
         logID(1011);
     }
@@ -497,7 +497,7 @@ export class Repeat extends ActionInterval {
     private _actionInstant = false;
     private _innerAction: FiniteTimeAction | null = null;
 
-    constructor (action?: FiniteTimeAction, times?: number) {
+    constructor (action: FiniteTimeAction | null = null, times: number = 0) {
         super();
         this.initWithAction(action, times);
     }
@@ -507,7 +507,7 @@ export class Repeat extends ActionInterval {
      * @param {Number} times
      * @return {Boolean}
      */
-    initWithAction (action?: FiniteTimeAction, times?: number): boolean {
+    initWithAction (action: FiniteTimeAction | null, times: number): boolean {
         if (!action || times === undefined) {
             return false;
         }
@@ -539,11 +539,11 @@ export class Repeat extends ActionInterval {
         this._total = 0;
         this._nextDt = (this._innerAction ? this._innerAction._duration : 0) / this._duration;
         super.startWithTarget(target);
-        this._innerAction?.startWithTarget(target);
+        if (this._innerAction) this._innerAction.startWithTarget(target);
     }
 
     stop (): void {
-        this._innerAction?.stop();
+        if (this._innerAction) this._innerAction.stop();
         super.stop();
     }
 
@@ -753,9 +753,9 @@ export function repeatForever (action?: ActionInterval): ActionInterval {
  */
 export class Spawn extends ActionInterval {
     static _actionOneTwo (action1?: FiniteTimeAction, action2?: FiniteTimeAction): Spawn {
-        const pSpawn = new Spawn();
-        pSpawn.initWithTwoActions(action1, action2);
-        return pSpawn;
+        const spawn = new Spawn();
+        spawn.initWithTwoActions(action1, action2);
+        return spawn;
     }
 
     private _one: FiniteTimeAction | null = null;
@@ -788,10 +788,10 @@ export class Spawn extends ActionInterval {
         }
     }
 
-    /* initializes the Spawn action with the 2 actions to spawn
-     * @param {FiniteTimeAction} action1
-     * @param {FiniteTimeAction} action2
-     * @return {Boolean}
+    /* Initializes the Spawn action with the 2 actions to spawn
+     * @param {FiniteTimeAction} action1 The first action
+     * @param {FiniteTimeAction} action2 The second action
+     * @return {Boolean} Return true if the initialization succeeds, otherwise return false.
      */
     initWithTwoActions (action1?: FiniteTimeAction, action2?: FiniteTimeAction): boolean {
         if (!action1 || !action2) {
@@ -809,9 +809,9 @@ export class Spawn extends ActionInterval {
             this._two = action2;
 
             if (d1 > d2) {
-                this._two = Sequence._actionOneTwo(action2 as ActionInterval, delayTime(d1 - d2));
+                this._two = Sequence._actionOneTwo(action2, delayTime(d1 - d2));
             } else if (d1 < d2) {
-                this._one = Sequence._actionOneTwo(action1 as ActionInterval, delayTime(d2 - d1));
+                this._one = Sequence._actionOneTwo(action1, delayTime(d2 - d1));
             }
 
             ret = true;
@@ -830,13 +830,13 @@ export class Spawn extends ActionInterval {
 
     startWithTarget<T> (target: T | null): void {
         super.startWithTarget(target);
-        this._one?.startWithTarget(target);
-        this._two?.startWithTarget(target);
+        if (this._one) this._one.startWithTarget(target);
+        if (this._two) this._two.startWithTarget(target);
     }
 
     stop (): void {
-        this._one?.stop();
-        this._two?.stop();
+        if (this._one) this._one.stop();
+        if (this._two) this._two.stop();
         super.stop();
     }
 

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -727,7 +727,7 @@ export class RepeatForever extends ActionInterval {
      * Get inner action.
      * @return {ActionInterval}
      */
-    getInnerAction (): ActionInstant | null {
+    getInnerAction (): ActionInterval | null {
         return this._innerAction;
     }
 }

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -452,7 +452,7 @@ export class Repeat extends ActionInterval {
     private _actionInstant = false;
     private _innerAction: FiniteTimeAction | null = null;
 
-    constructor (action: FiniteTimeAction | null = null, times: number = 0) {
+    constructor (action?: FiniteTimeAction, times?: number) {
         super();
         this.initWithAction(action, times);
     }
@@ -462,7 +462,7 @@ export class Repeat extends ActionInterval {
      * @param {Number} times
      * @return {Boolean}
      */
-    initWithAction (action: FiniteTimeAction | null, times: number): boolean {
+    initWithAction (action?: FiniteTimeAction, times?: number): boolean {
         if (!action || times === undefined) {
             return false;
         }

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -819,14 +819,13 @@ export class Spawn extends ActionInterval {
  * const action = spawn(jumpBy(2, new Vec2(300, 0), 50, 4), rotateBy(2, 720));
  * todo: It should be the direct use new
  */
-export function spawn (...actions: FiniteTimeAction[]): FiniteTimeAction;
-export function spawn (actions: FiniteTimeAction[]): FiniteTimeAction;
-export function spawn (tempArray: any): FiniteTimeAction {
+export function spawn (...actions: FiniteTimeAction[]): FiniteTimeAction | null;
+export function spawn (actions: FiniteTimeAction[]): FiniteTimeAction | null;
+export function spawn (tempArray: any): FiniteTimeAction | null {
     const paramArray = ((tempArray instanceof Array) ? tempArray : arguments) as FiniteTimeAction[];
     if (paramArray.length === 1) {
         errorID(1020);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return null as any;
+        return null;
     }
     if ((paramArray.length > 0) && (paramArray[paramArray.length - 1] == null)) logID(1015);
 
@@ -844,8 +843,7 @@ export function spawn (tempArray: any): FiniteTimeAction {
  * @extends ActionInterval
  */
 class DelayTime extends ActionInterval {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    update (dt: number): void { }
+    update (_dt: number): void { /* empty */ }
 
     reverse (): DelayTime {
         const action = new DelayTime(this._duration);

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -928,7 +928,7 @@ export class ReverseTime extends ActionInterval {
 
     startWithTarget<T> (target: T | null): void {
         super.startWithTarget(target);
-        this._other?.startWithTarget(target);
+        if (this._other) this._other.startWithTarget(target);
     }
 
     update (dt: number): void {
@@ -943,7 +943,7 @@ export class ReverseTime extends ActionInterval {
     }
 
     stop (): void {
-        this._other?.stop();
+        if (this._other) this._other.stop();
         super.stop();
     }
 }

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -51,8 +51,6 @@ export class ActionInterval extends FiniteTimeAction {
     protected MAX_VALUE = 2;
     protected _elapsed = 0;
     protected _firstTick = false;
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    protected _easeList: Function[] = [];
     protected _speed = 1;
     protected _repeatForever = false;
     _repeatMethod = false; // Compatible with repeat class, Discard after can be deleted
@@ -96,51 +94,14 @@ export class ActionInterval extends FiniteTimeAction {
         action._repeatForever = this._repeatForever;
         action._speed = this._speed;
         action._timesForRepeat = this._timesForRepeat;
-        action._easeList = this._easeList;
         action._speedMethod = this._speedMethod;
         action._repeatMethod = this._repeatMethod;
-    }
-
-    _reverseEaseList (action: ActionInterval): void {
-        if (this._easeList) {
-            action._easeList = [];
-            for (let i = 0; i < this._easeList.length; i++) {
-                action._easeList.push(this._easeList[i]);
-            }
-        }
     }
 
     clone (): ActionInterval {
         const action = new ActionInterval(this._duration);
         this._cloneDecoration(action);
         return action;
-    }
-
-    /**
-     * @en Implementation of ease motion.
-     * @zh 缓动运动。
-     * @method easing
-     * @param {Object} easeObj
-     * @returns {ActionInterval}
-     * @example
-     * import { easeIn } from 'cc';
-     * action.easing(easeIn(3.0));
-     */
-    easing (easeObj: any): ActionInterval {
-        if (this._easeList) this._easeList.length = 0;
-        else this._easeList = [];
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        for (let i = 0; i < arguments.length; i++) this._easeList.push(arguments[i]);
-        return this;
-    }
-
-    _computeEaseTime (dt: number): number {
-        // var locList = this._easeList;
-        // if ((!locList) || (locList.length === 0))
-        //     return dt;
-        // for (var i = 0, n = locList.length; i < n; i++)
-        //     dt = locList[i].easing(dt);
-        return dt;
     }
 
     step (dt: number): void {
@@ -384,7 +345,6 @@ export class Sequence extends ActionInterval {
         const locActions = this._actions;
         const locLast = this._last;
 
-        dt = this._computeEaseTime(dt);
         if (dt < locSplit) {
             // action[0]
             new_t = (locSplit !== 0) ? dt / locSplit : 1;
@@ -430,7 +390,6 @@ export class Sequence extends ActionInterval {
     reverse (): Sequence {
         const action: Sequence = Sequence._actionOneTwo(this._actions[1].reverse(), this._actions[0].reverse());
         this._cloneDecoration(action);
-        this._reverseEaseList(action);
         action._reversed = true;
         return action;
     }
@@ -548,7 +507,6 @@ export class Repeat extends ActionInterval {
     }
 
     update (dt: number): void {
-        dt = this._computeEaseTime(dt);
         const locInnerAction = this._innerAction;
         const locDuration = this._duration;
         const locTimes = this._times;
@@ -596,7 +554,6 @@ export class Repeat extends ActionInterval {
         const actionArg = this._innerAction ? this._innerAction.reverse() : undefined;
         const action = new Repeat(actionArg, this._times);
         this._cloneDecoration(action);
-        this._reverseEaseList(action);
         return action;
     }
 
@@ -707,7 +664,6 @@ export class RepeatForever extends ActionInterval {
         if (this._innerAction) {
             const action = new RepeatForever(this._innerAction.reverse());
             this._cloneDecoration(action);
-            this._reverseEaseList(action);
             return action;
         }
         return this;
@@ -841,7 +797,6 @@ export class Spawn extends ActionInterval {
     }
 
     update (dt: number): void {
-        dt = this._computeEaseTime(dt);
         if (this._one) this._one.update(dt);
         if (this._two) this._two.update(dt);
     }
@@ -850,7 +805,6 @@ export class Spawn extends ActionInterval {
         if (this._one && this._two) {
             const action = Spawn._actionOneTwo(this._one.reverse(), this._two.reverse());
             this._cloneDecoration(action);
-            this._reverseEaseList(action);
             return action;
         }
         return this;
@@ -900,7 +854,6 @@ class DelayTime extends ActionInterval {
     reverse (): DelayTime {
         const action = new DelayTime(this._duration);
         this._cloneDecoration(action);
-        this._reverseEaseList(action);
         return action;
     }
 
@@ -985,7 +938,6 @@ export class ReverseTime extends ActionInterval {
     }
 
     update (dt: number): void {
-        dt = this._computeEaseTime(dt);
         if (this._other) this._other.update(1 - dt);
     }
 

--- a/cocos/tween/actions/action-manager.ts
+++ b/cocos/tween/actions/action-manager.ts
@@ -39,10 +39,10 @@ let ID_COUNTER = 0;
  * @private
  */
 class HashElement {
-    actions: Action<unknown>[] = [];
+    actions: Action[] = [];
     target: unknown = null;
     actionIndex = 0;
-    currentAction: Action<unknown> | null = null;
+    currentAction: Action | null = null;
     paused = false;
     lock = false;
 }
@@ -117,7 +117,7 @@ export class ActionManager {
      * @param {object} target
      * @param {Boolean} paused
      */
-    addAction<T> (action: Action<T> | null, target: T, paused: boolean): void {
+    addAction<T> (action: Action | null, target: T, paused: boolean): void {
         if (!action || !target) {
             errorID(1000);
             return;
@@ -184,7 +184,7 @@ export class ActionManager {
      * @method removeAction
      * @param {Action} action
      */
-    removeAction<T> (action: Action<T> | null): void {
+    removeAction<T> (action: Action | null): void {
         // explicit null handling
         if (action == null) return;
         const target = action.getOriginalTarget()!;
@@ -287,7 +287,7 @@ export class ActionManager {
      * @param {T} target
      * @return {Action|null}  return the Action with the given tag on success
      */
-    getActionByTag<T> (tag: number, target: T): Action<T> | null {
+    getActionByTag<T> (tag: number, target: T): Action | null {
         if (tag === Action.TAG_INVALID) logID(1004);
 
         const element = this._hashTargets.get(target);
@@ -296,7 +296,7 @@ export class ActionManager {
                 for (let i = 0; i < element.actions.length; ++i) {
                     const action = element.actions[i];
                     if (action && action.getTag() === tag) {
-                        return action as Action<T>;
+                        return action;
                     }
                 }
             }
@@ -500,7 +500,7 @@ export class ActionManager {
         }
     }
 
-    private _isActionInterval<T> (action: any): action is ActionInterval<T> {
+    private _isActionInterval<T> (action: any): action is ActionInterval {
         return typeof action._speedMethod !== 'undefined';
     }
 }

--- a/cocos/tween/actions/action-manager.ts
+++ b/cocos/tween/actions/action-manager.ts
@@ -27,7 +27,6 @@
 
 import { errorID, logID } from '../../core/platform/debug';
 import { Action } from './action';
-import { Node } from '../../scene-graph';
 import { legacyCC } from '../../core/global-exports';
 import { isCCObject } from '../../core/data/object';
 import type { ActionInterval } from './action-interval';
@@ -40,10 +39,10 @@ let ID_COUNTER = 0;
  * @private
  */
 class HashElement {
-    actions: Action[] = [];
-    target: Record<string, unknown> | null = null; // ccobject
+    actions: Action<unknown>[] = [];
+    target: unknown = null;
     actionIndex = 0;
-    currentAction: Action | null = null; // CCAction
+    currentAction: Action<unknown> | null = null;
     paused = false;
     lock = false;
 }
@@ -68,19 +67,19 @@ class HashElement {
  * @example {@link cocos2d/core/CCActionManager/ActionManager.js}
  */
 export class ActionManager {
-    private _hashTargets = new Map();
+    private _hashTargets = new Map<unknown, HashElement>();
     private _arrayTargets: HashElement[] = [];
     private _currentTarget!: HashElement;
     private _elementPool: HashElement[] = [];
 
-    private _searchElementByTarget (arr: HashElement[], target: Record<string, unknown>): HashElement | null {
+    private _searchElementByTarget<T> (arr: HashElement[], target: T): HashElement | null {
         for (let k = 0; k < arr.length; k++) {
             if (target === arr[k].target) return arr[k];
         }
         return null;
     }
 
-    private _getElement (target: Record<string, unknown>, paused: boolean): HashElement {
+    private _getElement<T> (target: T, paused: boolean): HashElement {
         let element = this._elementPool.pop();
         if (!element) {
             element = new HashElement();
@@ -90,7 +89,7 @@ export class ActionManager {
         return element;
     }
 
-    private _putElement (element: HashElement): void {
+    private _putElement<T> (element: HashElement): void {
         element.actions.length = 0;
         element.actionIndex = 0;
         element.currentAction = null;
@@ -118,12 +117,14 @@ export class ActionManager {
      * @param {object} target
      * @param {Boolean} paused
      */
-    addAction (action: Action, target: Node, paused: boolean): void {
+    addAction<T> (action: Action<T> | null, target: T, paused: boolean): void {
         if (!action || !target) {
             errorID(1000);
             return;
         }
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
         if (target.uuid == null) {
             (target as any).uuid = `_TWEEN_UUID_${ID_COUNTER++}`;
         }
@@ -132,7 +133,7 @@ export class ActionManager {
         let element = this._hashTargets.get(target);
         // if doesn't exists, create a hashelement and push in mpTargets
         if (!element) {
-            element = this._getElement(target as any, paused);
+            element = this._getElement(target, paused);
             this._hashTargets.set(target, element);
             this._arrayTargets.push(element);
         } else if (!element.actions) {
@@ -156,7 +157,7 @@ export class ActionManager {
             if (element) this._putElement(element);
         }
         this._arrayTargets.length = 0;
-        this._hashTargets = new Map();
+        this._hashTargets = new Map<unknown, HashElement>();
     }
     /**
      * @en
@@ -166,9 +167,9 @@ export class ActionManager {
      * 移除指定对象上的所有动作。<br/>
      * 属于该目标的所有的动作将被删除。
      * @method removeAllActionsFromTarget
-     * @param {Node} target
+     * @param {T} target
      */
-    removeAllActionsFromTarget (target: Node): void {
+    removeAllActionsFromTarget<T> (target: T): void {
         // explicit null handling
         if (target == null) return;
         const element = this._hashTargets.get(target);
@@ -183,7 +184,7 @@ export class ActionManager {
      * @method removeAction
      * @param {Action} action
      */
-    removeAction (action: Action): void {
+    removeAction<T> (action: Action<T> | null): void {
         // explicit null handling
         if (action == null) return;
         const target = action.getOriginalTarget()!;
@@ -204,7 +205,7 @@ export class ActionManager {
     /**
      * @internal
      */
-    _removeActionByTag (tag: number, element: any, target?: Node): void {
+    _removeActionByTag<T> (tag: number, element: HashElement, target?: T): void {
         for (let i = 0, l = element.actions.length; i < l; ++i) {
             const action = element.actions[i];
             if (action && action.getTag() === tag) {
@@ -220,7 +221,7 @@ export class ActionManager {
     /**
      * @internal
      */
-    _removeAllActionsByTag (tag: number, element: any, target?: Node): void {
+    _removeAllActionsByTag<T> (tag: number, element: HashElement, target?: T): void {
         for (let i = element.actions.length - 1; i >= 0; --i) {
             const action = element.actions[i];
             if (action && action.getTag() === tag) {
@@ -237,9 +238,9 @@ export class ActionManager {
      * @zh 删除指定对象下特定标签的一个动作，将删除首个匹配到的动作。
      * @method removeActionByTag
      * @param {Number} tag
-     * @param {Node} target
+     * @param {T} target
      */
-    removeActionByTag (tag: number, target?: Node): void {
+    removeActionByTag<T> (tag: number, target?: T): void {
         if (tag === Action.TAG_INVALID) logID(1002);
 
         const hashTargets = this._hashTargets;
@@ -260,9 +261,9 @@ export class ActionManager {
      * @zh 删除指定对象下特定标签的所有动作。
      * @method removeAllActionsByTag
      * @param {Number} tag
-     * @param {Node} target
+     * @param {T} target
      */
-    removeAllActionsByTag (tag: number, target?: Node): void {
+    removeAllActionsByTag<T> (tag: number, target?: T): void {
         if (tag === Action.TAG_INVALID) logID(1002);
 
         const hashTargets = this._hashTargets;
@@ -283,10 +284,10 @@ export class ActionManager {
      * @zh 通过目标对象和标签获取一个动作。
      * @method getActionByTag
      * @param {Number} tag
-     * @param {Node} target
+     * @param {T} target
      * @return {Action|null}  return the Action with the given tag on success
      */
-    getActionByTag (tag: number, target: Node): Action | null {
+    getActionByTag<T> (tag: number, target: T): Action<T> | null {
         if (tag === Action.TAG_INVALID) logID(1004);
 
         const element = this._hashTargets.get(target);
@@ -295,7 +296,7 @@ export class ActionManager {
                 for (let i = 0; i < element.actions.length; ++i) {
                     const action = element.actions[i];
                     if (action && action.getTag() === tag) {
-                        return action as Action;
+                        return action as Action<T>;
                     }
                 }
             }
@@ -319,13 +320,13 @@ export class ActionManager {
      *  - 如果你正在运行 2 个序列动作（Sequence）和 5 个普通动作，这个函数将返回 7。<br/>
      *
      * @method getNumberOfRunningActionsInTarget
-     * @param {Node} target
+     * @param {T} target
      * @return {Number}
      */
-    getNumberOfRunningActionsInTarget (target: Node): number {
+    getNumberOfRunningActionsInTarget<T> (target: T): number {
         const element = this._hashTargets.get(target);
         if (element) {
-            return (element.actions) ? element.actions.length as number : 0;
+            return (element.actions) ? element.actions.length  : 0;
         }
 
         return 0;
@@ -334,9 +335,9 @@ export class ActionManager {
      * @en Pauses the target: all running actions and newly added actions will be paused.
      * @zh 暂停指定对象：所有正在运行的动作和新添加的动作都将会暂停。
      * @method pauseTarget
-     * @param {Node} target
+     * @param {T} target
      */
-    pauseTarget (target: Node): void {
+    pauseTarget<T> (target: T): void {
         const element = this._hashTargets.get(target);
         if (element) element.paused = true;
     }
@@ -344,9 +345,9 @@ export class ActionManager {
      * @en Resumes the target. All queued actions will be resumed.
      * @zh 让指定目标恢复运行。在执行序列中所有被暂停的动作将重新恢复运行。
      * @method resumeTarget
-     * @param {Node} target
+     * @param {T} target
      */
-    resumeTarget (target: Node): void {
+    resumeTarget<T> (target: T): void {
         const element = this._hashTargets.get(target);
         if (element) element.paused = false;
     }
@@ -357,14 +358,16 @@ export class ActionManager {
      * @method pauseAllRunningActions
      * @return {Array}  a list of targets whose actions were paused.
      */
-    pauseAllRunningActions (): Array<any> {
-        const idsWithActions: Record<string, unknown>[] = [];
+    pauseAllRunningActions (): unknown[] {
+        const idsWithActions: unknown[] = [];
         const locTargets = this._arrayTargets;
         for (let i = 0; i < locTargets.length; i++) {
             const element = locTargets[i];
             if (element && !element.paused) {
                 element.paused = true;
-                idsWithActions.push(element.target!);
+                if (element.target) {
+                    idsWithActions.push(element.target);
+                }
             }
         }
         return idsWithActions;
@@ -376,7 +379,7 @@ export class ActionManager {
      * @method resumeTargets
      * @param {Array} targetsToResume
      */
-    resumeTargets (targetsToResume: Array<any>): void {
+    resumeTargets<T> (targetsToResume: Array<T>): void {
         if (!targetsToResume) return;
 
         for (let i = 0; i < targetsToResume.length; i++) {
@@ -390,7 +393,7 @@ export class ActionManager {
      * @method pauseTargets
      * @param {Array} targetsToPause
      */
-    pauseTargets (targetsToPause: Array<any>): void {
+    pauseTargets<T> (targetsToPause: Array<T>): void {
         if (!targetsToPause) return;
 
         for (let i = 0; i < targetsToPause.length; i++) {
@@ -412,7 +415,7 @@ export class ActionManager {
     }
 
     // protected
-    private _removeActionAtIndex (index, element): void {
+    private _removeActionAtIndex<T> (index: number, element: HashElement): void {
         const action = element.actions[index];
 
         element.actions.splice(index, 1);
@@ -425,7 +428,7 @@ export class ActionManager {
         }
     }
 
-    private _deleteHashElement (element): boolean {
+    private _deleteHashElement (element: HashElement): boolean {
         let ret = false;
         if (element && !element.lock) {
             if (this._hashTargets.get(element.target)) {
@@ -459,7 +462,7 @@ export class ActionManager {
 
             const target = locCurrTarget.target;
             if (isCCObject(target) && !target.isValid) {
-                this.removeAllActionsFromTarget(target as unknown as Node);
+                this.removeAllActionsFromTarget(target);
                 elt--;
                 continue;
             }
@@ -472,7 +475,9 @@ export class ActionManager {
                     if (!locCurrTarget.currentAction) continue;
 
                     // use for speed
-                    locCurrTarget.currentAction.step(dt * (this._isActionInternal(locCurrTarget.currentAction) ? locCurrTarget.currentAction.getSpeed() : 1));
+                    locCurrTarget.currentAction.step(
+                        dt * (this._isActionInterval(locCurrTarget.currentAction) ? locCurrTarget.currentAction.getSpeed() : 1),
+                    );
 
                     if (locCurrTarget.currentAction && locCurrTarget.currentAction.isDone()) {
                         locCurrTarget.currentAction.stop();
@@ -495,7 +500,7 @@ export class ActionManager {
         }
     }
 
-    private _isActionInternal (action: any): action is ActionInterval {
+    private _isActionInterval<T> (action: any): action is ActionInterval<T> {
         return typeof action._speedMethod !== 'undefined';
     }
 }

--- a/cocos/tween/actions/action-manager.ts
+++ b/cocos/tween/actions/action-manager.ts
@@ -50,34 +50,22 @@ class HashElement {
 /**
  * @en
  * `ActionManager` is a class that can manage actions.<br/>
- * Normally you won't need to use this class directly. 99% of the cases you will use the CCNode interface,
+ * Normally you won't need to use this class directly. 99% of the cases you will use the `Tween` interface,
  * which uses this class's singleton object.
- * But there are some cases where you might need to use this class. <br/>
- * Examples:<br/>
- * - When you want to run an action where the target is different from a CCNode.<br/>
  * - When you want to pause / resume the actions<br/>
  * @zh
  * `ActionManager` 是可以管理动作的单例类。<br/>
- * 通常你并不需要直接使用这个类，99%的情况您将使用 CCNode 的接口。<br/>
+ * 通常你并不需要直接使用这个类，99%的情况您将使用 `Tween` 的接口。<br/>
  * 但也有一些情况下，您可能需要使用这个类。 <br/>
  * 例如：
- *  - 当你想要运行一个动作，但目标不是 CCNode 类型时。 <br/>
  *  - 当你想要暂停/恢复动作时。 <br/>
  * @class ActionManager
- * @example {@link cocos2d/core/CCActionManager/ActionManager.js}
  */
 export class ActionManager {
     private _hashTargets = new Map<unknown, HashElement>();
     private _arrayTargets: HashElement[] = [];
     private _currentTarget!: HashElement;
     private _elementPool: HashElement[] = [];
-
-    private _searchElementByTarget<T> (arr: HashElement[], target: T): HashElement | null {
-        for (let k = 0; k < arr.length; k++) {
-            if (target === arr[k].target) return arr[k];
-        }
-        return null;
-    }
 
     private _getElement<T> (target: T, paused: boolean): HashElement {
         let element = this._elementPool.pop();

--- a/cocos/tween/actions/action-manager.ts
+++ b/cocos/tween/actions/action-manager.ts
@@ -172,7 +172,7 @@ export class ActionManager {
      * @method removeAction
      * @param {Action} action
      */
-    removeAction<T> (action: Action | null): void {
+    removeAction (action: Action | null): void {
         // explicit null handling
         if (action == null) return;
         const target = action.getOriginalTarget()!;

--- a/cocos/tween/actions/action.ts
+++ b/cocos/tween/actions/action.ts
@@ -32,7 +32,7 @@ import { logID, errorID } from '../../core';
  * @zh Action 类是所有动作类型的基类。
  * @class Action
  */
-export class Action<T> {
+export class Action {
     /**
      * @en Default Action tag.
      * @zh 默认动作标签。
@@ -42,8 +42,8 @@ export class Action<T> {
      */
     static TAG_INVALID = -1;
 
-    protected originalTarget: T | undefined = undefined;
-    protected target: T | undefined = undefined;
+    protected originalTarget: unknown = null;
+    protected target: unknown = null;
     protected tag = Action.TAG_INVALID;
 
     /**
@@ -54,10 +54,10 @@ export class Action<T> {
      * @method clone
      * @return {Action}
      */
-    clone (): Action<T> {
-        const action = new Action<T>();
-        action.originalTarget = undefined;
-        action.target = undefined;
+    clone (): Action {
+        const action = new Action();
+        action.originalTarget = null;
+        action.target = null;
         action.tag = this.tag;
         return action;
     }
@@ -74,7 +74,7 @@ export class Action<T> {
     }
 
     // called before the action start. It will also set the target.
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<T> (target: T | null): void {
         this.originalTarget = target;
         this.target = target;
     }
@@ -100,8 +100,8 @@ export class Action<T> {
      * @method getTarget
      * @return {object}
      */
-    getTarget (): T | undefined {
-        return this.target;
+    getTarget<T> (): T | undefined {
+        return this.target as T;
     }
 
     /**
@@ -110,7 +110,7 @@ export class Action<T> {
      * @method setTarget
      * @param {object} target
      */
-    setTarget (target: T): void {
+    setTarget<T> (target: T): void {
         this.target = target;
     }
 
@@ -120,14 +120,14 @@ export class Action<T> {
      * @method getOriginalTarget
      * @return {object}
      */
-    getOriginalTarget (): T | undefined {
-        return this.originalTarget;
+    getOriginalTarget<T> (): T | undefined {
+        return this.originalTarget as T;
     }
 
     // Set the original target, since target can be nil.
     // Is the target that were used to run the action.
     // Unless you are doing something complex, like `ActionManager`, you should NOT call this method.
-    setOriginalTarget (originalTarget: T): void {
+    setOriginalTarget<T> (originalTarget: T): void {
         this.originalTarget = originalTarget;
     }
 
@@ -162,7 +162,7 @@ export class Action<T> {
      * @method reverse
      * @return {Action | undefined}
      */
-    reverse (): Action<T> | undefined {
+    reverse (): Action | undefined {
         logID(1008);
         return undefined;
     }
@@ -180,7 +180,7 @@ export class Action<T> {
  * @class FiniteTimeAction
  * @extends Action
  */
-export class FiniteTimeAction<T> extends Action<T> {
+export class FiniteTimeAction extends Action {
     _duration = 0;
     _timesForRepeat = 1;
 
@@ -212,11 +212,11 @@ export class FiniteTimeAction<T> extends Action<T> {
      * @method clone
      * @return {FiniteTimeAction}
      */
-    clone (): FiniteTimeAction<T> {
+    clone (): FiniteTimeAction {
         return new FiniteTimeAction();
     }
 
-    reverse (): FiniteTimeAction<T> {
+    reverse (): FiniteTimeAction {
         logID(1008);
         return this;
     }
@@ -227,14 +227,14 @@ export class FiniteTimeAction<T> extends Action<T> {
  * or less (speed < 1) time. <br/>
  * Useful to simulate 'slow motion' or 'fast forward' effect.
  */
-export class Speed<T> extends Action<T> {
+export class Speed<T> extends Action {
     protected _speed = 0;
-    protected _innerAction: Action<T> | null = null;
+    protected _innerAction: Action | null = null;
 
     /**
      * @warning This action can't be `Sequence-able` because it is not an `IntervalAction`
      */
-    constructor (action?: Action<T>, speed = 1) {
+    constructor (action?: Action, speed = 1) {
         super();
         if (action) this.initWithAction(action, speed);
     }
@@ -266,7 +266,7 @@ export class Speed<T> extends Action<T> {
      * @param {Number} speed
      * @return {Boolean}
      */
-    initWithAction (action: Action<T>, speed: number): boolean {
+    initWithAction (action: Action, speed: number): boolean {
         if (!action) {
             errorID(1021);
             return false;
@@ -285,13 +285,13 @@ export class Speed<T> extends Action<T> {
         return action;
     }
 
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<T> (target: T | null): void {
         super.startWithTarget(target);
-        this._innerAction?.startWithTarget(target);
+        if (this._innerAction) this._innerAction.startWithTarget(target);
     }
 
     stop (): void {
-        this._innerAction?.stop();
+        if (this._innerAction) this._innerAction.stop();
         super.stop();
     }
 
@@ -315,7 +315,7 @@ export class Speed<T> extends Action<T> {
      * @method setInnerAction
      * @param {ActionInterval} action
      */
-    setInnerAction (action: Action<T>): void {
+    setInnerAction (action: Action): void {
         if (this._innerAction !== action) {
             this._innerAction = action;
         }
@@ -326,7 +326,7 @@ export class Speed<T> extends Action<T> {
      * @method getInnerAction
      * @return {ActionInterval}
      */
-    getInnerAction (): Action<T> | null {
+    getInnerAction (): Action | null {
         return this._innerAction;
     }
 }

--- a/cocos/tween/actions/action.ts
+++ b/cocos/tween/actions/action.ts
@@ -100,7 +100,7 @@ export class Action {
      * @method getTarget
      * @return {object}
      */
-    getTarget<T> (): T | undefined {
+    getTarget<T> (): T | null {
         return this.target as T;
     }
 
@@ -120,7 +120,7 @@ export class Action {
      * @method getOriginalTarget
      * @return {object}
      */
-    getOriginalTarget<T> (): T | undefined {
+    getOriginalTarget<T> (): T | null {
         return this.originalTarget as T;
     }
 
@@ -160,11 +160,11 @@ export class Action {
      * - Will be rewritten
      * @zh 返回一个新的动作，执行与原动作完全相反的动作。
      * @method reverse
-     * @return {Action | undefined}
+     * @return {Action | null}
      */
-    reverse (): Action | undefined {
+    reverse (): Action | null {
         logID(1008);
-        return undefined;
+        return null;
     }
 }
 
@@ -234,7 +234,7 @@ export class Speed<T> extends Action {
     /**
      * @warning This action can't be `Sequence-able` because it is not an `IntervalAction`
      */
-    constructor (action?: Action, speed = 1) {
+    constructor (action?: Action | null, speed = 1) {
         super();
         if (action) this.initWithAction(action, speed);
     }

--- a/cocos/tween/actions/action.ts
+++ b/cocos/tween/actions/action.ts
@@ -75,7 +75,7 @@ export abstract class Action {
 
     // called after the action has finished. It will set the 'target' to nil.
     stop (): void {
-        this.target = undefined;
+        this.target = null;
     }
 
     // called every frame with it's delta time. <br />

--- a/cocos/tween/actions/action.ts
+++ b/cocos/tween/actions/action.ts
@@ -32,7 +32,7 @@ import { logID, errorID } from '../../core';
  * @zh Action 类是所有动作类型的基类。
  * @class Action
  */
-export class Action {
+export abstract class Action {
     /**
      * @en Default Action tag.
      * @zh 默认动作标签。
@@ -54,13 +54,7 @@ export class Action {
      * @method clone
      * @return {Action}
      */
-    clone (): Action {
-        const action = new Action();
-        action.originalTarget = null;
-        action.target = null;
-        action.tag = this.tag;
-        return action;
-    }
+    abstract clone (): Action;
 
     /**
      * @en
@@ -162,10 +156,7 @@ export class Action {
      * @method reverse
      * @return {Action | null}
      */
-    reverse (): Action | null {
-        logID(1008);
-        return null;
-    }
+    abstract reverse (): Action | null;
 }
 
 /**
@@ -180,7 +171,7 @@ export class Action {
  * @class FiniteTimeAction
  * @extends Action
  */
-export class FiniteTimeAction extends Action {
+export abstract class FiniteTimeAction extends Action {
     _duration = 0;
     _timesForRepeat = 1;
 
@@ -212,14 +203,9 @@ export class FiniteTimeAction extends Action {
      * @method clone
      * @return {FiniteTimeAction}
      */
-    clone (): FiniteTimeAction {
-        return new FiniteTimeAction();
-    }
+    abstract clone (): FiniteTimeAction;
 
-    reverse (): FiniteTimeAction {
-        logID(1008);
-        return this;
-    }
+    abstract reverse (): FiniteTimeAction;
 }
 
 /*

--- a/cocos/tween/actions/action.ts
+++ b/cocos/tween/actions/action.ts
@@ -227,7 +227,7 @@ export class FiniteTimeAction extends Action {
  * or less (speed < 1) time. <br/>
  * Useful to simulate 'slow motion' or 'fast forward' effect.
  */
-export class Speed<T> extends Action {
+export class Speed extends Action {
     protected _speed = 0;
     protected _innerAction: Action | null = null;
 
@@ -277,8 +277,8 @@ export class Speed<T> extends Action {
         return true;
     }
 
-    clone (): Speed<T> {
-        const action = new Speed<T>();
+    clone (): Speed {
+        const action = new Speed();
         if (this._innerAction) {
             action.initWithAction(this._innerAction.clone()!, this._speed);
         }
@@ -303,7 +303,7 @@ export class Speed<T> extends Action {
         return this._innerAction ? this._innerAction.isDone() : false;
     }
 
-    reverse (): Speed<T> {
+    reverse (): Speed {
         if (this._innerAction) {
             return new Speed(this._innerAction.reverse(), this._speed);
         }

--- a/cocos/tween/actions/action.ts
+++ b/cocos/tween/actions/action.ts
@@ -282,7 +282,7 @@ export class Speed extends Action {
     }
 
     step (dt: number): void {
-        this._innerAction?.step(dt * this._speed);
+        if (this._innerAction) this._innerAction.step(dt * this._speed);
     }
 
     isDone (): boolean {

--- a/cocos/tween/export-api.ts
+++ b/cocos/tween/export-api.ts
@@ -48,7 +48,7 @@ export type TweenEasing =
  * @zh
  * 缓动的可选属性的接口定义。
  */
-export interface ITweenOption {
+export interface ITweenOption<T> {
 
     /**
      * @en
@@ -57,6 +57,14 @@ export interface ITweenOption {
      * 缓动函数，可以使用已有的，也可以传入自定义的函数。
      */
     easing?: TweenEasing | ((k: number) => number);
+
+    /**
+     * @en
+     * Relative
+     * @zh
+     * 相对
+     */
+    relative?: boolean;
 
     /**
      * @en
@@ -72,7 +80,7 @@ export interface ITweenOption {
      * @zh
      * 回调，当缓动动作启动时触发。
      */
-    onStart?: (target?: object) => void;
+    onStart?: (target?: T) => void;
 
     /**
      * @en
@@ -80,7 +88,7 @@ export interface ITweenOption {
      * @zh
      * 回调，当缓动动作更新时触发。
      */
-    onUpdate?: (target?: object, ratio?: number) => void;
+    onUpdate?: (target?: T, ratio?: number) => void;
 
     /**
      * @en
@@ -88,5 +96,5 @@ export interface ITweenOption {
      * @zh
      * 回调，当缓动动作完成时触发。
      */
-    onComplete?: (target?: object) => void;
+    onComplete?: (target?: T) => void;
 }

--- a/cocos/tween/export-api.ts
+++ b/cocos/tween/export-api.ts
@@ -60,9 +60,9 @@ export interface ITweenOption<T> {
 
     /**
      * @en
-     * Relative
+     * Whether to use relative value calculation method during easing process
      * @zh
-     * 相对
+     * 缓动过程中是否采用相对值计算的方法
      */
     relative?: boolean;
 

--- a/cocos/tween/set-action.ts
+++ b/cocos/tween/set-action.ts
@@ -24,7 +24,7 @@
 
 import { ActionInstant } from './actions/action-instant';
 
-export class SetAction extends ActionInstant {
+export class SetAction<T> extends ActionInstant<T> {
     private _props: any;
 
     constructor (props?: any) {
@@ -49,8 +49,8 @@ export class SetAction extends ActionInstant {
         }
     }
 
-    clone (): SetAction {
-        const action = new SetAction();
+    clone (): SetAction<T> {
+        const action = new SetAction<T>();
         action.init(this._props);
         return action;
     }

--- a/cocos/tween/set-action.ts
+++ b/cocos/tween/set-action.ts
@@ -24,7 +24,7 @@
 
 import { ActionInstant } from './actions/action-instant';
 
-export class SetAction<T> extends ActionInstant<T> {
+export class SetAction extends ActionInstant {
     private _props: any;
 
     constructor (props?: any) {
@@ -34,7 +34,7 @@ export class SetAction<T> extends ActionInstant<T> {
         props !== undefined && this.init(props);
     }
 
-    init (props): boolean {
+    init (props: any): boolean {
         for (const name in props) {
             this._props[name] = props[name];
         }
@@ -45,12 +45,12 @@ export class SetAction<T> extends ActionInstant<T> {
         const props = this._props;
         const target = this.target;
         for (const name in props) {
-            target![name] = props[name];
+            (target as any)[name] = props[name];
         }
     }
 
-    clone (): SetAction<T> {
-        const action = new SetAction<T>();
+    clone (): SetAction {
+        const action = new SetAction();
         action.init(this._props);
         return action;
     }

--- a/cocos/tween/set-action.ts
+++ b/cocos/tween/set-action.ts
@@ -30,8 +30,7 @@ export class SetAction extends ActionInstant {
     constructor (props?: any) {
         super();
         this._props = {};
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        props !== undefined && this.init(props);
+        if (props) this.init(props);
     }
 
     init (props: any): boolean {

--- a/cocos/tween/tween-action.ts
+++ b/cocos/tween/tween-action.ts
@@ -22,10 +22,13 @@
  THE SOFTWARE.
 */
 
-import { warnID, warn, easing } from '../core';
+import { warnID, warn, easing, equals } from '../core';
 import { ActionInterval } from './actions/action-interval';
 import { ITweenOption, TweenEasing } from './export-api';
 import { VERSION } from '../core/global-exports';
+
+// type TypeEquality<T, U> = Extract<keyof T, keyof U> extends never ? false : true;
+type TypeEquality<T, U> = { [K in keyof T]: K extends keyof U ? T[K] : never } extends T ? true : false;
 
 /** adapter */
 function TweenEasingAdapter (easingName: string): string {
@@ -90,7 +93,7 @@ function TweenOptionChecker<T> (opts: ITweenOption<T>): void {
     }
 }
 
-export class TweenAction<T> extends ActionInterval<T> {
+export class TweenAction<T> extends ActionInterval {
     private _opts: ITweenOption<T> | undefined;
     private _props: any;
     private _originProps: any;
@@ -165,9 +168,10 @@ export class TweenAction<T> extends ActionInterval<T> {
         return action;
     }
 
-    startWithTarget (target: T | undefined): void {
+    startWithTarget<U> (target: U | undefined): void {
+        const isEqual: TypeEquality<T, U> = true;
         super.startWithTarget(target);
-        if (!target) return;
+        if (!target || !isEqual) return;
 
         const relative = !!this._opts!.relative;
         const props = this._props;
@@ -194,7 +198,7 @@ export class TweenAction<T> extends ActionInterval<T> {
                 }
             }
         }
-        if (this._opts!.onStart) { this._opts!.onStart(this.target); }
+        if (this._opts!.onStart) { this._opts!.onStart(this.target as T); }
     }
 
     update (t: number): void {
@@ -234,8 +238,8 @@ export class TweenAction<T> extends ActionInterval<T> {
 
             target[name] = prop.current;
         }
-        if (opts.onUpdate) { opts.onUpdate(this.target, t); }
-        if (t === 1 && opts.onComplete) { opts.onComplete(this.target); }
+        if (opts.onUpdate) { opts.onUpdate(this.target as T, t); }
+        if (t === 1 && opts.onComplete) { opts.onComplete(this.target as T); }
     }
 
     progress (start: number, end: number, current: number, t: number): number {

--- a/cocos/tween/tween-action.ts
+++ b/cocos/tween/tween-action.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { warnID, warn, easing, equals } from '../core';
+import { warnID, warn, easing } from '../core';
 import { ActionInterval } from './actions/action-interval';
 import { ITweenOption, TweenEasing } from './export-api';
 import { VERSION } from '../core/global-exports';

--- a/cocos/tween/tween-action.ts
+++ b/cocos/tween/tween-action.ts
@@ -27,7 +27,6 @@ import { ActionInterval } from './actions/action-interval';
 import { ITweenOption, TweenEasing } from './export-api';
 import { VERSION } from '../core/global-exports';
 
-// type TypeEquality<T, U> = Extract<keyof T, keyof U> extends never ? false : true;
 type TypeEquality<T, U> = { [K in keyof T]: K extends keyof U ? T[K] : never } extends T ? true : false;
 
 /** adapter */

--- a/cocos/tween/tween-system.ts
+++ b/cocos/tween/tween-system.ts
@@ -78,6 +78,6 @@ export class TweenSystem extends System {
 
 director.on(Director.EVENT_INIT, () => {
     const sys = new TweenSystem();
-    (TweenSystem.instance as any) = sys;
+    (TweenSystem as any).instance = sys;
     director.registerSystem(TweenSystem.ID, sys, System.Priority.MEDIUM);
 });

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -55,8 +55,8 @@ type ConstructorType<T> = OmitType<T, Function>;
  *   .start()
  */
 export class Tween<T> {
-    private _actions: Action<T>[] = [];
-    private _finalAction: Action<T> | null = null;
+    private _actions: Action[] = [];
+    private _finalAction: Action | null = null;
     private _target: T | null = null;
     private _tag = Action.TAG_INVALID;
 
@@ -83,7 +83,7 @@ export class Tween<T> {
      * @method then
      * @param other @en The rear tween of this tween @zh 当前缓动的后置缓动
      */
-    then (other: Tween<T> | Action<T>): Tween<T> {
+    then (other: Tween<T> | Action): Tween<T> {
         if (other instanceof Action) {
             this._actions.push(other.clone());
         } else {
@@ -219,7 +219,7 @@ export class Tween<T> {
      * @return {Tween}
      */
     set (props: ConstructorType<T>): Tween<T> {
-        const action = new SetAction<T>(props);
+        const action = new SetAction(props);
         this._actions.push(action);
         return this;
     }
@@ -234,7 +234,7 @@ export class Tween<T> {
      * @return {Tween}
      */
     delay (duration: number): Tween<T> {
-        const action = delayTime<T>(duration);
+        const action = delayTime(duration);
         this._actions.push(action);
         return this;
     }
@@ -250,7 +250,7 @@ export class Tween<T> {
      */
     // eslint-disable-next-line @typescript-eslint/ban-types
     call (callback: Function): Tween<T> {
-        const action = callFunc<T>(callback);
+        const action = callFunc(callback);
         this._actions.push(action);
         return this;
     }
@@ -265,7 +265,7 @@ export class Tween<T> {
      */
     sequence (...args: Tween<T>[]): Tween<T> {
         const action = Tween._wrappedSequence(...args);
-        if (action) this._actions.push(action as Action<T>);
+        if (action) this._actions.push(action);
         return this;
     }
 
@@ -279,7 +279,7 @@ export class Tween<T> {
      */
     parallel (...args: Tween<T>[]): Tween<T> {
         const action = Tween._wrappedParallel(...args);
-        this._actions.push(action as Action<T>);
+        this._actions.push(action);
         return this;
     }
 
@@ -299,7 +299,7 @@ export class Tween<T> {
         }
 
         const actions = this._actions;
-        let action: Action<T> | undefined | null;
+        let action: Action | undefined | null;
 
         if (embedTween instanceof Tween) {
             action = embedTween._union();
@@ -307,7 +307,7 @@ export class Tween<T> {
             action = actions.pop();
         }
 
-        if (action) actions.push(repeat(action as FiniteTimeAction<T>, repeatTimes)); //FIXME: remove 'as'
+        if (action) actions.push(repeat(action as FiniteTimeAction, repeatTimes)); //FIXME: remove 'as'
         return this;
     }
 
@@ -322,7 +322,7 @@ export class Tween<T> {
      */
     repeatForever (embedTween?: Tween<T>): Tween<T> {
         const actions = this._actions;
-        let action: Action<T> | undefined | null;
+        let action: Action | undefined | null;
 
         if (embedTween instanceof Tween) {
             action = embedTween._union();
@@ -330,7 +330,7 @@ export class Tween<T> {
             action = actions.pop();
         }
 
-        if (action) actions.push(repeatForever(action as ActionInterval<T>));
+        if (action) actions.push(repeatForever(action as ActionInterval)); //FIXME: remove 'as'
         return this;
     }
 
@@ -345,7 +345,7 @@ export class Tween<T> {
      */
     reverseTime (embedTween?: Tween<T>): Tween<T> {
         const actions = this._actions;
-        let action: Action<T> | undefined | null;
+        let action: Action | undefined | null;
 
         if (embedTween instanceof Tween) {
             action = embedTween._union();
@@ -353,7 +353,7 @@ export class Tween<T> {
             action = actions.pop();
         }
 
-        if (action) actions.push(reverseTime(action as ActionInterval<T>));
+        if (action) actions.push(reverseTime(action as ActionInterval)); //FIXME: remove 'as'
         return this;
     }
 
@@ -364,7 +364,7 @@ export class Tween<T> {
      * 添加一个隐藏 action，只适用于 target 是节点类型的。
      */
     hide (): Tween<T> {
-        const action = hide<T>();
+        const action = hide();
         this._actions.push(action);
         return this;
     }
@@ -376,7 +376,7 @@ export class Tween<T> {
      * 添加一个显示 action，只适用于 target 是节点类型的。
      */
     show (): Tween<T> {
-        const action = show<T>();
+        const action = show();
         this._actions.push(action);
         return this;
     }
@@ -388,7 +388,7 @@ export class Tween<T> {
      * 添加一个移除自己 action，只适用于 target 是节点类型的。
      */
     removeSelf (): Tween<T> {
-        const action = removeSelf<T>(false);
+        const action = removeSelf(false);
         this._actions.push(action);
         return this;
     }
@@ -400,7 +400,7 @@ export class Tween<T> {
      * 添加一个移除并销毁自己 action，只适用于 target 是节点类型的。
      */
     destroySelf (): Tween<T> {
-        const action = removeSelf<T>(true);
+        const action = removeSelf(true);
         this._actions.push(action);
         return this;
     }
@@ -435,13 +435,13 @@ export class Tween<T> {
         TweenSystem.instance.ActionManager.removeAllActionsFromTarget(target as any);
     }
 
-    private _union (): Action<T> | null {
+    private _union (): Action | null {
         const actions = this._actions;
-        let action: Action<T> | null;
+        let action: Action | null;
         if (actions.length === 1) {
             action = actions[0];
         } else {
-            action = sequence<T>(actions as FiniteTimeAction<T>[]); //FIXME: remove 'as'
+            action = sequence(actions as FiniteTimeAction[]); //FIXME: remove 'as'
         }
 
         return action;
@@ -451,32 +451,32 @@ export class Tween<T> {
         this.stop();
     }
 
-    private static readonly _tmp_args: Tween<unknown>[] | Action<unknown>[] = [];
+    private static readonly _tmp_args: Tween<unknown>[] | Action[] = [];
 
-    private static _wrappedSequence (...args: Action<unknown>[] | Tween<unknown>[]): ActionInterval<unknown> | null {
+    private static _wrappedSequence (...args: Action[] | Tween<unknown>[]): ActionInterval | null {
         const tmp_args = Tween._tmp_args;
         tmp_args.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {
             const arg = tmp_args[i] = args[i];
             if (arg instanceof Tween) {
-                tmp_args[i] = arg._union() as Action<unknown>; //FIXME: Remove 'as'
+                tmp_args[i] = arg._union() as Action; //FIXME: Remove 'as'
             }
         }
 
-        return sequence(tmp_args as FiniteTimeAction<unknown>[]);
+        return sequence(tmp_args as FiniteTimeAction[]);
     }
 
-    private static _wrappedParallel (...args: Action<unknown>[] | Tween<unknown>[]): FiniteTimeAction<unknown> {
+    private static _wrappedParallel (...args: Action[] | Tween<unknown>[]): FiniteTimeAction {
         const tmp_args = Tween._tmp_args;
         tmp_args.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {
             const arg = tmp_args[i] = args[i];
             if (arg instanceof Tween) {
-                tmp_args[i] = arg._union() as Action<unknown>;
+                tmp_args[i] = arg._union() as Action;
             }
         }
 
-        return spawn(tmp_args as FiniteTimeAction<unknown>[]);
+        return spawn(tmp_args as FiniteTimeAction[]);
     }
 }
 legacyCC.Tween = Tween;

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -188,8 +188,8 @@ export class Tween<T> {
      * @param opts.easing @en Tween function or a lambda @zh 缓动的曲线函数或lambda表达式
      */
     to (duration: number, props: ConstructorType<T>, opts?: ITweenOption<T>): Tween<T> {
-        opts = opts || Object.create(null);
-        opts!.relative = false;
+        opts = opts || (Object.create(null) as ITweenOption<T>);
+        opts.relative = false;
         const action = new TweenAction(duration, props, opts);
         this._actions.push(action);
         return this;
@@ -209,7 +209,7 @@ export class Tween<T> {
      * @return {Tween}
      */
     by (duration: number, props: ConstructorType<T>, opts?: ITweenOption<T>): Tween<T> {
-        opts = opts || (Object.create(null)) as ITweenOption<T>;
+        opts = opts || (Object.create(null) as ITweenOption<T>);
         opts.relative = true;
         const action = new TweenAction(duration, props, opts);
         this._actions.push(action);

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -83,13 +83,14 @@ export class Tween<T> {
      * @method then
      * @param other @en The rear tween of this tween @zh 当前缓动的后置缓动
      */
-    then (other: Tween<T> | Action): Tween<T> {
-        if (other instanceof Action) {
-            this._actions.push(other.clone());
-        } else {
-            const u = other._union();
-            if (u) this._actions.push(u);
-        }
+    then (other: Tween<T>): Tween<T> {
+        const u = other._union();
+        if (u) this._actions.push(u);
+        return this;
+    }
+
+    private insertAction (other: Action): Tween<T> {
+        this._actions.push(other.clone());
         return this;
     }
 
@@ -152,7 +153,7 @@ export class Tween<T> {
     clone (target: T): Tween<T> {
         const action = this._union();
         const r = tween(target);
-        return action ? r.then(action.clone()) : r;
+        return action ? r.insertAction(action.clone()) : r;
     }
 
     /**

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -79,7 +79,7 @@ export class Tween<T> {
 
     /**
      * @en
-     * Insert an action or tween to this sequence.
+     * Insert a tween to this sequence.
      * @zh
      * 插入一个 tween 到队列中。
      * @method then
@@ -91,6 +91,10 @@ export class Tween<T> {
         return this;
     }
 
+    /**
+     * Insert an action to this sequence.
+     * @param other @en The rear action of this tween @zh 当前缓动的后置缓动
+     */
     private insertAction (other: Action): Tween<T> {
         this._actions.push(other.clone());
         return this;

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -280,7 +280,7 @@ export class Tween<T> {
      */
     parallel (...args: Tween<T>[]): Tween<T> {
         const action = Tween._wrappedParallel(...args);
-        this._actions.push(action);
+        if (action) this._actions.push(action);
         return this;
     }
 
@@ -421,9 +421,8 @@ export class Tween<T> {
      * @zh
      * 停止所有指定标签的缓动
      */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     static stopAllByTag (tag: number, target?: object): void {
-        TweenSystem.instance.ActionManager.removeAllActionsByTag(tag, target as any);
+        TweenSystem.instance.ActionManager.removeAllActionsByTag(tag, target);
     }
     /**
      * @en
@@ -431,9 +430,8 @@ export class Tween<T> {
      * @zh
      * 停止所有指定对象的缓动
      */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     static stopAllByTarget (target?: object): void {
-        TweenSystem.instance.ActionManager.removeAllActionsFromTarget(target as any);
+        TweenSystem.instance.ActionManager.removeAllActionsFromTarget(target);
     }
 
     private _union (): Action | null {
@@ -454,7 +452,7 @@ export class Tween<T> {
 
     private static readonly _tmp_args: Tween<unknown>[] | Action[] = [];
 
-    private static _wrappedSequence (...args: Action[] | Tween<unknown>[]): ActionInterval | null {
+    private static _wrappedSequence (...args: Action[] | Tween<unknown>[]): FiniteTimeAction | null {
         const tmp_args = Tween._tmp_args;
         tmp_args.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {
@@ -467,7 +465,7 @@ export class Tween<T> {
         return sequence(tmp_args as FiniteTimeAction[]);
     }
 
-    private static _wrappedParallel (...args: Action[] | Tween<unknown>[]): FiniteTimeAction {
+    private static _wrappedParallel (...args: Action[] | Tween<unknown>[]): FiniteTimeAction | null {
         const tmp_args = Tween._tmp_args;
         tmp_args.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -25,7 +25,7 @@
 import { TweenSystem } from './tween-system';
 import { warn } from '../core';
 import { ActionInterval, sequence, repeat, repeatForever, reverseTime, delayTime, spawn } from './actions/action-interval';
-import { removeSelf, show, hide, callFunc } from './actions/action-instant';
+import { removeSelf, show, hide, callFunc, TCallFuncCallback } from './actions/action-instant';
 import { Action, FiniteTimeAction } from './actions/action';
 import { ITweenOption } from './export-api';
 import { TweenAction } from './tween-action';
@@ -246,11 +246,12 @@ export class Tween<T> {
      * 添加一个回调 action。
      * @method call
      * @param callback @en Callback function at the end of this tween @zh 当前缓动结束时的回调函数
+     * @param callbackThis @en The this object in callback function @zh 回调函数中的 this 对象
+     * @param data @en The Custom data that will be passed to callback @zh 要传递给回调函数的自定义数据
      * @return {Tween}
      */
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    call (callback: Function): Tween<T> {
-        const action = callFunc(callback);
+    call<TCallbackThis, TData> (callback: TCallFuncCallback<T, TData>, callbackThis?: TCallbackThis, data?: TData): Tween<T> {
+        const action = callFunc(callback, callbackThis, data);
         this._actions.push(action);
         return this;
     }

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -203,7 +203,7 @@ export class Tween<T> {
      */
     by (duration: number, props: ConstructorType<T>, opts?: ITweenOption<T>): Tween<T> {
         opts = opts || (Object.create(null)) as ITweenOption<T>;
-        (opts).relative = true;
+        opts.relative = true;
         const action = new TweenAction(duration, props, opts);
         this._actions.push(action);
         return this;

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -31,6 +31,7 @@ import { ITweenOption } from './export-api';
 import { TweenAction } from './tween-action';
 import { SetAction } from './set-action';
 import { legacyCC } from '../core/global-exports';
+import { Node } from '../scene-graph';
 
 // https://medium.com/dailyjs/typescript-create-a-condition-based-subset-types-9d902cea5b8c
 type FlagExcludedType<Base, Type> = { [Key in keyof Base]: Base[Key] extends Type ? never : Key };
@@ -39,6 +40,7 @@ type KeyPartial<T, K extends keyof T> = { [P in K]?: T[P] };
 type OmitType<Base, Type> = KeyPartial<Base, AllowedNames<Base, Type>>;
 // eslint-disable-next-line @typescript-eslint/ban-types
 type ConstructorType<T> = OmitType<T, Function>;
+type TweenWithNodeTargetOrUnknown<T> = T extends Node ? Tween<T> : unknown;
 
 /**
  * @en
@@ -365,10 +367,13 @@ export class Tween<T> {
      * @zh
      * 添加一个隐藏 action，只适用于 target 是节点类型的。
      */
-    hide (): Tween<T> {
-        const action = hide();
-        this._actions.push(action);
-        return this;
+    hide (): TweenWithNodeTargetOrUnknown<T> {
+        const isNode = this._target instanceof Node;
+        if (isNode) {
+            const action = hide();
+            this._actions.push(action);
+        }
+        return this as unknown as TweenWithNodeTargetOrUnknown<T>;
     }
 
     /**
@@ -377,10 +382,13 @@ export class Tween<T> {
      * @zh
      * 添加一个显示 action，只适用于 target 是节点类型的。
      */
-    show (): Tween<T> {
-        const action = show();
-        this._actions.push(action);
-        return this;
+    show (): TweenWithNodeTargetOrUnknown<T> {
+        const isNode = this._target instanceof Node;
+        if (isNode) {
+            const action = show();
+            this._actions.push(action);
+        }
+        return this as unknown as TweenWithNodeTargetOrUnknown<T>;
     }
 
     /**
@@ -389,10 +397,13 @@ export class Tween<T> {
      * @zh
      * 添加一个移除自己 action，只适用于 target 是节点类型的。
      */
-    removeSelf (): Tween<T> {
-        const action = removeSelf(false);
-        this._actions.push(action);
-        return this;
+    removeSelf (): TweenWithNodeTargetOrUnknown<T> {
+        const isNode = this._target instanceof Node;
+        if (isNode) {
+            const action = removeSelf(false);
+            this._actions.push(action);
+        }
+        return this as unknown as TweenWithNodeTargetOrUnknown<T>;
     }
 
     /**
@@ -401,10 +412,13 @@ export class Tween<T> {
      * @zh
      * 添加一个移除并销毁自己 action，只适用于 target 是节点类型的。
      */
-    destroySelf (): Tween<T> {
-        const action = removeSelf(true);
-        this._actions.push(action);
-        return this;
+    destroySelf (): TweenWithNodeTargetOrUnknown<T> {
+        const isNode = this._target instanceof Node;
+        if (isNode) {
+            const action = removeSelf(true);
+            this._actions.push(action);
+        }
+        return this as unknown as TweenWithNodeTargetOrUnknown<T>;
     }
 
     /**
@@ -453,11 +467,11 @@ export class Tween<T> {
 
     private static readonly _tmp_args: Tween<unknown>[] | Action[] = [];
 
-    private static _wrappedSequence (...args: Action[] | Tween<unknown>[]): FiniteTimeAction | null {
+    private static _wrappedSequence<U> (...args: Tween<U>[]): FiniteTimeAction | null {
         const tmp_args = Tween._tmp_args;
         tmp_args.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {
-            const arg = tmp_args[i] = args[i];
+            const arg = tmp_args[i] = args[i] as Tween<unknown>;
             if (arg instanceof Tween) {
                 tmp_args[i] = arg._union() as Action; //FIXME: Remove 'as'
             }
@@ -466,13 +480,13 @@ export class Tween<T> {
         return sequence(tmp_args as FiniteTimeAction[]);
     }
 
-    private static _wrappedParallel (...args: Action[] | Tween<unknown>[]): FiniteTimeAction | null {
+    private static _wrappedParallel<U> (...args: Tween<U>[]): FiniteTimeAction | null {
         const tmp_args = Tween._tmp_args;
         tmp_args.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {
-            const arg = tmp_args[i] = args[i];
+            const arg = tmp_args[i] = args[i] as Tween<unknown>;
             if (arg instanceof Tween) {
-                tmp_args[i] = arg._union() as Action;
+                tmp_args[i] = arg._union() as Action; //FIXME: Remove 'as'
             }
         }
 

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -56,7 +56,7 @@ type TweenWithNodeTargetOrUnknown<T> = T extends Node ? Tween<T> : unknown;
  *   .by(1, {scale: new Vec3(-1, -1, -1), position: new Vec3(-5, -5, -5)}, {easing: 'sineOutIn'})
  *   .start()
  */
-export class Tween<T> {
+export class Tween<T extends object = any> {
     private _actions: Action[] = [];
     private _finalAction: Action | null = null;
     private _target: T | null = null;
@@ -108,9 +108,9 @@ export class Tween<T> {
      * @method target
      * @param target @en The target of this tween @zh 当前缓动的目标对象
      */
-    target (target: T): Tween<T> {
-        this._target = target;
-        return this;
+    target<U extends object = any> (target: U): Tween<U> {
+        (this as unknown as Tween<U>)._target = target;
+        return this as unknown as Tween<U>;
     }
 
     /**
@@ -156,7 +156,7 @@ export class Tween<T> {
      * @method clone
      * @param target @en The target of clone tween @zh 克隆缓动的目标对象
      */
-    clone (target: T): Tween<T> {
+    clone<U extends object = any> (target: U): Tween<U> {
         const action = this._union();
         const r = tween(target);
         return action ? r.insertAction(action.clone()) : r;
@@ -469,13 +469,13 @@ export class Tween<T> {
         this.stop();
     }
 
-    private static readonly _tmp_args: Tween<unknown>[] | Action[] = [];
+    private static readonly _tmp_args: Tween<any>[] | Action[] = [];
 
-    private static _wrappedSequence<U> (...args: Tween<U>[]): FiniteTimeAction | null {
+    private static _wrappedSequence<U extends object = any> (...args: Tween<U>[]): FiniteTimeAction | null {
         const tmp_args = Tween._tmp_args;
         tmp_args.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {
-            const arg = tmp_args[i] = args[i] as Tween<unknown>;
+            const arg = tmp_args[i] = args[i];
             if (arg instanceof Tween) {
                 tmp_args[i] = arg._union() as Action; //FIXME: Remove 'as'
             }
@@ -484,11 +484,11 @@ export class Tween<T> {
         return sequence(tmp_args as FiniteTimeAction[]);
     }
 
-    private static _wrappedParallel<U> (...args: Tween<U>[]): FiniteTimeAction | null {
+    private static _wrappedParallel<U extends object = any> (...args: Tween<U>[]): FiniteTimeAction | null {
         const tmp_args = Tween._tmp_args;
         tmp_args.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {
-            const arg = tmp_args[i] = args[i] as Tween<unknown>;
+            const arg = tmp_args[i] = args[i];
             if (arg instanceof Tween) {
                 tmp_args[i] = arg._union() as Action; //FIXME: Remove 'as'
             }
@@ -513,7 +513,7 @@ legacyCC.Tween = Tween;
  *   .by(1, {scale: new Vec3(-1, -1, -1)}, {easing: 'sineOutIn'})
  *   .start()
  */
-export function tween<T> (target?: T): Tween<T> {
+export function tween<T extends object = any> (target?: T): Tween<T> {
     return new Tween<T>(target);
 }
 legacyCC.tween = tween;
@@ -525,7 +525,7 @@ legacyCC.tween = tween;
  * tweenUtil 是一个工具函数，帮助实例化 Tween 实例。
  * @deprecated please use `tween` instead.
  */
-export function tweenUtil<T> (target?: T): Tween<T> {
+export function tweenUtil<T extends object = any> (target?: T): Tween<T> {
     warn('tweenUtil\' is deprecated, please use \'tween\' instead ');
     return new Tween<T>(target);
 }

--- a/pal/integrity-check.ts
+++ b/pal/integrity-check.ts
@@ -42,13 +42,13 @@ type Guard = typeof guard;
  *
  * @note This function should be easily tree-shaken.
  */
-export function checkPalIntegrity<T> (impl: T & Guard) {
+export function checkPalIntegrity<T> (impl: T & Guard): void {
 }
 
 /**
  * Utility function, see example of `checkPalIntegrity()`.
  *
  */
-export function withImpl<T> () {
+export function withImpl<T> (): T & Guard {
     return 0 as unknown as T & Guard;
 }

--- a/pal/integrity-check.ts
+++ b/pal/integrity-check.ts
@@ -43,6 +43,7 @@ type Guard = typeof guard;
  * @note This function should be easily tree-shaken.
  */
 export function checkPalIntegrity<T> (impl: T & Guard): void {
+    /* empty */
 }
 
 /**


### PR DESCRIPTION
Re: #16937

If developers enable `strict` mode for their projects and write some code by using tween system like the following:

```ts
class MyCustomData {
    constructor (a: number) {
        this._aaa = a;
    }
    _aaa = 0;
}

class TestOne {
    _customData = new MyCustomData(0);

    foo (): void {
        const tweenDuration: number = 1.0;
        const t = tween(this._customData).to(
            tweenDuration,
            new MyCustomData(100),
            this,
        ).start();
    }

    onUpdate (target?: MyCustomData, ratio?: number): void {
        if (target && ratio) {
            // Write the code
        }
    }
}
```

Before this PR, the above code will trigger a ts compiler error:

```
Argument of type 'this' is not assignable to parameter of type 'ITweenOption | undefined'.
  Type 'TestOne' is not assignable to type 'ITweenOption'.
    Type 'this' is not assignable to type 'ITweenOption'.
      Type 'TestOne' is not assignable to type 'ITweenOption'.
        Types of property 'onUpdate' are incompatible.
          Type '(target?: MyCustomData | undefined, ratio?: number | undefined) => void' is not assignable to type '(target?: object | undefined, ratio?: number | undefined) => void'.
            Types of parameters 'target' and 'target' are incompatible.
              Type 'object | undefined' is not assignable to type 'MyCustomData | undefined'.
                Property '_aaa' is missing in type '{}' but required in type 'MyCustomData'.ts(2345)
MoveSprite.ts(20, 5): '_aaa' is declared here.
this: this
```

After apply this PR, the error will disappear, and also we get strong type restriction for `target`. That means it will trigger an error of type mismatch if the `onUpdate` target parameter's type is not matched with `_this._customData`.
For example, we write a wrong code to make the onUpdate target parameter type to `Node`:

```ts
class TestOne {
    _customData = new MyCustomData(0);

    foo (): void {
        const tweenDuration: number = 1.0;
        const t = tween(this._customData).to(
            tweenDuration,
            new MyCustomData(100),
            this,
        ).start();
    }

    onUpdate (target?: Node, ratio?: number): void { // Wrote wrong type of target
        if (target && ratio) {
            // Write the code
        }
    }
}
```

TS compiler will make an error: 

```
Argument of type 'this' is not assignable to parameter of type 'ITweenOption<MyCustomData> | undefined'.
  Type 'TestOne' is not assignable to type 'ITweenOption<MyCustomData>'.
    Type 'this' is not assignable to type 'ITweenOption<MyCustomData>'.
      Type 'TestOne' is not assignable to type 'ITweenOption<MyCustomData>'.
        Types of property 'onUpdate' are incompatible.
          Type '(target?: Node | undefined, ratio?: number | undefined) => void' is not assignable to type '(target?: MyCustomData | undefined, ratio?: number | undefined) => void'.
            Types of parameters 'target' and 'target' are incompatible.
              Type 'MyCustomData | undefined' is not assignable to type 'Node | undefined'.
                Type 'MyCustomData' is missing the following properties from type 'Node': components, _persistNode, name, uuid, and 124 more.ts(2345)
this: this
```

That's the reason why we don't change the `onUpdate (target?: object)` to `onUpdate (target?: any)` since `any` is the  loosest type which doesn't have any restrictions.  The `any` keyword needs to be avoided as much as possible.


### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
