### PR TITLE
update value as needed and reuse variables

### DIFF
--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -542,6 +542,10 @@ void Node::invalidateChildren(TransformBit dirtyBit) { // NOLINT(misc-no-recursi
 }
 
 void Node::setWorldPosition(float x, float y, float z) {
+    if (_worldPosition.approxEquals({x, y, z})) {
+        return;
+    }
+
     _worldPosition.set(x, y, z);
     if (_parent) {
         _parent->updateWorldTransform();
@@ -566,6 +570,10 @@ const Vec3 &Node::getWorldPosition() const {
 }
 
 void Node::setWorldRotation(float x, float y, float z, float w) {
+    if (_worldRotation.approxEquals({x, y, z, w})) {
+        return;
+    }
+
     _worldRotation.set(x, y, z, w);
     if (_parent) {
         _parent->updateWorldTransform();
@@ -592,6 +600,10 @@ const Quaternion &Node::getWorldRotation() const { // NOLINT(misc-no-recursion)
 }
 
 void Node::setWorldScale(float x, float y, float z) {
+    if (_worldScale.approxEquals({x, y, z})) {
+        return;
+    }
+
     if (_parent != nullptr) {
         updateWorldTransform(); // ensure reentryability
         Vec3 oldWorldScale = _worldScale;
@@ -746,7 +758,14 @@ void Node::setMatrix(const Mat4 &val) {
 }
 
 void Node::setWorldRotationFromEuler(float x, float y, float z) {
-    Quaternion::fromEuler(x, y, z, &_worldRotation);
+    Quaternion tmpRotation;
+    Quaternion::fromEuler(x, y, z, &tmpRotation);
+    if (tmpRotation.approxEquals(_worldRotation)) {
+        return;
+    }
+
+    _worldRotation = tmpRotation;
+
     if (_parent) {
         _parent->updateWorldTransform();
         _localRotation = _parent->_worldRotation.getConjugated() * _worldRotation;


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/16952

### Changelog

* reuse local variable
* use static method of  Vec3.set() and Quat.set() as they don't have to distinguish variable types, so they are more efficient
* make Node.setWorldPosition(), Node.setWorldRotation(), Node.setWorldRotationFromEuler(), Node.setWorldScale() update values add needed

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
