### PR TITLE
fix multi-light bugs

### DIFF
--- a/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -82,7 +82,7 @@ void RenderAdditiveLightQueue::recordCommandBuffer(gfx::Device *device, scene::C
             const auto *pass = lightPass.pass;
             const auto &dynamicOffsets = lightPass.dynamicOffsets;
             auto *shader = lightPass.shader;
-            const auto lights = lightPass.lights;
+            const auto &lights = lightPass.lights;
             auto *ia = subModel->getInputAssembler();
             auto *pso = PipelineStateManager::getOrCreatePipelineState(pass, shader, ia, renderPass);
             auto *descriptorSet = subModel->getDescriptorSet();
@@ -91,6 +91,7 @@ void RenderAdditiveLightQueue::recordCommandBuffer(gfx::Device *device, scene::C
             cmdBuffer->bindDescriptorSet(materialSet, pass->getDescriptorSet());
             cmdBuffer->bindInputAssembler(ia);
 
+            CC_ASSERT(dynamicOffsets.size() == lights.size());
             for (size_t i = 0; i < dynamicOffsets.size(); ++i) {
                 const auto *light = lights[i];
                 auto *globalDescriptorSet = _pipeline->getGlobalDSManager()->getOrCreateDescriptorSet(light);
@@ -201,7 +202,7 @@ void RenderAdditiveLightQueue::addRenderQueue(scene::SubModel *subModel, const s
         lightPass.subModel = subModel;
         lightPass.pass = pass;
         lightPass.shader = subModel->getShader(lightPassIdx);
-        lightPass.dynamicOffsets.resize(lightCount);
+        lightPass.dynamicOffsets.reserve(lightCount);
     }
 
     for (uint32_t i = 0; i < lightCount; ++i) {
@@ -221,13 +222,13 @@ void RenderAdditiveLightQueue::addRenderQueue(scene::SubModel *subModel, const s
                 } break;
                 case scene::BatchingSchemes::NONE: {
                     lightPass.lights.emplace_back(light);
-                    lightPass.dynamicOffsets[i] = _lightBufferStride * lightIdx;
+                    lightPass.dynamicOffsets.emplace_back(_lightBufferStride * lightIdx);
                 } break;
             }
-        } else {
-            lightPass.dynamicOffsets.clear();
         }
     }
+
+    CC_ASSERT(lightPass.lights.size() == lightPass.dynamicOffsets.size());
 
     if (batchingScheme == scene::BatchingSchemes::NONE) {
         _lightPasses.emplace_back(std::move(lightPass));


### PR DESCRIPTION
Re: #16853

Fix vector out of range.

First light call `lightPass.dynamicOffsets.clear();` Clear the dynamicOffsets
Second light call `lightPass.dynamicOffsets[i];` Trigger out of range

### Changelog

* Use same logic in `render-addtivie-light-queue.ts`
* Add more asserts.
* Fix unnecessary copy of light vector

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
