### PR TITLE
fixed #17031: Button could not be clicked after an exception is thrown while dispatching mouse/touch event.

### DIFF
--- a/cocos/2d/event/pointer-event-dispatcher.ts
+++ b/cocos/2d/event/pointer-event-dispatcher.ts
@@ -62,6 +62,10 @@ class PointerEventDispatcher implements IEventDispatcher {
         NodeEventProcessor.callbacksInvoker.on(DispatcherEventType.MARK_LIST_DIRTY, this._markListDirty, this);
     }
 
+    onThrowException (): void {
+        this._inDispatchCount = 0;
+    }
+
     public dispatchEvent (event: Event): boolean {
         const eventType = event.type as Input.EventType;
         if (touchEvents.includes(eventType)) {

--- a/cocos/input/input.ts
+++ b/cocos/input/input.ts
@@ -46,6 +46,8 @@ export interface IEventDispatcher {
      * @returns Whether dispatch to next event dispatcher
      */
     dispatchEvent(event: Event): boolean;
+
+    onThrowException(): void;
 }
 
 class InputEventDispatcher implements IEventDispatcher {
@@ -54,6 +56,10 @@ class InputEventDispatcher implements IEventDispatcher {
 
     constructor (inputEventTarget: EventTarget) {
         this._inputEventTarget = inputEventTarget;
+    }
+
+    onThrowException (): void {
+        // empty
     }
 
     public dispatchEvent (event: Event): boolean {
@@ -339,6 +345,7 @@ export class Input {
                 }
             } catch (e: any) {
                 this._clearEvents();
+                dispatcher.onThrowException();
                 throw e;
             }
         }


### PR DESCRIPTION
Re: #17031

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
