### PR TITLE
add spine safety protection

### DIFF
--- a/cocos/spine/assembler/simple.ts
+++ b/cocos/spine/assembler/simple.ts
@@ -161,7 +161,7 @@ function realTimeTraverse (comp: Skeleton): void {
     const vPtr = model.vPtr;
     const iPtr = model.iPtr;
     const ibuf = rd.indices!;
-    const HEAPU8 = spine.wasmUtil.wasm.HEAPU8;
+    const HEAPU8: Uint8Array = spine.wasmUtil.wasm.HEAPU8;
 
     comp._vBuffer?.set(HEAPU8.subarray(vPtr, vPtr + comp._vLength), 0);
     comp._iBuffer?.set(HEAPU8.subarray(iPtr, iPtr + comp._iLength), 0);
@@ -174,7 +174,7 @@ function realTimeTraverse (comp: Skeleton): void {
     let indexCount = 0;
     for (let i = 0; i < count; i += 6) {
         indexCount = data.get(i + 3);
-        const material = _getSlotMaterial(data.get(i + 4), comp);
+        const material = _getSlotMaterial(data.get(i + 4) as number, comp);
         const textureID: number = data.get(i + 5);
         comp.requestDrawData(material, textureID, indexOffset, indexCount);
         indexOffset += indexCount;

--- a/cocos/spine/assembler/simple.ts
+++ b/cocos/spine/assembler/simple.ts
@@ -117,7 +117,7 @@ export const simple: IAssembler = {
 
     updateRenderData (comp: Skeleton, batcher: Batcher2D) {
         const skeleton = comp._skeleton;
-        if (skeleton) {
+        if (skeleton && comp.node.active && comp.skeletonData?.isValid) {
             updateComponentRenderData(comp, batcher);
         }
     },

--- a/cocos/spine/assembler/simple.ts
+++ b/cocos/spine/assembler/simple.ts
@@ -158,8 +158,8 @@ function realTimeTraverse (comp: Skeleton): void {
     }
 
     const vbuf = rd.chunk.vb;
-    const vPtr = model.vPtr;
-    const iPtr = model.iPtr;
+    const vPtr: number = model.vPtr;
+    const iPtr: number = model.iPtr;
     const ibuf = rd.indices!;
     const HEAPU8: Uint8Array = spine.wasmUtil.wasm.HEAPU8;
 


### PR DESCRIPTION
在大型项目中，由于资源的加载和释放的情况更加复杂，在某些情况下切换游戏场景会出现 spine 错误。
In the large project，because the resource load and release is more complicated，the switching game scene will appear spine error in certain cases.
![a30ae047-5875-4c2c-9f68-4e0fa2612a3e](https://github.com/cocos/cocos-engine/assets/35944775/27678e0f-245f-4257-afcc-32f1fdf76e1f)
