### PR TITLE
use Uint8ClampedArray to save memory

### DIFF
--- a/cocos/core/math/color.ts
+++ b/cocos/core/math/color.ts
@@ -33,6 +33,10 @@ import { Vec4 } from './vec4';
 import { Vec3 } from './vec3';
 
 const toFloat = 1 / 255;
+const R_INDEX = 0;
+const G_INDEX = 1;
+const B_INDEX = 2;
+const A_INDEX = 3;
 
 /**
  * @en Representation of RGBA colors.<br/>
@@ -100,10 +104,10 @@ export class Color extends ValueType {
      */
     public static toVec4 (color: Color, out?: Vec4): Vec4 {
         out = out !== undefined ?  out : new Vec4();
-        out.x = color._r * toFloat;
-        out.y = color._g * toFloat;
-        out.z = color._b * toFloat;
-        out.w = color._a * toFloat;
+        out.x = color._data[R_INDEX] * toFloat;
+        out.y = color._data[G_INDEX] * toFloat;
+        out.z = color._data[B_INDEX] * toFloat;
+        out.w = color._data[A_INDEX] * toFloat;
         return out;
     }
     /**
@@ -117,10 +121,10 @@ export class Color extends ValueType {
      */
     public static fromVec4 (value: Vec4, out?: Color): Color {
         out = out === undefined ? new Color() : out;
-        out.r = value.x / toFloat;
-        out.g = value.y / toFloat;
-        out.b = value.z / toFloat;
-        out.a = value.w / toFloat;
+        out._data[R_INDEX] = value.x / toFloat;
+        out._data[G_INDEX] = value.y / toFloat;
+        out._data[B_INDEX] = value.z / toFloat;
+        out._data[A_INDEX] = value.w / toFloat;
         return out;
     }
     /**
@@ -323,21 +327,18 @@ export class Color extends ValueType {
         return ((a.r * 255) << 24 | (a.g * 255) << 16 | (a.b * 255) << 8 | a.a * 255) >>> 0;
     }
 
-    private _r = 0;
-    private _g = 0;
-    private _b = 0;
-    private _a = 0;
+    private _data = new Uint8ClampedArray(4);
 
     /**
      * @en Get or set red channel value.
      * @zh 获取或设置当前颜色的 Red 通道。
      */
     get r (): number {
-        return this._r;
+        return this._data[R_INDEX];
     }
 
     set r (red: number) {
-        this._r = ~~clamp(red, 0, 255);
+        this._data[R_INDEX] = red;
     }
 
     /**
@@ -345,11 +346,11 @@ export class Color extends ValueType {
      * @zh 获取或设置当前颜色的 Green 通道。
      */
     get g (): number {
-        return this._g;
+        return this._data[G_INDEX];
     }
 
     set g (green: number) {
-        this._g = ~~clamp(green, 0, 255);
+        this._data[G_INDEX] = green;
     }
 
     /**
@@ -357,33 +358,33 @@ export class Color extends ValueType {
      * @zh 获取或设置当前颜色的 Blue 通道。
      */
     get b (): number {
-        return this._b;
+        return this._data[B_INDEX];
     }
 
     set b (blue: number) {
-        this._b = ~~clamp(blue, 0, 255);
+        this._data[B_INDEX] = blue;
     }
 
     /** @en Get or set alpha channel value.
      * @zh 获取或设置当前颜色的透明度通道。
      */
     get a (): number {
-        return this._a;
+        return this._data[A_INDEX];
     }
 
     set a (alpha: number) {
-        this._a = ~~clamp(alpha, 0, 255);
+        this._data[A_INDEX] = alpha;
     }
 
     // compatibility with vector interfaces
-    get x (): number { return this._r * toFloat; }
-    set x (value: number) { this.r = value * 255; }
-    get y (): number { return this._g * toFloat; }
-    set y (value: number) { this.g = value * 255; }
-    get z (): number { return this._b * toFloat; }
-    set z (value: number) { this.b = value * 255; }
-    get w (): number { return this._a * toFloat; }
-    set w (value: number) { this.a = value * 255; }
+    get x (): number { return this._data[R_INDEX] * toFloat; }
+    set x (value: number) { this._data[R_INDEX] = value * 255; }
+    get y (): number { return this._data[G_INDEX] * toFloat; }
+    set y (value: number) { this._data[G_INDEX] = value * 255; }
+    get z (): number { return this._data[B_INDEX] * toFloat; }
+    set z (value: number) { this._data[B_INDEX] = value * 255; }
+    get w (): number { return this._data[A_INDEX] * toFloat; }
+    set w (value: number) { this._data[A_INDEX] = value * 255; }
 
     /**
      * @en Construct a same color from the given color
@@ -427,10 +428,8 @@ export class Color extends ValueType {
      */
     public clone (): Color {
         const ret = new Color();
-        ret._r = this._r;
-        ret._g = this._g;
-        ret._b = this._b;
-        ret._a = this._a;
+        ret._data.set(this._data);
+
         return ret;
     }
 
@@ -442,10 +441,10 @@ export class Color extends ValueType {
      */
     public equals (other: Readonly<Color>): boolean {
         const otherColor = other as Color;
-        return other && this._r === otherColor._r
-                     && this._g === otherColor._g
-                     && this._b === otherColor._b
-                     && this._a === otherColor._a;
+        return other && this._data[R_INDEX] === otherColor._data[R_INDEX]
+                     && this._data[G_INDEX] === otherColor._data[G_INDEX]
+                     && this._data[B_INDEX] === otherColor._data[B_INDEX]
+                     && this._data[A_INDEX] === otherColor._data[A_INDEX];
     }
 
     /**
@@ -551,9 +550,9 @@ export class Color extends ValueType {
         const prefix = '0';
         // #rrggbb
         const hex = [
-            (this._r < 16 ? prefix : '') + (this._r).toString(16),
-            (this._g < 16 ? prefix : '') + (this._g).toString(16),
-            (this._b < 16 ? prefix : '') + (this._b).toString(16),
+            (this._data[R_INDEX] < 16 ? prefix : '') + (this._data[R_INDEX]).toString(16),
+            (this._data[G_INDEX] < 16 ? prefix : '') + (this._data[G_INDEX]).toString(16),
+            (this._data[B_INDEX] < 16 ? prefix : '') + (this._data[B_INDEX]).toString(16),
         ];
         const i = -1;
         if (fmt === '#rgb') {
@@ -561,7 +560,7 @@ export class Color extends ValueType {
             hex[1] = hex[1][0];
             hex[2] = hex[2][0];
         } else if (fmt === '#rrggbbaa') {
-            hex.push((this._a < 16 ? prefix : '') + (this._a).toString(16));
+            hex.push((this._data[A_INDEX] < 16 ? prefix : '') + (this._data[A_INDEX]).toString(16));
         }
         return hex.join('');
     }
@@ -577,7 +576,7 @@ export class Color extends ValueType {
      * ```
      */
     public toRGBValue (): number {
-        return (this._b << 16 | this._g << 8 | this._r);
+        return (this._data[B_INDEX] << 16 | this._data[G_INDEX] << 8 | this._data[R_INDEX]);
     }
 
     /**
@@ -650,9 +649,9 @@ export class Color extends ValueType {
                 break;
             }
         }
-        this.r = r * 255;
-        this.g = g * 255;
-        this.b = b * 255;
+        this._data[R_INDEX] = r * 255;
+        this._data[G_INDEX] = g * 255;
+        this._data[B_INDEX] = b * 255;
         return this;
     }
 
@@ -668,9 +667,9 @@ export class Color extends ValueType {
      * ```
      */
     public toHSV (): { h: number; s: number; v: number; } {
-        const r = this._r * toFloat;
-        const g = this._g * toFloat;
-        const b = this._b * toFloat;
+        const r = this._data[R_INDEX] * toFloat;
+        const g = this._data[G_INDEX] * toFloat;
+        const b = this._data[B_INDEX] * toFloat;
         const hsv = { h: 0, s: 0, v: 0 };
         const max = Math.max(r, g, b);
         const min = Math.min(r, g, b);
@@ -708,15 +707,12 @@ export class Color extends ValueType {
     public set (r?: number | Readonly<Color>, g?: number, b?: number, a?: number): Color {
         if (typeof r === 'object') {
             const other = r as Color;
-            this.r = other._r;
-            this.g = other._g;
-            this.b = other._b;
-            this.a = other._a;
+            this._data.set(other._data);
         } else {
-            this.r = r ?? 0;
-            this.g = g ?? 0;
-            this.b = b ?? 0;
-            this.a = a ?? 255;
+            this._data[R_INDEX] = r ?? 0;
+            this._data[G_INDEX] = g ?? 0;
+            this._data[B_INDEX] = b ?? 0;
+            this._data[A_INDEX] = a ?? 255;
         }
         return this;
     }

--- a/cocos/core/utils/misc.ts
+++ b/cocos/core/utils/misc.ts
@@ -35,6 +35,10 @@ import type { Component } from '../../scene-graph';
 
 export const BUILTIN_CLASSID_RE = /^(?:cc|dragonBones|sp|ccsg)\..+/;
 
+export interface Modifiable {
+    getModifiableProperties(): string[];
+}
+
 const BASE64_KEYS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 const values: number[] = new Array(123); // max char code in base64Keys
 for (let i = 0; i < 123; ++i) { values[i] = 64; } // fill with placeholder('=') index

--- a/cocos/tween/tween-action.ts
+++ b/cocos/tween/tween-action.ts
@@ -191,8 +191,18 @@ export class TweenAction<T> extends ActionInterval {
                     prop.start = {}; prop.current = {}; prop.end = {};
                 }
 
-                for (const k in value) {
-                    if (Number.isNaN(_t[k] as number)) continue;
+                let propertyKeys: string[];
+                if (value.getModifiableProperties) {
+                    propertyKeys = value.getModifiableProperties();
+                } else {
+                    propertyKeys = Object.keys(value as object);
+                }
+
+                for (let i = 0, len = propertyKeys.length; i < len; ++i) {
+                    const k = propertyKeys[i];
+                    // eslint-disable-next-line no-restricted-globals
+                    if (isNaN(_t[k] as number)) continue;
+
                     prop.start[k] = _t[k];
                     prop.current[k] = _t[k];
                     prop.end[k] = relative ? _t[k] + value[k] : value[k];

--- a/tests/animation/__snapshots__/animation-clip.test.ts.snap
+++ b/tests/animation/__snapshots__/animation-clip.test.ts.snap
@@ -56,14 +56,14 @@ Array [
   },
   Object {
     "defaultProperties": Object {
-      "a": 25,
+      "a": 26,
       "b": 51,
-      "g": 76,
+      "g": 77,
       "r": 102,
     },
     "expectedAnimatedProperties": Object {
       "a": 191,
-      "r": 127,
+      "r": 128,
     },
     "specName": "Color",
   },

--- a/tests/core/math/color.test.ts
+++ b/tests/core/math/color.test.ts
@@ -209,7 +209,7 @@ describe('Test Color', () => {
             expect(srgb8BitToLinear(i)).toBe(srgbToLinear(i / 255.0));
         }
         expect(Color.toVec4(new Color(255, 188, 0, 255))).toEqual(new Vec4(1, 0.7372549019607844, 0, 1));
-        expect(Color.fromVec4(new Vec4 (1, 0.5, 0, 1))).toEqual(new Color(255, 127, 0, 255));
+        expect(Color.fromVec4(new Vec4 (1, 0.5, 0, 1))).toEqual(new Color(255, 128, 0, 255));
     });
 
     test('fromUint32', () => {

--- a/tests/value-types/color.test.ts
+++ b/tests/value-types/color.test.ts
@@ -8,7 +8,7 @@ test('creation test', function () {
     c0.r = 0;
     c0.b = 127.5;
     let c1 = new Color(c0);
-    expect(Color.toUint32(c1)).toBe(Number.parseInt('ff7fff00', 16));
+    expect(Color.toUint32(c1)).toBe(Number.parseInt('ff80ff00', 16));
     let c2 = new Color('#ffff087f');
     expect(c2.r).toBe(255);
     expect(c2.g).toBe(255);
@@ -40,10 +40,10 @@ test('method test', function () {
     let c1 = new Color(192, 128, 0, 0);
     let c2 = new Color();
     Color.lerp(c2, c0, c1, 0.2);
-    expect(c2.r).toBe(Math.floor(c0.r + (c1.r - c0.r) * 0.2));
-    expect(c2.g).toBe(Math.floor(c0.g + (c1.g - c0.g) * 0.2));
-    expect(c2.b).toBe(Math.floor(c0.b + (c1.b - c0.b) * 0.2));
-    expect(c2.a).toBe(Math.floor(c0.a + (c1.a - c0.a) * 0.2));
+    expect(c2.r).toBe(Math.round(c0.r + (c1.r - c0.r) * 0.2));
+    expect(c2.g).toBe(Math.round(c0.g + (c1.g - c0.g) * 0.2));
+    expect(c2.b).toBe(Math.round(c0.b + (c1.b - c0.b) * 0.2));
+    expect(c2.a).toBe(Math.round(c0.a + (c1.a - c0.a) * 0.2));
     Color.lerp(c2, c0, c1, 1);
     expect(c2).toEqual(c1);
 
@@ -53,25 +53,25 @@ test('method test', function () {
 
     c2.set(c1);
     c2.lerp(c0, 0.95);
-    expect(c2.r).toBe(Math.floor(c1.r + (c0.r - c1.r) * 0.95));
-    expect(c2.g).toBe(Math.floor(c1.g + (c0.g - c1.g) * 0.95));
-    expect(c2.b).toBe(Math.floor(c1.b + (c0.b - c1.b) * 0.95));
-    expect(c2.a).toBe(Math.floor(c1.a + (c0.a - c1.a) * 0.95));
+    expect(c2.r).toBe(Math.round(c1.r + (c0.r - c1.r) * 0.95));
+    expect(c2.g).toBe(Math.round(c1.g + (c0.g - c1.g) * 0.95));
+    expect(c2.b).toBe(Math.round(c1.b + (c0.b - c1.b) * 0.95));
+    expect(c2.a).toBe(Math.round(c1.a + (c0.a - c1.a) * 0.95));
 });
 
 test('conversion test', function() {
     let testColor = new Color( 255, 255, 0, 127.5 );
-    expect(testColor.toHEX('#rrggbbaa')).toBe("ffff007f");
+    expect(testColor.toHEX('#rrggbbaa')).toBe("ffff0080");
     expect(testColor.toHEX('#rrggbb')).toBe("ffff00");
-    expect(testColor.toCSS('#rrggbbaa')).toBe("#ffff007f");
+    expect(testColor.toCSS('#rrggbbaa')).toBe("#ffff0080");
     expect(testColor.toCSS('#rrggbb')).toBe("#ffff00");
     expect(testColor.toCSS('rgb')).toBe("rgb(255,255,0)");
     expect(testColor.toCSS('rgba')).toBe("rgba(255,255,0,0.50)");
 
     testColor = new Color( 0.3 * 255, 255, 0, 127.5 );
-    expect(testColor.toHEX('#rrggbbaa')).toBe("4cff007f");
+    expect(testColor.toHEX('#rrggbbaa')).toBe("4cff0080");
     expect(testColor.toHEX('#rrggbb')).toBe("4cff00");
-    expect(testColor.toCSS('#rrggbbaa')).toBe("#4cff007f");
+    expect(testColor.toCSS('#rrggbbaa')).toBe("#4cff0080");
     expect(testColor.toCSS('#rrggbb')).toBe("#4cff00");
     expect(testColor.toCSS('rgb')).toBe("rgb(76,255,0)");
 


### PR DESCRIPTION
### https://github.com/cocos/cocos-engine/issues/13229

* as r, g, b, a are private attributes, so can use Uint8ClampedArray to save memory
* the result is a little different from original implementation:
  * Uint8ClampedArray uses similar mechanism as Math.round()
  * original implementation uses similar mechanism as Math.floor()
  * so if a float like 127.5 will be converted to 128 now, as it will be converted to 127 in original implementation
-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
