### PR TITLE
fix RichText click event contains bug

### DIFF
--- a/cocos2d/core/components/CCRichText.js
+++ b/cocos2d/core/components/CCRichText.js
@@ -459,8 +459,7 @@ let RichText = cc.Class({
     },
 
     _containsTouchLocation (label, point) {
-        let myRect = label.getBoundingBoxToWorld();
-        return myRect.contains(point);
+        return label._hitTest(point);
     },
 
     _resetState () {


### PR DESCRIPTION
我使用的creator版本是2.4.10，当游戏的`cc.view.getFrameSize()`和`cc.Canvas.instance.designResolution`不一致时，修改适配方案，会导致RichText的click事件响应发生异常，论坛上也有人反馈类似的问题: https://forum.cocos.org/t/topic/155078

有问题的demo：
[NewProject.zip](https://github.com/cocos/cocos-engine/files/15453757/NewProject.zip)

## demo代码说明
Canvas的适配为fit width

![image](https://github.com/cocos/cocos-engine/assets/7894208/cf570aa7-0a10-4e89-866d-eb782001d485)

在测试例中我修改了适配

```
    cc.Canvas.instance.fitHeight = true;
```


## 复现步骤
这个问题在editor preview也就是localhost:7456预览时没有问题的，

构建 web-mobile/mobile-desktop后，运行web-mobile  （localhost:7456/build）, 调整游戏窗口大小到如下图情况：

![image](https://github.com/cocos/cocos-engine/assets/7894208/b932779c-a086-4cc9-8ab7-9f9ce0caef69)

 白色是Canvas的大小，红色是camera背景色，此时点击RichText，就会产生click不响应、或者响应位置异常的问题，这个跟窗口大小与Canvas大小有关系


Android/ios上没有测试，窗口大小和Canvas一致，是正常的，没有任何问题

![image](https://github.com/cocos/cocos-engine/assets/7894208/9a5e75ae-9ca4-4f85-9f62-9c69a710cd6a)


