### PR TITLE
[v3.8.5] Fix timeScale could not work for repeatForever.

### DIFF
--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -570,6 +570,7 @@ export class RepeatForever extends ActionInterval {
         }
 
         this._innerAction = action;
+        this._duration = Infinity;
         return true;
     }
 

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -597,6 +597,7 @@ export class RepeatForever extends ActionInterval {
         if (!locInnerAction) {
             return;
         }
+        dt *= this._speed;
         locInnerAction.step(dt);
         if (locInnerAction.isDone()) {
             // var diff = locInnerAction.getElapsed() - locInnerAction.getDurationScaled();

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -120,7 +120,7 @@ export abstract class ActionInterval extends FiniteTimeAction {
     abstract clone (): ActionInterval;
 
     step (dt: number): void {
-        if (this._paused) return;
+        if (this._paused || this._speed === 0) return;
         dt *= this._speed;
         if (this._firstTick) {
             this._firstTick = false;
@@ -592,7 +592,7 @@ export class RepeatForever extends ActionInterval {
     }
 
     step (dt: number): void {
-        if (this._paused) return;
+        if (this._paused || this._speed === 0) return;
         const locInnerAction = this._innerAction;
         if (!locInnerAction) {
             return;

--- a/tests/tween/tween.test.ts
+++ b/tests/tween/tween.test.ts
@@ -2228,6 +2228,43 @@ test('timeScale for repeatForever', function () {
     director.unregisterSystem(sys);
 });
 
+test('timeScale with zero', function () {
+    const sys = new TweenSystem();
+    (TweenSystem.instance as any) = sys;
+    director.registerSystem(TweenSystem.ID, sys, System.Priority.MEDIUM);
+
+    const node = new Node();
+
+    const t = tween(node)
+        .by(1, { position: new Vec3(100, 100, 100) })
+        .timeScale(0.5)
+        .start();
+
+    // Start
+    runFrames(1);
+
+    runFrames(30);
+    expect(node.position.equals(new Vec3(25, 25, 25))).toBeTruthy();
+
+    runFrames(30);
+    expect(node.position.equals(new Vec3(50, 50, 50))).toBeTruthy();
+
+    runFrames(30);
+    expect(node.position.equals(new Vec3(75, 75, 75))).toBeTruthy();
+
+    t.timeScale(0);
+
+    runFrames(30);
+    expect(node.position.equals(new Vec3(75, 75, 75))).toBeTruthy();
+
+    t.timeScale(0.5)
+
+    runFrames(30);
+    expect(node.position.equals(new Vec3(100, 100, 100))).toBeTruthy();
+
+    director.unregisterSystem(sys);
+});
+
 test('duration', function () {
     const sys = new TweenSystem();
     (TweenSystem.instance as any) = sys;

--- a/tests/tween/tween.test.ts
+++ b/tests/tween/tween.test.ts
@@ -2130,6 +2130,104 @@ test('timeScale negative value', function () {
     director.unregisterSystem(sys);
 });
 
+test('timeScale for repeat', function () {
+    const sys = new TweenSystem();
+    (TweenSystem.instance as any) = sys;
+    director.registerSystem(TweenSystem.ID, sys, System.Priority.MEDIUM);
+
+    const node = new Node();
+
+    const t = tween(node)
+        .by(1, { position: new Vec3(100, 100, 100) }).id(123)
+        .reverse(123)
+        .timeScale(0.5)
+        .union()
+        .repeat(10)
+        .start();
+
+    expect(t.duration === 10);
+
+    // Start
+    runFrames(1);
+
+    for (let i = 0; i < 10; ++i) {
+        runFrames(30);
+        expect(node.position.equals(new Vec3(25, 25, 25))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(50, 50, 50))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(75, 75, 75))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(100, 100, 100))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(75, 75, 75))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(50, 50, 50))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(25, 25, 25))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(0, 0, 0))).toBeTruthy();
+    }
+
+    director.unregisterSystem(sys);
+});
+
+test('timeScale for repeatForever', function () {
+    const sys = new TweenSystem();
+    (TweenSystem.instance as any) = sys;
+    director.registerSystem(TweenSystem.ID, sys, System.Priority.MEDIUM);
+
+    const node = new Node();
+
+    const t = tween(node)
+        .by(1, { position: new Vec3(100, 100, 100) }).id(123)
+        .reverse(123)
+        .timeScale(0.5)
+        .union()
+        .repeatForever()
+        .start();
+
+    expect(t.duration === Infinity);
+
+    for (let i = 0; i < 10; ++i) {
+        // Start
+        runFrames(1);
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(25, 25, 25))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(50, 50, 50))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(75, 75, 75))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(100, 100, 100))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(75, 75, 75))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(50, 50, 50))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(25, 25, 25))).toBeTruthy();
+
+        runFrames(30);
+        expect(node.position.equals(new Vec3(0, 0, 0))).toBeTruthy();
+    }
+
+    director.unregisterSystem(sys);
+});
+
 test('duration', function () {
     const sys = new TweenSystem();
     (TweenSystem.instance as any) = sys;


### PR DESCRIPTION
And RepeatForever's duration is Infinity.

Re: #16973

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
