### PR TITLE
modify the userdata type of IExposedAttributes

### DIFF
--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -521,7 +521,6 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
         }
         parseSimpleAttribute('slide', 'boolean');
         parseSimpleAttribute('unit', 'string');
-        parseSimpleAttribute('userData', 'object');
         parseSimpleAttribute('radioGroup', 'boolean');
     }
 
@@ -594,6 +593,7 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
     parseSimpleAttribute('min', 'number');
     parseSimpleAttribute('max', 'number');
     parseSimpleAttribute('step', 'number');
+    parseSimpleAttribute('userData', 'object');
 }
 
 CCClass.isArray = function (defaultVal): boolean {

--- a/cocos/core/data/utils/attribute-defines.ts
+++ b/cocos/core/data/utils/attribute-defines.ts
@@ -29,6 +29,8 @@ type GroupOptions = { name: string; } & Partial<{
     style: string;
 }>;
 
+export interface IExposedAttributesUserData extends Record<string, any> { }
+
 export interface IExposedAttributes {
     /**
      * 指定属性的类型。
@@ -146,7 +148,7 @@ export interface IExposedAttributes {
      * @en User custom data, which can be obtained through the `CCClass.attr()` interface.
      * @zh 用户自定义数据，可以通过 `CCClass.attr()` 接口获取自定义数据。
      */
-    userData?: Record<string, any>;
+    userData?: IExposedAttributesUserData;
 
     /**
      * 在允许的情况下，在编辑器中显示为一组单选按钮


### PR DESCRIPTION
Replace the IExposedAttributes userdata types from Record < string, any > to interface IExposedAttributesUserData extends Record < string, any> {}. The advantage of this modification is that we can take advantage of the type namesakes interface merging feature of ts to achieve better type hints.

For example, we have a type file in which we define the following:

```ts
declare module "cc" {
  export namespace __private {
    export interface _cocos_core_data_utils_attribute_defines__IExposedAttributesUserData extends  my interface type {
       // other prototype
    }
  }
}
```

So when we use
```typescript
@property({ type: property type, userData: { /*There will be our own defined type information. Very convenient/*  } }) _property: property type= null!;
```