### PR TITLE
fix a security issue (RCE) in web-interface-check.yml

### DIFF
--- a/.github/workflows/web-interface-check.yml
+++ b/.github/workflows/web-interface-check.yml
@@ -15,8 +15,6 @@ jobs:
     if: 
       (! contains(github.event.pull_request.body, '[X] does not change any runtime related code or build configuration'))
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/web-interface-check.yml
+++ b/.github/workflows/web-interface-check.yml
@@ -1,24 +1,28 @@
 name: <Web> Interface check
 
-#on: push
-on: [pull_request_target]
+on: [pull_request]
 
 # github.head_ref is only defined on pull_request events
 concurrency:
   group: ${{ github.workflow }}-${{ github.actor }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+
 jobs:
   interface_check:
     if: 
       (! contains(github.event.pull_request.body, '[X] does not change any runtime related code or build configuration'))
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Base Ref
         with:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
@@ -27,7 +31,7 @@ jobs:
       - run: |
           "EXT_VERSION=$(node ./engine/.github/workflows/get-native-external-version.js)" >> $env:GITHUB_ENV
         shell: pwsh
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Download external
         with:
           repository: cocos/cocos-engine-external
@@ -44,15 +48,17 @@ jobs:
         run: |
           npm cache clean --force
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Head Ref
         with:
           ref: 'refs/pull/${{ github.event.pull_request.number }}/merge' # Don't check out the head commit, checkout the "merge commit" instead
           path: './engine-HEAD'
+
       - run: |
           "EXT_VERSION_HEAD=$(node ./engine-HEAD/.github/workflows/get-native-external-version.js)" >> $env:GITHUB_ENV
         shell: pwsh
-      - uses: actions/checkout@v3
+
+      - uses: actions/checkout@v4
         name: Download external
         with:
           repository: cocos/cocos-engine-external
@@ -65,7 +71,7 @@ jobs:
         run: |
           npm install
 
-      - uses: LouisBrunner/diff-action@v0.1.2
+      - uses: LouisBrunner/diff-action@v2.0.0
         with:
           old: ./engine/bin/.declarations/cc.d.ts
           new: ./engine-HEAD/bin/.declarations/cc.d.ts
@@ -79,6 +85,23 @@ jobs:
           cat ./interface-diff.txt
           node ./.github/workflows/interface-check-report.js
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - name: Write PR number to file
+        uses: actions/github-script@v7
         with:
-          path: ./engine/interface-diff.txt
+          script: |
+            const fs = require('fs');
+            fs.writeFileSync('interface-check-pr.txt', process.env.PR_NUMBER);
+
+      - name: Upload PR number artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: interface-check-pr.txt
+          path: |
+            interface-check-pr.txt
+
+      - name: Upload interface diff artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: interface-diff.txt
+          path: |
+            ./engine/interface-diff.txt

--- a/.github/workflows/web-interface-post-comment.yml
+++ b/.github/workflows/web-interface-post-comment.yml
@@ -33,9 +33,18 @@ jobs:
             const pr = Number(fs.readFileSync('./artifacts/interface-check-pr.txt', 'utf8'));
             core.exportVariable('PR_NUMBER', pr);
 
-      - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v4
+      - name: Find Comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
+        id: fc
         with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Interface Check Report
+
+      - name: Update Comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ env.PR_NUMBER }}
           edit-mode: replace
           body-path: './artifacts/interface-diff.txt'

--- a/.github/workflows/web-interface-post-comment.yml
+++ b/.github/workflows/web-interface-post-comment.yml
@@ -1,0 +1,41 @@
+name: <Web> Interface Post Comment
+on:
+  workflow_run:
+    workflows: ["<Web> Interface check"]
+    types:
+    - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  post-pr-comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          merge-multiple: true
+          path: ./artifacts
+
+      - name: Display structure of downloaded files
+        run: |
+          ls -R ./artifacts
+          
+      - name: Set PR environment variable
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const pr = Number(fs.readFileSync('./artifacts/interface-check-pr.txt', 'utf8'));
+            core.exportVariable('PR_NUMBER', pr);
+
+      - name: Update Comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          edit-mode: replace
+          body-path: './artifacts/interface-diff.txt'


### PR DESCRIPTION
Continue: https://github.com/cocos/cocos-engine/pull/17157

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
