### PR TITLE
Update run_test_cases.yml

### DIFF
--- a/.github/workflows/run_test_cases.yml
+++ b/.github/workflows/run_test_cases.yml
@@ -49,10 +49,15 @@ jobs:
           pr_base_sha=$(echo "$pull_request" | jq -r '.base.sha')
           pr_updated_at=$(echo "$pull_request" | jq -r '.updated_at')
 
-          if [[ $(date -d "$pr_updated_at" +%s) -gt $(date -d "$last_update_date" +%s) ]]; then
-            exit 1
+          # Convert PR update time to Unix timestamp and compare with the last update time  
+          pr_updated_at_timestamp=$(date -d "$pr_updated_at" +%s)  
+          last_update_date_timestamp=$(date -d "$last_update_date" +%s)  
+          # Check if the PR has new updates  
+          if [[ $pr_updated_at_timestamp -gt $last_update_date_timestamp ]]; then  
+           # If there is an update, exit the script 
+             exit 1  
           fi
-          
+          # If there are no new updates, write the PR details to the output file
           echo "pr_html_url=$pr_html_url" >> $GITHUB_OUTPUT
           echo "pr_author=$pr_author" >> $GITHUB_OUTPUT
           echo "pr_head_ref=$pr_head_ref" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Convert PR update time to Unix timestamp and compare with the last update time

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
