### PR TITLE
Modify the display of the slash screen

### DIFF
--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -126,13 +126,13 @@ export class SplashScreen {
     }
 
     public init (): Promise<void[]> {
-        let policy: number = 0;
+        let policy: number = ResolutionPolicy.SHOW_ALL;
         if (!EDITOR) {
             const designResolution = settings.querySettings(Settings.Category.SCREEN, 'designResolution');
             policy = designResolution.policy as number;
         }
         this.settings = {
-            policy: (policy) ?? 0,
+            policy: (policy) ?? ResolutionPolicy.SHOW_ALL,
             displayRatio: settings.querySettings<number>(Settings.Category.SPLASH_SCREEN, 'displayRatio') ?? 0.4,
             totalTime: settings.querySettings<number>(Settings.Category.SPLASH_SCREEN, 'totalTime') ?? 3000,
             watermarkLocation: settings.querySettings<WatermarkLocationType>(Settings.Category.SPLASH_SCREEN, 'watermarkLocation') ?? 'default',

--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -45,7 +45,7 @@ type SplashBackgroundType = 'default' | 'color' | 'custom';
 type WatermarkLocationType = 'default' | 'topLeft' | 'topRight' | 'topCenter' | 'bottomLeft' | 'bottomCenter' | 'bottomRight';
 
 interface ISplashSetting {
-    policy: number;
+    policy?: number;
     displayRatio: number;
     totalTime: number;
     watermarkLocation: WatermarkLocationType;
@@ -129,7 +129,9 @@ export class SplashScreen {
         let policy: number = ResolutionPolicy.SHOW_ALL;
         if (!EDITOR) {
             const designResolution = settings.querySettings(Settings.Category.SCREEN, 'designResolution');
-            policy = designResolution.policy as number;
+            if (designResolution != null) {
+                policy = designResolution.policy as number;
+            }
         }
         this.settings = {
             policy: (policy) ?? ResolutionPolicy.SHOW_ALL,

--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -129,7 +129,7 @@ export class SplashScreen {
         let policy: number = ResolutionPolicy.SHOW_ALL;
         if (!EDITOR) {
             const designResolution = settings.querySettings(Settings.Category.SCREEN, 'designResolution');
-            if (designResolution != null) {
+            if (designResolution !== null) {
                 policy = designResolution.policy as number;
             }
         }

--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -323,20 +323,20 @@ export class SplashScreen {
                 scaleX = (dh / this.bgImage.height) * this.bgImage.width;
                 scaleY = dh;
             } else if (this.settings.policy === ResolutionPolicy.SHOW_ALL) {
-                if (dw > dh) {
-                    scaleX = (dh / this.bgImage.height) * this.bgImage.width;
-                    scaleY = dh;
-                } else {
+                if ((this.bgImage.width / this.bgHeight) > (dw / dh)) {
                     scaleX = dw;
                     scaleY = (dw / this.bgImage.width) * this.bgImage.height;
+                } else {
+                    scaleX = (dh / this.bgImage.height) * this.bgImage.width;
+                    scaleY = dh;
                 }
             } else if (this.settings.policy === ResolutionPolicy.NO_BORDER) {
                 if ((this.bgImage.width / this.bgImage.height) > (dw / dh)) {
-                    scaleX = dw;
-                    scaleY = (dw / this.bgImage.width) * this.bgImage.height;
-                } else {
                     scaleX = (dh / this.bgImage.height) * this.bgImage.width;
                     scaleY = dh;
+                } else {
+                    scaleX = dw;
+                    scaleY = (dw / this.bgImage.width) * this.bgImage.height;
                 }
             } else {
                 scaleX = dw;

--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -37,6 +37,7 @@ import { SetIndex } from '../rendering/define';
 import { ccwindow, legacyCC } from '../core/global-exports';
 import { XREye } from '../xr/xr-enums';
 import { PipelineRuntime } from '../rendering/custom';
+import { ResolutionPolicy } from '../ui/view';
 
 const v2_0 = new Vec2();
 type SplashLogoType = 'default' | 'none' | 'custom';
@@ -44,6 +45,7 @@ type SplashBackgroundType = 'default' | 'color' | 'custom';
 type WatermarkLocationType = 'default' | 'topLeft' | 'topRight' | 'topCenter' | 'bottomLeft' | 'bottomCenter' | 'bottomRight';
 
 interface ISplashSetting {
+    policy: number;
     displayRatio: number;
     totalTime: number;
     watermarkLocation: WatermarkLocationType;
@@ -96,7 +98,6 @@ export class SplashScreen {
     // layout
     private bgWidth = 1920;
     private bgHeight = 1080;
-    private bgRatio = 16 / 9;
     private logoWidthTemp = 140;
     private logoHeightTemp = 200;
     private logoWidth = 0;
@@ -125,7 +126,13 @@ export class SplashScreen {
     }
 
     public init (): Promise<void[]> {
+        let policy: number = 0;
+        if (!EDITOR) {
+            const designResolution = settings.querySettings(Settings.Category.SCREEN, 'designResolution');
+            policy = designResolution.policy as number;
+        }
         this.settings = {
+            policy: (policy) ?? 0,
             displayRatio: settings.querySettings<number>(Settings.Category.SPLASH_SCREEN, 'displayRatio') ?? 0.4,
             totalTime: settings.querySettings<number>(Settings.Category.SPLASH_SCREEN, 'totalTime') ?? 3000,
             watermarkLocation: settings.querySettings<WatermarkLocationType>(Settings.Category.SPLASH_SCREEN, 'watermarkLocation') ?? 'default',
@@ -307,12 +314,31 @@ export class SplashScreen {
         let scaleY = 1;
         // update bg uniform
         if (this.settings.background!.type === 'custom') {
-            if (dw < dh) {
-                scaleX = dh * this.bgRatio;
+            if (this.settings.policy === ResolutionPolicy.FIXED_WIDTH) {
+                scaleX = dw;
+                scaleY = (dw / this.bgImage.width) * this.bgImage.height;
+            } else if (this.settings.policy === ResolutionPolicy.FIXED_HEIGHT) {
+                scaleX = (dh / this.bgImage.height) * this.bgImage.width;
                 scaleY = dh;
+            } else if (this.settings.policy === ResolutionPolicy.SHOW_ALL) {
+                if (dw > dh) {
+                    scaleX = (dh / this.bgImage.height) * this.bgImage.width;
+                    scaleY = dh;
+                } else {
+                    scaleX = dw;
+                    scaleY = (dw / this.bgImage.width) * this.bgImage.height;
+                }
+            } else if (this.settings.policy === ResolutionPolicy.NO_BORDER) {
+                if ((this.bgImage.width / this.bgImage.height) > (dw / dh)) {
+                    scaleX = dw;
+                    scaleY = (dw / this.bgImage.width) * this.bgImage.height;
+                } else {
+                    scaleX = (dh / this.bgImage.height) * this.bgImage.width;
+                    scaleY = dh;
+                }
             } else {
                 scaleX = dw;
-                scaleY = dw * this.bgRatio;
+                scaleY = dh;
             }
 
             this.bgMat.setProperty('resolution', v2_0.set(dw, dh), 0);
@@ -325,9 +351,9 @@ export class SplashScreen {
         // update logo uniform
         const logoYTrans = dh * this.logoYTrans;
         if (this.settings.logo!.type !== 'none') {
-            scaleX = this.logoWidth * this.scaleSize * settings.displayRatio;
-            scaleY = this.logoHeight * this.scaleSize * settings.displayRatio;
-
+            // Product design is 0.185 of the height of the screen resolution as the display height of the logo.
+            scaleY = dh * 0.185 * settings.displayRatio;
+            scaleX = this.logoWidth * (dh * 0.185 / this.logoHeight) * settings.displayRatio;
             this.logoMat.setProperty('resolution', v2_0.set(dw, dh), 0);
             this.logoMat.setProperty('scale', v2_0.set(scaleX, scaleY), 0);
             this.logoMat.setProperty('translate', v2_0.set(dw * this.logoXTrans, logoYTrans), 0);

--- a/templates/wechatgame/first-screen.ejs
+++ b/templates/wechatgame/first-screen.ejs
@@ -95,7 +95,8 @@ let useLogo = <%= useLogo%>;
 let useDefaultLogo = <%= useDefaultLogo%>;
 let logoName = '<%= logoName %>';
 let bgName = '<%= bgName %>';
-let policy = '<%= policy %>';
+let fitWidth = <%= fitWidth %>;
+let fitHeight = <%= fitHeight %>;
 
 function initShaders(vshader, fshader) {
     return createProgram(vshader, fshader);
@@ -224,35 +225,31 @@ function updateSloganVertexBuffer() {
 function updateBgVertexBuffer() {
     let widthRatio = 1;
     let heightRatio = 1;
-    if(policy === 4) {
+    if(fitWidth && !fitHeight) {
         widthRatio = canvas.width;
         heightRatio = (canvas.width / bg.width) * bg.height;
-    } else if(policy === 3) {
+    } else if(!fitWidth && fitHeight) {
         widthRatio = (canvas.height / bg.height) * bg.width;
         heightRatio = canvas.height;
-    } else if(policy === 2) {
+    } else if(fitWidth && fitHeight) {
         if(canvas.width > canvas.height) {
             widthRatio = (canvas.height / bg.height) * bg.width;
             heightRatio = canvas.height;
-            console.log('qqqq    1');
         } else {
             widthRatio = canvas.width;
             heightRatio = (canvas.width / bg.width) * bg.height;
-            console.log('qqqq    2');
         }
-    } else if(policy === 1) {
+    } else if(!fitWidth && !fitHeight) {
         if((bg.width / bg.height) > (canvas.width / canvas.height)) {
             widthRatio = canvas.width;
             heightRatio = (canvas.width / bg.width) * bg.height;
-            console.log('qqqq    3');
         } else {
             widthRatio = (canvas.height / bg.height) * bg.width;
             heightRatio = canvas.height;
-            console.log('qqqq    4');
         }
     } else {
         widthRatio = canvas.width;
-        widthRatio = canvas.height;
+        heightRatio = canvas.height;
     }
     widthRatio /= canvas.width;
     heightRatio /= canvas.height;

--- a/templates/wechatgame/first-screen.ejs
+++ b/templates/wechatgame/first-screen.ejs
@@ -95,6 +95,7 @@ let useLogo = <%= useLogo%>;
 let useDefaultLogo = <%= useDefaultLogo%>;
 let logoName = '<%= logoName %>';
 let bgName = '<%= bgName %>';
+let policy = '<%= policy %>';
 
 function initShaders(vshader, fshader) {
     return createProgram(vshader, fshader);
@@ -191,16 +192,14 @@ function initProgressVertexBuffer() {
 }
 
 function updateVertexBuffer() {
-    // By default, maintain aspect ratio by constraining display at 200px height
-    const defaultRatio = 200 / image.height;
-    const widthRatio = image.width / canvas.width * 1.35 * defaultRatio * displayRatio;
-    const heightRatio = image.height / canvas.height * 1.35 * defaultRatio * displayRatio;
-    const heightOffset = 1/6; // canvas:(-1,1) -> (button, top); heightOffset = (5/12) * (-2) + 1 = 1/6
+    const heightRatio = 1.0 * 0.185 * displayRatio;
+    const widthRatio = image.width * (canvas.height * 0.185 / image.height) / canvas.width * displayRatio;
+    
     const vertices = new Float32Array([
-        widthRatio, heightOffset - heightRatio, 1.0, 1.0,
-        widthRatio, heightOffset + heightRatio, 1.0, 0.0,
-        -widthRatio, heightOffset - heightRatio, 0.0, 1.0,
-        -widthRatio, heightOffset + heightRatio, 0.0, 0.0,
+        widthRatio, -heightRatio, 1.0, 1.0,
+        widthRatio, heightRatio, 1.0, 0.0,
+        -widthRatio, -heightRatio, 0.0, 1.0,
+        -widthRatio, heightRatio, 0.0, 0.0,
     ]);
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
@@ -223,11 +222,46 @@ function updateSloganVertexBuffer() {
 }
 
 function updateBgVertexBuffer() {
+    let widthRatio = 1;
+    let heightRatio = 1;
+    if(policy === 4) {
+        widthRatio = canvas.width;
+        heightRatio = (canvas.width / bg.width) * bg.height;
+    } else if(policy === 3) {
+        widthRatio = (canvas.height / bg.height) * bg.width;
+        heightRatio = canvas.height;
+    } else if(policy === 2) {
+        if(canvas.width > canvas.height) {
+            widthRatio = (canvas.height / bg.height) * bg.width;
+            heightRatio = canvas.height;
+            console.log('qqqq    1');
+        } else {
+            widthRatio = canvas.width;
+            heightRatio = (canvas.width / bg.width) * bg.height;
+            console.log('qqqq    2');
+        }
+    } else if(policy === 1) {
+        if((bg.width / bg.height) > (canvas.width / canvas.height)) {
+            widthRatio = canvas.width;
+            heightRatio = (canvas.width / bg.width) * bg.height;
+            console.log('qqqq    3');
+        } else {
+            widthRatio = (canvas.height / bg.height) * bg.width;
+            heightRatio = canvas.height;
+            console.log('qqqq    4');
+        }
+    } else {
+        widthRatio = canvas.width;
+        widthRatio = canvas.height;
+    }
+    widthRatio /= canvas.width;
+    heightRatio /= canvas.height;
+
     const vertices = new Float32Array([
-        1.0, 1.0, 1.0, 1.0,
-        1.0, -1.0, 1.0, 0.0,
-        -1.0, 1.0, 0.0, 1.0,
-        -1.0, -1.0, 0.0, 0.0,
+        widthRatio, heightRatio, 1.0, 1.0,
+        widthRatio, -heightRatio, 1.0, 0.0,
+        -widthRatio, heightRatio, 0.0, 1.0,
+        -widthRatio, -heightRatio, 0.0, 0.0,
     ]);
     gl.bindBuffer(gl.ARRAY_BUFFER, bgVertexBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);

--- a/templates/wechatgame/first-screen.ejs
+++ b/templates/wechatgame/first-screen.ejs
@@ -232,20 +232,20 @@ function updateBgVertexBuffer() {
         widthRatio = (canvas.height / bg.height) * bg.width;
         heightRatio = canvas.height;
     } else if(fitWidth && fitHeight) {
-        if(canvas.width > canvas.height) {
-            widthRatio = (canvas.height / bg.height) * bg.width;
-            heightRatio = canvas.height;
-        } else {
+        if ((bg.width / bg.height) > (canvas.width / canvas.height)) {
             widthRatio = canvas.width;
             heightRatio = (canvas.width / bg.width) * bg.height;
+        } else {
+            widthRatio = (canvas.height / bg.height) * bg.width;
+            heightRatio = canvas.height;
         }
     } else if(!fitWidth && !fitHeight) {
-        if((bg.width / bg.height) > (canvas.width / canvas.height)) {
-            widthRatio = canvas.width;
-            heightRatio = (canvas.width / bg.width) * bg.height;
-        } else {
+        if ((bg.width / bg.height) > (canvas.width / canvas.height)) {
             widthRatio = (canvas.height / bg.height) * bg.width;
             heightRatio = canvas.height;
+        } else {
+            widthRatio = canvas.width;
+            heightRatio = (canvas.width / bg.width) * bg.height;
         }
     } else {
         widthRatio = canvas.width;


### PR DESCRIPTION
Re: #

### Changelog

https://github.com/cocos/3d-tasks/issues/18305#issuecomment-2205138839

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
