### PR TITLE
fix dangling reference caused by vector resize

### DIFF
--- a/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
@@ -228,23 +228,23 @@ void recreateTextureView(
 
 // NOLINTNEXTLINE(misc-no-recursion)
 void ResourceGraph::mount(gfx::Device* device, vertex_descriptor vertID) {
-    std::ignore = device;
     auto& resg = *this;
-    const auto& desc = get(ResourceGraph::DescTag{}, *this, vertID);
     visitObject(
         vertID, resg,
-        [&](const ManagedResource& resource) {
+        [](const ManagedResource& resource) {
             // to be removed
         },
-        [&](ManagedBuffer& buffer) {
+        [this, device, vertID](ManagedBuffer& buffer) {
             if (!buffer.buffer) {
+                const auto& desc = get(ResourceGraph::DescTag{}, *this, vertID);
                 auto info = getBufferInfo(desc);
                 buffer.buffer = device->createBuffer(info);
             }
             CC_ENSURES(buffer.buffer);
             buffer.fenceValue = nextFenceValue;
         },
-        [&](ManagedTexture& texture) {
+        [this, device, vertID, &resg](ManagedTexture& texture) {
+            const auto& desc = get(ResourceGraph::DescTag{}, *this, vertID);
             if (!texture.checkResource(desc)) {
                 auto info = getTextureInfo(desc);
                 texture.texture = device->createTexture(info);
@@ -262,25 +262,25 @@ void ResourceGraph::mount(gfx::Device* device, vertex_descriptor vertID) {
             CC_ENSURES(texture.texture);
             texture.fenceValue = nextFenceValue;
         },
-        [&](const PersistentBuffer& buffer) {
+        [](const PersistentBuffer& buffer) {
             CC_EXPECTS(buffer.buffer);
             std::ignore = buffer;
         },
-        [&](const PersistentTexture& texture) {
+        [](const PersistentTexture& texture) {
             CC_EXPECTS(texture.texture);
             std::ignore = texture;
         },
-        [&](const IntrusivePtr<gfx::Framebuffer>& fb) {
+        [](const IntrusivePtr<gfx::Framebuffer>& fb) {
             // deprecated
             CC_EXPECTS(false);
             CC_EXPECTS(fb);
             std::ignore = fb;
         },
-        [&](const RenderSwapchain& window) {
+        [](const RenderSwapchain& window) {
             CC_EXPECTS(window.swapchain || window.renderWindow);
             std::ignore = window;
         },
-        [&](const FormatView& view) { // NOLINT(misc-no-recursion)
+        [this, device, vertID, &resg](const FormatView& view) { // NOLINT(misc-no-recursion)
             std::ignore = view;
             auto parentID = parent(vertID, resg);
             CC_EXPECTS(parentID != resg.null_vertex());
@@ -292,9 +292,10 @@ void ResourceGraph::mount(gfx::Device* device, vertex_descriptor vertID) {
             CC_ENSURES(!resg.isTextureView(parentID));
             mount(device, parentID);
         },
-        [&](SubresourceView& view) { // NOLINT(misc-no-recursion)
+        [this, device, vertID, &resg](SubresourceView& view) { // NOLINT(misc-no-recursion)
             const auto [originView, parentID] = getOriginView(resg, vertID);
             mount(device, parentID); // NOLINT(misc-no-recursion)
+            const auto& desc = get(ResourceGraph::DescTag{}, *this, vertID);
             if (!isTextureEqual(view.textureView, desc)) {
                 recreateTextureView(device, *this, originView, parentID, view);
             }


### PR DESCRIPTION
Reference to object in vector was invalidated when vector is resized.

Reference creation is deferred after resizing.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
