### PR TITLE
Fix PhysicsContact.emit without rigidbody on one of colliders

### DIFF
--- a/cocos/physics-2d/box2d/physics-contact.ts
+++ b/cocos/physics-2d/box2d/physics-contact.ts
@@ -232,18 +232,18 @@ export class PhysicsContact implements IPhysics2DContact {
         const colliderA = this.colliderA;
         const colliderB = this.colliderB;
 
-        const bodyA = colliderA!.body;
-        const bodyB = colliderB!.body;
+        const hasListenerA = colliderA?.body?.enabledContactListener;
+        const hasListenerB = colliderB?.body?.enabledContactListener;
 
-        if (bodyA!.enabledContactListener) {
-            colliderA?.emit(contactType, colliderA, colliderB, this);
+        if (hasListenerA) {
+            colliderA.emit(contactType, colliderA, colliderB, this);
         }
 
-        if (bodyB!.enabledContactListener) {
-            colliderB?.emit(contactType, colliderB, colliderA, this);
+        if (hasListenerB) {
+            colliderB.emit(contactType, colliderB, colliderA, this);
         }
 
-        if (bodyA!.enabledContactListener || bodyB!.enabledContactListener) {
+        if (hasListenerA || hasListenerB) {
             PhysicsSystem2D.instance.emit(contactType, colliderA, colliderB, this);
         }
 
@@ -253,7 +253,7 @@ export class PhysicsContact implements IPhysics2DContact {
         }
     }
 
-    setEnabled (value): void {
+    setEnabled (value: boolean): void {
         this._b2contact!.SetEnabled(value);
     }
 
@@ -261,7 +261,7 @@ export class PhysicsContact implements IPhysics2DContact {
         return this._b2contact!.IsTouching();
     }
 
-    setTangentSpeed (value): void {
+    setTangentSpeed (value: number): void {
         this._b2contact!.SetTangentSpeed(value);
     }
 
@@ -269,7 +269,7 @@ export class PhysicsContact implements IPhysics2DContact {
         return this._b2contact!.GetTangentSpeed();
     }
 
-    setFriction (value): void {
+    setFriction (value: number): void {
         this._b2contact!.SetFriction(value);
     }
 
@@ -281,7 +281,7 @@ export class PhysicsContact implements IPhysics2DContact {
         return this._b2contact!.ResetFriction();
     }
 
-    setRestitution (value): void {
+    setRestitution (value: number): void {
         this._b2contact!.SetRestitution(value);
     }
 


### PR DESCRIPTION
Re: #

Without this fix, error will happen when:
1. One of colliders has enabledContactListener=true
2. One of colliders has no RigidBody2D component on it

### Changelog

* PhysicsContact.emit will not fail when one of colliders has no rigidbody attached to it

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [x] Your pull request title is using English, it's precise and appropriate.
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [x] Document new code with comments in source code based on API docs
- [x] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
