### PR TITLE
fixed #17051: [native] Keep the same behavior of Promise rejection and multiple resolve as nodejs and web.

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/ScriptEngine.h
+++ b/native/cocos/bindings/jswrapper/v8/ScriptEngine.h
@@ -370,7 +370,7 @@ private:
     #endif
     );
     static void onMessageCallback(v8::Local<v8::Message> message, v8::Local<v8::Value> data);
-    static void onPromiseRejectCallback(v8::PromiseRejectMessage msg);
+    static void onPromiseRejectCallback(v8::PromiseRejectMessage data);
 
     /**
      *  @brief Load the bytecode file and set the return value


### PR DESCRIPTION
And keep the same stack format as  web.

## Test code
```ts
function test1() {
    return new Promise(r => {
        a.a.a.a = 100;
      setTimeout(() => {
        r('first=');
        
      }, 1000);
    });
  }
  
  function test2() {
    return new Promise(r => {
      setTimeout(() => {
        r('second=');
      }, 2000);
    });
  }
  async function main() {
    // try {
      const p = await Promise.race([test1(), test2()])
    //   console.log('p===', p)
    // } catch (error) {
    //   console.log('error===', error)
    // }
  }
   

@ccclass('Test')
export class Test extends Component {
    start() {
        // this.doTest();

        main();

        setTimeout(()=>{
            b.b.b.b = 100;
        }, 1000);
        
    }
}
```

## Output log (Old behavior):
```
Uncaught Exception:
 - location :  
 - msg : resolveAfterPromiseResolved
 - detail : 
```

## Output log (Merge this PR)

```
assets/main/index.js:1983:10: ReferenceError: a is not defined
          a.a.a.a = 100;
          ^
ReferenceError: a is not defined
    at assets/main/index.js:1983:11
    at new Promise (<anonymous>)
    at test1 (assets/main/index.js:1982:16)
    at main (assets/main/index.js:1998:39)
    at Test.start (assets/main/index.js:2009:11)
    at eval (eval at createInvokeImplJit (src/cocos-js/_virtual_cc-020793ec.js:31703:63), <anonymous>:3:65)
    at OneOffInvoker._invoke (src/cocos-js/_virtual_cc-020793ec.js:31710:13)
    at OneOffInvoker.invoke (src/cocos-js/_virtual_cc-020793ec.js:31656:16)
    at ComponentScheduler.startPhase (src/cocos-js/_virtual_cc-020793ec.js:31817:29)
    at Director.tick (src/cocos-js/_virtual_cc-020793ec.js:35919:35)
```


Re: #17051

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
