### PR TITLE
Fixed an error when stopping previewing while particles are hidden

### DIFF
--- a/cocos/particle-2d/particle-simulator-2d.ts
+++ b/cocos/particle-2d/particle-simulator-2d.ts
@@ -140,7 +140,7 @@ export class Simulator {
         const particles = this.particles;
         for (let id = 0; id < particles.length; ++id) pool.put(particles[id]);
         particles.length = 0;
-        this.renderData.resize(0, 0);
+        if (this.renderData) this.renderData.resize(0, 0);
     }
 
     public emitParticle (pos): void {


### PR DESCRIPTION
Re: #

### Changelog

*  Fixed an error caused by no data during switching when the particle was in a hidden state

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

- Added null check for `this.renderData` in `reset()` method of `Simulator` class
- Prevents errors when stopping preview while particles are hidden
- Improves stability in `/cocos/particle-2d/particle-simulator-2d.ts`

<!-- /greptile_comment -->