### PR TITLE
Fix the issue where the completeListener in Spine does not trigger multiple times

### DIFF
--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -697,6 +697,7 @@ export class Skeleton extends UIRenderer {
     public onDestroy (): void {
         if (this._eventListenerID > 0) {
             TrackEntryListeners.removeListener(this._eventListenerID);
+            this._eventListenerID = -1;
         }
         this._drawList.destroy();
         this.destroyRenderData();

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -311,6 +311,7 @@ export class Skeleton extends UIRenderer {
     _iBuffer: Uint8Array | null = null;
     _model: any;
     _tempColor: TempColor = { r: 0, g: 0, b: 0, a: 0 };
+    private _eventListenerID: number = -1;
 
     constructor () {
         super();
@@ -694,6 +695,9 @@ export class Skeleton extends UIRenderer {
     }
 
     public onDestroy (): void {
+        if (this._eventListenerID > 0) {
+            TrackEntryListeners.removeListener(this._eventListenerID);
+        }
         this._drawList.destroy();
         this.destroyRenderData();
         this._cleanMaterialCache();
@@ -1689,8 +1693,8 @@ export class Skeleton extends UIRenderer {
     protected _ensureListener (): void {
         if (!this._listener) {
             this._listener = new TrackEntryListeners();
-            const listenerID = TrackEntryListeners.addListener(this._listener);
-            this._instance!.setListener(listenerID);
+            this._eventListenerID = TrackEntryListeners.addListener(this._listener);
+            this._instance!.setListener(this._eventListenerID);
         }
     }
 

--- a/cocos/spine/track-entry-listeners.ts
+++ b/cocos/spine/track-entry-listeners.ts
@@ -78,7 +78,6 @@ export class TrackEntryListeners {
             if (listener.dispose) {
                 listener.dispose(entry);
             }
-            this._listenerSet.delete(id);
             break;
         case spine.EventType.complete:
             if (listener.complete) {
@@ -137,6 +136,10 @@ export class TrackEntryListeners {
         const id = ++_listener_ID;
         TrackEntryListeners._listenerSet.set(id, listener);
         return id;
+    }
+
+    static removeListener(id: number): void {
+        TrackEntryListeners._listenerSet.delete(id);
     }
 
     private static _listenerSet = new Map<number, TrackEntryListeners>();


### PR DESCRIPTION
Re: #
https://github.com/cocos/3d-tasks/issues/18376
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

- Removed listener deletion in 'dispose' case of `emitListener` method in `/cocos/spine/track-entry-listeners.ts`
- Allows completeListener in Spine to trigger multiple times
- Improves functionality for animations needing repeated complete events
- Listeners now persist instead of being removed after first trigger
- No changes to public API or backward compatibility

<!-- /greptile_comment -->