### PR TITLE
support default framebuffer depth stencil

### DIFF
--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -884,7 +884,11 @@ class DeviceRenderPass implements RecordingInterface {
                     rasterV.loadOp === LoadOp.LOAD ? AccessFlagBit.DEPTH_STENCIL_ATTACHMENT_WRITE : AccessFlagBit.NONE,
                     rasterV.storeOp === StoreOp.STORE ? AccessFlagBit.DEPTH_STENCIL_ATTACHMENT_WRITE : AccessFlagBit.NONE,
                 ));
-                if (!resTex.swapchain && !resTex.framebuffer) depthTex = resTex.texture!;
+                if (!resTex.swapchain && !resTex.framebuffer) {
+                    depthTex = resTex.texture!;
+                } else if (resTex.swapchain) {
+                    depthTex = resTex.swapchain.depthStencilTexture;
+                }
                 this._clearDepth = rasterV.clearColor.x;
                 this._clearStencil = rasterV.clearColor.y;
                 break;

--- a/cocos/rendering/custom/pipeline.ts
+++ b/cocos/rendering/custom/pipeline.ts
@@ -741,12 +741,18 @@ export interface BasicPipeline extends PipelineRuntime {
     containsResource (name: string): boolean;
     /**
      * @en Add or update render window to the pipeline.
-     * @zh 注册或更新渲染窗口(RenderWindow)
+     * If the render window is a swapchain and its default framebuffer contains depth stencil buffer,
+     * user should specify the name of the depth stencil buffer.
+     * If the depth stencil name is specified but the depth stencil buffer does not exist, a managed one will be created.
+     * @zh 注册或更新渲染窗口(RenderWindow)。
+     * 如果渲染窗口是交换链并且默认Framebuffer包含深度模板缓冲。用户需要指定深度模板缓冲的名字。
+     * 如果指定了深度模板缓冲的名字，但深度模板缓冲不存在，会创建一个托管的深度模板缓冲。
      * @param name @en Resource name @zh 资源名字
      * @param format @en Expected format of the render window @zh 期望的渲染窗口格式
      * @param width @en Expected width of the render window @zh 期望的渲染窗口宽度
      * @param height @en Expected height of the render window @zh 期望的渲染窗口高度
      * @param renderWindow @en The render window to add. @zh 需要注册的渲染窗口
+     * @param depthStencilName @en The name of the depth stencil buffer of the default framebuffer. @zh 默认Framebuffer的深度模板缓冲的名字
      * @returns Resource ID
      */
     addRenderWindow (
@@ -754,7 +760,8 @@ export interface BasicPipeline extends PipelineRuntime {
         format: Format,
         width: number,
         height: number,
-        renderWindow: RenderWindow): number;
+        renderWindow: RenderWindow,
+        depthStencilName?: string): number;
     /**
      * @deprecated Method will be removed in the future
      * @en Update render window information.
@@ -762,7 +769,10 @@ export interface BasicPipeline extends PipelineRuntime {
      * @zh 更新渲染窗口信息。当渲染窗口发生更新时，用户应通知管线。
      * @param renderWindow @en The render window to update. @zh 渲染窗口
      */
-    updateRenderWindow (name: string, renderWindow: RenderWindow): void;
+    updateRenderWindow (
+        name: string,
+        renderWindow: RenderWindow,
+        depthStencilName?: string): void;
     /**
      * @en Add or update 2D render target.
      * @zh 添加或更新2D渲染目标
@@ -1040,6 +1050,7 @@ export interface BasicPipeline extends PipelineRuntime {
      */
     addCopyPass (copyPairs: CopyPair[]): void;
     /**
+     * @deprecated Method will be removed in the future
      * @en Builtin reflection probe pass
      * @zh 添加内置环境光反射通道
      * @param camera @en Capturing camera @zh 用于捕捉的相机

--- a/cocos/rendering/custom/web-pipeline.ts
+++ b/cocos/rendering/custom/web-pipeline.ts
@@ -892,12 +892,40 @@ export class WebPipeline implements BasicPipeline {
     addCustomTexture (name: string, info: TextureInfo, type: string): number {
         throw new Error('Method not implemented.');
     }
-    addRenderWindow (name: string, format: Format, width: number, height: number, renderWindow: RenderWindow): number {
+    addRenderWindow (
+        name: string,
+        format: Format,
+        width: number,
+        height: number,
+        renderWindow: RenderWindow,
+        depthStencilName?: string,
+    ): number {
         const resID = this._resourceGraph.find(name);
         if (resID !== 0xFFFFFFFF) {
-            this.updateRenderWindow(name, renderWindow);
+            this.updateRenderWindow(name, renderWindow, depthStencilName);
             return resID;
         }
+        if (depthStencilName) {
+            if (renderWindow.swapchain) {
+                this.addDepthStencilImpl(
+                    depthStencilName,
+                    renderWindow.swapchain.depthStencilTexture.format,
+                    width,
+                    height,
+                    ResourceResidency.BACKBUFFER,
+                    renderWindow.swapchain,
+                );
+            } else {
+                this.addDepthStencilImpl(
+                    depthStencilName,
+                    Format.DEPTH_STENCIL,
+                    width,
+                    height,
+                    ResourceResidency.MANAGED,
+                );
+            }
+        }
+
         // Objects need to be held for a long time, so there is no need to use pool management
         const desc = new ResourceDesc();
         desc.dimension = ResourceDimension.TEXTURE2D;
@@ -908,7 +936,7 @@ export class WebPipeline implements BasicPipeline {
         desc.format = renderWindow.framebuffer.colorTextures[0]!.format;
         desc.flags = ResourceFlags.COLOR_ATTACHMENT;
 
-        if (renderWindow.swapchain === null) {
+        if (!renderWindow.swapchain) {
             assert(renderWindow.framebuffer.colorTextures.length === 1
                 && renderWindow.framebuffer.colorTextures[0] !== null);
             desc.sampleCount = renderWindow.framebuffer.colorTextures[0].info.samples;
@@ -916,7 +944,6 @@ export class WebPipeline implements BasicPipeline {
                 ResourceGraphValue.Framebuffer,
                 renderWindow.framebuffer,
                 name,
-
                 desc,
                 new ResourceTraits(ResourceResidency.EXTERNAL),
                 new ResourceStates(),
@@ -927,7 +954,6 @@ export class WebPipeline implements BasicPipeline {
                 ResourceGraphValue.Swapchain,
                 new RenderSwapchain(renderWindow.swapchain),
                 name,
-
                 desc,
                 new ResourceTraits(ResourceResidency.BACKBUFFER),
                 new ResourceStates(),
@@ -935,7 +961,7 @@ export class WebPipeline implements BasicPipeline {
             );
         }
     }
-    updateRenderWindow (name: string, renderWindow: RenderWindow): void {
+    updateRenderWindow (name: string, renderWindow: RenderWindow, depthStencilName?: string): void {
         const resId = this.resourceGraph.vertex(name);
         const desc = this.resourceGraph.getDesc(resId);
         desc.width = renderWindow.width;
@@ -943,6 +969,26 @@ export class WebPipeline implements BasicPipeline {
         const currFbo = this.resourceGraph._vertices[resId]._object;
         if (currFbo !== renderWindow.framebuffer) {
             this.resourceGraph._vertices[resId]._object = renderWindow.framebuffer;
+        }
+        if (depthStencilName) {
+            if (renderWindow.swapchain) {
+                this.addDepthStencilImpl(
+                    depthStencilName,
+                    renderWindow.swapchain.depthStencilTexture.format,
+                    renderWindow.width,
+                    renderWindow.height,
+                    ResourceResidency.BACKBUFFER,
+                    renderWindow.swapchain,
+                );
+            } else {
+                this.addDepthStencilImpl(
+                    depthStencilName,
+                    Format.DEPTH_STENCIL,
+                    renderWindow.width,
+                    renderWindow.height,
+                    ResourceResidency.MANAGED,
+                );
+            }
         }
     }
     updateStorageBuffer (name: string, size: number, format = Format.UNKNOWN): void {
@@ -961,11 +1007,11 @@ export class WebPipeline implements BasicPipeline {
         if (format !== Format.UNKNOWN) desc.format = format;
     }
     updateDepthStencil (name: string, width: number, height: number, format: Format = Format.UNKNOWN): void {
-        const resId = this.resourceGraph.vertex(name);
-        const desc = this.resourceGraph.getDesc(resId);
-        desc.width = width;
-        desc.height = height;
-        if (format !== Format.UNKNOWN) desc.format = format;
+        const resId = this.resourceGraph.find(name);
+        if (resId === 0xFFFFFFFF) {
+            return;
+        }
+        this.updateDepthStencilImpl(resId, width, height, format);
     }
     updateStorageTexture (name: string, width: number, height: number, format = Format.UNKNOWN): void {
         const resId = this.resourceGraph.vertex(name);
@@ -1406,17 +1452,43 @@ export class WebPipeline implements BasicPipeline {
             ResourceGraphValue.Managed,
             new ManagedResource(),
             name,
-
             desc,
             new ResourceTraits(residency),
             new ResourceStates(),
             new SamplerInfo(Filter.LINEAR, Filter.LINEAR, Filter.NONE, Address.CLAMP, Address.CLAMP, Address.CLAMP),
         );
     }
-    addDepthStencil (name: string, format: Format, width: number, height: number, residency = ResourceResidency.MANAGED): number {
+    updateDepthStencilImpl (
+        resId: number,
+        width: number,
+        height: number,
+        format: Format,
+        swapchain?: Swapchain,
+    ): void {
+        const desc = this.resourceGraph.getDesc(resId);
+        desc.width = width;
+        desc.height = height;
+        if (swapchain) {
+            assert(this.resourceGraph.id(resId) === ResourceGraphValue.Swapchain);
+            const sc = this.resourceGraph.getSwapchain(resId);
+            assert(!!sc.swapchain);
+            sc.swapchain = swapchain;
+            desc.format = sc.swapchain.depthStencilTexture.format;
+        } else if (format !== Format.UNKNOWN) {
+            desc.format = format;
+        }
+    }
+    addDepthStencilImpl (
+        name: string,
+        format: Format,
+        width: number,
+        height: number,
+        residency: ResourceResidency,
+        swapchain?: Swapchain,
+    ): number {
         const resID = this._resourceGraph.find(name);
         if (resID !== 0xFFFFFFFF) {
-            this.updateDepthStencil(name, width, height, format);
+            this.updateDepthStencilImpl(resID, width, height, format, swapchain);
             return resID;
         }
         const desc = new ResourceDesc();
@@ -1428,16 +1500,32 @@ export class WebPipeline implements BasicPipeline {
         desc.format = format;
         desc.sampleCount = SampleCount.X1;
         desc.flags = ResourceFlags.DEPTH_STENCIL_ATTACHMENT | ResourceFlags.SAMPLED;
-        return this._resourceGraph.addVertex<ResourceGraphValue.Managed>(
-            ResourceGraphValue.Managed,
-            new ManagedResource(),
-            name,
 
-            desc,
-            new ResourceTraits(residency),
-            new ResourceStates(),
-            new SamplerInfo(Filter.POINT, Filter.POINT, Filter.NONE),
-        );
+        if (swapchain) {
+            assert(residency === ResourceResidency.BACKBUFFER);
+            return this._resourceGraph.addVertex<ResourceGraphValue.Swapchain>(
+                ResourceGraphValue.Swapchain,
+                new RenderSwapchain(swapchain),
+                name,
+                desc,
+                new ResourceTraits(residency),
+                new ResourceStates(),
+                new SamplerInfo(Filter.POINT, Filter.POINT, Filter.NONE),
+            );
+        } else {
+            return this._resourceGraph.addVertex<ResourceGraphValue.Managed>(
+                ResourceGraphValue.Managed,
+                new ManagedResource(),
+                name,
+                desc,
+                new ResourceTraits(residency),
+                new ResourceStates(),
+                new SamplerInfo(Filter.POINT, Filter.POINT, Filter.NONE),
+            );
+        }
+    }
+    addDepthStencil (name: string, format: Format, width: number, height: number, residency = ResourceResidency.MANAGED): number {
+        return this.addDepthStencilImpl(name, format, width, height, residency);
     }
     addStorageTexture (name: string, format: Format, width: number, height: number, residency = ResourceResidency.MANAGED): number {
         const resID = this._resourceGraph.find(name);
@@ -1457,7 +1545,6 @@ export class WebPipeline implements BasicPipeline {
             ResourceGraphValue.Managed,
             new ManagedResource(),
             name,
-
             desc,
             new ResourceTraits(residency),
             new ResourceStates(),
@@ -1483,7 +1570,6 @@ export class WebPipeline implements BasicPipeline {
             ResourceGraphValue.Managed,
             new ManagedResource(),
             name,
-
             desc,
             new ResourceTraits(residency),
             new ResourceStates(),

--- a/editor/assets/default_renderpipeline/builtin-pipeline.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline.ts
@@ -88,7 +88,6 @@ function getCsmMainLightViewport(
 }
 
 class PipelineConfigs {
-    gfxAPI: gfx.API = gfx.API.UNKNOWN;
     isWeb = false;
     isWebGL1 = false;
     isWebGPU = false;
@@ -114,10 +113,9 @@ function setupPipelineConfigs(
     const sampleFeature = FormatFeatureBit.SAMPLED_TEXTURE | FormatFeatureBit.LINEAR_FILTER;
     const device = ppl.device;
     // Platform
-    configs.gfxAPI = device.gfxAPI;
     configs.isWeb = !sys.isNative;
-    configs.isWebGL1 = configs.gfxAPI === gfx.API.WEBGL;
-    configs.isWebGPU = configs.gfxAPI === gfx.API.WEBGPU;
+    configs.isWebGL1 = device.gfxAPI === gfx.API.WEBGL;
+    configs.isWebGPU = device.gfxAPI === gfx.API.WEBGPU;
     configs.isMobile = sys.isMobile;
 
     // Rendering

--- a/editor/assets/default_renderpipeline/builtin-pipeline.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline.ts
@@ -1215,7 +1215,7 @@ if (rendering) {
             easuPass.addRenderTarget(fsrColorName, LoadOp.CLEAR, StoreOp.STORE, this._clearColorTransparentBlack);
             easuPass.addTexture(ldrColorName, 'outputResultMap');
             easuPass.setVec4('g_platform', this._configs.platform);
-            easuPass.setVec4('texSize', this._fsrTexSize);
+            easuPass.setVec4('fsrTexSize', this._fsrTexSize);
             easuPass
                 .addQueue(QueueHint.OPAQUE)
                 .addFullscreenQuad(fsrMaterial, 0);
@@ -1224,7 +1224,7 @@ if (rendering) {
             rcasPass.addRenderTarget(colorName, LoadOp.CLEAR, StoreOp.STORE, this._clearColorTransparentBlack);
             rcasPass.addTexture(fsrColorName, 'outputResultMap');
             rcasPass.setVec4('g_platform', this._configs.platform);
-            rcasPass.setVec4('texSize', this._fsrTexSize);
+            rcasPass.setVec4('fsrTexSize', this._fsrTexSize);
             rcasPass.setVec4('fsrParams', this._fsrParams);
             rcasPass
                 .addQueue(QueueHint.OPAQUE)

--- a/editor/assets/default_renderpipeline/builtin-pipeline.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline.ts
@@ -92,7 +92,6 @@ class PipelineConfigs {
     isWeb = false;
     isWebGL1 = false;
     isWebGPU = false;
-    isOpenGLFamily = false;
     isMobile = false;
     isHDR = false;
     useFloatOutput = false;
@@ -119,10 +118,6 @@ function setupPipelineConfigs(
     configs.isWeb = !sys.isNative;
     configs.isWebGL1 = configs.gfxAPI === gfx.API.WEBGL;
     configs.isWebGPU = configs.gfxAPI === gfx.API.WEBGPU;
-    configs.isOpenGLFamily = configs.gfxAPI === gfx.API.WEBGL
-        || configs.gfxAPI === gfx.API.WEBGL2
-        || configs.gfxAPI === gfx.API.GLES2
-        || configs.gfxAPI === gfx.API.GLES3;
     configs.isMobile = sys.isMobile;
 
     // Rendering
@@ -149,8 +144,6 @@ const defaultSettings = makePipelineSettings();
 class CameraConfigs {
     colorName = '';
     depthStencilName = '';
-    isDefaultFramebuffer = false;
-    defaultFramebufferHasDepthStencil = false;
     enableMainLightShadowMap = false;
     enableMainLightPlanarShadowMap = false;
     enablePostProcess = false;
@@ -206,10 +199,6 @@ function setupCameraConfigs(
 
     cameraConfigs.colorName = window.colorName;
     cameraConfigs.depthStencilName = window.depthStencilName;
-    cameraConfigs.isDefaultFramebuffer = !!window.swapchain;
-    cameraConfigs.defaultFramebufferHasDepthStencil
-        = cameraConfigs.isDefaultFramebuffer
-        && pipelineConfigs.isOpenGLFamily;
 
     cameraConfigs.useFullPipeline = (camera.visibility & (Layers.Enum.DEFAULT)) !== 0;
 
@@ -977,8 +966,7 @@ if (rendering) {
 
             // bind depth stencil buffer
             if (DEBUG) {
-                if (this._cameraConfigs.defaultFramebufferHasDepthStencil &&
-                    colorName === this._cameraConfigs.colorName &&
+                if (colorName === this._cameraConfigs.colorName &&
                     depthStencilName !== this._cameraConfigs.depthStencilName) {
                     warn('Default framebuffer cannot use custom depth stencil buffer');
                 }

--- a/editor/assets/effects/pipeline/post-process/fsr1.effect
+++ b/editor/assets/effects/pipeline/post-process/fsr1.effect
@@ -26,9 +26,9 @@ CCProgram vs %{
 }%
 
 CCProgram ubo %{
-    #pragma rate PostUBO pass
-    uniform PostUBO {
-        vec4 texSize;
+    #pragma rate FsrUBO pass
+    uniform FsrUBO {
+        vec4 fsrTexSize;
         vec4 fsrParams;
     };
     #pragma rate outputResultMap pass
@@ -44,7 +44,7 @@ CCProgram fs-easu %{
   #include <ubo>
 
   vec4 FsrRcasLoadF(vec2 p) {
-    vec4 color = texture(outputResultMap, p/texSize.zw);
+    vec4 color = texture(outputResultMap, p/fsrTexSize.zw);
     return color;
   }
   vec3 FsrEasuCF(vec2 p) {
@@ -58,10 +58,10 @@ CCProgram fs-easu %{
     vec4 con0, con1, con2, con3;
 
     // "rendersize" refers to size of source image before upscaling.
-    vec2 rendersize = texSize.xy;
+    vec2 rendersize = fsrTexSize.xy;
     FsrEasuCon(
       con0, con1, con2, con3,
-      rendersize, rendersize, texSize.zw
+      rendersize, rendersize, fsrTexSize.zw
     );
     FsrEasuF(c, gl_FragCoord.xy, con0, con1, con2, con3);
     float alpha = texture(outputResultMap, v_uv).a;
@@ -79,7 +79,7 @@ CCProgram fs-rcas %{
   #include <ubo>
 
   vec4 FsrRcasLoadF(vec2 p) {
-    vec4 color = texture(outputResultMap, p/texSize.zw);
+    vec4 color = texture(outputResultMap, p/fsrTexSize.zw);
     return color;
   }
   vec3 FsrEasuCF(vec2 p) {

--- a/editor/assets/effects/pipeline/post-process/fxaa-hq1.effect
+++ b/editor/assets/effects/pipeline/post-process/fxaa-hq1.effect
@@ -20,6 +20,7 @@ CCProgram fxaa-vs %{
 CCProgram fxaa-edge-fs %{
   precision highp float;
   precision mediump int;
+  #include <common/common-define>
 
   //#define FXAA_PRESET 5
   #include <post-process/fxaa-hq>

--- a/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
@@ -1626,8 +1626,8 @@ public:
     bool getEnableCpuLightCulling() const override;
     void setEnableCpuLightCulling(bool enable) override;
     bool containsResource(const ccstd::string &name) const override;
-    uint32_t addRenderWindow(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow *renderWindow) override;
-    void updateRenderWindow(const ccstd::string &name, scene::RenderWindow *renderWindow) override;
+    uint32_t addRenderWindow(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow *renderWindow, const ccstd::string &depthStencilName) override;
+    void updateRenderWindow(const ccstd::string &name, scene::RenderWindow *renderWindow, const ccstd::string &depthStencilName) override;
     uint32_t addRenderTarget(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) override;
     uint32_t addDepthStencil(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, ResourceResidency residency) override;
     void updateRenderTarget(const ccstd::string &name, uint32_t width, uint32_t height, gfx::Format format) override;
@@ -1699,6 +1699,7 @@ public:
     mutable PmrFlatMap<BuiltinCascadedShadowMapKey, BuiltinCascadedShadowMap> builtinCSMs;
     PipelineStatistics statistics;
     PipelineCustomization custom;
+    bool defaultFramebufferHasDepthStencil{false};
 };
 
 class NativeProgramProxy final : public ProgramProxy {

--- a/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
@@ -27,10 +27,10 @@
 #include "RenderGraphGraphs.h"
 #include "RenderGraphTypes.h"
 #include "cocos/renderer/gfx-base/GFXDevice.h"
+#include "cocos/scene/RenderWindow.h"
 #include "details/Range.h"
 #include "gfx-base/GFXDef-common.h"
 #include "pipeline/custom/RenderCommonFwd.h"
-#include "cocos/scene/RenderWindow.h"
 
 namespace cc {
 
@@ -159,7 +159,7 @@ gfx::TextureViewInfo getTextureViewInfo(const SubresourceView& subresView, gfx::
     };
 }
 
-bool isTextureEqual(const gfx::Texture *texture, const ResourceDesc& desc) {
+bool isTextureEqual(const gfx::Texture* texture, const ResourceDesc& desc) {
     if (!texture) {
         return false;
     }
@@ -400,7 +400,13 @@ gfx::Texture* ResourceGraph::getTexture(vertex_descriptor resID) {
         },
         [&](const RenderSwapchain& sc) {
             if (sc.swapchain) {
-                texture = sc.swapchain->getColorTexture();
+                const auto format = get(ResourceGraph::DescTag{}, *this, resID).format;
+                CC_EXPECTS(format != gfx::Format::UNKNOWN);
+                if (format == gfx::Format::DEPTH || format == gfx::Format::DEPTH_STENCIL) {
+                    texture = sc.swapchain->getDepthStencilTexture();
+                } else {
+                    texture = sc.swapchain->getColorTexture();
+                }
             } else {
                 CC_EXPECTS(sc.renderWindow);
                 const auto& fb = sc.renderWindow->getFramebuffer();

--- a/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
@@ -867,15 +867,21 @@ public:
     virtual bool containsResource(const ccstd::string &name) const = 0;
     /**
      * @en Add or update render window to the pipeline.
-     * @zh 注册或更新渲染窗口(RenderWindow)
+     * If the render window is a swapchain and its default framebuffer contains depth stencil buffer,
+     * user should specify the name of the depth stencil buffer.
+     * If the depth stencil name is specified but the depth stencil buffer does not exist, a managed one will be created.
+     * @zh 注册或更新渲染窗口(RenderWindow)。
+     * 如果渲染窗口是交换链并且默认Framebuffer包含深度模板缓冲。用户需要指定深度模板缓冲的名字。
+     * 如果指定了深度模板缓冲的名字，但深度模板缓冲不存在，会创建一个托管的深度模板缓冲。
      * @param name @en Resource name @zh 资源名字
      * @param format @en Expected format of the render window @zh 期望的渲染窗口格式
      * @param width @en Expected width of the render window @zh 期望的渲染窗口宽度
      * @param height @en Expected height of the render window @zh 期望的渲染窗口高度
      * @param renderWindow @en The render window to add. @zh 需要注册的渲染窗口
+     * @param depthStencilName @en The name of the depth stencil buffer of the default framebuffer. @zh 默认Framebuffer的深度模板缓冲的名字
      * @returns Resource ID
      */
-    virtual uint32_t addRenderWindow(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow *renderWindow) = 0;
+    virtual uint32_t addRenderWindow(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow *renderWindow, const ccstd::string &depthStencilName) = 0;
     /**
      * @deprecated Method will be removed in the future
      * @en Update render window information.
@@ -883,7 +889,7 @@ public:
      * @zh 更新渲染窗口信息。当渲染窗口发生更新时，用户应通知管线。
      * @param renderWindow @en The render window to update. @zh 渲染窗口
      */
-    virtual void updateRenderWindow(const ccstd::string &name, scene::RenderWindow *renderWindow) = 0;
+    virtual void updateRenderWindow(const ccstd::string &name, scene::RenderWindow *renderWindow, const ccstd::string &depthStencilName) = 0;
     /**
      * @en Add or update 2D render target.
      * @zh 添加或更新2D渲染目标
@@ -1090,6 +1096,7 @@ public:
      */
     virtual void addCopyPass(const ccstd::vector<CopyPair> &copyPairs) = 0;
     /**
+     * @deprecated Method will be removed in the future
      * @en Builtin reflection probe pass
      * @zh 添加内置环境光反射通道
      * @param camera @en Capturing camera @zh 用于捕捉的相机
@@ -1099,6 +1106,12 @@ public:
      * @engineInternal
      */
     virtual gfx::DescriptorSetLayout *getDescriptorSetLayout(const ccstd::string &shaderName, UpdateFrequency freq) = 0;
+    uint32_t addRenderWindow(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height, scene::RenderWindow *renderWindow) {
+        return addRenderWindow(name, format, width, height, renderWindow, "");
+    }
+    void updateRenderWindow(const ccstd::string &name, scene::RenderWindow *renderWindow) {
+        updateRenderWindow(name, renderWindow, "");
+    }
     uint32_t addRenderTarget(const ccstd::string &name, gfx::Format format, uint32_t width, uint32_t height) {
         return addRenderTarget(name, format, width, height, ResourceResidency::MANAGED);
     }


### PR DESCRIPTION
1. `addRenderWindow` now accepts `depthStencilName` parameter.
When `depthStencilName` is specified, a depth stencil resource will be added to resource graph:
* If default framebuffer has depth stencil, register it in the resource graph.
* If default framebuffer has no depth stencil, register a managed depth stencil in the resource graph.

2. Fixed FSR, rename the UBO to avoid conflicts(Web only). It needs further investigation. 
3. Fixed FXAA missing includes.
4. Lint

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Enhanced the default framebuffer handling in the rendering pipeline to improve flexibility and robustness across different graphics APIs and framebuffer configurations.

- Modified `cocos/rendering/custom/web-pipeline.ts` to introduce `tryAddRenderWindowDepthStencil` for flexible depth stencil buffer management.
- Updated `addRenderWindow` and `updateRenderWindow` methods in `cocos/rendering/custom/web-pipeline.ts` to utilize the new `tryAddRenderWindowDepthStencil` method.
- Ensured correct depth texture assignment in `cocos/rendering/custom/executor.ts` based on swapchain or framebuffer presence.
- Added support for specifying a depth stencil buffer name in `cocos/rendering/custom/pipeline.ts`.
- Enhanced framebuffer and render pass handling in `native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp` and `NativePipeline.cpp`.

<!-- /greptile_comment -->