### PR TITLE
fix bug: in editor, when switch the button transition Type from Color to Sprite and to Scale, back to Color, the default Normal Color will be black

### DIFF
--- a/cocos/ui/button.ts
+++ b/cocos/ui/button.ts
@@ -628,9 +628,6 @@ export class Button extends Component {
     }
 
     public update (dt: number): void {
-        if (EDITOR_NOT_IN_PREVIEW) {
-            return;
-        }
         const target = this.target;
         if (this._transitionFinished || !target) {
             return;
@@ -942,8 +939,9 @@ export class Button extends Component {
             return;
         }
 
-        if (EDITOR || state === State.DISABLED) {
+        if (EDITOR_NOT_IN_PREVIEW || state === State.DISABLED) {
             renderComp.color = color;
+            this._transitionFinished = true;
         } else {
             this._fromColor = renderComp.color.clone();
             this._toColor = color;

--- a/cocos/ui/button.ts
+++ b/cocos/ui/button.ts
@@ -628,7 +628,7 @@ export class Button extends Component {
     }
 
     public update (dt: number): void {
-        if (EDITOR){
+        if (EDITOR) {
             return;
         }
         const target = this.target;

--- a/cocos/ui/button.ts
+++ b/cocos/ui/button.ts
@@ -628,7 +628,7 @@ export class Button extends Component {
     }
 
     public update (dt: number): void {
-        if (EDITOR) {
+        if (EDITOR_NOT_IN_PREVIEW) {
             return;
         }
         const target = this.target;

--- a/cocos/ui/button.ts
+++ b/cocos/ui/button.ts
@@ -628,6 +628,9 @@ export class Button extends Component {
     }
 
     public update (dt: number): void {
+        if (EDITOR){
+            return;
+        }
         const target = this.target;
         if (this._transitionFinished || !target) {
             return;


### PR DESCRIPTION
in editor, when switch the button transition Type from Color to Sprite and to Scale, back to Color, the default Normal Color will be black

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

The pull request addresses a bug in the editor where switching the button transition type from Color to Sprite and Scale, and then back to Color, caused the default Normal Color to revert to black.

- Replaced `EDITOR` constant with `EDITOR_NOT_IN_PREVIEW` in `update` method to prevent transition logic in editor mode.
- Ensured button's normal color does not revert to black when switching transition types in the editor.

File affected:
- `cocos/ui/button.ts`

<!-- /greptile_comment -->