### PR TITLE
fix render window attach camera and resize logic

### DIFF
--- a/cocos/render-scene/core/render-window.ts
+++ b/cocos/render-scene/core/render-window.ts
@@ -313,6 +313,11 @@ export class RenderWindow {
         }
         this._cameras.push(camera);
         this.sortCameras();
+
+        // This resize should only be handled by the render pipeline
+        // If the camera is attached to the render window,
+        // resize handler should be called to update render window resouces
+        this._isResized = true;
     }
 
     /**

--- a/cocos/rendering/custom/framework.ts
+++ b/cocos/rendering/custom/framework.ts
@@ -66,6 +66,8 @@ export function defaultWindowResize (ppl: BasicPipeline, window: RenderWindow, w
     ppl.addDepthStencil(`ShadowDepth${id}`, Format.DEPTH_STENCIL, shadowSize.x, shadowSize.y);
 }
 
+const _resizedWindows: RenderWindow[] = [];
+
 export function dispatchResizeEvents (cameras: Camera[], builder: PipelineBuilder, ppl: BasicPipeline): void {
     if (!builder.windowResize) {
         // No game window resize handler defined.
@@ -73,6 +75,9 @@ export function dispatchResizeEvents (cameras: Camera[], builder: PipelineBuilde
         return;
     }
 
+    // Resize all windows.
+    // Notice: A window might be resized multiple times with different cameras.
+    // User should avoid resource collision between different cameras.
     for (const camera of cameras) {
         if (!camera.window.isRenderWindowResized() && !forceResize) {
             continue;
@@ -82,8 +87,17 @@ export function dispatchResizeEvents (cameras: Camera[], builder: PipelineBuilde
         const height = Math.max(Math.floor(camera.window.height), 1);
 
         builder.windowResize(ppl, camera.window, camera, width, height);
-        camera.window.setRenderWindowResizeHandled();
+
+        _resizedWindows.push(camera.window);
     }
+
+    // Reset resize flags
+    for (const window of _resizedWindows) {
+        window.setRenderWindowResizeHandled();
+    }
+
+    // Clear resized windows
+    _resizedWindows.length = 0;
 
     // For editor preview
     forceResize = false;

--- a/native/cocos/scene/RenderWindow.cpp
+++ b/native/cocos/scene/RenderWindow.cpp
@@ -185,6 +185,11 @@ void RenderWindow::attachCamera(Camera *camera) {
     }
     _cameras.emplace_back(camera);
     sortCameras();
+
+    // This resize should only be handled by the render pipeline
+    // If the camera is attached to the render window,
+    // resize handler should be called to update render window resouces
+    _isResized = true;
 }
 
 void RenderWindow::detachCamera(Camera *camera) {


### PR DESCRIPTION
When a new camera is attached to the render window, the render window will be set resized. The custom pipeline will update all associated resources.

Fix window resize logic, it will be resized multiple times with different cameras. User should reuse render window's resource and avoid collision.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

The pull request improves the handling of render window resizing and camera attachment logic to prevent multiple resize operations and resource collisions.

- Added `_isResized` flag in `cocos/render-scene/core/render-window.ts` to track window resize state.
- Introduced `_resizedWindows` array in `cocos/rendering/custom/framework.ts` to manage resized windows and reset flags post-processing.
- Updated `attachCamera` method in `cocos/render-scene/core/render-window.ts` to set `_isResized` flag when a new camera is attached.
- Enhanced `dispatchResizeEvents` function in `cocos/rendering/custom/framework.ts` to handle multiple cameras and avoid redundant resizing.
- Modified `native/cocos/scene/RenderWindow.cpp` to align with the new resize and camera attachment logic.

<!-- /greptile_comment -->