### PR TITLE
Optimize particle-simulator-2d: Pre-normalize color components to reduce division operations

### DIFF
--- a/cocos/particle-2d/particle-simulator-2d.ts
+++ b/cocos/particle-2d/particle-simulator-2d.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { Vec2, Color, js, misc, random, IColorLike } from '../core';
+import { Vec2, Color, js, misc, random, IColorLike, Vec4 } from '../core';
 import { vfmtPosUvColor, getComponentPerVertex } from '../2d/renderer/vertex-format';
 import { PositionType, EmitterMode, START_SIZE_EQUAL_TO_END_SIZE, START_RADIUS_EQUAL_TO_END_RADIUS } from './define';
 import { ParticleSystem2D } from './particle-system-2d';
@@ -33,6 +33,7 @@ const _pos = new Vec2();
 const _tpa = new Vec2();
 const _tpb = new Vec2();
 const _tpc = new Vec2();
+const _col = new Vec4();
 
 const formatBytes = getComponentPerVertex(vfmtPosUvColor);
 
@@ -313,11 +314,19 @@ export class Simulator {
             vbuf[offset + 28] = y + halfHeight;
             vbuf[offset + 29] = 0;
         }
+
+        // normalize
+        const pcol = particle.color as IColorLike;
+        _col.x = pcol.r / 255;
+        _col.y = pcol.g / 255;
+        _col.z = pcol.b / 255;
+        _col.w = pcol.a / 255;
+
         // color
-        Color.toArray(vbuf, particle.color as IColorLike, offset + 5);
-        Color.toArray(vbuf, particle.color as IColorLike, offset + 14);
-        Color.toArray(vbuf, particle.color as IColorLike, offset + 23);
-        Color.toArray(vbuf, particle.color as IColorLike, offset + 32);
+        Vec4.toArray(vbuf, _col, offset + 5);
+        Vec4.toArray(vbuf, _col, offset + 14);
+        Vec4.toArray(vbuf, _col, offset + 23);
+        Vec4.toArray(vbuf, _col, offset + 32);
     }
 
     public step (dt: number): void {


### PR DESCRIPTION
Optimize particle color setup
Pre-normalize color components to reduce division operations

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Optimized the particle color setup in `particle-simulator-2d.ts` by pre-normalizing color components to reduce division operations, enhancing performance.

- Introduced `_col` as a new `Vec4` instance to store normalized color values.
- Updated the buffer with pre-normalized color values instead of performing multiple division operations.
- Modified `updateParticleBuffer` method to use `_col` for setting color values.
- Ensured backward compatibility by maintaining existing functionality while optimizing performance.

<!-- /greptile_comment -->