### PR TITLE
[feature, native] TextDecoder support to decode utf-16 buffer and create TextDecoder with "utf-8" and "utf8"

### DIFF
--- a/native/cocos/bindings/manual/jsb_global.cpp
+++ b/native/cocos/bindings/manual/jsb_global.cpp
@@ -29,6 +29,7 @@
 #include "base/DeferredReleasePool.h"
 #include "base/Scheduler.h"
 #include "base/ThreadPool.h"
+#include "base/UTF8.h"
 #include "base/ZipUtils.h"
 #include "base/base64.h"
 #include "bindings/auto/jsb_cocos_auto.h"
@@ -1288,14 +1289,8 @@ SE_BIND_FINALIZE_FUNC(js_TextEncoder_finalize)
 
 static bool js_TextEncoder_constructor(se::State &s) // NOLINT(readability-identifier-naming)
 {
-    const auto &args = s.args();
-    size_t argc = args.size();
-    if (argc > 0) {
-        if (args[0].isString() && args[0].toString() != "utf-8") {
-            CC_LOG_WARNING("TextEncoder only supports utf-8");
-        }
-    }
-    s.thisObject()->setProperty("encoding", se::Value{"utf-8"});
+    // https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/TextEncoder
+    // Since TextEncoder doesn't associate with a c++ object, set the private object to nullptr.
     s.thisObject()->setPrivateObject(nullptr);
     return true;
 }
@@ -1303,6 +1298,7 @@ SE_BIND_CTOR(js_TextEncoder_constructor, __jsb_TextEncoder_class, js_TextEncoder
 
 static bool js_TextEncoder_encode(se::State &s) // NOLINT(readability-identifier-naming)
 {
+    // https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode
     const auto &args = s.args();
     size_t argc = args.size();
 
@@ -1335,15 +1331,31 @@ static bool js_TextDecoder_constructor(se::State &s) // NOLINT(readability-ident
 {
     const auto &args = s.args();
     size_t argc = args.size();
+    ccstd::string encoding = "utf-8";
     if (argc > 0) {
-        if (args[0].isString() && args[0].toString() != "utf-8") {
-            CC_LOG_WARNING("TextDecoder only supports utf-8");
+        if (args[0].isString()) {
+            // https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings
+            // NOTE: We only support utf-8 encoding now.
+            auto label = args[0].toString();
+            
+            std::transform(label.begin(), label.end(), label.begin(), [](char c){
+                return std::tolower(c);
+            });
+            
+            if (label == "unicode-1-1-utf-8" || label == "utf-8" || label == "utf8") {
+                encoding = "utf-8";
+            } else if (label == "utf-16" || label == "utf-16le") {
+                encoding = "utf-16le";
+            } else {
+                CC_LOG_WARNING("TextDecoder only supports utf-8 and utf-16, but got: %s", label.c_str());
+            }
         }
     }
-    s.thisObject()->setProperty("encoding", se::Value{"utf-8"});
+    s.thisObject()->setProperty("encoding", se::Value{encoding});
     s.thisObject()->setProperty("fatal", se::Value{false});
     s.thisObject()->setProperty("ignoreBOM", se::Value{false});
-    s.thisObject()->setPrivateObject(nullptr); // FIXME: Don't need this line if https://github.com/cocos/3d-tasks/issues/11365 is done.
+    // Since TextDecoder doesn't associate with a c++ object, set the private object to nullptr.
+    s.thisObject()->setPrivateObject(nullptr);
     return true;
 }
 SE_BIND_CTOR(js_TextDecoder_constructor, __jsb_TextDecoder_class, js_TextDecoder_finalize)
@@ -1362,8 +1374,25 @@ static bool js_TextDecoder_decode(se::State &s) // NOLINT(readability-identifier
         bool ok = uint8ArrayObj->getTypedArrayData(&uint8ArrayData, &length);
         SE_PRECONDITION2(ok, false, "js_TextDecoder_decode, get typedarray data failed!");
 
-        ccstd::string str{reinterpret_cast<const char *>(uint8ArrayData), length};
-        s.rval().setString(str);
+        se::Value encodingVal;
+        s.thisObject()->getProperty("encoding", &encodingVal);
+        if (encodingVal.isString()) {
+            const auto &encoding = encodingVal.toString();
+            if (encoding == "utf-8") {
+                ccstd::string str{reinterpret_cast<const char *>(uint8ArrayData), length};
+                s.rval().setString(str);
+            } else if (encoding == "utf-16le") {
+                std::u16string u16Str{reinterpret_cast<const char16_t *>(uint8ArrayData), length / 2};
+                ccstd::string u8Str;
+                cc::StringUtils::UTF16ToUTF8(u16Str, u8Str);
+                s.rval().setString(u8Str);
+            } else {
+                SE_REPORT_ERROR("Wrong encoding: %s, only utf-8 & utf-16 are supported", encoding.c_str());
+            }
+        } else {
+            SE_REPORT_ERROR("TextDecoder.encoding is not a string");
+        }
+
         return true;
     }
 

--- a/native/cocos/bindings/manual/jsb_global.cpp
+++ b/native/cocos/bindings/manual/jsb_global.cpp
@@ -1335,9 +1335,10 @@ static bool js_TextDecoder_constructor(se::State &s) // NOLINT(readability-ident
     if (argc > 0) {
         if (args[0].isString()) {
             // https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings
-            // NOTE: We only support utf-8 encoding now.
+            // NOTE: We only support utf-8 and utf-16 encoding now.
             auto label = args[0].toString();
             
+            // Convert to lowercase to support 'UTF-8', 'UTF-16'
             std::transform(label.begin(), label.end(), label.begin(), [](char c){
                 return std::tolower(c);
             });


### PR DESCRIPTION
Fix a warning ( TextDecoder only supports utf-8 ) while using bullet wasm since it use "utf8" and "utf-16" decoder.

Refer to https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings

Re: #

## Test code

```js
{
    const decoder = new TextDecoder('utf-16');
    
    const str = "你好世界, hello world";
    
    const uint16Array = new Uint16Array(str.length);
    
    for (let i = 0; i < str.length; i++) {
        uint16Array[i] = str.charCodeAt(i);
    }
    
    console.log(uint16Array);
    
    const s = decoder.decode(uint16Array);
    
    console.log(s); // Should ouput 你好世界, hello world
}

{
    const decoder = new TextDecoder('utf-8');
       
    const s = decoder.decode(new Uint8Array([50, 51, 52]));
    
    console.log(s); // Should output 234
    
}
```

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Added support for `TextDecoder` to handle 'utf-16' and 'utf8' encodings, addressing a warning related to `TextDecoder` only supporting 'utf-8' when using bullet wasm.

- Modified `native/cocos/bindings/manual/jsb_global.cpp` to enhance `TextDecoder` constructor and `decode` method for 'utf-16' and 'utf8' support.
- Simplified `TextEncoder` constructor by removing unnecessary checks and setting the encoding property directly.
- Updated `native/cocos/base/UTF8.cpp` to ensure compatibility with the new encoding support.

<!-- /greptile_comment -->