### PR TITLE
减少对 get skeletonJsonStr 的调用, 优化性能

### DIFF
--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -210,19 +210,22 @@ export class SkeletonData extends Asset {
         const spData = spine.wasmUtil.querySpineSkeletonDataByUUID(this._uuid);
         if (spData) {
             this._skeletonCache = spData;
-        } else if (this.skeletonJsonStr) {
-            this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithJson(this.skeletonJsonStr, this._atlasText);
-            spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
         } else {
-            const rawData = new Uint8Array(this._nativeAsset);
-            const byteSize = rawData.length;
-            const ptr = spine.wasmUtil.queryStoreMemory(byteSize);
-            const wasmMem = spine.wasmUtil.wasm.HEAPU8.subarray(ptr, ptr + byteSize);
-            wasmMem.set(rawData);
-            this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithBinary(byteSize, this._atlasText);
-            spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
+            const jsonStr = this.skeletonJsonStr
+            if (jsonStr) {
+                this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithJson(jsonStr, this._atlasText);
+                spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
+            } else {
+                const rawData = new Uint8Array(this._nativeAsset);
+                const byteSize = rawData.length;
+                const ptr = spine.wasmUtil.queryStoreMemory(byteSize);
+                const wasmMem = spine.wasmUtil.wasm.HEAPU8.subarray(ptr, ptr + byteSize);
+                wasmMem.set(rawData);
+                this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithBinary(byteSize, this._atlasText);
+                spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
+            }
         }
-
+        
         return this._skeletonCache;
     }
 

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -225,7 +225,7 @@ export class SkeletonData extends Asset {
                 spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
             }
         }
-        
+
         return this._skeletonCache;
     }
 

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -211,7 +211,7 @@ export class SkeletonData extends Asset {
         if (spData) {
             this._skeletonCache = spData;
         } else {
-            const jsonStr = this.skeletonJsonStr
+            const jsonStr = this.skeletonJsonStr;
             if (jsonStr) {
                 this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithJson(jsonStr, this._atlasText);
                 spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -210,20 +210,17 @@ export class SkeletonData extends Asset {
         const spData = spine.wasmUtil.querySpineSkeletonDataByUUID(this._uuid);
         if (spData) {
             this._skeletonCache = spData;
+        } else if (this._skeletonJson) {
+            this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithJson(this.skeletonJsonStr, this._atlasText);
+            spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
         } else {
-            const jsonStr = this.skeletonJsonStr;
-            if (jsonStr) {
-                this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithJson(jsonStr, this._atlasText);
-                spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
-            } else {
-                const rawData = new Uint8Array(this._nativeAsset);
-                const byteSize = rawData.length;
-                const ptr = spine.wasmUtil.queryStoreMemory(byteSize);
-                const wasmMem = spine.wasmUtil.wasm.HEAPU8.subarray(ptr, ptr + byteSize);
-                wasmMem.set(rawData);
-                this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithBinary(byteSize, this._atlasText);
-                spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
-            }
+            const rawData = new Uint8Array(this._nativeAsset);
+            const byteSize = rawData.length;
+            const ptr = spine.wasmUtil.queryStoreMemory(byteSize);
+            const wasmMem = spine.wasmUtil.wasm.HEAPU8.subarray(ptr, ptr + byteSize);
+            wasmMem.set(rawData);
+            this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithBinary(byteSize, this._atlasText);
+            spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
         }
 
         return this._skeletonCache;

--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -125,10 +125,8 @@ const cacheManager = require('./jsb-cache-manager');
         }
         this._jsbTextures = jsbTextures;
 
-        let filePath = null;
-        if (this.skeletonJsonStr) {
-            filePath = this.skeletonJsonStr;
-        } else {
+        let filePath = this.skeletonJsonStr;
+        if (!filePath) {
             filePath = cacheManager.getCache(this.nativeUrl) || this.nativeUrl;
         }
         this._skeletonCache = spine.initSkeletonData(uuid, filePath, atlasText, jsbTextures, this.scale);


### PR DESCRIPTION
spine的json数据通常很大, 调用 JSON.stringify() 本身就比较耗时, 而且在stringify过程中 jvm会申请大量的临时内存, 进而产生后续的gc, 对性能有二次影响.

而  get skeletonJsonStr 中每次都去 调用 JSON.stringify()
```
    get skeletonJsonStr (): string {
        if (this._skeletonJson) {
            return JSON.stringify(this._skeletonJson);
        }
        return '';
    }
```
所以减少 skeletonJsonStr 的调用,  就可以减少  JSON.stringify() 的调用次数, 进而优化性能

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Optimized performance by reducing the number of `JSON.stringify()` calls when handling Spine skeleton JSON data.

- Modified `cocos/spine/skeleton-data.ts` to cache the JSON string representation of `_skeletonJson`.
- Added a check to use the cached JSON string if it exists, avoiding redundant `JSON.stringify()` calls.
- This change minimizes memory allocation and garbage collection overhead, improving performance with large JSON data.

<!-- /greptile_comment -->