### PR TITLE
Due to ByteDance platform's web audio mode, bufferSource playback can cause memory leaks; therefore, the default audio playback has been changed to use InnerAudioContext.

### DIFF
--- a/pal/audio/minigame/player.ts
+++ b/pal/audio/minigame/player.ts
@@ -66,11 +66,11 @@ export class AudioPlayer {
 
     static load (url: string, opts?: AudioLoadOptions): Promise<AudioPlayer> {
         return new Promise((resolve, reject) => {
-            if (typeof minigame.tt === 'object' && typeof minigame.tt.getAudioContext !== 'undefined') {
+            /*if (typeof minigame.tt === 'object' && typeof minigame.tt.getAudioContext !== 'undefined') {
                 AudioPlayerWeb.load(url).then((webPlayer) => {
                     resolve(new AudioPlayer(webPlayer));
                 }).catch(reject);
-            } else {
+            } else */{
                 AudioPlayerMinigame.load(url).then((minigamePlayer) => {
                     resolve(new AudioPlayer(minigamePlayer));
                 }).catch(reject);
@@ -81,19 +81,19 @@ export class AudioPlayer {
         this._player.destroy();
     }
     static loadNative (url: string, opts?: AudioLoadOptions): Promise<unknown> {
-        if (typeof minigame.tt === 'object' && typeof minigame.tt.getAudioContext !== 'undefined') {
+        /*if (typeof minigame.tt === 'object' && typeof minigame.tt.getAudioContext !== 'undefined') {
             return AudioPlayerWeb.loadNative(url);
-        }
+        }*/
         return AudioPlayerMinigame.loadNative(url);
     }
     static loadOneShotAudio (url: string, volume: number, opts?: AudioLoadOptions): Promise<OneShotAudio> {
         return new Promise((resolve, reject) => {
-            if (typeof minigame.tt === 'object' && typeof minigame.tt.getAudioContext !== 'undefined') {
+            /*if (typeof minigame.tt === 'object' && typeof minigame.tt.getAudioContext !== 'undefined') {
                 AudioPlayerWeb.loadOneShotAudio(url, volume).then((oneShotAudioWeb) => {
                     // HACK: AudioPlayer should be a friend class in OneShotAudio
                     resolve(new (OneShotAudio as any)(oneShotAudioWeb));
                 }).catch(reject);
-            } else {
+            } else */{
                 AudioPlayerMinigame.loadOneShotAudio(url, volume).then((oneShotAudioMinigame) => {
                     // HACK: AudioPlayer should be a friend class in OneShotAudio
                     resolve(new (OneShotAudio as any)(oneShotAudioMinigame));

--- a/pal/audio/minigame/player.ts
+++ b/pal/audio/minigame/player.ts
@@ -70,11 +70,11 @@ export class AudioPlayer {
                 AudioPlayerWeb.load(url).then((webPlayer) => {
                     resolve(new AudioPlayer(webPlayer));
                 }).catch(reject);
-            } else */{
-                AudioPlayerMinigame.load(url).then((minigamePlayer) => {
-                    resolve(new AudioPlayer(minigamePlayer));
-                }).catch(reject);
-            }
+            } else {*/
+            AudioPlayerMinigame.load(url).then((minigamePlayer) => {
+                resolve(new AudioPlayer(minigamePlayer));
+            }).catch(reject);
+            // }
         });
     }
     destroy (): void {
@@ -93,12 +93,13 @@ export class AudioPlayer {
                     // HACK: AudioPlayer should be a friend class in OneShotAudio
                     resolve(new (OneShotAudio as any)(oneShotAudioWeb));
                 }).catch(reject);
-            } else */{
-                AudioPlayerMinigame.loadOneShotAudio(url, volume).then((oneShotAudioMinigame) => {
-                    // HACK: AudioPlayer should be a friend class in OneShotAudio
-                    resolve(new (OneShotAudio as any)(oneShotAudioMinigame));
-                }).catch(reject);
-            }
+            } else {*/
+            AudioPlayerMinigame.loadOneShotAudio(url, volume).then((oneShotAudioMinigame) => {
+                // HACK: AudioPlayer should be a friend class in OneShotAudio
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                resolve(new (OneShotAudio as any)(oneShotAudioMinigame));
+            }).catch(reject);
+            //}
         });
     }
     static readonly maxAudioChannel = 10;


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

The default audio playback method has been changed to use `InnerAudioContext` to address memory leaks on the ByteDance platform.

- Modified `pal/audio/minigame/player.ts` to default to `AudioPlayerMinigame` for audio playback.
- Commented out conditional checks for ByteDance platform's web audio mode.
- Ensured `AudioPlayerMinigame` class uses `InnerAudioContext` for efficient memory management.
- Potential risk of breaking functionality on platforms previously using `AudioPlayerWeb`.
- Future cleanup needed for commented-out code to avoid confusion.

<!-- /greptile_comment -->