### PR TITLE
Reduce the frequency of looking up matrix elements within the loop, and  reduce the division operations for color setup

### DIFF
--- a/cocos/2d/assembler/sprite/simple.ts
+++ b/cocos/2d/assembler/sprite/simple.ts
@@ -73,20 +73,24 @@ export const simple: IAssembler = {
         const node = sprite.node;
         const m = node.worldMatrix;
 
+        const m00 = m.m00; const m01 = m.m01; const m02 = m.m02; const m03 = m.m03;
+        const m04 = m.m04; const m05 = m.m05; const m06 = m.m06; const m07 = m.m07;
+        const m12 = m.m12; const m13 = m.m13; const m14 = m.m14; const m15 = m.m15;
+
         const stride = renderData.floatStride;
         let offset = 0;
         const length = dataList.length;
-        for (let i = 0; i < length; i++) {
+        for (let i = 0; i < length; ++i) {
             const curData = dataList[i];
             const x = curData.x;
             const y = curData.y;
-            let rhw = m.m03 * x + m.m07 * y + m.m15;
+            let rhw = m03 * x + m07 * y + m15;
             rhw = rhw ? 1 / rhw : 1;
 
             offset = i * stride;
-            vData[offset + 0] = (m.m00 * x + m.m04 * y + m.m12) * rhw;
-            vData[offset + 1] = (m.m01 * x + m.m05 * y + m.m13) * rhw;
-            vData[offset + 2] = (m.m02 * x + m.m06 * y + m.m14) * rhw;
+            vData[offset + 0] = (m00 * x + m04 * y + m12) * rhw;
+            vData[offset + 1] = (m01 * x + m05 * y + m13) * rhw;
+            vData[offset + 2] = (m02 * x + m06 * y + m14) * rhw;
         }
     },
 

--- a/cocos/2d/assembler/sprite/sliced.ts
+++ b/cocos/2d/assembler/sprite/sliced.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { Color, Mat4 } from '../../../core';
+import { Color } from '../../../core';
 import { IRenderData, RenderData } from '../../renderer/render-data';
 import { IBatcher } from '../../renderer/i-batcher';
 import { Sprite } from '../../components';
@@ -30,7 +30,6 @@ import { IAssembler } from '../../renderer/base';
 import { dynamicAtlasManager } from '../../utils/dynamic-atlas/atlas-manager';
 import { StaticVBChunk } from '../../renderer/static-vb-accessor';
 
-const m = new Mat4();
 const tempRenderData: IRenderData[] = [];
 for (let i = 0; i < 4; i++) {
     tempRenderData.push({ x: 0, y: 0, z: 0, u: 0, v: 0, color: new Color() });
@@ -180,13 +179,16 @@ export const sliced: IAssembler = {
     },
 
     updateWorldVertexData (sprite: Sprite, chunk: StaticVBChunk) {
-        const node = sprite.node;
-        node.getWorldMatrix(m);
-
         const renderData = sprite.renderData!;
         const stride = renderData.floatStride;
         const dataList: IRenderData[] = renderData.data;
         const vData = chunk.vb;
+        const node = sprite.node;
+        const m = node.worldMatrix;
+
+        const m00 = m.m00; const m01 = m.m01; const m02 = m.m02; const m03 = m.m03;
+        const m04 = m.m04; const m05 = m.m05; const m06 = m.m06; const m07 = m.m07;
+        const m12 = m.m12; const m13 = m.m13; const m14 = m.m14; const m15 = m.m15;
 
         let offset = 0;
         for (let row = 0; row < 4; ++row) {
@@ -195,13 +197,13 @@ export const sliced: IAssembler = {
                 const colD = dataList[col];
                 const x = colD.x;
                 const y = rowD.y;
-                let rhw = m.m03 * x + m.m07 * y + m.m15;
+                let rhw = m03 * x + m07 * y + m15;
                 rhw = rhw ? 1 / rhw : 1;
 
                 offset = (row * 4 + col) * stride;
-                vData[offset + 0] = (m.m00 * x + m.m04 * y + m.m12) * rhw;
-                vData[offset + 1] = (m.m01 * x + m.m05 * y + m.m13) * rhw;
-                vData[offset + 2] = (m.m02 * x + m.m06 * y + m.m14) * rhw;
+                vData[offset + 0] = (m00 * x + m04 * y + m12) * rhw;
+                vData[offset + 1] = (m01 * x + m05 * y + m13) * rhw;
+                vData[offset + 2] = (m02 * x + m06 * y + m14) * rhw;
             }
         }
     },

--- a/cocos/2d/assembler/utils.ts
+++ b/cocos/2d/assembler/utils.ts
@@ -22,32 +22,33 @@
  THE SOFTWARE.
 */
 
-import { Color, Mat4, clamp } from '../../core';
+import { Color, clamp } from '../../core';
 import { RenderData } from '../renderer/render-data';
 import { IBatcher } from '../renderer/i-batcher';
 import { Node } from '../../scene-graph/node';
 import { FormatInfos } from '../../gfx';
-
-const m = new Mat4();
 
 export function fillMeshVertices3D (node: Node, renderer: IBatcher, renderData: RenderData, color: Color): void {
     const chunk = renderData.chunk;
     const dataList = renderData.data;
     const vData = chunk.vb;
     const vertexCount = renderData.vertexCount;
+    const m = node.worldMatrix;
 
-    node.getWorldMatrix(m);
+    const m00 = m.m00; const m01 = m.m01; const m02 = m.m02; const m03 = m.m03;
+    const m04 = m.m04; const m05 = m.m05; const m06 = m.m06; const m07 = m.m07;
+    const m12 = m.m12; const m13 = m.m13; const m14 = m.m14; const m15 = m.m15;
 
     let vertexOffset = 0;
     for (let i = 0; i < vertexCount; i++) {
         const vert = dataList[i];
         const x = vert.x;
         const y = vert.y;
-        let rhw = m.m03 * x + m.m07 * y + m.m15;
+        let rhw = m03 * x + m07 * y + m15;
         rhw = rhw ? 1 / rhw : 1;
-        vData[vertexOffset + 0] = (m.m00 * x + m.m04 * y + m.m12) * rhw;
-        vData[vertexOffset + 1] = (m.m01 * x + m.m05 * y + m.m13) * rhw;
-        vData[vertexOffset + 2] = (m.m02 * x + m.m06 * y + m.m14) * rhw;
+        vData[vertexOffset + 0] = (m00 * x + m04 * y + m12) * rhw;
+        vData[vertexOffset + 1] = (m01 * x + m05 * y + m13) * rhw;
+        vData[vertexOffset + 2] = (m02 * x + m06 * y + m14) * rhw;
         Color.toArray(vData, color, vertexOffset + 5);
         vertexOffset += 9;
     }

--- a/cocos/2d/assembler/utils.ts
+++ b/cocos/2d/assembler/utils.ts
@@ -22,11 +22,13 @@
  THE SOFTWARE.
 */
 
-import { Color, clamp } from '../../core';
+import { Color, Vec4, clamp } from '../../core';
 import { RenderData } from '../renderer/render-data';
 import { IBatcher } from '../renderer/i-batcher';
 import { Node } from '../../scene-graph/node';
 import { FormatInfos } from '../../gfx';
+
+const _col = new Vec4();
 
 export function fillMeshVertices3D (node: Node, renderer: IBatcher, renderData: RenderData, color: Color): void {
     const chunk = renderData.chunk;
@@ -39,8 +41,11 @@ export function fillMeshVertices3D (node: Node, renderer: IBatcher, renderData: 
     const m04 = m.m04; const m05 = m.m05; const m06 = m.m06; const m07 = m.m07;
     const m12 = m.m12; const m13 = m.m13; const m14 = m.m14; const m15 = m.m15;
 
+    // convert to 0 ~ 1
+    _col.set(color.r / 255, color.g / 255, color.b / 255, color.a / 255);
+
     let vertexOffset = 0;
-    for (let i = 0; i < vertexCount; i++) {
+    for (let i = 0; i < vertexCount; ++i) {
         const vert = dataList[i];
         const x = vert.x;
         const y = vert.y;
@@ -49,7 +54,7 @@ export function fillMeshVertices3D (node: Node, renderer: IBatcher, renderData: 
         vData[vertexOffset + 0] = (m00 * x + m04 * y + m12) * rhw;
         vData[vertexOffset + 1] = (m01 * x + m05 * y + m13) * rhw;
         vData[vertexOffset + 2] = (m02 * x + m06 * y + m14) * rhw;
-        Color.toArray(vData, color, vertexOffset + 5);
+        Vec4.toArray(vData, _col, vertexOffset + 5);
         vertexOffset += 9;
     }
 


### PR DESCRIPTION
Reduce the frequency of looking up matrix elements within the loop.

I am not sure if V8 will optimize this situation.
But in general, doing this way is more efficient in JS.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Optimized matrix element lookups within loops to enhance performance in the 2D assembler code.

- **cocos/2d/assembler/utils.ts**: Cached matrix elements in `fillMeshVertices3D` to reduce lookup frequency.
- **cocos/2d/assembler/sprite/simple.ts**: Cached matrix elements in `updateWorldVerts` for performance improvement.
- **cocos/2d/assembler/sprite/sliced.ts**: Cached matrix elements in `updateWorldVertexData` to optimize loop performance.

No new functionality or changes to existing logic.

<!-- /greptile_comment -->