### PR TITLE
[optimization] free string memory after JSON is parsed.  

### DIFF
--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -401,13 +401,23 @@ Object *Object::createJSONObject(const ccstd::string &jsonStr) {
 }
 
 Object *Object::createJSONObject(std::u16string &&jsonStr) {
-    auto v8Str = v8::String::NewExternalTwoByte(__isolate, ccnew internal::ExternalStringResource(std::move(jsonStr)));
+    auto *external = ccnew internal::ExternalStringResource(std::move(jsonStr));
+    external->addRef();
+
+    auto v8Str = v8::String::NewExternalTwoByte(__isolate, external);
     if (v8Str.IsEmpty()) {
+        external->release();
         return nullptr;
     }
 
     v8::Local<v8::Context> context = __isolate->GetCurrentContext();
     v8::MaybeLocal<v8::Value> ret = v8::JSON::Parse(context, v8Str.ToLocalChecked());
+    
+    // After v8::JSON::Parse, the memory of u16string could be freed.
+    external->freeMemory();
+    external->release();
+    external = nullptr;
+    
     if (ret.IsEmpty()) {
         return nullptr;
     }

--- a/native/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Object.cpp
@@ -402,11 +402,8 @@ Object *Object::createJSONObject(const ccstd::string &jsonStr) {
 
 Object *Object::createJSONObject(std::u16string &&jsonStr) {
     auto *external = ccnew internal::ExternalStringResource(std::move(jsonStr));
-    external->addRef();
-
     auto v8Str = v8::String::NewExternalTwoByte(__isolate, external);
     if (v8Str.IsEmpty()) {
-        external->release();
         return nullptr;
     }
 
@@ -415,8 +412,6 @@ Object *Object::createJSONObject(std::u16string &&jsonStr) {
     
     // After v8::JSON::Parse, the memory of u16string could be freed.
     external->freeMemory();
-    external->release();
-    external = nullptr;
     
     if (ret.IsEmpty()) {
         return nullptr;

--- a/native/cocos/bindings/jswrapper/v8/Utils.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Utils.cpp
@@ -259,12 +259,23 @@ size_t ExternalStringResource::length() const {
 }
 
 void ExternalStringResource::Dispose() {
-    delete this;
+    release();
 }
 
 void ExternalStringResource::freeMemory() {
     _s.clear();
     _s.shrink_to_fit();
+}
+
+void ExternalStringResource::addRef() {
+    ++_refCount;
+}
+
+void ExternalStringResource::release() {
+    --_refCount;
+    if (_refCount == 0) {
+        delete this;
+    }
 }
 
 } // namespace internal

--- a/native/cocos/bindings/jswrapper/v8/Utils.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Utils.cpp
@@ -243,8 +243,6 @@ void clearPrivate(v8::Isolate *isolate, ObjectWrap &wrap) {
     }
 }
 
-std::atomic_int gExternalCount = 0;
-
 // ExternalStringResource
 ExternalStringResource::ExternalStringResource(std::u16string &&s)
 : _s(std::move(s)) {

--- a/native/cocos/bindings/jswrapper/v8/Utils.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Utils.cpp
@@ -243,6 +243,30 @@ void clearPrivate(v8::Isolate *isolate, ObjectWrap &wrap) {
     }
 }
 
+std::atomic_int gExternalCount = 0;
+
+// ExternalStringResource
+ExternalStringResource::ExternalStringResource(std::u16string &&s)
+: _s(std::move(s)) {
+}
+
+const uint16_t* ExternalStringResource::data() const {
+    return reinterpret_cast<const uint16_t*>(_s.data());
+}
+
+size_t ExternalStringResource::length() const {
+    return _s.length();
+}
+
+void ExternalStringResource::Dispose() {
+    delete this;
+}
+
+void ExternalStringResource::freeMemory() {
+    _s.clear();
+    _s.shrink_to_fit();
+}
+
 } // namespace internal
 } // namespace se
 

--- a/native/cocos/bindings/jswrapper/v8/Utils.cpp
+++ b/native/cocos/bindings/jswrapper/v8/Utils.cpp
@@ -257,23 +257,12 @@ size_t ExternalStringResource::length() const {
 }
 
 void ExternalStringResource::Dispose() {
-    release();
+    delete this;
 }
 
 void ExternalStringResource::freeMemory() {
     _s.clear();
     _s.shrink_to_fit();
-}
-
-void ExternalStringResource::addRef() {
-    ++_refCount;
-}
-
-void ExternalStringResource::release() {
-    --_refCount;
-    if (_refCount == 0) {
-        delete this;
-    }
 }
 
 } // namespace internal

--- a/native/cocos/bindings/jswrapper/v8/Utils.h
+++ b/native/cocos/bindings/jswrapper/v8/Utils.h
@@ -60,8 +60,12 @@ public:
     void Dispose() override;
 
     void freeMemory();
+    
+    void addRef();
+    void release();
 private:
     std::u16string _s;
+    uint32_t _refCount{1};
 };
 
 } // namespace internal

--- a/native/cocos/bindings/jswrapper/v8/Utils.h
+++ b/native/cocos/bindings/jswrapper/v8/Utils.h
@@ -60,12 +60,9 @@ public:
     void Dispose() override;
 
     void freeMemory();
-    
-    void addRef();
-    void release();
+
 private:
     std::u16string _s;
-    uint32_t _refCount{1};
 };
 
 } // namespace internal

--- a/native/cocos/bindings/jswrapper/v8/Utils.h
+++ b/native/cocos/bindings/jswrapper/v8/Utils.h
@@ -52,24 +52,14 @@ void clearPrivate(v8::Isolate *isolate, ObjectWrap &wrap);
 
 class ExternalStringResource : public v8::String::ExternalStringResource {
 public:
-    explicit ExternalStringResource(std::u16string &&s)
-    : _s(std::move(s)) {
-        
-    }
-    
+    explicit ExternalStringResource(std::u16string &&s);
     ~ExternalStringResource() override = default;
     
-    const uint16_t* data() const override {
-        return reinterpret_cast<const uint16_t*>(_s.data());
-    }
+    const uint16_t* data() const override;
+    size_t length() const override;
+    void Dispose() override;
 
-    size_t length() const override {
-        return _s.length();
-    }
-    
-    void Dispose() override {
-        delete this;
-    }
+    void freeMemory();
 private:
     std::u16string _s;
 };


### PR DESCRIPTION
V8's garbage collector only take care of JS Heap and ignore the external string size.  So  ExternalStringResource::Dispose may be delayed which will cause memory in high value.

Re: #17012

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Optimized memory management for external strings in JSON parsing by ensuring prompt memory release.

- Modified `native/cocos/bindings/jswrapper/v8/Utils.cpp` to call `delete this` in `ExternalStringResource::Dispose`.
- Removed atomic counter `gExternalCount` for tracking external strings.
- Explicitly cleared and shrunk string memory post-parsing to reduce memory usage.
- Adjusted `native/cocos/bindings/jswrapper/v8/Object.cpp` to align with new memory management logic.

<!-- /greptile_comment -->