### PR TITLE
simplified object getter

### DIFF
--- a/cocos/rendering/custom/compiler.ts
+++ b/cocos/rendering/custom/compiler.ts
@@ -122,7 +122,7 @@ class PassVisitor implements RenderGraphVisitor {
         if (!this.context.renderGraph.holds(RenderGraphValue.Scene, u)) {
             return null;
         }
-        return this.context.renderGraph.getScene(u);
+        return this.context.renderGraph.j<SceneData>(u);
     }
     protected _isScene (u: number): boolean {
         return this.context.renderGraph.holds(RenderGraphValue.Scene, u);

--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -541,7 +541,7 @@ class DeviceComputeQueue implements RecordingInterface {
         this._layoutID = value;
         const layoutGraph = context.layoutGraph;
         this._renderPhase = layoutGraph.holds(LayoutGraphDataValue.RenderPhase, value)
-            ? layoutGraph.getRenderPhase(value)
+            ? layoutGraph.j<RenderPhaseData>(value)
             : null;
         const layout = layoutGraph.getLayout(value);
         this._descSetData = layout.descriptorSets.get(UpdateFrequency.PER_PHASE)!;
@@ -594,7 +594,7 @@ class DeviceRenderQueue implements RecordingInterface {
         this._layoutID = value;
         const layoutGraph = context.layoutGraph;
         this._renderPhase = layoutGraph.holds(LayoutGraphDataValue.RenderPhase, value)
-            ? layoutGraph.getRenderPhase(value)
+            ? layoutGraph.j<RenderPhaseData>(value)
             : null;
         const layout = layoutGraph.getLayout(value);
         this._descSetData = layout.descriptorSets.get(UpdateFrequency.PER_PHASE)!;
@@ -683,7 +683,7 @@ class RenderPassLayoutInfo {
         this._layoutID = layoutId;
         this._vertID = vertId;
         const lg = context.layoutGraph;
-        this._stage = lg.getRenderStage(layoutId);
+        this._stage = lg.j<RenderStageData>(layoutId);
         this._layout = lg.getLayout(layoutId);
         const layoutData = this._layout.descriptorSets.get(UpdateFrequency.PER_PASS);
         if (!layoutData) {

--- a/cocos/rendering/custom/layout-graph-editor.ts
+++ b/cocos/rendering/custom/layout-graph-editor.ts
@@ -892,12 +892,12 @@ export class LayoutGraphInfo {
                 continue;
             }
             // skip RENDER_PASS
-            if (lg.getRenderStage(passID) === RenderPassType.RENDER_PASS) {
+            if (lg.j<RenderPassType>(passID) === RenderPassType.RENDER_PASS) {
                 continue;
             }
             // build SINGLE_RENDER_PASS or RENDER_SUBPASS
-            assert(lg.getRenderStage(passID) === RenderPassType.SINGLE_RENDER_PASS
-                || lg.getRenderStage(passID) === RenderPassType.RENDER_SUBPASS);
+            assert(lg.j<RenderPassType>(passID) === RenderPassType.SINGLE_RENDER_PASS
+                || lg.j<RenderPassType>(passID) === RenderPassType.RENDER_SUBPASS);
             const passDB = lg.getDescriptors(passID);
             // update children phases
             for (const e of lg.children(passID)) {
@@ -955,7 +955,7 @@ function buildLayoutGraphDataImpl (graph: LayoutGraph, builder: LayoutGraphBuild
         let isRenderPass = false;
         switch (graph.id(v)) {
         case LayoutGraphValue.RenderStage: {
-            const type = graph.getRenderStage(v);
+            const type = graph.j<RenderPassType>(v);
             const parentID = graph.getParent(v);
             if (type === RenderPassType.RENDER_SUBPASS) {
                 assert(parentID !== graph.nullVertex());
@@ -975,13 +975,13 @@ function buildLayoutGraphDataImpl (graph: LayoutGraph, builder: LayoutGraphBuild
         }
         case LayoutGraphValue.RenderPhase: {
             const parentID = graph.getParent(v);
-            const parentType = graph.getRenderStage(parentID);
+            const parentType = graph.j<RenderPassType>(parentID);
             assert(parentType === RenderPassType.RENDER_SUBPASS || parentType === RenderPassType.SINGLE_RENDER_PASS);
             const vertID = builder.addRenderPhase(graph.getName(v), parentID);
             if (vertID !== v) {
                 error('vertex id mismatch');
             }
-            const phase = graph.getRenderPhase(v);
+            const phase = graph.j<RenderPhase>(v);
             for (const shaderName of phase.shaders) {
                 builder.addShader(shaderName, v);
             }
@@ -1072,7 +1072,7 @@ class LayoutGraphBuilder2 {
     }
     addShader (name: string, parentPhaseID: number): void {
         const lg = this.lg;
-        const phaseData = lg.getRenderPhase(parentPhaseID);
+        const phaseData = lg.j<RenderPhaseData>(parentPhaseID);
         // 填充shaderData数据
         const shaderData = new ShaderProgramData();
         const id = phaseData.shaderPrograms.length;

--- a/cocos/rendering/custom/layout-graph-utils.ts
+++ b/cocos/rendering/custom/layout-graph-utils.ts
@@ -23,11 +23,12 @@
 ****************************************************************************/
 
 /* eslint-disable max-len */
+import type { LayoutGraphData, PipelineLayoutData, RenderPhaseData } from './layout-graph';
+import { DescriptorBlockData, DescriptorData, DescriptorSetLayoutData, LayoutGraphDataValue } from './layout-graph';
 import { EffectAsset } from '../../asset/assets';
 import { assert, error, warn } from '../../core';
 import { DescriptorSetInfo, DescriptorSetLayout, DescriptorSetLayoutBinding, DescriptorSetLayoutInfo, DescriptorType, Device, Feature, Format, FormatFeatureBit, GetTypeSize, PipelineLayout, PipelineLayoutInfo, ShaderStageFlagBit, Type, Uniform, UniformBlock } from '../../gfx';
 import { UBOForwardLight, UBOSkinning } from '../define';
-import { DescriptorBlockData, DescriptorData, DescriptorSetLayoutData, LayoutGraphData, LayoutGraphDataValue, PipelineLayoutData } from './layout-graph';
 import { UpdateFrequency, DescriptorBlockIndex, DescriptorTypeOrder, ParameterType } from './types';
 
 export const INVALID_ID = 0xFFFFFFFF;
@@ -455,7 +456,7 @@ export function initializeLayoutGraphData (device: Device, lg: LayoutGraphData):
         populatePipelineLayoutInfo(phaseLayout, UpdateFrequency.PER_PHASE, info);
         populatePipelineLayoutInfo(phaseLayout, UpdateFrequency.PER_BATCH, info);
         populatePipelineLayoutInfo(phaseLayout, UpdateFrequency.PER_INSTANCE, info);
-        const phase = lg.getRenderPhase(phaseID);
+        const phase = lg.j<RenderPhaseData>(phaseID);
         phase.pipelineLayout = device.createPipelineLayout(info);
     }
 }
@@ -573,7 +574,7 @@ export function getOrCreateDescriptorBlockData (
 
 export function getProgramID (lg: LayoutGraphData, phaseID: number, programName: string): number {
     assert(phaseID !== lg.nullVertex());
-    const phase = lg.getRenderPhase(phaseID);
+    const phase = lg.j<RenderPhaseData>(phaseID);
     const programID = phase.shaderIndex.get(programName);
     if (programID === undefined) {
         return INVALID_ID;
@@ -628,7 +629,7 @@ export function getPerBatchDescriptorSetLayoutData (
     programID,
 ): DescriptorSetLayoutData | null {
     assert(phaseID !== lg.nullVertex());
-    const phase = lg.getRenderPhase(phaseID);
+    const phase = lg.j<RenderPhaseData>(phaseID);
     assert(programID < phase.shaderPrograms.length);
     const program = phase.shaderPrograms[programID];
     const set = program.layout.descriptorSets.get(UpdateFrequency.PER_BATCH);
@@ -644,7 +645,7 @@ export function getPerInstanceDescriptorSetLayoutData (
     programID,
 ): DescriptorSetLayoutData | null {
     assert(phaseID !== lg.nullVertex());
-    const phase = lg.getRenderPhase(phaseID);
+    const phase = lg.j<RenderPhaseData>(phaseID);
     assert(programID < phase.shaderPrograms.length);
     const program = phase.shaderPrograms[programID];
     const set = program.layout.descriptorSets.get(UpdateFrequency.PER_INSTANCE);

--- a/cocos/rendering/custom/layout-graph.ts
+++ b/cocos/rendering/custom/layout-graph.ts
@@ -204,7 +204,7 @@ export class LayoutGraph implements BidirectionalGraph
         this.x.length = 0;
     }
     addVertex<T extends LayoutGraphValue> (
-        id: LayoutGraphValue,
+        id: T,
         object: LayoutGraphValueType[T],
         name: string,
         descriptors: DescriptorDB,
@@ -282,11 +282,8 @@ export class LayoutGraph implements BidirectionalGraph
             throw Error('polymorphic type not found');
         }
     }
-    getRenderStage (v: number): RenderPassType {
-        return this.x[v].j as RenderPassType;
-    }
-    getRenderPhase (v: number): RenderPhase {
-        return this.x[v].j as RenderPhase;
+    j<T extends LayoutGraphObject> (v: number): T {
+        return this.x[v].j as T;
     }
     //-----------------------------------------------------------------
     // ReferenceGraph
@@ -706,7 +703,7 @@ export class LayoutGraphData implements BidirectionalGraph
         this.x.length = 0;
     }
     addVertex<T extends LayoutGraphDataValue> (
-        id: LayoutGraphDataValue,
+        id: T,
         object: LayoutGraphDataValueType[T],
         name: string,
         update: UpdateFrequency,
@@ -794,11 +791,8 @@ export class LayoutGraphData implements BidirectionalGraph
             throw Error('polymorphic type not found');
         }
     }
-    getRenderStage (v: number): RenderStageData {
-        return this.x[v].j as RenderStageData;
-    }
-    getRenderPhase (v: number): RenderPhaseData {
-        return this.x[v].j as RenderPhaseData;
+    j<T extends LayoutGraphDataObject> (v: number): T {
+        return this.x[v].j as T;
     }
     //-----------------------------------------------------------------
     // ReferenceGraph
@@ -1101,10 +1095,10 @@ export function saveLayoutGraph (a: OutputArchive, g: LayoutGraph): void {
         saveDescriptorDB(a, g.getDescriptors(v));
         switch (g.id(v)) {
         case LayoutGraphValue.RenderStage:
-            a.n(g.getRenderStage(v));
+            a.n(g.x[v].j as RenderPassType);
             break;
         case LayoutGraphValue.RenderPhase:
-            saveRenderPhase(a, g.getRenderPhase(v));
+            saveRenderPhase(a, g.x[v].j as RenderPhase);
             break;
         default:
             break;
@@ -1471,10 +1465,10 @@ export function saveLayoutGraphData (a: OutputArchive, g: LayoutGraphData): void
         savePipelineLayoutData(a, g.getLayout(v));
         switch (g.id(v)) {
         case LayoutGraphDataValue.RenderStage:
-            saveRenderStageData(a, g.getRenderStage(v));
+            saveRenderStageData(a, g.x[v].j as RenderStageData);
             break;
         case LayoutGraphDataValue.RenderPhase:
-            saveRenderPhaseData(a, g.getRenderPhase(v));
+            saveRenderPhaseData(a, g.x[v].j as RenderPhaseData);
             break;
         default:
             break;

--- a/cocos/rendering/custom/render-graph.ts
+++ b/cocos/rendering/custom/render-graph.ts
@@ -756,7 +756,7 @@ export class ResourceGraph implements BidirectionalGraph
         this.x.length = 0;
     }
     addVertex<T extends ResourceGraphValue> (
-        id: ResourceGraphValue,
+        id: T,
         object: ResourceGraphValueType[T],
         name: string,
         desc: ResourceDesc,
@@ -873,32 +873,8 @@ export class ResourceGraph implements BidirectionalGraph
             throw Error('polymorphic type not found');
         }
     }
-    getManaged (v: number): ManagedResource {
-        return this.x[v].j as ManagedResource;
-    }
-    getManagedBuffer (v: number): ManagedBuffer {
-        return this.x[v].j as ManagedBuffer;
-    }
-    getManagedTexture (v: number): ManagedTexture {
-        return this.x[v].j as ManagedTexture;
-    }
-    getPersistentBuffer (v: number): PersistentBuffer {
-        return this.x[v].j as PersistentBuffer;
-    }
-    getPersistentTexture (v: number): PersistentTexture {
-        return this.x[v].j as PersistentTexture;
-    }
-    getFramebuffer (v: number): Framebuffer {
-        return this.x[v].j as Framebuffer;
-    }
-    getSwapchain (v: number): RenderSwapchain {
-        return this.x[v].j as RenderSwapchain;
-    }
-    getFormatView (v: number): FormatView {
-        return this.x[v].j as FormatView;
-    }
-    getSubresourceView (v: number): SubresourceView {
-        return this.x[v].j as SubresourceView;
+    j<T extends ResourceGraphObject> (v: number): T {
+        return this.x[v].j as T;
     }
     //-----------------------------------------------------------------
     // ReferenceGraph
@@ -1372,7 +1348,7 @@ export class RenderGraph implements BidirectionalGraph
         this.x.length = 0;
     }
     addVertex<T extends RenderGraphValue> (
-        id: RenderGraphValue,
+        id: T,
         object: RenderGraphValueType[T],
         name: string,
         layout: string,
@@ -1497,47 +1473,8 @@ export class RenderGraph implements BidirectionalGraph
             throw Error('polymorphic type not found');
         }
     }
-    getRasterPass (v: number): RasterPass {
-        return this.x[v].j as RasterPass;
-    }
-    getRasterSubpass (v: number): RasterSubpass {
-        return this.x[v].j as RasterSubpass;
-    }
-    getComputeSubpass (v: number): ComputeSubpass {
-        return this.x[v].j as ComputeSubpass;
-    }
-    getCompute (v: number): ComputePass {
-        return this.x[v].j as ComputePass;
-    }
-    getResolve (v: number): ResolvePass {
-        return this.x[v].j as ResolvePass;
-    }
-    getCopy (v: number): CopyPass {
-        return this.x[v].j as CopyPass;
-    }
-    getMove (v: number): MovePass {
-        return this.x[v].j as MovePass;
-    }
-    getRaytrace (v: number): RaytracePass {
-        return this.x[v].j as RaytracePass;
-    }
-    getQueue (v: number): RenderQueue {
-        return this.x[v].j as RenderQueue;
-    }
-    getScene (v: number): SceneData {
-        return this.x[v].j as SceneData;
-    }
-    getBlit (v: number): Blit {
-        return this.x[v].j as Blit;
-    }
-    getDispatch (v: number): Dispatch {
-        return this.x[v].j as Dispatch;
-    }
-    getClear (v: number): ClearView[] {
-        return this.x[v].j as ClearView[];
-    }
-    getViewport (v: number): Viewport {
-        return this.x[v].j as Viewport;
+    j<T extends RenderGraphObject> (v: number): T {
+        return this.x[v].j as T;
     }
     //-----------------------------------------------------------------
     // ReferenceGraph

--- a/cocos/rendering/custom/scene-culling.ts
+++ b/cocos/rendering/custom/scene-culling.ts
@@ -9,7 +9,7 @@ import { Layers, Node } from '../../scene-graph';
 import { PipelineSceneData } from '../pipeline-scene-data';
 import { hashCombineStr, getSubpassOrPassID, bool, AlignUp, SetLightUBO } from './define';
 import { LayoutGraphData } from './layout-graph';
-import { CullingFlags, RenderGraph, RenderGraphValue, SceneData } from './render-graph';
+import { CullingFlags, RenderGraph, RenderGraphValue, SceneData, RenderQueue as RenderQueue0 } from './render-graph';
 import { SceneFlags } from './types';
 import { RenderQueue, RenderQueueDesc, instancePool } from './web-pipeline-types';
 import { ObjectPool } from './utils';
@@ -322,7 +322,7 @@ export class SceneCulling {
     // target id
     numRenderQueues = 0;
     layoutGraph;
-    renderGraph;
+    renderGraph!: RenderGraph;
     enableLightCulling = true;
     resetPool (): void {
         const cullingPools = this.cullingPools;
@@ -400,7 +400,7 @@ export class SceneCulling {
     }
 
     private getOrCreateFrustumCulling (sceneId: number): number {
-        const sceneData: SceneData = this.renderGraph.getScene(sceneId);
+        const sceneData: SceneData = this.renderGraph.j<SceneData>(sceneId);
         const scene = sceneData.scene!;
         let queries = this.frustumCullings.get(scene);
         if (!queries) {
@@ -453,7 +453,7 @@ export class SceneCulling {
             if (!rg.holds(RenderGraphValue.Scene, v) || !rg.getValid(v)) {
                 continue;
             }
-            const sceneData = rg.getScene(v);
+            const sceneData = rg.j<SceneData>(v);
             if (!sceneData.scene) {
                 assert(!!sceneData.scene);
                 continue;
@@ -484,7 +484,7 @@ export class SceneCulling {
         const rg: RenderGraph = this.renderGraph;
         const renderQueueId = rg.getParent(scene);
         assert(rg.holds(RenderGraphValue.Queue, renderQueueId));
-        const graphRenderQueue = rg.getQueue(renderQueueId);
+        const graphRenderQueue = rg.j<RenderQueue0>(renderQueueId);
         return graphRenderQueue.phaseID;
     }
 
@@ -647,7 +647,7 @@ export class SceneCulling {
             const frustomCulledResultID = desc.frustumCulledResultID;
             const lightBoundsCullingID = desc.lightBoundsCulledResultID;
             const targetId = desc.renderQueueTarget;
-            const sceneData = rg.getScene(sceneId);
+            const sceneData = rg.j<SceneData>(sceneId);
             const isDrawBlend: boolean = bool(sceneData.flags & SceneFlags.TRANSPARENT_OBJECT);
             const isDrawOpaqueOrMask: boolean = bool(sceneData.flags & (SceneFlags.OPAQUE_OBJECT | SceneFlags.CUTOUT_OBJECT));
             const isDrawShadowCaster: boolean = bool(sceneData.flags & SceneFlags.SHADOW_CASTER);
@@ -658,7 +658,7 @@ export class SceneCulling {
             // render queue info
             const renderQueueId = rg.getParent(sceneId);
             assert(rg.holds(RenderGraphValue.Queue, renderQueueId));
-            const graphRenderQueue = rg.getQueue(renderQueueId);
+            const graphRenderQueue = rg.j<RenderQueue0>(renderQueueId);
             const phaseLayoutId = graphRenderQueue.phaseID;
             assert(phaseLayoutId !== this.layoutGraph.nullVertex());
 

--- a/cocos/rendering/custom/web-pipeline.ts
+++ b/cocos/rendering/custom/web-pipeline.ts
@@ -1453,7 +1453,7 @@ export class WebPipeline implements BasicPipeline {
         desc.height = height;
         if (swapchain) {
             assert(this.resourceGraph.id(resId) === ResourceGraphValue.Swapchain);
-            const sc = this.resourceGraph.getSwapchain(resId);
+            const sc = this.resourceGraph.j<RenderSwapchain>(resId);
             assert(!!sc.swapchain);
             sc.swapchain = swapchain;
             desc.format = sc.swapchain.depthStencilTexture.format;

--- a/cocos/rendering/custom/web-program-library.ts
+++ b/cocos/rendering/custom/web-program-library.ts
@@ -788,7 +788,7 @@ export function getOrCreateProgramDescriptorSetLayout (
     rate: UpdateFrequency,
 ): DescriptorSetLayout {
     assert(rate < UpdateFrequency.PER_PHASE);
-    const phase = lg.getRenderPhase(phaseID);
+    const phase = lg.j<RenderPhaseData>(phaseID);
     const programID = phase.shaderIndex.get(programName);
     if (programID === undefined) {
         return getEmptyDescriptorSetLayout();
@@ -815,7 +815,7 @@ export function getProgramDescriptorSetLayout (
     rate: UpdateFrequency,
 ): DescriptorSetLayout | null {
     assert(rate < UpdateFrequency.PER_PHASE);
-    const phase = lg.getRenderPhase(phaseID);
+    const phase = lg.j<RenderPhaseData>(phaseID);
     const programID = phase.shaderIndex.get(programName);
     if (programID === undefined) {
         return null;
@@ -930,7 +930,7 @@ export class WebProgramLibrary implements ProgramLibrary {
             populatePipelineLayoutInfo(phaseLayout, UpdateFrequency.PER_PHASE, info);
             populatePipelineLayoutInfo(phaseLayout, UpdateFrequency.PER_BATCH, info);
             populatePipelineLayoutInfo(phaseLayout, UpdateFrequency.PER_INSTANCE, info);
-            const phase = lg.getRenderPhase(phaseID);
+            const phase = lg.j<RenderPhaseData>(phaseID);
             phase.pipelineLayout = this.device.createPipelineLayout(info);
         }
 
@@ -989,7 +989,7 @@ export class WebProgramLibrary implements ProgramLibrary {
                 // collect program descriptors
                 let programData: ShaderProgramData | null = null;
                 if (!this.mergeHighFrequency) {
-                    const phase = lg.getRenderPhase(phaseID);
+                    const phase = lg.j<RenderPhaseData>(phaseID);
                     programData = new ShaderProgramData();
                     buildProgramData(programName, srcShaderInfo, lg, phase, programData, this.fixedLocal);
                 }
@@ -1203,11 +1203,11 @@ export class WebProgramLibrary implements ProgramLibrary {
     getPipelineLayout (device: Device, phaseID: number, programName: string): PipelineLayout {
         if (this.mergeHighFrequency) {
             assert(phaseID !== INVALID_ID);
-            const layout = this.layoutGraph.getRenderPhase(phaseID);
+            const layout = this.layoutGraph.j<RenderPhaseData>(phaseID);
             return layout.pipelineLayout!;
         }
         const lg = this.layoutGraph;
-        const phase = lg.getRenderPhase(phaseID);
+        const phase = lg.j<RenderPhaseData>(phaseID);
         const programID = phase.shaderIndex.get(programName);
         if (programID === undefined) {
             return getEmptyPipelineLayout();


### PR DESCRIPTION
Remove polymorphic object getters.
Add generic polymorphic object getter to `j`.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request simplifies object getters across multiple files in the rendering pipeline, enhancing code maintainability and readability.

- `cocos/rendering/custom/compiler.ts`: Refactored `_getSceneData` method to use `this.context.renderGraph.j<SceneData>(u)`.
- `cocos/rendering/custom/executor.ts`: Replaced `getRenderPhase` and `getRenderStage` with `j<RenderPhaseData>` and `j<RenderStageData>`.
- `cocos/rendering/custom/layout-graph-editor.ts`: Updated calls to `lg.getRenderStage` with `lg.j<RenderPassType>` and `lg.j<RenderPhase>`.
- `cocos/rendering/custom/layout-graph-utils.ts`: Refactored to use `lg.j<RenderPhaseData>(phaseID)` for retrieving `RenderPhaseData`.
- `cocos/rendering/custom/layout-graph.ts`: Simplified object getters with a generic method `j<T extends LayoutGraphObject>`.
- `cocos/rendering/custom/render-graph.ts`: Replaced specific getter methods with a generic method `j<T extends ResourceGraphObject>(v: number): T`.
- `cocos/rendering/custom/scene-culling.ts`: Updated scene data access to use the `j` method and marked `renderGraph` as non-nullable.
- `cocos/rendering/custom/web-pipeline.ts`: Modified swapchain retrieval to use `j<RenderSwapchain>`.
- `cocos/rendering/custom/web-program-library.ts`: Replaced `getRenderPhase` with `j<RenderPhaseData>` for render phase data retrieval.

<!-- /greptile_comment -->