### PR TITLE
fix #17484: 修复Tiled文件对象层自定义属性读取错误

### DIFF
--- a/cocos/tiledmap/tiled-types.ts
+++ b/cocos/tiledmap/tiled-types.ts
@@ -441,6 +441,11 @@ export class TMXObjectGroupInfo {
 }
 
 export interface TMXObject {
+    /**
+     * Properties of the layer info.
+     * @property {Object} properties
+     */
+    properties: PropertiesInfo = {} as any;
     id: number | string;
     name: string;
     width: number;

--- a/cocos/tiledmap/tiled-types.ts
+++ b/cocos/tiledmap/tiled-types.ts
@@ -441,7 +441,7 @@ export class TMXObjectGroupInfo {
 }
 
 export interface TMXObject {
-    properties: PropertiesInfo
+    properties: PropertiesInfo;
     id: number | string;
     name: string;
     width: number;

--- a/cocos/tiledmap/tiled-types.ts
+++ b/cocos/tiledmap/tiled-types.ts
@@ -441,11 +441,7 @@ export class TMXObjectGroupInfo {
 }
 
 export interface TMXObject {
-    /**
-     * Properties of the layer info.
-     * @property {Object} properties
-     */
-    properties: PropertiesInfo = {} as any;
+    properties: PropertiesInfo
     id: number | string;
     name: string;
     width: number;

--- a/cocos/tiledmap/tmx-xml-parser.ts
+++ b/cocos/tiledmap/tmx-xml-parser.ts
@@ -89,7 +89,7 @@ function strToColor (value: string): Color {
 
 function getPropertyList (node: Element, map?: PropertiesInfo): PropertiesInfo {
     const res: any[] = [];
-    const properties = node.getElementsByTagName('properties');
+    const properties = node.querySelectorAll(':scope > properties');
     for (let i = 0; i < properties.length; ++i) {
         const property = properties[i].getElementsByTagName('property');
         for (let j = 0; j < property.length; ++j) {

--- a/cocos/tiledmap/tmx-xml-parser.ts
+++ b/cocos/tiledmap/tmx-xml-parser.ts
@@ -945,7 +945,7 @@ export class TMXMapInfo {
 
                 objectProp.rotation = parseFloat(selObj.getAttribute('rotation')!) || 0;
 
-                getPropertyList(selObj, objectProp as any);
+                objectProp.properties = getPropertyList(selObj)
 
                 // visible
                 const visibleAttr = selObj.getAttribute('visible');


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This pull request addresses an issue with reading object layer properties in Tiled files, ensuring properties are correctly parsed and assigned.

- Added `properties` field to `TMXObject` interface in `cocos/tiledmap/tiled-types.ts`.
- Updated `getPropertyList` function in `cocos/tiledmap/tmx-xml-parser.ts` to correctly query properties.
- Ensured properties are correctly assigned to object layers in `TMXMapInfo` class in `cocos/tiledmap/tmx-xml-parser.ts`.

<!-- /greptile_comment -->