### PR TITLE
hide custom-pipeline-post-process in module config

### DIFF
--- a/editor/engine-features/render-config.json
+++ b/editor/engine-features/render-config.json
@@ -283,7 +283,8 @@
             "default": false,
             "label": "i18n:ENGINE.features.custom_pipeline_post_process.label",
             "description": "i18n:ENGINE.features.custom_pipeline_post_process.description",
-            "enginePlugin": false
+            "enginePlugin": false,
+            "hidden": true
         },
         "legacy-pipeline": {
             "default": false,


### PR DESCRIPTION
RT



<!-- greptile_comment -->

## Greptile Summary

The pull request hides the `custom-pipeline-post-process` feature in the module configuration.

- Modified `editor/engine-features/render-config.json` to include `hidden: true` for `custom-pipeline-post-process`.
- Ensure no dependent functionalities or user workflows are affected by this change.

<!-- /greptile_comment -->