### PR TITLE
[Fixed] Fix the problem of wrong edges of csm

### DIFF
--- a/cocos/rendering/custom/web-pipeline-types.ts
+++ b/cocos/rendering/custom/web-pipeline-types.ts
@@ -22,7 +22,7 @@ const _uboVec3 = new Vec3();
 const _uboCol = new Color();
 const _matView = new Mat4();
 const _mulMatView = new Mat4();
-export function setTextureUBOView (setter: WebSetter, camera: Camera | null, cfg: Readonly<PipelineSceneData>, layout = 'default'): void {
+export function setTextureUBOView (setter: WebSetter, cfg: Readonly<PipelineSceneData>, layout = 'default'): void {
     const skybox = cfg.skybox;
     const director = cclegacy.director;
     const root = director.root;
@@ -480,7 +480,7 @@ export function setShadowUBOView (setter: WebSetter, camera: Camera | null, layo
                     }
                     _uboVec.set(mainLight.csmTransitionRange, 0, 0, 0);
                     setter.setVec4('cc_csmSplitsInfo', _uboVec);
-                    _uboVec.set(0, 0, 0, 1.0 - mainLight.shadowSaturation);
+                    _uboVec.set(0.1, mainLight.shadowDistance, 0, 1.0 - mainLight.shadowSaturation);
                     setter.setVec4('cc_shadowNFLSInfo', _uboVec);
                     _uboVec.set(LightType.DIRECTIONAL, packing, mainLight.shadowNormalBias, mainLight.csmLevel);
                     setter.setVec4('cc_shadowLPNNInfo', _uboVec);

--- a/cocos/rendering/custom/web-pipeline.ts
+++ b/cocos/rendering/custom/web-pipeline.ts
@@ -276,7 +276,6 @@ export class WebRenderQueueBuilder extends WebSetter implements RenderQueueBuild
         } else {
             setShadowUBOView(this, camera, layoutName);
         }
-        setTextureUBOView(this, camera, this._pipeline);
     }
     addScene (camera: Camera, sceneFlags = SceneFlags.NONE, light: Light | undefined = undefined, scene: RenderScene | undefined = undefined): SceneBuilder {
         const sceneData = renderGraphPool.createSceneData(
@@ -299,7 +298,6 @@ export class WebRenderQueueBuilder extends WebSetter implements RenderQueueBuild
             );
             if (light && light.type !== LightType.DIRECTIONAL) setShadowUBOLightView(this, camera, light, 0, layoutName);
             else if (!(sceneFlags & SceneFlags.SHADOW_CASTER)) setShadowUBOView(this, camera, layoutName);
-            setTextureUBOView(this, camera, this._pipeline);
         }
         const sceneBuilder = pipelinePool.sceneBuilder.add();
         sceneBuilder.update(renderData, this._lg, this._renderGraph, sceneId, sceneData);
@@ -329,7 +327,6 @@ export class WebRenderQueueBuilder extends WebSetter implements RenderQueueBuild
         } else {
             setShadowUBOView(this, null, layoutName);
         }
-        setTextureUBOView(this, null, this._pipeline);
     }
     addCameraQuad (camera: Camera, material: Material, passID: number, sceneFlags = SceneFlags.NONE): void {
         this._renderGraph.addVertex<RenderGraphValue.Blit>(
@@ -355,7 +352,6 @@ export class WebRenderQueueBuilder extends WebSetter implements RenderQueueBuild
         } else {
             setShadowUBOView(this, camera, layoutName);
         }
-        setTextureUBOView(this, camera, this._pipeline);
     }
     clearRenderTarget (name: string, color: Color = new Color()): void {
         const clearView = renderGraphPool.createClearView(name, ClearFlagBit.COLOR);
@@ -1669,6 +1665,7 @@ export class WebPipeline implements BasicPipeline {
         const result = pipelinePool.renderPassBuilder.add();
         result.update(data, this._renderGraph!, this._layoutGraph, this._resourceGraph, vertID, pass, this._pipelineSceneData);
         this._updateRasterPassConstants(result, width, height, layoutName);
+        setTextureUBOView(result, this._pipelineSceneData);
         return result;
     }
     addRenderPass (width: number, height: number, layoutName = 'default'): BasicRenderPassBuilder {


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

The pull request focuses on fixing issues related to the edges of CSM (Cascaded Shadow Maps) and streamlining the UBO (Uniform Buffer Object) setting process.

- **`cocos/rendering/custom/web-pipeline-types.ts`**:
  - Removed `camera` parameter from `setTextureUBOView`.
  - Adjusted `cc_shadowNFLSInfo` UBO vector in `setShadowUBOView`.

- **`cocos/rendering/custom/web-pipeline.ts`**:
  - Removed calls to `setTextureUBOView` from several methods.
  - Added `setTextureUBOView` call in `_updateRasterPassConstants`.

These changes aim to improve the efficiency and accuracy of the rendering pipeline, particularly in handling shadows. Thorough testing is recommended to ensure no unintended side effects.

<!-- /greptile_comment -->