### PR TITLE
rename graph nullVertex to N

### DIFF
--- a/cocos/rendering/custom/define.ts
+++ b/cocos/rendering/custom/define.ts
@@ -484,7 +484,7 @@ export function getDescriptorSetDataFromLayout (layoutName: string): DescriptorS
         return descLayout;
     }
     const webPip = cclegacy.director.root.pipeline as WebPipeline;
-    const stageId = webPip.layoutGraph.locateChild(webPip.layoutGraph.nullVertex(), layoutName);
+    const stageId = webPip.layoutGraph.locateChild(webPip.layoutGraph.N, layoutName);
     assert(stageId !== 0xFFFFFFFF);
     const layout = webPip.layoutGraph.getLayout(stageId);
     const layoutData = layout.descriptorSets.get(UpdateFrequency.PER_PASS);
@@ -798,27 +798,27 @@ export function getSubpassOrPassID (sceneId: number, rg: RenderGraph, lg: Layout
     const subpassOrPassID = rg.getParent(queueId);
     assert(subpassOrPassID !== 0xFFFFFFFF);
     const passId = rg.getParent(subpassOrPassID);
-    let layoutId = lg.nullVertex();
+    let layoutId = lg.N;
     // single render pass
-    if (passId === rg.nullVertex()) {
+    if (passId === rg.N) {
         const layoutName: string = rg.getLayout(subpassOrPassID);
         assert(!!layoutName);
-        layoutId = lg.locateChild(lg.nullVertex(), layoutName);
+        layoutId = lg.locateChild(lg.N, layoutName);
     } else {
         const passLayoutName: string = rg.getLayout(passId);
         assert(!!passLayoutName);
-        const passLayoutId = lg.locateChild(lg.nullVertex(), passLayoutName);
-        assert(passLayoutId !== lg.nullVertex());
+        const passLayoutId = lg.locateChild(lg.N, passLayoutName);
+        assert(passLayoutId !== lg.N);
 
         const subpassLayoutName: string = rg.getLayout(subpassOrPassID);
         if (subpassLayoutName.length === 0) {
             layoutId = passLayoutId;
         } else {
             const subpassLayoutId = lg.locateChild(passLayoutId, subpassLayoutName);
-            assert(subpassLayoutId !== lg.nullVertex());
+            assert(subpassLayoutId !== lg.N);
             layoutId = subpassLayoutId;
         }
     }
-    assert(layoutId !== lg.nullVertex());
+    assert(layoutId !== lg.N);
     return layoutId;
 }

--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -936,14 +936,14 @@ class DeviceRenderPass implements RecordingInterface {
         const stageName = context.renderGraph.getLayout(this.rasterPassInfo.id);
         if (stageName) {
             const layoutGraph = context.layoutGraph;
-            const stageId = layoutGraph.locateChild(layoutGraph.nullVertex(), stageName);
+            const stageId = layoutGraph.locateChild(layoutGraph.N, stageName);
             if (stageId !== 0xFFFFFFFF) {
                 this._layout = new RenderPassLayoutInfo(stageId, this.rasterPassInfo.id, input);
             }
         }
     }
     getGlobalDescData (): DescriptorSetData {
-        const stageId = context.layoutGraph.locateChild(context.layoutGraph.nullVertex(), 'default');
+        const stageId = context.layoutGraph.locateChild(context.layoutGraph.N, 'default');
         assert(stageId !== 0xFFFFFFFF);
         const layout = context.layoutGraph.getLayout(stageId);
         const layoutData = layout.descriptorSets.get(UpdateFrequency.PER_PASS)!;
@@ -1194,14 +1194,14 @@ class DeviceComputePass implements RecordingInterface {
         const stageName = context.renderGraph.getLayout(this._computeInfo.id);
         if (stageName) {
             const layoutGraph = context.layoutGraph;
-            const stageId = layoutGraph.locateChild(layoutGraph.nullVertex(), stageName);
+            const stageId = layoutGraph.locateChild(layoutGraph.N, stageName);
             if (stageId !== 0xFFFFFFFF) {
                 this._layout = new RenderPassLayoutInfo(stageId, this._computeInfo.id, input);
             }
         }
     }
     getGlobalDescData (): DescriptorSetData {
-        const stageId = context.layoutGraph.locateChild(context.layoutGraph.nullVertex(), 'default');
+        const stageId = context.layoutGraph.locateChild(context.layoutGraph.N, 'default');
         assert(stageId !== 0xFFFFFFFF);
         const layout = context.layoutGraph.getLayout(stageId);
         const layoutData = layout.descriptorSets.get(UpdateFrequency.PER_PASS)!;

--- a/cocos/rendering/custom/graph.ts
+++ b/cocos/rendering/custom/graph.ts
@@ -750,7 +750,7 @@ implements IncidenceGraph, VertexListGraph {
         // this.edge_parallel_category = parallel.allow;
         // this.traversal_category = traversal.incidence | traversal.vertex_list;
     }
-    declare N: number | null;
+    declare readonly N: number | null;
 
     edge (u: vertex_descriptor, v: vertex_descriptor): boolean {
         return this.g.reference(u, v);

--- a/cocos/rendering/custom/graph.ts
+++ b/cocos/rendering/custom/graph.ts
@@ -230,7 +230,7 @@ export interface Graph {
     // readonly edge_parallel_category: parallel;
     // readonly traversal_category: traversal;
 
-    nullVertex (): vertex_descriptor | null;
+    readonly N: number | null; // nullVertex (): vertex_descriptor | null;
 }
 
 //--------------------------------------------------------------------------
@@ -467,11 +467,11 @@ export function removeAllEdgesFromList (edges: Set<Edge>, el: OutEP[], v: vertex
 }
 
 export function getPath (g: ReferenceGraph & NamedGraph, v: vertex_descriptor | null): string {
-    if (v === g.nullVertex()) {
+    if (v === g.N) {
         return '';
     }
     const paths: string[] = [];
-    for (; v !== g.nullVertex(); v = g.getParent(v as vertex_descriptor)) {
+    for (; v !== g.N; v = g.getParent(v as vertex_descriptor)) {
         paths.push(g.vertexName(v as vertex_descriptor));
     }
     let path = '';
@@ -483,7 +483,7 @@ export function getPath (g: ReferenceGraph & NamedGraph, v: vertex_descriptor | 
 }
 
 export function findRelative (g: ParentGraph, v: vertex_descriptor | null, path: string): vertex_descriptor | null {
-    const pseudo = g.nullVertex();
+    const pseudo = g.N;
     const names = path.split('/');
 
     if (names.length === 0) { // empty string
@@ -552,7 +552,7 @@ function getDefaultStartingVertex (g: IncidenceGraph & VertexListGraph): vertex_
     const iter = g.vertices();
     const v = iter.next();
     if (v.done) {
-        return g.nullVertex();
+        return g.N;
     } else {
         return v.value;
     }
@@ -745,13 +745,13 @@ export class ReferenceGraphView <BaseGraph extends ReferenceGraph & VertexListGr
 implements IncidenceGraph, VertexListGraph {
     constructor (g: BaseGraph) {
         this.g = g;
+        this.N = g.N;
         // this.directed_category = directional.directed;
         // this.edge_parallel_category = parallel.allow;
         // this.traversal_category = traversal.incidence | traversal.vertex_list;
     }
-    nullVertex (): vertex_descriptor | null {
-        return this.g.nullVertex();
-    }
+    declare N: number | null;
+
     edge (u: vertex_descriptor, v: vertex_descriptor): boolean {
         return this.g.reference(u, v);
     }

--- a/cocos/rendering/custom/layout-graph-editor.ts
+++ b/cocos/rendering/custom/layout-graph-editor.ts
@@ -515,23 +515,23 @@ export class LayoutGraphInfo {
     readonly enableDebug = false;
     private getPassID (passName: string, type: RenderPassType): number {
         const lg = this.lg;
-        let passID = lg.locateChild(lg.nullVertex(), passName);
-        if (passID === lg.nullVertex()) {
+        let passID = lg.locateChild(lg.N, passName);
+        if (passID === lg.N) {
             passID = lg.addVertex<LayoutGraphValue.RenderStage>(
                 LayoutGraphValue.RenderStage,
                 type,
                 passName,
                 new DescriptorDB(),
-                lg.nullVertex(),
+                lg.N,
             );
         }
-        assert(passID !== lg.nullVertex());
+        assert(passID !== lg.N);
         return passID;
     }
     private getSubpassID (subpassName: string, passID: number): number {
         const lg = this.lg;
         let subpassID = lg.locateChild(passID, subpassName);
-        if (subpassID === lg.nullVertex()) {
+        if (subpassID === lg.N) {
             subpassID = lg.addVertex<LayoutGraphValue.RenderStage>(
                 LayoutGraphValue.RenderStage,
                 RenderPassType.RENDER_SUBPASS,
@@ -540,13 +540,13 @@ export class LayoutGraphInfo {
                 passID,
             );
         }
-        assert(subpassID !== lg.nullVertex());
+        assert(subpassID !== lg.N);
         return subpassID;
     }
     private getPhaseID (phaseName: string, subpassOrPassID: number): number {
         const lg = this.lg;
         let phaseID = lg.locateChild(subpassOrPassID, phaseName);
-        if (phaseID === lg.nullVertex()) {
+        if (phaseID === lg.N) {
             phaseID = lg.addVertex<LayoutGraphValue.RenderPhase>(
                 LayoutGraphValue.RenderPhase,
                 new RenderPhase(),
@@ -555,7 +555,7 @@ export class LayoutGraphInfo {
                 subpassOrPassID,
             );
         }
-        assert(phaseID !== lg.nullVertex());
+        assert(phaseID !== lg.N);
         return phaseID;
     }
     private getDescriptorBlock (key: string, descriptorDB: DescriptorDB): DescriptorBlock {
@@ -958,9 +958,9 @@ function buildLayoutGraphDataImpl (graph: LayoutGraph, builder: LayoutGraphBuild
             const type = graph.j<RenderPassType>(v);
             const parentID = graph.getParent(v);
             if (type === RenderPassType.RENDER_SUBPASS) {
-                assert(parentID !== graph.nullVertex());
+                assert(parentID !== graph.N);
             } else {
-                assert(parentID === graph.nullVertex());
+                assert(parentID === graph.N);
             }
             if (type === RenderPassType.RENDER_PASS) {
                 isRenderPass = true;

--- a/cocos/rendering/custom/layout-graph-utils.ts
+++ b/cocos/rendering/custom/layout-graph-utils.ts
@@ -91,7 +91,7 @@ export function getDescriptorTypeOrder (type: DescriptorType): DescriptorTypeOrd
 
 // find passID using name
 export function getCustomPassID (lg: LayoutGraphData, name: string | undefined): number {
-    return lg.locateChild(lg.nullVertex(), name || 'default');
+    return lg.locateChild(lg.N, name || 'default');
 }
 
 // find subpassID using name
@@ -573,7 +573,7 @@ export function getOrCreateDescriptorBlockData (
 }
 
 export function getProgramID (lg: LayoutGraphData, phaseID: number, programName: string): number {
-    assert(phaseID !== lg.nullVertex());
+    assert(phaseID !== lg.N);
     const phase = lg.j<RenderPhaseData>(phaseID);
     const programID = phase.shaderIndex.get(programName);
     if (programID === undefined) {
@@ -601,7 +601,7 @@ export function getPerPassDescriptorSetLayoutData (
     lg: LayoutGraphData,
     subpassOrPassID: number,
 ): DescriptorSetLayoutData | null {
-    assert(subpassOrPassID !== lg.nullVertex());
+    assert(subpassOrPassID !== lg.N);
     const node = lg.getLayout(subpassOrPassID);
     const set = node.descriptorSets.get(UpdateFrequency.PER_PASS);
     if (set === undefined) {
@@ -614,7 +614,7 @@ export function getPerPhaseDescriptorSetLayoutData (
     lg: LayoutGraphData,
     phaseID: number,
 ): DescriptorSetLayoutData | null {
-    assert(phaseID !== lg.nullVertex());
+    assert(phaseID !== lg.N);
     const node = lg.getLayout(phaseID);
     const set = node.descriptorSets.get(UpdateFrequency.PER_PHASE);
     if (set === undefined) {
@@ -628,7 +628,7 @@ export function getPerBatchDescriptorSetLayoutData (
     phaseID: number,
     programID,
 ): DescriptorSetLayoutData | null {
-    assert(phaseID !== lg.nullVertex());
+    assert(phaseID !== lg.N);
     const phase = lg.j<RenderPhaseData>(phaseID);
     assert(programID < phase.shaderPrograms.length);
     const program = phase.shaderPrograms[programID];
@@ -644,7 +644,7 @@ export function getPerInstanceDescriptorSetLayoutData (
     phaseID: number,
     programID,
 ): DescriptorSetLayoutData | null {
-    assert(phaseID !== lg.nullVertex());
+    assert(phaseID !== lg.N);
     const phase = lg.j<RenderPhaseData>(phaseID);
     assert(programID < phase.shaderPrograms.length);
     const program = phase.shaderPrograms[programID];

--- a/cocos/rendering/custom/layout-graph.ts
+++ b/cocos/rendering/custom/layout-graph.ts
@@ -130,8 +130,8 @@ export class LayoutGraph implements BidirectionalGraph
 , AddressableGraph {
     //-----------------------------------------------------------------
     // Graph
-    // type vertex_descriptor = number;
-    nullVertex (): number { return 0xFFFFFFFF; }
+    /** null vertex descriptor */
+    readonly N = 0xFFFFFFFF;
     // type edge_descriptor = ED;
     //-----------------------------------------------------------------
     // IncidenceGraph
@@ -609,8 +609,8 @@ export class LayoutGraphData implements BidirectionalGraph
 , AddressableGraph {
     //-----------------------------------------------------------------
     // Graph
-    // type vertex_descriptor = number;
-    nullVertex (): number { return 0xFFFFFFFF; }
+    /** null vertex descriptor */
+    readonly N = 0xFFFFFFFF;
     // type edge_descriptor = ED;
     //-----------------------------------------------------------------
     // IncidenceGraph

--- a/cocos/rendering/custom/render-graph.ts
+++ b/cocos/rendering/custom/render-graph.ts
@@ -313,8 +313,8 @@ export class SubpassGraph implements BidirectionalGraph
 , ComponentGraph {
     //-----------------------------------------------------------------
     // Graph
-    // type vertex_descriptor = number;
-    nullVertex (): number { return 0xFFFFFFFF; }
+    /** null vertex descriptor */
+    readonly N = 0xFFFFFFFF;
     // type edge_descriptor = ED;
     //-----------------------------------------------------------------
     // IncidenceGraph
@@ -659,8 +659,8 @@ export class ResourceGraph implements BidirectionalGraph
 , UuidGraph<string> {
     //-----------------------------------------------------------------
     // Graph
-    // type vertex_descriptor = number;
-    nullVertex (): number { return 0xFFFFFFFF; }
+    /** null vertex descriptor */
+    readonly N = 0xFFFFFFFF;
     // type edge_descriptor = ED;
     //-----------------------------------------------------------------
     // IncidenceGraph
@@ -1239,8 +1239,8 @@ export class RenderGraph implements BidirectionalGraph
 , MutableReferenceGraph {
     //-----------------------------------------------------------------
     // Graph
-    // type vertex_descriptor = number;
-    nullVertex (): number { return 0xFFFFFFFF; }
+    /** null vertex descriptor */
+    readonly N = 0xFFFFFFFF;
     // type edge_descriptor = ED;
     //-----------------------------------------------------------------
     // IncidenceGraph

--- a/cocos/rendering/custom/scene-culling.ts
+++ b/cocos/rendering/custom/scene-culling.ts
@@ -660,7 +660,7 @@ export class SceneCulling {
             assert(rg.holds(RenderGraphValue.Queue, renderQueueId));
             const graphRenderQueue = rg.j<RenderQueue0>(renderQueueId);
             const phaseLayoutId = graphRenderQueue.phaseID;
-            assert(phaseLayoutId !== this.layoutGraph.nullVertex());
+            assert(phaseLayoutId !== this.layoutGraph.N);
 
             // culling source
             assert(frustomCulledResultID < this.frustumCullingResults.length);

--- a/cocos/rendering/custom/web-pipeline.ts
+++ b/cocos/rendering/custom/web-pipeline.ts
@@ -398,7 +398,7 @@ export class WebRenderSubpassBuilder extends WebSetter implements RenderSubpassB
         this._pipeline = pipeline;
 
         const layoutName = this._renderGraph.getLayout(this._vertID);
-        this._layoutID = layoutGraph.locateChild(layoutGraph.nullVertex(), layoutName);
+        this._layoutID = layoutGraph.locateChild(layoutGraph.N, layoutName);
     }
     update (
         data: RenderData,
@@ -416,7 +416,7 @@ export class WebRenderSubpassBuilder extends WebSetter implements RenderSubpassB
         this._pipeline = pipeline;
 
         const layoutName = this._renderGraph.getLayout(this._vertID);
-        this._layoutID = layoutGraph.locateChild(layoutGraph.nullVertex(), layoutName);
+        this._layoutID = layoutGraph.locateChild(layoutGraph.N, layoutName);
     }
     addRenderTarget (name: string, accessType: AccessType, slotName?: string | undefined, loadOp?: LoadOp | undefined, storeOp?: StoreOp | undefined, color?: Color | undefined): void {
         throw new Error('Method not implemented.');
@@ -482,7 +482,7 @@ export class WebRenderPassBuilder extends WebSetter implements BasicMultisampleR
         this._pass = pass;
         this._pipeline = pipeline;
         const layoutName = this._renderGraph.getLayout(this._vertID);
-        this._layoutID = layoutGraph.locateChild(layoutGraph.nullVertex(), layoutName);
+        this._layoutID = layoutGraph.locateChild(layoutGraph.N, layoutName);
     }
     update (data: RenderData, renderGraph: RenderGraph, layoutGraph: LayoutGraphData, resourceGraph: ResourceGraph, vertID: number, pass: RasterPass, pipeline: PipelineSceneData): void {
         this._renderGraph = renderGraph;
@@ -493,7 +493,7 @@ export class WebRenderPassBuilder extends WebSetter implements BasicMultisampleR
         this._pipeline = pipeline;
         this._data = data;
         const layoutName = this._renderGraph.getLayout(this._vertID);
-        this._layoutID = layoutGraph.locateChild(layoutGraph.nullVertex(), layoutName);
+        this._layoutID = layoutGraph.locateChild(layoutGraph.N, layoutName);
     }
 
     setCustomShaderStages (name: string, stageFlags: ShaderStageFlagBit): void {
@@ -733,7 +733,7 @@ export class WebComputePassBuilder extends WebSetter implements ComputePassBuild
         this._pipeline = pipeline;
 
         const layoutName = this._renderGraph.getLayout(this._vertID);
-        this._layoutID = layoutGraph.locateChild(layoutGraph.nullVertex(), layoutName);
+        this._layoutID = layoutGraph.locateChild(layoutGraph.N, layoutName);
     }
     update (data: RenderData, renderGraph: RenderGraph, layoutGraph: LayoutGraphData, resourceGraph: ResourceGraph, vertID: number, pass: ComputePass, pipeline: PipelineSceneData): void {
         this._data = data;
@@ -745,7 +745,7 @@ export class WebComputePassBuilder extends WebSetter implements ComputePassBuild
         this._pipeline = pipeline;
 
         const layoutName = this._renderGraph.getLayout(this._vertID);
-        this._layoutID = layoutGraph.locateChild(layoutGraph.nullVertex(), layoutName);
+        this._layoutID = layoutGraph.locateChild(layoutGraph.N, layoutName);
     }
     setCustomShaderStages (name: string, stageFlags: ShaderStageFlagBit): void {
         throw new Error('Method not implemented.');
@@ -1175,7 +1175,7 @@ export class WebPipeline implements BasicPipeline {
     }
 
     public getGlobalDescriptorSetData (): DescriptorSetData | undefined {
-        const stageId = this.layoutGraph.locateChild(this.layoutGraph.nullVertex(), 'default');
+        const stageId = this.layoutGraph.locateChild(this.layoutGraph.N, 'default');
         assert(stageId !== 0xFFFFFFFF);
         const layout = this.layoutGraph.getLayout(stageId);
         const layoutData = layout.descriptorSets.get(UpdateFrequency.PER_PASS);
@@ -1651,7 +1651,7 @@ export class WebPipeline implements BasicPipeline {
     }
     addRenderPassImpl (width: number, height: number, layoutName: string, count = 1, quality = 0): BasicMultisampleRenderPassBuilder {
         if (DEBUG) {
-            const stageId = this.layoutGraph.locateChild(this.layoutGraph.nullVertex(), layoutName);
+            const stageId = this.layoutGraph.locateChild(this.layoutGraph.N, layoutName);
             assert(stageId !== 0xFFFFFFFF);
             const layout = this.layoutGraph.getLayout(stageId);
             assert(Boolean(layout));


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Renamed `nullVertex` to `N` and made it readonly for improved code clarity and maintainability.

- `/cocos/rendering/custom/graph.ts`: Renamed `nullVertex` to `N` and set it as readonly to prevent modifications and enhance stability.

<!-- /greptile_comment -->