### PR TITLE
fix Skeleton's opacity can not work normally

### DIFF
--- a/cocos/spine/assembler/simple.ts
+++ b/cocos/spine/assembler/simple.ts
@@ -280,7 +280,7 @@ function cacheTraverse (comp: Skeleton): void {
 
     const nodeColor = comp.color;
     const opacity = comp.node._uiProps.opacity;
-    if (Math.abs(opacity - 1) > EPSILON || Color.toUint32(nodeColor) !== 0xffffffff ||  _premultipliedAlpha) {
+    if ((1 - opacity) > EPSILON || Color.toUint32(nodeColor) !== 0xffffffff ||  _premultipliedAlpha) {
         _nodeR = nodeColor.r / 255;
         _nodeG = nodeColor.g / 255;
         _nodeB = nodeColor.b / 255;

--- a/cocos/spine/assembler/simple.ts
+++ b/cocos/spine/assembler/simple.ts
@@ -33,7 +33,7 @@ import { legacyCC } from '../../core/global-exports';
 import { RenderData } from '../../2d/renderer/render-data';
 import { director } from '../../game';
 import spine from '../lib/spine-core.js';
-import { Color, Vec3 } from '../../core';
+import { Color, EPSILON, Vec3 } from '../../core';
 import { MaterialInstance } from '../../render-scene';
 
 const _slotColor = new Color(0, 0, 255, 255);
@@ -279,11 +279,12 @@ function cacheTraverse (comp: Skeleton): void {
     vUint8Buf.set(model.vData as TypedArray);
 
     const nodeColor = comp.color;
-    if (Color.toUint32(nodeColor) !== 0xffffffff ||  _premultipliedAlpha) {
+    const opacity = comp.node._uiProps.opacity;
+    if (Math.abs(opacity - 1) > EPSILON || Color.toUint32(nodeColor) !== 0xffffffff ||  _premultipliedAlpha) {
         _nodeR = nodeColor.r / 255;
         _nodeG = nodeColor.g / 255;
         _nodeB = nodeColor.b / 255;
-        _nodeA = nodeColor.a / 255;
+        _nodeA = nodeColor.a * opacity / 255;
         for (let i = 0; i < vc; i++) {
             const index = i * _byteStrideTwoColor + 5 * Float32Array.BYTES_PER_ELEMENT;
             const R = vUint8Buf[index];

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -1665,7 +1665,7 @@ export class Skeleton extends UIRenderer {
         const r = this._color.r / 255.0;
         const g = this._color.g / 255.0;
         const b = this._color.b / 255.0;
-        this._instance!.setColor(r, g, b, a);
+        this._instance!.setColor(r, g, b, a * this._color.a / 255.0);
     }
 
     /**

--- a/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
@@ -238,7 +238,7 @@ void SkeletonCacheAnimation::render(float /*dt*/) {
     }
 
     auto handleColor = [&](SkeletonCache::ColorData *colorData) {
-        tempA = colorData->finalColor.a * _nodeColor.a;
+        tempA = colorData->finalColor.a * _nodeColor.a * _entity->getOpacity();
         multiplier = _premultipliedAlpha ? tempA / 255 : 1;
         tempR = _nodeColor.r * multiplier;
         tempG = _nodeColor.g * multiplier;

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -543,7 +543,7 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
             continue;
         }
 
-        color.a = _skeleton->getColor().a * slot->getColor().a * color.a * _nodeColor.a * 255;
+        color.a = _skeleton->getColor().a * slot->getColor().a * color.a * _nodeColor.a * _entity->getOpacity() * 255;
         // skip rendering if the color of this attachment is 0
         if (color.a == 0) {
             _clipper->clipEnd(*slot);


### PR DESCRIPTION
Re: #
https://github.com/cocos/cocos-engine/issues/16960
https://github.com/cocos/cocos-engine/issues/16601

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This PR addresses issues with Skeleton opacity in the Cocos Engine, implementing changes to ensure proper opacity handling across different rendering modes.

- Modified `cocos/spine/assembler/simple.ts` to use a more precise EPSILON comparison for opacity calculations
- Updated `cocos/spine/skeleton.ts` to include node opacity in alpha value calculations for the `_updateColor` method
- Adjusted `SkeletonCacheAnimation::render` in native C++ code to incorporate entity opacity in final color calculations
- Modified `SkeletonRenderer::render` in native C++ code to include entity opacity in the opacity calculation

<!-- /greptile_comment -->