### PR TITLE
simplify pool creation

### DIFF
--- a/cocos/rendering/custom/layout-graph.ts
+++ b/cocos/rendering/custom/layout-graph.ts
@@ -853,6 +853,10 @@ export class LayoutGraphData implements BidirectionalGraph
     constantMacros = '';
 }
 
+function createPool<T> (Constructor: new() => T): RecyclePool<T> {
+    return new RecyclePool<T>(() => new Constructor(), 16);
+}
+
 export class LayoutGraphObjectPool {
     constructor (renderCommon: RenderCommonObjectPool) {
         this.renderCommon = renderCommon;
@@ -986,24 +990,24 @@ export class LayoutGraphObjectPool {
         return v;
     }
     public readonly renderCommon: RenderCommonObjectPool;
-    private readonly _descriptorDB: RecyclePool<DescriptorDB> = new RecyclePool<DescriptorDB>(() => new DescriptorDB(), 16);
-    private readonly _renderPhase: RecyclePool<RenderPhase> = new RecyclePool<RenderPhase>(() => new RenderPhase(), 16);
-    private readonly _layoutGraph: RecyclePool<LayoutGraph> = new RecyclePool<LayoutGraph>(() => new LayoutGraph(), 16);
-    private readonly _uniformData: RecyclePool<UniformData> = new RecyclePool<UniformData>(() => new UniformData(), 16);
-    private readonly _uniformBlockData: RecyclePool<UniformBlockData> = new RecyclePool<UniformBlockData>(() => new UniformBlockData(), 16);
-    private readonly _descriptorData: RecyclePool<DescriptorData> = new RecyclePool<DescriptorData>(() => new DescriptorData(), 16);
-    private readonly _descriptorBlockData: RecyclePool<DescriptorBlockData> = new RecyclePool<DescriptorBlockData>(() => new DescriptorBlockData(), 16);
-    private readonly _descriptorSetLayoutData: RecyclePool<DescriptorSetLayoutData> = new RecyclePool<DescriptorSetLayoutData>(() => new DescriptorSetLayoutData(), 16);
-    private readonly _descriptorSetData: RecyclePool<DescriptorSetData> = new RecyclePool<DescriptorSetData>(() => new DescriptorSetData(), 16);
-    private readonly _pipelineLayoutData: RecyclePool<PipelineLayoutData> = new RecyclePool<PipelineLayoutData>(() => new PipelineLayoutData(), 16);
-    private readonly _shaderBindingData: RecyclePool<ShaderBindingData> = new RecyclePool<ShaderBindingData>(() => new ShaderBindingData(), 16);
-    private readonly _shaderLayoutData: RecyclePool<ShaderLayoutData> = new RecyclePool<ShaderLayoutData>(() => new ShaderLayoutData(), 16);
-    private readonly _techniqueData: RecyclePool<TechniqueData> = new RecyclePool<TechniqueData>(() => new TechniqueData(), 16);
-    private readonly _effectData: RecyclePool<EffectData> = new RecyclePool<EffectData>(() => new EffectData(), 16);
-    private readonly _shaderProgramData: RecyclePool<ShaderProgramData> = new RecyclePool<ShaderProgramData>(() => new ShaderProgramData(), 16);
-    private readonly _renderStageData: RecyclePool<RenderStageData> = new RecyclePool<RenderStageData>(() => new RenderStageData(), 16);
-    private readonly _renderPhaseData: RecyclePool<RenderPhaseData> = new RecyclePool<RenderPhaseData>(() => new RenderPhaseData(), 16);
-    private readonly _layoutGraphData: RecyclePool<LayoutGraphData> = new RecyclePool<LayoutGraphData>(() => new LayoutGraphData(), 16);
+    private readonly _descriptorDB: RecyclePool<DescriptorDB> = createPool(DescriptorDB);
+    private readonly _renderPhase: RecyclePool<RenderPhase> = createPool(RenderPhase);
+    private readonly _layoutGraph: RecyclePool<LayoutGraph> = createPool(LayoutGraph);
+    private readonly _uniformData: RecyclePool<UniformData> = createPool(UniformData);
+    private readonly _uniformBlockData: RecyclePool<UniformBlockData> = createPool(UniformBlockData);
+    private readonly _descriptorData: RecyclePool<DescriptorData> = createPool(DescriptorData);
+    private readonly _descriptorBlockData: RecyclePool<DescriptorBlockData> = createPool(DescriptorBlockData);
+    private readonly _descriptorSetLayoutData: RecyclePool<DescriptorSetLayoutData> = createPool(DescriptorSetLayoutData);
+    private readonly _descriptorSetData: RecyclePool<DescriptorSetData> = createPool(DescriptorSetData);
+    private readonly _pipelineLayoutData: RecyclePool<PipelineLayoutData> = createPool(PipelineLayoutData);
+    private readonly _shaderBindingData: RecyclePool<ShaderBindingData> = createPool(ShaderBindingData);
+    private readonly _shaderLayoutData: RecyclePool<ShaderLayoutData> = createPool(ShaderLayoutData);
+    private readonly _techniqueData: RecyclePool<TechniqueData> = createPool(TechniqueData);
+    private readonly _effectData: RecyclePool<EffectData> = createPool(EffectData);
+    private readonly _shaderProgramData: RecyclePool<ShaderProgramData> = createPool(ShaderProgramData);
+    private readonly _renderStageData: RecyclePool<RenderStageData> = createPool(RenderStageData);
+    private readonly _renderPhaseData: RecyclePool<RenderPhaseData> = createPool(RenderPhaseData);
+    private readonly _layoutGraphData: RecyclePool<LayoutGraphData> = createPool(LayoutGraphData);
 }
 
 export function saveDescriptorDB (a: OutputArchive, v: DescriptorDB): void {

--- a/cocos/rendering/custom/render-graph.ts
+++ b/cocos/rendering/custom/render-graph.ts
@@ -1485,6 +1485,10 @@ export class RenderGraph implements BidirectionalGraph
     readonly sortedVertices: number[] = [];
 }
 
+function createPool<T> (Constructor: new() => T): RecyclePool<T> {
+    return new RecyclePool<T>(() => new Constructor(), 16);
+}
+
 export class RenderGraphObjectPool {
     constructor (renderCommon: RenderCommonObjectPool) {
         this.renderCommon = renderCommon;
@@ -1755,37 +1759,37 @@ export class RenderGraphObjectPool {
         return v;
     }
     public readonly renderCommon: RenderCommonObjectPool;
-    private readonly _clearValue: RecyclePool<ClearValue> = new RecyclePool<ClearValue>(() => new ClearValue(), 16);
-    private readonly _rasterView: RecyclePool<RasterView> = new RecyclePool<RasterView>(() => new RasterView(), 16);
-    private readonly _computeView: RecyclePool<ComputeView> = new RecyclePool<ComputeView>(() => new ComputeView(), 16);
-    private readonly _resourceDesc: RecyclePool<ResourceDesc> = new RecyclePool<ResourceDesc>(() => new ResourceDesc(), 16);
-    private readonly _resourceTraits: RecyclePool<ResourceTraits> = new RecyclePool<ResourceTraits>(() => new ResourceTraits(), 16);
-    private readonly _renderSwapchain: RecyclePool<RenderSwapchain> = new RecyclePool<RenderSwapchain>(() => new RenderSwapchain(), 16);
-    private readonly _resourceStates: RecyclePool<ResourceStates> = new RecyclePool<ResourceStates>(() => new ResourceStates(), 16);
-    private readonly _managedBuffer: RecyclePool<ManagedBuffer> = new RecyclePool<ManagedBuffer>(() => new ManagedBuffer(), 16);
-    private readonly _persistentBuffer: RecyclePool<PersistentBuffer> = new RecyclePool<PersistentBuffer>(() => new PersistentBuffer(), 16);
-    private readonly _managedTexture: RecyclePool<ManagedTexture> = new RecyclePool<ManagedTexture>(() => new ManagedTexture(), 16);
-    private readonly _persistentTexture: RecyclePool<PersistentTexture> = new RecyclePool<PersistentTexture>(() => new PersistentTexture(), 16);
-    private readonly _managedResource: RecyclePool<ManagedResource> = new RecyclePool<ManagedResource>(() => new ManagedResource(), 16);
-    private readonly _subpass: RecyclePool<Subpass> = new RecyclePool<Subpass>(() => new Subpass(), 16);
-    private readonly _subpassGraph: RecyclePool<SubpassGraph> = new RecyclePool<SubpassGraph>(() => new SubpassGraph(), 16);
-    private readonly _rasterSubpass: RecyclePool<RasterSubpass> = new RecyclePool<RasterSubpass>(() => new RasterSubpass(), 16);
-    private readonly _computeSubpass: RecyclePool<ComputeSubpass> = new RecyclePool<ComputeSubpass>(() => new ComputeSubpass(), 16);
-    private readonly _rasterPass: RecyclePool<RasterPass> = new RecyclePool<RasterPass>(() => new RasterPass(), 16);
-    private readonly _persistentRenderPassAndFramebuffer: RecyclePool<PersistentRenderPassAndFramebuffer> = new RecyclePool<PersistentRenderPassAndFramebuffer>(() => new PersistentRenderPassAndFramebuffer(), 16);
-    private readonly _formatView: RecyclePool<FormatView> = new RecyclePool<FormatView>(() => new FormatView(), 16);
-    private readonly _subresourceView: RecyclePool<SubresourceView> = new RecyclePool<SubresourceView>(() => new SubresourceView(), 16);
-    private readonly _resourceGraph: RecyclePool<ResourceGraph> = new RecyclePool<ResourceGraph>(() => new ResourceGraph(), 16);
-    private readonly _computePass: RecyclePool<ComputePass> = new RecyclePool<ComputePass>(() => new ComputePass(), 16);
-    private readonly _resolvePass: RecyclePool<ResolvePass> = new RecyclePool<ResolvePass>(() => new ResolvePass(), 16);
-    private readonly _copyPass: RecyclePool<CopyPass> = new RecyclePool<CopyPass>(() => new CopyPass(), 16);
-    private readonly _movePass: RecyclePool<MovePass> = new RecyclePool<MovePass>(() => new MovePass(), 16);
-    private readonly _raytracePass: RecyclePool<RaytracePass> = new RecyclePool<RaytracePass>(() => new RaytracePass(), 16);
-    private readonly _clearView: RecyclePool<ClearView> = new RecyclePool<ClearView>(() => new ClearView(), 16);
-    private readonly _renderQueue: RecyclePool<RenderQueue> = new RecyclePool<RenderQueue>(() => new RenderQueue(), 16);
-    private readonly _sceneData: RecyclePool<SceneData> = new RecyclePool<SceneData>(() => new SceneData(), 16);
-    private readonly _dispatch: RecyclePool<Dispatch> = new RecyclePool<Dispatch>(() => new Dispatch(), 16);
-    private readonly _blit: RecyclePool<Blit> = new RecyclePool<Blit>(() => new Blit(), 16);
-    private readonly _renderData: RecyclePool<RenderData> = new RecyclePool<RenderData>(() => new RenderData(), 16);
-    private readonly _renderGraph: RecyclePool<RenderGraph> = new RecyclePool<RenderGraph>(() => new RenderGraph(), 16);
+    private readonly _clearValue: RecyclePool<ClearValue> = createPool(ClearValue);
+    private readonly _rasterView: RecyclePool<RasterView> = createPool(RasterView);
+    private readonly _computeView: RecyclePool<ComputeView> = createPool(ComputeView);
+    private readonly _resourceDesc: RecyclePool<ResourceDesc> = createPool(ResourceDesc);
+    private readonly _resourceTraits: RecyclePool<ResourceTraits> = createPool(ResourceTraits);
+    private readonly _renderSwapchain: RecyclePool<RenderSwapchain> = createPool(RenderSwapchain);
+    private readonly _resourceStates: RecyclePool<ResourceStates> = createPool(ResourceStates);
+    private readonly _managedBuffer: RecyclePool<ManagedBuffer> = createPool(ManagedBuffer);
+    private readonly _persistentBuffer: RecyclePool<PersistentBuffer> = createPool(PersistentBuffer);
+    private readonly _managedTexture: RecyclePool<ManagedTexture> = createPool(ManagedTexture);
+    private readonly _persistentTexture: RecyclePool<PersistentTexture> = createPool(PersistentTexture);
+    private readonly _managedResource: RecyclePool<ManagedResource> = createPool(ManagedResource);
+    private readonly _subpass: RecyclePool<Subpass> = createPool(Subpass);
+    private readonly _subpassGraph: RecyclePool<SubpassGraph> = createPool(SubpassGraph);
+    private readonly _rasterSubpass: RecyclePool<RasterSubpass> = createPool(RasterSubpass);
+    private readonly _computeSubpass: RecyclePool<ComputeSubpass> = createPool(ComputeSubpass);
+    private readonly _rasterPass: RecyclePool<RasterPass> = createPool(RasterPass);
+    private readonly _persistentRenderPassAndFramebuffer: RecyclePool<PersistentRenderPassAndFramebuffer> = createPool(PersistentRenderPassAndFramebuffer);
+    private readonly _formatView: RecyclePool<FormatView> = createPool(FormatView);
+    private readonly _subresourceView: RecyclePool<SubresourceView> = createPool(SubresourceView);
+    private readonly _resourceGraph: RecyclePool<ResourceGraph> = createPool(ResourceGraph);
+    private readonly _computePass: RecyclePool<ComputePass> = createPool(ComputePass);
+    private readonly _resolvePass: RecyclePool<ResolvePass> = createPool(ResolvePass);
+    private readonly _copyPass: RecyclePool<CopyPass> = createPool(CopyPass);
+    private readonly _movePass: RecyclePool<MovePass> = createPool(MovePass);
+    private readonly _raytracePass: RecyclePool<RaytracePass> = createPool(RaytracePass);
+    private readonly _clearView: RecyclePool<ClearView> = createPool(ClearView);
+    private readonly _renderQueue: RecyclePool<RenderQueue> = createPool(RenderQueue);
+    private readonly _sceneData: RecyclePool<SceneData> = createPool(SceneData);
+    private readonly _dispatch: RecyclePool<Dispatch> = createPool(Dispatch);
+    private readonly _blit: RecyclePool<Blit> = createPool(Blit);
+    private readonly _renderData: RecyclePool<RenderData> = createPool(RenderData);
+    private readonly _renderGraph: RecyclePool<RenderGraph> = createPool(RenderGraph);
 }

--- a/cocos/rendering/custom/types.ts
+++ b/cocos/rendering/custom/types.ts
@@ -444,6 +444,10 @@ export class PipelineStatistics {
     numInstancingUniformBlocks = 0;
 }
 
+function createPool<T> (Constructor: new() => T): RecyclePool<T> {
+    return new RecyclePool<T>(() => new Constructor(), 16);
+}
+
 export class RenderCommonObjectPool {
     constructor () {
     }
@@ -556,16 +560,16 @@ export class RenderCommonObjectPool {
         v.reset();
         return v;
     }
-    private readonly _lightInfo: RecyclePool<LightInfo> = new RecyclePool<LightInfo>(() => new LightInfo(), 16);
-    private readonly _descriptor: RecyclePool<Descriptor> = new RecyclePool<Descriptor>(() => new Descriptor(), 16);
-    private readonly _descriptorBlock: RecyclePool<DescriptorBlock> = new RecyclePool<DescriptorBlock>(() => new DescriptorBlock(), 16);
-    private readonly _descriptorBlockFlattened: RecyclePool<DescriptorBlockFlattened> = new RecyclePool<DescriptorBlockFlattened>(() => new DescriptorBlockFlattened(), 16);
-    private readonly _descriptorBlockIndex: RecyclePool<DescriptorBlockIndex> = new RecyclePool<DescriptorBlockIndex>(() => new DescriptorBlockIndex(), 16);
-    private readonly _resolvePair: RecyclePool<ResolvePair> = new RecyclePool<ResolvePair>(() => new ResolvePair(), 16);
-    private readonly _copyPair: RecyclePool<CopyPair> = new RecyclePool<CopyPair>(() => new CopyPair(), 16);
-    private readonly _uploadPair: RecyclePool<UploadPair> = new RecyclePool<UploadPair>(() => new UploadPair(), 16);
-    private readonly _movePair: RecyclePool<MovePair> = new RecyclePool<MovePair>(() => new MovePair(), 16);
-    private readonly _pipelineStatistics: RecyclePool<PipelineStatistics> = new RecyclePool<PipelineStatistics>(() => new PipelineStatistics(), 16);
+    private readonly _lightInfo: RecyclePool<LightInfo> = createPool(LightInfo);
+    private readonly _descriptor: RecyclePool<Descriptor> = createPool(Descriptor);
+    private readonly _descriptorBlock: RecyclePool<DescriptorBlock> = createPool(DescriptorBlock);
+    private readonly _descriptorBlockFlattened: RecyclePool<DescriptorBlockFlattened> = createPool(DescriptorBlockFlattened);
+    private readonly _descriptorBlockIndex: RecyclePool<DescriptorBlockIndex> = createPool(DescriptorBlockIndex);
+    private readonly _resolvePair: RecyclePool<ResolvePair> = createPool(ResolvePair);
+    private readonly _copyPair: RecyclePool<CopyPair> = createPool(CopyPair);
+    private readonly _uploadPair: RecyclePool<UploadPair> = createPool(UploadPair);
+    private readonly _movePair: RecyclePool<MovePair> = createPool(MovePair);
+    private readonly _pipelineStatistics: RecyclePool<PipelineStatistics> = createPool(PipelineStatistics);
 }
 
 export function saveLightInfo (a: OutputArchive, v: LightInfo): void {


### PR DESCRIPTION
Reduce pool creation code.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

The pull request introduces a `createPool` helper function to streamline the creation of `RecyclePool` instances, reducing redundancy and improving maintainability across multiple classes.

- Added `createPool` function in `cocos/rendering/custom/layout-graph.ts` to simplify `RecyclePool` creation.
- Updated `LayoutGraphObjectPool` class in `cocos/rendering/custom/layout-graph.ts` to use `createPool`.
- Applied `createPool` function in `cocos/rendering/custom/render-graph.ts` for `RenderGraphObjectPool`.
- Refactored `RenderCommonObjectPool` class in `cocos/rendering/custom/types.ts` to utilize `createPool`.

These changes enhance code readability and maintainability without altering functionality.

<!-- /greptile_comment -->