### PR TITLE
reduce pool private member size

### DIFF
--- a/cocos/rendering/custom/layout-graph.ts
+++ b/cocos/rendering/custom/layout-graph.ts
@@ -862,12 +862,12 @@ export class LayoutGraphObjectPool {
         this.renderCommon = renderCommon;
     }
     reset (): void {
-        this.ddb.reset(); // DescriptorDB
+        this.dd.reset(); // DescriptorDB
         this.rp.reset(); // RenderPhase
         this.lg.reset(); // LayoutGraph
         this.ud.reset(); // UniformData
         this.ubd.reset(); // UniformBlockData
-        this.dd.reset(); // DescriptorData
+        this.dd1.reset(); // DescriptorData
         this.dbd.reset(); // DescriptorBlockData
         this.dsld.reset(); // DescriptorSetLayoutData
         this.dsd.reset(); // DescriptorSetData
@@ -882,7 +882,7 @@ export class LayoutGraphObjectPool {
         this.lgd.reset(); // LayoutGraphData
     }
     createDescriptorDB (): DescriptorDB {
-        const v = this.ddb.add(); // DescriptorDB
+        const v = this.dd.add(); // DescriptorDB
         v.reset();
         return v;
     }
@@ -915,7 +915,7 @@ export class LayoutGraphObjectPool {
         type: Type = Type.UNKNOWN,
         count = 1,
     ): DescriptorData {
-        const v = this.dd.add(); // DescriptorData
+        const v = this.dd1.add(); // DescriptorData
         v.reset(descriptorID, type, count);
         return v;
     }
@@ -990,12 +990,12 @@ export class LayoutGraphObjectPool {
         return v;
     }
     public readonly renderCommon: RenderCommonObjectPool;
-    private readonly ddb: RecyclePool<DescriptorDB> = createPool(DescriptorDB);
+    private readonly dd: RecyclePool<DescriptorDB> = createPool(DescriptorDB);
     private readonly rp: RecyclePool<RenderPhase> = createPool(RenderPhase);
     private readonly lg: RecyclePool<LayoutGraph> = createPool(LayoutGraph);
     private readonly ud: RecyclePool<UniformData> = createPool(UniformData);
     private readonly ubd: RecyclePool<UniformBlockData> = createPool(UniformBlockData);
-    private readonly dd: RecyclePool<DescriptorData> = createPool(DescriptorData);
+    private readonly dd1: RecyclePool<DescriptorData> = createPool(DescriptorData);
     private readonly dbd: RecyclePool<DescriptorBlockData> = createPool(DescriptorBlockData);
     private readonly dsld: RecyclePool<DescriptorSetLayoutData> = createPool(DescriptorSetLayoutData);
     private readonly dsd: RecyclePool<DescriptorSetData> = createPool(DescriptorSetData);

--- a/cocos/rendering/custom/layout-graph.ts
+++ b/cocos/rendering/custom/layout-graph.ts
@@ -862,37 +862,37 @@ export class LayoutGraphObjectPool {
         this.renderCommon = renderCommon;
     }
     reset (): void {
-        this._descriptorDB.reset();
-        this._renderPhase.reset();
-        this._layoutGraph.reset();
-        this._uniformData.reset();
-        this._uniformBlockData.reset();
-        this._descriptorData.reset();
-        this._descriptorBlockData.reset();
-        this._descriptorSetLayoutData.reset();
-        this._descriptorSetData.reset();
-        this._pipelineLayoutData.reset();
-        this._shaderBindingData.reset();
-        this._shaderLayoutData.reset();
-        this._techniqueData.reset();
-        this._effectData.reset();
-        this._shaderProgramData.reset();
-        this._renderStageData.reset();
-        this._renderPhaseData.reset();
-        this._layoutGraphData.reset();
+        this.ddb.reset(); // DescriptorDB
+        this.rp.reset(); // RenderPhase
+        this.lg.reset(); // LayoutGraph
+        this.ud.reset(); // UniformData
+        this.ubd.reset(); // UniformBlockData
+        this.dd.reset(); // DescriptorData
+        this.dbd.reset(); // DescriptorBlockData
+        this.dsld.reset(); // DescriptorSetLayoutData
+        this.dsd.reset(); // DescriptorSetData
+        this.pld.reset(); // PipelineLayoutData
+        this.sbd.reset(); // ShaderBindingData
+        this.sld.reset(); // ShaderLayoutData
+        this.td.reset(); // TechniqueData
+        this.ed.reset(); // EffectData
+        this.spd.reset(); // ShaderProgramData
+        this.rsd.reset(); // RenderStageData
+        this.rpd.reset(); // RenderPhaseData
+        this.lgd.reset(); // LayoutGraphData
     }
     createDescriptorDB (): DescriptorDB {
-        const v = this._descriptorDB.add();
+        const v = this.ddb.add(); // DescriptorDB
         v.reset();
         return v;
     }
     createRenderPhase (): RenderPhase {
-        const v = this._renderPhase.add();
+        const v = this.rp.add(); // RenderPhase
         v.reset();
         return v;
     }
     createLayoutGraph (): LayoutGraph {
-        const v = this._layoutGraph.add();
+        const v = this.lg.add(); // LayoutGraph
         v.clear();
         return v;
     }
@@ -901,12 +901,12 @@ export class LayoutGraphObjectPool {
         uniformType: Type = Type.UNKNOWN,
         offset = 0,
     ): UniformData {
-        const v = this._uniformData.add();
+        const v = this.ud.add(); // UniformData
         v.reset(uniformID, uniformType, offset);
         return v;
     }
     createUniformBlockData (): UniformBlockData {
-        const v = this._uniformBlockData.add();
+        const v = this.ubd.add(); // UniformBlockData
         v.reset();
         return v;
     }
@@ -915,7 +915,7 @@ export class LayoutGraphObjectPool {
         type: Type = Type.UNKNOWN,
         count = 1,
     ): DescriptorData {
-        const v = this._descriptorData.add();
+        const v = this.dd.add(); // DescriptorData
         v.reset(descriptorID, type, count);
         return v;
     }
@@ -924,7 +924,7 @@ export class LayoutGraphObjectPool {
         visibility: ShaderStageFlagBit = ShaderStageFlagBit.NONE,
         capacity = 0,
     ): DescriptorBlockData {
-        const v = this._descriptorBlockData.add();
+        const v = this.dbd.add(); // DescriptorBlockData
         v.reset(type, visibility, capacity);
         return v;
     }
@@ -932,7 +932,7 @@ export class LayoutGraphObjectPool {
         slot = 0xFFFFFFFF,
         capacity = 0,
     ): DescriptorSetLayoutData {
-        const v = this._descriptorSetLayoutData.add();
+        const v = this.dsld.add(); // DescriptorSetLayoutData
         v.reset(slot, capacity);
         return v;
     }
@@ -940,74 +940,74 @@ export class LayoutGraphObjectPool {
         descriptorSetLayout: DescriptorSetLayout | null = null,
         descriptorSet: DescriptorSet | null = null,
     ): DescriptorSetData {
-        const v = this._descriptorSetData.add();
+        const v = this.dsd.add(); // DescriptorSetData
         v.reset(descriptorSetLayout, descriptorSet);
         return v;
     }
     createPipelineLayoutData (): PipelineLayoutData {
-        const v = this._pipelineLayoutData.add();
+        const v = this.pld.add(); // PipelineLayoutData
         v.reset();
         return v;
     }
     createShaderBindingData (): ShaderBindingData {
-        const v = this._shaderBindingData.add();
+        const v = this.sbd.add(); // ShaderBindingData
         v.reset();
         return v;
     }
     createShaderLayoutData (): ShaderLayoutData {
-        const v = this._shaderLayoutData.add();
+        const v = this.sld.add(); // ShaderLayoutData
         v.reset();
         return v;
     }
     createTechniqueData (): TechniqueData {
-        const v = this._techniqueData.add();
+        const v = this.td.add(); // TechniqueData
         v.reset();
         return v;
     }
     createEffectData (): EffectData {
-        const v = this._effectData.add();
+        const v = this.ed.add(); // EffectData
         v.reset();
         return v;
     }
     createShaderProgramData (): ShaderProgramData {
-        const v = this._shaderProgramData.add();
+        const v = this.spd.add(); // ShaderProgramData
         v.reset();
         return v;
     }
     createRenderStageData (): RenderStageData {
-        const v = this._renderStageData.add();
+        const v = this.rsd.add(); // RenderStageData
         v.reset();
         return v;
     }
     createRenderPhaseData (): RenderPhaseData {
-        const v = this._renderPhaseData.add();
+        const v = this.rpd.add(); // RenderPhaseData
         v.reset();
         return v;
     }
     createLayoutGraphData (): LayoutGraphData {
-        const v = this._layoutGraphData.add();
+        const v = this.lgd.add(); // LayoutGraphData
         v.clear();
         return v;
     }
     public readonly renderCommon: RenderCommonObjectPool;
-    private readonly _descriptorDB: RecyclePool<DescriptorDB> = createPool(DescriptorDB);
-    private readonly _renderPhase: RecyclePool<RenderPhase> = createPool(RenderPhase);
-    private readonly _layoutGraph: RecyclePool<LayoutGraph> = createPool(LayoutGraph);
-    private readonly _uniformData: RecyclePool<UniformData> = createPool(UniformData);
-    private readonly _uniformBlockData: RecyclePool<UniformBlockData> = createPool(UniformBlockData);
-    private readonly _descriptorData: RecyclePool<DescriptorData> = createPool(DescriptorData);
-    private readonly _descriptorBlockData: RecyclePool<DescriptorBlockData> = createPool(DescriptorBlockData);
-    private readonly _descriptorSetLayoutData: RecyclePool<DescriptorSetLayoutData> = createPool(DescriptorSetLayoutData);
-    private readonly _descriptorSetData: RecyclePool<DescriptorSetData> = createPool(DescriptorSetData);
-    private readonly _pipelineLayoutData: RecyclePool<PipelineLayoutData> = createPool(PipelineLayoutData);
-    private readonly _shaderBindingData: RecyclePool<ShaderBindingData> = createPool(ShaderBindingData);
-    private readonly _shaderLayoutData: RecyclePool<ShaderLayoutData> = createPool(ShaderLayoutData);
-    private readonly _techniqueData: RecyclePool<TechniqueData> = createPool(TechniqueData);
-    private readonly _effectData: RecyclePool<EffectData> = createPool(EffectData);
-    private readonly _shaderProgramData: RecyclePool<ShaderProgramData> = createPool(ShaderProgramData);
-    private readonly _renderStageData: RecyclePool<RenderStageData> = createPool(RenderStageData);
-    private readonly _renderPhaseData: RecyclePool<RenderPhaseData> = createPool(RenderPhaseData);
-    private readonly _layoutGraphData: RecyclePool<LayoutGraphData> = createPool(LayoutGraphData);
+    private readonly ddb: RecyclePool<DescriptorDB> = createPool(DescriptorDB);
+    private readonly rp: RecyclePool<RenderPhase> = createPool(RenderPhase);
+    private readonly lg: RecyclePool<LayoutGraph> = createPool(LayoutGraph);
+    private readonly ud: RecyclePool<UniformData> = createPool(UniformData);
+    private readonly ubd: RecyclePool<UniformBlockData> = createPool(UniformBlockData);
+    private readonly dd: RecyclePool<DescriptorData> = createPool(DescriptorData);
+    private readonly dbd: RecyclePool<DescriptorBlockData> = createPool(DescriptorBlockData);
+    private readonly dsld: RecyclePool<DescriptorSetLayoutData> = createPool(DescriptorSetLayoutData);
+    private readonly dsd: RecyclePool<DescriptorSetData> = createPool(DescriptorSetData);
+    private readonly pld: RecyclePool<PipelineLayoutData> = createPool(PipelineLayoutData);
+    private readonly sbd: RecyclePool<ShaderBindingData> = createPool(ShaderBindingData);
+    private readonly sld: RecyclePool<ShaderLayoutData> = createPool(ShaderLayoutData);
+    private readonly td: RecyclePool<TechniqueData> = createPool(TechniqueData);
+    private readonly ed: RecyclePool<EffectData> = createPool(EffectData);
+    private readonly spd: RecyclePool<ShaderProgramData> = createPool(ShaderProgramData);
+    private readonly rsd: RecyclePool<RenderStageData> = createPool(RenderStageData);
+    private readonly rpd: RecyclePool<RenderPhaseData> = createPool(RenderPhaseData);
+    private readonly lgd: RecyclePool<LayoutGraphData> = createPool(LayoutGraphData);
 }
 
 export function saveDescriptorDB (a: OutputArchive, v: DescriptorDB): void {

--- a/cocos/rendering/custom/render-graph.ts
+++ b/cocos/rendering/custom/render-graph.ts
@@ -1494,39 +1494,39 @@ export class RenderGraphObjectPool {
         this.renderCommon = renderCommon;
     }
     reset (): void {
-        this._clearValue.reset();
-        this._rasterView.reset();
-        this._computeView.reset();
-        this._resourceDesc.reset();
-        this._resourceTraits.reset();
-        this._renderSwapchain.reset();
-        this._resourceStates.reset();
-        this._managedBuffer.reset();
-        this._persistentBuffer.reset();
-        this._managedTexture.reset();
-        this._persistentTexture.reset();
-        this._managedResource.reset();
-        this._subpass.reset();
-        this._subpassGraph.reset();
-        this._rasterSubpass.reset();
-        this._computeSubpass.reset();
-        this._rasterPass.reset();
-        this._persistentRenderPassAndFramebuffer.reset();
-        this._formatView.reset();
-        this._subresourceView.reset();
-        this._resourceGraph.reset();
-        this._computePass.reset();
-        this._resolvePass.reset();
-        this._copyPass.reset();
-        this._movePass.reset();
-        this._raytracePass.reset();
-        this._clearView.reset();
-        this._renderQueue.reset();
-        this._sceneData.reset();
-        this._dispatch.reset();
-        this._blit.reset();
-        this._renderData.reset();
-        this._renderGraph.reset();
+        this.cv.reset(); // ClearValue
+        this.rv.reset(); // RasterView
+        this.cv1.reset(); // ComputeView
+        this.rd.reset(); // ResourceDesc
+        this.rt.reset(); // ResourceTraits
+        this.rs.reset(); // RenderSwapchain
+        this.rs1.reset(); // ResourceStates
+        this.mb.reset(); // ManagedBuffer
+        this.pb.reset(); // PersistentBuffer
+        this.mt.reset(); // ManagedTexture
+        this.pt.reset(); // PersistentTexture
+        this.mr.reset(); // ManagedResource
+        this.s.reset(); // Subpass
+        this.sg.reset(); // SubpassGraph
+        this.rs2.reset(); // RasterSubpass
+        this.cs.reset(); // ComputeSubpass
+        this.rp.reset(); // RasterPass
+        this.prpaf.reset(); // PersistentRenderPassAndFramebuffer
+        this.fv.reset(); // FormatView
+        this.sv.reset(); // SubresourceView
+        this.rg.reset(); // ResourceGraph
+        this.cp.reset(); // ComputePass
+        this.rp1.reset(); // ResolvePass
+        this.cp1.reset(); // CopyPass
+        this.mp.reset(); // MovePass
+        this.rp2.reset(); // RaytracePass
+        this.cv2.reset(); // ClearView
+        this.rq.reset(); // RenderQueue
+        this.sd.reset(); // SceneData
+        this.d.reset(); // Dispatch
+        this.b.reset(); // Blit
+        this.rd1.reset(); // RenderData
+        this.rg1.reset(); // RenderGraph
     }
     createClearValue (
         x = 0,
@@ -1534,7 +1534,7 @@ export class RenderGraphObjectPool {
         z = 0,
         w = 0,
     ): ClearValue {
-        const v = this._clearValue.add();
+        const v = this.cv.add(); // ClearValue
         v.reset(x, y, z, w);
         return v;
     }
@@ -1547,7 +1547,7 @@ export class RenderGraphObjectPool {
         clearFlags: ClearFlagBit = ClearFlagBit.ALL,
         shaderStageFlags: ShaderStageFlagBit = ShaderStageFlagBit.NONE,
     ): RasterView {
-        const v = this._rasterView.add();
+        const v = this.rv.add(); // RasterView
         v.reset(slotName, accessType, attachmentType, loadOp, storeOp, clearFlags, shaderStageFlags);
         return v;
     }
@@ -1558,19 +1558,19 @@ export class RenderGraphObjectPool {
         clearValueType: ClearValueType = ClearValueType.NONE,
         shaderStageFlags: ShaderStageFlagBit = ShaderStageFlagBit.NONE,
     ): ComputeView {
-        const v = this._computeView.add();
+        const v = this.cv1.add(); // ComputeView
         v.reset(name, accessType, clearFlags, clearValueType, shaderStageFlags);
         return v;
     }
     createResourceDesc (): ResourceDesc {
-        const v = this._resourceDesc.add();
+        const v = this.rd.add(); // ResourceDesc
         v.reset();
         return v;
     }
     createResourceTraits (
         residency: ResourceResidency = ResourceResidency.MANAGED,
     ): ResourceTraits {
-        const v = this._resourceTraits.add();
+        const v = this.rt.add(); // ResourceTraits
         v.reset(residency);
         return v;
     }
@@ -1578,55 +1578,55 @@ export class RenderGraphObjectPool {
         swapchain: Swapchain | null = null,
         isDepthStencil = false,
     ): RenderSwapchain {
-        const v = this._renderSwapchain.add();
+        const v = this.rs.add(); // RenderSwapchain
         v.reset(swapchain, isDepthStencil);
         return v;
     }
     createResourceStates (): ResourceStates {
-        const v = this._resourceStates.add();
+        const v = this.rs1.add(); // ResourceStates
         v.reset();
         return v;
     }
     createManagedBuffer (
         buffer: Buffer | null = null,
     ): ManagedBuffer {
-        const v = this._managedBuffer.add();
+        const v = this.mb.add(); // ManagedBuffer
         v.reset(buffer);
         return v;
     }
     createPersistentBuffer (
         buffer: Buffer | null = null,
     ): PersistentBuffer {
-        const v = this._persistentBuffer.add();
+        const v = this.pb.add(); // PersistentBuffer
         v.reset(buffer);
         return v;
     }
     createManagedTexture (
         texture: Texture | null = null,
     ): ManagedTexture {
-        const v = this._managedTexture.add();
+        const v = this.mt.add(); // ManagedTexture
         v.reset(texture);
         return v;
     }
     createPersistentTexture (
         texture: Texture | null = null,
     ): PersistentTexture {
-        const v = this._persistentTexture.add();
+        const v = this.pt.add(); // PersistentTexture
         v.reset(texture);
         return v;
     }
     createManagedResource (): ManagedResource {
-        const v = this._managedResource.add();
+        const v = this.mr.add(); // ManagedResource
         v.reset();
         return v;
     }
     createSubpass (): Subpass {
-        const v = this._subpass.add();
+        const v = this.s.add(); // Subpass
         v.reset();
         return v;
     }
     createSubpassGraph (): SubpassGraph {
-        const v = this._subpassGraph.add();
+        const v = this.sg.add(); // SubpassGraph
         v.clear();
         return v;
     }
@@ -1635,19 +1635,19 @@ export class RenderGraphObjectPool {
         count = 1,
         quality = 0,
     ): RasterSubpass {
-        const v = this._rasterSubpass.add();
+        const v = this.rs2.add(); // RasterSubpass
         v.reset(subpassID, count, quality);
         return v;
     }
     createComputeSubpass (
         subpassID = 0xFFFFFFFF,
     ): ComputeSubpass {
-        const v = this._computeSubpass.add();
+        const v = this.cs.add(); // ComputeSubpass
         v.reset(subpassID);
         return v;
     }
     createRasterPass (): RasterPass {
-        const v = this._rasterPass.add();
+        const v = this.rp.add(); // RasterPass
         v.reset();
         return v;
     }
@@ -1655,47 +1655,47 @@ export class RenderGraphObjectPool {
         renderPass: RenderPass | null = null,
         framebuffer: Framebuffer | null = null,
     ): PersistentRenderPassAndFramebuffer {
-        const v = this._persistentRenderPassAndFramebuffer.add();
+        const v = this.prpaf.add(); // PersistentRenderPassAndFramebuffer
         v.reset(renderPass, framebuffer);
         return v;
     }
     createFormatView (): FormatView {
-        const v = this._formatView.add();
+        const v = this.fv.add(); // FormatView
         v.reset();
         return v;
     }
     createSubresourceView (): SubresourceView {
-        const v = this._subresourceView.add();
+        const v = this.sv.add(); // SubresourceView
         v.reset();
         return v;
     }
     createResourceGraph (): ResourceGraph {
-        const v = this._resourceGraph.add();
+        const v = this.rg.add(); // ResourceGraph
         v.clear();
         return v;
     }
     createComputePass (): ComputePass {
-        const v = this._computePass.add();
+        const v = this.cp.add(); // ComputePass
         v.reset();
         return v;
     }
     createResolvePass (): ResolvePass {
-        const v = this._resolvePass.add();
+        const v = this.rp1.add(); // ResolvePass
         v.reset();
         return v;
     }
     createCopyPass (): CopyPass {
-        const v = this._copyPass.add();
+        const v = this.cp1.add(); // CopyPass
         v.reset();
         return v;
     }
     createMovePass (): MovePass {
-        const v = this._movePass.add();
+        const v = this.mp.add(); // MovePass
         v.reset();
         return v;
     }
     createRaytracePass (): RaytracePass {
-        const v = this._raytracePass.add();
+        const v = this.rp2.add(); // RaytracePass
         v.reset();
         return v;
     }
@@ -1703,7 +1703,7 @@ export class RenderGraphObjectPool {
         slotName = '',
         clearFlags: ClearFlagBit = ClearFlagBit.ALL,
     ): ClearView {
-        const v = this._clearView.add();
+        const v = this.cv2.add(); // ClearView
         v.reset(slotName, clearFlags);
         return v;
     }
@@ -1712,7 +1712,7 @@ export class RenderGraphObjectPool {
         phaseID = 0xFFFFFFFF,
         passLayoutID = 0xFFFFFFFF,
     ): RenderQueue {
-        const v = this._renderQueue.add();
+        const v = this.rq.add(); // RenderQueue
         v.reset(hint, phaseID, passLayoutID);
         return v;
     }
@@ -1723,7 +1723,7 @@ export class RenderGraphObjectPool {
         cullingFlags: CullingFlags = CullingFlags.CAMERA_FRUSTUM,
         shadingLight: Light | null = null,
     ): SceneData {
-        const v = this._sceneData.add();
+        const v = this.sd.add(); // SceneData
         v.reset(scene, camera, flags, cullingFlags, shadingLight);
         return v;
     }
@@ -1734,7 +1734,7 @@ export class RenderGraphObjectPool {
         threadGroupCountY = 0,
         threadGroupCountZ = 0,
     ): Dispatch {
-        const v = this._dispatch.add();
+        const v = this.d.add(); // Dispatch
         v.reset(material, passID, threadGroupCountX, threadGroupCountY, threadGroupCountZ);
         return v;
     }
@@ -1744,52 +1744,52 @@ export class RenderGraphObjectPool {
         sceneFlags: SceneFlags = SceneFlags.NONE,
         camera: Camera | null = null,
     ): Blit {
-        const v = this._blit.add();
+        const v = this.b.add(); // Blit
         v.reset(material, passID, sceneFlags, camera);
         return v;
     }
     createRenderData (): RenderData {
-        const v = this._renderData.add();
+        const v = this.rd1.add(); // RenderData
         v.reset();
         return v;
     }
     createRenderGraph (): RenderGraph {
-        const v = this._renderGraph.add();
+        const v = this.rg1.add(); // RenderGraph
         v.clear();
         return v;
     }
     public readonly renderCommon: RenderCommonObjectPool;
-    private readonly _clearValue: RecyclePool<ClearValue> = createPool(ClearValue);
-    private readonly _rasterView: RecyclePool<RasterView> = createPool(RasterView);
-    private readonly _computeView: RecyclePool<ComputeView> = createPool(ComputeView);
-    private readonly _resourceDesc: RecyclePool<ResourceDesc> = createPool(ResourceDesc);
-    private readonly _resourceTraits: RecyclePool<ResourceTraits> = createPool(ResourceTraits);
-    private readonly _renderSwapchain: RecyclePool<RenderSwapchain> = createPool(RenderSwapchain);
-    private readonly _resourceStates: RecyclePool<ResourceStates> = createPool(ResourceStates);
-    private readonly _managedBuffer: RecyclePool<ManagedBuffer> = createPool(ManagedBuffer);
-    private readonly _persistentBuffer: RecyclePool<PersistentBuffer> = createPool(PersistentBuffer);
-    private readonly _managedTexture: RecyclePool<ManagedTexture> = createPool(ManagedTexture);
-    private readonly _persistentTexture: RecyclePool<PersistentTexture> = createPool(PersistentTexture);
-    private readonly _managedResource: RecyclePool<ManagedResource> = createPool(ManagedResource);
-    private readonly _subpass: RecyclePool<Subpass> = createPool(Subpass);
-    private readonly _subpassGraph: RecyclePool<SubpassGraph> = createPool(SubpassGraph);
-    private readonly _rasterSubpass: RecyclePool<RasterSubpass> = createPool(RasterSubpass);
-    private readonly _computeSubpass: RecyclePool<ComputeSubpass> = createPool(ComputeSubpass);
-    private readonly _rasterPass: RecyclePool<RasterPass> = createPool(RasterPass);
-    private readonly _persistentRenderPassAndFramebuffer: RecyclePool<PersistentRenderPassAndFramebuffer> = createPool(PersistentRenderPassAndFramebuffer);
-    private readonly _formatView: RecyclePool<FormatView> = createPool(FormatView);
-    private readonly _subresourceView: RecyclePool<SubresourceView> = createPool(SubresourceView);
-    private readonly _resourceGraph: RecyclePool<ResourceGraph> = createPool(ResourceGraph);
-    private readonly _computePass: RecyclePool<ComputePass> = createPool(ComputePass);
-    private readonly _resolvePass: RecyclePool<ResolvePass> = createPool(ResolvePass);
-    private readonly _copyPass: RecyclePool<CopyPass> = createPool(CopyPass);
-    private readonly _movePass: RecyclePool<MovePass> = createPool(MovePass);
-    private readonly _raytracePass: RecyclePool<RaytracePass> = createPool(RaytracePass);
-    private readonly _clearView: RecyclePool<ClearView> = createPool(ClearView);
-    private readonly _renderQueue: RecyclePool<RenderQueue> = createPool(RenderQueue);
-    private readonly _sceneData: RecyclePool<SceneData> = createPool(SceneData);
-    private readonly _dispatch: RecyclePool<Dispatch> = createPool(Dispatch);
-    private readonly _blit: RecyclePool<Blit> = createPool(Blit);
-    private readonly _renderData: RecyclePool<RenderData> = createPool(RenderData);
-    private readonly _renderGraph: RecyclePool<RenderGraph> = createPool(RenderGraph);
+    private readonly cv: RecyclePool<ClearValue> = createPool(ClearValue);
+    private readonly rv: RecyclePool<RasterView> = createPool(RasterView);
+    private readonly cv1: RecyclePool<ComputeView> = createPool(ComputeView);
+    private readonly rd: RecyclePool<ResourceDesc> = createPool(ResourceDesc);
+    private readonly rt: RecyclePool<ResourceTraits> = createPool(ResourceTraits);
+    private readonly rs: RecyclePool<RenderSwapchain> = createPool(RenderSwapchain);
+    private readonly rs1: RecyclePool<ResourceStates> = createPool(ResourceStates);
+    private readonly mb: RecyclePool<ManagedBuffer> = createPool(ManagedBuffer);
+    private readonly pb: RecyclePool<PersistentBuffer> = createPool(PersistentBuffer);
+    private readonly mt: RecyclePool<ManagedTexture> = createPool(ManagedTexture);
+    private readonly pt: RecyclePool<PersistentTexture> = createPool(PersistentTexture);
+    private readonly mr: RecyclePool<ManagedResource> = createPool(ManagedResource);
+    private readonly s: RecyclePool<Subpass> = createPool(Subpass);
+    private readonly sg: RecyclePool<SubpassGraph> = createPool(SubpassGraph);
+    private readonly rs2: RecyclePool<RasterSubpass> = createPool(RasterSubpass);
+    private readonly cs: RecyclePool<ComputeSubpass> = createPool(ComputeSubpass);
+    private readonly rp: RecyclePool<RasterPass> = createPool(RasterPass);
+    private readonly prpaf: RecyclePool<PersistentRenderPassAndFramebuffer> = createPool(PersistentRenderPassAndFramebuffer);
+    private readonly fv: RecyclePool<FormatView> = createPool(FormatView);
+    private readonly sv: RecyclePool<SubresourceView> = createPool(SubresourceView);
+    private readonly rg: RecyclePool<ResourceGraph> = createPool(ResourceGraph);
+    private readonly cp: RecyclePool<ComputePass> = createPool(ComputePass);
+    private readonly rp1: RecyclePool<ResolvePass> = createPool(ResolvePass);
+    private readonly cp1: RecyclePool<CopyPass> = createPool(CopyPass);
+    private readonly mp: RecyclePool<MovePass> = createPool(MovePass);
+    private readonly rp2: RecyclePool<RaytracePass> = createPool(RaytracePass);
+    private readonly cv2: RecyclePool<ClearView> = createPool(ClearView);
+    private readonly rq: RecyclePool<RenderQueue> = createPool(RenderQueue);
+    private readonly sd: RecyclePool<SceneData> = createPool(SceneData);
+    private readonly d: RecyclePool<Dispatch> = createPool(Dispatch);
+    private readonly b: RecyclePool<Blit> = createPool(Blit);
+    private readonly rd1: RecyclePool<RenderData> = createPool(RenderData);
+    private readonly rg1: RecyclePool<RenderGraph> = createPool(RenderGraph);
 }

--- a/cocos/rendering/custom/types.ts
+++ b/cocos/rendering/custom/types.ts
@@ -452,16 +452,16 @@ export class RenderCommonObjectPool {
     constructor () {
     }
     reset (): void {
-        this._lightInfo.reset();
-        this._descriptor.reset();
-        this._descriptorBlock.reset();
-        this._descriptorBlockFlattened.reset();
-        this._descriptorBlockIndex.reset();
-        this._resolvePair.reset();
-        this._copyPair.reset();
-        this._uploadPair.reset();
-        this._movePair.reset();
-        this._pipelineStatistics.reset();
+        this.li.reset(); // LightInfo
+        this.d.reset(); // Descriptor
+        this.db.reset(); // DescriptorBlock
+        this.dbf.reset(); // DescriptorBlockFlattened
+        this.dbi.reset(); // DescriptorBlockIndex
+        this.rp.reset(); // ResolvePair
+        this.cp.reset(); // CopyPair
+        this.up.reset(); // UploadPair
+        this.mp.reset(); // MovePair
+        this.ps.reset(); // PipelineStatistics
     }
     createLightInfo (
         light: Light | null = null,
@@ -469,24 +469,24 @@ export class RenderCommonObjectPool {
         culledByLight = false,
         probe: ReflectionProbe | null = null,
     ): LightInfo {
-        const v = this._lightInfo.add();
+        const v = this.li.add(); // LightInfo
         v.reset(light, level, culledByLight, probe);
         return v;
     }
     createDescriptor (
         type: Type = Type.UNKNOWN,
     ): Descriptor {
-        const v = this._descriptor.add();
+        const v = this.d.add(); // Descriptor
         v.reset(type);
         return v;
     }
     createDescriptorBlock (): DescriptorBlock {
-        const v = this._descriptorBlock.add();
+        const v = this.db.add(); // DescriptorBlock
         v.reset();
         return v;
     }
     createDescriptorBlockFlattened (): DescriptorBlockFlattened {
-        const v = this._descriptorBlockFlattened.add();
+        const v = this.dbf.add(); // DescriptorBlockFlattened
         v.reset();
         return v;
     }
@@ -496,7 +496,7 @@ export class RenderCommonObjectPool {
         descriptorType: DescriptorTypeOrder = DescriptorTypeOrder.UNIFORM_BUFFER,
         visibility: ShaderStageFlagBit = ShaderStageFlagBit.NONE,
     ): DescriptorBlockIndex {
-        const v = this._descriptorBlockIndex.add();
+        const v = this.dbi.add(); // DescriptorBlockIndex
         v.updateFrequency = updateFrequency;
         v.parameterType = parameterType;
         v.descriptorType = descriptorType;
@@ -510,7 +510,7 @@ export class RenderCommonObjectPool {
         mode: ResolveMode = ResolveMode.SAMPLE_ZERO,
         mode1: ResolveMode = ResolveMode.SAMPLE_ZERO,
     ): ResolvePair {
-        const v = this._resolvePair.add();
+        const v = this.rp.add(); // ResolvePair
         v.reset(source, target, resolveFlags, mode, mode1);
         return v;
     }
@@ -526,7 +526,7 @@ export class RenderCommonObjectPool {
         targetFirstSlice = 0,
         targetPlaneSlice = 0,
     ): CopyPair {
-        const v = this._copyPair.add();
+        const v = this.cp.add(); // CopyPair
         v.reset(source, target, mipLevels, numSlices, sourceMostDetailedMip, sourceFirstSlice, sourcePlaneSlice, targetMostDetailedMip, targetFirstSlice, targetPlaneSlice);
         return v;
     }
@@ -538,7 +538,7 @@ export class RenderCommonObjectPool {
         targetFirstSlice = 0,
         targetPlaneSlice = 0,
     ): UploadPair {
-        const v = this._uploadPair.add();
+        const v = this.up.add(); // UploadPair
         v.reset(target, mipLevels, numSlices, targetMostDetailedMip, targetFirstSlice, targetPlaneSlice);
         return v;
     }
@@ -551,25 +551,25 @@ export class RenderCommonObjectPool {
         targetFirstSlice = 0,
         targetPlaneSlice = 0,
     ): MovePair {
-        const v = this._movePair.add();
+        const v = this.mp.add(); // MovePair
         v.reset(source, target, mipLevels, numSlices, targetMostDetailedMip, targetFirstSlice, targetPlaneSlice);
         return v;
     }
     createPipelineStatistics (): PipelineStatistics {
-        const v = this._pipelineStatistics.add();
+        const v = this.ps.add(); // PipelineStatistics
         v.reset();
         return v;
     }
-    private readonly _lightInfo: RecyclePool<LightInfo> = createPool(LightInfo);
-    private readonly _descriptor: RecyclePool<Descriptor> = createPool(Descriptor);
-    private readonly _descriptorBlock: RecyclePool<DescriptorBlock> = createPool(DescriptorBlock);
-    private readonly _descriptorBlockFlattened: RecyclePool<DescriptorBlockFlattened> = createPool(DescriptorBlockFlattened);
-    private readonly _descriptorBlockIndex: RecyclePool<DescriptorBlockIndex> = createPool(DescriptorBlockIndex);
-    private readonly _resolvePair: RecyclePool<ResolvePair> = createPool(ResolvePair);
-    private readonly _copyPair: RecyclePool<CopyPair> = createPool(CopyPair);
-    private readonly _uploadPair: RecyclePool<UploadPair> = createPool(UploadPair);
-    private readonly _movePair: RecyclePool<MovePair> = createPool(MovePair);
-    private readonly _pipelineStatistics: RecyclePool<PipelineStatistics> = createPool(PipelineStatistics);
+    private readonly li: RecyclePool<LightInfo> = createPool(LightInfo);
+    private readonly d: RecyclePool<Descriptor> = createPool(Descriptor);
+    private readonly db: RecyclePool<DescriptorBlock> = createPool(DescriptorBlock);
+    private readonly dbf: RecyclePool<DescriptorBlockFlattened> = createPool(DescriptorBlockFlattened);
+    private readonly dbi: RecyclePool<DescriptorBlockIndex> = createPool(DescriptorBlockIndex);
+    private readonly rp: RecyclePool<ResolvePair> = createPool(ResolvePair);
+    private readonly cp: RecyclePool<CopyPair> = createPool(CopyPair);
+    private readonly up: RecyclePool<UploadPair> = createPool(UploadPair);
+    private readonly mp: RecyclePool<MovePair> = createPool(MovePair);
+    private readonly ps: RecyclePool<PipelineStatistics> = createPool(PipelineStatistics);
 }
 
 export function saveLightInfo (a: OutputArchive, v: LightInfo): void {


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Renamed private member variables in `LayoutGraphObjectPool`, `RenderGraphObjectPool`, and `RenderCommonObjectPool` classes to optimize memory usage and potentially improve performance.

- Renamed `ddb` to `dd` and `dd` to `dd1` in `cocos/rendering/custom/layout-graph.ts`.
- Renamed private members in `cocos/rendering/custom/render-graph.ts` to shorter names in `RenderGraphObjectPool`.
- Renamed private members in `cocos/rendering/custom/types.ts` to shorter names in `RenderCommonObjectPool`.

Ensure no dependent code or documentation references the old variable names.

<!-- /greptile_comment -->