### PR TITLE
WeChat mini game platform remove splash-screen implementation

### DIFF
--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { EDITOR } from 'internal:constants';
+import { EDITOR, WECHAT } from 'internal:constants';
 import { Material } from '../asset/assets/material';
 import { clamp01, Mat4, Vec2, Settings, settings, sys, cclegacy, easing, preTransforms } from '../core';
 import {
@@ -114,6 +114,9 @@ export class SplashScreen {
     private scaleSize = 1;
 
     public get isFinished (): boolean {
+        if (WECHAT) {
+            return true;
+        }
         return this._curTime >= this.settings.totalTime;
     }
 
@@ -126,6 +129,9 @@ export class SplashScreen {
     }
 
     public init (): Promise<void[]> {
+        if (WECHAT) {
+            return Promise.resolve([]);
+        }
         let policy: number = ResolutionPolicy.SHOW_ALL;
         if (!EDITOR) {
             const designResolution = settings.querySettings(Settings.Category.SCREEN, 'designResolution');
@@ -190,6 +196,9 @@ export class SplashScreen {
     }
 
     private preInit (): void {
+        if (WECHAT) {
+            return;
+        }
         const clearColor = this.settings.background?.color;
         this.clearColors = clearColor ? [new Color(clearColor.x, clearColor.y, clearColor.z, clearColor.w)] : [new Color(0, 0, 0, 1)];
         const { device, swapchain } = this;
@@ -246,6 +255,9 @@ export class SplashScreen {
     }
 
     private initLayout (): void {
+        if (WECHAT) {
+            return;
+        }
         if (this.isMobile) {
             this.bgWidth = 812;
             this.bgHeight = 375;
@@ -275,6 +287,9 @@ export class SplashScreen {
     }
 
     private initScale (): void {
+        if (WECHAT) {
+            return;
+        }
         const dw = this.swapchain.width; const dh = this.swapchain.height;
         let desiredWidth = this.isMobile ? 375 : 1080;
         let desiredHeight = this.isMobile ? 812 : 1920;
@@ -291,6 +306,9 @@ export class SplashScreen {
     }
 
     public update (deltaTime: number): void {
+        if (WECHAT) {
+            return;
+        }
         const settings = this.settings;
         const { device, swapchain } = this;
         Mat4.ortho(
@@ -382,6 +400,9 @@ export class SplashScreen {
     }
 
     private initBG (): void {
+        if (WECHAT) {
+            return;
+        }
         const device = this.device;
 
         this.bgMat = new Material();
@@ -416,6 +437,9 @@ export class SplashScreen {
     }
 
     private initLogo (): void {
+        if (WECHAT) {
+            return;
+        }
         const device = this.device;
 
         this.logoMat = new Material();
@@ -459,6 +483,9 @@ export class SplashScreen {
     }
 
     private initWaterMark (): void {
+        if (WECHAT) {
+            return;
+        }
         // create texture from image
         const watermarkImg = ccwindow.document.createElement('canvas');
         watermarkImg.height = this.textHeight * this.scaleSize;
@@ -494,6 +521,9 @@ export class SplashScreen {
     }
 
     private frame (): void {
+        if (WECHAT) {
+            return;
+        }
         const { device, swapchain } = this;
 
         if (!sys.isXR || xr.entry.isRenderAllowable()) {
@@ -620,6 +650,9 @@ export class SplashScreen {
     }
 
     private destroy (): void {
+        if (WECHAT) {
+            return;
+        }
         this.device = null!;
         this.swapchain = null!;
         this.clearColors = null!;

--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -129,6 +129,7 @@ export class SplashScreen {
     }
 
     public init (): Promise<void[]> {
+        // The WeChat mini-game's splash screen is using the implementation in first-screen.
         if (WECHAT) {
             return Promise.resolve([]);
         }


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

The changes in `cocos/game/splash-screen.ts` add checks for the `WECHAT` constant to disable the splash screen for the WeChat mini game platform.

- Added `if (WECHAT) { return; }` checks in `init()`, `preInit()`, `initLayout()`, `initScale()`, `update()`, `initBG()`, `initLogo()`, `initWaterMark()`, `frame()`, and `destroy()` methods.
- Ensures splash screen is bypassed entirely on WeChat platform.
- No impact on other platforms; functionality remains unchanged.
- No security issues or logical errors detected.
- Verify no dependencies on splash screen functionality elsewhere in the codebase.

<!-- /greptile_comment -->