### PR TITLE
Improved min and max modifiers, support for func

### DIFF
--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -590,8 +590,20 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
             error(ERR_Type, 'range', className, propertyName, 'array');
         }
     }
-    parseSimpleAttribute('min', 'number');
-    parseSimpleAttribute('max', 'number');
+    if (DEV) {
+        const parseReturnNumberFuncAttribute = (attributeName: keyof IAcceptableAttributes) => {
+            const value = attributes[attributeName];
+            if (value === undefined) { return; }
+
+            if (typeof value === 'number' || typeof value === 'function') {
+                (attrs || initAttrs())[`${propertyNamePrefix}${attributeName}`] = value;
+            } else {
+                error(ERR_Type, attributeName, className, propertyName, 'number | function');
+            }
+        };
+        parseReturnNumberFuncAttribute('min');
+        parseReturnNumberFuncAttribute('max');
+    }
     parseSimpleAttribute('step', 'number');
     parseSimpleAttribute('userData', 'object');
 }

--- a/cocos/core/data/decorators/editable.ts
+++ b/cocos/core/data/decorators/editable.ts
@@ -232,7 +232,7 @@ export const range: (values: [number, number, number] | [number, number]) => Leg
  * 设置该属性在编辑器中允许的最小值。
  * @param value 最小值。
  */
-export const rangeMin: (value: number) => LegacyPropertyDecorator = !DEV
+export const rangeMin: (value: number | (() => number)) => LegacyPropertyDecorator = !DEV
     ? emptyDecoratorFn
     : setPropertyStashVar1WithImplicitVisible('min');
 
@@ -243,7 +243,7 @@ export const rangeMin: (value: number) => LegacyPropertyDecorator = !DEV
  * 设置该属性在编辑器中允许的最大值。
  * @param value 最大值。
  */
-export const rangeMax: (value: number) => LegacyPropertyDecorator = !DEV
+export const rangeMax: (value: number | (() => number)) => LegacyPropertyDecorator = !DEV
     ? emptyDecoratorFn
     : setPropertyStashVar1WithImplicitVisible('max');
 

--- a/cocos/core/data/utils/attribute-defines.ts
+++ b/cocos/core/data/utils/attribute-defines.ts
@@ -87,12 +87,12 @@ export interface IExposedAttributes {
     /**
      * 当该属性为数值类型时，指定了该属性允许的最小值。
      */
-    min?: number;
+    min?: number | (() => number);
 
     /**
      * 当该属性为数值类型时，指定了该属性允许的最大值。
      */
-    max?: number;
+    max?: number | (() => number);
 
     /**
      * 当该属性为数值类型时并在编辑器中提供了滑动条时，指定了滑动条的步长。

--- a/cocos/misc/camera-component.ts
+++ b/cocos/misc/camera-component.ts
@@ -393,7 +393,9 @@ export class Camera extends Component {
      * @zh 相机的远裁剪距离，应在可接受范围内尽量取最小。
      */
     @displayOrder(11)
-    @rangeMin(0)
+    @rangeMin(function (this: Camera): number {
+        return this._near + 0.001;
+    })
     @tooltip('i18n:camera.far')
     get far (): number {
         return this._far;

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -59,6 +59,8 @@ describe(`Decorators`, () => {
     class Dummy {}
 
     describe('Visible', () => {
+        function minFn () { return 0; }
+        function maxFn () { return 1; }
         function visibleFn () { return false; }
 
         const withVisibleTrueSerializableFalse = <T>(v: T) => ({ visible: true, serializable: false, ...v });
@@ -88,7 +90,9 @@ describe(`Decorators`, () => {
             ['@range([a, b])', [range([2, 3])], withVisibleTrueSerializableFalse({ min: 2, max: 3 })],
             ['@range([a, b, c])', [range([2, 3, 4])], withVisibleTrueSerializableFalse({ min: 2, max: 3, step: 4 })],
             ['@rangeMin(a)', [rangeMin(6)], withVisibleTrueSerializableFalse({ min: 6 })],
+            ['@rangeMin(Function)', [rangeMin(minFn)], withVisibleTrueSerializableFalse({ min: minFn })],
             ['@rangeMax(a)', [rangeMax(6)], withVisibleTrueSerializableFalse({ max: 6 })],
+            ['@rangeMax(Function)', [rangeMax(maxFn)], withVisibleTrueSerializableFalse({ max: maxFn })],
             ['@rangeStep(a)', [rangeStep(6)], withVisibleTrueSerializableFalse({ step: 6 })],
             ['@slide', [slide], withVisibleTrueSerializableFalse({ slide: true })],
             ['@displayOrder(a)', [displayOrder(6)], withVisibleTrueSerializableFalse({ displayOrder: 6 })],


### PR DESCRIPTION
Re: #

### Changelog

* Improved min and max modifiers, support for func

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request enhances the `min` and `max` modifiers in the Cocos Creator engine, adding support for dynamic range definitions using functions.

- Updated `cocos/core/data/class.ts` and `cocos/core/data/decorators/editable.ts` to allow `min` and `max` attributes as numbers or functions
- Modified `cocos/misc/camera-component.ts` to use a dynamic `rangeMin` for the `far` property, ensuring it's always greater than `near`
- Added new tests in `tests/core/decorator.test.ts` to cover the new functionality of `rangeMin` and `rangeMax` decorators
- Implemented a new `AfterPresent` event in `native/cocos/core/Root.cpp` and `native/cocos/core/Root.h` for improved rendering process control

<!-- /greptile_comment -->