### PR TITLE
fixed 3d-tasks/18423: Rendering is not correct on VK backend.

### DIFF
--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -130,10 +130,14 @@ static bool js_root_registerListeners(se::State &s) // NOLINT(readability-identi
 
     DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::BeforeCommit, _onDirectorBeforeCommit, {});
     DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::BeforeRender, _onDirectorBeforeRender, {});
-    DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::AfterRender, _onDirectorAfterRender, {
+    DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::AfterRender, _onDirectorAfterRender, {});
+    DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::PipelineChanged, _onDirectorPipelineChanged, {});
+
+    // NOTE: Async tasks must be executed after present, otherwise it will cause render issues on VK backend.
+    // Refer to https://github.com/cocos/3d-tasks/issues/18423
+    cobj->on<cc::Root::AfterPresent>([](cc::Root *rootObj){
         CC_CURRENT_APPLICATION()->getEngine()->getScheduler()->runFunctionsToBePerformedInCocosThread();
     });
-    DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::PipelineChanged, _onDirectorPipelineChanged, {});
 
     return true;
 }

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -135,7 +135,7 @@ static bool js_root_registerListeners(se::State &s) // NOLINT(readability-identi
 
     // NOTE: Async tasks must be executed after present, otherwise it will cause render issues on VK backend.
     // Refer to https://github.com/cocos/3d-tasks/issues/18423
-    cobj->on<cc::Root::AfterPresent>([](cc::Root *rootObj){
+    cobj->on<cc::Root::AfterPresent>([](cc::Root */*rootObj*/){
         CC_CURRENT_APPLICATION()->getEngine()->getScheduler()->runFunctionsToBePerformedInCocosThread();
     });
 

--- a/native/cocos/core/Root.cpp
+++ b/native/cocos/core/Root.cpp
@@ -443,6 +443,7 @@ void Root::frameMoveEnd() {
         emit<AfterRender>();
 #endif
         _device->present();
+        emit<AfterPresent>();
     }
 
     if (_batcher != nullptr) {

--- a/native/cocos/core/Root.h
+++ b/native/cocos/core/Root.h
@@ -64,6 +64,7 @@ class Root final {
     TARGET_EVENT_ARG0(BeforeCommit)
     TARGET_EVENT_ARG0(BeforeRender)
     TARGET_EVENT_ARG0(AfterRender)
+    TARGET_EVENT_ARG0(AfterPresent)
     TARGET_EVENT_ARG0(PipelineChanged)
     DECLARE_TARGET_EVENT_END()
 public:


### PR DESCRIPTION
Async tasks must be executed after present.

Re: https://github.com/cocos/3d-tasks/issues/18423

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

The changes in this pull request address rendering issues on the Vulkan backend by ensuring that asynchronous tasks are executed after the present operation.

- Added `cc::Root::AfterPresent` event in `/native/cocos/core/Root.h`.
- Emitted `AfterPresent` event after `_device->present();` in `/native/cocos/core/Root.cpp`.
- Added `AfterPresent` event listener in `js_root_registerListeners` function in `/native/cocos/bindings/manual/jsb_scene_manual.cpp`.

<!-- /greptile_comment -->