### PR TITLE
RenderPass now considers clearColor

### DIFF
--- a/native/cocos/renderer/gfx-base/GFXDef.cpp
+++ b/native/cocos/renderer/gfx-base/GFXDef.cpp
@@ -248,6 +248,16 @@ bool operator==(const BufferBarrierInfo &lhs, const BufferBarrierInfo &rhs) {
     return !memcmp(&lhs, &rhs, sizeof(BufferBarrierInfo));
 }
 
+template <>
+ccstd::hash_t Hasher<Color>::operator()(const Color &info) const {
+    ccstd::hash_t seed = 0;
+    ccstd::hash_combine(seed, info.x);
+    ccstd::hash_combine(seed, info.y);
+    ccstd::hash_combine(seed, info.z);
+    ccstd::hash_combine(seed, info.w);
+    return seed;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 bool operator==(const Viewport &lhs, const Viewport &rhs) {

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
@@ -108,8 +108,8 @@ struct RasterView {
 };
 
 inline bool operator==(const RasterView& lhs, const RasterView& rhs) noexcept {
-    return std::forward_as_tuple(lhs.slotName, lhs.slotName1, lhs.accessType, lhs.attachmentType, lhs.loadOp, lhs.storeOp, lhs.clearFlags, lhs.shaderStageFlags) ==
-           std::forward_as_tuple(rhs.slotName, rhs.slotName1, rhs.accessType, rhs.attachmentType, rhs.loadOp, rhs.storeOp, rhs.clearFlags, rhs.shaderStageFlags);
+    return std::forward_as_tuple(lhs.slotName, lhs.slotName1, lhs.accessType, lhs.attachmentType, lhs.loadOp, lhs.storeOp, lhs.clearFlags, lhs.clearColor, lhs.shaderStageFlags) ==
+           std::forward_as_tuple(rhs.slotName, rhs.slotName1, rhs.accessType, rhs.attachmentType, rhs.loadOp, rhs.storeOp, rhs.clearFlags, rhs.clearColor, rhs.shaderStageFlags);
 }
 
 inline bool operator!=(const RasterView& lhs, const RasterView& rhs) noexcept {
@@ -1219,6 +1219,7 @@ inline hash_t hash<cc::render::RasterView>::operator()(const cc::render::RasterV
     hash_combine(seed, val.loadOp);
     hash_combine(seed, val.storeOp);
     hash_combine(seed, val.clearFlags);
+    hash_combine(seed, val.clearColor);
     hash_combine(seed, val.shaderStageFlags);
     return seed;
 }


### PR DESCRIPTION
https://github.com/cocos/3d-tasks/issues/18404

Fix ui-fill-z

Currently, vulkan dynamic states is not supported, as a result, different clear color must has different render pass.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

The pull request introduces changes to ensure that `clearColor` is considered in render passes, which is crucial for differentiating them based on their clear color.

- Added `clearColor` attribute to `RasterView` in `native/cocos/renderer/pipeline/custom/RenderGraphTypes.h`.
- Updated hash function for `RasterView` to include `clearColor`.
- Introduced a new specialization of the `Hasher` template for the `Color` struct in `native/cocos/renderer/gfx-base/GFXDef.cpp`.
- Ensured `Color` objects can be hashed consistently using `quickHashTrivialStruct`.

These changes are essential for handling Vulkan dynamic states and ensuring accurate render pass differentiation.

<!-- /greptile_comment -->