### PR TITLE
Fix the issue where the profiler does not display when only the UI is present.

### DIFF
--- a/editor/assets/default_renderpipeline/builtin-pipeline.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline.ts
@@ -688,8 +688,13 @@ if (rendering) {
                 .addScene(camera, SceneFlags.OPAQUE);
 
             // The blend queue is used for UI and Gizmos
+            let flags = SceneFlags.BLEND | SceneFlags.UI;
+            if (this._cameraConfigs.enableProfiler) {
+                flags |= SceneFlags.PROFILER;
+                pass.showStatistics = true;
+            }
             pass.addQueue(QueueHint.BLEND)
-                .addScene(camera, SceneFlags.BLEND | SceneFlags.UI);
+                .addScene(camera, flags);
         }
 
         private _buildForwardPipeline(


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Based on the provided information and the changes made to the builtin-pipeline.ts file, here's a concise summary of the pull request:

This pull request addresses an issue where the profiler wasn't displaying when only UI elements were present in the scene. The key change involves modifying the rendering pipeline to ensure the profiler is rendered even without 3D elements.

Key points:
- Modified the _addUIQueue method in builtin-pipeline.ts to include the SceneFlags.PROFILER flag when the profiler is enabled
- This change ensures the profiler is rendered alongside UI elements, improving visibility in UI-only scenes
- The fix maintains compatibility with existing rendering processes while addressing a specific edge case
- The update enhances the profiler's functionality across different scene compositions

This change improves the engine's debugging capabilities by making the profiler more consistently visible, which is crucial for performance monitoring and optimization in various development scenarios.

<!-- /greptile_comment -->