### PR TITLE
fix: resort event listeners after updating sibling index on native pl…

### DIFF
--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -1351,6 +1351,7 @@ nodeProto._onSiblingIndexChanged = function (index) {
         } else {
             siblings.push(this);
         }
+        this._eventProcessor.onUpdatingSiblingIndex();
     }
 }
 


### PR DESCRIPTION
Changelog
resort event listeners after updating sibling index on native platform

realted issue: [#12777 ](https://github.com/cocos/cocos-engine/issues/12777)

I got the problem on android platform, and I see @PPpro has fixed it on web platform in #14389 , but it still exist on the native platform.


-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request addresses an issue with event listener sorting after updating sibling index on native platforms in the Cocos Engine.

- Modified `cocos/scene-graph/node.jsb.ts` to call `this._eventProcessor.onUpdatingSiblingIndex()` in the `_onSiblingIndexChanged` method
- Extends the fix previously implemented for web platforms (#14389) to native platforms
- Resolves issue #12777 where 'setSiblingIndex' did not trigger '_sortPointerEventProcessorList'
- Ensures correct event dispatching order after modifying node ordering on native platforms

<!-- /greptile_comment -->