### PR TITLE
export Bullet

### DIFF
--- a/cocos/physics/bullet/instantiated.ts
+++ b/cocos/physics/bullet/instantiated.ts
@@ -87,7 +87,6 @@ interface BtCache {
 
 // eslint-disable-next-line import/no-mutable-exports
 export let bt = {} as Bullet.instance;
-globalThis.Bullet = bt as any;
 export const btCache = {} as BtCache;
 btCache.BODY_CACHE_NAME = 'body';
 btCache.CCT_CACHE_NAME = 'cct';
@@ -108,6 +107,7 @@ function initWASM (wasmFactory, wasmUrl: string): Promise<void> {
         }).then((instance: any) => {
             log('[bullet]:bullet wasm lib loaded.');
             bt = instance as Bullet.instance;
+            globalThis.Bullet = bt as any;
         }).then(resolve).catch((err: any) => reject(errorMessage(err)));
     });
 }

--- a/cocos/physics/bullet/instantiated.ts
+++ b/cocos/physics/bullet/instantiated.ts
@@ -87,6 +87,7 @@ interface BtCache {
 
 // eslint-disable-next-line import/no-mutable-exports
 export let bt = {} as Bullet.instance;
+globalThis.Bullet = bt as any;
 export const btCache = {} as BtCache;
 btCache.BODY_CACHE_NAME = 'body';
 btCache.CCT_CACHE_NAME = 'cct';


### PR DESCRIPTION
Bullet is exported until this PR: https://github.com/cocos/cocos-engine/pull/16350. I don't know why that PR removed the codes as the modification out of the range of its title.

And there is forum ticket discussion it: https://forum.cocos.org/t/topic/158556.

<!-- greptile_comment -->

## Greptile Summary

This PR reintroduces the global export of the Bullet physics library in the Cocos Engine, addressing a previous removal and community discussion.

- Added `globalThis.Bullet = bt as any;` in `cocos/physics/bullet/instantiated.ts` to make Bullet globally accessible after initialization
- The change ensures Bullet is only exposed globally after it has been fully initialized
- While addressing the need for global access, this approach may introduce potential security risks and namespace pollution
- Consider exploring alternative methods to provide necessary access while maintaining better encapsulation

<!-- /greptile_comment -->