### PR TITLE
constrain UI phase ID to PassLayout/'default'

### DIFF
--- a/native/cocos/renderer/pipeline/custom/NativeExecutor.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeExecutor.cpp
@@ -718,7 +718,7 @@ struct RenderGraphVisitor : boost::dfs_visitor<> {
                             : locate(LayoutGraphData::null_vertex(),
                                      get(RenderGraph::LayoutTag{}, ctx.g, subpassID),
                                      ctx.lg);
-                    CC_ENSURES(passLayoutID != LayoutGraphData::null_vertex());
+                    CC_ENSURES(subpassLayoutID != LayoutGraphData::null_vertex());
                     const auto phaseLayoutID = locate(subpassLayoutID, "default", ctx.lg);
                     if (phaseLayoutID != LayoutGraphData::null_vertex()) {
                         submitUICommands(ctx.currentPass, phaseLayoutID, camera, ctx.cmdBuff);

--- a/native/cocos/renderer/pipeline/custom/NativeExecutor.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeExecutor.cpp
@@ -252,7 +252,7 @@ void updateGlobal(
 
 void submitUICommands(
     gfx::RenderPass* renderPass,
-    uint32_t subpassOrPassLayoutID,
+    uint32_t phaseLayoutID,
     const scene::Camera* camera,
     gfx::CommandBuffer* cmdBuff) {
     const auto cameraVisFlags = camera->getVisibility();
@@ -264,7 +264,7 @@ void submitUICommands(
         const auto& passes = batch->getPasses();
         for (size_t i = 0; i < batch->getShaders().size(); ++i) {
             const scene::Pass* pass = passes[i];
-            if (pass->getSubpassOrPassID() != subpassOrPassLayoutID) {
+            if (pass->getPhaseID() != phaseLayoutID) {
                 continue;
             }
             auto* shader = batch->getShaders()[i];
@@ -687,8 +687,13 @@ struct RenderGraphVisitor : boost::dfs_visitor<> {
             const auto queueID = parent(sceneID, ctx.g);
             const auto& queueData = get(QueueTag{}, queueID, ctx.g);
             const auto passOrSubpassID = parent(queueID, ctx.g);
+            // To render UI, the phase layout of the material Pass
+            // must be PassLayout/'default'
             if (queueData.passLayoutID != LayoutGraphData::null_vertex()) {
-                submitUICommands(ctx.currentPass, queueData.passLayoutID, camera, ctx.cmdBuff);
+                const auto phaseLayoutID = locate(queueData.passLayoutID, "default", ctx.lg);
+                if (phaseLayoutID != LayoutGraphData::null_vertex()) {
+                    submitUICommands(ctx.currentPass, phaseLayoutID, camera, ctx.cmdBuff);
+                }
             } else {
                 const auto passID = parent(passOrSubpassID, ctx.g);
                 if (passID == RenderGraph::null_vertex()) { // Pass
@@ -696,7 +701,11 @@ struct RenderGraphVisitor : boost::dfs_visitor<> {
                         locate(LayoutGraphData::null_vertex(),
                                get(RenderGraph::LayoutTag{}, ctx.g, passOrSubpassID),
                                ctx.lg);
-                    submitUICommands(ctx.currentPass, passLayoutID, camera, ctx.cmdBuff);
+                    CC_ENSURES(passLayoutID != LayoutGraphData::null_vertex());
+                    const auto phaseLayoutID = locate(passLayoutID, "default", ctx.lg);
+                    if (phaseLayoutID != LayoutGraphData::null_vertex()) {
+                        submitUICommands(ctx.currentPass, phaseLayoutID, camera, ctx.cmdBuff);
+                    }
                 } else { // Subpass
                     const auto subpassID = passOrSubpassID;
                     const auto& passLayoutName = get(RenderGraph::LayoutTag{}, ctx.g, passID);
@@ -709,7 +718,11 @@ struct RenderGraphVisitor : boost::dfs_visitor<> {
                             : locate(LayoutGraphData::null_vertex(),
                                      get(RenderGraph::LayoutTag{}, ctx.g, subpassID),
                                      ctx.lg);
-                    submitUICommands(ctx.currentPass, subpassLayoutID, camera, ctx.cmdBuff);
+                    CC_ENSURES(passLayoutID != LayoutGraphData::null_vertex());
+                    const auto phaseLayoutID = locate(subpassLayoutID, "default", ctx.lg);
+                    if (phaseLayoutID != LayoutGraphData::null_vertex()) {
+                        submitUICommands(ctx.currentPass, phaseLayoutID, camera, ctx.cmdBuff);
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://github.com/cocos/3d-tasks/issues/18445

Previously all materials passes will be rendered, if their `${PassLayoutName}` equals the one in render graph node.
Now they are constrained to `${PassLayoutName}/'default'`.
As a result, `'default'/'additive-light'` objects will not be rendered in UI. This behavior is the same as in `legacy-pipeline`.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request modifies the UI rendering logic in the NativeExecutor.cpp file, focusing on constraining UI layout to PassLayout/'default' and updating the submitUICommands function.

- Added `phaseLayoutID` parameter to `submitUICommands` in `native/cocos/renderer/pipeline/custom/NativeExecutor.cpp`
- Implemented check to ensure UI elements are only rendered in the correct pipeline phase
- Aligned UI rendering behavior with legacy pipeline by constraining to 'default' phase layout
- Potential impact on rendering of 'additive-light' objects in UI, which will no longer be rendered

<!-- /greptile_comment -->