### PR TITLE
viewport uses Math.round

### DIFF
--- a/editor/assets/default_renderpipeline/builtin-pipeline.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline.ts
@@ -647,12 +647,12 @@ if (rendering) {
             const depthStencilName = this._cameraConfigs.depthStencilName;
 
             const viewport = camera.viewport;  // Reduce C++/TS interop
-            this._viewport.left = Math.floor(viewport.x * width);
-            this._viewport.top = Math.floor(viewport.y * height);
+            this._viewport.left = Math.round(viewport.x * width);
+            this._viewport.top = Math.round(viewport.y * height);
             // Here we must use camera.viewport.width instead of camera.viewport.z, which
             // is undefined on native platform. The same as camera.viewport.height.
-            this._viewport.width = Math.max(Math.floor(viewport.width * width), 1);
-            this._viewport.height = Math.max(Math.floor(viewport.height * height), 1);
+            this._viewport.width = Math.max(Math.round(viewport.width * width), 1);
+            this._viewport.height = Math.max(Math.round(viewport.height * height), 1);
 
             const clearColor = camera.clearColor;  // Reduce C++/TS interop
             this._clearColor.x = clearColor.x;
@@ -1294,12 +1294,12 @@ if (rendering) {
 
             // Prepare camera viewport
             const viewport = camera.viewport; // Reduce C++/TS interop
-            this._viewport.left = Math.floor(viewport.x * width);
-            this._viewport.top = Math.floor(viewport.y * height);
+            this._viewport.left = Math.round(viewport.x * width);
+            this._viewport.top = Math.round(viewport.y * height);
             // Here we must use camera.viewport.width instead of camera.viewport.z, which
             // is undefined on native platform. The same as camera.viewport.height.
-            this._viewport.width = Math.max(Math.floor(viewport.width * width), 1);
-            this._viewport.height = Math.max(Math.floor(viewport.height * height), 1);
+            this._viewport.width = Math.max(Math.round(viewport.width * width), 1);
+            this._viewport.height = Math.max(Math.round(viewport.height * height), 1);
 
             // MSAA
             const enableMSAA = !disableMSAA && this._cameraConfigs.enableMSAA;


### PR DESCRIPTION
When calculating viewport, uses `Math.round` instead of `Math.floor`.
`Math.round` is more consistent with legacy pipeline.

https://github.com/cocos/3d-tasks/issues/18404
fix ui-fill-z

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request modifies the viewport calculation in the forward rendering pipeline, changing from `Math.floor` to `Math.round`. The change aims to improve consistency with the legacy pipeline and addresses an issue related to UI fill-z.

Key points:
- Viewport calculation now uses `Math.round` instead of `Math.floor`
- The change affects the left, top, width, and height calculations of the viewport
- This modification is intended to make the viewport more consistent with the legacy pipeline
- The change is related to fixing a UI fill-z issue (https://github.com/cocos/3d-tasks/issues/18404)
- The modification is made in the `editor/assets/default_renderpipeline/builtin-pipeline.ts` file

<!-- /greptile_comment -->