### PR TITLE
only delete claimed list when preventSwallow is false

### DIFF
--- a/cocos/2d/event/pointer-event-dispatcher.ts
+++ b/cocos/2d/event/pointer-event-dispatcher.ts
@@ -157,8 +157,10 @@ class PointerEventDispatcher implements IEventDispatcher {
                         pointerEventProcessor._handleEventTouch(eventTouch);
                         if (eventTouch.type === (InputEventType.TOUCH_END as string) || eventTouch.type === (InputEventType.TOUCH_CANCEL as string)) {
                             js.array.removeAt(pointerEventProcessor.claimedTouchIdList, index);
-                            // The event is handled, so should remove other EventProcessor's claimedTouchIdList.
-                            this._removeClaimedTouch(i + 1, touch.getID());
+                            // The event is handled, and the event can be swallowed, so should remove other EventProcessor's claimedTouchIdList.
+                            if (!eventTouch.preventSwallow) {
+                                this._removeClaimedTouch(i + 1, touch.getID());
+                            }
                         }
                         dispatchToNextEventDispatcher = false;
                         if (!eventTouch.preventSwallow) {


### PR DESCRIPTION
This PR fixed the issue that only one touch listener can receive TOUCH_END or TOUCH_CANCEL issue. The corresponding forum ticket is https://forum.cocos.org/t/topic/159379/365.

Reason: all touch listeners that listen TOUCH_END or TOUCH_CANCEL are removed when the corresponding TOUCH_BEGIN event is handled.

How to fix: Remove the touch listeners only when the touch event is allowed to be swallowed.

This issue is caused by https://github.com/cocos/cocos-engine/pull/16893.

<!-- greptile_comment -->

## Greptile Summary

This pull request addresses an issue in the Cocos engine's touch event handling system. The key changes are:

- Modified the `dispatchEventTouch` method in `PointerEventDispatcher` class
- Adjusted the logic for removing claimed touch IDs from event processors

Key points:

- The fix allows multiple touch listeners to receive TOUCH_END or TOUCH_CANCEL events when the event is not swallowed
- Claimed touch IDs are now only removed when `preventSwallow` is false, ensuring better event propagation
- This change improves the flexibility of the event handling system, particularly for multi-touch scenarios
- The issue was introduced by a previous pull request (#16893) and is now being corrected

This update enhances the engine's ability to handle complex touch interactions more effectively.

<!-- /greptile_comment -->