### PR TITLE
remove all CC_USE_RGBE_OUTPUT

### DIFF
--- a/cocos/rendering/custom/web-pipeline-types.ts
+++ b/cocos/rendering/custom/web-pipeline-types.ts
@@ -227,18 +227,15 @@ export class ProbeHelperQueue {
 
     removeMacro (): void {
         for (const subModel of this.probeMap) {
-            let patches: IMacroPatch[] = [];
-            patches = patches.concat(subModel.patches!);
-            if (!patches.length) continue;
-            for (let j = 0; j < patches.length;) {
-                const patch = patches[j];
-                if (patch.name === CC_USE_RGBE_OUTPUT) {
-                    patches.splice(j, 1);
-                } else {
-                    ++j;
-                }
+            if (!subModel.patches) continue;
+            const patches = subModel.patches.filter(
+                (patch) => patch.name !== CC_USE_RGBE_OUTPUT,
+            );
+            if (patches.length === 0) {
+                subModel.onMacroPatchesStateChanged(null);
+            } else {
+                subModel.onMacroPatchesStateChanged(patches);
             }
-            subModel.onMacroPatchesStateChanged(patches);
         }
     }
     applyMacro (model: Model, probeLayoutId: number): void {

--- a/cocos/rendering/custom/web-pipeline-types.ts
+++ b/cocos/rendering/custom/web-pipeline-types.ts
@@ -230,11 +230,12 @@ export class ProbeHelperQueue {
             let patches: IMacroPatch[] = [];
             patches = patches.concat(subModel.patches!);
             if (!patches.length) continue;
-            for (let j = 0; j < patches.length; j++) {
+            for (let j = 0; j < patches.length;) {
                 const patch = patches[j];
                 if (patch.name === CC_USE_RGBE_OUTPUT) {
                     patches.splice(j, 1);
-                    break;
+                } else {
+                    ++j;
                 }
             }
             subModel.onMacroPatchesStateChanged(patches);


### PR DESCRIPTION
https://github.com/cocos/3d-tasks/issues/18426

remove all duplicated `CC_USE_RGBE_OUTPUT`.

It's better not to add `CC_USE_RGBE_OUTPUT` multiple times.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request simplifies the rendering pipeline code by removing redundant `CC_USE_RGBE_OUTPUT` macro usage in the `ProbeHelperQueue` class.

- Refactored `removeMacro` method in `cocos/rendering/custom/web-pipeline-types.ts` to use Array.filter() for improved readability
- Eliminated duplicate `CC_USE_RGBE_OUTPUT` macro checks, streamlining the code
- Enhanced maintainability of the rendering pipeline implementation

<!-- /greptile_comment -->