### PR TITLE
[3.8.4] [native] Fix that 2d object's world transform not being updated if modifying local position/rotation/scale in Director.EVENT_AFTER_DRAW callback.

### DIFF
--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -208,7 +208,7 @@ CC_FORCE_INLINE void Batcher2d::handleComponentDraw(RenderEntity* entity, Render
     }
 
     if (!drawInfo->getIsMeshBuffer()) {
-        if (node->getChangedFlags() || drawInfo->getVertDirty()) {
+        if (node->getChangedFlags() || node->isTransformDirty() || drawInfo->getVertDirty()) {
             fillVertexBuffers(entity, drawInfo);
             drawInfo->setVertDirty(false);
         }

--- a/native/cocos/bindings/manual/jsb_scene_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_scene_manual.cpp
@@ -133,12 +133,6 @@ static bool js_root_registerListeners(se::State &s) // NOLINT(readability-identi
     DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::AfterRender, _onDirectorAfterRender, {});
     DISPATCH_EVENT_TO_JS_ARGS_0(cc::Root::PipelineChanged, _onDirectorPipelineChanged, {});
 
-    // NOTE: Async tasks must be executed after present, otherwise it will cause render issues on VK backend.
-    // Refer to https://github.com/cocos/3d-tasks/issues/18423
-    cobj->on<cc::Root::AfterPresent>([](cc::Root */*rootObj*/){
-        CC_CURRENT_APPLICATION()->getEngine()->getScheduler()->runFunctionsToBePerformedInCocosThread();
-    });
-
     return true;
 }
 SE_BIND_FUNC(js_root_registerListeners) // NOLINT(readability-identifier-naming)

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -307,6 +307,10 @@ void Engine::tick() {
 
         cc::DeferredReleasePool::clear();
         if (_xr) _xr->endRenderFrame();
+        
+        // Executing async tasks at the end of the current frame to make the callback invoked as soon as possible.
+        _scheduler->runFunctionsToBePerformedInCocosThread();
+        
         now = std::chrono::steady_clock::now();
         dtNS = dtNS * 0.1 + 0.9 * static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(now - prevTime).count());
         dt = static_cast<float>(dtNS) / NANOSECONDS_PER_SECOND;


### PR DESCRIPTION
And run performed functions at the end of Engine::tick instead of Director::AfterPersent.

Added testcase: 

https://github.com/cocos/cocos-test-projects/pull/881

https://github.com/cocos/cocos-test-projects/pull/882

Reported at : https://forum.cocos.org/t/topic/159379/380?u=dumganhar

## Reason

Review the code in director.ts:

```ts
public tick (dt: number): void {
    ......

        this.emit(Director.EVENT_BEFORE_DRAW);
        uiRendererManager.updateAllDirtyRenderers();
        this._root!.frameMove(dt);
        // The old code will invoke Scheduler::runFunctionsToBePerformedInCocosThread in frameMove.
        // And the code in those user callback may call `node.setPosition/setScale/setRotation` to update the local transform for node.
        // The return value of Node's getChangedFlags() will be updated, but since it's invoked after render, the world transform will not be updated in the current frame.
        // In the next frame, Batcher2D will only check whether the return value of Node::getChangedFlags() is dirty, 
        // because it's in the next frame, Node::getChangedFlags will return 0 which means `NO CHANGES`.
        // This make the 2D object's world transform not being updated.
        this.emit(Director.EVENT_AFTER_DRAW);

        Node.resetHasChangedFlags();
        Node.clearNodeArray();
        scalableContainerManager.update(dt);
        this.emit(Director.EVENT_END_FRAME);
        this._totalFrames++;
    }
}
```

```cpp
inline uint32_t getChangedFlags() const {
    return _hasChangedFlagsVersion == globalFlagChangeVersion ? _hasChangedFlags : 0;
}

CC_FORCE_INLINE void Batcher2d::handleComponentDraw(RenderEntity* entity, RenderDrawInfo* drawInfo, Node* node) {
    ......
    if (!drawInfo->getIsMeshBuffer()) {
        if (node->getChangedFlags() ||  drawInfo->getVertDirty()) { // Only check getChangedFlags here which is not enough, should also check Node::isTransformDirty().
            fillVertexBuffers(entity, drawInfo);
            drawInfo->setVertDirty(false);
        }
        if (entity->getVBColorDirty()) {
            fillColors(entity, drawInfo);
        }

        fillIndexBuffers(drawInfo);
    }

    if (isMask) {
        _stencilManager->enableMask();
    }
}
```

Re: # 

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request addresses an issue with 2D object world transforms not updating correctly when modified in the Director.EVENT_AFTER_DRAW callback, by adjusting the timing of transform updates and async task execution.

- Modified `Batcher2d::handleComponentDraw` in `native/cocos/2d/renderer/Batcher2d.cpp` to check `node->isTransformDirty()` for more accurate transform updates
- Removed AfterPresent event listener in `native/cocos/bindings/manual/jsb_scene_manual.cpp` to adjust async task execution timing
- Added `_scheduler->runFunctionsToBePerformedInCocosThread()` call at the end of `Engine::tick()` in `native/cocos/engine/Engine.cpp` for improved async task handling
- These changes ensure proper updating of 2D object world transforms when modified in specific callbacks

<!-- /greptile_comment -->