### PR TITLE
Add Migu channel identifier

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -34,6 +34,7 @@ const isHuaweiGame = (settingPlatform === 'huawei');
 const isJKWGame = (settingPlatform === 'jkw-game');
 const isQttGame = (settingPlatform === 'qtt-game');
 const isLinkSure = (settingPlatform === 'link-sure');
+const isMigu = (settingPlatform === 'migu-runtime');
 
 const _global = typeof window === 'undefined' ? global : window;
  
@@ -470,6 +471,13 @@ function initSys () {
      sys.TAOBAO_MINIGAME = 121;
 
     /**
+     * @property {Number} MIGU_MINIGAME
+     * @readOnly
+     * @default 122
+     */
+    sys.MIGU_MINIGAME = 122;
+
+    /**
      * BROWSER_TYPE_WECHAT
      * @property {String} BROWSER_TYPE_WECHAT
      * @readOnly
@@ -727,6 +735,8 @@ function initSys () {
             platform = sys.QTT_GAME;
         } else if (isLinkSure) {
             platform = sys.LINKSURE;
+        } else if (isMigu) {
+            platform = sys.MIGU_MINIGAME;
         }
         else {
             platform = __getPlatform();
@@ -744,7 +754,8 @@ function initSys () {
                         isOppoGame ||
                         isHuaweiGame ||
                         isJKWGame ||
-                        isQttGame);
+                        isQttGame ||
+                        isMigu);
 
         sys.os = __getOS();
         sys.language = __getCurrentLanguage();


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This pull request adds support for the Migu mini-game platform to the Cocos Creator engine.

- Introduced new constant `isMigu` and platform identifier `sys.MIGU_MINIGAME` in `cocos2d/core/platform/CCSys.js`
- Updated `isMobile` check to include the new Migu platform
- Added Migu platform handling in the platform detection logic
- Assigned `sys.MIGU_MINIGAME` (value 122) as the new platform identifier

<!-- /greptile_comment -->