### PR TITLE
Add Migu channel identifier

### DIFF
--- a/cocos2d/core/platform/CCSys.js
+++ b/cocos2d/core/platform/CCSys.js
@@ -34,6 +34,7 @@ const isHuaweiGame = (settingPlatform === 'huawei');
 const isJKWGame = (settingPlatform === 'jkw-game');
 const isQttGame = (settingPlatform === 'qtt-game');
 const isLinkSure = (settingPlatform === 'link-sure');
+const isMigu = (settingPlatform === 'migu-runtime');
 
 const _global = typeof window === 'undefined' ? global : window;
  
@@ -470,6 +471,13 @@ function initSys () {
      sys.TAOBAO_MINIGAME = 121;
 
     /**
+     * @property {Number} MIGU_MINIGAME
+     * @readOnly
+     * @default 122
+     */
+    sys.MIGU_MINIGAME = 122;
+
+    /**
      * BROWSER_TYPE_WECHAT
      * @property {String} BROWSER_TYPE_WECHAT
      * @readOnly
@@ -727,6 +735,8 @@ function initSys () {
             platform = sys.QTT_GAME;
         } else if (isLinkSure) {
             platform = sys.LINKSURE;
+        } else if (isMigu) {
+            platform = sys.MIGU_MINIGAME;
         }
         else {
             platform = __getPlatform();
@@ -744,7 +754,8 @@ function initSys () {
                         isOppoGame ||
                         isHuaweiGame ||
                         isJKWGame ||
-                        isQttGame);
+                        isQttGame ||
+                        isMigu);
 
         sys.os = __getOS();
         sys.language = __getCurrentLanguage();


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This pull request adds support for the Migu mini-game platform in the Cocos Creator engine's CCSys.js file.

- Introduces new constant `isMigu` and platform identifier `sys.MIGU_MINIGAME`
- Updates `sys.isMobile` check to include the Migu platform
- Adds `sys.MIGU_MINIGAME = 122` to the list of platform constants
- Modifies platform detection logic to handle Migu mini-game platform
- Ensures consistency with existing code structure for other game platforms

<!-- /greptile_comment -->