### PR TITLE
Fix the rendering exception of the RenderTexture in the TikTok mini-game.

### DIFF
--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -22,6 +22,7 @@
  THE SOFTWARE.
 */
 
+import { BYTEDANCE } from 'internal:constants';
 import { debugID, error, errorID, CachedArray, cclegacy, assertID } from '../../core';
 import { WebGLCommandAllocator } from './webgl-command-allocator';
 import { WebGLEXT } from './webgl-define';
@@ -855,7 +856,8 @@ export function WebGLCmdFuncCreateTexture (device: WebGLDevice, gpuTexture: IWeb
             errorID(9100, maxSize, device.capabilities.maxTextureSize);
         }
 
-        if (!device.textureExclusive[gpuTexture.format] && (!device.extensions.WEBGL_depth_texture && FormatInfos[gpuTexture.format].hasDepth)) {
+        if (!device.textureExclusive[gpuTexture.format]
+            && ((!device.extensions.WEBGL_depth_texture || BYTEDANCE) && FormatInfos[gpuTexture.format].hasDepth)) {
             gpuTexture.glInternalFmt = GFXFormatToWebGLInternalFormat(gpuTexture.format, gl);
             gpuTexture.glRenderbuffer = gl.createRenderbuffer();
             if (gpuTexture.size > 0) {

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -855,7 +855,7 @@ export function WebGLCmdFuncCreateTexture (device: WebGLDevice, gpuTexture: IWeb
         if (maxSize > device.capabilities.maxTextureSize) {
             errorID(9100, maxSize, device.capabilities.maxTextureSize);
         }
-
+        // TODO: The system bug in the TikTok mini-game; once they fix it, a rollback will be necessary.
         if (!device.textureExclusive[gpuTexture.format]
             && ((!device.extensions.WEBGL_depth_texture || BYTEDANCE) && FormatInfos[gpuTexture.format].hasDepth)) {
             gpuTexture.glInternalFmt = GFXFormatToWebGLInternalFormat(gpuTexture.format, gl);


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This pull request addresses a rendering exception related to RenderTexture in the TikTok mini-game environment. The key changes include:

- Added a comment in `cocos/gfx/webgl/webgl-commands.ts` about a system bug in the TikTok mini-game platform
- Implemented a temporary workaround for the RenderTexture rendering issue
- Suggested a potential rollback once TikTok fixes the underlying system bug

This change demonstrates the engine's adaptability to platform-specific issues and highlights the ongoing collaboration between the engine developers and platform providers to ensure optimal performance across different environments.

<!-- /greptile_comment -->