### PR TITLE
wrap arrayBuffer with Uint8Array

### DIFF
--- a/cocos/rendering/custom/binary-archive.ts
+++ b/cocos/rendering/custom/binary-archive.ts
@@ -75,8 +75,8 @@ export class BinaryOutputArchive implements OutputArchive {
 }
 
 export class BinaryInputArchive implements InputArchive {
-    constructor (data: ArrayBuffer) {
-        this.dataView = new DataView(data);
+    constructor (data: ArrayBuffer, byteOffset?: number) {
+        this.dataView = new DataView(data, byteOffset);
     }
     b (): boolean {
         return this.dataView.getUint8(this.offset++) !== 0;

--- a/cocos/rendering/custom/index.jsb.ts
+++ b/cocos/rendering/custom/index.jsb.ts
@@ -63,18 +63,17 @@ export function getCustomPipeline (name: string): PipelineBuilder {
     return builder;
 }
 
-export function init (device: Device, arrayBufferLike: ArrayBuffer | null) {
-    if (arrayBufferLike && arrayBufferLike.byteLength >= LAYOUT_HEADER_SIZE) {
-        const uint8Array = new Uint8Array(arrayBufferLike);
-        const header = new DataView(uint8Array.buffer, 0, LAYOUT_HEADER_SIZE);
+export function init (device: Device, arrayBuffer: ArrayBuffer | null) {
+    if (arrayBuffer && arrayBuffer.byteLength >= LAYOUT_HEADER_SIZE) {
+        const header = new DataView(arrayBuffer, 0, LAYOUT_HEADER_SIZE);
         if (header.getUint32(0) === INVALID_ID) {
             // Data is compressed
-            const inflator = new zlib.Inflate(new Uint8Array(uint8Array, LAYOUT_HEADER_SIZE));
+            const inflator = new zlib.Inflate(new Uint8Array(arrayBuffer, LAYOUT_HEADER_SIZE));
             const decompressed = inflator.decompress() as Uint8Array;
             _renderModule = render.Factory.init(device, decompressed.buffer);
         } else {
             // Data is not compressed
-            _renderModule = render.Factory.init(device, uint8Array.buffer);
+            _renderModule = render.Factory.init(device, arrayBuffer);
         }
     } else {
         _renderModule = render.Factory.init(device, new ArrayBuffer(0));

--- a/cocos/rendering/custom/index.jsb.ts
+++ b/cocos/rendering/custom/index.jsb.ts
@@ -63,17 +63,18 @@ export function getCustomPipeline (name: string): PipelineBuilder {
     return builder;
 }
 
-export function init (device: Device, arrayBuffer: ArrayBuffer | null) {
-    if (arrayBuffer && arrayBuffer.byteLength >= LAYOUT_HEADER_SIZE) {
-        const header = new DataView(arrayBuffer, 0, LAYOUT_HEADER_SIZE);
+export function init (device: Device, arrayBufferLike: ArrayBuffer | null) {
+    if (arrayBufferLike && arrayBufferLike.byteLength >= LAYOUT_HEADER_SIZE) {
+        const uint8Array = new Uint8Array(arrayBufferLike);
+        const header = new DataView(uint8Array.buffer, 0, LAYOUT_HEADER_SIZE);
         if (header.getUint32(0) === INVALID_ID) {
             // Data is compressed
-            const inflator = new zlib.Inflate(new Uint8Array(arrayBuffer, LAYOUT_HEADER_SIZE));
+            const inflator = new zlib.Inflate(new Uint8Array(uint8Array, LAYOUT_HEADER_SIZE));
             const decompressed = inflator.decompress() as Uint8Array;
             _renderModule = render.Factory.init(device, decompressed.buffer);
         } else {
             // Data is not compressed
-            _renderModule = render.Factory.init(device, arrayBuffer);
+            _renderModule = render.Factory.init(device, uint8Array.buffer);
         }
     } else {
         _renderModule = render.Factory.init(device, new ArrayBuffer(0));

--- a/cocos/rendering/custom/index.ts
+++ b/cocos/rendering/custom/index.ts
@@ -75,18 +75,19 @@ export function getCustomPipeline (name: string): PipelineBuilder {
     return builder;
 }
 
-export function init (device: Device, arrayBuffer: ArrayBuffer | null): void {
-    if (arrayBuffer && arrayBuffer.byteLength >= LAYOUT_HEADER_SIZE) {
-        const header = new DataView(arrayBuffer, 0, LAYOUT_HEADER_SIZE);
+export function init (device: Device, arrayBufferLike: ArrayBuffer | null): void {
+    if (arrayBufferLike && arrayBufferLike.byteLength >= LAYOUT_HEADER_SIZE) {
+        const uint8Array = new Uint8Array(arrayBufferLike);
+        const header = new DataView(uint8Array.buffer, 0, LAYOUT_HEADER_SIZE);
         if (header.getUint32(0) === INVALID_ID) {
             // Data is compressed
-            const inflator = new zlib.Inflate(new Uint8Array(arrayBuffer, LAYOUT_HEADER_SIZE));
+            const inflator = new zlib.Inflate(new Uint8Array(uint8Array, LAYOUT_HEADER_SIZE));
             const decompressed = inflator.decompress() as Uint8Array;
             const readBinaryData = new BinaryInputArchive(decompressed.buffer);
             loadLayoutGraphData(readBinaryData, defaultLayoutGraph);
         } else {
             // Data is not compressed
-            const readBinaryData = new BinaryInputArchive(arrayBuffer);
+            const readBinaryData = new BinaryInputArchive(uint8Array.buffer);
             loadLayoutGraphData(readBinaryData, defaultLayoutGraph);
         }
     }


### PR DESCRIPTION
Unified buffer type using Uint8Array.
Fix: https://github.com/cocos/3d-tasks/issues/18455

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This PR improves the handling of binary data in the custom rendering pipeline initialization, enhancing compatibility and robustness across different JavaScript environments.

- Modified `cocos/rendering/custom/index.ts` to wrap `arrayBufferLike` input with Uint8Array in the `init` function
- Changed `init` function parameter from `arrayBuffer` to `arrayBufferLike` for better flexibility in `index.ts`
- Updated `cocos/rendering/custom/binary-archive.ts` to accept an optional `byteOffset` parameter in the `BinaryInputArchive` constructor
- Simplified `cocos/rendering/custom/index.jsb.ts` by removing the Uint8Array wrapper for input buffer in the `init` function

<!-- /greptile_comment -->