### PR TITLE
docs: fix spelling issues

### DIFF
--- a/docs/CPP_CODING_STYLE.md
+++ b/docs/CPP_CODING_STYLE.md
@@ -20,7 +20,7 @@ _Forked from [Google's C++ coding style](https://google.github.io/styleguide/cpp
   - [Nonmember, Static Member, and Global Functions](#nonmember-static-member-and-global-functions)
   - [Local Variables](#local-variables)
   - [Static and Global Variables](#static-and-global-variables)
-    - [Decision on destrcution:](#decision-on-destrcution)
+    - [Decision on destruction:](#decision-on-destrcution)
     - [Decision on initialization](#decision-on-initialization)
     - [Common patterns](#common-patterns)
   - [thread_local variables](#thread_local-variables)

--- a/docs/CPP_CODING_STYLE.md
+++ b/docs/CPP_CODING_STYLE.md
@@ -381,7 +381,7 @@ Global and static variables that use dynamic initialization or have non-trivial 
 
 **Decision:**
 
-### Decision on destrcution:
+### Decision on destruction:
 
 When destructors are trivial, their execution is not subject to ordering at all (they are effectively not "run"); otherwise we are exposed to the risk of accessing objects after the end of their lifetime. Therefore, we only allow objects with static storage duration if they are trivially destructible. Fundamental types (like pointers and int) are trivially destructible, as are arrays of trivially destructible types. Note that variables marked with constexpr are trivially destructible.
 

--- a/docs/contribution/deprecated-api.md
+++ b/docs/contribution/deprecated-api.md
@@ -46,7 +46,7 @@ interface IReplacement {
     customFunction?: Function;
     /** Setter of custom replacement properties */
     customSetter?: (v: any) => void;
-     /** Getter for custom replacement propertys */
+     /** Getter for custom replacement properties */
     customGetter?: () => any;
 }
 

--- a/docs/contribution/modules.md
+++ b/docs/contribution/modules.md
@@ -53,6 +53,6 @@ If your API need to be in a brand new public module, you need to create the new 
 Creating a public module is simply adding a module file under `/exports`.
 Then, you need some extra steps to bring your public module to users:
 
-- Add an new element into `features` array in [cc.config.json](../../cc.config.json), **feature** means a feature set which might be selected by user. `modules` field indicates which public modules(see above) should be considered included while this feature is enabled. Each element of `modules` should be the extension-less file name of a public module. That JSON configuration file should have been associated with a schema file. For more fields or controls over that file, see the schema file.
+- Add a new element into `features` array in [cc.config.json](../../cc.config.json), **feature** means a feature set which might be selected by user. `modules` field indicates which public modules(see above) should be considered included while this feature is enabled. Each element of `modules` should be the extension-less file name of a public module. That JSON configuration file should have been associated with a schema file. For more fields or controls over that file, see the schema file.
 
 - Navigate to [render-config.json](../../editor/engine-features/render-config.json) to configure the feature's exterior in Editor. Also there's an associated schema file.


### PR DESCRIPTION
Hello
I found and fixed several spelling issues in your docs.
Br, Elias.


<!-- greptile_comment -->

## Greptile Summary

This pull request addresses minor spelling corrections in documentation files, improving readability and professionalism without affecting code functionality.

- Corrected 'destrcution' to 'destruction' in `docs/CPP_CODING_STYLE.md`
- Fixed 'propertys' to 'properties' in `docs/contribution/deprecated-api.md`
- Changed 'an new element' to 'a new element' in `docs/contribution/modules.md`

<!-- /greptile_comment -->