### PR TITLE
Revert "Fix the display of WebGPU under the new pipeline with CSM, re…

### DIFF
--- a/cocos/rendering/custom/define.ts
+++ b/cocos/rendering/custom/define.ts
@@ -644,7 +644,7 @@ export function updatePerPassUBO (layout: string, sceneId: number, user: RenderD
         const bindId = getDescBinding(key, descriptorSetData);
         if (bindId === -1) { continue; }
         const tex = descriptorSet.getTexture(bindId);
-        if (tex !== value
+        if (!tex || value !== webPip.defaultShadowTexture
         // @ts-ignore
         || (!tex.gpuTexture && !(tex.gpuTextureView && tex.gpuTextureView.gpuTexture))) {
             bindGlobalDesc(descriptorSet, bindId, value);
@@ -654,7 +654,7 @@ export function updatePerPassUBO (layout: string, sceneId: number, user: RenderD
         const bindId = getDescBinding(key, descriptorSetData);
         if (bindId === -1) { continue; }
         const sampler = descriptorSet.getSampler(bindId);
-        if (sampler !== value) {
+        if (!sampler || value !== webPip.defaultSampler) {
             bindGlobalDesc(descriptorSet, bindId, value);
         }
     }


### PR DESCRIPTION
…solve the conflict between binding and render attachment, and optimize the memory pool. (#17562)"

This reverts commit 3dfdc021b03ebe0ee2f1163f907e93c041d52577.

Previous pr will break post process code in builtin pipeline, which has greater impact.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request reverts changes made to optimize WebGPU rendering with Cascaded Shadow Maps (CSM) and memory pool management.

- Reverts modifications in `cocos/rendering/custom/define.ts` that optimized texture and sampler binding in the `updatePerPassUBO` function
- Undoes significant changes in `cocos/rendering/custom/executor.ts`, including the removal of the `RenderPassLayoutInfo` class and reverting `DeviceRenderPass` and `DeviceComputePass` class modifications
- Rolls back optimizations made to the `ExecutorPools` class for memory usage and resource management
- Reverts changes aimed at resolving conflicts between binding and render attachment in WebGPU pipeline

<!-- /greptile_comment -->