### PR TITLE
rename event name to fix event name conflict with NodeEventType.MOUSE_ENTER/MOUSE_LEAVE

### DIFF
--- a/cocos/input/types/event-enum.ts
+++ b/cocos/input/types/event-enum.ts
@@ -343,14 +343,14 @@ export enum InputEventType {
      * trigger this event.
      * @zh 当鼠标离开窗口或者 canvas 时发出该消息。只有 Windows、macOS 或者 PC web 会触发该事件。
      */
-    MOUSE_LEAVE = 'mouse-leave',
+    MOUSE_LEAVE = 'mouse-leave-window',
 
     /**
      * @en The event type indicates mouse enters the window or canvas. Only Windows, macOS or web PC can
      * trigger this event.
      * @zh 当鼠标进入窗口或者 canvas 时发出该消息。只有 Windows、macOS 或者 PC web 会触发该事件。
      */
-    MOUSE_ENTER = 'mouse-enter',
+    MOUSE_ENTER = 'mouse-enter-window',
 
     /**
      * @en


### PR DESCRIPTION
- `_handleMouseMove()` in node-event-processort.ts may change event type to NodeEventType.MOUSE_ENTER or NodeEventType.MOUSE_LEAVE, which are the same name as InputEventType.MOUSE_ENTER and InputEventType.MOUSE_LEAVE and will re-dispatch the event. 
- _handleMouseLeave() and _handleMouseEnter() will response corresponding event and change the value of _isMouseLeaveWindow
- _handleMouseMove() will return if the value of _isMouseLeaveWindow is true, then mouse move events will not be handled

<!-- greptile_comment -->

## Greptile Summary

This pull request renames two event types in the InputEventType enum to resolve a conflict with NodeEventType, addressing issues with mouse event handling and dispatching.

- Changed InputEventType.MOUSE_LEAVE to 'mouse-leave-window' in `cocos/input/types/event-enum.ts`
- Changed InputEventType.MOUSE_ENTER to 'mouse-enter-window' in `cocos/input/types/event-enum.ts`
- Modification aims to prevent event re-dispatching in `node-event-processor.ts`
- Change affects mouse event handling in both web and native implementations

<!-- /greptile_comment -->