### PR TITLE
add checkDepComponentInEditor decorator

### DIFF
--- a/cocos/core/data/class-decorator.ts
+++ b/cocos/core/data/class-decorator.ts
@@ -26,7 +26,7 @@
 export { uniquelyReferenced } from './decorators/serializable';
 export { ccclass } from './decorators/ccclass';
 export { property } from './decorators/property';
-export { requireComponent, executionOrder, disallowMultiple } from './decorators/component';
+export { requireComponent, checkDepComponentInEditor, executionOrder, disallowMultiple } from './decorators/component';
 export { executeInEditMode, menu, playOnFocus, inspector, icon, help } from './decorators/editable';
 export { type, integer, float, boolean, string } from './decorators/type';
 

--- a/cocos/core/data/decorators/component.ts
+++ b/cocos/core/data/decorators/component.ts
@@ -23,8 +23,12 @@
 */
 
 import { DEV } from 'internal:constants';
-import { CCClass } from '../class';
-import { makeEditorClassDecoratorFn, makeSmartEditorClassDecorator, emptySmartClassDecorator } from './utils';
+import {
+    makeEditorClassDecoratorFn,
+    makeSmartEditorClassDecorator,
+    emptySmartClassDecorator,
+    emptyDecoratorFn,
+} from './utils';
 
 /**
  * @en Declare that the current component relies on another type of component.
@@ -44,6 +48,22 @@ import { makeEditorClassDecoratorFn, makeSmartEditorClassDecorator, emptySmartCl
  * ```
  */
 export const requireComponent: (requiredComponent: Function | Function[]) => ClassDecorator = makeEditorClassDecoratorFn('requireComponent');
+
+/**
+ * @en Checks for dependent components before adding a component declared as CCClass. If the dependent component does not exist, prompt for it
+ * @zh 为声明为 CCClass 的组件进行添加前检查依赖组件。如果依赖的组件不存在，进行提示
+ * @param checkDepComponentInEditor
+ * @example
+ * ```ts
+ * import { _decorator, Sprite, Component } from cc;
+ * import { ccclass, checkDepComponentInEditor } from _decorator;
+ *
+ * @ccclass
+ * @checkDepComponentInEditor('cc.Sprite')
+ * class SpriteCtrl extends Component {}
+ * ```
+ */
+export const checkDepComponentInEditor: (component: string | string[]) => ClassDecorator =    DEV ? makeEditorClassDecoratorFn('checkDepComponentInEditor') : emptyDecoratorFn;
 
 /**
  * @en Set the component priority, it decides at which order the life cycle functions of components will be invoked. Smaller priority gets invoked before larger priority.

--- a/cocos/scene-graph/component.ts
+++ b/cocos/scene-graph/component.ts
@@ -768,6 +768,9 @@ value(Component, '_registerEditorProps', (cls, props): void => {
                 cls._executeInEditMode = !!val;
                 break;
 
+            case 'checkDepComponentInEditor':
+                cls._checkComponentInEditor = val;
+                break;
             case 'playOnFocus':
                 if (val) {
                     const willExecuteInEditMode = ('executeInEditMode' in props) ? props.executeInEditMode : cls._executeInEditMode;

--- a/editor/assets/default_renderpipeline/builtin-pipeline-settings.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline-settings.ts
@@ -42,11 +42,12 @@ import {
     fillRequiredPipelineSettings,
 } from './builtin-pipeline-types';
 
-const { ccclass, disallowMultiple, executeInEditMode, menu, property, requireComponent, type } = _decorator;
+const { ccclass, disallowMultiple, executeInEditMode, menu, property, checkDepComponentInEditor, requireComponent, type } = _decorator;
 
 @ccclass('BuiltinPipelineSettings')
 @menu('Rendering/BuiltinPipelineSettings')
 @requireComponent(Camera)
+@checkDepComponentInEditor('cc.Camera')
 @disallowMultiple
 @executeInEditMode
 export class BuiltinPipelineSettings extends Component {

--- a/editor/i18n/en/components.js
+++ b/editor/i18n/en/components.js
@@ -48,5 +48,9 @@ module.exports = {
         },
 
         blockInputEventsTip: 'This component will block all input events, preventing the input from penetrating to other nodes below the screen, typically for the background of the top-level UI of the screen.',
+
+        builtin_pipeline_settings: {
+            depend_component_warn: 'This component can only be added to a node that contains {dependent} component.',
+        },
     },
 };

--- a/editor/i18n/zh/components.js
+++ b/editor/i18n/zh/components.js
@@ -44,5 +44,9 @@ module.exports = {
         },
 
         blockInputEventsTip: '该组件将拦截所有输入事件，防止输入穿透到屏幕下方的其它节点，一般用于屏幕上层 UI 的背景。',
+
+        builtin_pipeline_settings: {
+            depend_component_warn: '该组件只能添加到包含 {dependent} 组件的节点中。',
+        },
     },
 };


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/discussions/18458

Depends: https://github.com/cocos/cocos-editor/pull/3127

### Changelog

* add checkDepComponentInEditor decorator

<img width="260" alt="image" src="https://github.com/user-attachments/assets/05ebecc5-4831-4bef-ae8d-8884f708f719">

<img width="260" alt="image" src="https://github.com/user-attachments/assets/6f14a0f7-a01a-4f87-a8be-044353468e4e">

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This pull request introduces a new decorator `checkDepComponentInEditor` to enhance component dependency management in the Cocos Engine editor environment.

- Added `checkDepComponentInEditor` decorator in `cocos/core/data/decorators/component.ts` to check for dependent components before adding a new one
- Implemented `_checkComponentInEditor` property setting in `cocos/scene-graph/component.ts` for editor-related component checks
- Applied the new decorator to `BuiltinPipelineSettings` class in `editor/assets/default_renderpipeline/builtin-pipeline-settings.ts`
- Added localization strings for dependency warning messages in both English and Chinese (editor/i18n/en/components.js and editor/i18n/zh/components.js)

<!-- /greptile_comment -->