### PR TITLE
Fix the issue where the cached animationCache object is using a released skeleton object due to asset release.

### DIFF
--- a/cocos/spine/skeleton-cache.ts
+++ b/cocos/spine/skeleton-cache.ts
@@ -358,6 +358,9 @@ class SkeletonCache {
             }
         }
 
+        const skeletonInfo = this._skeletonCache[assetUuid];
+        if (!skeletonInfo) return;
+
         const sharedOperate = (aniKey: string, animationCache: AnimationCache): void => {
             this._animationPool[`${assetUuid}#${aniKey}`] = animationCache;
             animationCache.clear();
@@ -366,9 +369,6 @@ class SkeletonCache {
             animationCache.destroy();
         };
         const operate = this._privateMode ? privateOperate : sharedOperate;
-
-        const skeletonInfo = this._skeletonCache[assetUuid];
-        if (!skeletonInfo) return;
         const animationsCache = skeletonInfo.animationsCache;
         for (const aniKey in animationsCache) {
             // Clear cache texture, and put cache into pool.
@@ -465,6 +465,14 @@ class SkeletonCache {
                     animationPool[key].destroy();
                     delete animationPool[key];
                 }
+            }
+            let skeletonInfo = this._skeletonCache[uuid];
+            const skeleton = skeletonInfo && skeletonInfo.skeleton;
+            if (skeleton) {
+                spine.wasmUtil.destroySpineSkeleton(skeleton);
+            }
+            if (skeletonInfo) {
+                delete this._skeletonCache[uuid];
             }
         } else {
             const animationPool = this._animationPool;


### PR DESCRIPTION
Re: #

relelated issue:
https://forum.cocos.org/t/topic/160979

This issue was caused by this [pull request](https://github.com/cocos/cocos-engine/pull/17432).  
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
