### PR TITLE
V3.8.4 pipeline reflection probe

### DIFF
--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -1446,6 +1446,7 @@ class DeviceRenderScene implements RecordingInterface {
         const renderQueueDesc = sceneCulling.renderQueueIndex.get(this.graphScene.sceneID)!;
         const renderQueue = sceneCulling.renderQueues[renderQueueDesc.renderQueueTarget];
         const graphSceneData = this.graphScene.scene!;
+        if (bool(graphSceneData.flags & SceneFlags.REFLECTION_PROBE)) renderQueue.probeQueue.applyMacro();
         renderQueue.recordCommands(context.commandBuffer, this._renderPass);
         if (bool(graphSceneData.flags & SceneFlags.REFLECTION_PROBE)) renderQueue.probeQueue.removeMacro();
         if (graphSceneData.flags & SceneFlags.GEOMETRY) {

--- a/cocos/rendering/custom/pipeline.ts
+++ b/cocos/rendering/custom/pipeline.ts
@@ -28,6 +28,7 @@
  * ========================= !DO NOT CHANGE THE FOLLOWING SECTION MANUALLY! =========================
  */
 /* eslint-disable max-len */
+import type { AABB } from '../../core/geometry/aabb';
 import type { Material } from '../../asset/assets';
 import type { Camera } from '../../render-scene/scene/camera';
 import type { DirectionalLight } from '../../render-scene/scene/directional-light';
@@ -480,6 +481,7 @@ export interface SceneBuilder extends Setter {
         light: Light,
         csmLevel?: number,
         optCamera?: Camera): void;
+    setCullingWorldBounds (aabb: AABB): void;
 }
 
 /**

--- a/cocos/rendering/custom/render-graph.ts
+++ b/cocos/rendering/custom/render-graph.ts
@@ -29,6 +29,7 @@
  */
 /* eslint-disable max-len */
 import { AdjI, AdjacencyGraph, BidirectionalGraph, ComponentGraph, ED, InEI, MutableGraph, MutableReferenceGraph, NamedGraph, OutE, OutEI, PolymorphicGraph, PropertyGraph, ReferenceGraph, UuidGraph, VertexListGraph } from './graph';
+import type { AABB } from '../../core/geometry/aabb';
 import type { Material } from '../../asset/assets';
 import type { Camera } from '../../render-scene/scene/camera';
 import type { Buffer, Framebuffer, RenderPass, Sampler, SamplerInfo, Swapchain, Texture } from '../../gfx';
@@ -990,6 +991,7 @@ export const enum CullingFlags {
     CAMERA_FRUSTUM = 0x1,
     LIGHT_FRUSTUM = 0x2,
     LIGHT_BOUNDS = 0x4,
+    WORLD_BOUNDS = 0x8,
 }
 
 export class SceneData {
@@ -1000,6 +1002,7 @@ export class SceneData {
         light: LightInfo = new LightInfo(),
         cullingFlags: CullingFlags = CullingFlags.CAMERA_FRUSTUM,
         shadingLight: Light | null = null,
+        worldBounds: AABB | null = null,
     ) {
         this.scene = scene;
         this.camera = camera;
@@ -1007,6 +1010,7 @@ export class SceneData {
         this.flags = flags;
         this.cullingFlags = cullingFlags;
         this.shadingLight = shadingLight;
+        this.worldBounds = worldBounds;
     }
     reset (
         scene: RenderScene | null,
@@ -1014,6 +1018,7 @@ export class SceneData {
         flags: SceneFlags,
         cullingFlags: CullingFlags,
         shadingLight: Light | null,
+        worldBounds: AABB | null,
     ): void {
         this.scene = scene;
         this.camera = camera;
@@ -1021,6 +1026,7 @@ export class SceneData {
         this.flags = flags;
         this.cullingFlags = cullingFlags;
         this.shadingLight = shadingLight;
+        this.worldBounds = worldBounds;
     }
     declare /*pointer*/ scene: RenderScene | null;
     declare /*pointer*/ camera: Camera | null;
@@ -1028,6 +1034,7 @@ export class SceneData {
     declare flags: SceneFlags;
     declare cullingFlags: CullingFlags;
     declare /*refcount*/ shadingLight: Light | null;
+    declare worldBounds: AABB | null;
 }
 
 export class Dispatch {
@@ -1722,9 +1729,10 @@ export class RenderGraphObjectPool {
         flags: SceneFlags = SceneFlags.NONE,
         cullingFlags: CullingFlags = CullingFlags.CAMERA_FRUSTUM,
         shadingLight: Light | null = null,
+        worldBounds: AABB | null = null,
     ): SceneData {
         const v = this.sd.add(); // SceneData
-        v.reset(scene, camera, flags, cullingFlags, shadingLight);
+        v.reset(scene, camera, flags, cullingFlags, shadingLight, worldBounds);
         return v;
     }
     createDispatch (

--- a/cocos/rendering/custom/scene-culling.ts
+++ b/cocos/rendering/custom/scene-culling.ts
@@ -254,7 +254,7 @@ function addRenderObject (
 ): void {
     const probeQueue = queue.probeQueue;
     if (isDrawProbe) {
-        probeQueue.applyMacro(model, phaseLayoutId);
+        probeQueue.addToProbeQueue(model, phaseLayoutId);
     }
     const subModels = model.subModels;
     const subModelCount = subModels.length;

--- a/cocos/rendering/custom/web-pipeline-types.ts
+++ b/cocos/rendering/custom/web-pipeline-types.ts
@@ -225,6 +225,17 @@ export class ProbeHelperQueue {
         this.probeMap.length = 0;
     }
 
+    applyMacro (): void {
+        for (const subModel of this.probeMap) {
+            let patches: IMacroPatch[] = [
+                { name: CC_USE_RGBE_OUTPUT, value: true },
+            ];
+            if (subModel.patches) {
+                patches = patches.concat(subModel.patches);
+            }
+            subModel.onMacroPatchesStateChanged(patches);
+        }
+    }
     removeMacro (): void {
         for (const subModel of this.probeMap) {
             if (!subModel.patches) continue;
@@ -238,7 +249,7 @@ export class ProbeHelperQueue {
             }
         }
     }
-    applyMacro (model: Model, probeLayoutId: number): void {
+    addToProbeQueue (model: Model, probeLayoutId: number): void {
         const subModels = model.subModels;
         for (let j = 0; j < subModels.length; j++) {
             const subModel: SubModel = subModels[j];
@@ -258,13 +269,6 @@ export class ProbeHelperQueue {
             }
             if (passIdx < 0) { continue; }
             if (!bUseReflectPass) {
-                let patches: IMacroPatch[] = [];
-                patches = patches.concat(subModel.patches!);
-                const useRGBEPatchs: IMacroPatch[] = [
-                    { name: CC_USE_RGBE_OUTPUT, value: true },
-                ];
-                patches = patches.concat(useRGBEPatchs);
-                subModel.onMacroPatchesStateChanged(patches);
                 this.probeMap.push(subModel);
             }
         }

--- a/cocos/rendering/custom/web-pipeline.ts
+++ b/cocos/rendering/custom/web-pipeline.ts
@@ -53,6 +53,7 @@ import { Director } from '../../game';
 import { ReflectionProbeManager } from '../../3d';
 import { legacyCC } from '../../core/global-exports';
 import { WebSetter, setCameraUBOValues, setShadowUBOLightView, setShadowUBOView, setTextureUBOView } from './web-pipeline-types';
+import { AABB } from '../../core/geometry/aabb';
 
 const _uboVec = new Vec4();
 const _samplerPointInfo = new SamplerInfo(
@@ -220,6 +221,10 @@ export class WebSceneBuilder extends WebSetter implements SceneBuilder {
         const passId = this._renderGraph.getParent(queueId);
         const layoutName = this._renderGraph.getLayout(passId);
         setShadowUBOLightView(this, this._scene.camera, light, csmLevel, layoutName);
+    }
+    setCullingWorldBounds (aabb: AABB): void {
+        this._scene.cullingFlags |= CullingFlags.WORLD_BOUNDS;
+        this._scene.worldBounds = aabb;
     }
     private _renderGraph: RenderGraph;
     private _scene: SceneData;

--- a/editor/assets/default_renderpipeline/builtin-pipeline-settings.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline-settings.ts
@@ -319,6 +319,7 @@ export class BuiltinPipelineSettings extends Component {
         group: { id: 'Bloom', name: 'Bloom (PostProcessing)', style: 'section' },
         type: CCFloat,
         min: 0,
+        step: 0.01,
     })
     set bloomThreshold(value: number) {
         this._settings.bloom.threshold = value;
@@ -332,6 +333,7 @@ export class BuiltinPipelineSettings extends Component {
         group: { id: 'Bloom', name: 'Bloom (PostProcessing)', style: 'section' },
         type: CCFloat,
         min: 0,
+        visible: false,
     })
     set bloomIntensity(value: number) {
         this._settings.bloom.intensity = value;

--- a/editor/assets/default_renderpipeline/builtin-pipeline.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline.ts
@@ -1440,7 +1440,8 @@ if (rendering) {
             colorName: string,
             depthStencilName: string,
             mainLight: renderer.scene.DirectionalLight | null,
-            scene: renderer.RenderScene | null = null,
+            scene: renderer.RenderScene | null,
+            probe?: renderer.scene.ReflectionProbe,
         ): void {
             // set viewport
             const colorStoreOp = this._cameraConfigs.enableMSAA ? StoreOp.DISCARD : StoreOp.STORE;
@@ -1482,11 +1483,14 @@ if (rendering) {
             // TODO(zhouzhenglong): Separate OPAQUE and MASK queue
 
             // add opaque and mask queue
-            pass.addQueue(QueueHint.NONE, 'reflect-map') // Currently we put OPAQUE and MASK into one queue, so QueueHint is NONE
+            const builder = pass.addQueue(QueueHint.NONE, 'reflect-map') // Currently we put OPAQUE and MASK into one queue, so QueueHint is NONE
                 .addScene(camera,
                     SceneFlags.OPAQUE | SceneFlags.MASK | SceneFlags.REFLECTION_PROBE,
                     mainLight || undefined,
                     scene ? scene : undefined);
+            if (probe) {
+                builder.setCullingWorldBounds(probe.boundingBox);
+            }
         }
 
         private _tryAddReflectionProbePasses(ppl: rendering.BasicPipeline, id: number,
@@ -1542,7 +1546,7 @@ if (rendering) {
                         const probePass = ppl.addRenderPass(width, height, 'default');
                         probePass.name = `CubeProbe${probeID}${faceIdx}`;
                         this._buildReflectionProbePass(probePass, id, probe.camera,
-                            colorName, depthStencilName, mainLight, scene);
+                            colorName, depthStencilName, mainLight, scene, probe);
                     }
                     probe.needRender = false;
                 }

--- a/editor/assets/default_renderpipeline/builtin-pipeline.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline.ts
@@ -154,6 +154,7 @@ class CameraConfigs {
     enableFXAA = false;
     enableFSR = false;
     enableHDR = false;
+    enablePlanarReflectionProbe = false;
     useFullPipeline = false;
     singleForwardRadiancePass = false;
     radianceFormat = gfx.Format.RGBA8;
@@ -211,6 +212,8 @@ function setupCameraConfigs(
         && !!camera.scene
         && !!camera.scene.mainLight
         && camera.scene.mainLight.shadowEnabled;
+
+    cameraConfigs.enablePlanarReflectionProbe = isMainGameWindow || camera.cameraUsage === CameraUsage.SCENE_VIEW;
 
     cameraConfigs.enableProfiler = DEBUG && isMainGameWindow;
 
@@ -1506,6 +1509,9 @@ if (rendering) {
                 const height = Math.max(Math.floor(area.y), 1);
 
                 if (probe.probeType === renderer.scene.ProbeType.PLANAR) {
+                    if (!this._cameraConfigs.enablePlanarReflectionProbe) {
+                        continue;
+                    }
                     const window: renderer.RenderWindow = probe.realtimePlanarTexture!.window!;
                     const colorName = `PlanarProbeRT${probeID}`;
                     const depthStencilName = `PlanarProbeDS${probeID}`;

--- a/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
@@ -196,6 +196,7 @@ public:
     }
 
     void useLightFrustum(IntrusivePtr<scene::Light> light, uint32_t csmLevel, const scene::Camera *optCamera) override;
+    void setCullingWorldBounds(const geometry::AABB &aabb) override;
 };
 
 class NativeRenderSubpassBuilderImpl : public NativeSetter {

--- a/native/cocos/renderer/pipeline/custom/NativeRenderGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeRenderGraph.cpp
@@ -725,7 +725,8 @@ CullingFlags makeCullingFlags(const LightInfo &light) {
 void NativeRenderQueueBuilder::addSceneOfCamera(
     scene::Camera *camera, LightInfo light, SceneFlags sceneFlags) {
     const auto *pLight = light.light.get();
-    SceneData scene(camera->getScene(), camera, sceneFlags, light, makeCullingFlags(light), light.light);
+    SceneData scene(camera->getScene(), camera, sceneFlags, light,
+        makeCullingFlags(light), light.light, geometry::AABB{});
     auto sceneID = addVertex2(
         SceneTag{},
         std::forward_as_tuple("Camera"),
@@ -809,6 +810,12 @@ void NativeSceneBuilder::useLightFrustum(
     }
 }
 
+void NativeSceneBuilder::setCullingWorldBounds(const geometry::AABB& aabb) {
+    auto &sceneData = get(SceneTag{}, nodeID, *renderGraph);
+    sceneData.cullingFlags |= CullingFlags::WORLD_BOUNDS;
+    sceneData.worldBounds = aabb;
+}
+
 SceneBuilder *NativeRenderQueueBuilder::addScene(
     const scene::Camera *camera, SceneFlags sceneFlags,
     scene::Light *light, scene::RenderScene *scene) {
@@ -826,7 +833,8 @@ SceneBuilder *NativeRenderQueueBuilder::addScene(
             // Objects are projected to camera by default and are culled further if light is available.
             light ? CullingFlags::CAMERA_FRUSTUM | CullingFlags::LIGHT_BOUNDS
                   : CullingFlags::CAMERA_FRUSTUM,
-            light),
+            light,
+            geometry::AABB{}),
         *renderGraph, nodeID);
     CC_ENSURES(sceneID != RenderGraph::null_vertex());
 

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
@@ -878,6 +878,7 @@ enum class CullingFlags : uint32_t {
     CAMERA_FRUSTUM = 0x1,
     LIGHT_FRUSTUM = 0x2,
     LIGHT_BOUNDS = 0x4,
+    WORLD_BOUNDS = 0x8,
 };
 
 constexpr CullingFlags operator|(const CullingFlags lhs, const CullingFlags rhs) noexcept {
@@ -910,13 +911,14 @@ constexpr bool any(CullingFlags e) noexcept {
 
 struct SceneData {
     SceneData() = default;
-    SceneData(const scene::RenderScene* sceneIn, const scene::Camera* cameraIn, SceneFlags flagsIn, LightInfo lightIn, CullingFlags cullingFlagsIn, IntrusivePtr<scene::Light> shadingLightIn) noexcept
+    SceneData(const scene::RenderScene* sceneIn, const scene::Camera* cameraIn, SceneFlags flagsIn, LightInfo lightIn, CullingFlags cullingFlagsIn, IntrusivePtr<scene::Light> shadingLightIn, geometry::AABB worldBoundsIn) noexcept
     : scene(sceneIn),
       camera(cameraIn),
       light(std::move(lightIn)),
       flags(flagsIn),
       cullingFlags(cullingFlagsIn),
-      shadingLight(std::move(shadingLightIn)) {}
+      shadingLight(std::move(shadingLightIn)),
+      worldBounds(worldBoundsIn) {}
 
     const scene::RenderScene* scene{nullptr};
     const scene::Camera* camera{nullptr};
@@ -924,6 +926,7 @@ struct SceneData {
     SceneFlags flags{SceneFlags::NONE};
     CullingFlags cullingFlags{CullingFlags::CAMERA_FRUSTUM};
     IntrusivePtr<scene::Light> shadingLight;
+    geometry::AABB worldBounds;
 };
 
 struct Dispatch {

--- a/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderInterfaceTypes.h
@@ -569,6 +569,7 @@ public:
      * @param optCamera @en Additional scene culling camera. @zh 额外的场景裁切相机
      */
     virtual void useLightFrustum(IntrusivePtr<scene::Light> light, uint32_t csmLevel, const scene::Camera *optCamera) = 0;
+    virtual void setCullingWorldBounds(const geometry::AABB &aabb) = 0;
     void useLightFrustum(IntrusivePtr<scene::Light> light) {
         useLightFrustum(std::move(light), 0, nullptr);
     }


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

Based on the changes in NativeRenderGraph.cpp, here are the key points about the implementation of reflection probes and scene culling optimizations:

- Added setCullingWorldBounds method to NativeSceneBuilder class, allowing setting of an axis-aligned bounding box (AABB) for scene culling
- Introduced worldBounds field in SceneData structure to store the culling bounds
- Updated CullingFlags to include WORLD_BOUNDS flag for optimized culling
- Enhanced SceneBuilder to support reflection probe functionality

These changes enable more efficient scene culling by using world bounds and improve support for reflection probes in the custom rendering pipeline. The additions align with the pull request's focus on implementing reflection probes and optimizing scene culling.

<!-- /greptile_comment -->