### PR TITLE
Fix the issue where post-processing modifications after rendering are ineffective.

### DIFF
--- a/cocos/rendering/custom/define.ts
+++ b/cocos/rendering/custom/define.ts
@@ -448,16 +448,7 @@ export function getDescBindingFromName (bindingName: string): number {
     return -1;
 }
 
-const uniformMap: Map<string, Float32Array> = new Map();
-const buffHashMap: Map<Buffer, number> = new Map();
-function numsHash (arr: number[]): number {
-    let hash = 0;
-    for (let i = 0; i < arr.length; i++) {
-        hash = hashCombineNum(arr[i], hash);
-    }
-    return hash;
-}
-
+const uniformMap: Map<Buffer, Float32Array> = new Map();
 class DescBuffManager {
     private buffers: Buffer[] = [];
     private currBuffIdx: number = 0;
@@ -484,20 +475,14 @@ class DescBuffManager {
     updateBuffer (bindId: number, vals: number[], layout: string, setData: DescriptorSetData): void {
         const descriptorSet = setData.descriptorSet!;
         const buffer = this.getCurrentBuffer();
-        const uniformKey = `${layout}${bindId}${this.currBuffIdx}`;
-        let currUniform = uniformMap.get(uniformKey);
-        const currHash = numsHash(vals);
+        let currUniform = uniformMap.get(buffer);
         if (!currUniform) {
             currUniform = new Float32Array(vals);
-            uniformMap.set(uniformKey, currUniform);
+            uniformMap.set(buffer, currUniform);
         }
-        const destHash = buffHashMap.get(buffer);
-        if (destHash !== currHash) {
-            currUniform.set(vals);
-            buffer.update(currUniform);
-            bindGlobalDesc(descriptorSet, bindId, buffer);
-            buffHashMap.set(buffer, currHash);
-        }
+        currUniform.set(vals);
+        buffer.update(currUniform);
+        bindGlobalDesc(descriptorSet, bindId, buffer);
     }
 }
 

--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -1995,7 +1995,7 @@ class PreRenderVisitor extends BaseRenderVisitor implements RenderGraphVisitor {
         if (!this.rg.getValid(this.sceneID)) return;
         const renderQueue = this.currQueue as DeviceRenderQueue;
         const graphScene = context.pools.addGraphScene();
-        graphScene.init(null, value, -1);
+        graphScene.init(null, value, this.sceneID);
         const renderScene = renderQueue.addScene(graphScene);
         renderScene.preRecord();
     }

--- a/editor/assets/default_renderpipeline/builtin-pipeline-settings.ts
+++ b/editor/assets/default_renderpipeline/builtin-pipeline-settings.ts
@@ -327,12 +327,6 @@ export class BuiltinPipelineSettings extends Component {
         return this._settings.bloom.threshold;
     }
 
-    @property({
-        tooltip: 'i18n:bloom.intensity',
-        group: { id: 'Bloom', name: 'Bloom (PostProcessing)', style: 'section' },
-        type: CCFloat,
-        min: 0,
-    })
     set bloomIntensity(value: number) {
         this._settings.bloom.intensity = value;
     }


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This pull request modifies the BuiltinPipelineSettings class in the default render pipeline, specifically affecting the bloom intensity property.

- Removed @property decorator for 'bloomIntensity' setter in `editor/assets/default_renderpipeline/builtin-pipeline-settings.ts`
- Potential impact on bloom intensity property visibility and editability in the editor interface
- Getter and setter methods for bloomIntensity remain intact, preserving programmatic access

<!-- /greptile_comment -->