### PR TITLE
Update node.ts setSiblingIndex support negative index

### DIFF
--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -630,7 +630,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
             return;
         }
         const siblings = this._parent._children;
-        index = index !== -1 ? index : siblings.length - 1;
+        index = index >= 0 ? index : siblings.length + index;
         const oldIndex = siblings.indexOf(this);
         if (index !== oldIndex) {
             siblings.splice(oldIndex, 1);

--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -353,7 +353,8 @@ void Node::setSiblingIndex(index_t index) {
         return;
     }
     ccstd::vector<IntrusivePtr<Node>> &siblings = _parent->_children;
-    index = index != -1 ? index : static_cast<index_t>(siblings.size()) - 1;
+    index = index >= 0 ? index : static_cast<index_t>(siblings.size()) + index;
+    index = index >= 0 ? index : 0;
     index_t oldIdx = getIdxOfChild(siblings, this);
     if (index != oldIdx) {
         if (oldIdx != CC_INVALID_INDEX) {


### PR DESCRIPTION
eg.
-1 equals siblings.length -1.
-2 equals siblings.length -2.
-3 equals siblings.length -3.

Re: #

### Changelog

* Support negative index in setSiblingIndex method

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the setSiblingIndex method in the Node class to support negative indices for more convenient node positioning within the scene graph.

- Modifies `setSiblingIndex` in `cocos/scene-graph/node.ts` to handle negative indices
- Allows positioning nodes relative to the end of the sibling list (e.g. -1 for last position)
- Affects core functionality of node positioning and hierarchy management
- Requires careful review to ensure consistency with existing behavior
- May impact other engine components that rely on sibling indexing

<!-- /greptile_comment -->