### PR TITLE
fixed #17606: node.setWorldScale(0, 0, 0) causes NaN issue in scale and worldMatrix properties

### DIFF
--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -2571,7 +2571,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
             const zScale = Vec3.set(v3_b, this._mat.m08, this._mat.m09, this._mat.m10).length();
             v3_a.x = xScale !== 0 ? worldScale.x / xScale : 0;
             v3_a.y = yScale !== 0 ? worldScale.y / yScale : 0;
-            v3_a.z = zScale !== 0 ?  worldScale.z / zScale : 0;
+            v3_a.z = zScale !== 0 ? worldScale.z / zScale : 0;
             Mat4.scale(m4_1, this._mat, v3_a);
             Mat4.multiply(m4_2, Mat4.invert(m4_2, parent._mat), m4_1);
             Mat3.fromQuat(m3_1, Quat.conjugate(qt_1, this._lrot));

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -2566,9 +2566,12 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
             Vec3.copy(worldScale, v3_a);
         }
         if (parent) {
-            v3_a.x = worldScale.x / Vec3.set(v3_b, this._mat.m00, this._mat.m01, this._mat.m02).length();
-            v3_a.y = worldScale.y / Vec3.set(v3_b, this._mat.m04, this._mat.m05, this._mat.m06).length();
-            v3_a.z = worldScale.z / Vec3.set(v3_b, this._mat.m08, this._mat.m09, this._mat.m10).length();
+            const xScale = Vec3.set(v3_b, this._mat.m00, this._mat.m01, this._mat.m02).length();
+            const yScale = Vec3.set(v3_b, this._mat.m04, this._mat.m05, this._mat.m06).length();
+            const zScale = Vec3.set(v3_b, this._mat.m08, this._mat.m09, this._mat.m10).length();
+            v3_a.x = xScale !== 0 ? worldScale.x / xScale : 0;
+            v3_a.y = yScale !== 0 ? worldScale.y / yScale : 0;
+            v3_a.z = zScale !== 0 ?  worldScale.z / zScale : 0;
             Mat4.scale(m4_1, this._mat, v3_a);
             Mat4.multiply(m4_2, Mat4.invert(m4_2, parent._mat), m4_1);
             Mat3.fromQuat(m3_1, Quat.conjugate(qt_1, this._lrot));

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -2599,9 +2599,14 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
             Mat4.multiply(m4_2, Mat4.invert(m4_2, parent._mat), m4_1);
             Mat3.fromQuat(m3_1, Quat.conjugate(qt_1, this._lrot));
             Mat3.multiplyMat4(m3_1, m3_1, m4_2);
-            this._lscale.x = Vec3.set(v3_a, m3_1.m00, m3_1.m01, m3_1.m02).length();
-            this._lscale.y = Vec3.set(v3_a, m3_1.m03, m3_1.m04, m3_1.m05).length();
-            this._lscale.z = Vec3.set(v3_a, m3_1.m06, m3_1.m07, m3_1.m08).length();
+
+            const localScale = this._lscale;
+            localScale.x = Vec3.set(v3_a, m3_1.m00, m3_1.m01, m3_1.m02).length();
+            localScale.y = Vec3.set(v3_a, m3_1.m03, m3_1.m04, m3_1.m05).length();
+            localScale.z = Vec3.set(v3_a, m3_1.m06, m3_1.m07, m3_1.m08).length();
+            if (localScale.x === 0 || localScale.y === 0 || localScale.z === 0) {
+                rotationFlag = TransformBit.ROTATION;
+            }
         } else {
             Vec3.copy(this._lscale, worldScale);
         }

--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -654,6 +654,10 @@ void Node::setWorldScale(float x, float y, float z) {
         _localScale.x = Vec3{localRS.m[0], localRS.m[1], localRS.m[2]}.length();
         _localScale.y = Vec3{localRS.m[3], localRS.m[4], localRS.m[5]}.length();
         _localScale.z = Vec3{localRS.m[6], localRS.m[7], localRS.m[8]}.length();
+        
+        if (_localScale.x == 0 || _localScale.y == 0 || _localScale.z == 0) {
+            rotationFlag = TransformBit::ROTATION;
+        }
     } else {
         _worldScale.set(x, y, z);
         _localScale = _worldScale;

--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -617,7 +617,7 @@ void Node::setWorldScale(float x, float y, float z) {
         Mat3 localRS;
         Mat3 localRotInv;
         Mat4 worldMatrixTmp = _worldMatrix;
-        Vec3 rescaleFactor = _worldScale / oldWorldScale;
+        Vec3 rescaleFactor = oldWorldScale == Vec3::ZERO ? Vec3::ZERO : _worldScale / oldWorldScale;
         // apply new world scale to temp world matrix
         worldMatrixTmp.scale(rescaleFactor); // need opt
         // get temp local matrix

--- a/native/tests/unit-test/src/node_test.cpp
+++ b/native/tests/unit-test/src/node_test.cpp
@@ -181,11 +181,11 @@ TEST(NodeTest, setWorldScale0yz_and_rotation) {
     )));
     
     EXPECT_TRUE(son->getRotation().approxEquals(Quaternion(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627)));
-    EXPECT_TRUE(son->getWorldRotation().approxEquals(Quaternion(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627)));
+    EXPECT_TRUE(son->getWorldRotation().approxEquals(Quaternion(0, 0, 0, 1))); // Could not decompose rotation in Mat4.toSRT since there is a axis is zero, so the rotation will be reset to unit quaternion.
     
     son->setRotationFromEuler(20, 20, 20);
     EXPECT_TRUE(son->getRotation().approxEquals(Quaternion(0.1981076317236749, 0.1981076317236749, 0.1387164571097902, 0.9498760324550678)));
-    EXPECT_TRUE(son->getWorldRotation().approxEquals(Quaternion(0, 0, 0, 1))); // Could not decompose rotation in Mat4.toSRT since there is a axis is zero, so the rotation will be reset to unit quaternion.
+    EXPECT_TRUE(son->getWorldRotation().approxEquals(Quaternion(0, 0, 0, 1)));
     
     son->setRotationFromEuler(10, 10, 10);
     EXPECT_TRUE(son->getRotation().approxEquals(Quaternion(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627)));

--- a/native/tests/unit-test/src/node_test.cpp
+++ b/native/tests/unit-test/src/node_test.cpp
@@ -103,23 +103,126 @@ TEST(NodeTest, activeInHierarchyChanged) {
 
 */
 
-TEST(NodeTest, setWorldScale000) {
+TEST(NodeTest, setWorldScale000_and_rotation) {
     cc::IntrusivePtr<cc::Node> parent(new Node());
 
     parent->setScale(2, 2, 2);
 
     cc::IntrusivePtr<cc::Node> son(new Node());
+    son->setRotationFromEuler(10, 0, 0);
     son->setParent(parent);
+    son->updateWorldTransform();
+    EXPECT_TRUE(son->getScale() == Vec3::ONE);
+    EXPECT_TRUE(son->getWorldScale().approxEquals(Vec3(2.f, 2.f, 2.f)));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        2, 0, 0, 0,
+        0, 1.969615506024416, 0.34729635533386066, 0,
+        0, -0.34729635533386066, 1.969615506024416, 0,
+        0, 0, 0, 1
+    )));
+
     son->setWorldScale(0, 0, 0);
-    son->updateWorldTransform();
-    son->setWorldScale(1, 1, 1);
-    son->updateWorldTransform();
-    son->setWorldScale(0, 0, 0);
-    son->updateWorldTransform();
-    
     EXPECT_TRUE(son->getScale() == Vec3::ZERO);
     EXPECT_TRUE(son->getWorldScale() == Vec3::ZERO);
-    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 1
+    )));
+    
+    son->setWorldScale(2, 2, 2);
+    EXPECT_TRUE(son->getScale().approxEquals(Vec3::ONE));
+    EXPECT_TRUE(son->getWorldScale().approxEquals(Vec3(2.f, 2.f, 2.f)));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        2, 0, 0, 0,
+        0, 1.969615506024416, 0.34729635533386066, 0,
+        0, -0.34729635533386066, 1.969615506024416, 0,
+        0, 0, 0, 1
+    )));
+
+    son->setWorldScale(1, 1, 1);
+    EXPECT_TRUE(son->getScale().approxEquals(Vec3(0.5f, 0.5f, 0.5f)));
+    EXPECT_TRUE(son->getWorldScale().approxEquals(Vec3::ONE));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        1, 0, 0, 0,
+        0, 0.984807753012208, 0.17364817766693033, 0,
+        0, -0.17364817766693033, 0.984807753012208, 0,
+        0, 0, 0, 1
+    )));
+}
+
+TEST(NodeTest, setWorldScale0yz_and_rotation) {
+    cc::IntrusivePtr<cc::Node> parent(new Node());
+    
+    parent->setScale(2, 2, 2);
+    
+    cc::IntrusivePtr<cc::Node> son(new Node());
+    son->setRotationFromEuler(10, 10, 10);
+    son->setParent(parent);
+    son->updateWorldTransform();
+    EXPECT_TRUE(son->getScale().approxEquals(Vec3::ONE));
+    EXPECT_TRUE(son->getWorldScale().approxEquals(Vec3(2, 2, 2)));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        1.9396926207859084, 0.3472963553338607, -0.3420201433256687, 0,
+        -0.2765167096193736, 1.9396926207859084, 0.40141131793955337, 0,
+        0.40141131793955337, -0.3420201433256687, 1.9292203542855129, 0,
+        0, 0, 0, 1
+    )));
+    
+    son->setWorldScale(0, 2, 2);
+    EXPECT_TRUE(son->getScale().approxEquals(Vec3(0, 1, 1)));
+    EXPECT_TRUE(son->getWorldScale().approxEquals(Vec3(0, 2, 2)));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        0, 0, 0, 0,
+        -0.2765167096193736, 1.9396926207859084, 0.40141131793955337, 0,
+        0.40141131793955337, -0.3420201433256687, 1.9292203542855129, 0,
+        0, 0, 0, 1
+    )));
+    
+    EXPECT_TRUE(son->getRotation().approxEquals(Quaternion(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627)));
+    EXPECT_TRUE(son->getWorldRotation().approxEquals(Quaternion(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627)));
+    
+    son->setRotationFromEuler(20, 20, 20);
+    EXPECT_TRUE(son->getRotation().approxEquals(Quaternion(0.1981076317236749, 0.1981076317236749, 0.1387164571097902, 0.9498760324550678)));
+    EXPECT_TRUE(son->getWorldRotation().approxEquals(Quaternion(0, 0, 0, 1))); // Could not decompose rotation in Mat4.toSRT since there is a axis is zero, so the rotation will be reset to unit quaternion.
+    
+    son->setRotationFromEuler(10, 10, 10);
+    EXPECT_TRUE(son->getRotation().approxEquals(Quaternion(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627)));
+    EXPECT_TRUE(son->getWorldRotation().approxEquals(Quaternion(0, 0, 0, 1)));
+    
+    son->setWorldScale(1, 1, 1);
+    EXPECT_TRUE(son->getScale().approxEquals(Vec3(0.5, 0.5, 0.5)));
+    EXPECT_TRUE(son->getWorldScale().approxEquals(Vec3(1, 1, 1)));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        0.9698463103929542, 0.17364817766693036, -0.17101007166283436, 0,
+        -0.1382583548096868, 0.9698463103929542, 0.20070565896977668, 0,
+        0.20070565896977668, -0.17101007166283436, 0.9646101771427564, 0,
+        0, 0, 0, 1
+    )));
+    
+    EXPECT_TRUE(son->getRotation().approxEquals(Quaternion(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627)));
+    EXPECT_TRUE(son->getWorldRotation().approxEquals(Quaternion(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627)));
+    
+    son->setWorldScale(2, 0, 0);
+    EXPECT_TRUE(son->getScale().approxEquals(Vec3(1, 0, 0)));
+    EXPECT_TRUE(son->getWorldScale().approxEquals(Vec3(2, 0, 0)));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        1.9396926207859084, 0.3472963553338607, -0.3420201433256687, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 1
+    )));
+    
+    son->setWorldScale(2, 2, 2);
+    EXPECT_TRUE(son->getScale().approxEquals(Vec3(1, 1, 1)));
+    EXPECT_TRUE(son->getWorldScale().approxEquals(Vec3(2, 2, 2)));
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(
+        1.9396926207859084, 0.3472963553338607, -0.3420201433256687, 0,
+        -0.2765167096193736, 1.9396926207859084, 0.40141131793955337, 0,
+        0.40141131793955337, -0.3420201433256687, 1.9292203542855129, 0,
+        0, 0, 0, 1
+    )));
 }
 
 } // namespace

--- a/native/tests/unit-test/src/node_test.cpp
+++ b/native/tests/unit-test/src/node_test.cpp
@@ -22,11 +22,12 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
-/*
-#include "core/Director.h"
+
+//#include "core/Director.h"
 #include "core/Root.h"
-#include "core/platform/event-manager/Events.h"
-#include "core/scene-graph/SceneGraphModuleHeader.h"
+#include "core/scene-graph/Node.h"
+//#include "core/platform/event-manager/Events.h"
+//#include "core/scene-graph/SceneGraphModuleHeader.h"
 #include "gtest/gtest.h"
 #include "renderer/GFXDeviceManager.h"
 #include "renderer/gfx-base/GFXDef.h"
@@ -37,6 +38,8 @@ using namespace cc::event;
 using namespace cc::gfx;
 
 namespace {
+
+/*
 
 class MyCallbackTarget {
 public:
@@ -97,5 +100,27 @@ TEST(NodeTest, activeInHierarchyChanged) {
     // xwx FIXME: gfx-validator Assert
     destroyCocos();
 }
-} // namespace
+
 */
+
+TEST(NodeTest, setWorldScale000) {
+    cc::IntrusivePtr<cc::Node> parent(new Node());
+
+    parent->setScale(2, 2, 2);
+
+    cc::IntrusivePtr<cc::Node> son(new Node());
+    son->setParent(parent);
+    son->setWorldScale(0, 0, 0);
+    son->updateWorldTransform();
+    son->setWorldScale(1, 1, 1);
+    son->updateWorldTransform();
+    son->setWorldScale(0, 0, 0);
+    son->updateWorldTransform();
+    
+    EXPECT_TRUE(son->getScale() == Vec3::ZERO);
+    EXPECT_TRUE(son->getWorldScale() == Vec3::ZERO);
+    EXPECT_TRUE(son->getWorldMatrix().approxEquals(Mat4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)));
+}
+
+} // namespace
+

--- a/tests/core/node.test.ts
+++ b/tests/core/node.test.ts
@@ -633,11 +633,11 @@ describe(`Node`, () => {
         ))).toBeTruthy();
 
         expect(son.rotation.equals(new Quat(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627))).toBeTruthy();
-        expect(son.worldRotation.equals(new Quat(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627))).toBeTruthy();
+        expect(son.worldRotation.equals(new Quat(0, 0, 0, 1))).toBeTruthy(); // Could not decompose rotation in Mat4.toSRT since there is a axis is zero, so the rotation will be reset to unit quaternion.
 
         son.setRotationFromEuler(20, 20, 20);
         expect(son.rotation.equals(new Quat(0.1981076317236749, 0.1981076317236749, 0.1387164571097902, 0.9498760324550678))).toBeTruthy();
-        expect(son.worldRotation.equals(new Quat(0, 0, 0, 1))).toBeTruthy(); // Could not decompose rotation in Mat4.toSRT since there is a axis is zero, so the rotation will be reset to unit quaternion.
+        expect(son.worldRotation.equals(new Quat(0, 0, 0, 1))).toBeTruthy();
 
         son.setRotationFromEuler(10, 10, 10);
         expect(son.rotation.equals(new Quat(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627))).toBeTruthy();

--- a/tests/core/node.test.ts
+++ b/tests/core/node.test.ts
@@ -523,6 +523,26 @@ describe(`Node`, () => {
         expect(son.getScale()).toEqual(new Vec3(1/2, 1/3, 1/4));
     });
 
+    test ('setWorldScale(0, 0, 0)', ()=> {
+        let parent = new Node();
+
+        parent.setScale(2, 2, 2);
+
+        let son = new Node();
+        son.parent = parent;
+        son.setWorldScale(0, 0, 0);
+        son.updateWorldTransform();
+        son.setWorldScale(1, 1, 1);
+        son.updateWorldTransform();
+        son.setWorldScale(0, 0, 0);
+        son.updateWorldTransform();
+
+        expect(son.scale).toEqual(new Vec3(0, 0, 0));
+        expect(son.worldScale).toEqual(new Vec3(0, 0, 0));
+        expect(son.worldMatrix).toEqual(new Mat4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1));
+
+    });
+
     test ('angle', ()=> {
         let node = new Node();
 

--- a/tests/core/node.test.ts
+++ b/tests/core/node.test.ts
@@ -530,17 +530,150 @@ describe(`Node`, () => {
 
         let son = new Node();
         son.parent = parent;
-        son.setWorldScale(0, 0, 0);
-        son.updateWorldTransform();
-        son.setWorldScale(1, 1, 1);
-        son.updateWorldTransform();
-        son.setWorldScale(0, 0, 0);
         son.updateWorldTransform();
 
+        son.setWorldScale(0, 0, 0);
         expect(son.scale).toEqual(new Vec3(0, 0, 0));
         expect(son.worldScale).toEqual(new Vec3(0, 0, 0));
         expect(son.worldMatrix).toEqual(new Mat4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1));
 
+        son.setWorldScale(1, 1, 1);
+        expect(son.scale).toEqual(new Vec3(0.5, 0.5, 0.5));
+        expect(son.worldScale).toEqual(new Vec3(1, 1, 1));
+        expect(son.worldMatrix).toEqual(new Mat4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1));
+
+        son.setWorldScale(2, 2, 2);
+        expect(son.scale).toEqual(new Vec3(1, 1, 1));
+        expect(son.worldScale).toEqual(new Vec3(2, 2, 2));
+        expect(son.worldMatrix).toEqual(new Mat4(2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1));
+
+        son.setWorldScale(0, 0, 0);
+        expect(son.scale).toEqual(new Vec3(0, 0, 0));
+        expect(son.worldScale).toEqual(new Vec3(0, 0, 0));
+        expect(son.worldMatrix).toEqual(new Mat4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1));
+
+    });
+
+    test ('setWorldScale(0, 0, 0) and rotation', ()=> {
+        let parent = new Node();
+
+        parent.setScale(2, 2, 2);
+
+        let son = new Node();
+        son.setRotationFromEuler(10, 0, 0);
+        son.parent = parent;
+        son.updateWorldTransform();
+        expect(son.scale.equals(new Vec3(1, 1, 1))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(2, 2, 2))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            2, 0, 0, 0,
+            0, 1.969615506024416, 0.34729635533386066, 0,
+            0, -0.34729635533386066, 1.969615506024416, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
+
+        son.setWorldScale(0, 0, 0);
+        expect(son.scale.equals(new Vec3(0, 0, 0))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(0, 0, 0))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
+
+        son.setWorldScale(2, 2, 2);
+        expect(son.scale.equals(new Vec3(1, 1, 1))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(2, 2, 2))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            2, 0, 0, 0,
+            0, 1.969615506024416, 0.34729635533386066, 0,
+            0, -0.34729635533386066, 1.969615506024416, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
+
+        son.setWorldScale(1, 1, 1);
+        expect(son.scale.equals(new Vec3(0.5, 0.5, 0.5))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(1, 1, 1))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            1, 0, 0, 0,
+            0, 0.984807753012208, 0.17364817766693033, 0,
+            0, -0.17364817766693033, 0.984807753012208, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
+
+    });
+
+    test ('setWorldScale(0, y, z) and rotation', ()=> {
+        let parent = new Node();
+
+        parent.setScale(2, 2, 2);
+
+        let son = new Node();
+        son.setRotationFromEuler(10, 10, 10);
+        son.parent = parent;
+        son.updateWorldTransform();
+        expect(son.scale.equals(new Vec3(1, 1, 1))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(2, 2, 2))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            1.9396926207859084, 0.3472963553338607, -0.3420201433256687, 0,
+            -0.2765167096193736, 1.9396926207859084, 0.40141131793955337, 0,
+            0.40141131793955337, -0.3420201433256687, 1.9292203542855129, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
+
+        son.setWorldScale(0, 2, 2);
+        expect(son.scale.equals(new Vec3(0, 1, 1))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(0, 2, 2))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            0, 0, 0, 0,
+            -0.2765167096193736, 1.9396926207859084, 0.40141131793955337, 0,
+            0.40141131793955337, -0.3420201433256687, 1.9292203542855129, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
+
+        expect(son.rotation.equals(new Quat(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627))).toBeTruthy();
+        expect(son.worldRotation.equals(new Quat(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627))).toBeTruthy();
+
+        son.setRotationFromEuler(20, 20, 20);
+        expect(son.rotation.equals(new Quat(0.1981076317236749, 0.1981076317236749, 0.1387164571097902, 0.9498760324550678))).toBeTruthy();
+        expect(son.worldRotation.equals(new Quat(0, 0, 0, 1))).toBeTruthy(); // Could not decompose rotation in Mat4.toSRT since there is a axis is zero, so the rotation will be reset to unit quaternion.
+
+        son.setRotationFromEuler(10, 10, 10);
+        expect(son.rotation.equals(new Quat(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627))).toBeTruthy();
+        expect(son.worldRotation.equals(new Quat(0, 0, 0, 1))).toBeTruthy();
+
+        son.setWorldScale(1, 1, 1);
+        expect(son.scale.equals(new Vec3(0.5, 0.5, 0.5))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(1, 1, 1))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            0.9698463103929542, 0.17364817766693036, -0.17101007166283436, 0,
+            -0.1382583548096868, 0.9698463103929542, 0.20070565896977668, 0,
+            0.20070565896977668, -0.17101007166283436, 0.9646101771427564, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
+        expect(son.rotation.equals(new Quat(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627))).toBeTruthy();
+        expect(son.worldRotation.equals(new Quat(0.09406091491321403, 0.09406091491321403, 0.07892647901187543, 0.9879654343559627))).toBeTruthy();
+
+        son.setWorldScale(2, 0, 0);
+        expect(son.scale.equals(new Vec3(1, 0, 0))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(2, 0, 0))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            1.9396926207859084, 0.3472963553338607, -0.3420201433256687, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
+
+        son.setWorldScale(2, 2, 2);
+        expect(son.scale.equals(new Vec3(1, 1, 1))).toBeTruthy();
+        expect(son.worldScale.equals(new Vec3(2, 2, 2))).toBeTruthy();
+        expect(son.worldMatrix.equals(new Mat4(
+            1.9396926207859084, 0.3472963553338607, -0.3420201433256687, 0,
+            -0.2765167096193736, 1.9396926207859084, 0.40141131793955337, 0,
+            0.40141131793955337, -0.3420201433256687, 1.9292203542855129, 0,
+            0, 0, 0, 1
+        ))).toBeTruthy();
     });
 
     test ('angle', ()=> {


### PR DESCRIPTION
Re: #17606

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
