### PR TITLE
Fix spine::Animation & spine::Timeline can not release normally

### DIFF
--- a/cocos/spine/lib/spine-core.d.ts
+++ b/cocos/spine/lib/spine-core.d.ts
@@ -168,8 +168,6 @@ declare namespace spine {
         frameVertices: Array<ArrayLike<number>>;
         constructor(frameCount: number);
         getPropertyId(): number;
-        setSlotIndex(index: number);
-        setAttachment(attachment: Attachment);
         setFrame(frameIndex: number, time: number, vertices: []): void;
         apply(skeleton: Skeleton, lastTime: number, time: number, firedEvents: Array<Event>, alpha: number, blend: MixBlend, direction: MixDirection): void;
     }

--- a/cocos/spine/lib/spine-core.d.ts
+++ b/cocos/spine/lib/spine-core.d.ts
@@ -168,7 +168,9 @@ declare namespace spine {
         frameVertices: Array<ArrayLike<number>>;
         constructor(frameCount: number);
         getPropertyId(): number;
-        setFrame(frameIndex: number, time: number, vertices: ArrayLike<number>): void;
+        setSlotIndex(index: number);
+        setAttachment(attachment: Attachment);
+        setFrame(frameIndex: number, time: number, vertices: []): void;
         apply(skeleton: Skeleton, lastTime: number, time: number, firedEvents: Array<Event>, alpha: number, blend: MixBlend, direction: MixDirection): void;
     }
     class EventTimeline implements Timeline {

--- a/cocos/spine/lib/spine-define.ts
+++ b/cocos/spine/lib/spine-define.ts
@@ -28,10 +28,21 @@ import spine from './spine-core.js';
 import { js } from '../../core';
 
 function resizeArray (array, newSize): Array<any> {
-    if (!array) return new Array(newSize);
-    if (newSize === array.length) return array;
-    if (newSize < array.length) return array.slice(0, newSize);
-    else return new Array(newSize);
+    if (!array) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return new Array(newSize);
+    }
+    if (newSize === array.length) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return array;
+    }
+    if (newSize < array.length) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return array.slice(0, newSize);
+    } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return new Array(newSize);
+    }
 }
 
 function overrideDefineArrayProp (prototype: any, getPropVector: any, name: string): void {
@@ -44,6 +55,7 @@ function overrideDefineArrayProp (prototype: any, getPropVector: any, name: stri
             array = resizeArray(array, count);
             for (let i = 0; i < count; i++) array[i] = vectors.get(i);
             this[_name] = array;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             return array;
         },
     });
@@ -82,6 +94,7 @@ function overrideDefineArrayFunction (prototype: any, getPropVector: any, name: 
             array = resizeArray(array, count);
             for (let i = 0; i < count; i++) array[i] = vectors.get(i);
             this[_name] = array;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             return array;
         },
     });
@@ -121,7 +134,6 @@ function overrideClass (wasm): void {
     spine.Event = wasm.Event;
     spine.EventData = wasm.EventData;
     spine.Attachment = wasm.Attachment;
-    spine.SpineAnimationState = wasm.SpineAnimationState;
     spine.VertexAttachment = wasm.VertexAttachment;
     spine.BoundingBoxAttachment = wasm.BoundingBoxAttachment;
     spine.ClippingAttachment = wasm.ClippingAttachment;

--- a/cocos/spine/lib/spine-define.ts
+++ b/cocos/spine/lib/spine-define.ts
@@ -121,6 +121,7 @@ function overrideClass (wasm): void {
     spine.Event = wasm.Event;
     spine.EventData = wasm.EventData;
     spine.Attachment = wasm.Attachment;
+    spine.SpineAnimationState = wasm.SpineAnimationState;
     spine.VertexAttachment = wasm.VertexAttachment;
     spine.BoundingBoxAttachment = wasm.BoundingBoxAttachment;
     spine.ClippingAttachment = wasm.ClippingAttachment;

--- a/cocos/spine/skeleton-cache.ts
+++ b/cocos/spine/skeleton-cache.ts
@@ -114,6 +114,7 @@ export class AnimationCache {
     }
 
     public setSkin (skinName: string): void {
+        if (!skinName || skinName.length === 0) return;
         if (this._skeleton) this._skeleton.setSkinByName(skinName);
         this._instance!.setSkin(skinName);
     }
@@ -449,7 +450,6 @@ class SkeletonCache {
                 animationCache = new AnimationCache(spData);
                 animationCache._privateMode = this._privateMode;
             }
-            animationCache.init(skeletonInfo, animationName);
             animationsCache[animationName] = animationCache;
         }
         animationCache.init(skeletonInfo, animationName);

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -2389,6 +2389,10 @@ if(USE_MIDDLEWARE)
                                      cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
             NO_WERROR   NO_UBUILD    cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
                                      cocos/editor-support/spine-creator-support/SkeletonRenderer.h
+            NO_WERROR                cocos/editor-support/spine-creator-support/SpineAnimation.cpp
+                                     cocos/editor-support/spine-creator-support/SpineAnimation.h
+            NO_WERROR                cocos/editor-support/spine-creator-support/SpineAnimationState.cpp
+                                     cocos/editor-support/spine-creator-support/SpineAnimationState.h
             NO_WERROR                cocos/editor-support/spine-creator-support/spine-cocos2dx.cpp
                                      cocos/editor-support/spine-creator-support/spine-cocos2dx.h
             NO_WERROR                cocos/editor-support/spine-creator-support/VertexEffectDelegate.cpp

--- a/native/cocos/bindings/manual/jsb_conversions_spec.cpp
+++ b/native/cocos/bindings/manual/jsb_conversions_spec.cpp
@@ -1134,6 +1134,9 @@ bool sevalue_to_native(const se::Value &from, cc::IBArray *to, se::Object * /*ct
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 bool sevalue_to_native(const se::Value &val, spine::String *obj, se::Object * /*unused*/) {
+    if (!val.isString()) {
+        return false;
+    }
     *obj = val.toString().data();
     return true;
 }

--- a/native/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
@@ -28,6 +28,8 @@
  *****************************************************************************/
 
 #include "spine-creator-support/SkeletonAnimation.h"
+#include "SpineAnimationState.h"
+
 #include <algorithm>
 #include "base/DeferredReleasePool.h"
 #include "base/Log.h"
@@ -99,7 +101,7 @@ void SkeletonAnimation::initialize() {
     super::initialize();
 
     _ownsAnimationStateData = true;
-    _state = new (__FILE__, __LINE__) AnimationState(new (__FILE__, __LINE__) AnimationStateData(_skeleton->getData()));
+    _state = new (__FILE__, __LINE__) SpineAnimationState(new (__FILE__, __LINE__) AnimationStateData(_skeleton->getData()));
     _state->setRendererObject(this);
     _state->setListener(animationCallback);
 }
@@ -140,7 +142,7 @@ void SkeletonAnimation::setAnimationStateData(AnimationStateData *stateData) {
     }
 
     _ownsAnimationStateData = false;
-    _state = new (__FILE__, __LINE__) AnimationState(stateData);
+    _state = new (__FILE__, __LINE__) SpineAnimationState(stateData);
     _state->setRendererObject(this);
     _state->setListener(animationCallback);
 }

--- a/native/cocos/editor-support/spine-creator-support/SkeletonCacheMgr.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCacheMgr.cpp
@@ -48,7 +48,7 @@ void SkeletonCacheMgr::removeSkeletonCache(const std::string &uuid) {
     auto it = _caches.find(uuid);
     if (it != _caches.end()) {
         auto *item = it->second;
-        delete item;
+        item->release();
         _caches.erase(it);
     }
 }

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
@@ -1,3 +1,26 @@
+/*
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
 
 #include "SpineAnimation.h"
 

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
@@ -1,0 +1,24 @@
+
+#include "SpineAnimation.h"
+
+using namespace spine;
+
+spine::Vector<Timeline*> convertAndUseVector(const std::vector<std::shared_ptr<Timeline>>& stdVec) {
+    spine::Vector<Timeline*> spineVec;
+
+    for (const auto& element : stdVec) {
+        spineVec.add(element.get());
+    }
+
+    return spineVec;
+}
+
+SpineAnimation::SpineAnimation(const String& name, std::vector<std::shared_ptr<Timeline>> timelines, float duration) : Animation(name, convertAndUseVector(timelines), duration) {
+    _vecTimelines = timelines;
+}
+
+SpineAnimation::~SpineAnimation() {
+    _vecTimelines.clear();
+    auto& timelines = getTimelines();
+    timelines.clear();
+}

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
@@ -13,7 +13,7 @@ spine::Vector<Timeline*> convertAndUseVector(const std::vector<std::shared_ptr<T
     return spineVec;
 }
 
-SpineAnimation::SpineAnimation(const String& name, std::vector<std::shared_ptr<Timeline>> timelines, float duration) : Animation(name, convertAndUseVector(timelines), duration) {
+SpineAnimation::SpineAnimation(const String& name, std::vector<std::shared_ptr<Timeline>> timelines, float duration) : Animation(name, std::move(convertAndUseVector(timelines)), duration) {
     _vecTimelines = timelines;
 }
 

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
@@ -3,22 +3,21 @@
 
 using namespace spine;
 
-spine::Vector<Timeline*> convertAndUseVector(const std::vector<std::shared_ptr<Timeline>>& stdVec) {
-    spine::Vector<Timeline*> spineVec;
-
+spine::Vector<Timeline*>& convertAndUseVector(const std::vector<std::shared_ptr<Timeline>>& stdVec, spine::Vector<Timeline*>& _spineVecTimelines) {
     for (const auto& element : stdVec) {
-        spineVec.add(element.get());
+        _spineVecTimelines.add(element.get());
     }
 
-    return spineVec;
+    return _spineVecTimelines;
 }
 
-SpineAnimation::SpineAnimation(const String& name, std::vector<std::shared_ptr<Timeline>> timelines, float duration) : Animation(name, std::move(convertAndUseVector(timelines)), duration) {
+SpineAnimation::SpineAnimation(const String& name, std::vector<std::shared_ptr<Timeline>> timelines, float duration) : Animation(name, convertAndUseVector(timelines, _spineVecTimelines), duration) {
     _vecTimelines = timelines;
 }
 
 SpineAnimation::~SpineAnimation() {
     _vecTimelines.clear();
+    _spineVecTimelines.clear();
     auto& timelines = getTimelines();
     timelines.clear();
 }

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
@@ -24,23 +24,25 @@
 
 #include "SpineAnimation.h"
 
-using namespace spine;
+namespace spine {
 
-spine::Vector<Timeline*>& convertAndUseVector(const std::vector<std::shared_ptr<Timeline>>& stdVec, spine::Vector<Timeline*>& _spineVecTimelines) {
+spine::Vector<Timeline*>& convertAndUseVector(const std::vector<std::shared_ptr<Timeline>>& stdVec) {
+    static spine::Vector<Timeline*> spineVecTimelines;
+    spineVecTimelines.clear();
     for (const auto& element : stdVec) {
-        _spineVecTimelines.add(element.get());
+        spineVecTimelines.add(element.get());
     }
 
-    return _spineVecTimelines;
+    return spineVecTimelines;
 }
 
-SpineAnimation::SpineAnimation(const String& name, std::vector<std::shared_ptr<Timeline>> timelines, float duration) : Animation(name, convertAndUseVector(timelines, _spineVecTimelines), duration) {
+SpineAnimation::SpineAnimation(const String& name, const std::vector<std::shared_ptr<Timeline>>& timelines, float duration) : Animation(name, convertAndUseVector(timelines), duration) {
     _vecTimelines = timelines;
 }
 
 SpineAnimation::~SpineAnimation() {
     _vecTimelines.clear();
-    _spineVecTimelines.clear();
     auto& timelines = getTimelines();
     timelines.clear();
 }
+} // namespace spine

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.h
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <spine/Animation.h>
+#include <vector>
+#include <memory>
+
+namespace spine {
+
+class SpineAnimation : public Animation {
+public:
+    SpineAnimation(const String &name, std::vector<std::shared_ptr<Timeline>> timelines, float duration);
+
+    ~SpineAnimation();
+
+private:
+    std::vector<std::shared_ptr<Timeline>> _vecTimelines;
+};
+
+} // namespace spine

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.h
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.h
@@ -32,13 +32,12 @@ namespace spine {
 
 class SpineAnimation : public Animation {
 public:
-    SpineAnimation(const String &name, std::vector<std::shared_ptr<Timeline>> timelines, float duration);
+    SpineAnimation(const String &name, const std::vector<std::shared_ptr<Timeline>>& timelines, float duration);
 
     ~SpineAnimation();
 
 private:
     std::vector<std::shared_ptr<Timeline>> _vecTimelines;
-    spine::Vector<Timeline*> _spineVecTimelines;
 };
 
 } // namespace spine

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.h
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.h
@@ -1,3 +1,27 @@
+/*
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
 #pragma once
 
 #include <spine/Animation.h>

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimation.h
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimation.h
@@ -14,6 +14,7 @@ public:
 
 private:
     std::vector<std::shared_ptr<Timeline>> _vecTimelines;
+    spine::Vector<Timeline*> _spineVecTimelines;
 };
 
 } // namespace spine

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimationState.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimationState.cpp
@@ -1,3 +1,26 @@
+/*
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
 
 #include "SpineAnimationState.h"
 

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimationState.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimationState.cpp
@@ -1,0 +1,20 @@
+
+#include "SpineAnimationState.h"
+
+using namespace spine; 
+
+SpineAnimationState::SpineAnimationState(AnimationStateData* data) : AnimationState(data) {
+
+}
+
+SpineAnimationState::~SpineAnimationState() {
+    _vecAnimations.clear();
+}
+
+TrackEntry* SpineAnimationState::addAnimation(size_t trackIndex, std::shared_ptr<Animation> animation, bool loop, float delay) {
+    _vecAnimations.push_back(animation);
+    return AnimationState::addAnimation(trackIndex, animation.get(), loop, delay);
+}
+
+
+

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimationState.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimationState.cpp
@@ -24,10 +24,8 @@
 
 #include "SpineAnimationState.h"
 
-using namespace spine; 
-
+namespace spine {
 SpineAnimationState::SpineAnimationState(AnimationStateData* data) : AnimationState(data) {
-
 }
 
 SpineAnimationState::~SpineAnimationState() {
@@ -35,9 +33,7 @@ SpineAnimationState::~SpineAnimationState() {
 }
 
 TrackEntry* SpineAnimationState::addAnimation(size_t trackIndex, std::shared_ptr<Animation> animation, bool loop, float delay) {
-    _vecAnimations.push_back(animation);
+    _vecAnimations.emplace_back(animation);
     return AnimationState::addAnimation(trackIndex, animation.get(), loop, delay);
 }
-
-
-
+} // namespace spine

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimationState.h
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimationState.h
@@ -27,29 +27,27 @@
  * THE SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
-#include "SkeletonCacheMgr.h"
-#include "base/DeferredReleasePool.h"
+#pragma once
+
+#include <spine/AnimationState.h>
+#include "spine/Animation.h"
+#include<vector>
+#include<memory>
 
 namespace spine {
-SkeletonCacheMgr *SkeletonCacheMgr::instance = nullptr;
-SkeletonCache *SkeletonCacheMgr::buildSkeletonCache(const std::string &uuid) {
-    SkeletonCache *animation = _caches.at(uuid);
-    if (!animation) {
-        animation = new SkeletonCache();
-        animation->addRef();
-        animation->initWithUUID(uuid);
-        _caches.insert(uuid, animation);
-        cc::DeferredReleasePool::add(animation);
-    }
-    return animation;
-}
 
-void SkeletonCacheMgr::removeSkeletonCache(const std::string &uuid) {
-    auto it = _caches.find(uuid);
-    if (it != _caches.end()) {
-        auto *item = it->second;
-        delete item;
-        _caches.erase(it);
-    }
-}
+
+class SP_API SpineAnimationState : public AnimationState {
+
+public:
+    explicit SpineAnimationState(AnimationStateData* data);
+
+    ~SpineAnimationState();
+
+    TrackEntry* addAnimation(size_t trackIndex, std::shared_ptr<Animation> animation, bool loop, float delay);
+
+private:
+    std::vector<std::shared_ptr<Animation>> _vecAnimations;
+};
 } // namespace spine
+

--- a/native/cocos/editor-support/spine-creator-support/SpineAnimationState.h
+++ b/native/cocos/editor-support/spine-creator-support/SpineAnimationState.h
@@ -1,31 +1,26 @@
-/******************************************************************************
- * Spine Runtimes License Agreement
- * Last updated January 1, 2020. Replaces all prior versions.
- *
- * Copyright (c) 2013-2020, Esoteric Software LLC
- *
- * Integration of the Spine Runtimes into software or otherwise creating
- * derivative works of the Spine Runtimes is permitted under the terms and
- * conditions of Section 2 of the Spine Editor License Agreement:
- * http://esotericsoftware.com/spine-editor-license
- *
- * Otherwise, it is permitted to integrate the Spine Runtimes into software
- * or otherwise create derivative works of the Spine Runtimes (collectively,
- * "Products"), provided that each user of the Products must obtain their own
- * Spine Editor license and redistribution of the Products in any form must
- * include this license and copyright notice.
- *
- * THE SPINE RUNTIMES ARE PROVIDED BY ESOTERIC SOFTWARE LLC "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL ESOTERIC SOFTWARE LLC BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES,
- * BUSINESS INTERRUPTION, OR LOSS OF USE, DATA, OR PROFITS) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THE SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+/*
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
 
 #pragma once
 

--- a/native/cocos/editor-support/spine-creator-support/spine-cocos2dx.h
+++ b/native/cocos/editor-support/spine-creator-support/spine-cocos2dx.h
@@ -35,6 +35,8 @@
 #include "spine-creator-support/SkeletonCacheMgr.h"
 #include "spine-creator-support/SkeletonDataMgr.h"
 #include "spine-creator-support/SkeletonRenderer.h"
+#include "spine-creator-support/SpineAnimation.h"
+#include "spine-creator-support/SpineAnimationState.h"
 #include "spine/spine.h"
 
 namespace spine {

--- a/native/cocos/editor-support/spine-wasm/SpineAnimationState.cpp
+++ b/native/cocos/editor-support/spine-wasm/SpineAnimationState.cpp
@@ -1,0 +1,18 @@
+
+#include "SpineAnimationState.h"
+
+using namespace spine;
+
+SpineAnimationState::SpineAnimationState(AnimationStateData* data) : AnimationState(data) {
+}
+
+SpineAnimationState::~SpineAnimationState() {
+    _mapAnimations.clear();
+}
+
+TrackEntry* SpineAnimationState::addAnimation(size_t trackIndex, Animation* animation, bool loop, float delay) {
+    if (_mapAnimations.count(animation) == 0) {
+        _mapAnimations[animation] = std::shared_ptr<Animation>(animation);
+    }
+    return AnimationState::addAnimation(trackIndex, animation, loop, delay);
+}

--- a/native/cocos/editor-support/spine-wasm/SpineAnimationState.cpp
+++ b/native/cocos/editor-support/spine-wasm/SpineAnimationState.cpp
@@ -1,3 +1,26 @@
+/*
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
 
 #include "SpineAnimationState.h"
 

--- a/native/cocos/editor-support/spine-wasm/SpineAnimationState.cpp
+++ b/native/cocos/editor-support/spine-wasm/SpineAnimationState.cpp
@@ -24,8 +24,7 @@
 
 #include "SpineAnimationState.h"
 
-using namespace spine;
-
+namespace spine {
 SpineAnimationState::SpineAnimationState(AnimationStateData* data) : AnimationState(data) {
 }
 
@@ -39,3 +38,4 @@ TrackEntry* SpineAnimationState::addAnimation(size_t trackIndex, Animation* anim
     }
     return AnimationState::addAnimation(trackIndex, animation, loop, delay);
 }
+} // namespace spine

--- a/native/cocos/editor-support/spine-wasm/SpineAnimationState.h
+++ b/native/cocos/editor-support/spine-wasm/SpineAnimationState.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <spine/AnimationState.h>
+#include <map>
+#include <memory>
+#include "spine/Animation.h"
+
+namespace spine {
+
+class SP_API SpineAnimationState : public AnimationState {
+public:
+    explicit SpineAnimationState(AnimationStateData* data);
+
+    ~SpineAnimationState();
+
+    TrackEntry* addAnimation(size_t trackIndex, Animation* animation, bool loop, float delay);
+
+private:
+    std::map<Animation*, std::shared_ptr<Animation>> _mapAnimations;
+};
+} // namespace spine

--- a/native/cocos/editor-support/spine-wasm/SpineAnimationState.h
+++ b/native/cocos/editor-support/spine-wasm/SpineAnimationState.h
@@ -1,3 +1,27 @@
+/*
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
 #pragma once
 
 #include <spine/AnimationState.h>

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -1,3 +1,26 @@
+/*
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
 #include "spine-skeleton-instance.h"
 #include <spine/spine.h>
 #include <vector>
@@ -5,7 +28,7 @@
 #include "spine-mesh-data.h"
 #include "spine-wasm.h"
 #include "util-function.h"
-#include "../spine-creator-support/SpineAnimationState.h"
+#include "SpineAnimationState.h"
 
 SlotMesh globalMesh(nullptr, nullptr, 0, 0);
 

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -5,6 +5,7 @@
 #include "spine-mesh-data.h"
 #include "spine-wasm.h"
 #include "util-function.h"
+#include "../spine-creator-support/SpineAnimationState.h"
 
 SlotMesh globalMesh(nullptr, nullptr, 0, 0);
 
@@ -57,7 +58,7 @@ Skeleton *SpineSkeletonInstance::initSkeleton(SkeletonData *data) {
     _skeletonData = data;
     _skeleton = new Skeleton(_skeletonData);
     _animStateData = new AnimationStateData(_skeletonData);
-    _animState = new AnimationState(_animStateData);
+    _animState = new SpineAnimationState(_animStateData);
     _clipper = new SkeletonClipping();
     _skeleton->setToSetupPose();
     _skeleton->updateWorldTransform();

--- a/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
@@ -75,7 +75,7 @@ Animation* constructorSpineAnimation(emscripten::val name, emscripten::val value
         vecTimeline[i] = value[i].as<val>().as<Timeline*>(allow_raw_pointer<spine::Timeline*>());
     }
 
-    String strName(name.as<std::string>().c_str(), true);
+    String strName(name.as<std::string>().c_str(), false);
     return new Animation(strName, vecTimeline, duration);
 }
 

--- a/native/cocos/editor-support/spine/TranslateTimeline.h
+++ b/native/cocos/editor-support/spine/TranslateTimeline.h
@@ -53,6 +53,7 @@ public:
     virtual void apply(Skeleton& skeleton, float lastTime, float time, Vector<Event*>* pEvents, float alpha, MixBlend blend, MixDirection direction);
 
     virtual int getPropertyId();
+    inline void setBoneIndex(int inValue) {_boneIndex = inValue;}
 
     /// Sets the time and value of the specified keyframe.
     void setFrame(int frameIndex, float time, float x, float y);

--- a/native/tools/swig-config/spine.i
+++ b/native/tools/swig-config/spine.i
@@ -176,6 +176,8 @@ using namespace spine;
 %rename(events) spine::AnimationState::_events;
 %rename(queue) spine::AnimationState::_queue;
 %rename(animationsChanged) spine::AnimationState::_animationsChanged;
+%rename(addAnimationWith) spine::AnimationState::addAnimation(size_t trackIndex, Animation* animation, bool loop, float delay);
+%rename(addAnimationWith) spine::SpineAnimationState::addAnimation(size_t trackIndex, std::shared_ptr<Animation> animation, bool loop, float delay);
 %rename(trackEntryPool) spine::AnimationState::_trackEntryPool;
 %rename(listener) spine::TrackEntry::_listener;
 %rename(nextAnimationLast) spine::TrackEntry::_nextAnimationLast;
@@ -619,6 +621,8 @@ using namespace spine;
 %include "editor-support/spine-creator-support/SkeletonDataMgr.h"
 %include "editor-support/spine-creator-support/SkeletonCacheAnimation.h"
 %include "editor-support/spine-creator-support/SkeletonCacheMgr.h"
+%include "editor-support/spine-creator-support/SpineAnimation.h"
+%include "editor-support/spine-creator-support/SpineAnimationState.h"
 
 %extend spine::IkConstraint {
     void apply1(Bone *bone, float targetX, float targetY, bool compress, bool stretch, bool uniform, float alpha) {

--- a/platforms/native/engine/jsb-spine-skeleton.js
+++ b/platforms/native/engine/jsb-spine-skeleton.js
@@ -30,7 +30,8 @@ const cacheManager = require('./jsb-cache-manager');
     if (cc.internal.SpineSkeletonData === undefined) return;
     const spine = globalThis.spine;
     const middleware = globalThis.middleware;
-
+    spine.AnimationState = spine.SpineAnimationState;
+    spine.Animation = spine.SpineAnimation;
     middleware.generateGetSet(spine);
 
     // spine global time scale


### PR DESCRIPTION
Re: #
https://github.com/cocos/cocos-test-projects/pull/887

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
