### PR TITLE
Fix dereference dangling pointer.

### DIFF
--- a/native/cocos/renderer/pipeline/custom/NativePipeline.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativePipeline.cpp
@@ -289,6 +289,8 @@ uint32_t addDepthStencilImpl(
     if (swapchain) {
         CC_EXPECTS(residency == ResourceResidency::BACKBUFFER);
         CC_EXPECTS(ppl.defaultFramebufferHasDepthStencil);
+        RenderSwapchain sc{swapchain, true};
+        sc.texture = RenderSwapchain::getDepthStencilTexture(swapchain);
         resID = addVertex(
             SwapchainTag{},
             std::forward_as_tuple(name.c_str()),
@@ -296,7 +298,7 @@ uint32_t addDepthStencilImpl(
             std::forward_as_tuple(ResourceTraits{residency}),
             std::forward_as_tuple(),
             std::forward_as_tuple(samplerInfo),
-            std::forward_as_tuple(RenderSwapchain{swapchain, true}),
+            std::forward_as_tuple(sc),
             ppl.resourceGraph);
     } else {
         CC_EXPECTS(residency == ResourceResidency::MANAGED || residency == ResourceResidency::MEMORYLESS);
@@ -378,6 +380,9 @@ uint32_t NativePipeline::addRenderWindow(
         sc.renderWindow = renderWindow;
         CC_ENSURES(!sc.isDepthStencil);
 
+        sc.texture = RenderSwapchain::getColorTexture(renderWindow);
+        CC_ENSURES(sc.texture);
+
         CC_ENSURES(desc.format != gfx::Format::UNKNOWN);
         return addVertex(
             SwapchainTag{},
@@ -396,6 +401,10 @@ uint32_t NativePipeline::addRenderWindow(
     desc.format = renderWindow->getFramebuffer()->getColorTextures()[0]->getFormat();
     CC_ENSURES(desc.format != gfx::Format::UNKNOWN);
 
+    RenderSwapchain sc{renderWindow->getSwapchain(), false};
+    sc.texture = RenderSwapchain::getColorTexture(renderWindow->getSwapchain());
+    CC_ENSURES(sc.texture);
+
     return addVertex(
         SwapchainTag{},
         std::forward_as_tuple(name.c_str()),
@@ -403,7 +412,7 @@ uint32_t NativePipeline::addRenderWindow(
         std::forward_as_tuple(ResourceTraits{ResourceResidency::BACKBUFFER}),
         std::forward_as_tuple(),
         std::forward_as_tuple(),
-        std::forward_as_tuple(RenderSwapchain{renderWindow->getSwapchain(), false}),
+        std::forward_as_tuple(sc),
         resourceGraph);
 }
 

--- a/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
@@ -36,6 +36,29 @@ namespace cc {
 
 namespace render {
 
+gfx::Texture* RenderSwapchain::getColorTexture(gfx::Swapchain* swapchain) noexcept {
+    CC_EXPECTS(swapchain);
+    gfx::Texture* texture = swapchain->getColorTexture();
+    CC_ENSURES(texture);
+    return texture;
+}
+
+gfx::Texture* RenderSwapchain::getColorTexture(scene::RenderWindow* renderWindow) noexcept {
+    const auto& fb = renderWindow->getFramebuffer();
+    CC_EXPECTS(fb);
+    CC_EXPECTS(fb->getColorTextures().size() == 1);
+    gfx::Texture* texture = fb->getColorTextures()[0];
+    CC_ENSURES(texture);
+    return texture;
+}
+
+gfx::Texture* RenderSwapchain::getDepthStencilTexture(gfx::Swapchain* swapchain) noexcept {
+    CC_EXPECTS(swapchain);
+    gfx::Texture* texture = swapchain->getDepthStencilTexture();
+    CC_ENSURES(texture);
+    return texture;
+}
+
 ResourceGroup::~ResourceGroup() noexcept {
     for (const auto& buffer : instancingBuffers) {
         buffer->clear();
@@ -398,23 +421,7 @@ gfx::Texture* ResourceGraph::getTexture(vertex_descriptor resID) {
             return fb->getColorTextures()[0];
         },
         [](const RenderSwapchain& sc) -> gfx::Texture* {
-            gfx::Texture* texture1 = nullptr;
-            if (sc.swapchain) {
-                if (sc.isDepthStencil) {
-                    texture1 = sc.swapchain->getDepthStencilTexture();
-                } else {
-                    texture1 = sc.swapchain->getColorTexture();
-                }
-            } else {
-                CC_EXPECTS(sc.renderWindow);
-                CC_EXPECTS(!sc.isDepthStencil);
-                const auto& fb = sc.renderWindow->getFramebuffer();
-                CC_EXPECTS(fb);
-                CC_EXPECTS(fb->getColorTextures().size() == 1);
-                CC_EXPECTS(fb->getColorTextures().at(0));
-                texture1 = fb->getColorTextures()[0];
-            }
-            return texture1;
+            return sc.texture;
         },
         [](const FormatView& view) -> gfx::Texture* {
             // TODO(zhouzhenglong): add ImageView support

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
@@ -192,12 +192,17 @@ struct RenderSwapchain {
     : swapchain(swapchainIn),
       isDepthStencil(isDepthStencilIn) {}
 
+    static gfx::Texture* getColorTexture(gfx::Swapchain* swapchain) noexcept;
+    static gfx::Texture* getColorTexture(scene::RenderWindow* renderWindow) noexcept;
+    static gfx::Texture* getDepthStencilTexture(gfx::Swapchain* swapchain) noexcept;
+
     gfx::Swapchain* swapchain{nullptr};
     scene::RenderWindow* renderWindow{nullptr};
     uint32_t currentID{0};
     uint32_t numBackBuffers{0};
     uint32_t generation{0xFFFFFFFF};
     bool isDepthStencil{false};
+    gfx::Texture* texture{nullptr};
 };
 
 struct ResourceStates {


### PR DESCRIPTION
Render Window cached in the pipeline might be dangling.

We should not dereference the render window pointer when releasing all associated framebuffers.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
