### PR TITLE
The openharmony platform uses dynamic linking to load opengles.

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -362,7 +362,7 @@ NO_WERROR   cocos/audio/common/utils/primitives.cpp
                 cocos/audio/android/UrlAudioPlayer.cpp
                 cocos/audio/android/UrlAudioPlayer.h
             )
-        elseif(OPENHARMONY) 
+        elseif(OPENHARMONY)
             cocos_source_files(
                 cocos/audio/openharmony/PcmAudioService.cpp
                 cocos/audio/openharmony/PcmAudioService.h
@@ -1643,10 +1643,14 @@ cocos_source_files(
 if(CC_USE_GLES2 OR CC_USE_GLES3)
     cocos_source_files(
         cocos/renderer/gfx-gles-common/GLESCommandPool.h
-        cocos/renderer/gfx-gles-common/eglw.cpp
-        cocos/renderer/gfx-gles-common/gles2w.cpp
     )
-    if(CC_USE_GLES3)
+    if(NOT OPENHARMONY)
+        cocos_source_files(
+            cocos/renderer/gfx-gles-common/eglw.cpp
+            cocos/renderer/gfx-gles-common/gles2w.cpp
+        )
+    endif()
+    if(CC_USE_GLES3 AND NOT OPENHARMONY)
         cocos_source_files(
             cocos/renderer/gfx-gles-common/gles3w.cpp
         )
@@ -3197,7 +3201,7 @@ target_compile_definitions(${ENGINE_NAME}
         ${CC_EXTERNAL_PRIVATE_DEFINITIONS}
 )
 
-if(NOT APPLE)
+if(NOT APPLE AND NOT OPENHARMONY)
     target_include_directories(${ENGINE_NAME} PUBLIC
         ${CWD}/external/sources/EGL
     )
@@ -3282,7 +3286,7 @@ if(OPENHARMONY)
                 libace_ndk.z )
 
     target_link_libraries(${ENGINE_NAME} PUBLIC
-        ${EGL-lib} ${GLESv3-lib} ${hilog-lib} libace_napi.z.so libace_ndk.z.so libz.so 
+        ${EGL-lib} ${GLESv3-lib} ${hilog-lib} libace_napi.z.so libace_ndk.z.so libz.so
         libuv.so libnative_drawing.so librawfile.z.so libOpenSLES.so libohaudio.so libavplayer.so
         ${CC_EXTERNAL_LIBS}
     )
@@ -3375,7 +3379,7 @@ set(COCOS_SOURCE_LIST_EXCLUDE_GENRATED ${COCOS_SOURCE_LIST})
 set(COCOS_GENERATED_LIST)
 foreach(src IN LISTS COCOS_SOURCE_LIST_EXCLUDE_GENRATED)
     get_source_file_property(IS_GENERATED ${src} GENERATED)
-    if(IS_GENERATED) 
+    if(IS_GENERATED)
         list(REMOVE_ITEM COCOS_SOURCE_LIST_EXCLUDE_GENRATED ${src})
         list(APPEND COCOS_GENERATED_LIST ${src})
     endif()

--- a/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
@@ -814,7 +814,10 @@ static void renderBufferStorage(GLES3Device *device, GLES3GPUTexture *gpuTexture
         glRenderbuffer = gpuTexture->glRenderbuffer;
     }
     if (gpuTexture->glSamples > 1) {
+        #if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
+        // Can't use the GL_EXT_multisampled_render_to_texture macro to determine this, because GL_EXT_multisampled_render_to_texture is defined, but the link will fail.
         GL_CHECK(glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, gpuTexture->glSamples, gpuTexture->glInternalFmt, gpuTexture->width, gpuTexture->height));
+        #endif
     } else {
         GL_CHECK(glRenderbufferStorage(GL_RENDERBUFFER, gpuTexture->glInternalFmt, gpuTexture->width, gpuTexture->height));
     }
@@ -2573,19 +2576,28 @@ void cmdFuncGLES3MemoryBarrier(GLES3Device * /*device*/, GLbitfield barriers, GL
 
 void cmdFuncGLES3InsertMarker(GLES3Device *device, GLsizei length, const char *marker) {
     if (device->constantRegistry()->debugMarker) {
+        #if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
+        // Can't use the GL_EXT_debug_marker macro to determine this, because GL_EXT_debug_marker is defined, but the link will fail.
         glInsertEventMarkerEXT(length, marker);
+        #endif
     }
 }
 
 void cmdFuncGLES3PushGroupMarker(GLES3Device *device, GLsizei length, const char *marker) {
     if (device->constantRegistry()->debugMarker) {
+        #if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
+        // Can't use the GL_EXT_debug_marker macro to determine this, because GL_EXT_debug_marker is defined, but the link will fail.
         glPushGroupMarkerEXT(length, marker);
+        #endif
     }
 }
 
 void cmdFuncGLES3PopGroupMarker(GLES3Device *device) {
     if (device->constantRegistry()->debugMarker) {
+        #if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
+        // Can't use the GL_EXT_debug_marker macro to determine this, because GL_EXT_debug_marker is defined, but the link will fail.
         glPopGroupMarkerEXT();
+        #endif
     }
 }
 
@@ -3163,12 +3175,14 @@ void GLES3GPUFramebufferObject::finalize(GLES3GPUStateCache *cache) {
         auto *texture = view->gpuTexture;
         if (samples > 1) {
             CC_ASSERT(view->gpuTexture->glTexture != 0);
+            #if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
             GL_CHECK(glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER,
                                                           attachment,
                                                           GL_TEXTURE_2D,
                                                           texture->glTexture,
                                                           view->baseLevel,
                                                           static_cast<GLsizei>(samples)));
+            #endif
             return;
         }
 

--- a/native/cocos/renderer/gfx-gles3/GLES3Swapchain.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Swapchain.cpp
@@ -62,7 +62,7 @@ void GLES3Swapchain::doInit(const SwapchainInfo &info) {
     auto height = static_cast<int32_t>(info.height);
     const auto *context = GLES3Device::getInstance()->context();
     _gpuSwapchain = ccnew GLES3GPUSwapchain;
-#if CC_PLATFORM == CC_PLATFORM_LINUX
+#if CC_PLATFORM == CC_PLATFORM_LINUX || CC_PLATFORM == CC_PLATFORM_OPENHARMONY
     auto window = reinterpret_cast<EGLNativeWindowType>(info.windowHandle);
 #else
     auto *window = reinterpret_cast<EGLNativeWindowType>(info.windowHandle);
@@ -187,7 +187,7 @@ void GLES3Swapchain::doDestroySurface() {
 
 void GLES3Swapchain::doCreateSurface(void *windowHandle) {
     auto *context = GLES3Device::getInstance()->context();
-#if CC_PLATFORM == CC_PLATFORM_LINUX
+#if CC_PLATFORM == CC_PLATFORM_LINUX || CC_PLATFORM == CC_PLATFORM_OPENHARMONY
     auto window = reinterpret_cast<EGLNativeWindowType>(windowHandle);
 #else
     auto *window = reinterpret_cast<EGLNativeWindowType>(windowHandle);

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -113,6 +113,8 @@ bool gles3wOpen() {
 
 bool gles3wClose() {
     bool ret = true;
+
+#if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
     if (libegl) {
         ret &= dlclose(libegl) == 0;
         libegl = nullptr;
@@ -122,14 +124,17 @@ bool gles3wClose() {
         ret &= dlclose(libgles) == 0;
         libgles = nullptr;
     }
+#endif
 
     return ret;
 }
 
 void *gles3wLoad(const char *proc) {
     void *res = nullptr;
+#if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
     if (eglGetProcAddress) res = reinterpret_cast<void *>(eglGetProcAddress(proc));
     if (!res) res = dlsym(libegl, proc);
+#endif
     return res;
 }
 #endif
@@ -139,6 +144,7 @@ PFNGLES3WLOADPROC pfnGLES3wLoadProc() {
 }
 
 bool gles3wInit() {
+#if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
     if (!gles3wOpen()) {
         return false;
     }
@@ -147,6 +153,7 @@ bool gles3wInit() {
     gles3wLoadProcs(gles3wLoad);
 
     pfnGles3wLoad = gles3wLoad;
+#endif
     return true;
 }
 

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.h
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.h
@@ -24,9 +24,21 @@
 
 #pragma once
 
+#if CC_PLATFORM != CC_PLATFORM_OPENHARMONY
 #include "../gfx-gles-common/eglw.h"
 #include "../gfx-gles-common/gles2w.h"
 #include "../gfx-gles-common/gles3w.h"
+#else
+    #define EGL_EGL_PROTOTYPES 1
+    #define GL_GLEXT_PROTOTYPES 1
+    #include <EGL/egl.h>
+    #include <EGL/eglext.h>
+    #include <EGL/eglplatform.h>
+    #include <GLES2/gl2.h>
+    #include <GLES2/gl2ext.h>
+    #include <GLES3/gl32.h>
+    using PFNGLES3WLOADPROC = void *(*)(const char *);
+#endif
 
 PFNGLES3WLOADPROC pfnGLES3wLoadProc();
 bool gles3wInit();

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos-creator",
         "name": "engine-native-external",
-        "checkout": "v3.8.2-23"
+        "checkout": "v384-oh-1"
     }
 }


### PR DESCRIPTION
Re: #

### Changelog

https://github.com/cocos/cocos-engine-external/pull/460

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
