### PR TITLE
Fix the UIOpacity issue when the node is re-added to the scene.

### DIFF
--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -229,13 +229,14 @@ export class UIOpacity extends Component {
     }
 
     public onEnable (): void {
+        this.node.on(NodeEventType.PARENT_CHANGED, this._parentChanged, this);
+        this.node._uiProps.localOpacity = this._parentOpacity * this._opacity / 255;
         if (this._parentOpacityResetFlag) {
             this._parentChanged();
             this._parentOpacityResetFlag = false;
+        } else {
+            this._setEntityLocalOpacityRecursively(this.node._uiProps.localOpacity);
         }
-        this.node.on(NodeEventType.PARENT_CHANGED, this._parentChanged, this);
-        this.node._uiProps.localOpacity = this._parentOpacity * this._opacity / 255;
-        this._setEntityLocalOpacityRecursively(this.node._uiProps.localOpacity);
     }
 
     public onDisable (): void {

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -206,8 +206,7 @@ export class UIOpacity extends Component {
         if (parent) {
             this._parentOpacity = this._getParentOpacity(parent);
             opacity = this._parentOpacity;
-        }
-        else {
+        } else {
             this._parentOpacityResetFlag = true;
         }
         UIOpacity.setEntityLocalOpacityDirtyRecursively(this.node, true, opacity, false);

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -59,6 +59,8 @@ export class UIOpacity extends Component {
      */
     private _parentOpacity: number = 1.0;
 
+    private _parentOpacityResetFlag: boolean = true;
+
     /**
      * @en
      * The transparency value of the impact.
@@ -97,7 +99,7 @@ export class UIOpacity extends Component {
             // }
             // UIRenderer.setEntityColorDirtyRecursively(this.node, dirty);
 
-            UIOpacity.setEntityLocalOpacityDirtyRecursively(this.node, dirty, 1, false);
+            UIOpacity.setEntityLocalOpacityDirtyRecursively(this.node, dirty, this._parentOpacity, false);
         }
     }
 
@@ -205,6 +207,9 @@ export class UIOpacity extends Component {
             this._parentOpacity = this._getParentOpacity(parent);
             opacity = this._parentOpacity;
         }
+        else {
+            this._parentOpacityResetFlag = true;
+        }
         UIOpacity.setEntityLocalOpacityDirtyRecursively(this.node, true, opacity, false);
     }
 
@@ -227,6 +232,10 @@ export class UIOpacity extends Component {
     }
 
     public onEnable (): void {
+        if (this._parentOpacityResetFlag) {
+            this._parentChanged();
+            this._parentOpacityResetFlag = false;
+        }
         this.node.on(NodeEventType.PARENT_CHANGED, this._parentChanged, this);
         this.node._uiProps.localOpacity = this._parentOpacity * this._opacity / 255;
         this._setEntityLocalOpacityRecursively(this.node._uiProps.localOpacity);

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -196,6 +196,9 @@ export class UIOpacity extends Component {
     }
 
     protected _parentChanged (): void {
+        if (!JSB) {
+            return;
+        }
         const parent = this.node.getParent();
         let opacity = 1;
         if (parent) {

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -154,9 +154,7 @@ export class UIOpacity extends Component {
                 // there is a just UIRenderer but no UIOpacity on the node, we should just transport the parentOpacity to the node.
                 render.renderEntity.localOpacity = parentOpacity;
             }
-            if (JSB) {
-                render.node._uiProps.localOpacity = render.renderEntity.localOpacity;
-            }
+            render.node._uiProps.localOpacity = render.renderEntity.localOpacity;
             //No need for recursion here. Because it doesn't affect the capacity of the child nodes.
             return;
         }

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -152,7 +152,9 @@ export class UIOpacity extends Component {
                 // there is a just UIRenderer but no UIOpacity on the node, we should just transport the parentOpacity to the node.
                 render.renderEntity.localOpacity = parentOpacity;
             }
-            render.node._uiProps.localOpacity = render.renderEntity.localOpacity;
+            if (JSB) {
+                render.node._uiProps.localOpacity = render.renderEntity.localOpacity;
+            }
             //No need for recursion here. Because it doesn't affect the capacity of the child nodes.
             return;
         }


### PR DESCRIPTION
issue:
[https://forum.cocos.org/t/topic/159379/745](https://forum.cocos.org/t/topic/159379/745)

`
if (JSB) { render.node._uiProps.localOpacity = render.renderEntity.localOpacity; }
`
'render.node._uiProps.localOpacity' still needs to be updated on native for fix another issue.
[#17503](https://github.com/cocos/cocos-engine/pull/17503)

If possible, it would be great to have this fix synced to v3.8.4 as well.
@minggo 

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
