### PR TITLE
Fix the issue that can not destroy Node in contract listener call back in Box2D

### DIFF
--- a/cocos/physics-2d/box2d-wasm/rigid-body.ts
+++ b/cocos/physics-2d/box2d-wasm/rigid-body.ts
@@ -22,12 +22,13 @@
  THE SOFTWARE.
 */
 
+import { DEBUG } from 'internal:constants';
 import { B2, B2ObjectType, getTSObjectFromWASMObjectPtr } from './instantiated';
 import { IRigidBody2D } from '../spec/i-rigid-body';
 import { RigidBody2D } from '../framework/components/rigid-body-2d';
 import { PhysicsSystem2D } from '../framework/physics-system';
 import { B2PhysicsWorld } from './physics-world';
-import { Vec2, toRadian, Vec3, Quat, IVec2Like, toDegree, TWO_PI, HALF_PI } from '../../core';
+import { Vec2, toRadian, Vec3, Quat, IVec2Like, toDegree, TWO_PI, HALF_PI, error } from '../../core';
 import { PHYSICS_2D_PTM_RATIO, ERigidBody2DType } from '../framework/physics-types';
 
 import { Node } from '../../scene-graph/node';
@@ -249,7 +250,11 @@ export class B2RigidBody2D implements IRigidBody2D {
         return this._body!.IsEnabled();
     }
     setActive (v: boolean): void {
-        if (!this._body!.GetWorld().IsLocked()) this._body!.SetEnabled(v);
+        if (!this._body!.GetWorld().IsLocked()) {
+            this._body!.SetEnabled(v);
+        } else if (DEBUG) {
+            error('Can not active RigidBody in contract listener.');
+        }
     }
     wakeUp (): void {
         this._body!.SetAwake(true);

--- a/cocos/physics-2d/box2d-wasm/rigid-body.ts
+++ b/cocos/physics-2d/box2d-wasm/rigid-body.ts
@@ -28,7 +28,7 @@ import { IRigidBody2D } from '../spec/i-rigid-body';
 import { RigidBody2D } from '../framework/components/rigid-body-2d';
 import { PhysicsSystem2D } from '../framework/physics-system';
 import { B2PhysicsWorld } from './physics-world';
-import { Vec2, toRadian, Vec3, Quat, IVec2Like, toDegree, TWO_PI, HALF_PI, error } from '../../core';
+import { Vec2, toRadian, Vec3, Quat, IVec2Like, toDegree, TWO_PI, HALF_PI, warn } from '../../core';
 import { PHYSICS_2D_PTM_RATIO, ERigidBody2DType } from '../framework/physics-types';
 
 import { Node } from '../../scene-graph/node';
@@ -253,7 +253,7 @@ export class B2RigidBody2D implements IRigidBody2D {
         if (!this._body!.GetWorld().IsLocked()) {
             this._body!.SetEnabled(v);
         } else if (DEBUG) {
-            error('Can not active RigidBody in contract listener.');
+            warn('Can not active RigidBody in contract listener.');
         }
     }
     wakeUp (): void {

--- a/cocos/physics-2d/box2d-wasm/rigid-body.ts
+++ b/cocos/physics-2d/box2d-wasm/rigid-body.ts
@@ -249,7 +249,7 @@ export class B2RigidBody2D implements IRigidBody2D {
         return this._body!.IsEnabled();
     }
     setActive (v: boolean): void {
-        this._body!.SetEnabled(v);
+        if (!this._body!.GetWorld().IsLocked()) this._body!.SetEnabled(v);
     }
     wakeUp (): void {
         this._body!.SetAwake(true);

--- a/cocos/physics-2d/box2d/rigid-body.ts
+++ b/cocos/physics-2d/box2d/rigid-body.ts
@@ -228,7 +228,7 @@ export class b2RigidBody2D implements IRigidBody2D {
         return this._body!.IsActive();
     }
     setActive (v: boolean): void {
-        this._body!.SetActive(v);
+        if (!this._body!.m_world.IsLocked()) this._body!.SetActive(v);
     }
     wakeUp (): void {
         this._body!.SetAwake(true);

--- a/cocos/physics-2d/box2d/rigid-body.ts
+++ b/cocos/physics-2d/box2d/rigid-body.ts
@@ -23,11 +23,12 @@
 */
 
 import b2 from '@cocos/box2d';
+import { DEBUG } from 'internal:constants';
 import { IRigidBody2D } from '../spec/i-rigid-body';
 import { RigidBody2D } from '../framework/components/rigid-body-2d';
 import { PhysicsSystem2D } from '../framework/physics-system';
 import { b2PhysicsWorld } from './physics-world';
-import { Vec2, toRadian, Vec3, Quat, IVec2Like, toDegree, TWO_PI, HALF_PI } from '../../core';
+import { Vec2, toRadian, Vec3, Quat, IVec2Like, toDegree, TWO_PI, HALF_PI, error } from '../../core';
 import { PHYSICS_2D_PTM_RATIO, ERigidBody2DType } from '../framework/physics-types';
 
 import { Node } from '../../scene-graph/node';
@@ -228,7 +229,11 @@ export class b2RigidBody2D implements IRigidBody2D {
         return this._body!.IsActive();
     }
     setActive (v: boolean): void {
-        if (!this._body!.m_world.IsLocked()) this._body!.SetActive(v);
+        if (!this._body!.m_world.IsLocked()) {
+            this._body!.SetActive(v);
+        } else if (DEBUG) {
+            error('Can not active RigidBody in contract listener.');
+        }
     }
     wakeUp (): void {
         this._body!.SetAwake(true);

--- a/cocos/physics-2d/box2d/rigid-body.ts
+++ b/cocos/physics-2d/box2d/rigid-body.ts
@@ -28,7 +28,7 @@ import { IRigidBody2D } from '../spec/i-rigid-body';
 import { RigidBody2D } from '../framework/components/rigid-body-2d';
 import { PhysicsSystem2D } from '../framework/physics-system';
 import { b2PhysicsWorld } from './physics-world';
-import { Vec2, toRadian, Vec3, Quat, IVec2Like, toDegree, TWO_PI, HALF_PI, error } from '../../core';
+import { Vec2, toRadian, Vec3, Quat, IVec2Like, toDegree, TWO_PI, HALF_PI, warn } from '../../core';
 import { PHYSICS_2D_PTM_RATIO, ERigidBody2DType } from '../framework/physics-types';
 
 import { Node } from '../../scene-graph/node';
@@ -232,7 +232,7 @@ export class b2RigidBody2D implements IRigidBody2D {
         if (!this._body!.m_world.IsLocked()) {
             this._body!.SetActive(v);
         } else if (DEBUG) {
-            error('Can not active RigidBody in contract listener.');
+            warn('Can not active RigidBody in contract listener.');
         }
     }
     wakeUp (): void {

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos-creator",
         "name": "engine-native-external",
-        "checkout": "v3.8.5-2"
+        "checkout": "v3.8.5-3"
     }
 }


### PR DESCRIPTION
Steps to reproduce the issue:
- open the project
[Hello384_1.zip](https://github.com/user-attachments/files/17340143/Hello384_1.zip)

- then will see error message when two objects collides

Reason:
- destroy a Node will inactive all components
- inactive Box2D rigidbody will trigger exception in contract listener call back as physics world is locked

How to fix:
- check physics world status before active/inactive rigidbody

Indeed there are more codes should do check, but it is more common to destroy node in call back. And it invokes physics codes indirectly, so it is not easy to notice error usage here. If invoke other physics codes directly in call back is not allowed.

It works before v3.8.0 because of the PR: https://github.com/cocos/cocos-engine/pull/14026. That PR will delay emitting contract listener. And this PR is reverted in https://github.com/cocos/cocos-engine/pull/15564. I don't know why to revert the implementation.