### PR TITLE
Fix ASTC textures were not displayed correctly on some devices.

### DIFF
--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -2724,8 +2724,8 @@ export function WebGLCmdFuncCopyBuffersToTexture (
                 );
             } else {
                 const isFullCopy = (
-                    gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight &&
-                    offset.x === 0 && offset.y === 0
+                    gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight
+                    && offset.x === 0 && offset.y === 0
                 );
                 if (!isFullCopy && gpuTexture.glInternalFmt$ !== (WebGLEXT.COMPRESSED_RGB_ETC1_WEBGL as number) && !device.extensions.noCompressedTexSubImage2D$) {
                     gl.compressedTexSubImage2D(

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -2727,7 +2727,8 @@ export function WebGLCmdFuncCopyBuffersToTexture (
                     gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight
                     && offset.x === 0 && offset.y === 0
                 );
-                if (!isFullCopy && gpuTexture.glInternalFmt$ !== (WebGLEXT.COMPRESSED_RGB_ETC1_WEBGL as number) && !device.extensions.noCompressedTexSubImage2D$) {
+                if (!isFullCopy && gpuTexture.glInternalFmt$ !== (WebGLEXT.COMPRESSED_RGB_ETC1_WEBGL as number)
+                    && !device.extensions.noCompressedTexSubImage2D$) {
                     gl.compressedTexSubImage2D(
                         WebGLConstants.TEXTURE_2D,
                         mipLevel,
@@ -2793,28 +2794,34 @@ export function WebGLCmdFuncCopyBuffersToTexture (
                         gpuTexture.glType$,
                         pixels,
                     );
-                } else if (gpuTexture.glInternalFmt$ !== (WebGLEXT.COMPRESSED_RGB_ETC1_WEBGL as number)
-                    && !device.extensions.noCompressedTexSubImage2D$) {
-                    gl.compressedTexSubImage2D(
-                        WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
-                        mipLevel,
-                        offset.x,
-                        offset.y,
-                        destWidth,
-                        destHeight,
-                        gpuTexture.glFormat$,
-                        pixels,
+                } else {
+                    const isFullCopy = (
+                        gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight
+                        && offset.x === 0 && offset.y === 0
                     );
-                } else { // WEBGL_compressed_texture_etc1
-                    gl.compressedTexImage2D(
-                        WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
-                        mipLevel,
-                        gpuTexture.glInternalFmt$,
-                        destWidth,
-                        destHeight,
-                        0,
-                        pixels,
-                    );
+                    if (!isFullCopy && gpuTexture.glInternalFmt$ !== (WebGLEXT.COMPRESSED_RGB_ETC1_WEBGL as number)
+                        && !device.extensions.noCompressedTexSubImage2D$) {
+                        gl.compressedTexSubImage2D(
+                            WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
+                            mipLevel,
+                            offset.x,
+                            offset.y,
+                            destWidth,
+                            destHeight,
+                            gpuTexture.glFormat$,
+                            pixels,
+                        );
+                    } else { // WEBGL_compressed_texture_etc1
+                        gl.compressedTexImage2D(
+                            WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
+                            mipLevel,
+                            gpuTexture.glInternalFmt$,
+                            destWidth,
+                            destHeight,
+                            0,
+                            pixels,
+                        );
+                    }
                 }
             }
         }

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -2722,27 +2722,33 @@ export function WebGLCmdFuncCopyBuffersToTexture (
                     gpuTexture.glType$,
                     pixels,
                 );
-            } else if (gpuTexture.glInternalFmt$ !== (WebGLEXT.COMPRESSED_RGB_ETC1_WEBGL as number) && !device.extensions.noCompressedTexSubImage2D$) {
-                gl.compressedTexSubImage2D(
-                    WebGLConstants.TEXTURE_2D,
-                    mipLevel,
-                    offset.x,
-                    offset.y,
-                    destWidth,
-                    destHeight,
-                    gpuTexture.glFormat$,
-                    pixels,
+            } else {
+                const isFullCopy = (
+                    gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight &&
+                    offset.x === 0 && offset.y === 0
                 );
-            } else { // WEBGL_compressed_texture_etc1
-                gl.compressedTexImage2D(
-                    WebGLConstants.TEXTURE_2D,
-                    mipLevel,
-                    gpuTexture.glInternalFmt$,
-                    destWidth,
-                    destHeight,
-                    0,
-                    pixels,
-                );
+                if (!isFullCopy && gpuTexture.glInternalFmt$ !== (WebGLEXT.COMPRESSED_RGB_ETC1_WEBGL as number) && !device.extensions.noCompressedTexSubImage2D$) {
+                    gl.compressedTexSubImage2D(
+                        WebGLConstants.TEXTURE_2D,
+                        mipLevel,
+                        offset.x,
+                        offset.y,
+                        destWidth,
+                        destHeight,
+                        gpuTexture.glFormat$,
+                        pixels,
+                    );
+                } else { // WEBGL_compressed_texture_etc1
+                    gl.compressedTexImage2D(
+                        WebGLConstants.TEXTURE_2D,
+                        mipLevel,
+                        gpuTexture.glInternalFmt$,
+                        destWidth,
+                        destHeight,
+                        0,
+                        pixels,
+                    );
+                }
             }
         }
         break;

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2829,27 +2829,33 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
                     gpuTexture.glType$,
                     pixels,
                 );
-            } else if (gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
-                gl.compressedTexSubImage2D(
-                    WebGLConstants.TEXTURE_2D,
-                    mipLevel,
-                    offset.x,
-                    offset.y,
-                    destWidth,
-                    destHeight,
-                    gpuTexture.glFormat$,
-                    pixels,
+            } else {
+                const isFullCopy = (
+                    gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight
+                    && offset.x === 0 && offset.y === 0
                 );
-            } else { // WEBGL_compressed_texture_etc1
-                gl.compressedTexImage2D(
-                    WebGLConstants.TEXTURE_2D,
-                    mipLevel,
-                    gpuTexture.glInternalFmt$,
-                    destWidth,
-                    destHeight,
-                    0,
-                    pixels,
-                );
+                if (!isFullCopy && gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
+                    gl.compressedTexSubImage2D(
+                        WebGLConstants.TEXTURE_2D,
+                        mipLevel,
+                        offset.x,
+                        offset.y,
+                        destWidth,
+                        destHeight,
+                        gpuTexture.glFormat$,
+                        pixels,
+                    );
+                } else { // WEBGL_compressed_texture_etc1
+                    gl.compressedTexImage2D(
+                        WebGLConstants.TEXTURE_2D,
+                        mipLevel,
+                        gpuTexture.glInternalFmt$,
+                        destWidth,
+                        destHeight,
+                        0,
+                        pixels,
+                    );
+                }
             }
         }
         break;
@@ -2899,30 +2905,36 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
                         gpuTexture.glType$,
                         pixels,
                     );
-                } else if (gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
-                    gl.compressedTexSubImage3D(
-                        WebGLConstants.TEXTURE_2D_ARRAY,
-                        mipLevel,
-                        offset.x,
-                        offset.y,
-                        offset.z,
-                        destWidth,
-                        destHeight,
-                        extent.depth,
-                        gpuTexture.glFormat$,
-                        pixels,
+                } else {
+                    const isFullCopy = (
+                        gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight
+                        && offset.x === 0 && offset.y === 0
                     );
-                } else { // WEBGL_compressed_texture_etc1
-                    gl.compressedTexImage3D(
-                        WebGLConstants.TEXTURE_2D_ARRAY,
-                        mipLevel,
-                        gpuTexture.glInternalFmt$,
-                        destWidth,
-                        destHeight,
-                        extent.depth,
-                        0,
-                        pixels,
-                    );
+                    if (!isFullCopy && gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
+                        gl.compressedTexSubImage3D(
+                            WebGLConstants.TEXTURE_2D_ARRAY,
+                            mipLevel,
+                            offset.x,
+                            offset.y,
+                            offset.z,
+                            destWidth,
+                            destHeight,
+                            extent.depth,
+                            gpuTexture.glFormat$,
+                            pixels,
+                        );
+                    } else { // WEBGL_compressed_texture_etc1
+                        gl.compressedTexImage3D(
+                            WebGLConstants.TEXTURE_2D_ARRAY,
+                            mipLevel,
+                            gpuTexture.glInternalFmt$,
+                            destWidth,
+                            destHeight,
+                            extent.depth,
+                            0,
+                            pixels,
+                        );
+                    }
                 }
             }
         }
@@ -2970,36 +2982,30 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
                     gpuTexture.glType$,
                     pixels,
                 );
-            } else {
-                const isFullCopy = (
-                    gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight
-                    && offset.x === 0 && offset.y === 0
+            } else if (gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
+                gl.compressedTexSubImage3D(
+                    WebGLConstants.TEXTURE_2D_ARRAY,
+                    mipLevel,
+                    offset.x,
+                    offset.y,
+                    offset.z,
+                    destWidth,
+                    destHeight,
+                    extent.depth,
+                    gpuTexture.glFormat$,
+                    pixels,
                 );
-                if (!isFullCopy && gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
-                    gl.compressedTexSubImage3D(
-                        WebGLConstants.TEXTURE_2D_ARRAY,
-                        mipLevel,
-                        offset.x,
-                        offset.y,
-                        offset.z,
-                        destWidth,
-                        destHeight,
-                        extent.depth,
-                        gpuTexture.glFormat$,
-                        pixels,
-                    );
-                } else { // WEBGL_compressed_texture_etc1
-                    gl.compressedTexImage3D(
-                        WebGLConstants.TEXTURE_2D_ARRAY,
-                        mipLevel,
-                        gpuTexture.glInternalFmt$,
-                        destWidth,
-                        destHeight,
-                        extent.depth,
-                        0,
-                        pixels,
-                    );
-                }
+            } else { // WEBGL_compressed_texture_etc1
+                gl.compressedTexImage3D(
+                    WebGLConstants.TEXTURE_2D_ARRAY,
+                    mipLevel,
+                    gpuTexture.glInternalFmt$,
+                    destWidth,
+                    destHeight,
+                    extent.depth,
+                    0,
+                    pixels,
+                );
             }
         }
         break;
@@ -3044,27 +3050,33 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
                         gpuTexture.glType$,
                         pixels,
                     );
-                } else if (gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
-                    gl.compressedTexSubImage2D(
-                        WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
-                        mipLevel,
-                        offset.x,
-                        offset.y,
-                        destWidth,
-                        destHeight,
-                        gpuTexture.glFormat$,
-                        pixels,
+                } else {
+                    const isFullCopy = (
+                        gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight
+                        && offset.x === 0 && offset.y === 0
                     );
-                } else { // WEBGL_compressed_texture_etc1
-                    gl.compressedTexImage2D(
-                        WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
-                        mipLevel,
-                        gpuTexture.glInternalFmt$,
-                        destWidth,
-                        destHeight,
-                        0,
-                        pixels,
-                    );
+                    if (!isFullCopy && gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
+                        gl.compressedTexSubImage2D(
+                            WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
+                            mipLevel,
+                            offset.x,
+                            offset.y,
+                            destWidth,
+                            destHeight,
+                            gpuTexture.glFormat$,
+                            pixels,
+                        );
+                    } else { // WEBGL_compressed_texture_etc1
+                        gl.compressedTexImage2D(
+                            WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
+                            mipLevel,
+                            gpuTexture.glInternalFmt$,
+                            destWidth,
+                            destHeight,
+                            0,
+                            pixels,
+                        );
+                    }
                 }
             }
         }

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2970,30 +2970,36 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
                     gpuTexture.glType$,
                     pixels,
                 );
-            } else if (gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
-                gl.compressedTexSubImage3D(
-                    WebGLConstants.TEXTURE_2D_ARRAY,
-                    mipLevel,
-                    offset.x,
-                    offset.y,
-                    offset.z,
-                    destWidth,
-                    destHeight,
-                    extent.depth,
-                    gpuTexture.glFormat$,
-                    pixels,
+            } else {
+                const isFullCopy = (
+                    gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight &&
+                    offset.x === 0 && offset.y === 0
                 );
-            } else { // WEBGL_compressed_texture_etc1
-                gl.compressedTexImage3D(
-                    WebGLConstants.TEXTURE_2D_ARRAY,
-                    mipLevel,
-                    gpuTexture.glInternalFmt$,
-                    destWidth,
-                    destHeight,
-                    extent.depth,
-                    0,
-                    pixels,
-                );
+                if (!isFullCopy && gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
+                    gl.compressedTexSubImage3D(
+                        WebGLConstants.TEXTURE_2D_ARRAY,
+                        mipLevel,
+                        offset.x,
+                        offset.y,
+                        offset.z,
+                        destWidth,
+                        destHeight,
+                        extent.depth,
+                        gpuTexture.glFormat$,
+                        pixels,
+                    );
+                } else { // WEBGL_compressed_texture_etc1
+                    gl.compressedTexImage3D(
+                        WebGLConstants.TEXTURE_2D_ARRAY,
+                        mipLevel,
+                        gpuTexture.glInternalFmt$,
+                        destWidth,
+                        destHeight,
+                        extent.depth,
+                        0,
+                        pixels,
+                    );
+                }
             }
         }
         break;

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2972,8 +2972,8 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
                 );
             } else {
                 const isFullCopy = (
-                    gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight &&
-                    offset.x === 0 && offset.y === 0
+                    gpuTexture.width$ === destWidth && gpuTexture.height$ === destHeight
+                    && offset.x === 0 && offset.y === 0
                 );
                 if (!isFullCopy && gpuTexture.glInternalFmt$ !== WebGL2EXT.COMPRESSED_RGB_ETC1_WEBGL as number) {
                     gl.compressedTexSubImage3D(


### PR DESCRIPTION
Device: Lenovo Tab M10 FHD Plus
Chip: MediaTek Helio P22T (MT8768T)
Platform: Web-mobile

Unable to display ASTC textures correctly.
![Screenshot_2024-10-24-14-31-58-549](https://github.com/user-attachments/assets/05773a7c-e2e5-4fbf-946d-9bb59cff1ce2)

After the fix.
![Screenshot_2024-10-24-14-34-43-124](https://github.com/user-attachments/assets/1b187368-a716-4584-96ce-b87c58748047)

Test demo:
[astc-test.zip](https://github.com/user-attachments/files/17502402/astc-test.zip)

Reproduction steps:
1. A specific device is required.
2. Use non-power-of-two ASTC textures.
3. Build the project.
4. Run on the device.


### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
