### PR TITLE
reuse _tempVec2 and avoid creating new temple object

### DIFF
--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -78,12 +78,7 @@ const eventMap = {
     'scroll-began': 12,
 };
 
-interface MoveDeltaOptions {
-    anchor: Vec2,
-    applyToHorizontal: boolean,
-    applyToVertical: boolean,
-}
-const _moveDeltaOptions: MoveDeltaOptions = {
+const _moveDeltaOptions = {
     anchor: _tempVec2,
     applyToHorizontal: false,
     applyToVertical: false,
@@ -1838,7 +1833,7 @@ export class ScrollView extends ViewGroup {
         }
     }
 
-    protected _calculateMovePercentDelta (options: MoveDeltaOptions): Vec3 {
+    protected _calculateMovePercentDelta (options): Vec3 {
         const anchor = options.anchor;
         const applyToHorizontal = options.applyToHorizontal;
         const applyToVertical = options.applyToVertical;

--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -79,7 +79,7 @@ const eventMap = {
 };
 
 const _moveDeltaOptions = {
-    anchor: _tempVec2,
+    anchor: v2(),
     applyToHorizontal: false,
     applyToVertical: false,
 };

--- a/cocos/ui/scroll-view.ts
+++ b/cocos/ui/scroll-view.ts
@@ -78,6 +78,17 @@ const eventMap = {
     'scroll-began': 12,
 };
 
+interface MoveDeltaOptions {
+    anchor: Vec2,
+    applyToHorizontal: boolean,
+    applyToVertical: boolean,
+}
+const _moveDeltaOptions: MoveDeltaOptions = {
+    anchor: _tempVec2,
+    applyToHorizontal: false,
+    applyToVertical: false,
+};
+
 /**
  * @en
  * Enum for ScrollView event type.
@@ -486,11 +497,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToBottom (timeInSecond?: number, attenuated = true): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(0, 0),
-            applyToHorizontal: false,
-            applyToVertical: true,
-        });
+        _moveDeltaOptions.anchor.set(0, 0);
+        _moveDeltaOptions.applyToHorizontal = false;
+        _moveDeltaOptions.applyToVertical = true;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -516,11 +526,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToTop (timeInSecond?: number, attenuated = true): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(0, 1),
-            applyToHorizontal: false,
-            applyToVertical: true,
-        });
+        _moveDeltaOptions.anchor.set(0, 1);
+        _moveDeltaOptions.applyToHorizontal = false;
+        _moveDeltaOptions.applyToVertical = true;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -546,11 +555,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToLeft (timeInSecond?: number, attenuated = true): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(0, 0),
-            applyToHorizontal: true,
-            applyToVertical: false,
-        });
+        _moveDeltaOptions.anchor.set(0, 0);
+        _moveDeltaOptions.applyToHorizontal = true;
+        _moveDeltaOptions.applyToVertical = false;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -576,11 +584,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToRight (timeInSecond?: number, attenuated = true): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(1, 0),
-            applyToHorizontal: true,
-            applyToVertical: false,
-        });
+        _moveDeltaOptions.anchor.set(1, 0);
+        _moveDeltaOptions.applyToHorizontal = true;
+        _moveDeltaOptions.applyToVertical = false;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -606,11 +613,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToTopLeft (timeInSecond?: number, attenuated = true): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(0, 1),
-            applyToHorizontal: true,
-            applyToVertical: true,
-        });
+        _moveDeltaOptions.anchor.set(0, 1);
+        _moveDeltaOptions.applyToHorizontal = true;
+        _moveDeltaOptions.applyToVertical = true;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -636,11 +642,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToTopRight (timeInSecond?: number, attenuated = true): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(1, 1),
-            applyToHorizontal: true,
-            applyToVertical: true,
-        });
+        _moveDeltaOptions.anchor.set(1, 1);
+        _moveDeltaOptions.applyToHorizontal = true;
+        _moveDeltaOptions.applyToVertical = true;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -666,11 +671,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToBottomLeft (timeInSecond?: number, attenuated = true): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(0, 0),
-            applyToHorizontal: true,
-            applyToVertical: true,
-        });
+        _moveDeltaOptions.anchor.set(0, 0);
+        _moveDeltaOptions.applyToHorizontal = true;
+        _moveDeltaOptions.applyToVertical = true;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -696,11 +700,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToBottomRight (timeInSecond?: number, attenuated = true): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(1, 0),
-            applyToHorizontal: true,
-            applyToVertical: true,
-        });
+        _moveDeltaOptions.anchor.set(1, 0);
+        _moveDeltaOptions.applyToHorizontal = true;
+        _moveDeltaOptions.applyToVertical = true;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -806,11 +809,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToPercentHorizontal (percent: number, timeInSecond: number, attenuated: boolean): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(percent, 0),
-            applyToHorizontal: true,
-            applyToVertical: false,
-        });
+        _moveDeltaOptions.anchor.set(percent, 0);
+        _moveDeltaOptions.applyToHorizontal = true;
+        _moveDeltaOptions.applyToVertical = false;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated !== false);
@@ -842,11 +844,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollTo (anchor: Vec2, timeInSecond?: number, attenuated?: boolean): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(anchor),
-            applyToHorizontal: true,
-            applyToVertical: true,
-        });
+        _moveDeltaOptions.anchor.set(anchor);
+        _moveDeltaOptions.applyToHorizontal = true;
+        _moveDeltaOptions.applyToVertical = true;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated);
@@ -873,11 +874,10 @@ export class ScrollView extends ViewGroup {
      * ```
      */
     public scrollToPercentVertical (percent: number, timeInSecond?: number, attenuated?: boolean): void {
-        const moveDelta = this._calculateMovePercentDelta({
-            anchor: new Vec2(0, percent),
-            applyToHorizontal: false,
-            applyToVertical: true,
-        });
+        _moveDeltaOptions.anchor.set(0, percent);
+        _moveDeltaOptions.applyToHorizontal = false;
+        _moveDeltaOptions.applyToVertical = true;
+        const moveDelta = this._calculateMovePercentDelta(_moveDeltaOptions);
 
         if (timeInSecond) {
             this._startAutoScroll(moveDelta, timeInSecond, attenuated);
@@ -1838,7 +1838,7 @@ export class ScrollView extends ViewGroup {
         }
     }
 
-    protected _calculateMovePercentDelta (options): Vec3 {
+    protected _calculateMovePercentDelta (options: MoveDeltaOptions): Vec3 {
         const anchor = options.anchor;
         const applyToHorizontal = options.applyToHorizontal;
         const applyToVertical = options.applyToVertical;


### PR DESCRIPTION
_calculateMovePercentDelta() just uses anchor.x and anchor.y, and will not pass it to other functions, so it is safe to reuse _moveDeltaOptions and _tempVec2.

The best solution is change the parameter from `_calculateMovePercentDelta(options: MoveDeltaOptions) ` to `_calculateMovePercentDelta(anchor: Vec2, applyToHorizontal: boolean, applyToVertical: boolean)`. Then even don't have to:
- define MoveDeltaOptions
- create _moveDeltaOptions
- and don't have assign _moveDeltaOptions before invoking _calculateMovePercentDelta()

But it will break the compatibility, as _calculateMovePercentDelta() is a protected function.