### PR TITLE
fix:AudioEngine->stop

### DIFF
--- a/native/cocos/audio/android/UrlAudioPlayer.h
+++ b/native/cocos/audio/android/UrlAudioPlayer.h
@@ -119,6 +119,7 @@ private:
 
     std::thread::id _callerThreadId;
     std::shared_ptr<bool> _isDestroyed;
+    std::mutex destoryMutex;
 
     friend class SLUrlAudioPlayerCallbackProxy;
     friend class AudioPlayerProvider;


### PR DESCRIPTION

Re: #17511 

### Changelog

*While checking the logs on the Android platform, it was found that there is a resource contention in the audio thread during unloading.

### log
"main" prio=5 tid=1 Native
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x75a41838 self=0x77a4e14c00
  | sysTid=7285 nice=-10 cgrp=default sched=0/0 handle=0x782ab2e548
  | state=S schedstat=( 13260262794 2232927320 20174 ) utm=1134 stm=191 core=0 HZ=100
  | stack=0x7fbfeae000-0x7fbfeb0000 stackSize=8MB
  | held mutexes=
  kernel: (couldn't read /proc/self/task/7285/stack)
  native: #00 pc 000000000001ed30  /system/lib64/libc.so (syscall+32)
  native: #01 pc 0000000000021ffc  /system/lib64/libc.so (__futex_wait_ex(void volatile*, bool, int, bool, timespec const*)+140)
  native: #02 pc 00000000000826b0  /system/lib64/libc.so (pthread_cond_timedwait+120)
  native: #03 pc 00000000018255dc  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  native: #04 pc 0000000001825664  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  native: #05 pc 00000000018248f4  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  native: #06 pc 000000000182243c  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  native: #07 pc 000000000055c1e0  /system/lib64/libart.so (offset 30b000) (art_quick_generic_jni_trampoline+144)
  native: #08 pc 0000000000553188  /system/lib64/libart.so (offset 30b000) (art_quick_invoke_stub+584)
  native: #09 pc 00000000000d0110  /system/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200)
  native: #10 pc 0000000000282a28  /system/lib64/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+344)
  native: #11 pc 000000000027ca04  /system/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+948)
  native: #12 pc 0000000000522a38  /system/lib64/libart.so (offset 30b000) (MterpInvokeVirtual+584)
  native: #13 pc 0000000000545714  /system/lib64/libart.so (offset 30b000) (ExecuteMterpImpl+14228)
  native: #14 pc 000000000060909a  [anon:libc_malloc] (com.google.androidgamesdk.GameActivity.onPause+10)
  native: #15 pc 0000000000256850  /system/lib64/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEb.llvm.3086389725+496)
  native: #16 pc 000000000025c080  /system/lib64/libart.so (art::interpreter::ArtInterpreterToInterpreterBridge(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*, art::JValue*)+216)
  native: #17 pc 000000000027c9e8  /system/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+920)
  native: #18 pc 00000000005230c8  /system/lib64/libart.so (offset 30b000) (MterpInvokeSuper+1408)
  native: #19 pc 0000000000545794  /system/lib64/libart.so (offset 30b000) (ExecuteMterpImpl+14356)
  native: #20 pc 000000000057d1cc  [anon:libc_malloc] (com.cocos.lib.CocosActivity.onPause)
  native: #21 pc 0000000000256850  /system/lib64/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEb.llvm.3086389725+496)
  native: #22 pc 00000000005135a0  /system/lib64/libart.so (offset 30b000) (artQuickToInterpreterBridge+1032)
  native: #23 pc 000000000055c2fc  /system/lib64/libart.so (offset 30b000) (art_quick_to_interpreter_bridge+92)
  at com.google.androidgamesdk.GameActivity.onPauseNative(Native method)
  at com.google.androidgamesdk.GameActivity.onPause(SourceFile:2)
  at com.cocos.lib.CocosActivity.onPause(SourceFile:1)
  at android.app.Activity.performPause(Activity.java:7450)
  at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1495)
  at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:4114)
  at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4079)
  at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4031)
  at android.app.servertransaction.PauseActivityItem.execute(PauseActivityItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:145)
  at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:70)
  at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1834)
  at android.os.Handler.dispatchMessage(Handler.java:106)
  at android.os.Looper.loop(Looper.java:193)
  at android.app.ActivityThread.main(ActivityThread.java:6928)
  at java.lang.reflect.Method.invoke(Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:504)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)



"Thread-13" prio=10 tid=44 Native
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x132c2bb0 self=0x7785232000
  | sysTid=7381 nice=-10 cgrp=default sched=0/0 handle=0x77838f94f0
  | state=S schedstat=( 715909010519 8349930136 117286 ) utm=71141 stm=449 core=5 HZ=100
  | stack=0x77837fe000-0x7783800000 stackSize=1009KB
  | held mutexes=
  kernel: (couldn't read /proc/self/task/7381/stack)
  native: #00 pc 000000000001ed2c  /system/lib64/libc.so (syscall+28)
  native: #01 pc 0000000000021ffc  /system/lib64/libc.so (__futex_wait_ex(void volatile*, bool, int, bool, timespec const*)+140)
  native: #02 pc 000000000008260c  /system/lib64/libc.so (pthread_cond_wait+60)
  native: #03 pc 000000000000fe1c  /system/lib64/libutils.so (android::Thread::requestExitAndWait()+84)
  native: #04 pc 000000000001bcd8  /system/lib64/libstagefright_foundation.so (android::ALooper::stop()+416)
  native: #05 pc 000000000001b054  /system/lib64/libwilhelm.so (android::GenericPlayer::preDestroy()+44)
  native: #06 pc 0000000000019e64  /system/lib64/libwilhelm.so (android::GenericMediaPlayer::preDestroy()+284)
  native: #07 pc 0000000000013470  /system/lib64/libwilhelm.so (android_audioPlayer_preDestroy(CAudioPlayer_struct*)+96)
  native: #08 pc 0000000000020ee8  /system/lib64/libwilhelm.so (CAudioPlayer_PreDestroy(void*)+8)
  native: #09 pc 0000000000028a50  /system/lib64/libwilhelm.so (IObject_Destroy(SLObjectItf_ const* const*)+72)
  native: #10 pc 0000000001930ba8  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (cc::UrlAudioPlayer::destroy()+204)
  native: #11 pc 0000000001930a64  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (cc::UrlAudioPlayer::stop()+376)
  native: #12 pc 00000000018fed24  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (cc::AudioEngineImpl::stop(int)+120)
  native: #13 pc 00000000018ee01c  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (cc::AudioEngine::stop(int)+104)
  native: #14 pc 00000000021bbde0  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  native: #15 pc 000000000186572c  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (jsbFunctionWrapper(v8::FunctionCallbackInfo<v8::Value> const&, bool (*)(se::State&), char const*)+376)
  native: #16 pc 00000000021bbc60  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (js_cc_AudioEngine_stop_staticRegistry(v8::FunctionCallbackInfo<v8::Value> const&)+52)
  native: #17 pc 0000000002e5ece8  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  native: #18 pc 0000000002e5e348  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  native: #19 pc 0000000002e5dad8  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  native: #20 pc 0000000002d76468  /data/app/com.iflytek.aistudyclient.pre.flash-rt5Bm7yGxXRHsA_UyfHIjQ==/lib/arm64/libcocos.so (???)
  (no managed stack frames)

