### PR TITLE
Fix the display issue in the editor after replacing Spine resources.

### DIFF
--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -273,7 +273,7 @@ export class SkeletonData extends Asset {
 
     private mergedUUID (): string {
         return this._uuid + murmurhash2_32_gc(this._atlasText, 668).toString();
-    }   
+    }
 
     /**
      * @en Destroy skeleton data.

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -208,8 +208,8 @@ export class SkeletonData extends Asset {
             return null;
         }
 
-        let uuid = this.mergedUUID();
-        let spData = spine.wasmUtil.querySpineSkeletonDataByUUID(uuid);
+        const uuid = this.mergedUUID();
+        const spData = spine.wasmUtil.querySpineSkeletonDataByUUID(uuid);
         if (spData) {
             this._skeletonCache = spData;
         } else if (this._skeletonJson) {

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -23,7 +23,7 @@
 */
 
 import { EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
-import { CCString, Enum, error } from '../core';
+import { CCString, Enum, error, murmurhash2_32_gc } from '../core';
 import SkeletonCache from './skeleton-cache';
 import { Skeleton } from './skeleton';
 import spine from './lib/spine-core';
@@ -207,12 +207,14 @@ export class SkeletonData extends Asset {
             }
             return null;
         }
-        const spData = spine.wasmUtil.querySpineSkeletonDataByUUID(this._uuid);
+
+        let uuid = this.mergedUUID();
+        let spData = spine.wasmUtil.querySpineSkeletonDataByUUID(uuid);
         if (spData) {
             this._skeletonCache = spData;
         } else if (this._skeletonJson) {
             this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithJson(this.skeletonJsonStr, this._atlasText);
-            spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
+            spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, uuid);
         } else {
             const rawData = new Uint8Array(this._nativeAsset);
             const byteSize = rawData.length;
@@ -220,7 +222,7 @@ export class SkeletonData extends Asset {
             const wasmMem = spine.wasmUtil.wasm.HEAPU8.subarray(ptr, ptr + byteSize);
             wasmMem.set(rawData);
             this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithBinary(byteSize, this._atlasText);
-            spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, this._uuid);
+            spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, uuid);
         }
 
         return this._skeletonCache;
@@ -268,13 +270,18 @@ export class SkeletonData extends Asset {
         }
         return null;
     }
+
+    private mergedUUID (): string {
+        return this._uuid + murmurhash2_32_gc(this._atlasText, 668).toString();
+    }   
+
     /**
      * @en Destroy skeleton data.
      * @zh 销毁 skeleton data。
      */
     public destroy (): boolean {
         SkeletonCache.sharedCache.destroyCachedAnimations(this._uuid);
-        spine.wasmUtil.destroySpineSkeletonDataWithUUID(this._uuid);
+        spine.wasmUtil.destroySpineSkeletonDataWithUUID(this.mergedUUID());
         return super.destroy();
     }
 }

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -1017,6 +1017,7 @@ export class Skeleton extends UIRenderer {
      * @param skinName @en The name of skin. @zh 皮肤名称。
      */
     public setSkin (name: string): void {
+        if (!name) return;
         if (this._skeleton) this._skeleton.setSkinByName(name);
         this._instance!.setSkin(name);
         if (this.isAnimationCached()) {


### PR DESCRIPTION
Re: #
https://github.com/cocos/3d-tasks/issues/18545
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
