### PR TITLE
add inspector set prop label and tooltip and create ui-radio-group api

### DIFF
--- a/editor/inspector/utils/prop.js
+++ b/editor/inspector/utils/prop.js
@@ -351,14 +351,15 @@ exports.getName = function(dump) {
         return '';
     }
 
-    if (dump.displayName) {
-        if (dump.displayName.startsWith(i18nPrefix)) {
-            const key = dump.displayName.substring(i18nPrefix.length);
+    if (typeof dump.displayName === 'string') {
+        const displayName = dump.displayName.trim();
+        if (displayName.startsWith(i18nPrefix)) {
+            const key = displayName.substring(i18nPrefix.length);
             if (Editor.I18n.t(key)) {
-                return dump.displayName;
+                return displayName;
             }
-        } else {
-            return dump.displayName;
+        } else if (displayName) {
+            return displayName;
         }
     }
 
@@ -557,6 +558,42 @@ exports.disconnectGroup = function(panel) {
     }
 };
 
+/**
+ * 根据配置创建 ui-radio-group
+ * @param {object} options
+ * @param {any[]} options.enumList
+ * @param {string} options.tooltip
+ * @param {(elementName: string) => string}options.getIconName
+ * @param {(event: CustomEvent) => {}} options.onChange
+ * @returns
+ */
+exports.createRadioGroup = function(options) {
+    const { enumList, getIconName, onChange, tooltip: rawTooltip } = options;
+    const $radioGroup = document.createElement('ui-radio-group');
+    $radioGroup.setAttribute('slot', 'content');
+    $radioGroup.addEventListener('change', (e) => {
+        onChange(e);
+    });
+
+    for (let index = 0; index < enumList.length; index++) {
+        const element = enumList[index];
+        const icon = document.createElement('ui-icon');
+        const button = document.createElement('ui-radio-button');
+
+        const iconName = getIconName(element.name);
+        const tooltip = `${rawTooltip}_${element.name.toLocaleLowerCase()}`;
+
+        icon.value = iconName;
+        button.appendChild(icon);
+        button.value = element.value;
+        button.setAttribute('tooltip', tooltip);
+
+        $radioGroup.appendChild(button);
+    }
+
+    return $radioGroup;
+};
+
 exports.injectionStyle = `
 ui-prop,
 ui-section { margin-top: 4px; }
@@ -577,3 +614,51 @@ ui-prop[ui-section-config]:last-child {
     border-bottom: solid 1px var(--color-normal-fill-emphasis);
 }
 `;
+
+/**
+ * 获取 api 文档路径，通过 i18n 配置的 cc.xxx.properties
+ * 格式来获取 className 如果没有就不加入 ui-link 组件
+ * @param dump
+ */
+function getDocsURL(dump) {
+    const mathResults = dump.displayName && dump.displayName.match(/(?<=cc\.\s*)(\w+)/);
+    const className = mathResults && mathResults.length > 0 ? mathResults[0] : '';
+    if (!className) {
+        return '';
+    }
+    return `${Editor.App.urls.api}/class/${className}?id=${dump.name}`;
+}
+
+exports.setTooltip = function(dump, $label, name) {
+    if (!name) {
+        name = exports.getName(dump);
+    }
+    if (dump.tooltip) {
+        let tooltipValid = true;
+        if (dump.tooltip.startsWith(i18nPrefix)) {
+            const key = dump.tooltip.substring(i18nPrefix.length);
+            if (!Editor.I18n.t(key)) {
+                tooltipValid = false;
+            }
+        }
+
+        if (tooltipValid) {
+            const url = getDocsURL(dump);
+            const attributeTitle = `<ui-label style="font-weight:bold;" value="i18n:ENGINE.common.attribute.title"></ui-label>`;
+            const attributeName = url ? `
+                <ui-link value='${url}'>
+                    <ui-label value="${dump.name || name}"></ui-label>
+                </ui-link>`.trim() : `<ui-label value="${dump.name || name}"></ui-label>`;
+
+            $label.setAttribute('tooltip', `
+                <div>${attributeTitle}${attributeName}</div><br><ui-label value="${dump.tooltip}"></ui-label>`.trim()
+            );
+        }
+    }
+};
+
+exports.setLabel = function(dump, $label) {
+    const name = exports.getName(dump);
+    $label.value = name;
+    exports.setTooltip(dump, $label, name);
+};

--- a/editor/inspector/utils/prop.js
+++ b/editor/inspector/utils/prop.js
@@ -559,7 +559,7 @@ exports.disconnectGroup = function(panel) {
 };
 
 /**
- * 根据配置创建 ui-radio-group
+ * Create ui-radio-group according to configuration
  * @param {object} options
  * @param {any[]} options.enumList
  * @param {string} options.tooltip
@@ -616,8 +616,8 @@ ui-prop[ui-section-config]:last-child {
 `;
 
 /**
- * 获取 api 文档路径，通过 i18n 配置的 cc.xxx.properties
- * 格式来获取 className 如果没有就不加入 ui-link 组件
+ * Obtain the api document path and obtain the className through the cc.xxx.properties configured by i18n.
+ * If it does not exist, the ui-link component will not be added.
  * @param dump
  */
 function getDocsURL(dump) {


### PR DESCRIPTION
Re: #

### Changelog

* add inspector set prop label and tooltip api

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
