### PR TITLE
Fix the issue where the return value of getSafeArea in WeChat may be undefined.

### DIFF
--- a/pal/minigame/wechat.ts
+++ b/pal/minigame/wechat.ts
@@ -154,7 +154,18 @@ minigame.createInnerAudioContext = createInnerAudioContextPolyfill(wx, {
 // FIX_ME: wrong safe area when orientation is landscape left
 minigame.getSafeArea = function (): SafeArea {
     const locSystemInfo = wx.getSystemInfoSync() as SystemInfo;
-    return locSystemInfo.safeArea;
+    let safeArea = locSystemInfo.safeArea;
+    if (!safeArea) {
+        safeArea = {
+            left: 0,
+            top: 0,
+            bottom: systemInfo.screenHeight,
+            right: systemInfo.screenWidth,
+            width: systemInfo.screenWidth,
+            height: systemInfo.screenHeight,
+        };
+    }
+    return safeArea;
 };
 // #endregion SafeArea
 

--- a/pal/minigame/wechat_mini_program.ts
+++ b/pal/minigame/wechat_mini_program.ts
@@ -158,7 +158,18 @@ minigame.createInnerAudioContext = createInnerAudioContextPolyfill(wx, {
 // FIX_ME: wrong safe area when orientation is landscape left
 minigame.getSafeArea = (): SafeArea => {
     const locSystemInfo = wx.getSystemInfoSync() as SystemInfo;
-    return locSystemInfo.safeArea;
+    let safeArea = locSystemInfo.safeArea;
+    if (!safeArea) {
+        safeArea = {
+            left: 0,
+            top: 0,
+            bottom: systemInfo.screenHeight,
+            right: systemInfo.screenWidth,
+            width: systemInfo.screenWidth,
+            height: systemInfo.screenHeight,
+        };
+    }
+    return safeArea;
 };
 // #endregion SafeArea
 


### PR DESCRIPTION
Re: #
https://github.com/cocos/cocos-engine/issues/17816

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
