### PR TITLE
Fix the issue where UI batching breaks under specific conditions.

### DIFF
--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -343,9 +343,7 @@ export class UIRenderer extends Renderer {
         this.node.off(NodeEventType.PARENT_CHANGED, this._colorDirty, this);
         // When disabling, it is necessary to free up idle space to fully utilize chunks
         // and avoid breaking batch processing.
-        if (this._renderData) {
-            this.destroyRenderData();
-        }
+        this.destroyRenderData();
         uiRendererManager.removeRenderer(this);
         this._renderFlag = false;
         this._renderEntity.enabled = false;

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -320,6 +320,10 @@ export class UIRenderer extends Renderer {
         this.node.on(NodeEventType.ANCHOR_CHANGED, this._nodeStateChange, this);
         this.node.on(NodeEventType.SIZE_CHANGED, this._nodeStateChange, this);
         this.node.on(NodeEventType.PARENT_CHANGED, this._colorDirty, this);
+        // If the renderData is invalid, it needs to be rebuilt to recalculate the batch processing.
+        if (!this._renderData && this._flushAssembler) {
+            this._flushAssembler();
+        }
         this.updateMaterial();
         this._colorDirty();
         uiRendererManager.addRenderer(this);
@@ -337,6 +341,11 @@ export class UIRenderer extends Renderer {
         this.node.off(NodeEventType.ANCHOR_CHANGED, this._nodeStateChange, this);
         this.node.off(NodeEventType.SIZE_CHANGED, this._nodeStateChange, this);
         this.node.off(NodeEventType.PARENT_CHANGED, this._colorDirty, this);
+        // When disabling, it is necessary to free up idle space to fully utilize chunks
+        // and avoid breaking batch processing.
+        if (this._renderData) {
+            this.destroyRenderData();
+        }
         uiRendererManager.removeRenderer(this);
         this._renderFlag = false;
         this._renderEntity.enabled = false;


### PR DESCRIPTION
1. When a node is recycled or the component is in a deactivated state, space should be freed up so that other active UI components can reuse it.
2. When the component is reactivated, it should be rebuilt and re-included in the batching process.