### PR TITLE
为 CocosDownloader.java 添加必要的 null check.

### DIFF
--- a/native/cocos/platform/android/java/src/com/cocos/lib/CocosDownloader.java
+++ b/native/cocos/platform/android/java/src/com/cocos/lib/CocosDownloader.java
@@ -180,7 +180,11 @@ public class CocosDownloader {
 
                         host = domain.startsWith("www.") ? domain.substring(4) : domain;
                         if (fileLen > 0) {
-                            SharedPreferences sharedPreferences = GlobalObject.getContext().getSharedPreferences("breakpointDownloadSupport", Context.MODE_PRIVATE);
+                            Context context = GlobalObject.getContext();
+                            if (context == null) {
+                                return;
+                            }
+                            SharedPreferences sharedPreferences = context.getSharedPreferences("breakpointDownloadSupport", Context.MODE_PRIVATE);
                             if (sharedPreferences.contains(host) && sharedPreferences.getBoolean(host, false)) {
                                 downloadStart = fileLen;
                             } else {
@@ -246,6 +250,9 @@ public class CocosDownloader {
 
                                 // save breakpointDownloadSupport Data to SharedPreferences storage
                                 Context context = GlobalObject.getContext();
+                                if (context == null) {
+                                    return;
+                                }
                                 SharedPreferences sharedPreferences = context.getSharedPreferences("breakpointDownloadSupport", Context.MODE_PRIVATE);
                                 SharedPreferences.Editor editor = sharedPreferences.edit();
                                 long total = response.body().contentLength() + downloadStart;


### PR DESCRIPTION
解决 GlobalObject.getContext() 为 null 时,  下载任务出错的bug.
目前 3.8.4 版本 构建的 安卓原生app  运行时 偶尔会出现下列错误, 导致程序异常: 

```
java.lang.NullPointerException
Attempt to invoke virtual method 'android.content.SharedPreferences android.content.Context.getSharedPreferences(java.lang.String, int)' on a null object reference.

at com.cocos.lib.CocosDownloader$c$c.a(Unknown Source:33)
at k1.w$b.e(Unknown Source:19)
at l1.b.run(Unknown Source:17)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
at java.lang.Thread.run(Thread.java:1012)
```

此 PR 尝试解决该问题.

虽然提到了 3.8.6 , 但是希望 3.8.5 就能解决.
另外 不知道 iOS 版本是否也有类似问题.
如果有 麻烦 cocos官方修复下. 
