### PR TITLE
Video player position gets displaced when entering fullscreen (Web)

### DIFF
--- a/cocos/video/video-player-impl-web.ts
+++ b/cocos/video/video-player-impl-web.ts
@@ -330,10 +330,6 @@ export class VideoPlayerImplWeb extends VideoPlayerImpl {
             return;
         }
 
-        if (screen.fullScreen()) {
-            return;
-        }
-
         // use stayOnBottom
         if (this._dirty) {
             this._dirty = false;


### PR DESCRIPTION
Matrix still needs to be updated in fullscreen mode.

Before:
![WeChat 截圖_20241125164812](https://github.com/user-attachments/assets/89774983-a1c3-4b4e-8f25-08d8e274b4e1)
After:
![WeChat 截圖_20241125164309](https://github.com/user-attachments/assets/d9d26d63-8936-4a46-8783-2971e9786ea5)

Test deme:
[video-test.zip](https://github.com/user-attachments/files/17899988/video-test.zip)


### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
