### PR TITLE
Fix the character spacing error in the rendering of Label under Char Mode

### DIFF
--- a/cocos2d/core/renderer/utils/label/bmfont.js
+++ b/cocos2d/core/renderer/utils/label/bmfont.js
@@ -187,6 +187,10 @@ export default class BmfontAssembler extends Assembler2D {
         }
     }
 
+    _clearHorizontalKerning() {
+        _horizontalKernings.length = 0;
+    }
+
     _multilineTextWrap (nextTokenFunc) {
         let textLen = _string.length;
 

--- a/cocos2d/core/renderer/utils/label/letter-font.js
+++ b/cocos2d/core/renderer/utils/label/letter-font.js
@@ -306,7 +306,11 @@ export default class LetterFontAssembler extends WebglBmfontAssembler {
 
         return fontDesc;
     }
-    _computeHorizontalKerningForText () {}
+
+    _computeHorizontalKerningForText () {
+        this._clearHorizontalKerning();
+    }
+
     _determineRect (tempRect) {
         return false;
     }


### PR DESCRIPTION
Due to the uncleaned Kerning information, all Label renderings using Char Mode will result in rendering errors due to reused Kerning.

How to reproduce the issue:

1. Create an empty project
2. Create a Label, using the BMFont in the attached file for rendering
3. Run the project, and the engine's built-in Stats character spacing is problematic

[bmfont.zip](https://github.com/user-attachments/files/17930557/bmfont.zip)

Screenshot:

![CleanShot 2024-11-27 at 15 29 09@2x](https://github.com/user-attachments/assets/365aad75-e59c-4788-807c-ef0216ba23af)

(The first and second characters are too close.)

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [x] Your pull request title is using English, it's precise and appropriate.
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [x] Document new code with comments in source code based on API docs
- [x] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [x] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
