### PR TITLE
Fix that assets in scene configured with `autorelease` could not be auto released after switching scene. It's a memory leak from v3.8.1.

### DIFF
--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -1171,6 +1171,14 @@ Object.defineProperty(nodeProto, 'scene', {
     }
 });
 
+Object.defineProperty(nodeProto, 'id', {
+    configurable: true,
+    enumerable: true,
+    set(id) {
+        this._id = id;
+    }
+});
+
 nodeProto.rotate = function (rot: Quat, ns?: NodeSpace): void {
     _tempFloatArray[1] = rot.x;
     _tempFloatArray[2] = rot.y;


### PR DESCRIPTION
This issue started from https://github.com/cocos/cocos-engine/pull/14572. `set id(v)` was added only for non-native platforms. On native, node.id will not set the `_id` value.

Re: https://github.com/cocos/3d-tasks/issues/18596

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
