### PR TITLE
fixed #18000: [v3.8.5][bug] Nested tween with different target in parallel action could not work correctly.

### DIFF
--- a/cocos/tween/actions/action-instant.ts
+++ b/cocos/tween/actions/action-instant.ts
@@ -72,7 +72,7 @@ export abstract class ActionInstant extends FiniteTimeAction {
  */
 export class Show<T extends Node> extends ActionInstant {
     update (_dt: number): void {
-        const target = (this.workerTarget ?? this.target) as T;
+        const target = this._getWorkerTarget<T>();
         if (!target) return;
         const _renderComps = target.getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
@@ -112,7 +112,7 @@ export function show<T extends Node> (): Show<T> {
  */
 export class Hide<T extends Node> extends ActionInstant {
     update (_dt: number): void {
-        const target = (this.workerTarget ?? this.target) as T;
+        const target = this._getWorkerTarget<T>();
         if (!target) return;
         const _renderComps = target.getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
@@ -152,7 +152,7 @@ export function hide<T extends Node> (): Hide<T> {
  */
 export class ToggleVisibility<T extends Node> extends ActionInstant {
     update (_dt: number): void {
-        const target = (this.workerTarget ?? this.target) as T;
+        const target = this._getWorkerTarget<T>();
         if (!target) return;
         const _renderComps = target.getComponentsInChildren(Renderer);
         for (let i = 0; i < _renderComps.length; ++i) {
@@ -204,7 +204,7 @@ export class RemoveSelf<T extends Node> extends ActionInstant {
     }
 
     update (_dt: number): void {
-        const target = (this.workerTarget ?? this.target) as T;
+        const target = this._getWorkerTarget<T>();
         if (!target) return;
         target.removeFromParent();
         if (this._isNeedCleanUp) {
@@ -302,7 +302,7 @@ export class CallFunc<CallbackThis, Target, Data> extends ActionInstant {
      */
     execute (): void {
         if (this._callback) {
-            const target = (this.workerTarget ?? this.target) as Target;
+            const target = this._getWorkerTarget() as Target;
             this._callback.call(this._callbackThis, target, this._data);
         }
     }

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -355,8 +355,12 @@ export class Sequence extends ActionInterval {
         if (this._actions.length < 2) {
             return;
         }
-        this._actions[1]._owner = owner;
         const actionOne = this._actions[0];
+        const actionTwo = this._actions[1];
+
+        if (!actionTwo._owner) {
+            actionTwo._owner = owner;
+        }
         if (actionOne instanceof Sequence || actionOne instanceof Spawn) {
             actionOne.updateOwner(owner);
         } else if (!actionOne._owner) { // action's owner should never be changed, so only set owner when it's not set yet.
@@ -837,7 +841,9 @@ export class Spawn extends ActionInterval {
         if (!this._one || !this._two) {
             return;
         }
-        this._two._owner = owner;
+        if (!this._two._owner) {
+            this._two._owner = owner;
+        }
         const one = this._one;
         if (one instanceof Spawn || one instanceof Sequence) {
             one.updateOwner(owner);

--- a/cocos/tween/actions/action-interval.ts
+++ b/cocos/tween/actions/action-interval.ts
@@ -28,7 +28,7 @@
 import { FiniteTimeAction } from './action';
 import { macro, logID, errorID } from '../../core';
 import { ActionInstant } from './action-instant';
-import type { TweenUpdateCallback } from '../tween';
+import type { Tween, TweenUpdateCallback } from '../tween';
 
 // Extra action for making a Sequence or Spawn when only adding one action to it.
 class DummyAction extends FiniteTimeAction {
@@ -351,16 +351,16 @@ export class Sequence extends ActionInterval {
         return action;
     }
 
-    updateWorkerTarget<T> (workerTarget: T): void {
+    updateOwner<T extends object> (owner: Tween<T>): void {
         if (this._actions.length < 2) {
             return;
         }
-        this._actions[1].workerTarget = workerTarget;
+        this._actions[1]._owner = owner;
         const actionOne = this._actions[0];
         if (actionOne instanceof Sequence || actionOne instanceof Spawn) {
-            actionOne.updateWorkerTarget(workerTarget);
-        } else {
-            actionOne.workerTarget = workerTarget;
+            actionOne.updateOwner(owner);
+        } else if (!actionOne._owner) { // action's owner should never be changed, so only set owner when it's not set yet.
+            actionOne._owner = owner;
         }
     }
 
@@ -833,16 +833,16 @@ export class Spawn extends ActionInterval {
         return this;
     }
 
-    updateWorkerTarget<T> (workerTarget: T): void {
+    updateOwner<T extends object> (owner: Tween<T>): void {
         if (!this._one || !this._two) {
             return;
         }
-        this._two.workerTarget = workerTarget;
+        this._two._owner = owner;
         const one = this._one;
         if (one instanceof Spawn || one instanceof Sequence) {
-            one.updateWorkerTarget(workerTarget);
-        } else {
-            one.workerTarget = workerTarget;
+            one.updateOwner(owner);
+        } else if (!one._owner) { // action's owner should never be changed, so only set owner when it's not set yet.
+            one._owner = owner;
         }
     }
 

--- a/cocos/tween/tween-action.ts
+++ b/cocos/tween/tween-action.ts
@@ -205,7 +205,7 @@ export class TweenAction<T extends object> extends ActionInterval {
     clone (): TweenAction<T> {
         const action = new TweenAction(this._duration, this._originProps, this._opts);
         action._reversed = this._reversed;
-        action.workerTarget = this.workerTarget;
+        action._owner = this._owner;
         action._id = this._id;
         this._cloneDecoration(action);
         return action;
@@ -220,7 +220,7 @@ export class TweenAction<T extends object> extends ActionInterval {
         const action = new TweenAction(this._duration, this._originProps, this._opts);
         this._cloneDecoration(action);
         action._reversed = !this._reversed;
-        action.workerTarget = this.workerTarget;
+        action._owner = this._owner;
         return action;
     }
 
@@ -229,7 +229,7 @@ export class TweenAction<T extends object> extends ActionInterval {
         if (!isEqual) return;
         super.startWithTarget(target);
 
-        const workerTarget = (this.workerTarget ?? this.target) as T;
+        const workerTarget = this._getWorkerTarget<T>();
         if (!workerTarget) return;
         const relative = !!this._opts.relative;
         const props = this._props;
@@ -355,7 +355,7 @@ export class TweenAction<T extends object> extends ActionInterval {
     }
 
     update (t: number): void {
-        const workerTarget = (this.workerTarget ?? this.target) as T;
+        const workerTarget = this._getWorkerTarget<T>();
         if (!workerTarget) return;
 
         if (!this._opts) return;

--- a/cocos/tween/tween.ts
+++ b/cocos/tween/tween.ts
@@ -851,29 +851,33 @@ export class Tween<T extends object = any> {
         return action;
     }
 
-    private static readonly _tmp_args: FiniteTimeAction[] = [];
+    private static readonly _tmpArgs: FiniteTimeAction[] = [];
 
     private static _tweenToActions<U extends object = any> (args: Tween<U>[]): void {
-        const tmp_args = Tween._tmp_args;
-        tmp_args.length = 0;
+        const tmpArgs = Tween._tmpArgs;
+        tmpArgs.length = 0;
         for (let l = args.length, i = 0; i < l; i++) {
             const t = args[i];
             const action = t._union(true);
             if (action) {
                 action.setSpeed(t._timeScale);
-                tmp_args.push(action);
+                tmpArgs.push(action);
             }
         }
     }
 
     private static _wrappedSequence<U extends object = any> (args: Tween<U>[]): Sequence | null {
         Tween._tweenToActions(args);
-        return sequence(Tween._tmp_args);
+        const ret = sequence(Tween._tmpArgs);
+        this._tmpArgs.length = 0;
+        return ret;
     }
 
     private static _wrappedParallel<U extends object = any> (args: Tween<U>[]): Spawn | null {
         Tween._tweenToActions(args);
-        return spawn(Tween._tmp_args);
+        const ret = spawn(Tween._tmpArgs);
+        this._tmpArgs.length = 0;
+        return ret;
     }
 }
 legacyCC.Tween = Tween;


### PR DESCRIPTION
Re: #18000

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
