### PR TITLE
fixed #17016: wrong assertion if label is empty and uses BitmapFont

### DIFF
--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -484,7 +484,9 @@ export class RenderData extends BaseRenderData {
         // Hack Do not update pre frame
         if (JSB && this.multiOwner === false) {
             if (DEBUG) {
-                assert(this._renderDrawInfo.render2dBuffer.length === this._floatStride * this._data.length, 'Vertex count doesn\'t match.');
+                if (this._renderDrawInfo && this._renderDrawInfo.render2dBuffer) {
+                    assert(this._renderDrawInfo.render2dBuffer.length === this._floatStride * this._data.length, 'Vertex count doesn\'t match.');
+                }
             }
             // sync shared buffer to native
             this._renderDrawInfo.fillRender2dBuffer(this._data);

--- a/cocos/2d/renderer/render-draw-info.ts
+++ b/cocos/2d/renderer/render-draw-info.ts
@@ -90,7 +90,7 @@ export class RenderDrawInfo {
     protected declare _uint32SharedBuffer: Uint32Array;
 
     // SharedBuffer of pos/uv/color
-    protected declare _render2dBuffer: Float32Array;
+    protected _render2dBuffer: Float32Array = null!;
 
     constructor (nativeDrawInfo?: NativeRenderDrawInfo) {
         this.init(nativeDrawInfo);

--- a/cocos/2d/renderer/render-draw-info.ts
+++ b/cocos/2d/renderer/render-draw-info.ts
@@ -90,7 +90,7 @@ export class RenderDrawInfo {
     protected declare _uint32SharedBuffer: Uint32Array;
 
     // SharedBuffer of pos/uv/color
-    protected _render2dBuffer: Float32Array = null!;
+    protected _render2dBuffer: Float32Array | null = null;
 
     constructor (nativeDrawInfo?: NativeRenderDrawInfo) {
         this.init(nativeDrawInfo);
@@ -107,7 +107,7 @@ export class RenderDrawInfo {
         return this._nativeObj;
     }
 
-    get render2dBuffer (): Float32Array {
+    get render2dBuffer (): Float32Array | null {
         return this._render2dBuffer;
     }
 
@@ -301,6 +301,9 @@ export class RenderDrawInfo {
 
     public fillRender2dBuffer (vertexDataArr: IRenderData[]): void {
         if (JSB) {
+            if (!this._render2dBuffer) {
+                return;
+            }
             const fillLength = Math.min(this._vbCount, vertexDataArr.length);
             let bufferOffset = 0;
             for (let i = 0; i < fillLength; i++) {


### PR DESCRIPTION
Re: #17016

Also reported at https://forum.cocos.org/t/topic/160454/17

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
