### PR TITLE
Fix memory leaks in Spine caused by not calling freeStoreMemory.

### DIFF
--- a/cocos/spine/lib/spine-core.d.ts
+++ b/cocos/spine/lib/spine-core.d.ts
@@ -1215,7 +1215,7 @@ declare namespace spine {
         static spineWasmInit(): void;
         static spineWasmDestroy(): void;
         static freeStoreMemory(): void;
-        static queryStoreMemory(size: number): number;
+        static createStoreMemory(size: number): number;
         static querySpineSkeletonDataByUUID(uuid: string): SkeletonData;
         static createSpineSkeletonDataWithJson(jsonStr: string, atlasText: string): SkeletonData;
         static createSpineSkeletonDataWithBinary(byteSize: number, atlasText: string): SkeletonData;

--- a/cocos/spine/lib/spine-core.d.ts
+++ b/cocos/spine/lib/spine-core.d.ts
@@ -1214,6 +1214,7 @@ declare namespace spine {
     class wasmUtil {
         static spineWasmInit(): void;
         static spineWasmDestroy(): void;
+        static freeStoreMemory(): void;
         static queryStoreMemory(size: number): number;
         static querySpineSkeletonDataByUUID(uuid: string): SkeletonData;
         static createSpineSkeletonDataWithJson(jsonStr: string, atlasText: string): SkeletonData;

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -218,7 +218,7 @@ export class SkeletonData extends Asset {
         } else {
             const rawData = new Uint8Array(this._nativeAsset);
             const byteSize = rawData.length;
-            const ptr = spine.wasmUtil.queryStoreMemory(byteSize);
+            const ptr = spine.wasmUtil.createStoreMemory(byteSize);
             const wasmMem = spine.wasmUtil.wasm.HEAPU8.subarray(ptr, ptr + byteSize);
             wasmMem.set(rawData);
             this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithBinary(byteSize, this._atlasText);

--- a/cocos/spine/skeleton-data.ts
+++ b/cocos/spine/skeleton-data.ts
@@ -223,6 +223,7 @@ export class SkeletonData extends Asset {
             wasmMem.set(rawData);
             this._skeletonCache = spine.wasmUtil.createSpineSkeletonDataWithBinary(byteSize, this._atlasText);
             spine.wasmUtil.registerSpineSkeletonDataWithUUID(this._skeletonCache, uuid);
+            spine.wasmUtil.freeStoreMemory();
         }
 
         return this._skeletonCache;

--- a/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
@@ -1383,6 +1383,7 @@ EMSCRIPTEN_BINDINGS(cocos_spine) {
     .class_function("spineWasmInit", &SpineWasmUtil::spineWasmInit)
     .class_function("spineWasmDestroy", &SpineWasmUtil::spineWasmDestroy)
     .class_function("queryStoreMemory", &SpineWasmUtil::queryStoreMemory)
+    .class_function("freeStoreMemory", &SpineWasmUtil::freeStoreMemory)
     .class_function("querySpineSkeletonDataByUUID", &SpineWasmUtil::querySpineSkeletonDataByUUID, allow_raw_pointers())
     .class_function("createSpineSkeletonDataWithJson", &SpineWasmUtil::createSpineSkeletonDataWithJson, allow_raw_pointers())
     .class_function("createSpineSkeletonDataWithBinary", &SpineWasmUtil::createSpineSkeletonDataWithBinary, allow_raw_pointers())

--- a/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-type-export.cpp
@@ -1382,7 +1382,7 @@ EMSCRIPTEN_BINDINGS(cocos_spine) {
     class_<SpineWasmUtil>("SpineWasmUtil")
     .class_function("spineWasmInit", &SpineWasmUtil::spineWasmInit)
     .class_function("spineWasmDestroy", &SpineWasmUtil::spineWasmDestroy)
-    .class_function("queryStoreMemory", &SpineWasmUtil::queryStoreMemory)
+    .class_function("createStoreMemory", &SpineWasmUtil::createStoreMemory)
     .class_function("freeStoreMemory", &SpineWasmUtil::freeStoreMemory)
     .class_function("querySpineSkeletonDataByUUID", &SpineWasmUtil::querySpineSkeletonDataByUUID, allow_raw_pointers())
     .class_function("createSpineSkeletonDataWithJson", &SpineWasmUtil::createSpineSkeletonDataWithJson, allow_raw_pointers())

--- a/native/cocos/editor-support/spine-wasm/spine-wasm.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-wasm.cpp
@@ -15,7 +15,6 @@ EventType SpineWasmUtil::s_currentType = EventType_Event;
 TrackEntry* SpineWasmUtil::s_currentEntry = nullptr;
 Event* SpineWasmUtil::s_currentEvent = nullptr;
 uint8_t* SpineWasmUtil::s_mem = nullptr;
-uint32_t SpineWasmUtil::s_memSize = 0;
 
 void SpineWasmUtil::spineWasmInit() {
     // LogUtil::Initialize();
@@ -95,9 +94,8 @@ void SpineWasmUtil::destroySpineSkeleton(Skeleton* skeleton) {
     }
 }
 
-uint32_t SpineWasmUtil::queryStoreMemory(uint32_t size) {
+uint32_t SpineWasmUtil::createStoreMemory(uint32_t size) {
     s_mem = new uint8_t[size];
-    s_memSize = size;
 
     return (uint32_t)s_mem;
 }
@@ -107,7 +105,6 @@ void SpineWasmUtil::freeStoreMemory() {
         delete[] s_mem;
         s_mem = nullptr;
     }
-    s_memSize = 0;
 }
 
 uint32_t SpineWasmUtil::getCurrentListenerID() {

--- a/native/cocos/editor-support/spine-wasm/spine-wasm.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-wasm.cpp
@@ -96,16 +96,9 @@ void SpineWasmUtil::destroySpineSkeleton(Skeleton* skeleton) {
 }
 
 uint32_t SpineWasmUtil::queryStoreMemory(uint32_t size) {
-    if (s_mem) {
-        if (s_memSize < size) {
-            delete[] s_mem;
-            s_mem = new uint8_t[size];
-            s_memSize = size;
-        }
-    } else {
-        s_mem = new uint8_t[size];
-        s_memSize = size;
-    }
+    s_mem = new uint8_t[size];
+    s_memSize = size;
+
     return (uint32_t)s_mem;
 }
 

--- a/native/cocos/editor-support/spine-wasm/spine-wasm.h
+++ b/native/cocos/editor-support/spine-wasm/spine-wasm.h
@@ -7,7 +7,7 @@ class SpineWasmUtil {
 public:
     static void spineWasmInit();
     static void spineWasmDestroy();
-    static uint32_t queryStoreMemory(uint32_t size);
+    static uint32_t createStoreMemory(uint32_t size);
     static void freeStoreMemory();
 
     static spine::SkeletonData* querySpineSkeletonDataByUUID(const spine::String& uuid);
@@ -28,5 +28,4 @@ public:
     static spine::Event* s_currentEvent;
 
     static uint8_t* s_mem;
-    static uint32_t s_memSize;
 };


### PR DESCRIPTION
Re: #
https://github.com/cocos/3d-tasks/issues/18640

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
