### PR TITLE
Fix spine can not show normally after disable and then active node.

### DIFF
--- a/native/cocos/editor-support/MiddlewareManager.cpp
+++ b/native/cocos/editor-support/MiddlewareManager.cpp
@@ -54,7 +54,7 @@ MeshBuffer *MiddlewareManager::getMeshBuffer(int format) {
     return mb;
 }
 
-void MiddlewareManager::updateCache() {
+void MiddlewareManager::updateOperateCache() {
     for (auto &iter: _operateCacheMap) {
         auto it = std::find(_updateList.begin(), _updateList.end(), iter.first);
         if (iter.second) {
@@ -69,7 +69,7 @@ void MiddlewareManager::updateCache() {
 }
 
 void MiddlewareManager::update(float dt) {
-    updateCache();
+    updateOperateCache();
     _attachInfo.reset();
     auto *attachBuffer = _attachInfo.getBuffer();
     if (attachBuffer) {

--- a/native/cocos/editor-support/MiddlewareManager.cpp
+++ b/native/cocos/editor-support/MiddlewareManager.cpp
@@ -55,15 +55,17 @@ MeshBuffer *MiddlewareManager::getMeshBuffer(int format) {
 }
 
 void MiddlewareManager::updateCache() {
-    for (auto &iter: _updateMap) {
+    for (auto &iter: _operateCacheMap) {
         auto it = std::find(_updateList.begin(), _updateList.end(), iter.first);
-        if (iter.second && it == _updateList.end()) {
-            _updateList.push_back(iter.first);
-        } else if (!iter.second && it != _updateList.end()) {
+        if (iter.second) {
+            if (it == _updateList.end()) {
+                _updateList.push_back(iter.first);
+            }
+        } else if (it != _updateList.end()) {
             _updateList.erase(it);
         }
     }
-    _updateMap.clear();
+    _operateCacheMap.clear();
 }
 
 void MiddlewareManager::update(float dt) {
@@ -116,11 +118,11 @@ void MiddlewareManager::render(float dt) {
 }
 
 void MiddlewareManager::addTimer(IMiddleware *editor) {
-    _updateMap[editor] = true;
+    _operateCacheMap[editor] = true;
 }
 
 void MiddlewareManager::removeTimer(IMiddleware *editor) {
-    _updateMap[editor] = false;
+    _operateCacheMap[editor] = false;
 }
 
 se_object_ptr MiddlewareManager::getVBTypedArray(int format, int bufferPos) {

--- a/native/cocos/editor-support/MiddlewareManager.cpp
+++ b/native/cocos/editor-support/MiddlewareManager.cpp
@@ -54,20 +54,20 @@ MeshBuffer *MiddlewareManager::getMeshBuffer(int format) {
     return mb;
 }
 
-void MiddlewareManager::clearRemoveList() {
-    for (auto *editor : _removeList) {
-        auto it = std::find(_updateList.begin(), _updateList.end(), editor);
-        if (it != _updateList.end()) {
+void MiddlewareManager::updateCache() {
+    for (auto &iter: _updateMap) {
+        auto it = std::find(_updateList.begin(), _updateList.end(), iter.first);
+        if (iter.second && it == _updateList.end()) {
+            _updateList.push_back(iter.first);
+        } else if (!iter.second && it != _updateList.end()) {
             _updateList.erase(it);
         }
     }
-
-    _removeList.clear();
+    _updateMap.clear();
 }
 
 void MiddlewareManager::update(float dt) {
-    isUpdating = true;
-
+    updateCache();
     _attachInfo.reset();
     auto *attachBuffer = _attachInfo.getBuffer();
     if (attachBuffer) {
@@ -76,23 +76,8 @@ void MiddlewareManager::update(float dt) {
 
     for (size_t i = 0, len = _updateList.size(); i < len; ++i) {
         auto *editor = _updateList[i];
-        if (!_removeList.empty()) {
-            auto removeIt = std::find(_removeList.begin(), _removeList.end(), editor);
-            if (removeIt == _removeList.end()) {
-                if (editor) {
-                    editor->update(dt);
-                }
-            }
-        } else {
-            if (editor) {
-                editor->update(dt);
-            }
-        }
+        editor->update(dt);
     }
-
-    isUpdating = false;
-
-    clearRemoveList();
 }
 
 void MiddlewareManager::render(float dt) {
@@ -103,21 +88,11 @@ void MiddlewareManager::render(float dt) {
         }
     }
 
-    isRendering = true;
 
     for (size_t i = 0, len = _updateList.size(); i < len; ++i) {
         auto *editor = _updateList[i];
-        if (!_removeList.empty()) {
-            auto removeIt = std::find(_removeList.begin(), _removeList.end(), editor);
-            if (removeIt == _removeList.end()) {
-                editor->render(dt);
-            }
-        } else {
-            editor->render(dt);
-        }
+        editor->render(dt);
     }
-
-    isRendering = false;
 
     for (auto it : _mbMap) {
         auto *buffer = it.second;
@@ -138,33 +113,14 @@ void MiddlewareManager::render(float dt) {
         }
         batch2d->syncMeshBuffersToNative(accID, std::move(uiMeshArray));
     }
-
-    clearRemoveList();
 }
 
 void MiddlewareManager::addTimer(IMiddleware *editor) {
-    auto it1 = std::find(_removeList.begin(), _removeList.end(), editor);
-    if (it1 != _removeList.end()) {
-        _removeList.erase(it1);
-    }
-
-    auto it0 = std::find(_updateList.begin(), _updateList.end(), editor);
-    if (it0 != _updateList.end()) {
-        return;
-    }
-    
-    _updateList.push_back(editor);
+    _updateMap[editor] = true;
 }
 
 void MiddlewareManager::removeTimer(IMiddleware *editor) {
-    if (isUpdating || isRendering) {
-        _removeList.push_back(editor);
-    } else {
-        auto it = std::find(_updateList.begin(), _updateList.end(), editor);
-        if (it != _updateList.end()) {
-            _updateList.erase(it);
-        }
-    }
+    _updateMap[editor] = false;
 }
 
 se_object_ptr MiddlewareManager::getVBTypedArray(int format, int bufferPos) {

--- a/native/cocos/editor-support/MiddlewareManager.cpp
+++ b/native/cocos/editor-support/MiddlewareManager.cpp
@@ -143,15 +143,16 @@ void MiddlewareManager::render(float dt) {
 }
 
 void MiddlewareManager::addTimer(IMiddleware *editor) {
-    auto it0 = std::find(_updateList.begin(), _updateList.end(), editor);
-    if (it0 != _updateList.end()) {
-        return;
-    }
-
     auto it1 = std::find(_removeList.begin(), _removeList.end(), editor);
     if (it1 != _removeList.end()) {
         _removeList.erase(it1);
     }
+
+    auto it0 = std::find(_updateList.begin(), _updateList.end(), editor);
+    if (it0 != _updateList.end()) {
+        return;
+    }
+    
     _updateList.push_back(editor);
 }
 

--- a/native/cocos/editor-support/MiddlewareManager.h
+++ b/native/cocos/editor-support/MiddlewareManager.h
@@ -83,13 +83,13 @@ public:
     void render(float dt);
 
     /**
-     * @brief Third party module add in _updateMap,it will update perframe.
+     * @brief Mark the add flag to _operateCacheMap, and perform the update in the next frame
      * @param[in] editor Module must implement IMiddleware interface.
      */
     void addTimer(IMiddleware *editor);
 
     /**
-     * @brief Third party module remove from _updateMap,it will stop update.
+     * @brief Mark the remove flag to _operateCacheMap, and perform the update in the next frame
      * @param[in] editor Module must implement IMiddleware interface.
      */
     void removeTimer(IMiddleware *editor);
@@ -112,7 +112,7 @@ private:
     void updateCache();
 
     ccstd::vector<IMiddleware *> _updateList;
-    ccstd::unordered_map<IMiddleware *, bool> _updateMap;
+    ccstd::unordered_map<IMiddleware *, bool> _operateCacheMap;
     ccstd::unordered_map<int, MeshBuffer *> _mbMap;
 
     SharedBufferManager _renderInfo;

--- a/native/cocos/editor-support/MiddlewareManager.h
+++ b/native/cocos/editor-support/MiddlewareManager.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include "MeshBuffer.h"
 #include "MiddlewareMacro.h"
@@ -108,16 +108,12 @@ public:
     MiddlewareManager();
     ~MiddlewareManager();
 
-    // If manager is traversing _updateMap, will set the flag untill traverse is finished.
-    bool isRendering = false;
-    bool isUpdating = false;
-
 private:
-    void clearRemoveList();
+    void updateCache();
 
     ccstd::vector<IMiddleware *> _updateList;
-    ccstd::vector<IMiddleware *> _removeList;
-    std::map<int, MeshBuffer *> _mbMap;
+    ccstd::unordered_map<IMiddleware *, bool> _updateMap;
+    ccstd::unordered_map<int, MeshBuffer *> _mbMap;
 
     SharedBufferManager _renderInfo;
     SharedBufferManager _attachInfo;

--- a/native/cocos/editor-support/MiddlewareManager.h
+++ b/native/cocos/editor-support/MiddlewareManager.h
@@ -109,7 +109,7 @@ public:
     ~MiddlewareManager();
 
 private:
-    void updateCache();
+    void updateOperateCache();
 
     ccstd::vector<IMiddleware *> _updateList;
     ccstd::unordered_map<IMiddleware *, bool> _operateCacheMap;

--- a/native/cocos/editor-support/dragonbones-creator-support/CCArmatureCacheDisplay.cpp
+++ b/native/cocos/editor-support/dragonbones-creator-support/CCArmatureCacheDisplay.cpp
@@ -141,7 +141,6 @@ void CCArmatureCacheDisplay::render(float /*dt*/) {
     if (!frameData) return;
 
     auto *mgr = MiddlewareManager::getInstance();
-    if (!mgr->isRendering) return;
     auto *entity = _entity;
     entity->clearDynamicRenderDrawInfos();
 

--- a/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/native/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -108,7 +108,6 @@ void CCArmatureDisplay::dbRender() {
     entity->clearDynamicRenderDrawInfos();
 
     auto *mgr = MiddlewareManager::getInstance();
-    if (!mgr->isRendering) return;
 
     auto *attachMgr = mgr->getAttachInfoMgr();
     auto *attachInfo = attachMgr->getBuffer();

--- a/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
@@ -165,7 +165,6 @@ void SkeletonCacheAnimation::render(float /*dt*/) {
     if (segments.empty() || colors.empty()) return;
 
     auto *mgr = MiddlewareManager::getInstance();
-    if (!mgr->isRendering) return;
 
     _sharedBufferOffset->reset();
     _sharedBufferOffset->clear();

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -266,7 +266,6 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
 
     // avoid other place call update.
     auto *mgr = MiddlewareManager::getInstance();
-    if (!mgr->isRendering) return;
 
     auto *attachMgr = mgr->getAttachInfoMgr();
     auto *attachInfo = attachMgr->getBuffer();


### PR DESCRIPTION
Re: #
https://github.com/cocos/cocos-engine/issues/18008

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
