### PR TITLE
fixed #17593: [v3.8.6] 2D Particle crash on native platforms.

### DIFF
--- a/cocos/misc/renderer.ts
+++ b/cocos/misc/renderer.ts
@@ -176,6 +176,9 @@ export class Renderer extends Component {
         if (material && material instanceof MaterialInstance) {
             errorID(12012);
         }
+
+        if (this._materials[index] === material) return;
+
         this._materials[index] = material;
         const inst = this._materialInstances[index];
         if (inst) {

--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -373,7 +373,7 @@ void Batcher2d::generateBatch(RenderEntity* entity, RenderDrawInfo* drawInfo) {
     curdrawBatch->setIndexCount(indexCount);
     curdrawBatch->fillPass(_currMaterial, depthStencil, dssHash);
     const auto &passes = curdrawBatch->getPasses();
-    if (!passes.empty())
+    if (!passes.empty()) {
         const auto& pass = passes.at(0);
         if (entity->getUseLocal()) {
             drawInfo->updateLocalDescriptorSet(entity->getRenderTransform(), pass->getLocalSetLayout());

--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -334,7 +334,7 @@ void Batcher2d::generateBatch(RenderEntity* entity, RenderDrawInfo* drawInfo) {
         return;
     }
     gfx::InputAssembler* ia = nullptr;
-    
+
     uint32_t indexOffset = 0;
     uint32_t indexCount = 0;
     if (drawInfo->getIsMeshBuffer()) {
@@ -345,9 +345,9 @@ void Batcher2d::generateBatch(RenderEntity* entity, RenderDrawInfo* drawInfo) {
         _meshRenderDrawInfo.emplace_back(drawInfo);
     } else {
         UIMeshBuffer* currMeshBuffer = drawInfo->getMeshBuffer();
-        
+
         currMeshBuffer->setDirty(true);
-        
+
         ia = currMeshBuffer->requireFreeIA(getDevice());
         indexCount = currMeshBuffer->getIndexOffset() - _indexStart;
         if (ia == nullptr) {
@@ -356,16 +356,16 @@ void Batcher2d::generateBatch(RenderEntity* entity, RenderDrawInfo* drawInfo) {
         indexOffset = _indexStart;
         _indexStart = currMeshBuffer->getIndexOffset();
     }
-    
+
     _currMeshBuffer = nullptr;
-    
+
     // stencilStage
     gfx::DepthStencilState* depthStencil = nullptr;
     ccstd::hash_t dssHash = 0;
     StencilStage entityStage = entity->getEnumStencilStage();
     depthStencil = _stencilManager->getDepthStencilState(entityStage, _currMaterial);
     dssHash = _stencilManager->getStencilHash(entityStage);
-    
+
     auto* curdrawBatch = _drawBatchPool.alloc();
     curdrawBatch->setVisFlags(_currLayer);
     curdrawBatch->setInputAssembler(ia);


### PR DESCRIPTION
Batcher2D may use destroyed Material whose passes is empty, which will cause 'curdrawBatch->getPasses().at(0);' vector visit overflow.

Re: #17593

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
