### PR TITLE
Improve handling of SpriteAtlas after setting up a SpriteFrame in Sprite

### DIFF
--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -27,7 +27,7 @@ import { ccclass, help, executionOrder, menu, tooltip, displayOrder, type, range
 import { BUILD, EDITOR } from 'internal:constants';
 import { SpriteAtlas } from '../assets/sprite-atlas';
 import { SpriteFrame, SpriteFrameEvent } from '../assets/sprite-frame';
-import { Vec2, cclegacy, ccenum, clamp, warnID, warn } from '../../core';
+import { Vec2, cclegacy, ccenum, clamp, warnID } from '../../core';
 import { IBatcher } from '../renderer/i-batcher';
 import { UIRenderer, InstanceMaterialType } from '../framework/ui-renderer';
 import { PixelFormat } from '../../asset/assets/asset-enum';

--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -27,14 +27,13 @@ import { ccclass, help, executionOrder, menu, tooltip, displayOrder, type, range
 import { BUILD, EDITOR } from 'internal:constants';
 import { SpriteAtlas } from '../assets/sprite-atlas';
 import { SpriteFrame, SpriteFrameEvent } from '../assets/sprite-frame';
-import { Vec2, cclegacy, ccenum, clamp, warnID, error } from '../../core';
+import { Vec2, cclegacy, ccenum, clamp, warnID, warn } from '../../core';
 import { IBatcher } from '../renderer/i-batcher';
 import { UIRenderer, InstanceMaterialType } from '../framework/ui-renderer';
 import { PixelFormat } from '../../asset/assets/asset-enum';
 import { TextureBase } from '../../asset/assets/texture-base';
 import { Material, RenderTexture } from '../../asset/assets';
 import { NodeEventType } from '../../scene-graph/node-event';
-import assetManager from '../../asset/asset-manager/asset-manager';
 
 /**
  * @en
@@ -488,7 +487,6 @@ export class Sprite extends UIRenderer {
 
         if (EDITOR) {
             this._resized();
-            this._applyAtlas(this._spriteFrame);
             this.node.on(NodeEventType.SIZE_CHANGED, this._resized, this);
         }
     }
@@ -716,32 +714,6 @@ export class Sprite extends UIRenderer {
             if (self._type === SpriteType.SLICED) {
                 spriteFrame.on(SpriteFrameEvent.UV_UPDATED, self._updateUVs, self);
             }
-        }
-
-        if (EDITOR) {
-            self._applyAtlas(spriteFrame);
-        }
-    }
-
-    private _applyAtlas (spriteFrame: SpriteFrame | null): void {
-        if (!EDITOR) return;
-
-        if (!spriteFrame) return;
-
-        if (spriteFrame.atlasUuid.length === 0) {
-            this.spriteAtlas = null;
-            return;
-        }
-
-        if (!this.spriteAtlas || this.spriteAtlas.uuid !== spriteFrame.atlasUuid) {
-            assetManager.loadAny(spriteFrame.atlasUuid, (err: Error, asset: SpriteAtlas) => {
-                if (err) {
-                    this.spriteAtlas = null;
-                    error(err);
-                } else {
-                    this.spriteAtlas = asset;
-                }
-            });
         }
     }
 }

--- a/editor/inspector/components/sprite.js
+++ b/editor/inspector/components/sprite.js
@@ -11,7 +11,7 @@ exports.close = close;
 const { setHidden, setReadonly, isMultipleInvalid } = require('../utils/prop');
 
 const AUTO_ATLAS_EXTNAME = '.pac';
-const ASSET_Dir = join(Editor.Project.path, 'assets');
+const ASSET_DIR = join(Editor.Project.path, 'assets');
 
 // Query the automatic atlas with the .pac suffix
 async function findAutoAtlasFolder(spriteFrameUuid) {
@@ -22,7 +22,7 @@ async function findAutoAtlasFolder(spriteFrameUuid) {
     }
 
     let dir = dirname(filePath);
-    while (dir !== ASSET_Dir) {
+    while (dir !== ASSET_DIR) {
         const files = readdirSync(dir);
         const file = files.find(file => file.endsWith(AUTO_ATLAS_EXTNAME));
         if (file) {

--- a/editor/inspector/components/sprite.js
+++ b/editor/inspector/components/sprite.js
@@ -1,3 +1,6 @@
+const { lstatSync, existsSync, readdirSync } = require('fs-extra');
+const { dirname, join } = require('path');
+
 const { template, $, update, close } = require('./base');
 
 exports.template = template;
@@ -6,6 +9,43 @@ exports.update = update;
 exports.close = close;
 
 const { setHidden, setReadonly, isMultipleInvalid } = require('../utils/prop');
+
+const AUTO_ATLAS_EXTNAME = '.pac';
+const ASSET_Dir = join(Editor.Project.path, 'assets');
+
+// Query the automatic atlas with the .pac suffix
+async function findAutoAtlasFolder(spriteFrameUuid) {
+    const filePath = await Editor.Message.request('asset-db', 'query-path', spriteFrameUuid);
+
+    if (!filePath) {
+        return;
+    }
+
+    let dir = dirname(filePath);
+    while (dir !== ASSET_Dir) {
+        const files = readdirSync(dir);
+        const file = files.find(file => file.endsWith(AUTO_ATLAS_EXTNAME));
+        if (file) {
+            const meta = await Editor.Message.request('asset-db', 'query-asset-meta', join(dir, file));
+            if (meta && meta.importer === 'auto-atlas') {
+                return meta.uuid;
+            }
+        } else {
+            dir = dirname(dir);
+        }
+    }
+    return null;
+}
+
+// query the dom node by type
+function findDomByType(parentElement, type) {
+    for (const child of parentElement.children) {
+        if (child.dump.type === type) {
+            return child;
+        }
+    }
+    return null;
+}
 
 exports.ready = function() {
     this.elements = {
@@ -28,6 +68,46 @@ exports.ready = function() {
         fillRange: {
             update(element, dump) {
                 this.elements.fillType.update.call(this, element, dump);
+            },
+        },
+        spriteFrame: {
+            ready(element, dump) {
+                element.addEventListener('change-dump', (event) => {
+                    const spriteFrameDump = event.target.dump;
+                    const spriteFrameUuid = spriteFrameDump.value.uuid;
+                    if (!spriteFrameUuid) {
+                        return;
+                    }
+
+                    const parentElement = event.target.parentElement;
+                    if (!parentElement) {
+                        return;
+                    }
+
+                    Editor.Message.request('asset-db', 'query-asset-meta', spriteFrameUuid)
+                        .then(async (spriteFrameMeta) => {
+                            if (!spriteFrameMeta || !spriteFrameMeta.userData) {
+                                return;
+                            }
+
+                            let autoAtlasUuid = '';
+                            if (!spriteFrameMeta.userData.atlasUuid) {
+                                autoAtlasUuid = await findAutoAtlasFolder(spriteFrameUuid);
+                            }
+
+                            const spriteAtlasDom = findDomByType(parentElement, 'cc.SpriteAtlas');
+                            if (!spriteAtlasDom) {
+                                return;
+                            }
+
+                            spriteAtlasDom.value = spriteFrameMeta.userData.atlasUuid || autoAtlasUuid;
+                            spriteAtlasDom.dispatch('change');
+                            spriteAtlasDom.dispatch('confirm');
+                        })
+                        .catch((err) => {
+                            console.error(err);
+                        });
+                });
             },
         },
     };


### PR DESCRIPTION
Re: #

https://forum.cocos.org/t/topic/163455/388

### Changelog

1. Remove `_applyAtlas` from the engine code and handle it in the Editor Sprite inspector panel instead.
2.Dependent atlas asset are only set if the user sets a SpriteFrame

Since the SpriteFrame's atlasUuid is null when using auto-atlas, the meta importer is the auto-atlas asset by up-querying for a suffix of .pac

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
