### PR TITLE
Remove treating AMOTION_EVENT_TOOL_TYPE_STYLUS events as mouse events

### DIFF
--- a/native/cocos/platform/android/AndroidPlatform.cpp
+++ b/native/cocos/platform/android/AndroidPlatform.cpp
@@ -423,7 +423,7 @@ public:
             int actionMasked = action & AMOTION_EVENT_ACTION_MASK;
             int eventChangedIndex = -1;
 
-            bool isMouseEvent = motionEvent->pointerCount > 0 && (motionEvent->pointers[0].toolType == AMOTION_EVENT_TOOL_TYPE_STYLUS || motionEvent->pointers[0].toolType == AMOTION_EVENT_TOOL_TYPE_MOUSE);
+            bool isMouseEvent = motionEvent->pointerCount > 0 && motionEvent->pointers[0].toolType == AMOTION_EVENT_TOOL_TYPE_MOUSE;
 
             if (actionMasked == AMOTION_EVENT_ACTION_DOWN ||
                 actionMasked == AMOTION_EVENT_ACTION_POINTER_DOWN) {

--- a/native/cocos/platform/android/AndroidPlatform.cpp
+++ b/native/cocos/platform/android/AndroidPlatform.cpp
@@ -237,7 +237,7 @@ public:
                     controllerEvent = true;
                 } else {
                     // Didn't belong to a game controller, process it ourselves if it is a touch event
-                    bool isMouseEvent = motionEvent->pointerCount > 0 && (motionEvent->pointers[0].toolType == AMOTION_EVENT_TOOL_TYPE_STYLUS || motionEvent->pointers[0].toolType == AMOTION_EVENT_TOOL_TYPE_MOUSE);
+                    bool isMouseEvent = motionEvent->pointerCount > 0 && motionEvent->pointers[0].toolType == AMOTION_EVENT_TOOL_TYPE_MOUSE;
                     if (isMouseEvent) {
                         cookGameActivityMouseEvent(motionEvent);
                     } else {


### PR DESCRIPTION
Re: #

### Changelog

https://github.com/cocos/cocos-engine/issues/16533

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
