### PR TITLE
fix #17890: preview scene in editor should also destroy object at the end of the frame rendering

### DIFF
--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -298,7 +298,7 @@ class CCObject implements EditorExtendableObject {
         this._objFlags |= ToDestroy;
         objectsToDestroy.push(this);
 
-        if (EDITOR && deferredDestroyTimer === null && legacyCC.engine && !legacyCC.engine._isUpdating) {
+        if (EDITOR_NOT_IN_PREVIEW && deferredDestroyTimer === null && legacyCC.engine && !legacyCC.engine._isUpdating) {
             // auto destroy immediate in edit mode
             deferredDestroyTimer = setTimeout(CCObject._deferredDestroy);
         }


### PR DESCRIPTION
https://github.com/cocos/cocos-engine/issues/17890

As the modification shows, `setTimeout(CCObject._deferredDestroy);` may destroy object at any time. It doesn't promise to destroy objects at the end of the frame. Then other engine components may refer the an invalid object. Which is problem. 

preview scene in editor will trigger the issue. So just destroy objects immediately only in editor mode. Editor doesn't use `requestAnimationFrame` to drive engine loop, it control the loop itself.