### PR TITLE
fix bug when fileSource variable is empty

### DIFF
--- a/editor/inspector/assets/effect.js
+++ b/editor/inspector/assets/effect.js
@@ -26,18 +26,18 @@ exports.template = /* html */`
 `;
 
 exports.style = /* css */`
-    .asset-effect { 
-        padding-right: 4px;    
+    .asset-effect {
+        padding-right: 4px;
     }
 
     .asset-effect[multiple-invalid] > *:not(.multiple-warn-tip) {
         display: none!important;
      }
-    
+
      .asset-effect[multiple-invalid] > .multiple-warn-tip {
         display: block;
      }
-    
+
     .asset-effect .multiple-warn-tip {
         display: none;
         text-align: center;
@@ -305,7 +305,7 @@ exports.methods = {
 
         const fileSource = panel.asset.library['.json'];
 
-        if (fileSource && !existsSync(fileSource)) {
+        if (!fileSource || !existsSync(fileSource)) {
             console.error('Read effect json file in library failed.');
             return false;
         }


### PR DESCRIPTION
Re: #

### Changelog

* Before reading fileSource, it is necessary to check both whether the fileSource field exists and whether the file itself exists.（found it from [sentry](https://sentry.cocos.org/organizations/sentry/issues/29/?environment=production&project=11&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=user&statsPeriod=14d&stream_index=2) ）

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
