### PR TITLE
Fix crashes caused by compatibility issues on Android 6.0 and below.

### DIFF
--- a/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
@@ -66,7 +66,9 @@ void *gles2wLoad(const char *proc) {
 }
 #else
     #include <dlfcn.h>
-#include <BasePlatform.h>
+    #include "BasePlatform.h"
+    #include "eglw.h"
+    #include "gles2w.h"
 
 namespace {
     void *libegl = nullptr;

--- a/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
@@ -66,6 +66,7 @@ void *gles2wLoad(const char *proc) {
 }
 #else
     #include <dlfcn.h>
+#include <BasePlatform.h>
 
 static void *libegl = nullptr;
 static void *libgles = nullptr;
@@ -98,7 +99,12 @@ bool gles2wClose() {
 void *gles2wLoad(const char *proc) {
     void *res = nullptr;
     if (eglGetProcAddress) res = reinterpret_cast<void *>(eglGetProcAddress(proc));
-    if (!res) res = dlsym(libegl, proc);
+    auto sdkVersion = cc::BasePlatform::getPlatform()->getSdkVersion();
+    if (sdkVersion <= 23) {
+        if (!res) res = dlsym(libgles, proc);
+    } else {
+        if (!res) res = dlsym(libegl, proc);
+    }
     return res;
 }
 #endif

--- a/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
@@ -69,8 +69,8 @@ void *gles2wLoad(const char *proc) {
 #include <BasePlatform.h>
 
 namespace {
-    static void *libegl = nullptr;
-    static void *libgles = nullptr;
+    void *libegl = nullptr;
+    void *libgles = nullptr;
 }
 
 bool gles2wOpen() {

--- a/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
@@ -28,10 +28,8 @@
     #define WIN32_LEAN_AND_MEAN 1
     #include <windows.h>
 
-namespace {
-    static HMODULE libegl = NULL;
-    static HMODULE libgles = NULL;
-}
+static HMODULE libegl = NULL;
+static HMODULE libgles = NULL;
 
 bool gles2wOpen() {
     libegl = LoadLibraryA("libEGL.dll");
@@ -70,8 +68,10 @@ void *gles2wLoad(const char *proc) {
     #include <dlfcn.h>
 #include <BasePlatform.h>
 
-static void *libegl = nullptr;
-static void *libgles = nullptr;
+namespace {
+    static void *libegl = nullptr;
+    static void *libgles = nullptr;
+}
 
 bool gles2wOpen() {
     libegl = dlopen("libEGL.so", RTLD_LAZY | RTLD_GLOBAL);

--- a/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
@@ -28,8 +28,10 @@
     #define WIN32_LEAN_AND_MEAN 1
     #include <windows.h>
 
-static HMODULE libegl = NULL;
-static HMODULE libgles = NULL;
+namespace {
+    static HMODULE libegl = NULL;
+    static HMODULE libgles = NULL;
+}
 
 bool gles2wOpen() {
     libegl = LoadLibraryA("libEGL.dll");

--- a/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Wrangler.cpp
@@ -67,8 +67,8 @@ void *gles2wLoad(const char *proc) {
 #else
     #include <dlfcn.h>
     #include "BasePlatform.h"
-    #include "eglw.h"
-    #include "gles2w.h"
+    #include "../gfx-gles-common/eglw.h"
+    #include "../gfx-gles-common/gles2w.h"
 
 namespace {
     void *libegl = nullptr;

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -31,11 +31,9 @@
     #define WIN32_LEAN_AND_MEAN 1
     #include <windows.h>
 
-namespace {
-    static HMODULE libegl = NULL;
-    static HMODULE libgles = NULL;
-    static PFNGLES3WLOADPROC pfnGles3wLoad = NULL;
-}
+static HMODULE libegl = NULL;
+static HMODULE libgles = NULL;
+static PFNGLES3WLOADPROC pfnGles3wLoad = NULL;
 
 bool gles3wOpen() {
     std::string eglPath = "libEGL.dll";
@@ -104,9 +102,11 @@ void *gles3wLoad(const char *proc) {
     #include <dlfcn.h>
 #include <BasePlatform.h>
 
-static void *libegl = nullptr;
-static void *libgles = nullptr;
-static PFNGLES3WLOADPROC pfnGles3wLoad = nullptr;
+namespace {
+    static void *libegl = nullptr;
+    static void *libgles = nullptr;
+    static PFNGLES3WLOADPROC pfnGles3wLoad = nullptr;
+}
 
 bool gles3wOpen() {
     libegl = dlopen("libEGL.so", RTLD_LAZY | RTLD_GLOBAL);

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -101,8 +101,8 @@ void *gles3wLoad(const char *proc) {
 #else
     #include <dlfcn.h>
     #include "BasePlatform.h"
-    #include "eglw.h"
-    #include "gles3w.h"
+    #include "../gfx-gles-common/eglw.h"
+    #include "../gfx-gles-common/gles3w.h"
 
 
 namespace {

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -103,9 +103,9 @@ void *gles3wLoad(const char *proc) {
 #include <BasePlatform.h>
 
 namespace {
-    static void *libegl = nullptr;
-    static void *libgles = nullptr;
-    static PFNGLES3WLOADPROC pfnGles3wLoad = nullptr;
+    void *libegl = nullptr;
+    void *libgles = nullptr;
+    PFNGLES3WLOADPROC pfnGles3wLoad = nullptr;
 }
 
 bool gles3wOpen() {

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -23,12 +23,12 @@
 ****************************************************************************/
 
 #include "GLES3Wrangler.h"
-#include <string>
-#include "base/Log.h"
-#include "base/memory/Memory.h"
 
 #if defined(_WIN32) && !defined(ANDROID)
     #define WIN32_LEAN_AND_MEAN 1
+    #include <string>
+    #include "base/Log.h"
+    #include "base/memory/Memory.h"
     #include <windows.h>
 
 static HMODULE libegl = NULL;

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -100,7 +100,10 @@ void *gles3wLoad(const char *proc) {
 }
 #else
     #include <dlfcn.h>
-#include <BasePlatform.h>
+    #include "BasePlatform.h"
+    #include "eglw.h"
+    #include "gles3w.h"
+
 
 namespace {
     void *libegl = nullptr;

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -102,6 +102,7 @@ void *gles3wLoad(const char *proc) {
     #include <dlfcn.h>
     #include "BasePlatform.h"
     #include "../gfx-gles-common/eglw.h"
+    #include "../gfx-gles-common/gles2w.h"
     #include "../gfx-gles-common/gles3w.h"
 
 

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -31,9 +31,11 @@
     #define WIN32_LEAN_AND_MEAN 1
     #include <windows.h>
 
-static HMODULE libegl = NULL;
-static HMODULE libgles = NULL;
-static PFNGLES3WLOADPROC pfnGles3wLoad = NULL;
+namespace {
+    static HMODULE libegl = NULL;
+    static HMODULE libgles = NULL;
+    static PFNGLES3WLOADPROC pfnGles3wLoad = NULL;
+}
 
 bool gles3wOpen() {
     std::string eglPath = "libEGL.dll";

--- a/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Wrangler.cpp
@@ -100,6 +100,7 @@ void *gles3wLoad(const char *proc) {
 }
 #else
     #include <dlfcn.h>
+#include <BasePlatform.h>
 
 static void *libegl = nullptr;
 static void *libgles = nullptr;
@@ -129,7 +130,12 @@ bool gles3wClose() {
 void *gles3wLoad(const char *proc) {
     void *res = nullptr;
     if (eglGetProcAddress) res = reinterpret_cast<void *>(eglGetProcAddress(proc));
-    if (!res) res = dlsym(libegl, proc);
+    auto sdkVersion = cc::BasePlatform::getPlatform()->getSdkVersion();
+    if (sdkVersion <= 23) {
+        if (!res) res = dlsym(libgles, proc);
+    } else {
+        if (!res) res = dlsym(libegl, proc);
+    }
     return res;
 }
 #endif


### PR DESCRIPTION
Re: #
https://forum.cocos.org/t/topic/157585


On devices running Android 6.0 (API level 23) and below, libGLESv3 or libGLESv2 includes the libEGL interfaces. This is because earlier versions of Android merged the implementation of OpenGL ES, with libGLESv3 not only providing OpenGL ES 3.x functionality but also integrating EGL features.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
