### PR TITLE
[v3.8.6] Optimize code size for optional chaining

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@cocos/box2d": "1.0.1",
         "@cocos/cannon": "1.2.8",
-        "@cocos/ccbuild": "^2.3.6",
+        "@cocos/ccbuild": "^2.3.8",
         "@cocos/dragonbones-js": "^1.0.1"
       },
       "devDependencies": {
@@ -2063,9 +2063,9 @@
       }
     },
     "node_modules/@cocos/ccbuild": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmmirror.com/@cocos/ccbuild/-/ccbuild-2.3.6.tgz",
-      "integrity": "sha512-0aVnhw9vaI0BqKSQ+ukcRt0kIxRMRmT5K5wVQ4QUl+re2Scyuf3Gxe4lm1/lWPRBhzwzV7McCTc1TZE+cey06Q==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@cocos/ccbuild/-/ccbuild-2.3.8.tgz",
+      "integrity": "sha512-nONliOMD++qXsx4+JjzKZAP7I2bUeGwUFWiOAAx9r4CPqRqspZrPEXyGapWUq88DJg0pQ+56uQCrxvP9Qu5GcQ==",
       "license": "MIT",
       "workspaces": [
         "./modules/*"
@@ -2075,6 +2075,7 @@
         "@babel/generator": "^7.22.10",
         "@babel/helper-module-imports": "7.18.6",
         "@babel/parser": "^7.20.13",
+        "@babel/plugin-proposal-optional-chaining": "^7.18.9",
         "@babel/plugin-syntax-decorators": "^7.19.0",
         "@babel/plugin-syntax-typescript": "^7.20.0",
         "@babel/plugin-transform-for-of": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@cocos/box2d": "1.0.1",
     "@cocos/cannon": "1.2.8",
-    "@cocos/ccbuild": "^2.3.6",
+    "@cocos/ccbuild": "^2.3.8",
     "@cocos/dragonbones-js": "^1.0.1"
   }
 }


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/18222

Use babel plugin https://babeljs.io/docs/babel-plugin-transform-optional-chaining 
loose mode.

### Example

ts code:

```ts
foo?.bar;
```

New js output:

```js
foo == null ? void 0 : foo.bar;
```

Old js output:

```js
foo === null || foo === void 0 ? void 0 : foo.bar;
```

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
