### PR TITLE
Optimize code size for webgl-commands.ts & webgl2-commands.ts

### DIFF
--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -2772,8 +2772,8 @@ export function WebGLCmdFuncCopyBuffersToTexture (
 
             offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
             offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
-            extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtent.width : alignTo(regionTexExtentWidth, blockSizeWidth);
-            extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtent.width
+            extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtentWidth : alignTo(regionTexExtentWidth, blockSizeWidth);
+            extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtentWidth
                 : alignTo(regionTexExtentHeight, blockSizeHeight);
             stride.width = region.buffStride > 0 ?  region.buffStride : extent.width;
             stride.height = region.buffTexHeight > 0 ? region.buffTexHeight : extent.height;

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -2689,16 +2689,24 @@ export function WebGLCmdFuncCopyBuffersToTexture (
             const region = regions[i];
             const mipLevel = region.texSubres.mipLevel;
 
-            offset.x =  region.texOffset.x === 0 ? 0 : alignTo(region.texOffset.x, blockSize.width);
-            offset.y =  region.texOffset.y === 0 ? 0 : alignTo(region.texOffset.y, blockSize.height);
-            extent.width = region.texExtent.width < blockSize.width ? region.texExtent.width : alignTo(region.texExtent.width, blockSize.width);
-            extent.height = region.texExtent.height < blockSize.height ? region.texExtent.width
-                : alignTo(region.texExtent.height, blockSize.height);
-            stride.width = region.buffStride > 0 ?  region.buffStride : extent.width;
+            const regionTexOffset = region.texOffset;
+            const regionTexExtent = region.texExtent;
+            const regionTexExtentWidth = regionTexExtent.width;
+            const regionTexExtentHeight = regionTexExtent.height;
+            const blockSizeWidth = blockSize.width;
+            const blockSizeHeight = blockSize.height;
+            const regionBuffStride = region.buffStride;
+
+            offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
+            offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
+            extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtentWidth : alignTo(regionTexExtentWidth, blockSizeWidth);
+            extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtentWidth
+                : alignTo(regionTexExtentHeight, blockSizeHeight);
+            stride.width = regionBuffStride > 0 ?  regionBuffStride : extent.width;
             stride.height = region.buffTexHeight > 0 ? region.buffTexHeight : extent.height;
 
-            const destWidth  = (region.texExtent.width + offset.x === (gpuTexture.width >> mipLevel)) ? region.texExtent.width : extent.width;
-            const destHeight = (region.texExtent.height + offset.y === (gpuTexture.height >> mipLevel)) ? region.texExtent.height : extent.height;
+            const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
+            const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
             let pixels: ArrayBufferView;
             const buffer = buffers[n++];
@@ -2752,16 +2760,24 @@ export function WebGLCmdFuncCopyBuffersToTexture (
             const region = regions[i];
             const mipLevel = region.texSubres.mipLevel;
 
-            offset.x =  region.texOffset.x === 0 ? 0 : alignTo(region.texOffset.x, blockSize.width);
-            offset.y =  region.texOffset.y === 0 ? 0 : alignTo(region.texOffset.y, blockSize.height);
-            extent.width = region.texExtent.width < blockSize.width ? region.texExtent.width : alignTo(region.texExtent.width, blockSize.width);
-            extent.height = region.texExtent.height < blockSize.height ? region.texExtent.width
-                : alignTo(region.texExtent.height, blockSize.height);
+            const regionTexOffset = region.texOffset;
+            const regionTexExtent = region.texExtent;
+            const regionTexExtentWidth = regionTexExtent.width;
+            const regionTexExtentHeight = regionTexExtent.height;
+            const blockSizeWidth = blockSize.width;
+            const blockSizeHeight = blockSize.height;
+            const regionBuffStride = region.buffStride;
+
+            offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
+            offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
+            extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtent.width : alignTo(regionTexExtentWidth, blockSizeWidth);
+            extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtent.width
+                : alignTo(regionTexExtentHeight, blockSizeHeight);
             stride.width = region.buffStride > 0 ?  region.buffStride : extent.width;
             stride.height = region.buffTexHeight > 0 ? region.buffTexHeight : extent.height;
 
-            const destWidth  = (region.texExtent.width + offset.x === (gpuTexture.width >> mipLevel)) ? region.texExtent.width : extent.width;
-            const destHeight = (region.texExtent.height + offset.y === (gpuTexture.height >> mipLevel)) ? region.texExtent.height : extent.height;
+            const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
+            const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
             const fcount = region.texSubres.baseArrayLayer + region.texSubres.layerCount;
             for (f = region.texSubres.baseArrayLayer; f < fcount; ++f) {

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -2592,14 +2592,16 @@ export function WebGLCmdFuncCopyTexImagesToTexture (
     case WebGLConstants.TEXTURE_CUBE_MAP: {
         for (let i = 0; i < regions.length; i++) {
             const region = regions[i];
+            const regionTexOffset = region.texOffset;
+            const regionTexSubres = region.texSubres;
             // console.debug('Copying image to texture cube: ' + region.texExtent.width + ' x ' + region.texExtent.height);
-            const fcount = region.texSubres.baseArrayLayer + region.texSubres.layerCount;
-            for (f = region.texSubres.baseArrayLayer; f < fcount; ++f) {
+            const fcount = regionTexSubres.baseArrayLayer + regionTexSubres.layerCount;
+            for (f = regionTexSubres.baseArrayLayer; f < fcount; ++f) {
                 gl.texSubImage2D(
                     WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
-                    region.texSubres.mipLevel,
-                    region.texOffset.x,
-                    region.texOffset.y,
+                    regionTexSubres.mipLevel,
+                    regionTexOffset.x,
+                    regionTexOffset.y,
                     gpuTexture.glFormat,
                     gpuTexture.glType,
                     texImages[n++],
@@ -2762,11 +2764,11 @@ export function WebGLCmdFuncCopyBuffersToTexture (
 
             const regionTexOffset = region.texOffset;
             const regionTexExtent = region.texExtent;
+            const regionTexSubres = region.texSubres;
             const regionTexExtentWidth = regionTexExtent.width;
             const regionTexExtentHeight = regionTexExtent.height;
             const blockSizeWidth = blockSize.width;
             const blockSizeHeight = blockSize.height;
-            const regionBuffStride = region.buffStride;
 
             offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
             offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
@@ -2779,8 +2781,8 @@ export function WebGLCmdFuncCopyBuffersToTexture (
             const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
             const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
-            const fcount = region.texSubres.baseArrayLayer + region.texSubres.layerCount;
-            for (f = region.texSubres.baseArrayLayer; f < fcount; ++f) {
+            const fcount = regionTexSubres.baseArrayLayer + regionTexSubres.layerCount;
+            for (f = regionTexSubres.baseArrayLayer; f < fcount; ++f) {
                 let pixels: ArrayBufferView;
                 const buffer = buffers[n++];
                 if (stride.width === extent.width && stride.height === extent.height) {

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2798,17 +2798,24 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
         for (let k = 0; k < regions.length; k++) {
             const region = regions[k];
             const mipLevel = region.texSubres.mipLevel;
+            const regionTexOffset = region.texOffset;
+            const regionTexExtent = region.texExtent;
+            const regionTexExtentWidth = regionTexExtent.width;
+            const regionTexExtentHeight = regionTexExtent.height;
+            const blockSizeWidth = blockSize.width;
+            const blockSizeHeight = blockSize.height;
+            const regionBuffStride = region.buffStride;
 
-            offset.x =  region.texOffset.x === 0 ? 0 : alignTo(region.texOffset.x, blockSize.width);
-            offset.y =  region.texOffset.y === 0 ? 0 : alignTo(region.texOffset.y, blockSize.height);
-            extent.width = region.texExtent.width < blockSize.width ? region.texExtent.width : alignTo(region.texExtent.width, blockSize.width);
-            extent.height = region.texExtent.height < blockSize.height ? region.texExtent.width
-                : alignTo(region.texExtent.height, blockSize.height);
-            stride.width = region.buffStride > 0 ?  region.buffStride : extent.width;
+            offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
+            offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
+            extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtentWidth : alignTo(regionTexExtentWidth, blockSizeWidth);
+            extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtentWidth
+                : alignTo(regionTexExtentHeight, blockSizeHeight);
+            stride.width = regionBuffStride > 0 ?  regionBuffStride : extent.width;
             stride.height = region.buffTexHeight > 0 ? region.buffTexHeight : extent.height;
 
-            const destWidth  = (region.texExtent.width + offset.x === (gpuTexture.width >> mipLevel)) ? region.texExtent.width : extent.width;
-            const destHeight = (region.texExtent.height + offset.y === (gpuTexture.height >> mipLevel)) ? region.texExtent.height : extent.height;
+            const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
+            const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
             let pixels: ArrayBufferView;
             const buffer = buffers[n++];
@@ -2862,17 +2869,25 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
             const region = regions[k];
             const mipLevel = region.texSubres.mipLevel;
 
-            offset.x =  region.texOffset.x === 0 ? 0 : alignTo(region.texOffset.x, blockSize.width);
-            offset.y =  region.texOffset.y === 0 ? 0 : alignTo(region.texOffset.y, blockSize.height);
-            extent.width = region.texExtent.width < blockSize.width ? region.texExtent.width : alignTo(region.texExtent.width, blockSize.width);
-            extent.height = region.texExtent.height < blockSize.height ? region.texExtent.width
-                : alignTo(region.texExtent.height, blockSize.height);
+            const regionTexOffset = region.texOffset;
+            const regionTexExtent = region.texExtent;
+            const regionTexExtentWidth = regionTexExtent.width;
+            const regionTexExtentHeight = regionTexExtent.height;
+            const blockSizeWidth = blockSize.width;
+            const blockSizeHeight = blockSize.height;
+            const regionBuffStride = region.buffStride;
+
+            offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
+            offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
+            extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtentWidth : alignTo(regionTexExtentWidth, blockSizeWidth);
+            extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtentWidth
+                : alignTo(regionTexExtent.height, blockSizeHeight);
             extent.depth = 1;
-            stride.width = region.buffStride > 0 ?  region.buffStride : extent.width;
+            stride.width = regionBuffStride > 0 ?  regionBuffStride : extent.width;
             stride.height = region.buffTexHeight > 0 ? region.buffTexHeight : extent.height;
 
-            const destWidth  = (region.texExtent.width + offset.x === (gpuTexture.width >> mipLevel)) ? region.texExtent.width : extent.width;
-            const destHeight = (region.texExtent.height + offset.y === (gpuTexture.height >> mipLevel)) ? region.texExtent.height : extent.height;
+            const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
+            const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
             const fcount = region.texSubres.baseArrayLayer + region.texSubres.layerCount;
             for (f = region.texSubres.baseArrayLayer; f < fcount; ++f) {
@@ -2935,19 +2950,26 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
         for (let k = 0; k < regions.length; k++) {
             const region = regions[k];
             const mipLevel = region.texSubres.mipLevel;
+            const regionTexOffset = region.texOffset;
+            const regionTexExtent = region.texExtent;
+            const regionTexExtentWidth = regionTexExtent.width;
+            const regionTexExtentHeight = regionTexExtent.height;
+            const blockSizeWidth = blockSize.width;
+            const blockSizeHeight = blockSize.height;
+            const regionBuffStride = region.buffStride;
 
-            offset.x = region.texOffset.x === 0 ? 0 : alignTo(region.texOffset.x, blockSize.width);
-            offset.y = region.texOffset.y === 0 ? 0 : alignTo(region.texOffset.y, blockSize.height);
-            offset.z = region.texOffset.z;
-            extent.width = region.texExtent.width < blockSize.width ? region.texExtent.width : alignTo(region.texExtent.width, blockSize.width);
-            extent.height = region.texExtent.height < blockSize.height ? region.texExtent.width
-                : alignTo(region.texExtent.height, blockSize.height);
-            extent.depth = region.texExtent.depth;
-            stride.width = region.buffStride > 0 ?  region.buffStride : extent.width;
+            offset.x = regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
+            offset.y = regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
+            offset.z = regionTexOffset.z;
+            extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtentWidth : alignTo(regionTexExtentWidth, blockSizeWidth);
+            extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtentWidth
+                : alignTo(regionTexExtentHeight, blockSizeHeight);
+            extent.depth = regionTexExtent.depth;
+            stride.width = regionBuffStride > 0 ?  regionBuffStride : extent.width;
             stride.height = region.buffTexHeight > 0 ? region.buffTexHeight : extent.height;
 
-            const destWidth  = (region.texExtent.width + offset.x === (gpuTexture.width >> mipLevel)) ? region.texExtent.width : extent.width;
-            const destHeight = (region.texExtent.height + offset.y === (gpuTexture.height >> mipLevel)) ? region.texExtent.height : extent.height;
+            const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
+            const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
             let pixels: ArrayBufferView;
             const buffer = buffers[n++];
@@ -3006,16 +3028,24 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
             const region = regions[k];
             const mipLevel = region.texSubres.mipLevel;
 
-            offset.x =  region.texOffset.x === 0 ? 0 : alignTo(region.texOffset.x, blockSize.width);
-            offset.y =  region.texOffset.y === 0 ? 0 : alignTo(region.texOffset.y, blockSize.height);
-            extent.width = region.texExtent.width < blockSize.width ? region.texExtent.width : alignTo(region.texExtent.width, blockSize.width);
-            extent.height = region.texExtent.height < blockSize.height ? region.texExtent.width
-                : alignTo(region.texExtent.height, blockSize.height);
-            stride.width = region.buffStride > 0 ?  region.buffStride : extent.width;
+            const regionTexOffset = region.texOffset;
+            const regionTexExtent = region.texExtent;
+            const regionTexExtentWidth = regionTexExtent.width;
+            const regionTexExtentHeight = regionTexExtent.height;
+            const blockSizeWidth = blockSize.width;
+            const blockSizeHeight = blockSize.height;
+            const regionBuffStride = region.buffStride;
+
+            offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
+            offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
+            extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtentWidth : alignTo(regionTexExtentWidth, blockSizeWidth);
+            extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtentWidth
+                : alignTo(regionTexExtentHeight, blockSizeHeight);
+            stride.width = regionBuffStride > 0 ?  regionBuffStride : extent.width;
             stride.height = region.buffTexHeight > 0 ? region.buffTexHeight : extent.height;
 
-            const destWidth  = (region.texExtent.width + offset.x === (gpuTexture.width >> mipLevel)) ? region.texExtent.width : extent.width;
-            const destHeight = (region.texExtent.height + offset.y === (gpuTexture.height >> mipLevel)) ? region.texExtent.height : extent.height;
+            const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
+            const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
             const fcount = region.texSubres.baseArrayLayer + region.texSubres.layerCount;
             for (f = region.texSubres.baseArrayLayer; f < fcount; ++f) {

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2703,13 +2703,15 @@ export function WebGL2CmdFuncCopyTexImagesToTexture (
     case WebGLConstants.TEXTURE_CUBE_MAP: {
         for (let k = 0; k < regions.length; k++) {
             const region = regions[k];
-            const fcount = region.texSubres.baseArrayLayer + region.texSubres.layerCount;
-            for (f = region.texSubres.baseArrayLayer; f < fcount; ++f) {
+            const regionTexSubres = region.texSubres;
+            const regionTexOffset = region.texOffset;
+            const fcount = regionTexSubres.baseArrayLayer + regionTexSubres.layerCount;
+            for (f = regionTexSubres.baseArrayLayer; f < fcount; ++f) {
                 gl.texSubImage2D(
                     WebGLConstants.TEXTURE_CUBE_MAP_POSITIVE_X + f,
-                    region.texSubres.mipLevel,
-                    region.texOffset.x,
-                    region.texOffset.y,
+                    regionTexSubres.mipLevel,
+                    regionTexOffset.x,
+                    regionTexOffset.y,
                     gpuTexture.glFormat,
                     gpuTexture.glType,
                     texImages[n++],
@@ -2876,6 +2878,7 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
             const blockSizeWidth = blockSize.width;
             const blockSizeHeight = blockSize.height;
             const regionBuffStride = region.buffStride;
+            const regionTexSubres = region.texSubres;
 
             offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
             offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
@@ -2889,8 +2892,8 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
             const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
             const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
-            const fcount = region.texSubres.baseArrayLayer + region.texSubres.layerCount;
-            for (f = region.texSubres.baseArrayLayer; f < fcount; ++f) {
+            const fcount = regionTexSubres.baseArrayLayer + regionTexSubres.layerCount;
+            for (f = regionTexSubres.baseArrayLayer; f < fcount; ++f) {
                 offset.z = f;
 
                 let pixels: ArrayBufferView;
@@ -3035,6 +3038,7 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
             const blockSizeWidth = blockSize.width;
             const blockSizeHeight = blockSize.height;
             const regionBuffStride = region.buffStride;
+            const regionTexSubres = region.texSubres;
 
             offset.x =  regionTexOffset.x === 0 ? 0 : alignTo(regionTexOffset.x, blockSizeWidth);
             offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
@@ -3047,8 +3051,8 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
             const destWidth  = (regionTexExtentWidth + offset.x === (gpuTexture.width >> mipLevel)) ? regionTexExtentWidth : extent.width;
             const destHeight = (regionTexExtentHeight + offset.y === (gpuTexture.height >> mipLevel)) ? regionTexExtentHeight : extent.height;
 
-            const fcount = region.texSubres.baseArrayLayer + region.texSubres.layerCount;
-            for (f = region.texSubres.baseArrayLayer; f < fcount; ++f) {
+            const fcount = regionTexSubres.baseArrayLayer + regionTexSubres.layerCount;
+            for (f = regionTexSubres.baseArrayLayer; f < fcount; ++f) {
                 let pixels: ArrayBufferView;
                 const buffer = buffers[n++];
                 if (stride.width === extent.width && stride.height === extent.height) {

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -2884,7 +2884,7 @@ export function WebGL2CmdFuncCopyBuffersToTexture (
             offset.y =  regionTexOffset.y === 0 ? 0 : alignTo(regionTexOffset.y, blockSizeHeight);
             extent.width = regionTexExtentWidth < blockSizeWidth ? regionTexExtentWidth : alignTo(regionTexExtentWidth, blockSizeWidth);
             extent.height = regionTexExtentHeight < blockSizeHeight ? regionTexExtentWidth
-                : alignTo(regionTexExtent.height, blockSizeHeight);
+                : alignTo(regionTexExtentHeight, blockSizeHeight);
             extent.depth = 1;
             stride.width = regionBuffStride > 0 ?  regionBuffStride : extent.width;
             stride.height = region.buffTexHeight > 0 ? region.buffTexHeight : extent.height;


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/18222

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
