### PR TITLE
Fix deprecated String.substr, use String.substring instead.

### DIFF
--- a/cocos/2d/utils/html-text-parser.ts
+++ b/cocos/2d/utils/html-text-parser.ts
@@ -181,12 +181,12 @@ export class HtmlTextParser {
             tagName = header[0].trim();
             if (tagName.startsWith('img') && tagName[tagName.length - 1] === '/') {
                 header = imageAttrReg.exec(attribute);
-                let tagValue;
+                let tagValue: string;
                 let isValidImageTag = false;
                 while (header) {
                     // skip the invalid tags at first
                     attribute = attribute.substring(attribute.indexOf(header[0]));
-                    tagName = attribute.substr(0, header[0].length);
+                    tagName = attribute.substring(0, header[0].length);
                     const originTagNameLength = tagName.length;
                     tagName = tagName.replace(/[^a-zA-Z]/g, '').trim();
                     tagName = tagName.toLowerCase();
@@ -199,7 +199,7 @@ export class HtmlTextParser {
                         rightQuot = -1;
                     }
                     nextSpace = remainingArgument.indexOf(' ', rightQuot + 1 >= remainingArgument.length ? -1 : rightQuot + 1);
-                    tagValue = (nextSpace > -1) ? remainingArgument.substr(0, nextSpace) : remainingArgument;
+                    tagValue = (nextSpace > -1) ? remainingArgument.substring(0, nextSpace) : remainingArgument;
                     attribute = remainingArgument.substring(nextSpace).trim();
 
                     if (tagValue.endsWith('/')) {
@@ -259,16 +259,16 @@ export class HtmlTextParser {
             if (attribute) {
                 const outlineAttrReg = /(\s)*color(\s)*=|(\s)*width(\s)*=|(\s)*click(\s)*=|(\s)*param(\s)*=/;
                 header = outlineAttrReg.exec(attribute);
-                let tagValue;
+                let tagValue: string;
                 while (header) {
                     // skip the invalid tags at first
                     attribute = attribute.substring(attribute.indexOf(header[0]));
-                    tagName = attribute.substr(0, header[0].length);
+                    tagName = attribute.substring(0, header[0].length);
                     // remove space and = character
                     remainingArgument = attribute.substring(tagName.length).trim();
                     nextSpace = remainingArgument.indexOf(' ');
                     if (nextSpace > -1) {
-                        tagValue = remainingArgument.substr(0, nextSpace);
+                        tagValue = remainingArgument.substring(0, nextSpace);
                     } else {
                         tagValue = remainingArgument;
                     }

--- a/cocos/asset/asset-manager/asset-manager.ts
+++ b/cocos/asset/asset-manager/asset-manager.ts
@@ -334,7 +334,7 @@ export class AssetManager {
     /**
      * @engineInternal
      */
-    public get files(): Cache {
+    public get files (): Cache {
         return this._files;
     }
 
@@ -445,11 +445,11 @@ export class AssetManager {
         this.dependUtil.init();
         let importBase = options.importBase || settings.querySettings(SettingsCategory.ASSETS, 'importBase') || '';
         if (importBase && importBase.endsWith('/')) {
-            importBase = importBase.substr(0, importBase.length - 1);
+            importBase = importBase.substring(0, importBase.length - 1);
         }
         let nativeBase = options.nativeBase || settings.querySettings(SettingsCategory.ASSETS, 'nativeBase') || '';
         if (nativeBase && nativeBase.endsWith('/')) {
-            nativeBase = nativeBase.substr(0, nativeBase.length - 1);
+            nativeBase = nativeBase.substring(0, nativeBase.length - 1);
         }
         this.generalImportBase = importBase;
         this.generalNativeBase = nativeBase;

--- a/cocos/asset/asset-manager/deprecated.ts
+++ b/cocos/asset/asset-manager/deprecated.ts
@@ -916,7 +916,7 @@ replaceProperty(url, 'url', [
         customFunction: (url: string): string => {
             if (url.startsWith('resources/')) {
                 return transform({
-                    path: path.changeExtname(url.substr(10)),
+                    path: path.changeExtname(url.substring(10)),
                     bundle: BuiltinBundleName.RESOURCES,
                     __isNative__: true,
                     ext: path.extname(url),

--- a/cocos/asset/asset-manager/task.ts
+++ b/cocos/asset/asset-manager/task.ts
@@ -298,7 +298,7 @@ export default class Task {
             }
             break;
         default: {
-            const str = `on${event[0].toUpperCase()}${event.substr(1)}`;
+            const str = `on${event[0].toUpperCase()}${event.substring(1)}`;
             if (typeof this[str] === 'function') {
                 this[str](param1, param2, param3, param4);
             }

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -1181,7 +1181,7 @@ export function WebGLCmdFuncCreateShader (device: WebGLDevice, gpuShader: IWebGL
             let varName: string;
             const nameOffset = attribName.indexOf('[');
             if (nameOffset !== -1) {
-                varName = attribName.substr(0, nameOffset);
+                varName = attribName.substring(0, nameOffset);
             } else {
                 varName = attribName;
             }
@@ -1287,7 +1287,7 @@ export function WebGLCmdFuncCreateShader (device: WebGLDevice, gpuShader: IWebGL
                     let varName: string;
                     const nameOffset = uniformInfo.name.indexOf('[');
                     if (nameOffset !== -1) {
-                        varName = uniformInfo.name.substr(0, nameOffset);
+                        varName = uniformInfo.name.substring(0, nameOffset);
                     } else {
                         varName = uniformInfo.name;
                     }

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -1540,7 +1540,7 @@ export function WebGL2CmdFuncCreateShader (device: WebGL2Device, gpuShader: IWeb
             let varName: string;
             const nameOffset = attribInfo.name.indexOf('[');
             if (nameOffset !== -1) {
-                varName = attribInfo.name.substr(0, nameOffset);
+                varName = attribInfo.name.substring(0, nameOffset);
             } else {
                 varName = attribInfo.name;
             }
@@ -1576,7 +1576,7 @@ export function WebGL2CmdFuncCreateShader (device: WebGL2Device, gpuShader: IWeb
             blockName = gl.getActiveUniformBlockName(gpuShader.glProgram, b)!;
             const nameOffset = blockName.indexOf('[');
             if (nameOffset !== -1) {
-                blockName = blockName.substr(0, nameOffset);
+                blockName = blockName.substring(0, nameOffset);
             }
 
             // blockIdx = gl.getUniformBlockIndex(gpuShader.glProgram, blockName);

--- a/pal/system-info/minigame/system-info.ts
+++ b/pal/system-info/minigame/system-info.ts
@@ -125,7 +125,7 @@ class SystemInfo extends EventTarget {
 
         // init languageCode and language
         this.nativeLanguage = minigameSysInfo.language;
-        this.language = minigameSysInfo.language.substr(0, 2) as Language;
+        this.language = minigameSysInfo.language.substring(0, 2) as Language;
 
         // init os, osVersion and osMainVersion
         const minigamePlatform = minigameSysInfo.platform.toLocaleLowerCase();

--- a/scripts/native-pack-tool/source/platforms/ios.ts
+++ b/scripts/native-pack-tool/source/platforms/ios.ts
@@ -169,7 +169,7 @@ export class IOSPackTool extends MacOSPackTool {
                 .filter(
                     (x) => x.startsWith('iPhone') && x.indexOf('Simulator') >= 0);
         const exact = (l: string) => {
-            const p = l.split('(')[0].substr(6);
+            const p = l.split('(')[0].substring(6);
             const m = l.match(/\((\d+\.\d+)\)/);
             if (m) {
                 return parseInt(m[1]) + m.index!;

--- a/tests/core/serialization/shared/utils.ts
+++ b/tests/core/serialization/shared/utils.ts
@@ -10,7 +10,7 @@ export const runTest: RunTest = runTest_;
 export function getCaseName(fileName: string) {
     const baseName = ps.basename(fileName, ps.dirname(fileName));
     if (baseName.endsWith('.test.ts')) {
-        return baseName.substr(0, baseName.length - '.test.ts'.length);
+        return baseName.substring(0, baseName.length - '.test.ts'.length);
     } else {
         return baseName;
     }


### PR DESCRIPTION
```
The signature '(from: number, length?: number | undefined): string' of 'labelString.substr' is deprecated.ts(6387)
lib.es5.d.ts(522, 8): The declaration was marked as deprecated here.
(method) String.substr(from: number, length?: number): string
Gets a substring beginning at the specified location and having the specified length.

@deprecated — A legacy feature for browser compatibility

@param from — The starting position of the desired substring. The index of the first character in the string is zero.

@param length — The number of characters to include in the returned substring.
```
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
