### PR TITLE
Fixed an issue where setting a SpriteFrame on the Sprite Inspector panel caused a false freeze

### DIFF
--- a/editor/inspector/components/sprite.js
+++ b/editor/inspector/components/sprite.js
@@ -22,7 +22,9 @@ async function findAutoAtlasFolder(spriteFrameUuid) {
     }
 
     let dir = dirname(filePath);
-    while (dir !== ASSET_DIR) {
+    // Some resources may not be located in the assets directory, 
+    // so it's necessary to perform length checks to avoid infinite loops.
+    while (dir !== ASSET_DIR && dir.length > 1) {
         const files = readdirSync(dir);
         const file = files.find(file => file.endsWith(AUTO_ATLAS_EXTNAME));
         if (file) {


### PR DESCRIPTION
Re: #

### Changelog

* This does not take into account the problem that the asset is not in the assets directory, resulting in an endless loop of while, which indicates that it has reached the root directory by judging the length

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
