### PR TITLE
Fix wrong position and rectangle border of gizmo in editor.

### DIFF
--- a/cocos/2d/framework/ui-skew-utils.ts
+++ b/cocos/2d/framework/ui-skew-utils.ts
@@ -54,6 +54,8 @@ export function getParentWorldMatrixNoSkew (parent: Node | null, out: Mat4): boo
             Mat4.multiply(out, out, m4_1);
         }
         ret = true;
+    } else {
+        out.set(parent._mat);
     }
 
     tempNodes.length = 0;

--- a/cocos/2d/framework/ui-skew-utils.ts
+++ b/cocos/2d/framework/ui-skew-utils.ts
@@ -30,14 +30,20 @@ const m4_1 = mat4();
 const tempNodes: Node[] = [];
 const DEG_TO_RAD = Math.PI / 180.0;
 
-export function getParentWorldMatrixNoSkew (parent: Node | null, out: Mat4): boolean {
-    if (!parent) {
+/**
+ * Check whether the node or its parent has skew components and return the original world matrix without skew to `out` parameter.
+ * @param node The node and its parent for finding skew.
+ * @param out The node's original world matrix without skew.
+ * @return true if the node or its parent has skew components, otherwise returns false.
+ */
+export function findSkewAndGetOriginalWorldMatrix (node: Node | null, out: Mat4): boolean {
+    if (!node) {
         return false;
     }
     tempNodes.length = 0;
     const ancestors: Node[] = tempNodes;
     let startNode: Node | null = null;
-    for (let cur: Node | null = parent; cur; cur = cur.parent) {
+    for (let cur: Node | null = node; cur; cur = cur.parent) {
         ancestors.push(cur);
         if (cur._uiProps._uiSkewComp) {
             startNode = cur;
@@ -49,13 +55,13 @@ export function getParentWorldMatrixNoSkew (parent: Node | null, out: Mat4): boo
         out.set(startNode.parent!._mat); // Set the first no-skew node's world matrix to out.
         const start = ancestors.indexOf(startNode);
         for (let i = start; i >= 0; --i) {
-            const node = ancestors[i];
-            Mat4.fromSRT(m4_1, node.rotation, node.position, node.scale);
+            const cur = ancestors[i];
+            Mat4.fromSRT(m4_1, cur.rotation, cur.position, cur.scale);
             Mat4.multiply(out, out, m4_1);
         }
         ret = true;
     } else {
-        out.set(parent._mat);
+        out.set(node._mat);
     }
 
     tempNodes.length = 0;

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -2283,7 +2283,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
                     let originalWorldMatrix = childMat;
                     Mat4.fromSRT(m4_1, child._lrot, child._lpos, child._lscale); // m4_1 stores local matrix
                     if (HAS_UI_SKEW && skewCompCount > 0) {
-                        foundSkewInAncestor = getParentWorldMatrixNoSkew(cur, m4_2); // m4_2 stores parent's world matrix without skew
+                        foundSkewInAncestor = findSkewAndGetOriginalWorldMatrix(cur, m4_2); // m4_2 stores parent's world matrix without skew
                         uiSkewComp = child._uiProps._uiSkewComp;
                         if (uiSkewComp || foundSkewInAncestor) {
                             // Save the original world matrix without skew side effect.

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -2262,7 +2262,8 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
         let dirtyBits = 0;
         let positionDirty = 0;
         let rotationScaleSkewDirty = 0;
-        let uiSkewComp: UISkew | null;
+        let uiSkewComp: UISkew | null = null;
+        let foundSkewInAncestor = false;
 
         while (i) {
             child = dirtyNodes[--i];
@@ -2281,22 +2282,29 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
                 if (rotationScaleSkewDirty) {
                     let originalWorldMatrix = childMat;
                     Mat4.fromSRT(m4_1, child._lrot, child._lpos, child._lscale); // m4_1 stores local matrix
-
                     if (HAS_UI_SKEW && skewCompCount > 0) {
+                        foundSkewInAncestor = getParentWorldMatrixNoSkew(cur, m4_2); // m4_2 stores parent's world matrix without skew
                         uiSkewComp = child._uiProps._uiSkewComp;
-                        if (uiSkewComp) {
+                        if (uiSkewComp || foundSkewInAncestor) {
                             // Save the original world matrix without skew side effect.
-                            Mat4.multiply(m4_2, cur._mat, m4_1); // m4_2 stores orignal world matrix with skew
-                            // If skew is dirty, rotation and scale must be also dirty.
-                            // See _updateNodeTransformFlags in ui-skew.ts.
-                            updateLocalMatrixBySkew(uiSkewComp, m4_1);
+                            Mat4.multiply(m4_2, m4_2, m4_1); // m4_2 stores orignal world matrix with skew
+                            if (uiSkewComp) {
+                                updateLocalMatrixBySkew(uiSkewComp, m4_1);
+                            }
                             originalWorldMatrix = m4_2;
                         }
                     }
-                    Mat4.multiply(childMat, cur._mat, m4_1);
+
+                    Mat4.multiply(childMat, cur._mat, m4_1); // m4_1 stores local matrix with skew
 
                     const rotTmp = dirtyBits & TransformBit.ROTATION ? child._rot : null;
                     Mat4.toSRT(originalWorldMatrix, rotTmp, childPos, child._scale);
+
+                    if (HAS_UI_SKEW && foundSkewInAncestor) {
+                        // NOTE: world position from Mat4.toSRT(originalWorldMatrix, ...) will not consider the skew factor.
+                        // So we need to update the world position manually here.
+                        Vec3.transformMat4(childPos, child._lpos, cur._mat);
+                    }
                 }
             } else {
                 if (positionDirty) {

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -40,7 +40,7 @@ import { PrefabInfo, PrefabInstance } from './prefab/prefab-info';
 import { NodeEventType } from './node-event';
 import { Event } from '../input/types';
 import { DispatcherEventType, NodeEventProcessor } from './node-event-processor';
-import { getParentWorldMatrixNoSkew, updateLocalMatrixBySkew } from '../2d/framework/ui-skew-utils';
+import { findSkewAndGetOriginalWorldMatrix, updateLocalMatrixBySkew } from '../2d/framework/ui-skew-utils';
 
 import type { Scene } from './scene';
 import type { Director } from '../game/director';
@@ -2030,7 +2030,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
                         if (hasSkew) {
                             if (oldParent) {
                                 // Calculate old parent's world matrix without skew side effect.
-                                const foundSkewInOldParent = getParentWorldMatrixNoSkew(oldParent, m4_2);
+                                const foundSkewInOldParent = findSkewAndGetOriginalWorldMatrix(oldParent, m4_2);
                                 Mat4.fromSRT(m4_1, self._lrot, self._lpos, self._lscale);
                                 const oldParentMatWithoutSkew = foundSkewInOldParent ? m4_2 : oldParent._mat;
                                 // Calculate current node's world matrix without skew side effect.
@@ -2038,7 +2038,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
                             }
 
                             // Calculate new parent's world matrix without skew side effect.
-                            const foundSkewInNewParent = getParentWorldMatrixNoSkew(parent, m4_2);
+                            const foundSkewInNewParent = findSkewAndGetOriginalWorldMatrix(parent, m4_2);
                             if (foundSkewInNewParent) {
                                 newParentMatWithoutSkew = m4_2;
                             }

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -2287,7 +2287,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
                         uiSkewComp = child._uiProps._uiSkewComp;
                         if (uiSkewComp || foundSkewInAncestor) {
                             // Save the original world matrix without skew side effect.
-                            Mat4.multiply(m4_2, m4_2, m4_1); // m4_2 stores orignal world matrix with skew
+                            Mat4.multiply(m4_2, m4_2, m4_1); // m4_2 stores orignal world matrix without skew
                             if (uiSkewComp) {
                                 updateLocalMatrixBySkew(uiSkewComp, m4_1);
                             }


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/pull/18212

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
