### PR TITLE
refactor(components): enhance component accessor type safety with generics

### DIFF
--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -877,7 +877,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
       * var test = node.getComponent("Test");
       * ```
       */
-    public getComponent(className: string): Component | null;
+    public getComponent<T extends Component>(className: string): T | null;
 
     public getComponent<T extends Component> (typeOrClassName: string | Constructor<T> | AbstractedConstructor<T>): T | null {
         const constructor = getConstructor(typeOrClassName);
@@ -899,11 +899,11 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * @zh 返回节点上指定类型的所有组件。
      * @param className The class name of the target component
      */
-    public getComponents(className: string): Component[];
+    public getComponents<T extends Component>(className: string): T[];
 
-    public getComponents<T extends Component> (typeOrClassName: string | Constructor<T> | AbstractedConstructor<T>): Component[] {
+    public getComponents<T extends Component> (typeOrClassName: string | Constructor<T> | AbstractedConstructor<T>): T[] {
         const constructor = getConstructor(typeOrClassName);
-        const components: Component[] = [];
+        const components: T[] = [];
         if (constructor) {
             Node._findComponents(this, constructor, components);
         }
@@ -930,7 +930,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * var Test = node.getComponentInChildren("Test");
      * ```
      */
-    public getComponentInChildren(className: string): Component | null;
+    public getComponentInChildren<T extends Component>(className: string): T | null;
 
     public getComponentInChildren<T extends Component> (typeOrClassName: string | Constructor<T> | AbstractedConstructor<T>): T | null {
         const constructor = getConstructor(typeOrClassName);
@@ -960,11 +960,11 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * var tests = node.getComponentsInChildren("Test");
      * ```
      */
-    public getComponentsInChildren(className: string): Component[];
+    public getComponentsInChildren<T extends Component>(className: string): T[];
 
-    public getComponentsInChildren<T extends Component> (typeOrClassName: string | Constructor<T> | AbstractedConstructor<T>): Component[] {
+    public getComponentsInChildren<T extends Component> (typeOrClassName: string | Constructor<T> | AbstractedConstructor<T>): T[] {
         const constructor = getConstructor(typeOrClassName);
-        const components: Component[] = [];
+        const components: T[] = [];
         if (constructor) {
             Node._findComponents(this, constructor, components);
             Node._findChildComponents(this._children, constructor, components);
@@ -994,7 +994,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * var test = node.addComponent("Test");
      * ```
      */
-    public addComponent(className: string): Component;
+    public addComponent<T extends Component>(className: string): T;
 
     public addComponent<T extends Component> (typeOrClassName: string | Constructor<T>): T {
         if (EDITOR && (this._objFlags & Destroying)) {


### PR DESCRIPTION

Re: #

### Changelog

- Convert component accessor methods to use generic types for precise type inference
- Improve developer experience with auto-completion and type checking

Before:
```
const clz = node.getComponent('clz') as CLZ | null
```

After:
```
const clz = node.getComponent<CLZ>('clz')
```


-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
