### PR TITLE
Treeshake unused pal input modules for mini-game platforms

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -716,7 +716,11 @@
             "cocos/serialization/instantiate-jit.ts",
             "cocos/game/splash-screen.ts",
             "cocos/core/utils/jsb-utils.ts",
-            "cocos/2d/framework/ui-skew-utils.ts"
+            "cocos/2d/framework/ui-skew-utils.ts",
+            "pal/input/minigame/gamepad-input.ts",
+            "pal/input/minigame/handheld-input.ts",
+            "pal/input/minigame/handle-input.ts",
+            "pal/input/minigame/hmd-input.ts"
         ]
     }
 }

--- a/cocos/input/input.ts
+++ b/cocos/input/input.ts
@@ -24,7 +24,7 @@
  THE SOFTWARE.
 */
 
-import { EDITOR_NOT_IN_PREVIEW, NATIVE } from 'internal:constants';
+import { EDITOR_NOT_IN_PREVIEW, HTML5, NATIVE } from 'internal:constants';
 import { AccelerometerInputSource, GamepadInputDevice, HMDInputDevice, HandheldInputDevice,
     HandleInputDevice, KeyboardInputSource, MouseInputSource, TouchInputSource } from 'pal/input';
 import { touchManager } from '../../pal/input/touch-manager';
@@ -139,9 +139,10 @@ export class Input {
     private _mouseInput = new MouseInputSource();
     private _keyboardInput = new KeyboardInputSource();
     private _accelerometerInput = new AccelerometerInputSource();
-    private _handleInput = new HandleInputDevice();
-    private _hmdInput = new HMDInputDevice();
-    private _handheldInput = new HandheldInputDevice();
+
+    private declare _handleInput: HandleInputDevice;
+    private declare _hmdInput: HMDInputDevice;
+    private declare _handheldInput: HandheldInputDevice;
 
     private _eventKeyboardList: EventKeyboard[] = [];
     private _eventAccelerationList: EventAcceleration[] = [];
@@ -156,10 +157,17 @@ export class Input {
     private _eventDispatcherList: IEventDispatcher[] = [];
 
     constructor () {
+        if (HTML5 || NATIVE) {
+            this._handleInput = new HandleInputDevice();
+            this._hmdInput = new HMDInputDevice();
+            this._handheldInput = new HandheldInputDevice();
+        }
         this._registerEvent();
         this._inputEventDispatcher = new InputEventDispatcher(this._eventTarget);
         this._registerEventDispatcher(this._inputEventDispatcher);
-        GamepadInputDevice._init();
+        if (HTML5 || NATIVE) {
+            GamepadInputDevice._init();
+        }
     }
 
     /**
@@ -419,41 +427,43 @@ export class Input {
             });
         }
 
-        if (sys.hasFeature(sys.Feature.EVENT_GAMEPAD)) {
-            const eventGamepadList = self._eventGamepadList;
-            GamepadInputDevice._on(InputEventType.GAMEPAD_CHANGE, (event): void => {
-                self._dispatchOrPushEvent(event, eventGamepadList);
-            });
-            GamepadInputDevice._on(InputEventType.GAMEPAD_INPUT, (event): void => {
-                self._dispatchOrPushEvent(event, eventGamepadList);
-            });
-            GamepadInputDevice._on(InputEventType.HANDLE_POSE_INPUT, (event): void => {
-                self._dispatchOrPushEvent(event, eventGamepadList);
-            });
-        }
+        if (HTML5 || NATIVE) {
+            if (sys.hasFeature(sys.Feature.EVENT_GAMEPAD)) {
+                const eventGamepadList = self._eventGamepadList;
+                GamepadInputDevice._on(InputEventType.GAMEPAD_CHANGE, (event): void => {
+                    self._dispatchOrPushEvent(event, eventGamepadList);
+                });
+                GamepadInputDevice._on(InputEventType.GAMEPAD_INPUT, (event): void => {
+                    self._dispatchOrPushEvent(event, eventGamepadList);
+                });
+                GamepadInputDevice._on(InputEventType.HANDLE_POSE_INPUT, (event): void => {
+                    self._dispatchOrPushEvent(event, eventGamepadList);
+                });
+            }
 
-        if (sys.hasFeature(sys.Feature.EVENT_HANDLE)) {
-            const eventHandleList = self._eventHandleList;
-            handleInput._on(InputEventType.HANDLE_INPUT, (event): void => {
-                self._dispatchOrPushEvent(event, eventHandleList);
-            });
-            handleInput._on(InputEventType.HANDLE_POSE_INPUT, (event): void => {
-                self._dispatchOrPushEvent(event, eventHandleList);
-            });
-        }
+            if (sys.hasFeature(sys.Feature.EVENT_HANDLE)) {
+                const eventHandleList = self._eventHandleList;
+                handleInput._on(InputEventType.HANDLE_INPUT, (event): void => {
+                    self._dispatchOrPushEvent(event, eventHandleList);
+                });
+                handleInput._on(InputEventType.HANDLE_POSE_INPUT, (event): void => {
+                    self._dispatchOrPushEvent(event, eventHandleList);
+                });
+            }
 
-        if (sys.hasFeature(sys.Feature.EVENT_HMD)) {
-            const eventHMDList = self._eventHMDList;
-            self._hmdInput._on(InputEventType.HMD_POSE_INPUT, (event): void => {
-                self._dispatchOrPushEvent(event, eventHMDList);
-            });
-        }
+            if (sys.hasFeature(sys.Feature.EVENT_HMD)) {
+                const eventHMDList = self._eventHMDList;
+                self._hmdInput._on(InputEventType.HMD_POSE_INPUT, (event): void => {
+                    self._dispatchOrPushEvent(event, eventHMDList);
+                });
+            }
 
-        if (sys.hasFeature(sys.Feature.EVENT_HANDHELD)) {
-            const eventHandheldList = self._eventHandheldList;
-            self._handheldInput._on(InputEventType.HANDHELD_POSE_INPUT, (event): void => {
-                self._dispatchOrPushEvent(event, eventHandheldList);
-            });
+            if (sys.hasFeature(sys.Feature.EVENT_HANDHELD)) {
+                const eventHandheldList = self._eventHandheldList;
+                self._handheldInput._on(InputEventType.HANDHELD_POSE_INPUT, (event): void => {
+                    self._dispatchOrPushEvent(event, eventHandheldList);
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/18222

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
