### PR TITLE
MouseJoint Touch Issue

### DIFF
--- a/cocos/physics-2d/box2d-wasm/joints/mouse-joint.ts
+++ b/cocos/physics-2d/box2d-wasm/joints/mouse-joint.ts
@@ -119,6 +119,13 @@ export class B2MouseJoint extends B2Joint implements IMouseJoint {
     }
 
     onTouchEnd (event: Touch): void {
+        const canvas = find('Canvas');
+        if (canvas) {
+            canvas.off(NodeEventType.TOUCH_START, this.onTouchBegan, this);
+            canvas.off(NodeEventType.TOUCH_MOVE, this.onTouchMove, this);
+            canvas.off(NodeEventType.TOUCH_END, this.onTouchEnd, this);
+            canvas.off(NodeEventType.TOUCH_CANCEL, this.onTouchEnd, this);
+        }
         this.destroy();
         this._isTouched = false;
     }

--- a/cocos/physics-2d/box2d-wasm/joints/mouse-joint.ts
+++ b/cocos/physics-2d/box2d-wasm/joints/mouse-joint.ts
@@ -119,6 +119,12 @@ export class B2MouseJoint extends B2Joint implements IMouseJoint {
     }
 
     onTouchEnd (event: Touch): void {
+        
+        this.destroy();
+        this._isTouched = false;
+    }
+    destroy (): void {
+        super.destroy();
         const canvas = find('Canvas');
         if (canvas) {
             canvas.off(NodeEventType.TOUCH_START, this.onTouchBegan, this);
@@ -126,10 +132,7 @@ export class B2MouseJoint extends B2Joint implements IMouseJoint {
             canvas.off(NodeEventType.TOUCH_END, this.onTouchEnd, this);
             canvas.off(NodeEventType.TOUCH_CANCEL, this.onTouchEnd, this);
         }
-        this.destroy();
-        this._isTouched = false;
     }
-
     update (): void {
         if (!this._isTouched || !this.isValid()) {
             return;

--- a/cocos/physics-2d/box2d/joints/mouse-joint.ts
+++ b/cocos/physics-2d/box2d/joints/mouse-joint.ts
@@ -66,7 +66,10 @@ export class b2MouseJoint extends b2Joint implements IMouseJoint {
     _createJointDef (): any {
         const def = new b2.MouseJointDef();
         const comp = this._jointComp as MouseJoint2D;
-        def.target.Set(this._touchPoint.x / PHYSICS_2D_PTM_RATIO, this._touchPoint.y / PHYSICS_2D_PTM_RATIO);
+        def.target.Set(
+            this._touchPoint.x / PHYSICS_2D_PTM_RATIO,
+            this._touchPoint.y / PHYSICS_2D_PTM_RATIO,
+        );
         def.maxForce = comp.maxForce;
         def.dampingRatio = comp.dampingRatio;
         def.frequencyHz = comp.frequency;
@@ -85,18 +88,16 @@ export class b2MouseJoint extends b2Joint implements IMouseJoint {
         }
     }
 
-    onEnable (): void {
-    }
+    onEnable (): void {}
 
-    start (): void {
-    }
+    start (): void {}
 
     onTouchBegan (event: Touch): void {
         this._isTouched = true;
 
         const target = this._touchPoint.set(event.getUILocation());
 
-        const world = (PhysicsSystem2D.instance.physicsWorld as b2PhysicsWorld);
+        const world = PhysicsSystem2D.instance.physicsWorld as b2PhysicsWorld;
         const colliders = world.testPoint(target);
         if (colliders.length <= 0) return;
 
@@ -117,6 +118,13 @@ export class b2MouseJoint extends b2Joint implements IMouseJoint {
     }
 
     onTouchEnd (event: Touch): void {
+        const canvas = find('Canvas');
+        if (canvas) {
+            canvas.off(NodeEventType.TOUCH_START, this.onTouchBegan, this);
+            canvas.off(NodeEventType.TOUCH_MOVE, this.onTouchMove, this);
+            canvas.off(NodeEventType.TOUCH_END, this.onTouchEnd, this);
+            canvas.off(NodeEventType.TOUCH_CANCEL, this.onTouchEnd, this);
+        }
         this._destroy();
         this._isTouched = false;
     }

--- a/cocos/physics-2d/box2d/joints/mouse-joint.ts
+++ b/cocos/physics-2d/box2d/joints/mouse-joint.ts
@@ -118,6 +118,13 @@ export class b2MouseJoint extends b2Joint implements IMouseJoint {
     }
 
     onTouchEnd (event: Touch): void {
+     
+        this._destroy();
+        this._isTouched = false;
+    }
+
+    _destroy (): void {
+        super._destroy();
         const canvas = find('Canvas');
         if (canvas) {
             canvas.off(NodeEventType.TOUCH_START, this.onTouchBegan, this);
@@ -125,8 +132,6 @@ export class b2MouseJoint extends b2Joint implements IMouseJoint {
             canvas.off(NodeEventType.TOUCH_END, this.onTouchEnd, this);
             canvas.off(NodeEventType.TOUCH_CANCEL, this.onTouchEnd, this);
         }
-        this._destroy();
-        this._isTouched = false;
     }
 
     update (): void {
@@ -142,4 +147,5 @@ export class b2MouseJoint extends b2Joint implements IMouseJoint {
         this.setTarget(this._touchPoint);
         // }
     }
+    
 }


### PR DESCRIPTION
This code ensures that all touch event listeners (TOUCH_START, TOUCH_MOVE, TOUCH_END, and TOUCH_CANCEL) attached to the Canvas node are properly removed when the MouseJoint component is destroyed.

Purpose:
Prevents touch event listeners from remaining in memory after the MouseJoint is destroyed. Avoids unexpected behavior caused by lingering event handlers that could still trigger interactions. Improves memory management and performance by ensuring proper cleanup of event listeners.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
