### PR TITLE
Fix the issue with incorrect initialization script order in the editor preview

### DIFF
--- a/cocos/game/game.ts
+++ b/cocos/game/game.ts
@@ -993,8 +993,10 @@ export class Game extends EventTarget {
         return new Promise<void>((resolve, reject): void => {
             // Since there is no script in the bundle during preview, we need to load the user's script in the following way
             if (PREVIEW && !TEST && !EDITOR && !NATIVE) {
-                const bundneName = 'cce:/internal/x/prerequisite-imports';
-                import(bundneName).then((): void => resolve(), (reason): void => reject(reason));
+                const bundleName = 'cce:/internal/x/prerequisite-imports';
+                import(bundleName).then((): void => resolve(), (reason): void => reject(reason));
+            } else  if (!EDITOR_NOT_IN_PREVIEW) {
+                globalThis.cce.Script && globalThis.cce.Script.init().then(() => resolve());
             } else {
                 resolve();
             }

--- a/cocos/game/game.ts
+++ b/cocos/game/game.ts
@@ -995,7 +995,7 @@ export class Game extends EventTarget {
             if (PREVIEW && !TEST && !EDITOR && !NATIVE) {
                 const bundleName = 'cce:/internal/x/prerequisite-imports';
                 import(bundleName).then((): void => resolve(), (reason): void => reject(reason));
-            } else  if (!EDITOR_NOT_IN_PREVIEW) {
+            } else if (EDITOR && !EDITOR_NOT_IN_PREVIEW) {
                 globalThis.cce.Script && globalThis.cce.Script.init().then(() => resolve());
             } else {
                 resolve();


### PR DESCRIPTION
Re: # https://github.com/cocos/cocos-engine/issues/17792

https://forum.cocos.org/t/topic/165212/72

### Changelog

* Ensure that the script initialization order during editor preview is consistent with that of browser preview.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
