### PR TITLE
Fix restart crash on HarmonyOS NEXT platform when using JSVM

### DIFF
--- a/native/cocos/bindings/jswrapper/jsvm/Object.cpp
+++ b/native/cocos/bindings/jswrapper/jsvm/Object.cpp
@@ -37,8 +37,6 @@
 namespace se {
 std::unique_ptr<std::unordered_map<Object*, void*>> __objectMap; // Currently, the value `void*` is always nullptr
 
-
-
 Object::Object() {}
 Object::~Object() {
     if (__objectMap) {

--- a/native/cocos/bindings/jswrapper/jsvm/Object.cpp
+++ b/native/cocos/bindings/jswrapper/jsvm/Object.cpp
@@ -36,18 +36,17 @@
 
 namespace se {
 std::unique_ptr<std::unordered_map<Object*, void*>> __objectMap; // Currently, the value `void*` is always nullptr
-std::set<Object*> Object::objBaseSet = {};
 
-bool Object::restarting = false;
+
 
 Object::Object() {}
 Object::~Object() {
-    if(restarting) {
-        objBaseSet.insert(this);
-    }
     if (__objectMap) {
         __objectMap->erase(this);
     }
+
+    delete _privateObject;
+    _privateObject = nullptr;
 }
 
 Object* Object::createObjectWithClass(Class* cls) {
@@ -652,7 +651,6 @@ std::string Object::toString() const {
 }
 
 void Object::root() {
-    JSVM_Status status;
     if (_rootCount == 0) {
         uint32_t result = 0;
         _objRef.incRef(_env);
@@ -661,7 +659,6 @@ void Object::root() {
 }
 
 void Object::unroot() {
-    JSVM_Status status;
     if (_rootCount > 0) {
         --_rootCount;
         if (_rootCount == 0) {
@@ -704,37 +701,34 @@ void Object::weakCallback(JSVM_Env env, void* nativeObject, void* finalizeHint /
         }
         void* rawPtr = reinterpret_cast<Object*>(finalizeHint)->_privateData;
         Object* seObj = reinterpret_cast<Object*>(finalizeHint);
-
-        auto it = objBaseSet.find(seObj);
-        if(it != objBaseSet.end()) {
+        if (seObj->_onCleaingPrivateData) { //called by cleanPrivateData, not release seObj;
             return;
         }
-        
-        if (seObj->_onCleaingPrivateData) { //called by cleanPrivateData, not release seObj;
+        if(!NativePtrToObjectMap::isValid()) {
             return;
         }
         if (seObj->_clearMappingInFinalizer && rawPtr != nullptr) {
             auto iter = NativePtrToObjectMap::find(rawPtr);
             if (iter != NativePtrToObjectMap::end()) {
-                    if (seObj->_finalizeCb != nullptr) {
-                    seObj->_finalizeCb(env, finalizeHint, finalizeHint);
-                } else {
-                    assert(seObj->_getClass() != nullptr);
-                    if (seObj->_getClass()->_getFinalizeFunction() != nullptr) {
-                        seObj->_getClass()->_getFinalizeFunction()(env, finalizeHint, finalizeHint);
-                    }
-                }
-                seObj->decRef();
                 NativePtrToObjectMap::erase(iter);
             } else {
                 SE_LOGE("not find ptr in NativePtrToObjectMap");
             }
         }
+
+        if (seObj->_finalizeCb != nullptr) {
+            seObj->_finalizeCb(env, finalizeHint, finalizeHint);
+        } else {
+            assert(seObj->_getClass() != nullptr);
+            if (seObj->_getClass()->_getFinalizeFunction() != nullptr) {
+                seObj->_getClass()->_getFinalizeFunction()(env, finalizeHint, finalizeHint);
+            }
+        }
+        seObj->decRef();
     }
 }
 
 void Object::setup() {
-    restarting = false;
     __objectMap = std::make_unique<std::unordered_map<Object*, void*>>();
 }
 
@@ -749,11 +743,11 @@ void Object::cleanup() {
         obj = e.second;
 
         if (obj->_finalizeCb != nullptr) {
-            obj->_finalizeCb(ScriptEngine::getEnv(), nativeObj, nullptr);
+            obj->_finalizeCb(ScriptEngine::getEnv(), obj, nullptr);
         } else {
             if (obj->_getClass() != nullptr) {
                 if (obj->_getClass()->_getFinalizeFunction() != nullptr) {
-                    obj->_getClass()->_getFinalizeFunction()(ScriptEngine::getEnv(), nativeObj, nullptr);
+                    obj->_getClass()->_getFinalizeFunction()(ScriptEngine::getEnv(), obj, nullptr);
                 }
             }
         }

--- a/native/cocos/bindings/jswrapper/jsvm/Object.h
+++ b/native/cocos/bindings/jswrapper/jsvm/Object.h
@@ -117,12 +117,6 @@ public:
         BIGINT64,
         BIGUINT64
     };
-
-    static std::set<Object*> objBaseSet;
-    static bool restarting;
-    static void resetBaseSet() {
-          objBaseSet.erase(objBaseSet.begin(), objBaseSet.end());
-    }
     
     using BufferContentsFreeFunc = void (*)(void *contents, size_t byteLength, void *userData);
 

--- a/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.cpp
@@ -349,11 +349,10 @@ void ScriptEngine::cleanup() {
     if (!_isValid) {
         return;
     }
-    
     SE_LOGD("ScriptEngine::cleanup begin ...\n");
     _isInCleanup = true;
     se::AutoHandleScope hs;
-    do{    
+    do{
         for (const auto &hook : _beforeCleanupHookArray) {
             hook();
         }

--- a/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.cpp
@@ -352,22 +352,18 @@ void ScriptEngine::cleanup() {
     
     SE_LOGD("ScriptEngine::cleanup begin ...\n");
     _isInCleanup = true;
-    
-    //cc::events::ScriptEngine::broadcast(cc::ScriptEngineEvent::BEFORE_CLEANUP);
-
-    do{
-        se::AutoHandleScope hs;
+    se::AutoHandleScope hs;
+    do{    
         for (const auto &hook : _beforeCleanupHookArray) {
             hook();
         }
-        _beforeCleanupHookArray.clear();
     }while (0);
-    
+    _beforeCleanupHookArray.clear();
 
     SAFE_DEC_REF(_globalObj);
     Object::cleanup();
     Class::cleanup();
-   
+    garbageCollect();
 
     __oldConsoleLog.setUndefined();
     __oldConsoleDebug.setUndefined();
@@ -375,8 +371,6 @@ void ScriptEngine::cleanup() {
     __oldConsoleWarn.setUndefined();
     __oldConsoleError.setUndefined();
     __oldConsoleAssert.setUndefined();
-    garbageCollect();
-
 
     _globalObj = nullptr;
     _isValid   = false;

--- a/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.cpp
@@ -138,17 +138,14 @@ SE_BIND_FUNC(JSB_console_assert)
 ScriptEngine *gSriptEngineInstance = nullptr;
 
 ScriptEngine::ScriptEngine() {
-    static bool initialized = false;
-    if (initialized) {
-        return;
-    }
-    JSVM_InitOptions initOptions;
-    memset(&initOptions, 0, sizeof(initOptions));
-    OH_JSVM_Init(&initOptions);
-    initialized = true;
+    OH_JSVM_Init(nullptr);
+    gSriptEngineInstance = this;
 };
 
-ScriptEngine::~ScriptEngine() = default;
+ScriptEngine::~ScriptEngine() {
+    cleanup();
+    gSriptEngineInstance = nullptr;
+};
 
 void ScriptEngine::setFileOperationDelegate(const FileOperationDelegate &delegate) {
     _fileOperationDelegate = delegate;
@@ -303,6 +300,21 @@ bool ScriptEngine::init() {
 
 Object *ScriptEngine::getGlobalObject() const { return _globalObj; }
     
+void ScriptEngine::closeEngine() {
+    JSVM_Env env = _env;
+    _env = nullptr;
+
+    JSVM_Status status;
+    NODE_API_CALL(status, env, OH_JSVM_CloseEnvScope(env, _envScope));
+    NODE_API_CALL(status, env, OH_JSVM_DestroyEnv(env));
+    NODE_API_CALL(status, env, OH_JSVM_CloseVMScope(_vm, _vmScope));
+    NODE_API_CALL(status, env, OH_JSVM_DestroyVM(_vm));
+    _envScope = nullptr;
+    env = nullptr;
+    _vmScope = nullptr;
+    _vm = nullptr;
+}
+
 bool ScriptEngine::start() {
     bool ok = true;
     if (!init()) {
@@ -337,22 +349,25 @@ void ScriptEngine::cleanup() {
     if (!_isValid) {
         return;
     }
-    Object::restarting = true;
-    Object::resetBaseSet();
+    
     SE_LOGD("ScriptEngine::cleanup begin ...\n");
     _isInCleanup = true;
-    se::AutoHandleScope hs;
+    
+    //cc::events::ScriptEngine::broadcast(cc::ScriptEngineEvent::BEFORE_CLEANUP);
+
     do{
+        se::AutoHandleScope hs;
         for (const auto &hook : _beforeCleanupHookArray) {
             hook();
         }
+        _beforeCleanupHookArray.clear();
     }while (0);
-    _beforeCleanupHookArray.clear();
+    
 
     SAFE_DEC_REF(_globalObj);
     Object::cleanup();
     Class::cleanup();
-    garbageCollect();
+   
 
     __oldConsoleLog.setUndefined();
     __oldConsoleDebug.setUndefined();
@@ -360,20 +375,8 @@ void ScriptEngine::cleanup() {
     __oldConsoleWarn.setUndefined();
     __oldConsoleError.setUndefined();
     __oldConsoleAssert.setUndefined();
+    garbageCollect();
 
-    JSVM_Env env = _env;
-    _env = nullptr;
-
-    JSVM_Status status;
-    NODE_API_CALL(status, env, OH_JSVM_CloseEnvScope(env, _envScope));
-
-    NODE_API_CALL(status, env, OH_JSVM_DestroyEnv(env));
-    NODE_API_CALL(status, env, OH_JSVM_CloseVMScope(_vm, _vmScope));
-    NODE_API_CALL(status, env, OH_JSVM_DestroyVM(_vm));
-    _envScope = nullptr;
-    env = nullptr;
-    _vmScope = nullptr;
-    _vm = nullptr;
 
     _globalObj = nullptr;
     _isValid   = false;

--- a/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.h
+++ b/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.h
@@ -78,6 +78,11 @@ public:
     ScriptEngine();
     ~ScriptEngine();
     /**
+	     *  @brief Shut down the JSVM engine, because cleanup doesn't destroy all objects immediately.
+	     */
+	void closeEngine();
+	
+    /**
          *  @brief Sets the delegate for file operation.
          *  @param delegate[in] The delegate instance for file operation.
          */

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -81,9 +81,9 @@ bool setCanvasCallback(se::Object *global) {
     auto dpr = cc::BasePlatform::getPlatform()->getInterface<cc::IScreen>()->getDevicePixelRatio();
 
     se::Value jsbVal;
-    bool ok = global->getProperty("jsb", &jsbVal);
+    const bool ok = global->getProperty("jsb", &jsbVal);
     if (!jsbVal.isObject()) {
-        se::HandleObject jsbObj(se::Object::createPlainObject());
+        const se::HandleObject jsbObj(se::Object::createPlainObject());
         global->setProperty("jsb", se::Value(jsbObj));
         jsbVal.setObject(jsbObj, true);
     }
@@ -91,13 +91,13 @@ bool setCanvasCallback(se::Object *global) {
     se::Value windowVal;
     jsbVal.toObject()->getProperty("window", &windowVal);
     if (!windowVal.isObject()) {
-        se::HandleObject windowObj(se::Object::createPlainObject());
+        const se::HandleObject windowObj(se::Object::createPlainObject());
         jsbVal.toObject()->setProperty("window", se::Value(windowObj));
         windowVal.setObject(windowObj, true);
     }
 
-    int width = static_cast<int>(viewSize.width / dpr);
-    int height = static_cast<int>(viewSize.height / dpr);
+    const int width = static_cast<int>(viewSize.width / dpr);
+    const int height = static_cast<int>(viewSize.height / dpr);
     windowVal.toObject()->setProperty("innerWidth", se::Value(width));
     windowVal.toObject()->setProperty("innerHeight", se::Value(height));
 

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -73,7 +73,7 @@
 namespace {
 
 bool setCanvasCallback(se::Object *global) {
-    se::AutoHandleScope scope;
+    const se::AutoHandleScope scope;
     se::ScriptEngine *se = se::ScriptEngine::getInstance();
     auto *window = CC_GET_MAIN_SYSTEM_WINDOW();
     auto handler = window->getWindowHandle();

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -207,6 +207,10 @@ void Engine::destroy() {
     if (cc::render::getRenderingModule()) {
         cc::render::Factory::destroy(cc::render::getRenderingModule());
     }
+    #if(CC_PLATFORM == CC_PLATFORM_OPENHARMONY && SCRIPT_ENGINE_TYPE == SCRIPT_ENGINE_JSVM)
+        // When using JSVM, not all objects are destroyed during cleanup, so we need to close JSVM at the end.
+        _scriptEngine->closeEngine();
+    #endif
 
     CC_SAFE_DESTROY_AND_DELETE(_gfxDevice);
     delete _fs;


### PR DESCRIPTION
Re: #

### Changelog

https://github.com/cocos/3d-tasks/issues/17970

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
