### PR TITLE
Update ccbuild to 2.3.13 which supports to override constant values in feature definition.

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -26,6 +26,9 @@
         },
         "3d": {
             "modules": ["3d"],
+            "overrideConstants": {
+                "USE_3D": true
+            },
             "dependentAssets": [
                 "511d2633-09a7-4bdd-ac42-f778032124b3",
                 "5d45aa00-e064-4938-b314-4265f0c2258c",
@@ -68,6 +71,9 @@
         },
         "ui-skew": {
             "modules": ["ui-skew"],
+            "overrideConstants": {
+                "USE_UI_SKEW": true
+            },
             "dependentModules": ["2d"]
         },
         "ui": {
@@ -159,7 +165,10 @@
             "modules": ["video"]
         },
         "xr": {
-            "modules": ["xr"]
+            "modules": ["xr"],
+            "overrideConstants": {
+                "USE_XR": true
+            }
         },
         "light-probe": { 
             "modules": [ "light-probe" ] 
@@ -259,7 +268,10 @@
             "isNativeOnly": true
         },
         "meshopt": {
-            "modules": []
+            "modules": [],
+            "overrideConstants": {
+                "CULL_MESHOPT": false
+            }
         }
     },
     "moduleOverrides": [{
@@ -722,13 +734,19 @@
         "USE_3D": {
             "comment": "An internal constant to indicate whether we're using 3d module.",
             "type": "boolean",
-            "value": true,
+            "value": false,
             "internal": true
         },
         "USE_UI_SKEW": {
             "comment": "An internal constant to indicate whether we're using ui-skew module.",
             "type": "boolean",
-            "value": true,
+            "value": false,
+            "internal": true
+        },
+        "USE_XR": {
+            "comment": "An internal constant to indicate whether we're using xr module.",
+            "type": "boolean",
+            "value": false,
             "internal": true
         }
     },

--- a/cc.config.schema.json
+++ b/cc.config.schema.json
@@ -118,6 +118,16 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "overrideConstants": {
+          "additionalProperties": {
+            "type": [
+              "number",
+              "boolean"
+            ]
+          },
+          "description": "Constants to override when this feature is enabled. The overridden constants should be defined in cc.config.json.",
+          "type": "object"
         }
       },
       "required": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@cocos/box2d": "1.0.1",
         "@cocos/cannon": "1.2.8",
-        "@cocos/ccbuild": "^2.3.12",
+        "@cocos/ccbuild": "^2.3.13",
         "@cocos/dragonbones-js": "^1.0.1"
       },
       "devDependencies": {
@@ -2063,9 +2063,9 @@
       }
     },
     "node_modules/@cocos/ccbuild": {
-      "version": "2.3.12",
-      "resolved": "https://registry.npmjs.org/@cocos/ccbuild/-/ccbuild-2.3.12.tgz",
-      "integrity": "sha512-QFMYiBVc6xhoKqjJY2zvdoOtHJ3f/Z0loDZPN+CyqulHrTAevp2VWyS/eu5htcKdg3HX0r2+vz+55cJXpA7OrQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@cocos/ccbuild/-/ccbuild-2.3.13.tgz",
+      "integrity": "sha512-NxMCiulV2M6Hy5xyVEz1brIXcDNA/m7XdjoZ2iVDrVgIi3z/8CZ/3ljG4v4j+8eQAuSPNvOugScLiIMkLvuWeg==",
       "license": "MIT",
       "workspaces": [
         "./modules/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@cocos/box2d": "1.0.1",
         "@cocos/cannon": "1.2.8",
-        "@cocos/ccbuild": "^2.3.10",
+        "@cocos/ccbuild": "^2.3.12",
         "@cocos/dragonbones-js": "^1.0.1"
       },
       "devDependencies": {
@@ -2063,9 +2063,13 @@
       }
     },
     "node_modules/@cocos/ccbuild": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/@cocos/ccbuild/-/ccbuild-2.3.10.tgz",
-      "integrity": "sha512-paleC8syjqEtxmH3PU5NaI87x/YJ1ANTZbQNENOZ3SY90nvhl6Vj6AkD8AcNnR96klUS0Sh2t5YbZkPGT7LDAQ==",
+      "version": "2.3.12",
+      "resolved": "https://registry.npmjs.org/@cocos/ccbuild/-/ccbuild-2.3.12.tgz",
+      "integrity": "sha512-QFMYiBVc6xhoKqjJY2zvdoOtHJ3f/Z0loDZPN+CyqulHrTAevp2VWyS/eu5htcKdg3HX0r2+vz+55cJXpA7OrQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./modules/*"
+      ],
       "dependencies": {
         "@babel/core": "^7.20.12",
         "@babel/generator": "^7.22.10",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@cocos/box2d": "1.0.1",
     "@cocos/cannon": "1.2.8",
-    "@cocos/ccbuild": "^2.3.10",
+    "@cocos/ccbuild": "^2.3.12",
     "@cocos/dragonbones-js": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@cocos/box2d": "1.0.1",
     "@cocos/cannon": "1.2.8",
-    "@cocos/ccbuild": "^2.3.12",
+    "@cocos/ccbuild": "^2.3.13",
     "@cocos/dragonbones-js": "^1.0.1"
   }
 }


### PR DESCRIPTION
Re: 

https://github.com/cocos/cocos-ccbuild/pull/85
https://github.com/cocos/cocos-ccbuild/pull/86
https://github.com/cocos/cocos-ccbuild/pull/87
https://github.com/cocos/cocos-ccbuild/pull/88

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
