### PR TITLE
UIRenderer.updateMaterial should not be marked as `@mangle`

### DIFF
--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -471,8 +471,11 @@ export class UIRenderer extends Renderer {
     }
 
     /**
+     * cocos-test-projects/assets/cases/rendertexture depends on this method, so it should not be marked as `@mangle` now.
+     * FIXME(cjh): `protected` is not equal to `@engineInternal + public`, because `protected` methods are also APIs exposed to developers,
+     * For example, developers could implement a class which extends `UIRenderer` and call this method.
+     * The mistake was merged in https://github.com/cocos/cocos-engine/pull/14572 , and it needs to be fixed in the future.
      * @engineInternal
-     * @mangle
      */
     public updateMaterial (): void {
         if (this._customMaterial) {

--- a/cocos/dragon-bones/ArmatureDisplay.ts
+++ b/cocos/dragon-bones/ArmatureDisplay.ts
@@ -711,11 +711,11 @@ export class ArmatureDisplay extends UIRenderer {
     /**
      * @engineInternal
      */
-    public updateMaterial (): void {
-        let mat;
+    public override updateMaterial (): void {
+        let mat: Material;
         if (this._customMaterial) mat = this._customMaterial;
         else mat = this._updateBuiltinMaterial();
-        this.setSharedMaterial(mat as Material, 0);
+        this.setSharedMaterial(mat, 0);
         this._cleanMaterialCache();
     }
 

--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -1193,7 +1193,7 @@ export class Skeleton extends UIRenderer {
     /**
      * @engineInternal
      */
-    public updateMaterial (): void {
+    public override updateMaterial (): void {
         let mat: Material;
         if (this._customMaterial) mat = this._customMaterial;
         else mat = this._updateBuiltinMaterial();


### PR DESCRIPTION
This fix an error reported in daily build.

cocos-test-projects/assets/cases/rendertexture depends on this method, so it should not be marked as `@mangle` now.

`protected` is not equal to `@engineInternal + public`, because `protected` methods are also APIs exposed to developers,
For example, developers could implement a class which extends `UIRenderer` and call this method.
The mistake was merged in https://github.com/cocos/cocos-engine/pull/14572 , and it needs to be fixed in the future.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
