### PR TITLE
Optimize code size: strip XR relevant code by USE_XR constants

### DIFF
--- a/.github/workflows/package-size-check.js
+++ b/.github/workflows/package-size-check.js
@@ -11,7 +11,7 @@ const features = [];
 files.forEach(file => {
     const filePath = ps.join(exportsDir, file);
     const feature = ps.parse(ps.basename(filePath)).name;
-    if (feature !== 'vendor-google') {
+    if (feature !== 'vendor-google' && feature !== 'xr') {
         features.push(feature);
     }
 });

--- a/cocos/game/game.ts
+++ b/cocos/game/game.ts
@@ -23,7 +23,7 @@
  THE SOFTWARE.
 */
 
-import { DEBUG, EDITOR, NATIVE, PREVIEW, TEST, EDITOR_NOT_IN_PREVIEW, WECHAT } from 'internal:constants';
+import { DEBUG, EDITOR, NATIVE, PREVIEW, TEST, EDITOR_NOT_IN_PREVIEW, WECHAT, USE_XR } from 'internal:constants';
 import { systemInfo } from 'pal/system-info';
 import { findCanvas, loadJsFile } from 'pal/env';
 import { Pacer } from 'pal/pacer';
@@ -915,6 +915,7 @@ export class Game extends EventTarget {
     }
 
     private _initXR (): void {
+        if (!USE_XR) return;
         if (typeof globalThis.__globalXR === 'undefined') {
             globalThis.__globalXR = {};
         }

--- a/cocos/game/splash-screen.ts
+++ b/cocos/game/splash-screen.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { EDITOR } from 'internal:constants';
+import { EDITOR, USE_XR } from 'internal:constants';
 import { Material, MaterialPropertyFull } from '../asset/assets/material';
 import { clamp01, Mat4, Vec2, settings, sys, cclegacy, easing, preTransforms, SettingsCategory } from '../core';
 import {
@@ -513,7 +513,7 @@ export class SplashScreen {
         if (!sys.isXR || xr.entry.isRenderAllowable()) {
             const renderSize = sys.isXR ? 2 : 1;
             for (let xrEye = 0; xrEye < renderSize; xrEye++) {
-                if (sys.isXR) {
+                if (USE_XR && sys.isXR) {
                     xr.entry.renderLoopStart(xrEye);
                     const xrFov = xr.entry.getEyeFov(xrEye);
                     // device's fov may be asymmetry
@@ -627,7 +627,7 @@ export class SplashScreen {
                 device.present();
                 device.enableAutoBarrier(!legacyCC.rendering);
 
-                if (sys.isXR) {
+                if (USE_XR && sys.isXR) {
                     xr.entry.renderLoopEnd(xrEye);
                 }
             }

--- a/cocos/gfx/webgl2/webgl2-swapchain.ts
+++ b/cocos/gfx/webgl2/webgl2-swapchain.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { EDITOR } from 'internal:constants';
+import { EDITOR, USE_XR } from 'internal:constants';
 import { systemInfo } from 'pal/system-info';
 import { warnID, warn, debug } from '../../core/platform/debug';
 import { WebGL2StateCache } from './webgl2-state-cache';
@@ -122,7 +122,7 @@ export function getExtensions (gl: WebGL2RenderingContext): IWebGL2Extensions {
 export function getContext (canvas: HTMLCanvasElement): WebGL2RenderingContext | null {
     let context: WebGL2RenderingContext | null = null;
     try {
-        if (globalThis.__globalXR?.webxrCompatible) {
+        if (USE_XR && globalThis.__globalXR?.webxrCompatible) {
             const glAttribs = {
                 alpha: macro.ENABLE_TRANSPARENT_CANVAS,
                 antialias: EDITOR || macro.ENABLE_WEBGL_ANTIALIAS,

--- a/cocos/render-scene/scene/camera.ts
+++ b/cocos/render-scene/scene/camera.ts
@@ -21,7 +21,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
 */
-import { EDITOR } from 'internal:constants';
+import { EDITOR, USE_XR } from 'internal:constants';
 import { SurfaceTransform, ClearFlagBit, Device, Color, ClearFlags } from '../../gfx';
 import { lerp, Mat4, Rect, toRadian, Vec3, IVec4Like, preTransforms, warnID, geometry, cclegacy, Vec4, rect, mat4, v3 } from '../../core';
 import { CAMERA_DEFAULT_MASK } from '../../rendering/define';
@@ -1015,11 +1015,13 @@ export class Camera {
         if (!this._node) return;
 
         let viewProjDirty = false;
-        const xr = globalThis.__globalXR;
-        if (xr && xr.isWebXR && xr.webXRWindowMap && xr.updateViewport) {
-            const x = xr.webXRMatProjs ? 1 / xr.webXRMatProjs.length : 1;
-            const wndXREye = xr.webXRWindowMap.get(this._window);
-            this.setViewportInOrientedSpace(new Rect(x * wndXREye, 0, x, 1));
+        if (USE_XR) {
+            const xr = globalThis.__globalXR;
+            if (xr && xr.isWebXR && xr.webXRWindowMap && xr.updateViewport) {
+                const x = xr.webXRMatProjs ? 1 / xr.webXRMatProjs.length : 1;
+                const wndXREye = xr.webXRWindowMap.get(this._window);
+                this.setViewportInOrientedSpace(new Rect(x * wndXREye, 0, x, 1));
+            }
         }
 
         const forward = this._forward;
@@ -1045,7 +1047,7 @@ export class Camera {
             const projectionSignY = this._device.capabilities.clipSpaceSignY;
             // Only for rendertexture processing
             if (this._proj === CameraProjection.PERSPECTIVE) {
-                if (xr && xr.isWebXR && xr.webXRWindowMap && xr.webXRMatProjs) {
+                if (USE_XR && xr && xr.isWebXR && xr.webXRWindowMap && xr.webXRMatProjs) {
                     const wndXREye = xr.webXRWindowMap.get(this._window);
                     matProj.set(xr.webXRMatProjs[wndXREye] as Mat4);
                 } else {

--- a/cocos/root.ts
+++ b/cocos/root.ts
@@ -22,6 +22,7 @@
  THE SOFTWARE.
 */
 
+import { USE_XR } from 'internal:constants';
 import { Pool, cclegacy, warnID, settings, macro, log, errorID, SettingsCategory } from './core';
 import { DebugView } from './rendering/debug-view';
 import { Camera, CameraType, Light, Model, TrackingType } from './render-scene/scene';
@@ -476,7 +477,7 @@ export class Root {
             this._fpsTime = 0.0;
         }
 
-        if (globalThis.__globalXR?.isWebXR) {
+        if (USE_XR && globalThis.__globalXR?.isWebXR) {
             this._doWebXRFrameMove();
         } else {
             this._frameMoveBegin();
@@ -686,6 +687,7 @@ export class Root {
     }
 
     private _doWebXRFrameMove (): void {
+        if (!USE_XR) return;
         const xr = globalThis.__globalXR;
         if (!xr) {
             return;

--- a/pal/input/web/gamepad-input.ts
+++ b/pal/input/web/gamepad-input.ts
@@ -24,6 +24,7 @@
 
 import { GamepadCallback } from 'pal/input';
 import { systemInfo } from 'pal/system-info';
+import { USE_XR } from 'internal:constants';
 import { InputEventType } from '../../../cocos/input/types/event-enum';
 import { EventTarget } from '../../../cocos/core/event/event-target';
 import legacyCC from '../../../predefine';
@@ -330,6 +331,7 @@ export class GamepadInputDevice {
     }
 
     private static _scanWebXRGamepads (devices: GamepadInputDevice[]): void {
+        if (!USE_XR) return;
         const webxrGamepadMap = GamepadInputDevice._getWebXRGamepadMap();
         if (!webxrGamepadMap) {
             // update cache
@@ -434,6 +436,7 @@ export class GamepadInputDevice {
     }
 
     private static _scanWebXRGamepadsPose (): void {
+        if (!USE_XR) return;
         const infoList = globalThis.__globalXR?.webxrHandlePoseInfos as IPoseInfo[];
         if (!infoList || !GamepadInputDevice.xr) {
             return;
@@ -678,12 +681,14 @@ export class GamepadInputDevice {
         const leftStickUp = new InputSourceButton();
         leftStickUp.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
-                if (webxrGamepad) {
-                    if (webxrGamepad.axes.length > XR_AXIS_STICK_Y && webxrGamepad.axes[XR_AXIS_STICK_Y] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_Y]).negative;
-                    } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_Y && webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y]).negative;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
+                    if (webxrGamepad) {
+                        if (webxrGamepad.axes.length > XR_AXIS_STICK_Y && webxrGamepad.axes[XR_AXIS_STICK_Y] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_Y]).negative;
+                        } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_Y && webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y]).negative;
+                        }
                     }
                 }
                 return 0;
@@ -697,12 +702,14 @@ export class GamepadInputDevice {
         const leftStickDown = new InputSourceButton();
         leftStickDown.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
-                if (webxrGamepad) {
-                    if (webxrGamepad.axes.length > XR_AXIS_STICK_Y && webxrGamepad.axes[XR_AXIS_STICK_Y] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_Y]).positive;
-                    } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_Y && webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y]).positive;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
+                    if (webxrGamepad) {
+                        if (webxrGamepad.axes.length > XR_AXIS_STICK_Y && webxrGamepad.axes[XR_AXIS_STICK_Y] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_Y]).positive;
+                        } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_Y && webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y]).positive;
+                        }
                     }
                 }
                 return 0;
@@ -716,12 +723,14 @@ export class GamepadInputDevice {
         const leftStickLeft = new InputSourceButton();
         leftStickLeft.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
-                if (webxrGamepad) {
-                    if (webxrGamepad.axes.length > XR_AXIS_STICK_X && webxrGamepad.axes[XR_AXIS_STICK_X] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_X]).negative;
-                    } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_X && webxrGamepad.axes[XR_AXIS_TOUCHPAD_X] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_X]).negative;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
+                    if (webxrGamepad) {
+                        if (webxrGamepad.axes.length > XR_AXIS_STICK_X && webxrGamepad.axes[XR_AXIS_STICK_X] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_X]).negative;
+                        } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_X && webxrGamepad.axes[XR_AXIS_TOUCHPAD_X] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_X]).negative;
+                        }
                     }
                 }
                 return 0;
@@ -735,12 +744,14 @@ export class GamepadInputDevice {
         const leftStickRight = new InputSourceButton();
         leftStickRight.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
-                if (webxrGamepad) {
-                    if (webxrGamepad.axes.length > XR_AXIS_STICK_X && webxrGamepad.axes[XR_AXIS_STICK_X] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_X]).positive;
-                    } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_X && webxrGamepad.axes[XR_AXIS_TOUCHPAD_X] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_X]).positive;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
+                    if (webxrGamepad) {
+                        if (webxrGamepad.axes.length > XR_AXIS_STICK_X && webxrGamepad.axes[XR_AXIS_STICK_X] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_X]).positive;
+                        } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_X && webxrGamepad.axes[XR_AXIS_TOUCHPAD_X] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_X]).positive;
+                        }
                     }
                 }
                 return 0;
@@ -756,12 +767,14 @@ export class GamepadInputDevice {
         const rightStickUp = new InputSourceButton();
         rightStickUp.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRRightHandedness);
-                if (webxrGamepad) {
-                    if (webxrGamepad.axes.length > XR_AXIS_STICK_Y && webxrGamepad.axes[XR_AXIS_STICK_Y] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_Y]).negative;
-                    } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_Y && webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y]).negative;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRRightHandedness);
+                    if (webxrGamepad) {
+                        if (webxrGamepad.axes.length > XR_AXIS_STICK_Y && webxrGamepad.axes[XR_AXIS_STICK_Y] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_Y]).negative;
+                        } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_Y && webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y]).negative;
+                        }
                     }
                 }
                 return 0;
@@ -775,12 +788,14 @@ export class GamepadInputDevice {
         const rightStickDown = new InputSourceButton();
         rightStickDown.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRRightHandedness);
-                if (webxrGamepad) {
-                    if (webxrGamepad.axes.length > XR_AXIS_STICK_Y && webxrGamepad.axes[XR_AXIS_STICK_Y] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_Y]).positive;
-                    } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_Y && webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y]).positive;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRRightHandedness);
+                    if (webxrGamepad) {
+                        if (webxrGamepad.axes.length > XR_AXIS_STICK_Y && webxrGamepad.axes[XR_AXIS_STICK_Y] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_Y]).positive;
+                        } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_Y && webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_Y]).positive;
+                        }
                     }
                 }
                 return 0;
@@ -794,12 +809,14 @@ export class GamepadInputDevice {
         const rightStickLeft = new InputSourceButton();
         rightStickLeft.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRRightHandedness);
-                if (webxrGamepad) {
-                    if (webxrGamepad.axes.length > XR_AXIS_STICK_X && webxrGamepad.axes[XR_AXIS_STICK_X] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_X]).negative;
-                    } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_X && webxrGamepad.axes[XR_AXIS_TOUCHPAD_X] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_X]).negative;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRRightHandedness);
+                    if (webxrGamepad) {
+                        if (webxrGamepad.axes.length > XR_AXIS_STICK_X && webxrGamepad.axes[XR_AXIS_STICK_X] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_X]).negative;
+                        } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_X && webxrGamepad.axes[XR_AXIS_TOUCHPAD_X] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_X]).negative;
+                        }
                     }
                 }
                 return 0;
@@ -813,12 +830,14 @@ export class GamepadInputDevice {
         const rightStickRight = new InputSourceButton();
         rightStickRight.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRRightHandedness);
-                if (webxrGamepad) {
-                    if (webxrGamepad.axes.length > XR_AXIS_STICK_X && webxrGamepad.axes[XR_AXIS_STICK_X] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_X]).positive;
-                    } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_X && webxrGamepad.axes[XR_AXIS_TOUCHPAD_X] !== 0) {
-                        return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_X]).positive;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRRightHandedness);
+                    if (webxrGamepad) {
+                        if (webxrGamepad.axes.length > XR_AXIS_STICK_X && webxrGamepad.axes[XR_AXIS_STICK_X] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_STICK_X]).positive;
+                        } else if (webxrGamepad.axes.length > XR_AXIS_TOUCHPAD_X && webxrGamepad.axes[XR_AXIS_TOUCHPAD_X] !== 0) {
+                            return this._axisToButtons(webxrGamepad.axes[XR_AXIS_TOUCHPAD_X]).positive;
+                        }
                     }
                 }
                 return 0;
@@ -837,9 +856,11 @@ export class GamepadInputDevice {
         this._gripLeft = new InputSourceButton();
         this._gripLeft.getValue = (): number => {
             if (this.deviceId === -1) {
-                const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
-                if (webxrGamepad && webxrGamepad.buttons.length > XR_GRIP) {
-                    return webxrGamepad.buttons[XR_GRIP].value;
+                if (USE_XR) {
+                    const webxrGamepad = GamepadInputDevice._getWebXRGamepadMap()?.get(XRLeftHandedness);
+                    if (webxrGamepad && webxrGamepad.buttons.length > XR_GRIP) {
+                        return webxrGamepad.buttons[XR_GRIP].value;
+                    }
                 }
             }
             return 0;

--- a/pal/input/web/touch-input.ts
+++ b/pal/input/web/touch-input.ts
@@ -23,7 +23,7 @@
 */
 
 import { TouchCallback } from 'pal/input';
-import { EDITOR, TEST } from 'internal:constants';
+import { EDITOR, TEST, USE_XR } from 'internal:constants';
 import { systemInfo } from 'pal/system-info';
 import { screenAdapter } from 'pal/screen-adapter';
 import { Rect, Vec2 } from '../../../cocos/core/math';
@@ -111,7 +111,7 @@ export class TouchInputSource {
 
     private _getLocation (touch: globalThis.Touch, canvasRect: Rect): Vec2 {
         // webxr has been converted to screen coordinates via camera
-        if (globalThis.__globalXR && globalThis.__globalXR.ar && globalThis.__globalXR.ar.isWebXR()) {
+        if (USE_XR && globalThis.__globalXR && globalThis.__globalXR.ar && globalThis.__globalXR.ar.isWebXR()) {
             return new Vec2(touch.clientX, touch.clientY);
         }
 

--- a/pal/pacer/pacer-web.ts
+++ b/pal/pacer/pacer-web.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { EDITOR } from 'internal:constants';
+import { EDITOR, USE_XR } from 'internal:constants';
 import { assertIsTrue } from '../../cocos/core/data/utils/asserts';
 import { checkPalIntegrity, withImpl } from '../integrity-check';
 
@@ -85,7 +85,7 @@ export class Pacer {
 
     start (): void {
         if (this._isPlaying) return;
-        const recordStartTime = EDITOR || this._rAF === undefined || globalThis.__globalXR?.isWebXR;
+        const recordStartTime = EDITOR || this._rAF === undefined || (USE_XR && globalThis.__globalXR?.isWebXR);
         const updateCallback = (): void => {
             if (recordStartTime) this._startTime = performance.now();
             if (this._isPlaying) {
@@ -129,7 +129,7 @@ export class Pacer {
     };
 
     private _stTime (callback: () => void): number {
-        if (EDITOR || this._rAF === undefined || globalThis.__globalXR?.isWebXR) {
+        if (EDITOR || this._rAF === undefined || (USE_XR && globalThis.__globalXR?.isWebXR)) {
             const currTime = performance.now();
             const elapseTime = Math.max(0, currTime - this._startTime);
             const timeToCall = Math.max(0, this._frameTime - elapseTime);
@@ -140,7 +140,7 @@ export class Pacer {
     }
 
     private _ctTime (id: number | undefined): void {
-        if (EDITOR || this._cAF === undefined || globalThis.__globalXR?.isWebXR) {
+        if (EDITOR || this._cAF === undefined || (USE_XR && globalThis.__globalXR?.isWebXR)) {
             clearTimeout(id);
         } else if (id) {
             this._cAF.call(window, id);

--- a/pal/utils.ts
+++ b/pal/utils.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { EDITOR } from 'internal:constants';
+import { EDITOR, USE_XR } from 'internal:constants';
 import { warnID } from '../cocos/core/platform/debug';
 
 /**
@@ -202,7 +202,7 @@ export function setTimeoutRAF<T extends any[]> (callback: (...args: T) => void, 
     || window.oRequestAnimationFrame
     || window.msRequestAnimationFrame;
 
-    if (EDITOR || raf === undefined || globalThis.__globalXR?.isWebXR) {
+    if (EDITOR || raf === undefined || (USE_XR && globalThis.__globalXR?.isWebXR)) {
         return setTimeout(callback, delay, ...args);
     }
 
@@ -234,7 +234,7 @@ export function clearTimeoutRAF (id: number): void {
         || window.mozCancelAnimationFrame
         || window.webkitCancelAnimationFrame
         || window.ocancelAnimationFrame;
-    if (EDITOR || caf === undefined || globalThis.__globalXR?.isWebXR) {
+    if (EDITOR || caf === undefined || (USE_XR && globalThis.__globalXR?.isWebXR)) {
         clearTimeout(id);
     } else {
         caf(id);


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/18222

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
