### PR TITLE
fixed #18374: 2D Node with MotionStreak and Rigidbody has wrong offset

### DIFF
--- a/cocos/particle-2d/motion-streak-2d-assembler.ts
+++ b/cocos/particle-2d/motion-streak-2d-assembler.ts
@@ -218,16 +218,6 @@ class MotionStreakAssembler implements IAssembler {
         }
     }
 
-    updateRenderData (comp: MotionStreak): void {
-        if (JSB) {
-            // A dirty hack
-            // The world matrix was updated in advance and needs to be avoided at the cpp level
-            // Need a flag to explicitly not update the world transform to solve this problem
-            comp.renderData!.renderDrawInfo.setVertDirty(false);
-            comp.node.hasChangedFlags = 0;
-        }
-    }
-
     fillBuffers (comp: MotionStreak, renderer: IBatcher): void {
         const renderData = comp.renderData!;
         const chunk = renderData.chunk;

--- a/cocos/particle-2d/motion-streak-2d.ts
+++ b/cocos/particle-2d/motion-streak-2d.ts
@@ -24,7 +24,7 @@
 */
 
 import { ccclass, executeInEditMode, serializable, playOnFocus, menu, help, editable, type } from 'cc.decorator';
-import { EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
+import { EDITOR_NOT_IN_PREVIEW, JSB } from 'internal:constants';
 import { UIRenderer } from '../2d/framework';
 import { Texture2D } from '../asset/assets/texture-2d';
 import type { IBatcher } from '../2d/renderer/i-batcher';
@@ -195,6 +195,9 @@ export class MotionStreak extends UIRenderer {
             if (this._assembler && this._assembler.createData) {
                 this._renderData = this._assembler.createData(this) as RenderData;
                 this._renderData.material = this.material;
+                if (JSB) {
+                    this._renderData.renderDrawInfo.setVertexPositionInWorld(true);
+                }
                 this._updateColor();
             }
         }

--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -208,10 +208,13 @@ CC_FORCE_INLINE void Batcher2d::handleComponentDraw(RenderEntity* entity, Render
     }
 
     if (!drawInfo->getIsMeshBuffer()) {
-        if (node->getChangedFlags() || node->isTransformDirty() || drawInfo->getVertDirty()) {
-            fillVertexBuffers(entity, drawInfo);
-            drawInfo->setVertDirty(false);
+        if (!drawInfo->isVertexPositionInWorld()) {
+            if (node->getChangedFlags() || node->isTransformDirty() || drawInfo->getVertDirty()) {
+                fillVertexBuffers(entity, drawInfo);
+                drawInfo->setVertDirty(false);
+            }
         }
+
         if (entity->getVBColorDirty()) {
             fillColors(entity, drawInfo);
         }

--- a/native/cocos/2d/renderer/RenderDrawInfo.cpp
+++ b/native/cocos/2d/renderer/RenderDrawInfo.cpp
@@ -37,6 +37,9 @@ void mat4ToFloatArray(const cc::Mat4& mat, float* out, index_t ofs = 0) {
 }
 
 RenderDrawInfo::RenderDrawInfo() {
+    _drawInfoAttrs._isMeshBuffer = 0;
+    _drawInfoAttrs._isVertexPositionInWorld = 0;
+    _drawInfoAttrs._padding = 0;
     _attrSharedBufferActor.initialize(&_drawInfoAttrs, sizeof(_drawInfoAttrs));
 }
 

--- a/native/cocos/2d/renderer/RenderDrawInfo.h
+++ b/native/cocos/2d/renderer/RenderDrawInfo.h
@@ -109,9 +109,15 @@ public:
         _drawInfoAttrs._dataHash = dataHash;
     }
 
-    inline bool getIsMeshBuffer() const { return _drawInfoAttrs._isMeshBuffer; }
+    inline bool getIsMeshBuffer() const {
+        return _drawInfoAttrs._isMeshBuffer != 0;
+    }
     inline void setIsMeshBuffer(bool isMeshBuffer) {
-        _drawInfoAttrs._isMeshBuffer = isMeshBuffer;
+        _drawInfoAttrs._isMeshBuffer = isMeshBuffer ? 1 : 0;
+    }
+    
+    inline bool isVertexPositionInWorld() const {
+        return _drawInfoAttrs._isVertexPositionInWorld != 0;
     }
 
     inline uint8_t getStride() const { return _drawInfoAttrs._stride; }
@@ -256,7 +262,9 @@ private:
     struct DrawInfoAttrs {
         RenderDrawInfoType _drawInfoType{RenderDrawInfoType::COMP};
         bool _vertDirty{false};
-        bool _isMeshBuffer{false};
+        uint8_t _isMeshBuffer: 1;
+        uint8_t _isVertexPositionInWorld: 1;
+        uint8_t _padding: 6;
         uint8_t _stride{0};
         uint16_t _bufferId{0};
         uint16_t _accId{0};


### PR DESCRIPTION
Re: #18374

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
