### PR TITLE
Fix some memory leaks of JSVM backend for HarmonyOS next platforms

### DIFF
--- a/native/cocos/bindings/jswrapper/jsvm/Class.cpp
+++ b/native/cocos/bindings/jswrapper/jsvm/Class.cpp
@@ -231,6 +231,8 @@ void Class::destroy() {
         }
         _ctor.reset();
     }
+    
+    OH_JSVM_DeleteReference(ScriptEngine::getEnv(), _constructor);
 }
 
 void Class::cleanup() {

--- a/native/cocos/bindings/jswrapper/jsvm/Object.h
+++ b/native/cocos/bindings/jswrapper/jsvm/Object.h
@@ -213,7 +213,7 @@ public:
     /**
      * @brief Sets whether to clear the mapping of native object & se::Object in finalizer
      */
-    void setClearMappingInFinalizer(bool v) { _clearMappingInFinalizer = v; }
+    void setClearMappingInFinalizer(bool v);
 
     /**
          *  @brief Tests whether an object is an array.

--- a/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.cpp
+++ b/native/cocos/bindings/jswrapper/jsvm/ScriptEngine.cpp
@@ -161,19 +161,12 @@ const ScriptEngine::FileOperationDelegate &ScriptEngine::getFileOperationDelegat
 }
 
 ScriptEngine *ScriptEngine::getInstance() {
-    if (gSriptEngineInstance == nullptr) {
-        gSriptEngineInstance = new ScriptEngine();
-    }
-
     return gSriptEngineInstance;
 }
 
 void ScriptEngine::destroyInstance() {
-    if (gSriptEngineInstance) {
-        gSriptEngineInstance->cleanup();
-        delete gSriptEngineInstance;
-        gSriptEngineInstance = nullptr;
-    }
+    // ScriptEngine instance is managed in Engine.cpp, it will be deleted in `Engine::~Engine()`
+    // So doesn't need to implement this method now.
 }
 
 bool ScriptEngine::runScript(const std::string &path, Value *ret /* = nullptr */) {
@@ -227,10 +220,12 @@ bool ScriptEngine::evalString(const char *scriptStr, ssize_t length, Value *ret,
        return false;
     }
 
-    if(!cachedData || cacheRejected) {
-        NODE_API_CALL(status, _env,
-                      OH_JSVM_CreateCodeCache(_env, compiledScript, (const uint8_t **)&cachedData, &cacheLength));
-    }
+    // NOTE: Currently, we don't support JSVM code cache saving/loading.
+    // So creating code cache here is useless and wastes memory.
+//    if(!cachedData || cacheRejected) {
+//        NODE_API_CALL(status, _env,
+//                      OH_JSVM_CreateCodeCache(_env, compiledScript, (const uint8_t **)&cachedData, &cacheLength));
+//    }
     
     if(ret) {
         internal::jsToSeValue(result, ret);

--- a/native/cocos/engine/Engine.cpp
+++ b/native/cocos/engine/Engine.cpp
@@ -215,7 +215,7 @@ void Engine::destroy() {
     if (cc::render::getRenderingModule()) {
         cc::render::Factory::destroy(cc::render::getRenderingModule());
     }
-    #if(CC_PLATFORM == CC_PLATFORM_OPENHARMONY && SCRIPT_ENGINE_TYPE == SCRIPT_ENGINE_JSVM)
+    #if (SCRIPT_ENGINE_TYPE == SCRIPT_ENGINE_JSVM)
         // When using JSVM, not all objects are destroyed during cleanup, so we need to close JSVM at the end.
         _scriptEngine->closeEngine();
     #endif


### PR DESCRIPTION
Including:

- Fix a memory leak of JSVM_Ref for se::Class::_constructor.
- Fix memory leaks of se::Object instances associated with Spine objects.
- JSVM code cache is not supported now, doesn't need to create code cache since it's not consumed.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
