### PR TITLE
fix spine renderDrawInfo not clear at onDisable

### DIFF
--- a/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCacheAnimation.cpp
@@ -460,6 +460,9 @@ void SkeletonCacheAnimation::beginSchedule() {
 void SkeletonCacheAnimation::stopSchedule() {
     MiddlewareManager::getInstance()->removeTimer(this);
 
+    if (_entity != nullptr) {
+        _entity->clearDynamicRenderDrawInfos();
+    }
     if (_sharedBufferOffset) {
         _sharedBufferOffset->reset();
         _sharedBufferOffset->clear();

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -114,6 +114,9 @@ void SkeletonRenderer::onDisable() {
 
 void SkeletonRenderer::stopSchedule() {
     MiddlewareManager::getInstance()->removeTimer(this);
+    if (_entity != nullptr) {
+        _entity->clearDynamicRenderDrawInfos();
+    }
     if (_sharedBufferOffset) {
         _sharedBufferOffset->reset();
         _sharedBufferOffset->clear();


### PR DESCRIPTION
issue: https://forum.cocos.org/t/topic/166248
![076fe7fa-6b6c-465f-8bcc-778bd544f691](https://github.com/user-attachments/assets/68171841-ae19-46ff-824d-4a24f87de92e)

After review code, I find that when call **SkeletonRenderer::render** 
`    
auto *entity = _entity;
entity->clearDynamicRenderDrawInfos();
_sharedBufferOffset->reset();
 _sharedBufferOffset->clear();
` 
be called; 
but when call **SkeletonRenderer::onDisable**, only clear _sharedBufferOffset but not clear _entity .

after clear _entity at SkeletonRenderer::onDisable. no crash happened.
