### PR TITLE
Fix memory leaks of old render pipeline on native platforms.

### DIFF
--- a/native/cocos/renderer/pipeline/forward/ForwardFlow.cpp
+++ b/native/cocos/renderer/pipeline/forward/ForwardFlow.cpp
@@ -42,7 +42,9 @@ RenderFlowInfo ForwardFlow::initInfo = {
 };
 const RenderFlowInfo &ForwardFlow::getInitializeInfo() { return ForwardFlow::initInfo; }
 
-ForwardFlow::~ForwardFlow() = default;
+ForwardFlow::~ForwardFlow() {
+    destroy();
+}
 
 bool ForwardFlow::initialize(const RenderFlowInfo &info) {
     RenderFlow::initialize(info);

--- a/native/cocos/renderer/pipeline/forward/ForwardPipeline.cpp
+++ b/native/cocos/renderer/pipeline/forward/ForwardPipeline.cpp
@@ -60,6 +60,8 @@ bool ForwardPipeline::initialize(const RenderPipelineInfo &info) {
     RenderPipeline::initialize(info);
 
     if (_flows.empty()) {
+        _flows.reserve(3);
+
         auto *shadowFlow = ccnew ShadowFlow;
         shadowFlow->initialize(ShadowFlow::getInitializeInfo());
         _flows.emplace_back(shadowFlow);

--- a/native/cocos/renderer/pipeline/reflection-probe/ReflectionProbeFlow.cpp
+++ b/native/cocos/renderer/pipeline/reflection-probe/ReflectionProbeFlow.cpp
@@ -42,7 +42,9 @@ RenderFlowInfo ReflectionProbeFlow::initInfo = {
 const RenderFlowInfo &ReflectionProbeFlow::getInitializeInfo() { return ReflectionProbeFlow::initInfo; }
 
 ReflectionProbeFlow::ReflectionProbeFlow() = default;
-ReflectionProbeFlow::~ReflectionProbeFlow() = default;
+ReflectionProbeFlow::~ReflectionProbeFlow() {
+    destroy();
+}
 
 bool ReflectionProbeFlow::initialize(const RenderFlowInfo &info) {
     RenderFlow::initialize(info);

--- a/native/cocos/renderer/pipeline/shadow/ShadowFlow.cpp
+++ b/native/cocos/renderer/pipeline/shadow/ShadowFlow.cpp
@@ -52,7 +52,9 @@ RenderFlowInfo ShadowFlow::initInfo = {
 const RenderFlowInfo &ShadowFlow::getInitializeInfo() { return ShadowFlow::initInfo; }
 
 ShadowFlow::ShadowFlow() = default;
-ShadowFlow::~ShadowFlow() = default;
+ShadowFlow::~ShadowFlow() {
+    destroy();
+}
 
 bool ShadowFlow::initialize(const RenderFlowInfo &info) {
     RenderFlow::initialize(info);
@@ -345,8 +347,10 @@ void ShadowFlow::initShadowFrameBuffer(const RenderPipeline *pipeline, const sce
 }
 
 void ShadowFlow::destroy() {
-    _pipeline->getGlobalDSManager()->bindTexture(SHADOWMAP::BINDING, nullptr);
-    _pipeline->getGlobalDSManager()->bindTexture(SPOTSHADOWMAP::BINDING, nullptr);
+    if (_pipeline != nullptr && _pipeline->getGlobalDSManager() != nullptr) {
+        _pipeline->getGlobalDSManager()->bindTexture(SHADOWMAP::BINDING, nullptr);
+        _pipeline->getGlobalDSManager()->bindTexture(SPOTSHADOWMAP::BINDING, nullptr);
+    }
 
     _renderPass = nullptr;
     renderPassHashMap.clear();


### PR DESCRIPTION
ForwardPipeline::initialize may be invoked twice.

```cpp
using RenderFlowList = ccstd::vector<IntrusivePtr<RenderFlow>>;
RenderFlowList _flows;

bool RenderPipeline::initialize(const RenderPipelineInfo &info) {
    _flows = info.flows; // initialize will be invoked twice, this assignment will trigger old RenderFlow::~RenderFlow but without calling `destroy` to release memory.
    _tag = info.tag;
    return true;
}
```

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
