### PR TITLE
Fix instantiation ignoring node copies with mounted children

### DIFF
--- a/cocos/serialization/instantiate.ts
+++ b/cocos/serialization/instantiate.ts
@@ -59,7 +59,7 @@ function hasImplementedInstantiate (original: any): original is { _instantiate (
     return typeof original._instantiate === 'function';
 }
 
-// 用于检测当前节点是否是一个 PrefabInstance 中的 Mounted 的节点
+// Used to detect whether the current node is a Mounted node in a PrefabInstance
 function isMountedChild (node: Node): boolean {
     const editorExtras = node[editorExtrasTag];
     if (typeof editorExtras === 'object') {

--- a/cocos/serialization/instantiate.ts
+++ b/cocos/serialization/instantiate.ts
@@ -24,7 +24,19 @@
 */
 
 import { DEV, JSB } from 'internal:constants';
-import { CCObject, CCObjectFlags, isCCObject, js, ValueType, isCCClassOrFastDefined, getError, warn, misc, cclegacy } from '../core';
+import {
+    CCObject,
+    CCObjectFlags,
+    isCCObject,
+    js,
+    ValueType,
+    isCCClassOrFastDefined,
+    getError,
+    warn,
+    misc,
+    cclegacy,
+    editorExtrasTag,
+} from '../core';
 import { Prefab } from '../scene-graph/prefab';
 import { Node } from '../scene-graph/node';
 import { Component } from '../scene-graph/component';
@@ -45,6 +57,15 @@ type CustomInstantiation = <T>(this: T, instantiated?: T) => T;
 
 function hasImplementedInstantiate (original: any): original is { _instantiate (...args: unknown[]): unknown } {
     return typeof original._instantiate === 'function';
+}
+
+// 用于检测当前节点是否是一个 PrefabInstance 中的 Mounted 的节点
+function isMountedChild (node: Node): boolean {
+    const editorExtras = node[editorExtrasTag];
+    if (typeof editorExtras === 'object') {
+        return !!((editorExtras as { mountedRoot: Node }).mountedRoot);
+    }
+    return false;
 }
 
 /**
@@ -285,8 +306,8 @@ function instantiateObj (obj: TypedArray | any[] | CCObject, parent: any): any {
                 }
             } else if (parent instanceof Node) {
                 if (obj instanceof Node) {
-                    if (!obj.isChildOf(parent)) {
-                        // should not clone other nodes if not descendant
+                    if (!obj.isChildOf(parent) && !isMountedChild(obj)) {
+                        // should not clone other nodes if not descendant and there is no mounted child
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
                         return obj;
                     }


### PR DESCRIPTION
Re: #

https://github.com/cocos/3d-tasks/issues/12682
https://github.com/cocos/3d-tasks/issues/17636

### Changelog

* Fix instantiation ignoring node copies with mounted children

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
