### PR TITLE
Simplify CCObjectFlags enum to fix inline-enum build error

### DIFF
--- a/cocos/core/data/object.ts
+++ b/cocos/core/data/object.ts
@@ -60,13 +60,17 @@ export enum CCObjectFlags {
 
     // var Hide = HideInGame | HideInEditor,
     // should not clone or serialize these flags
-    PersistentMask = ~(ToDestroy | Dirty | Destroying | DontDestroy | Deactivating
-                           | IsPreloadStarted | IsOnLoadStarted | IsOnLoadCalled | IsStartCalled
-                           | IsOnEnableCalled | IsEditorOnEnableCalled
-                           | IsRotationLocked | IsScaleLocked | IsAnchorLocked | IsSizeLocked | IsPositionLocked
-    /* RegisteredInEditor */),
+    // All flags representing non-persistent (temporary, runtime-only) states.
+    NonPersistentMask = ToDestroy | Dirty | Destroying | DontDestroy | Deactivating
+                      | IsPreloadStarted | IsOnLoadStarted | IsOnLoadCalled | IsStartCalled
+                      | IsOnEnableCalled | IsEditorOnEnableCalled
+                      | IsRotationLocked | IsScaleLocked | IsAnchorLocked | IsSizeLocked | IsPositionLocked
+                      /* RegisteredInEditor */,
 
-    // all the hideFlags
+    // PersistentMask includes all flags except those explicitly marked as NonPersistentMask.
+    PersistentMask = ~NonPersistentMask,
+
+    // All flags related to hiding objects in the editor or hierarchy
     AllHideMasks = DontSave | EditorOnly | LockedInEditor | HideInHierarchy,
 }
 


### PR DESCRIPTION

### Changelog

* Simplify `CCObjectFlags` enum by introducing `NonPersistentMask` for better compatibility with the `inline-enum` plugin.

### Motivation

This PR fixes the following build error caused by unsupported unary expressions (`~`) within the `inline-enum` build step:

<details>
<summary>Click to expand build error details</summary>

```log
export * from '/Users/yury/work/Tools/cocos-engine-3.8.7/exports/gfx-webgl2.ts';


3-28-2025 09:21:31 - error: [build-engine]Error: unhandled UnaryExpression argument type BinaryExpression in /Users/yury/work/Tools/cocos-engine-3.8.7/cocos/core/data/object.ts
    at handleOneTsEnum (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/node_modules/@cocos/ccbuild/modules/build-engine/lib/engine-js/rollup-plugins/inline-enum/core/enum.js:187:17)
    at async handleOneTsFile (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/node_modules/@cocos/ccbuild/modules/build-engine/lib/engine-js/rollup-plugins/inline-enum/core/enum.js:264:5)
    at async Promise.all (index 477)
    at async scanEnums (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/node_modules/@cocos/ccbuild/modules/build-engine/lib/engine-js/rollup-plugins/inline-enum/core/enum.js:308:3)
    at async rpInlineEnum (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/node_modules/@cocos/ccbuild/modules/build-engine/lib/engine-js/rollup-plugins/inline-enum/index.js:34:7)
    at async buildJsEngine (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/node_modules/@cocos/ccbuild/modules/build-engine/lib/engine-js/index.js:228:29)
    at async Object.buildEngineCommand (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/builtin/builder/dist/worker/builder/asset-handler/script/build-engine.ccc:1:749)
    at async excuteScript (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/builtin/builder/dist/worker/worker-pools/sub-process.ccc:1:408)
    at async process.<anonymous> (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/builtin/builder/dist/worker/worker-pools/sub-process.ccc:1:187)

3-28-2025 09:21:31 - debug: excute-script over with build-engine 1194ms
3-28-2025 09:21:31 - debug: [Build Memory track]: Build script start:253.42MB, end 257.40MB, increase: 3.98MB
3-28-2025 09:21:31 - debug: run build task Build script failed!, progress: 33%
3-28-2025 09:21:31 - debug: [Build Memory track]: builder:build-project-total start:177.00MB, end 257.42MB, increase: 80.43MB
3-28-2025 09:21:31 - log: Asset DB is resume!
3-28-2025 09:21:31 - debug: builder:build-project-total (9610ms)
3-28-2025 09:21:31 - debug: build success in 9610!
3-28-2025 09:21:31 - error: Error: excute-task build-engine failed!
    at ChildProcess.<anonymous> (/Applications/Cocos/Creator/3.8.5/CocosCreator.app/Contents/Resources/app.asar/builtin/builder/dist/worker/worker-pools/sub-process-manager.ccc:1:2624)
    at ChildProcess.emit (node:events:519:28)
    at emit (node:internal/child_process:951:14)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```

</details>

This change resolves the issue by explicitly defining a mask without the unary (`~`) operation, ensuring compatibility with the existing build process.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [x] Your pull request title is using English, it's precise and appropriate.
- [x] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [x] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [x] Document new code with comments in source code based on API docs
- [x] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
