### PR TITLE
Support to build simulator with spine 3.8 or 4.2 and don't pack unused files ( *.lib, *.exp, *.a ).

### DIFF
--- a/native/gulpfile.js
+++ b/native/gulpfile.js
@@ -81,6 +81,15 @@ gulp.task('gen-simulator', async function () {
             args.push('Xcode');
             args.push(`-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64`);
         }
+
+        if (process.env.SPINE_VERSION === '3.8') {
+            args.push('-DUSE_SPINE_3_8=ON')
+            args.push('-DUSE_SPINE_4_2=OFF')
+        } else if (process.env.SPINE_VERSION === '4.2') {
+            args.push('-DUSE_SPINE_3_8=OFF')
+            args.push('-DUSE_SPINE_4_2=ON')
+        }
+
         args.push('-DCC_DEBUG_FORCE=ON','-DUSE_V8_DEBUGGER_FORCE=ON');
         args.push(absolutePath('./tools/simulator/frameworks/runtime-src/'));
         const newEnv = {};
@@ -159,9 +168,22 @@ gulp.task('clean-simulator', async function () {
         formatPath(Path.join(__dirname, './simulator/*')),
         formatPath(`!${Path.join(__dirname, './simulator/Release')}`),
     ];
-    if (!isWin32) {
-        delPatterns.push(formatPath(Path.join(__dirname, './simulator/Release/libsimulator.a')));
+
+    let filesToDelete = [];
+    if (isWin32) {
+        filesToDelete = [
+            './simulator/Release/*.lib',
+            './simulator/Release/*.exp',
+        ];
+    } else {
+        filesToDelete = [
+            './simulator/Release/*.a'
+        ];
     }
+
+    filesToDelete.forEach((relativePath) => {
+        delPatterns.push(formatPath(Path.join(__dirname, relativePath)));
+    });
     console.log('delete patterns: ', JSON.stringify(delPatterns, undefined, 2));
     await del(delPatterns, { force: true });
     //check if target file exists


### PR DESCRIPTION
Prebuilt simulator with spine 4.2 or 3.8 support could be found at https://github.com/cocos-creator-simulator-prebuilt/cocos-engine/releases/tag/3.8.6-simulator-1

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
