### PR TITLE
remove the code that queries the auto atlas when setting up a SpriteFrame

### DIFF
--- a/editor/inspector/components/sprite.js
+++ b/editor/inspector/components/sprite.js
@@ -7,13 +7,6 @@ exports.close = close;
 
 const { setHidden, setReadonly, isMultipleInvalid } = require('../utils/prop');
 
-// Query an automatic atlas
-async function findAutoAtlasFolder(spriteFrameUuid) {
-    // auto atlas
-    const info = await Editor.Message.request('builder', 'request-to-build-worker', 'build-worker:query-atlas-by-sprite', spriteFrameUuid);
-    return info && info.uuid;
-}
-
 // query the dom node by type
 function findDomByType(parentElement, type) {
     for (const child of parentElement.children) {
@@ -55,15 +48,10 @@ exports.ready = function() {
                     .then(async (spriteFrameMeta) => {
                         if (!spriteFrameMeta || !spriteFrameMeta.userData) { return; }
 
-                        let autoAtlasUuid = '';
-                        if (!spriteFrameMeta.userData.atlasUuid) {
-                            autoAtlasUuid = await findAutoAtlasFolder(spriteFrameUuid);
-                        }
-
                         const spriteAtlasDom = findDomByType(parentElement, 'cc.SpriteAtlas');
                         if (!spriteAtlasDom) { return; }
 
-                        spriteAtlasDom.value = spriteFrameMeta.userData.atlasUuid || autoAtlasUuid;
+                        spriteAtlasDom.value = spriteFrameMeta.userData.atlasUuid;
                         spriteAtlasDom.dispatch('change');
                         spriteAtlasDom.dispatch('confirm');
                     })


### PR DESCRIPTION
Re: #

### Changelog

* https://forum.cocos.org/t/topic/166875/5

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
