### PR TITLE
Fix a bug that spine asset exported to jpeg format causes crash on native platforms

### DIFF
--- a/native/cocos/bindings/manual/jsb_conversions_spec.cpp
+++ b/native/cocos/bindings/manual/jsb_conversions_spec.cpp
@@ -1207,9 +1207,12 @@ bool seval_to_Map_string_key(const se::Value &v, cc::RefMap<ccstd::string, cc::m
 
     se::Value tmp;
     for (const auto &key : allKeys) {
-        auto pngPos = key.find(".png");
-        if (pngPos == ccstd::string::npos) {
-            continue;
+        auto picExist = key.find(".png");
+        if (picExist == ccstd::string::npos) {
+            picExist = key.find(".jpg");
+            if (picExist == ccstd::string::npos) {
+                continue;
+            }
         }
 
         ok = obj->getProperty(key.c_str(), &tmp);


### PR DESCRIPTION
Fix the bug when spine picture suffix with jpg, then in Native it will crash.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
