### PR TITLE
Fix renderDrawInfo is not cleared for ParticleSystem2D component which causes memory overflow on native platforms.

### DIFF
--- a/cocos/2d/assembler/graphics/webgl/impl.ts
+++ b/cocos/2d/assembler/graphics/webgl/impl.ts
@@ -25,7 +25,7 @@
 import { JSB } from 'internal:constants';
 import { Color, Vec2 } from '../../../../core';
 import { Graphics } from '../../../components/graphics';
-import { RenderData, MeshRenderData, BaseRenderData } from '../../../renderer/render-data';
+import { RenderData, MeshRenderData } from '../../../renderer/render-data';
 import { RenderDrawInfoType } from '../../../renderer/render-draw-info';
 import { arc, ellipse, roundRect, tesselateBezier } from '../helper';
 import { LineCap, LineJoin, PointFlags } from '../types';

--- a/cocos/2d/assembler/graphics/webgl/impl.ts
+++ b/cocos/2d/assembler/graphics/webgl/impl.ts
@@ -25,7 +25,7 @@
 import { JSB } from 'internal:constants';
 import { Color, Vec2 } from '../../../../core';
 import { Graphics } from '../../../components/graphics';
-import { RenderData, MeshRenderData } from '../../../renderer/render-data';
+import { RenderData, MeshRenderData, BaseRenderData } from '../../../renderer/render-data';
 import { RenderDrawInfoType } from '../../../renderer/render-draw-info';
 import { arc, ellipse, roundRect, tesselateBezier } from '../helper';
 import { LineCap, LineJoin, PointFlags } from '../types';
@@ -187,7 +187,9 @@ export class Impl {
             }
 
             MeshRenderData.remove(data);
-            data.removeRenderDrawInfo(this._comp);
+            if (JSB) {
+                this._comp.renderEntity.clearRenderDrawInfos();
+            }
         }
 
         this._renderDataList.length = 0;

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -407,10 +407,11 @@ export class UIRenderer extends Renderer {
      * @zh 销毁当前渲染数据。
      */
     public destroyRenderData (): void {
+        this.renderEntity.clearRenderDrawInfos();
         if (!this._renderData) {
             return;
         }
-        this._renderData.removeRenderDrawInfo(this);
+
         RenderData.remove(this._renderData);
         this._renderData = null;
     }

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -168,6 +168,9 @@ export class BaseRenderData {
         }
     }
 
+    /**
+     * @deprecated Please use RenderEntity.clearRenderDrawInfos instead.
+     */
     public removeRenderDrawInfo (comp: UIRenderer): void {
         if (JSB) {
             const renderEntity: RenderEntity = comp.renderEntity;

--- a/cocos/2d/renderer/render-entity.ts
+++ b/cocos/2d/renderer/render-entity.ts
@@ -186,6 +186,16 @@ export class RenderEntity {
         }
     }
 
+    public clearRenderDrawInfos (): void {
+        if (JSB) {
+            if (this._renderEntityType === RenderEntityType.DYNAMIC) {
+                this.removeDynamicRenderDrawInfo();
+            } else if (this._renderEntityType === RenderEntityType.STATIC) {
+                this.clearStaticRenderDrawInfos();
+            }
+        }
+    }
+
     public setDynamicRenderDrawInfo (renderDrawInfo: RenderDrawInfo | null, index: number): void {
         if (JSB) {
             if (renderDrawInfo) {


### PR DESCRIPTION
Removing RenderDrawInfo should not associate with `renderData`, it's the responsibility of RenderEntity.

Re: https://github.com/cocos/cocos-engine/issues/18554

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
