### PR TITLE
Fix b2ChainShape::m_vertices, b2PolygonShape::m_vertices/m_normals were not bound for Box2D-JSB.

### DIFF
--- a/native/cocos/bindings/manual/jsb_box2d_manual.cpp
+++ b/native/cocos/bindings/manual/jsb_box2d_manual.cpp
@@ -310,6 +310,55 @@ bool js_ContactImpulse_tangentImpulses_get(se::State &s) {
 }
 SE_BIND_PROP_GET(js_ContactImpulse_tangentImpulses_get)
 
+bool js_PolygonShape_m_vertices_get(se::State &s) {
+    b2PolygonShape *cobj = SE_THIS_OBJECT<b2PolygonShape>(s);
+    if (nullptr == cobj) return true;
+
+    static ccstd::array<b2Vec2, b2_maxPolygonVertices> vertices;
+    for (size_t i = 0; i < b2_maxPolygonVertices; ++i) {
+        vertices[i] = cobj->m_vertices[i];
+    }
+
+    bool ok = nativevalue_to_se(vertices, s.rval());
+    SE_PRECONDITION2(ok, false, "Error processing arguments");
+
+    return true;
+}
+SE_BIND_PROP_GET(js_PolygonShape_m_vertices_get)
+
+bool js_PolygonShape_m_normals_get(se::State &s) {
+    b2PolygonShape *cobj = SE_THIS_OBJECT<b2PolygonShape>(s);
+    if (nullptr == cobj) return true;
+
+    static ccstd::array<b2Vec2, b2_maxPolygonVertices> normals;
+    for (size_t i = 0; i < b2_maxPolygonVertices; ++i) {
+        normals[i] = cobj->m_normals[i];
+    }
+
+    bool ok = nativevalue_to_se(normals, s.rval());
+    SE_PRECONDITION2(ok, false, "Error processing arguments");
+
+    return true;
+}
+SE_BIND_PROP_GET(js_PolygonShape_m_normals_get)
+
+bool js_ChainShape_m_vertices_get(se::State &s) {
+    b2ChainShape *cobj = SE_THIS_OBJECT<b2ChainShape>(s);
+    if (nullptr == cobj) return true;
+
+    ccstd::vector<b2Vec2> vertices;
+    vertices.reserve(cobj->m_count);
+    for (size_t i = 0; i < cobj->m_count; ++i) {
+        vertices.emplace_back(cobj->m_vertices[i]);
+    }
+
+    bool ok = nativevalue_to_se(vertices, s.rval());
+    SE_PRECONDITION2(ok, false, "Error processing arguments");
+
+    return true;
+}
+SE_BIND_PROP_GET(js_ChainShape_m_vertices_get)
+
 } // namespace {
 
 bool register_all_box2d_manual(se::Object *obj) { // NOLINT
@@ -341,7 +390,12 @@ bool register_all_box2d_manual(se::Object *obj) { // NOLINT
 
     __jsb_b2ContactImpulse_proto->defineProperty("normalImpulses", _SE(js_ContactImpulse_normalImpulses_get), nullptr);
     __jsb_b2ContactImpulse_proto->defineProperty("tangentImpulses", _SE(js_ContactImpulse_tangentImpulses_get), nullptr);
-
+    
+    __jsb_b2PolygonShape_proto->defineProperty("m_vertices", _SE(js_PolygonShape_m_vertices_get), nullptr);
+    __jsb_b2PolygonShape_proto->defineProperty("m_normals", _SE(js_PolygonShape_m_normals_get), nullptr);
+    
+    __jsb_b2ChainShape_proto->defineProperty("m_vertices", _SE(js_ChainShape_m_vertices_get), nullptr);
+    
     nsObj->setProperty("maxFloat", se::Value(b2_maxFloat));
     nsObj->setProperty("epsilon", se::Value(b2_epsilon));
     nsObj->setProperty("pi", se::Value(b2_pi));

--- a/native/tools/swig-config/box2d.i
+++ b/native/tools/swig-config/box2d.i
@@ -54,7 +54,6 @@
 %ignore b2Hull::points;
 
 %ignore b2PolygonShape::m_vertices;
-
 %ignore b2PolygonShape::m_normals;
 
 %ignore b2ContactImpulse::normalImpulses;
@@ -62,6 +61,7 @@
 
 %ignore b2ChainShape::CreateLoop;
 %ignore b2ChainShape::CreateChain;
+%ignore b2ChainShape::m_vertices;
 %ignore b2DistanceProxy::Set;
 %ignore b2PolygonShape::Set;
 %ignore b2Joint::Draw;


### PR DESCRIPTION
Reported at https://forum.cocos.org/t/topic/165212/708

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
