### PR TITLE
Implement tooltip descriptions for ModelBakeSettings

### DIFF
--- a/editor/i18n/en/modules/rendering.js
+++ b/editor/i18n/en/modules/rendering.js
@@ -7,38 +7,50 @@ module.exports = {
                 groups: {
                     LightMap: {
                         displayName: 'Light Map Settings',
+                        tooltip: '',
                     },
                     LightProbe: {
                         displayName: 'Light Probe Settings',
+                        tooltip: '',
                     },
                     ReflectionProbe: {
                         displayName: 'Reflection Probe Settings',
+                        tooltip: '',
                     },
                 },
                 properties: {
                     'bakeable': {
                         displayName: 'Bakeable',
+                        tooltip: 'Whether the model is static and bake-able with light map. <br>' +
+                            'Notice: the model\'s vertex data must have the second UV attribute to enable light map baking.',
                     },
                     'castShadow': {
                         displayName: 'Cast Shadows',
+                        tooltip: 'Whether to cast shadow in light map baking.',
                     },
                     'receiveShadow': {
                         displayName: 'Receive Shadows',
+                        tooltip: 'Whether to receive shadow in light map baking.',
                     },
                     'lightmapSize': {
                         displayName: 'Light Map Size',
+                        tooltip: 'The lightmap size.',
                     },
                     'useLightProbe': {
                         displayName: 'Use Light Probe',
+                        tooltip: 'Whether to use light probe which provides indirect light to dynamic objects.',
                     },
                     'bakeToLightProbe': {
                         displayName: 'Bake To Light Probe',
+                        tooltip: 'Whether the model is used to calculate light probe.',
                     },
                     'reflectionProbe': {
                         displayName: 'Reflection Probe',
+                        tooltip: 'Used to set whether to use the reflection probe or set probe\'s type.',
                     },
                     'bakeToReflectionProbe': {
                         displayName: 'Bake To Reflection Probe',
+                        tooltip: 'Whether the model can be render by the reflection probe.',
                     },
                 },
             },
@@ -46,6 +58,7 @@ module.exports = {
                 groups: {
                     DynamicShadow: {
                         displayName: 'Dynamic Shadow Settings',
+                        tooltip: '',
                     },
                 },
                 properties: {

--- a/editor/i18n/zh/modules/rendering.js
+++ b/editor/i18n/zh/modules/rendering.js
@@ -7,38 +7,50 @@ module.exports = {
                 groups: {
                     LightMap: {
                         displayName: '光照贴图设置',
+                        tooltip: '',
                     },
                     LightProbe: {
                         displayName: '光照探针设置',
+                        tooltip: '',
                     },
                     ReflectionProbe: {
                         displayName: '反射探针设置',
+                        tooltip: '',
                     },
                 },
                 properties: {
                     'bakeable': {
                         displayName: '可烘焙',
+                        tooltip: '模型是否是静态的并可以烘培光照贴图。<br>' +
+                            '注意：模型顶点数据必须包含第二套 UV 属性来支持光照贴图烘焙。',
                     },
                     'castShadow': {
                         displayName: '投射阴影',
+                        tooltip: '在光照贴图烘焙中是否投射阴影。',
                     },
                     'receiveShadow': {
                         displayName: '接收阴影',
+                        tooltip: '在光照贴图烘焙中是否接受阴影。',
                     },
                     'lightmapSize': {
                         displayName: '光照贴图尺寸',
+                        tooltip: '光照图大小。',
                     },
                     'useLightProbe': {
                         displayName: '使用光照探针',
+                        tooltip: '模型是否使用光照探针，光照探针为动态物体提供间接光。',
                     },
                     'bakeToLightProbe': {
                         displayName: '烘焙至光照探针',
+                        tooltip: '模型是否用于计算光照探针。',
                     },
                     'reflectionProbe': {
                         displayName: '反射探针',
+                        tooltip: '用于设置是否使用反射探针或者设置反射探针的类型。',
                     },
                     'bakeToReflectionProbe': {
                         displayName: '烘焙至反射探针',
+                        tooltip: '模型是否能被反射探针渲染。',
                     },
                 },
             },
@@ -46,6 +58,7 @@ module.exports = {
                 groups: {
                     DynamicShadow: {
                         displayName: '动态阴影设置',
+                        tooltip: '',
                     },
                 },
                 properties: {


### PR DESCRIPTION
Re: #

### Changelog

* Implement tooltip descriptions for ModelBakeSettings

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
