### PR TITLE
修正 UIOpacity 组件 在处理 localOpacity 和 _parentOpacity 时的若干错误

### DIFF
--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -204,6 +204,7 @@ export class UIOpacity extends Component {
             this._parentOpacity = this._getParentOpacity(parent);
             opacity = this._parentOpacity;
         } else {
+            this._parentOpacity = 1;
             this._parentOpacityResetFlag = true;
         }
         setEntityLocalOpacityDirtyRecursively(this.node, true, opacity, false);

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -215,11 +215,14 @@ export class UIOpacity extends Component {
         if (!JSB) {
             return;
         }
+
+        this.node._uiProps.localOpacity = opacity;
+
         const render = this.node._uiProps.uiComp as UIRenderer;
         if (render && render.color) { // exclude UIMeshRenderer which has not color
             render.renderEntity.colorDirty = true;
             render.renderEntity.localOpacity = opacity;
-            render.node._uiProps.localOpacity = opacity;
+            // render.node._uiProps.localOpacity = opacity;
             return;
         }
         // The current node is not recursive, only the child nodes are recursive.
@@ -230,12 +233,13 @@ export class UIOpacity extends Component {
 
     public onEnable (): void {
         this.node.on(NodeEventType.PARENT_CHANGED, this._parentChanged, this);
-        this.node._uiProps.localOpacity = this._parentOpacity * this._opacity / 255;
+        const opacity = this._opacity / 255;
+        this.node._uiProps.localOpacity = opacity;
         if (this._parentOpacityResetFlag) {
             this._parentChanged();
             this._parentOpacityResetFlag = false;
         } else {
-            this._setEntityLocalOpacityRecursively(this.node._uiProps.localOpacity);
+            this._setEntityLocalOpacityRecursively(this._parentOpacity * opacity);
         }
     }
 

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -242,6 +242,7 @@ export class UIOpacity extends Component {
     public onDisable (): void {
         this.node.off(NodeEventType.PARENT_CHANGED, this._parentChanged, this);
         this.node._uiProps.localOpacity = 1;
+        this._parentOpacity = 1;
         this._setEntityLocalOpacityRecursively(this.node._uiProps.localOpacity);
     }
 }

--- a/cocos/2d/components/ui-opacity.ts
+++ b/cocos/2d/components/ui-opacity.ts
@@ -243,6 +243,6 @@ export class UIOpacity extends Component {
         this.node.off(NodeEventType.PARENT_CHANGED, this._parentChanged, this);
         this.node._uiProps.localOpacity = 1;
         this._parentOpacity = 1;
-        this._setEntityLocalOpacityRecursively(this.node._uiProps.localOpacity);
+        this._setEntityLocalOpacityRecursively(1);
     }
 }


### PR DESCRIPTION
当 onDisable 时,    _parentOpacity 需要还原为 1 .
当 触发_parentChanged() 时, 如果父节点不存在 ,  _parentOpacity 也需要还原为 1 .

否则 下次执行  UIOpacity 的 onEnable() 时,   还是用的之前的  _parentOpacity .

```ts
    public onEnable (): void {
        this.node.on(NodeEventType.PARENT_CHANGED, this._parentChanged, this);

        // 这里用的还是 之前的 this._parentOpacity . _parentOpacityResetFlag 并没有发挥什么作用.
        this.node._uiProps.localOpacity = this._parentOpacity * this._opacity / 255;

        if (this._parentOpacityResetFlag) {
            this._parentChanged();
            this._parentOpacityResetFlag = false;
        } else {
            this._setEntityLocalOpacityRecursively(this.node._uiProps.localOpacity);
        }
    }
```

另外 ,  onEnable 中, `this.node._uiProps.localOpacity = this._parentOpacity * this._opacity / 255` 这行本身就存在错误.
#18624 在这里有讨论.


这个 PR 用来解决下列 BUG (原生平台): 
```
父节点A  opacity = 100
父节点 B opacity = 255.
父节点A下包含一个正在播放的 Spine 动画节点.
此时 将 Spine 动画节点移动到 父节点B 下,  这个动画仍然会呈现半透明状 (会受到父节点 A的 opacity = 100 的影响).
```

此 bug 并非必现,取决于 spine 动画的某些特质 和 移动节点的时机 以及整个节点树的层级影响.
我实际项目中结构比上面的描述要复杂一些. 而且用到的节点池.

将某些spine 动画用完了,放到池子里, 下次从池子里取出并使用时 ,我发现某些动画会呈现半透明.
于是研究了一下, 当spine 动画节点放回到池子里时,它的父节点是半透明的, 即使放到池子里时, 我已经设置了spine 节点的 parent=null, 仍然会出现下次使用时, 透明度不正确的情况,
于是顺着这个线索研究了一下, 得到了此 PR里的结论.

根本原因还是  localOpacity 和  _parentOpacity 的错乱造成的.




Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
