### PR TITLE
Update profiler default background color and add Profiler.setBackgroundColor API

### DIFF
--- a/cocos/profiler/profiler.ts
+++ b/cocos/profiler/profiler.ts
@@ -33,7 +33,7 @@ import { Node } from '../scene-graph/node';
 import { ICounterOption } from './counter';
 import { PerfCounter } from './perf-counter';
 import { Pass } from '../render-scene';
-import { preTransforms, System, sys, cclegacy, settings, warnID, SettingsCategory, CCObjectFlags } from '../core';
+import { preTransforms, System, sys, cclegacy, settings, warnID, SettingsCategory, CCObjectFlags, Color } from '../core';
 import { Root } from '../root';
 import { director, DirectorEvent, Game, game } from '../game';
 import { ccwindow } from '../core/global-exports';
@@ -92,6 +92,8 @@ const _constants = {
     textureHeight: 280,
 };
 
+const _defaultBackgroundColor = new Color(150, 150, 150, 100);
+
 export class Profiler extends System {
     private _profilerStats: IProfilerState | null = null;
     private _showFPS = false;
@@ -100,8 +102,8 @@ export class Profiler extends System {
     private _device: Device | null = null;
     private _swapchain: Swapchain | null = null;
     private _meshRenderer: MeshRenderer = null!;
-    private readonly _canvas: HTMLCanvasElement | null = null;
-    private readonly _ctx: CanvasRenderingContext2D | null = null;
+    private _canvas: HTMLCanvasElement | null = null;
+    private _ctx: CanvasRenderingContext2D | null = null;
     private _texture: Texture | null = null;
     private readonly _region: BufferTextureCopy = new BufferTextureCopy();
     private readonly _canvasArr: HTMLCanvasElement[] = [];
@@ -114,20 +116,16 @@ export class Profiler extends System {
     private _statsDone = false;
     private _inited = false;
 
-    private _lineHeight = _constants.textureHeight / (Object.keys(_profileInfo).length + 1);
+    private readonly _lineHeight = _constants.textureHeight / (Object.keys(_profileInfo).length + 1);
     private _wordHeight = 0;
     private _eachNumWidth = 0;
     private _totalLines = 0; // total lines to display
 
     private lastTime = 0;   // update use time
+    private _backgroundColor = _defaultBackgroundColor.clone();
 
     constructor () {
         super();
-        if (!TEST) {
-            this._canvas = ccwindow.document.createElement('canvas');
-            this._ctx = this._canvas.getContext('2d')!;
-            this._canvasArr.push(this._canvas);
-        }
     }
 
     init (): void {
@@ -136,6 +134,17 @@ export class Profiler extends System {
             this.showStats();
         } else {
             this.hideStats();
+        }
+    }
+
+    public setBackgroundColor (color: Readonly<Color>): void {
+        if (this._backgroundColor.equals(color)) {
+            return;
+        }
+        this._backgroundColor.set(color);
+        if (this._showFPS) {
+            this.hideStats();
+            this.showStats();
         }
     }
 
@@ -161,9 +170,39 @@ export class Profiler extends System {
 
     public hideStats (): void {
         if (this._showFPS) {
+            this._profilerStats = null;
             if (this._rootNode) {
-                this._rootNode.active = false;
+                this._rootNode.destroy();
+                this._rootNode = null;
             }
+            this._device = null;
+            this._swapchain = null;
+            if (this._meshRenderer) {
+                this._meshRenderer.destroy();
+                this._meshRenderer = null!;
+            }
+            this._canvas = null;
+            this._ctx = null;
+            if (this._texture) {
+                this._texture.destroy();
+                this._texture = null;
+            }
+
+            this._canvasArr.length = 0;
+            this.digitsData = null!;
+            this.offsetData = null!;
+            if (this.pass) {
+                this.pass.destroy();
+                this.pass = null!;
+            }
+            this._canvasDone = false;
+            this._statsDone = false;
+            this._inited = false;
+
+            this._wordHeight = 0;
+            this._eachNumWidth = 0;
+            this._totalLines = 0;
+            this.lastTime = 0;
 
             director.off(DirectorEvent.BEFORE_UPDATE, this.beforeUpdate, this);
             director.off(DirectorEvent.AFTER_UPDATE, this.afterUpdate, this);
@@ -181,6 +220,10 @@ export class Profiler extends System {
     public showStats (): void {
         const game: Game = cclegacy.game;
         if (!this._showFPS) {
+            this._canvas = ccwindow.document.createElement('canvas');
+            this._ctx = this._canvas.getContext('2d')!;
+            this._canvasArr.push(this._canvas);
+
             if (!this._device) {
                 const root = cclegacy.director.root as Root;
                 this._device = deviceManager.gfxDevice;
@@ -277,7 +320,11 @@ export class Profiler extends System {
             ctx.fillText(_characters[j], j * this._eachNumWidth, this._totalLines * this._lineHeight);
         }
 
-        ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+        const backgroundR = this._backgroundColor.r;
+        const backgroundG = this._backgroundColor.g;
+        const backgroundB = this._backgroundColor.b;
+        const backgroundA = this._backgroundColor.a / 255;
+        ctx.fillStyle = `rgba(${backgroundR}, ${backgroundG}, ${backgroundB}, ${backgroundA})`;
         ctx.fillRect(canvas.width - 4, canvas.height - 4, 4, 4);
 
         this._eachNumWidth /= canvas.width;

--- a/cocos/profiler/profiler.ts
+++ b/cocos/profiler/profiler.ts
@@ -169,49 +169,50 @@ export class Profiler extends System {
     }
 
     public hideStats (): void {
-        if (this._showFPS) {
-            this._profilerStats = null;
-            if (this._rootNode) {
-                this._rootNode.destroy();
-                this._rootNode = null;
+        const self = this;
+        if (self._showFPS) {
+            self._profilerStats = null;
+            if (self._rootNode) {
+                self._rootNode.destroy();
+                self._rootNode = null;
             }
-            this._device = null;
-            this._swapchain = null;
-            if (this._meshRenderer) {
-                this._meshRenderer.destroy();
-                this._meshRenderer = null!;
+            self._device = null;
+            self._swapchain = null;
+            const meshRenderer = self._meshRenderer;
+            if (meshRenderer) {
+                meshRenderer.sharedMaterial?.destroy();
+                meshRenderer.mesh?.destroy();
+                meshRenderer.destroy();
+                self._meshRenderer = null!;
             }
-            this._canvas = null;
-            this._ctx = null;
-            if (this._texture) {
-                this._texture.destroy();
-                this._texture = null;
+            self._canvas = null;
+            self._ctx = null;
+            if (self._texture) {
+                self._texture.destroy();
+                self._texture = null;
             }
 
-            this._canvasArr.length = 0;
-            this.digitsData = null!;
-            this.offsetData = null!;
-            if (this.pass) {
-                this.pass.destroy();
-                this.pass = null!;
-            }
-            this._canvasDone = false;
-            this._statsDone = false;
-            this._inited = false;
+            self._canvasArr.length = 0;
+            self.digitsData = null!;
+            self.offsetData = null!;
+            self.pass = null!; // Pass was destroyed in the material
+            self._canvasDone = false;
+            self._statsDone = false;
+            self._inited = false;
 
-            this._wordHeight = 0;
-            this._eachNumWidth = 0;
-            this._totalLines = 0;
-            this.lastTime = 0;
+            self._wordHeight = 0;
+            self._eachNumWidth = 0;
+            self._totalLines = 0;
+            self.lastTime = 0;
 
-            director.off(DirectorEvent.BEFORE_UPDATE, this.beforeUpdate, this);
-            director.off(DirectorEvent.AFTER_UPDATE, this.afterUpdate, this);
-            director.off(DirectorEvent.BEFORE_PHYSICS, this.beforePhysics, this);
-            director.off(DirectorEvent.AFTER_PHYSICS, this.afterPhysics, this);
-            director.off(DirectorEvent.BEFORE_DRAW, this.beforeDraw, this);
-            director.off(DirectorEvent.AFTER_RENDER, this.afterRender, this);
-            director.off(DirectorEvent.AFTER_DRAW, this.afterPresent, this);
-            this._showFPS = false;
+            director.off(DirectorEvent.BEFORE_UPDATE, self.beforeUpdate, self);
+            director.off(DirectorEvent.AFTER_UPDATE, self.afterUpdate, self);
+            director.off(DirectorEvent.BEFORE_PHYSICS, self.beforePhysics, self);
+            director.off(DirectorEvent.AFTER_PHYSICS, self.afterPhysics, self);
+            director.off(DirectorEvent.BEFORE_DRAW, self.beforeDraw, self);
+            director.off(DirectorEvent.AFTER_RENDER, self.afterRender, self);
+            director.off(DirectorEvent.AFTER_DRAW, self.afterPresent, self);
+            self._showFPS = false;
             director.root!.pipeline.profiler = null;
             cclegacy.game.config.showFPS = false;
         }


### PR DESCRIPTION

<img width="961" alt="Screenshot 2025-04-17 at 22 19 53" src="https://github.com/user-attachments/assets/543df99b-ce1c-4956-9589-a0610c3bbae1" />
<img width="962" alt="Screenshot 2025-04-17 at 22 19 41" src="https://github.com/user-attachments/assets/da53adc5-59e0-4bf4-8744-ae94a6de1dbe" />

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
