### PR TITLE
Fixed the issue of missing components when selecting multiple nodes

### DIFF
--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -1242,13 +1242,11 @@ const Elements = {
             setLabel(panel.dump.layer, panel.$.nodeLayer);
 
             // Find a list of components that need to be rendered
-            const componentList = [];
-            for (let i = 0; i < panel.dump.__comps__.length; i++) {
-                const comp = panel.dump.__comps__[i];
-                if (panel.dumps.every(dump => dump.__comps__.some(__comp__ => __comp__.type === comp.type))) {
-                    componentList.push(comp);
-                }
-            }
+            const componentList = panel.dump.__comps__.filter(comp =>
+                panel.dumps.every(dump =>
+                    dump.__comps__.some(__comp__ => __comp__.type === comp.type)
+                )
+            );
 
             const sectionBody = panel.$.sectionBody;
 

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -1241,15 +1241,11 @@ const Elements = {
             panel.$.nodeMobility.render(panel.dump.mobility);
             setLabel(panel.dump.layer, panel.$.nodeLayer);
 
-            // 查找需要渲染的 component 列表
+            // Find a list of components that need to be rendered
             const componentList = [];
             for (let i = 0; i < panel.dump.__comps__.length; i++) {
                 const comp = panel.dump.__comps__[i];
-                if (
-                    panel.dumps.every((dump) => {
-                        return dump.__comps__.find(__comp__ => __comp__.type === comp.type);
-                    })
-                ) {
+                if (panel.dumps.every(dump => dump.__comps__.some(__comp__ => __comp__.type === comp.type))) {
                     componentList.push(comp);
                 }
             }

--- a/editor/inspector/contributions/node.js
+++ b/editor/inspector/contributions/node.js
@@ -1247,7 +1247,7 @@ const Elements = {
                 const comp = panel.dump.__comps__[i];
                 if (
                     panel.dumps.every((dump) => {
-                        return dump.__comps__[i] && dump.__comps__[i].type === comp.type;
+                        return dump.__comps__.find(__comp__ => __comp__.type === comp.type);
                     })
                 ) {
                     componentList.push(comp);


### PR DESCRIPTION
Re: #


### Changelog

* Fixed the problem that when selecting multiple nodes, the positions of components are also matched, which leads to the loss of other components if the positions of components are inconsistent

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
