### PR TITLE
Fix spine callback issues

### DIFF
--- a/native/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
@@ -46,7 +46,11 @@ struct TrackEntryListeners {
 };
 
 void animationCallback(AnimationState *state, EventType type, TrackEntry *entry, Event *event) {
-    (static_cast<SkeletonAnimation *>(state->getRendererObject()))->cacheAnimationEvent(entry, type, event);
+    auto *skeletonAnimation = static_cast<SkeletonAnimation *>(state->getRendererObject());
+    skeletonAnimation->cacheAnimationEvent(entry, type, event);
+    if (type == EventType::EventType_Dispose) {
+        skeletonAnimation->dispatchEvents();
+    }
 }
 
 void trackEntryCallback(AnimationState *state, EventType type, TrackEntry *entry, Event *event) {

--- a/native/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
@@ -49,6 +49,10 @@ void animationCallback(AnimationState *state, EventType type, TrackEntry *entry,
     auto *skeletonAnimation = static_cast<SkeletonAnimation *>(state->getRendererObject());
     skeletonAnimation->cacheAnimationEvent(entry, type, event);
     if (type == EventType::EventType_Dispose) {
+         /**
+         * In the official implementation of Spine's AnimationState class, the animationCallback is invoked after the trackEntryCallback. 
+         * After the AnimationState completes the EventType_Dispose callback, the TrackEntry will be reclaimed, so this event must be dispatched immediately.
+         */
         skeletonAnimation->dispatchEvents();
     }
 }

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -26,6 +26,14 @@ static void animationCallback(AnimationState *state, EventType type, TrackEntry 
         info.eventType = type;
         info.event = event;
         instance->animationEvents.add(info);
+
+        if (type == spine::EventType::EventType_Dispose) {
+            /**
+             * In the official implementation of Spine's AnimationState class, the animationCallback is invoked after the trackEntryCallback. 
+             * After the AnimationState completes the EventType_Dispose callback, the TrackEntry will be reclaimed, so this event must be dispatched immediately.
+             */
+            instance->dispatchEvents();
+        }
     }
 }
 
@@ -37,12 +45,6 @@ static void trackEntryCallback(AnimationState *state, EventType type, TrackEntry
         info.eventType = type;
         info.event = event;
         instance->trackEvents.add(info);
-
-        if (type == EventType_Dispose) {
-            if (entry->getRendererObject()) {
-                entry->setRendererObject(nullptr);
-            }
-        }
     }
 }
 
@@ -135,20 +137,7 @@ void SpineSkeletonInstance::updateAnimation(float dltTime) {
     _skeleton->update(dltTime);
     _animState->update(dltTime);
     _animState->apply(*_skeleton);
-    //Cache animation events then call back to JS.
-    auto vecAnimationEvents = animationEvents;
-    animationEvents.clear();
-    //Cache track events then call back to JS.
-    auto vecTrackEvents = trackEvents;
-    trackEvents.clear();
-    for (int i = 0; i < vecAnimationEvents.size(); i++) {
-        auto& info = vecAnimationEvents[i];
-        onAnimationStateEvent(info.entry, info.eventType, info.event);
-    }
-    for (int i = 0; i < vecTrackEvents.size(); i++) {
-        auto& info = vecTrackEvents[i];
-        onTrackEntryEvent(info.entry, info.eventType, info.event);
-    }
+    dispatchEvents();
 }
 
 SpineModel *SpineSkeletonInstance::updateRenderData() {
@@ -522,6 +511,7 @@ void SpineSkeletonInstance::onTrackEntryEvent(TrackEntry *entry, EventType type,
     SpineWasmUtil::s_currentEvent = event;
     spineTrackListenerCallback();
     if (type == EventType_Dispose) {
+        entry->setRendererObject(nullptr);
         _trackListenerSet.remove(entry);
     }
 }
@@ -677,5 +667,22 @@ void SpineSkeletonInstance::setSlotTexture(const spine::String &slotName, const 
         if (attachmentVertices) {
             attachmentVertices->_textureUUID = textureUuid;
         }
+    }
+}
+
+void SpineSkeletonInstance::dispatchEvents() {
+    //Cache animation events then call back to JS.
+    auto vecAnimationEvents = animationEvents;
+    animationEvents.clear();
+    //Cache track events then call back to JS.
+    auto vecTrackEvents = trackEvents;
+    trackEvents.clear();
+    for (int i = 0; i < vecAnimationEvents.size(); i++) {
+        auto& info = vecAnimationEvents[i];
+        onAnimationStateEvent(info.entry, info.eventType, info.event);
+    }
+    for (int i = 0; i < vecTrackEvents.size(); i++) {
+        auto& info = vecTrackEvents[i];
+        onTrackEntryEvent(info.entry, info.eventType, info.event);
     }
 }

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -671,12 +671,18 @@ void SpineSkeletonInstance::setSlotTexture(const spine::String &slotName, const 
 }
 
 void SpineSkeletonInstance::dispatchEvents() {
-    //Cache animation events then call back to JS.
-    auto vecAnimationEvents = animationEvents;
-    animationEvents.clear();
-    //Cache track events then call back to JS.
-    auto vecTrackEvents = trackEvents;
-    trackEvents.clear();
+    spine::Vector<SpineEventInfo> vecAnimationEvents;
+    spine::Vector<SpineEventInfo> vecTrackEvents;
+    if (animationEvents.size() > 0) {
+        //Cache animation events then call back to JS.
+        vecAnimationEvents.addAll(animationEvents);
+        animationEvents.clear();
+    }
+    if (trackEvents.size() > 0) {
+        //Cache track events then call back to JS.
+        vecTrackEvents.addAll(trackEvents);
+        trackEvents.clear();
+    }
     for (int i = 0; i < vecAnimationEvents.size(); i++) {
         auto& info = vecAnimationEvents[i];
         onAnimationStateEvent(info.entry, info.eventType, info.event);

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
@@ -76,6 +76,8 @@ public:
     // Used internal for cache event
     spine::Vector<SpineEventInfo> animationEvents;
     spine::Vector<SpineEventInfo> trackEvents;
+    // Used internal for dispatch event
+    void dispatchEvents();
 private:
     void collectMeshData();
 

--- a/native/cocos/editor-support/spine/3.8/spine/Vector.h
+++ b/native/cocos/editor-support/spine/3.8/spine/Vector.h
@@ -117,14 +117,14 @@ public:
         }
     }
 
-    void addAll(Vector<T> &inValue) {
+    void addAll(const Vector<T> &inValue) {
         ensureCapacity(this->size() + inValue.size());
         for (size_t i = 0; i < inValue.size(); i++) {
             add(inValue[i]);
         }
     }
 
-    void clearAndAddAll(Vector<T> &inValue) {
+    void clearAndAddAll(const Vector<T> &inValue) {
         this->clear();
         this->addAll(inValue);
     }
@@ -199,6 +199,13 @@ public:
         return _buffer;
     }
 
+    Vector &operator=(const Vector &inVector) {
+        if (this != &inVector) {
+            clearAndAddAll(inVector);
+        }
+        return *this;
+    }
+
 private:
     size_t _size;
     size_t _capacity;
@@ -227,8 +234,6 @@ private:
     inline void destroy(T *buffer) {
         buffer->~T();
     }
-
-    // Vector &operator=(const Vector &inVector) {};
 };
 } // namespace spine
 

--- a/native/cocos/editor-support/spine/4.2/spine/Vector.h
+++ b/native/cocos/editor-support/spine/4.2/spine/Vector.h
@@ -116,14 +116,14 @@ namespace spine {
 			}
 		}
 
-		inline void addAll(const Vector<T> &inValue) {
+		void addAll(const Vector<T> &inValue) {
 			ensureCapacity(this->size() + inValue.size());
 			for (size_t i = 0; i < inValue.size(); i++) {
 				add(inValue[i]);
 			}
 		}
 
-		inline void clearAndAddAll(const Vector<T> &inValue) {
+		void clearAndAddAll(const Vector<T> &inValue) {
 			this->clear();
 			this->addAll(inValue);
 		}
@@ -233,8 +233,6 @@ namespace spine {
 		inline void destroy(T *buffer) {
 			buffer->~T();
 		}
-
-		// Vector &operator=(const Vector &inVector) {};
 	};
 }
 

--- a/native/cocos/editor-support/spine/4.2/spine/Vector.h
+++ b/native/cocos/editor-support/spine/4.2/spine/Vector.h
@@ -116,14 +116,14 @@ namespace spine {
 			}
 		}
 
-		inline void addAll(Vector<T> &inValue) {
+		inline void addAll(const Vector<T> &inValue) {
 			ensureCapacity(this->size() + inValue.size());
 			for (size_t i = 0; i < inValue.size(); i++) {
 				add(inValue[i]);
 			}
 		}
 
-		inline void clearAndAddAll(Vector<T> &inValue) {
+		inline void clearAndAddAll(const Vector<T> &inValue) {
 			this->clear();
 			this->addAll(inValue);
 		}
@@ -192,6 +192,13 @@ namespace spine {
 
 		inline friend bool operator!=(Vector<T> &lhs, Vector<T> &rhs) {
 			return !(lhs == rhs);
+		}
+
+		Vector &operator=(const Vector &inVector) {
+			if (this != &inVector) {
+				clearAndAddAll(inVector);
+			}
+			return *this;
 		}
 
 		inline T *buffer() {

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos",
         "name": "cocos-engine-external",
-        "checkout": "v3.8.7-8"
+        "checkout": "v3.8.7-9"
     }
 }

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos",
         "name": "cocos-engine-external",
-        "checkout": "v3.8.7-7"
+        "checkout": "v3.8.7-8"
     }
 }


### PR DESCRIPTION
1. Callbacks set via setTrackEndListener are not triggered.
2. The setEndListener callback interface cannot retrieve the animation name through the trackEntry parameter.

Re: #
https://github.com/cocos/cocos-engine/pull/18610
https://github.com/cocos/cocos-test-projects/pull/920
https://github.com/cocos/cocos-engine-external/pull/488

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
