### PR TITLE
Fix the inconsistent behavior between Spine vector's setSize and std::vector's resize, which causes the Spine vector to allocate additional space upfront.

### DIFF
--- a/native/cocos/editor-support/spine/3.8/spine/Vector.h
+++ b/native/cocos/editor-support/spine/3.8/spine/Vector.h
@@ -80,7 +80,11 @@ public:
         size_t oldSize = _size;
         _size = newSize;
         if (_capacity < newSize) {
-            _capacity = (int)(_size * 1.75f);
+            if (_capacity == 0) {
+                _capacity = _size;
+            } else {
+                _capacity = (int)(_size * 1.75f);
+            }
             if (_capacity < 8) _capacity = 8;
             _buffer = spine::SpineExtension::realloc<T>(_buffer, _capacity, __SPINE_FILE__, __SPINE_LINE__);
         }

--- a/native/cocos/editor-support/spine/4.2/spine/Vector.h
+++ b/native/cocos/editor-support/spine/4.2/spine/Vector.h
@@ -58,7 +58,7 @@ namespace spine {
 			deallocate(_buffer);
 		}
 
-		inline void clear() {
+		void clear() {
 			for (size_t i = 0; i < _size; ++i) {
 				destroy(_buffer + (_size - 1 - i));
 			}
@@ -74,12 +74,16 @@ namespace spine {
 			return _size;
 		}
 
-		inline void setSize(size_t newSize, const T &defaultValue) {
+		void setSize(size_t newSize, const T &defaultValue) {
 			assert(newSize >= 0);
 			size_t oldSize = _size;
 			_size = newSize;
 			if (_capacity < newSize) {
-				_capacity = (int) (_size * 1.75f);
+				if (_capacity == 0) {
+					_capacity = _size;
+				} else {
+					_capacity = (int) (_size * 1.75f);
+				}
 				if (_capacity < 8) _capacity = 8;
 				_buffer = spine::SpineExtension::realloc<T>(_buffer, _capacity, __FILE__, __LINE__);
 			}
@@ -94,13 +98,13 @@ namespace spine {
 			}
 		}
 
-		inline void ensureCapacity(size_t newCapacity = 0) {
+		void ensureCapacity(size_t newCapacity = 0) {
 			if (_capacity >= newCapacity) return;
 			_capacity = newCapacity;
 			_buffer = SpineExtension::realloc<T>(_buffer, newCapacity, __FILE__, __LINE__);
 		}
 
-		inline void add(const T &inValue) {
+		void add(const T &inValue) {
 			if (_size == _capacity) {
 				// inValue might reference an element in this buffer
 				// When we reallocate, the reference becomes invalid.
@@ -128,7 +132,7 @@ namespace spine {
 			this->addAll(inValue);
 		}
 
-		inline void removeAt(size_t inIndex) {
+		void removeAt(size_t inIndex) {
 			assert(inIndex < _size);
 
 			--_size;

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos",
         "name": "cocos-engine-external",
-        "checkout": "v3.8.7-9"
+        "checkout": "v3.8.7-10"
     }
 }


### PR DESCRIPTION
Re: #
https://github.com/EsotericSoftware/spine-runtimes/pull/2830

![image](https://github.com/user-attachments/assets/ac39337f-2cd8-4e15-8620-b554bb685589)
As shown in the screenshot, when the vector is empty, the first call to resize results in capacity and size being equal, meaning no additional capacity is allocated.
### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
