### PR TITLE
 Fix the issue in Spine 4.2 where setSlotTexture with createNew: true  affects other instances and causes abnormal rendering

### DIFF
--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.h
@@ -50,13 +50,11 @@ class Material;
 
 class AttachmentVertices;
 
-namespace {
 struct SlotCacheInfo {
     bool isOwner{false};
     spine::Attachment *attachment{nullptr};
     AttachmentVertices *attachmentVertices{nullptr};
 };
-} // namespace
 
 /** Draws a skeleton.
      */

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.h
@@ -50,10 +50,13 @@ class Material;
 
 class AttachmentVertices;
 
+namespace {
 struct SlotCacheInfo {
     bool isOwner{false};
-    spine::Attachment* attachment{nullptr};
+    spine::Attachment *attachment{nullptr};
+    AttachmentVertices *attachmentVertices{nullptr};
 };
+} // namespace
 
 /** Draws a skeleton.
      */
@@ -160,6 +163,7 @@ public:
 
 protected:
     void setSkeletonData(spine::SkeletonData *skeletonData, bool ownsSkeletonData);
+    void releaseSlotCacheInfo(SlotCacheInfo &info);
 
     bool _ownsSkeletonData = false;
     bool _ownsSkeleton = false;

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -12,12 +12,6 @@ extern void spineTrackListenerCallback();
 }
 using namespace spine;
 
-#ifdef CC_SPINE_VERSION_3_8
-static void deleteAttachmentVertices(void *vertices) {
-    delete static_cast<AttachmentVertices *>(vertices);
-}
-#endif
-
 static void animationCallback(AnimationState *state, EventType type, TrackEntry *entry, Event *event) {
     SpineSkeletonInstance *instance = (static_cast<SpineSkeletonInstance *>(state->getRendererObject()));
     if (instance) {
@@ -73,6 +67,7 @@ SpineSkeletonInstance::~SpineSkeletonInstance() {
             if (info.attachment && info.isOwner) {
                 delete info.attachment;
                 info.attachment = nullptr;
+                delete info.attachmentVertices;
             }
         }
     }
@@ -157,6 +152,7 @@ SpineModel *SpineSkeletonInstance::updateRenderData() {
         _model->byteStride = sizeof(V3F_T2F_C4B);
     }
     collectMeshData();
+    globalMesh.textureID = "";
     _model->setBufferPtr(SpineMeshData::vb(), SpineMeshData::ib());
     return _model;
 }
@@ -202,19 +198,24 @@ void SpineSkeletonInstance::collectMeshData() {
         color.b = _userData.color.b;
         color.a = _userData.color.a;
         spine::Attachment* attachmentSlot = slot->getAttachment();
+        AttachmentVertices *cacheSlotAttachmentVertices = nullptr;
         if (_userData.useSlotTexture && _slotTextureSet.containsKey(slot)) {
             auto info = _slotTextureSet[slot];
             attachmentSlot = info.attachment;
+            cacheSlotAttachmentVertices = info.attachmentVertices;
         }
         const spine::RTTI& attachmentRTTI = attachmentSlot->getRTTI();
         if (attachmentRTTI.isExactly(spine::RegionAttachment::rtti)) {
             debugShapeType = DEBUG_SHAPE_TYPE::DEBUG_REGION;
             auto *attachment = static_cast<spine::RegionAttachment *>(attachmentSlot);
+            auto *attachmentVertices = cacheSlotAttachmentVertices;
+            if (!attachmentVertices) {
 #ifdef CC_SPINE_VERSION_3_8
-            auto *attachmentVertices = reinterpret_cast<AttachmentVertices *>(attachment->getRendererObject());
+                attachmentVertices = reinterpret_cast<AttachmentVertices *>(attachment->getRendererObject());
 #else
-            auto *attachmentVertices = reinterpret_cast<AttachmentVertices *>(attachment->getRegion()->rendererObject);
+                attachmentVertices = reinterpret_cast<AttachmentVertices *>(attachment->getRegion()->rendererObject);
 #endif
+            }
 
             auto *triangles = attachmentVertices->_triangles;
             auto vertCount = triangles->vertCount;
@@ -249,11 +250,14 @@ void SpineSkeletonInstance::collectMeshData() {
         } else if (attachmentRTTI.isExactly(spine::MeshAttachment::rtti)) {
             debugShapeType = DEBUG_SHAPE_TYPE::DEBUG_MESH;
             auto *attachment = static_cast<spine::MeshAttachment *>(attachmentSlot);
+            auto *attachmentVertices = cacheSlotAttachmentVertices;
+            if (!attachmentVertices) {
 #ifdef CC_SPINE_VERSION_3_8
-            auto *attachmentVertices = static_cast<AttachmentVertices *>(attachment->getRendererObject());
+                attachmentVertices = static_cast<AttachmentVertices *>(attachment->getRendererObject());
 #else
-            auto *attachmentVertices = static_cast<AttachmentVertices *>(attachment->getRegion()->rendererObject);
+                attachmentVertices = static_cast<AttachmentVertices *>(attachment->getRegion()->rendererObject);
 #endif
+            }
 
             auto *triangles = attachmentVertices->_triangles;
             auto vertCount = triangles->vertCount;
@@ -534,12 +538,10 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
     if (!attachment) return;
     if (createNew) {
         attachment = attachment->copy();
-        slot->setAttachment(attachment);
     }
     SlotCacheInfo info;
     info.attachment = attachment;
     info.isOwner = createNew;
-    _slotTextureSet.put(slot, info);
     if (attachment->getRTTI().isExactly(spine::RegionAttachment::rtti)) {
         auto *region = static_cast<RegionAttachment *>(attachment);
 #ifdef CC_SPINE_VERSION_3_8
@@ -554,7 +556,7 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
         auto *attachmentVertices = static_cast<AttachmentVertices *>(region->getRendererObject());
         if (createNew) {
             attachmentVertices = attachmentVertices->copy();
-            region->setRendererObject(attachmentVertices, deleteAttachmentVertices);
+            info.attachmentVertices = attachmentVertices;
         }
 #else
         auto *textureRegion = region->getRegion();
@@ -563,6 +565,11 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
             textureRegion->height = height;
             textureRegion->originalWidth = width;
             textureRegion->originalHeight = height;
+
+            textureRegion->u = 0;
+            textureRegion->v = 0;
+            textureRegion->u2 = 1.0f;
+            textureRegion->v2 = 1.0f;
         }
         region->setWidth(width);
         region->setHeight(height);
@@ -579,7 +586,7 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
         auto *attachmentVertices = static_cast<AttachmentVertices *>(region->getRegion()->rendererObject);
         if (createNew) {
             attachmentVertices = attachmentVertices->copy();
-            region->getRegion()->rendererObject = attachmentVertices;
+            info.attachmentVertices = attachmentVertices;
         }
 #endif
         V3F_T2F_C4B *vertices = attachmentVertices->_triangles->verts;
@@ -607,7 +614,7 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
         auto *attachmentVertices = static_cast<AttachmentVertices *>(mesh->getRendererObject());
         if (createNew) {
             attachmentVertices = attachmentVertices->copy();
-            mesh->setRendererObject(attachmentVertices, deleteAttachmentVertices);
+            info.attachmentVertices = attachmentVertices;
         }
 #else
         auto *region = mesh->getRegion();
@@ -628,7 +635,7 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
         auto *attachmentVertices = static_cast<AttachmentVertices *>(mesh->getRegion()->rendererObject);
         if (createNew) {
             attachmentVertices = attachmentVertices->copy();
-            mesh->getRegion()->rendererObject = attachmentVertices;
+            info.attachmentVertices = attachmentVertices;
         }
 #endif
         V3F_T2F_C4B *vertices = attachmentVertices->_triangles->verts;
@@ -638,6 +645,7 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
             vertices[i].texCoord.v = UVs[ii + 1];
         }
     }
+    _slotTextureSet.put(slot, info);
     _skeleton->updateCache();
 }
 
@@ -647,23 +655,7 @@ void SpineSkeletonInstance::setSlotTexture(const spine::String &slotName, const 
     if (!slot) return;
     _userData.useSlotTexture = true;
     if (_slotTextureSet.containsKey(slot)) {
-        AttachmentVertices *attachmentVertices =  nullptr;
-        auto* attachment = _slotTextureSet[slot].attachment;
-        if (attachment->getRTTI().isExactly(spine::RegionAttachment::rtti)) {
-            auto *regionAttachment = static_cast<RegionAttachment *>(attachment);
-#ifdef CC_SPINE_VERSION_3_8
-            attachmentVertices = static_cast<AttachmentVertices *>(regionAttachment->getRendererObject());
-#else
-            attachmentVertices = static_cast<AttachmentVertices *>(regionAttachment->getRegion()->rendererObject);
-#endif
-        } else if(attachment->getRTTI().isExactly(spine::MeshAttachment::rtti)) {
-            auto *meshAttachment = static_cast<MeshAttachment *>(attachment);
-#ifdef CC_SPINE_VERSION_3_8
-            attachmentVertices = static_cast<AttachmentVertices *>(meshAttachment->getRendererObject());
-#else
-            attachmentVertices = static_cast<AttachmentVertices *>(meshAttachment->getRegion()->rendererObject);
-#endif
-        }
+        AttachmentVertices *attachmentVertices =  _slotTextureSet[slot].attachmentVertices;
         if (attachmentVertices) {
             attachmentVertices->_textureUUID = textureUuid;
         }

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -655,7 +655,7 @@ void SpineSkeletonInstance::setSlotTexture(const spine::String &slotName, const 
     if (!slot) return;
     _userData.useSlotTexture = true;
     if (_slotTextureSet.containsKey(slot)) {
-        AttachmentVertices *attachmentVertices =  _slotTextureSet[slot].attachmentVertices;
+        AttachmentVertices *attachmentVertices = _slotTextureSet[slot].attachmentVertices;
         if (attachmentVertices) {
             attachmentVertices->_textureUUID = textureUuid;
         }

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -64,11 +64,7 @@ SpineSkeletonInstance::~SpineSkeletonInstance() {
         while (entries.hasNext()) {
             auto entry = entries.next();
             auto info = entry.value;
-            if (info.attachment && info.isOwner) {
-                delete info.attachment;
-                info.attachment = nullptr;
-                delete info.attachmentVertices;
-            }
+            releaseSlotCacheInfo(info);
         }
     }
 }
@@ -645,6 +641,10 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
             vertices[i].texCoord.v = UVs[ii + 1];
         }
     }
+    if (_slotTextureSet.containsKey(slot)) {
+        auto cacheInfo = _slotTextureSet[slot];
+        releaseSlotCacheInfo(cacheInfo);
+    }
     _slotTextureSet.put(slot, info);
     _skeleton->updateCache();
 }
@@ -682,5 +682,14 @@ void SpineSkeletonInstance::dispatchEvents() {
     for (int i = 0; i < vecTrackEvents.size(); i++) {
         auto& info = vecTrackEvents[i];
         onTrackEntryEvent(info.entry, info.eventType, info.event);
+    }
+}
+
+void SpineSkeletonInstance::releaseSlotCacheInfo(SlotCacheInfo &info) {
+    if (info.attachment && info.isOwner) {
+        delete info.attachment;
+        info.attachment = nullptr;
+        delete info.attachmentVertices;
+        info.attachmentVertices = nullptr;
     }
 }

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
@@ -82,6 +82,7 @@ public:
     void dispatchEvents();
 private:
     void collectMeshData();
+    void releaseSlotCacheInfo(SlotCacheInfo &info);
 
 private:
     spine::Skeleton *_skeleton = nullptr;

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.h
@@ -6,17 +6,19 @@
 #include <string>
 #include "mesh-type-define.h"
 #include "spine-model.h"
+#include "AtlasAttachmentLoaderExtension.h"
 
 namespace {
     struct SpineEventInfo {
-        spine::TrackEntry* entry{nullptr};
+        spine::TrackEntry *entry{nullptr};
         spine::EventType eventType{spine::EventType::EventType_Start};
         spine::Event *event{nullptr};
     };
 
     struct SlotCacheInfo {
         bool isOwner{false};
-        spine::Attachment* attachment{nullptr};
+        spine::Attachment *attachment{nullptr};
+        AttachmentVertices *attachmentVertices{nullptr};
     };
 }
 enum DEBUG_SHAPE_TYPE {

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos",
         "name": "cocos-engine-external",
-        "checkout": "v3.8.7-10"
+        "checkout": "v3.8.7-11"
     }
 }

--- a/native/tools/swig-config/spine_3_8.i
+++ b/native/tools/swig-config/spine_3_8.i
@@ -52,6 +52,7 @@ using namespace spine;
 %ignore spine::Polygon::Polygon;
 %ignore spine::Polygon::_vertices;
 
+%ignore cc::SlotCacheInfo;
 %ignore cc::SkeletonRenderer::create;
 %ignore cc::SkeletonRenderer::initWithJsonFile;
 %ignore cc::SkeletonRenderer::initWithBinaryFile;

--- a/native/tools/swig-config/spine_4_2.i
+++ b/native/tools/swig-config/spine_4_2.i
@@ -51,6 +51,7 @@ using namespace spine;
 %ignore spine::Polygon::Polygon;
 %ignore spine::Polygon::_vertices;
 
+%ignore cc::SlotCacheInfo;
 %ignore cc::SkeletonRenderer::create;
 %ignore cc::SkeletonRenderer::initWithJsonFile;
 %ignore cc::SkeletonRenderer::initWithBinaryFile;


### PR DESCRIPTION
Re: #
https://github.com/cocos/3d-tasks/issues/18680
https://github.com/cocos/3d-tasks/issues/18807

https://github.com/cocos/cocos-engine-external/pull/491

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
