### PR TITLE
Fixed the issue of not displaying when rendering multiple tilemaps

### DIFF
--- a/cocos/tiledmap/assembler/simple.ts
+++ b/cocos/tiledmap/assembler/simple.ts
@@ -74,9 +74,6 @@ class Simple implements IAssembler {
             const batcher = director.root!.batcher2D;
             _accessor = new StaticVBAccessor(device, vfmtPosUvColor);
             //batcher.registerBufferAccessor(Number.parseInt('TILED-MAP', 36), _accessor);
-            director.on(DirectorEvent.BEFORE_DRAW, () => {
-                _accessor.reset();
-            });
         }
     }
 

--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -1520,11 +1520,10 @@ export class TiledLayer extends UIRenderer {
 
     private fillIndicesBuffer (renderData: RenderData, drawInfo: RenderDrawInfo): void {
         const iBuf = renderData.chunk.meshBuffer.iData;
-
-        let indexOffset = renderData.chunk.meshBuffer.indexOffset;
-        drawInfo.setIndexOffset(indexOffset);
         let vertexId = renderData.chunk.vertexOffset;
         const quadCount = renderData.vertexCount / 4;
+        let indexOffset = (vertexId / 4) * 6;
+        drawInfo.setIndexOffset(indexOffset);
         for (let i = 0; i < quadCount; i += 1) {
             iBuf[indexOffset] = vertexId;
             iBuf[indexOffset + 1] = vertexId + 1;


### PR DESCRIPTION
Re: #

### Changelog

https://forum.cocos.org/t/topic/167470/11

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
