### PR TITLE
Fixed the problem of texture map offset when tilemap window is resized

### DIFF
--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -46,6 +46,8 @@ import { RenderDrawInfo, RenderDrawInfoType } from '../2d/renderer/render-draw-i
 import { Texture2D } from '../asset/assets';
 import { director } from '../game';
 import { Camera } from '../render-scene/scene';
+import { View } from '../ui/view';
+import { screenAdapter } from 'pal/screen-adapter';
 
 const _mat4_temp = new Mat4();
 const _vec2_temp = new Vec2();
@@ -455,6 +457,9 @@ export class TiledLayer extends UIRenderer {
         this.node.on(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
         this.node.parent!.on(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
         this.node.parent!.on(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
+        View.instance.on('canvas-resize', this._resize);
+        screenAdapter.on('window-resize', this._resize);
+        
         this._markForUpdateRenderData();
         // delay 1 frame, since camera's matrix data is dirty
         this.scheduleOnce(this.updateCulling.bind(this));
@@ -467,6 +472,8 @@ export class TiledLayer extends UIRenderer {
         this.node.off(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
         this.node.off(NodeEventType.TRANSFORM_CHANGED, this.updateCulling, this);
         this.node.off(NodeEventType.ANCHOR_CHANGED, this._syncAnchorPoint, this);
+        View.instance.off('canvas-resize', this._resize);
+        screenAdapter.off('window-resize', this._resize);
         this._uninstallCamera();
     }
 
@@ -477,6 +484,10 @@ export class TiledLayer extends UIRenderer {
         this._leftDownToCenterX = trans.width * trans.anchorX * scale.x;
         this._leftDownToCenterY = trans.height * trans.anchorY * scale.y;
         this._cullingDirty = true;
+        this._markForUpdateRenderData();
+    }
+
+    protected _resize(): void {
         this._markForUpdateRenderData();
     }
 

--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -27,6 +27,7 @@
 import { ccclass } from 'cc.decorator';
 
 import { EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
+import { screenAdapter } from 'pal/screen-adapter';
 import { UIRenderer } from '../2d/framework/ui-renderer';
 import { SpriteFrame } from '../2d/assets/sprite-frame';
 import { Component, Node } from '../scene-graph';
@@ -47,7 +48,6 @@ import { Texture2D } from '../asset/assets';
 import { director } from '../game';
 import { Camera } from '../render-scene/scene';
 import { View } from '../ui/view';
-import { screenAdapter } from 'pal/screen-adapter';
 
 const _mat4_temp = new Mat4();
 const _vec2_temp = new Vec2();
@@ -459,7 +459,6 @@ export class TiledLayer extends UIRenderer {
         this.node.parent!.on(NodeEventType.SIZE_CHANGED, this.updateCulling, this);
         View.instance.on('canvas-resize', this._resize);
         screenAdapter.on('window-resize', this._resize);
-        
         this._markForUpdateRenderData();
         // delay 1 frame, since camera's matrix data is dirty
         this.scheduleOnce(this.updateCulling.bind(this));


### PR DESCRIPTION
Re: #

### Changelog

https://github.com/cocos/cocos-engine/issues/18155

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
