### PR TITLE
In Spine 4.2, the attachment->computeWorldVertices() method may modify UV values, requiring updates every frame.

### DIFF
--- a/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
@@ -41,6 +41,7 @@ using namespace spine;
 namespace cc {
 
 class SkeletonDataInfo;
+class AttachmentVertices;
 
 /**
  * Cache skeleton data.
@@ -71,6 +72,9 @@ public:
     // equal to 'deleteByUUID'
     void releaseByUUID(const std::string &uuid);
 
+    std::unordered_map<Attachment *, AttachmentVertices *>
+        *getSkeletonDataInfo(const std::string &uuid);
+
     using destroyCallback = std::function<void(int)>;
     void setDestroyCallback(destroyCallback callback) {
         _destroyCallback = std::move(callback);
@@ -81,5 +85,4 @@ private:
     destroyCallback _destroyCallback = nullptr;
     std::map<std::string, SkeletonDataInfo *> _dataMap;
 };
-
 } // namespace cc

--- a/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
@@ -33,6 +33,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include "base/RefCounted.h"
 #include "spine/SkeletonData.h"
 #include "spine/spine.h"

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -65,14 +65,6 @@ enum DebugType {
     BONES
 };
 
-template<typename VertexType, typename UVArrayType>
-void loopUVCoords(VertexType* tmp, const UVArrayType& uvs, int count) {
-    for (int i = 0, ii = 0; i < count; ++i, ii += 2) {
-        tmp[i].texCoord.u = uvs[ii];
-        tmp[i].texCoord.v = uvs[ii + 1];
-    }
-}
-
 extern "C" AttachmentVertices *generateAttachmentVertices(Attachment *attachment);
 namespace cc {
 SkeletonRenderer *SkeletonRenderer::create() {
@@ -1168,12 +1160,15 @@ void SkeletonRenderer::setSlotTexture(const std::string &slotName, cc::Texture2D
     if (!attachment) return;
     auto width = tex2d->getWidth();
     auto height = tex2d->getHeight();
+    auto *verticesMap = SkeletonDataMgr::getInstance()->getSkeletonDataInfo(_uuid);
+    if (!verticesMap) return;
+    auto &attachmentVerticesMap = *verticesMap;
+    auto *attachmentVertices = attachmentVerticesMap.at(attachment);
 
     if (createAttachment) {
         attachment = attachment->copy();
     }
     SlotCacheInfo slotCacheInfo{createAttachment, attachment, nullptr};
-    AttachmentVertices *attachmentVertices = nullptr;
     if (attachment->getRTTI().isExactly(spine::RegionAttachment::rtti)) {
         auto region = static_cast<RegionAttachment *>(attachment);
 #if CC_USE_SPINE_3_8
@@ -1185,7 +1180,6 @@ void SkeletonRenderer::setSlotTexture(const std::string &slotName, cc::Texture2D
         region->setHeight(height);
         region->setUVs(0, 0, 1.0f, 1.0f, false);
         region->updateOffset();
-        attachmentVertices = static_cast<AttachmentVertices *>(region->getRendererObject());
         if (createAttachment) {
             attachmentVertices = attachmentVertices->copy();
             slotCacheInfo.attachmentVertices = attachmentVertices;
@@ -1215,8 +1209,6 @@ void SkeletonRenderer::setSlotTexture(const std::string &slotName, cc::Texture2D
         uvs[0] = 1;
         uvs[1] = 1;
         region->updateRegion();
-        auto *tmpMap = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(textureRegion->rendererObject);
-        attachmentVertices = (*tmpMap)[slot->getAttachment()];
         if (createAttachment) {
             attachmentVertices = attachmentVertices->copy();
             slotCacheInfo.attachmentVertices = attachmentVertices;
@@ -1244,7 +1236,6 @@ void SkeletonRenderer::setSlotTexture(const std::string &slotName, cc::Texture2D
         mesh->setRegionRotate(true);
         mesh->setRegionDegrees(0);
         mesh->updateUVs();
-        attachmentVertices = static_cast<AttachmentVertices *>(mesh->getRendererObject());
         if (createAttachment) {
             attachmentVertices = attachmentVertices->copy();
             slotCacheInfo.attachmentVertices = attachmentVertices;
@@ -1265,8 +1256,6 @@ void SkeletonRenderer::setSlotTexture(const std::string &slotName, cc::Texture2D
         mesh->setWidth(width);
         mesh->setHeight(height);
         mesh->updateRegion();
-        auto *tmpMap = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(mesh->getRegion()->rendererObject);
-        attachmentVertices = (*tmpMap)[slot->getAttachment()];
         if (createAttachment) {
             attachmentVertices = attachmentVertices->copy();
             slotCacheInfo.attachmentVertices = attachmentVertices;

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -44,6 +44,15 @@
 #include "spine-creator-support/AttachmentVertices.h"
 #include "spine-creator-support/spine-cocos2dx.h"
 
+
+#define LOOP_UV_COORDS(tmp_var, uvs_var, loop_count) \
+    for (int _i = 0, _ii = 0; _i < (loop_count); ++_i, _ii += 2) { \
+        (tmp_var)[_i].texCoord.u = (uvs_var)[_ii]; \
+        (tmp_var)[_i].texCoord.v = (uvs_var)[_ii + 1]; \
+    }
+
+
+
 USING_NS_MW;             // NOLINT(google-build-using-namespace)
 using namespace spine;   // NOLINT(google-build-using-namespace)
 using namespace cc;      // NOLINT(google-build-using-namespace)
@@ -64,6 +73,7 @@ enum DebugType {
     BONES
 };
 
+extern "C" AttachmentVertices *generateAttachmentVertices(Attachment *attachment);
 namespace cc {
 SkeletonRenderer *SkeletonRenderer::create() {
     return new SkeletonRenderer();
@@ -410,6 +420,9 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
    void *effect = nullptr;
 #endif
 
+    auto *verticesMap = SkeletonDataMgr::getInstance()->getSkeletonDataInfo(_uuid);
+    if (!verticesMap) return;
+    auto &attachmentVerticesMap = *verticesMap;
     auto &drawOrder = _skeleton->getDrawOrder();
     for (size_t i = 0, n = drawOrder.size(); i < n; ++i) {
         isFull = 0;
@@ -440,7 +453,12 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
 
         cc::middleware::Triangles triangles;
         cc::middleware::TwoColorTriangles trianglesTwoColor;
-        attachmentVertices = nullptr;
+        auto iterAttachment = attachmentVerticesMap.find(tmpAttachment);
+        if (iterAttachment != attachmentVerticesMap.end()) {
+            attachmentVertices = iterAttachment->second;
+        } else {
+            attachmentVertices = nullptr;
+        }
 
         auto iter = _slotTextureSet.find(slot);
         if (iter != _slotTextureSet.end()) {
@@ -449,14 +467,17 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
         }
         if (tmpAttachment->getRTTI().isExactly(RegionAttachment::rtti)) {
             auto *attachment = dynamic_cast<RegionAttachment *>(tmpAttachment);
-            if (!attachmentVertices) {
-#if CC_USE_SPINE_3_8
-                attachmentVertices = reinterpret_cast<AttachmentVertices *>(attachment->getRendererObject());
-#else
-                auto *tmpMap = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(attachment->getRegion()->rendererObject);
-                attachmentVertices = (*tmpMap)[attachment];
-#endif
+#if CC_USE_SPINE_4_2
+            if (!attachment->getRegion()) {
+                attachment->getSequence()->apply(slot, attachment);
+                if (attachment->getRegion()) {
+                    attachmentVertices = generateAttachmentVertices(attachment);
+                    if (attachmentVertices) {
+                        attachmentVerticesMap[attachment] = attachmentVertices;
+                    }
+                }
             }
+#endif
 
             // Early exit if attachment is invisible
             if (attachment->getColor().a == 0) {
@@ -473,6 +494,7 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
 #if CC_USE_SPINE_3_8
                 attachment->computeWorldVertices(slot->getBone(), reinterpret_cast<float *>(triangles.verts), 0, vs1);
 #else
+                LOOP_UV_COORDS(triangles.verts, attachment->getUVs(), triangles.vertCount);
                 attachment->computeWorldVertices(*slot, reinterpret_cast<float *>(triangles.verts), 0, vs1);
 #endif
 
@@ -486,12 +508,13 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
                 vbSize = trianglesTwoColor.vertCount * sizeof(V3F_T2F_C4B_C4B);
                 isFull |= vb.checkSpace(vbSize, true);
                 trianglesTwoColor.verts = reinterpret_cast<V3F_T2F_C4B_C4B *>(vb.getCurBuffer());
+#if CC_USE_SPINE_3_8
                 for (int ii = 0; ii < trianglesTwoColor.vertCount; ii++) {
                     trianglesTwoColor.verts[ii].texCoord = attachmentVertices->_triangles->verts[ii].texCoord;
                 }
-#if CC_USE_SPINE_3_8
                 attachment->computeWorldVertices(slot->getBone(), reinterpret_cast<float *>(trianglesTwoColor.verts), 0, vs2);
 #else
+                LOOP_UV_COORDS(trianglesTwoColor.verts, attachment->getUVs(), trianglesTwoColor.vertCount);
                 attachment->computeWorldVertices(*slot, reinterpret_cast<float *>(trianglesTwoColor.verts), 0, vs2);
 #endif
 
@@ -521,14 +544,17 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
             }
         } else if (tmpAttachment->getRTTI().isExactly(MeshAttachment::rtti)) {
             auto *attachment = dynamic_cast<MeshAttachment *>(tmpAttachment);
-            if (!attachmentVertices) {
-#if CC_USE_SPINE_3_8
-                attachmentVertices = static_cast<AttachmentVertices *>(attachment->getRendererObject());
-#else
-                auto *tmpMap = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(attachment->getRegion()->rendererObject);
-                attachmentVertices = (*tmpMap)[attachment];
-#endif
+#if CC_USE_SPINE_4_2
+            if (!attachment->getRegion()) {
+                attachment->getSequence()->apply(slot, attachment);
+                if (attachment->getRegion()) {
+                    attachmentVertices = generateAttachmentVertices(attachment);
+                    if (attachmentVertices) {
+                        attachmentVerticesMap[attachment] = attachmentVertices;
+                    }
+                }
             }
+#endif
 
             // Early exit if attachment is invisible
             if (attachment->getColor().a == 0) {
@@ -542,6 +568,9 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
                 isFull |= vb.checkSpace(vbSize, true);
                 triangles.verts = reinterpret_cast<V3F_T2F_C4B *>(vb.getCurBuffer());
                 memcpy(static_cast<void *>(triangles.verts), static_cast<void *>(attachmentVertices->_triangles->verts), vbSize);
+#ifdef CC_USE_SPINE_4_2
+                LOOP_UV_COORDS(triangles.verts, attachment->getUVs(), triangles.vertCount);
+#endif
                 attachment->computeWorldVertices(*slot, 0, attachment->getWorldVerticesLength(), reinterpret_cast<float *>(triangles.verts), 0, vs1);
 
                 triangles.indexCount = attachmentVertices->_triangles->indexCount;
@@ -554,9 +583,13 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
                 vbSize = trianglesTwoColor.vertCount * sizeof(V3F_T2F_C4B_C4B);
                 isFull |= vb.checkSpace(vbSize, true);
                 trianglesTwoColor.verts = reinterpret_cast<V3F_T2F_C4B_C4B *>(vb.getCurBuffer());
+#ifdef CC_USE_SPINE_3_8
                 for (int ii = 0; ii < trianglesTwoColor.vertCount; ii++) {
                     trianglesTwoColor.verts[ii].texCoord = attachmentVertices->_triangles->verts[ii].texCoord;
                 }
+#else
+                LOOP_UV_COORDS(trianglesTwoColor.verts, attachment->getUVs(), trianglesTwoColor.vertCount);
+#endif
                 attachment->computeWorldVertices(*slot, 0, attachment->getWorldVerticesLength(), reinterpret_cast<float *>(trianglesTwoColor.verts), 0, vs2);
 
                 trianglesTwoColor.indexCount = attachmentVertices->_triangles->indexCount;

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -45,14 +45,6 @@
 #include "spine-creator-support/spine-cocos2dx.h"
 
 
-#define LOOP_UV_COORDS(tmp_var, uvs_var, loop_count) \
-    for (int _i = 0, _ii = 0; _i < (loop_count); ++_i, _ii += 2) { \
-        (tmp_var)[_i].texCoord.u = (uvs_var)[_ii]; \
-        (tmp_var)[_i].texCoord.v = (uvs_var)[_ii + 1]; \
-    }
-
-
-
 USING_NS_MW;             // NOLINT(google-build-using-namespace)
 using namespace spine;   // NOLINT(google-build-using-namespace)
 using namespace cc;      // NOLINT(google-build-using-namespace)
@@ -72,6 +64,14 @@ enum DebugType {
     MESH,
     BONES
 };
+
+template<typename VertexType, typename UVArrayType>
+void loopUVCoords(VertexType* tmp, const UVArrayType& uvs, int count) {
+    for (int i = 0, ii = 0; i < count; ++i, ii += 2) {
+        tmp[i].texCoord.u = uvs[ii];
+        tmp[i].texCoord.v = uvs[ii + 1];
+    }
+}
 
 extern "C" AttachmentVertices *generateAttachmentVertices(Attachment *attachment);
 namespace cc {
@@ -494,7 +494,7 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
 #if CC_USE_SPINE_3_8
                 attachment->computeWorldVertices(slot->getBone(), reinterpret_cast<float *>(triangles.verts), 0, vs1);
 #else
-                LOOP_UV_COORDS(triangles.verts, attachment->getUVs(), triangles.vertCount);
+                loopUVCoords(triangles.verts, attachment->getUVs(), triangles.vertCount);
                 attachment->computeWorldVertices(*slot, reinterpret_cast<float *>(triangles.verts), 0, vs1);
 #endif
 
@@ -514,7 +514,7 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
                 }
                 attachment->computeWorldVertices(slot->getBone(), reinterpret_cast<float *>(trianglesTwoColor.verts), 0, vs2);
 #else
-                LOOP_UV_COORDS(trianglesTwoColor.verts, attachment->getUVs(), trianglesTwoColor.vertCount);
+                loopUVCoords(trianglesTwoColor.verts, attachment->getUVs(), trianglesTwoColor.vertCount);
                 attachment->computeWorldVertices(*slot, reinterpret_cast<float *>(trianglesTwoColor.verts), 0, vs2);
 #endif
 
@@ -569,7 +569,7 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
                 triangles.verts = reinterpret_cast<V3F_T2F_C4B *>(vb.getCurBuffer());
                 memcpy(static_cast<void *>(triangles.verts), static_cast<void *>(attachmentVertices->_triangles->verts), vbSize);
 #ifdef CC_USE_SPINE_4_2
-                LOOP_UV_COORDS(triangles.verts, attachment->getUVs(), triangles.vertCount);
+                loopUVCoords(triangles.verts, attachment->getUVs(), triangles.vertCount);
 #endif
                 attachment->computeWorldVertices(*slot, 0, attachment->getWorldVerticesLength(), reinterpret_cast<float *>(triangles.verts), 0, vs1);
 
@@ -588,7 +588,7 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
                     trianglesTwoColor.verts[ii].texCoord = attachmentVertices->_triangles->verts[ii].texCoord;
                 }
 #else
-                LOOP_UV_COORDS(trianglesTwoColor.verts, attachment->getUVs(), trianglesTwoColor.vertCount);
+                loopUVCoords(trianglesTwoColor.verts, attachment->getUVs(), trianglesTwoColor.vertCount);
 #endif
                 attachment->computeWorldVertices(*slot, 0, attachment->getWorldVerticesLength(), reinterpret_cast<float *>(trianglesTwoColor.verts), 0, vs2);
 

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.h
@@ -50,6 +50,15 @@ class Material;
 
 class AttachmentVertices;
 
+
+template <typename VertexType, typename UVArrayType>
+void loopUVCoords(VertexType *tmp, const UVArrayType &uvs, int count) {
+    for (int i = 0, ii = 0; i < count; ++i, ii += 2) {
+        tmp[i].texCoord.u = uvs[ii];
+        tmp[i].texCoord.v = uvs[ii + 1];
+    }
+}
+
 struct SlotCacheInfo {
     bool isOwner{false};
     spine::Attachment *attachment{nullptr};

--- a/native/cocos/editor-support/spine-creator-support/spine-cocos2dx.cpp
+++ b/native/cocos/editor-support/spine-creator-support/spine-cocos2dx.cpp
@@ -49,83 +49,13 @@ USING_NS_MW;           // NOLINT(google-build-using-namespace)
 using namespace cc;    // NOLINT(google-build-using-namespace)
 using namespace spine; // NOLINT(google-build-using-namespace)
 
-#if CC_USE_SPINE_3_8
-static void deleteAttachmentVertices(void *vertices) {
-    delete static_cast<AttachmentVertices *>(vertices);
-}
-#endif
-
-static uint16_t quadTriangles[6] = {0, 1, 2, 2, 3, 0};
-
-#if CC_USE_SPINE_4_2
-/**
-* The relationship between ​​AtlasRegion​​ and ​​AttachmentVertices​​ is ​​one-to-many​​.
-*/
-static void saveAttachmentVertices(Attachment *attachment, AtlasRegion *region, AttachmentVertices *attachmentVertices) {
-    spine::HashMap<Attachment *, AttachmentVertices *> *map = nullptr;
-    if (region->rendererObject && region->rendererObject != region->page->texture) {
-        map = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(region->rendererObject);
-    } else {
-        map = new spine::HashMap<Attachment *, AttachmentVertices *>();
-        region->rendererObject = map;
-    }
-    map->put(attachment, attachmentVertices);
-}
-#endif
-
-static void setAttachmentVertices(RegionAttachment *attachment) {
-#if CC_USE_SPINE_3_8
-    auto *region = static_cast<AtlasRegion *>(attachment->getRendererObject());
-    auto *attachmentVertices = new AttachmentVertices(static_cast<middleware::Texture2D *>(region->page->getRendererObject()), 4, quadTriangles, 6);
-#else
-    auto *region = static_cast<AtlasRegion *>(attachment->getRegion());
-    auto *attachmentVertices = new AttachmentVertices(static_cast<middleware::Texture2D *>(region->page->texture), 4, quadTriangles, 6);
-#endif
-    V3F_T2F_C4B *vertices = attachmentVertices->_triangles->verts;
-    for (int i = 0, ii = 0; i < 4; ++i, ii += 2) {
-        vertices[i].texCoord.u = attachment->getUVs()[ii];
-        vertices[i].texCoord.v = attachment->getUVs()[ii + 1];
-    }
-#if CC_USE_SPINE_3_8
-    attachment->setRendererObject(attachmentVertices, deleteAttachmentVertices);
-#else
-   saveAttachmentVertices(attachment, region, attachmentVertices);
-#endif
-}
-
-static void setAttachmentVertices(MeshAttachment *attachment) {
-#if CC_USE_SPINE_3_8
-    auto *region = static_cast<AtlasRegion *>(attachment->getRendererObject());
-    auto *attachmentVertices = new AttachmentVertices(static_cast<middleware::Texture2D *>(region->page->getRendererObject()),
-                                                      static_cast<int32_t>(attachment->getWorldVerticesLength() >> 1), attachment->getTriangles().buffer(), static_cast<int32_t>(attachment->getTriangles().size()));
-#else
-    auto *region = static_cast<AtlasRegion *>(attachment->getRegion());
-    auto *attachmentVertices = new AttachmentVertices(static_cast<middleware::Texture2D *>(region->page->texture),
-                                                      static_cast<int32_t>(attachment->getWorldVerticesLength() >> 1), attachment->getTriangles().buffer(), static_cast<int32_t>(attachment->getTriangles().size()));
-#endif
-    V3F_T2F_C4B *vertices = attachmentVertices->_triangles->verts;
-    for (size_t i = 0, ii = 0, nn = attachment->getWorldVerticesLength(); ii < nn; ++i, ii += 2) {
-        vertices[i].texCoord.u = attachment->getUVs()[ii];
-        vertices[i].texCoord.v = attachment->getUVs()[ii + 1];
-    }
-#if CC_USE_SPINE_3_8
-    attachment->setRendererObject(attachmentVertices, deleteAttachmentVertices);
-#else
-    saveAttachmentVertices(attachment, region, attachmentVertices);
-#endif
-}
-
 Cocos2dAtlasAttachmentLoader::Cocos2dAtlasAttachmentLoader(Atlas *atlas) : AtlasAttachmentLoader(atlas) {
 }
 
 Cocos2dAtlasAttachmentLoader::~Cocos2dAtlasAttachmentLoader() = default;
 
 void Cocos2dAtlasAttachmentLoader::configureAttachment(Attachment *attachment) {
-    if (attachment->getRTTI().isExactly(RegionAttachment::rtti)) {
-        setAttachmentVertices(dynamic_cast<RegionAttachment *>(attachment));
-    } else if (attachment->getRTTI().isExactly(MeshAttachment::rtti)) {
-        setAttachmentVertices(dynamic_cast<MeshAttachment *>(attachment));
-    }
+    //
 }
 
 uint32_t wrap(TextureWrap wrap) {

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -17,7 +17,6 @@ extern HashMap<SkeletonData *, HashMap<Attachment *, AttachmentVertices *>*> spi
 extern HashMap<SkeletonData *, HashMap<spine::String, spine::String>*> spineTexturesMap;
 
 
-//------------------------- UV坐标处理 -------------------------
 template<typename VertexType, typename UVArrayType>
 void loopUVCoords(VertexType* tmp, const UVArrayType& uvs, int count) {
     for (int i = 0, ii = 0; i < count; ++i, ii += 2) {
@@ -30,12 +29,11 @@ void loopUVCoords(VertexType* tmp, const UVArrayType& uvs, int count) {
 template<typename MeshT, 
          typename AttachmentT,
          typename VerticesT,
-         typename TexMapT> // 默认使用全局版本控制
+         typename TexMapT>
 void setSpineTextureID(MeshT& currMesh,
                       AttachmentT* attachment,
                       VerticesT* vertices,
                       TexMapT* texMap) {
-    // Spine 4.2 实现
     if (auto* region = static_cast<AtlasRegion*>(attachment->getRegion())) {
         if (region->page && region->page->name != vertices->_textureName) {
             currMesh.textureID = (*texMap)[region->page->name];

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -16,44 +16,74 @@ using namespace spine;
 extern HashMap<SkeletonData *, HashMap<Attachment *, AttachmentVertices *>*> spineAttachmentVerticesMap;
 extern HashMap<SkeletonData *, HashMap<spine::String, spine::String>*> spineTexturesMap;
 
-#define LOOP_UV_COORDS(tmp_var, uvs_var, loop_count) \
-    for (int _i = 0, _ii = 0; _i < (loop_count); ++_i, _ii += 2) { \
-        (tmp_var)[_i].texCoord.u = (uvs_var)[_ii]; \
-        (tmp_var)[_i].texCoord.v = (uvs_var)[_ii + 1]; \
+
+//------------------------- UV坐标处理 -------------------------
+template<typename VertexType, typename UVArrayType>
+void loopUVCoords(VertexType* tmp, const UVArrayType& uvs, int count) {
+    for (int i = 0, ii = 0; i < count; ++i, ii += 2) {
+        tmp[i].texCoord.u = uvs[ii];
+        tmp[i].texCoord.v = uvs[ii + 1];
     }
+}
 
 #ifdef CC_SPINE_VERSION_4_2
-    #define SET_SPINE_TEXTURE_ID(currMesh, attachment, attachmentVertices, texturesMap) \
-        do { \
-            auto* region = static_cast<AtlasRegion*>(attachment->getRegion()); \
-            if (region && region->page && (region->page->name != attachmentVertices->_textureName)) { \
-                currMesh.textureID = (*texturesMap)[region->page->name]; \
-            } else { \
-                currMesh.textureID = attachmentVertices->_textureUUID; \
-            } \
-        } while(0)
+template<typename MeshT, 
+         typename AttachmentT,
+         typename VerticesT,
+         typename TexMapT> // 默认使用全局版本控制
+void setSpineTextureID(MeshT& currMesh,
+                      AttachmentT* attachment,
+                      VerticesT* vertices,
+                      TexMapT* texMap) {
+    // Spine 4.2 实现
+    if (auto* region = static_cast<AtlasRegion*>(attachment->getRegion())) {
+        if (region->page && region->page->name != vertices->_textureName) {
+            currMesh.textureID = (*texMap)[region->page->name];
+            return;
+        }
+    }
+    currMesh.textureID = vertices->_textureUUID;
+}
 
-    #define INIT_ATTACHMENT_VERTICES(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap) \
-        do { \
-            if (!(attachmentVertices) && !(attachment)->getRegion()) { \
-                (attachment)->getSequence()->apply((slot), (attachment)); \
-                if ((attachment)->getRegion()) { \
-                    (attachmentVertices) = generateAttachmentVertices((attachment)); \
-                    if ((texturesMap)->containsKey((attachmentVertices)->_textureName)) { \
-                        (attachmentVertices)->_textureUUID = (*(texturesMap))[(attachmentVertices)->_textureName]; \
-                    } \
-                    (attachmentVerticesMap)->put((attachment), (attachmentVertices)); \
-                } \
-            } \
-        } while(0)
+template<typename VerticesT, typename AttachmentT, 
+         typename SlotT, typename TexMapT, typename VertMapT>
+void initAttachmentVertices(VerticesT*& vertices,
+                      AttachmentT* attachment,
+                      SlotT* slot,
+                      TexMapT* texMap,
+                      VertMapT* vertMap) 
+{
+    if (!vertices && !attachment->getRegion()) {
+        attachment->getSequence()->apply(slot, attachment);
+        if (attachment->getRegion()) {
+            vertices = generateAttachmentVertices(attachment);
+            if (texMap->containsKey(vertices->_textureName)) {
+                vertices->_textureUUID = (*texMap)[vertices->_textureName];
+            }
+            vertMap->put(attachment, vertices);
+        }
+    }
+}
 #else
-    #define SET_SPINE_TEXTURE_ID(currMesh, attachment, attachmentVertices, texturesMap) \
-        do { \
-            currMesh.textureID = attachmentVertices->_textureUUID; \
-        } while(0)
+template<typename MeshT, 
+         typename AttachmentT,
+         typename VerticesT,
+         typename TexMapT>
+void setSpineTextureID(MeshT& currMesh,
+                      AttachmentT*,
+                      VerticesT* vertices,
+                      TexMapT*)
+{
+    //do nothing
+    currMesh.textureID = vertices->_textureUUID;
+}
 
-    #define INIT_ATTACHMENT_VERTICES(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap) \
-        do { /* Empty for non-4.2 versions */ } while(0)
+template<typename VerticesT, typename AttachmentT, 
+         typename SlotT, typename TexMapT, typename VertMapT>
+void initAttachmentVertices(VerticesT*&, AttachmentT*, SlotT*, TexMapT*, VertMapT*) 
+{
+    //do nothing
+}
 #endif
 
 
@@ -225,6 +255,8 @@ void SpineSkeletonInstance::collectMeshData() {
 #ifdef CC_SPINE_VERSION_4_2
     if (!spineTexturesMap.containsKey(_skeletonData)) return;
     auto* texturesMap = spineTexturesMap[_skeletonData];
+#else
+    HashMap<spine::String, spine::String> *texturesMap = nullptr;
 #endif
     if (!spineAttachmentVerticesMap.containsKey(_skeletonData)) return;
     auto* attachmentVerticesMap = spineAttachmentVerticesMap[_skeletonData];
@@ -262,8 +294,8 @@ void SpineSkeletonInstance::collectMeshData() {
         if (attachmentRTTI.isExactly(spine::RegionAttachment::rtti)) {
             debugShapeType = DEBUG_SHAPE_TYPE::DEBUG_REGION;
             auto *attachment = static_cast<spine::RegionAttachment *>(attachmentSlot);
-            INIT_ATTACHMENT_VERTICES(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap);
-            SET_SPINE_TEXTURE_ID(currMesh, attachment, attachmentVertices, texturesMap);
+            initAttachmentVertices(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap);
+            setSpineTextureID(currMesh, attachment, attachmentVertices, texturesMap);
             auto *triangles = attachmentVertices->_triangles;
             auto vertCount = triangles->vertCount;
             auto indexCount = triangles->indexCount;
@@ -277,13 +309,13 @@ void SpineSkeletonInstance::collectMeshData() {
 #ifdef CC_SPINE_VERSION_4_2
                 const auto& uvs = attachment->getUVs();
                 V3F_T2F_C4B* tmp = (V3F_T2F_C4B *)(vertices);
-                LOOP_UV_COORDS(tmp, uvs, 4);
+                loopUVCoords(tmp, uvs, 4);
  #endif
             } else {
                 V3F_T2F_C4B_C4B *verts = (V3F_T2F_C4B_C4B *)vertices;
 #ifdef CC_SPINE_VERSION_4_2
                     const auto& uvs = attachment->getUVs();
-                    LOOP_UV_COORDS(verts, uvs, vertCount);
+                    loopUVCoords(verts, uvs, vertCount);
 #else
                     for (int ii = 0; ii < vertCount; ii++) {
                         verts[ii].texCoord = triangles->verts[ii].texCoord;
@@ -305,8 +337,8 @@ void SpineSkeletonInstance::collectMeshData() {
         } else if (attachmentRTTI.isExactly(spine::MeshAttachment::rtti)) {
             debugShapeType = DEBUG_SHAPE_TYPE::DEBUG_MESH;
             auto *attachment = static_cast<spine::MeshAttachment *>(attachmentSlot);
-            INIT_ATTACHMENT_VERTICES(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap);
-            SET_SPINE_TEXTURE_ID(currMesh, attachment, attachmentVertices, texturesMap);
+            initAttachmentVertices(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap);
+            setSpineTextureID(currMesh, attachment, attachmentVertices, texturesMap);
             auto *triangles = attachmentVertices->_triangles;
             auto vertCount = triangles->vertCount;
             auto indexCount = triangles->indexCount;
@@ -322,13 +354,13 @@ void SpineSkeletonInstance::collectMeshData() {
                 // Calling 'attachment->computeWorldVertices()' can alter the UV coordinates.
                 const auto& uvs = attachment->getUVs();
                 V3F_T2F_C4B* tmp = (V3F_T2F_C4B *)(vertices);
-                LOOP_UV_COORDS(tmp, uvs, 4);
+                loopUVCoords(tmp, uvs, 4);
 #endif
             } else {
                 V3F_T2F_C4B_C4B *verts = (V3F_T2F_C4B_C4B *)vertices;
 #ifdef CC_SPINE_VERSION_4_2
                 const auto& uvs = attachment->getUVs();
-                LOOP_UV_COORDS(verts, uvs, vertCount);
+                loopUVCoords(verts, uvs, vertCount);
 #else
                 for (int ii = 0; ii < vertCount; ii++) {
                     verts[ii].texCoord = triangles->verts[ii].texCoord;

--- a/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-skeleton-instance.cpp
@@ -9,8 +9,53 @@ SlotMesh globalMesh(nullptr, nullptr, 0, 0);
 extern "C" {
 extern void spineListenerCallBackFromJS();
 extern void spineTrackListenerCallback();
+AttachmentVertices* generateAttachmentVertices(spine::Attachment* attachment);
 }
+
 using namespace spine;
+extern HashMap<SkeletonData *, HashMap<Attachment *, AttachmentVertices *>*> spineAttachmentVerticesMap;
+extern HashMap<SkeletonData *, HashMap<spine::String, spine::String>*> spineTexturesMap;
+
+#define LOOP_UV_COORDS(tmp_var, uvs_var, loop_count) \
+    for (int _i = 0, _ii = 0; _i < (loop_count); ++_i, _ii += 2) { \
+        (tmp_var)[_i].texCoord.u = (uvs_var)[_ii]; \
+        (tmp_var)[_i].texCoord.v = (uvs_var)[_ii + 1]; \
+    }
+
+#ifdef CC_SPINE_VERSION_4_2
+    #define SET_SPINE_TEXTURE_ID(currMesh, attachment, attachmentVertices, texturesMap) \
+        do { \
+            auto* region = static_cast<AtlasRegion*>(attachment->getRegion()); \
+            if (region && region->page && (region->page->name != attachmentVertices->_textureName)) { \
+                currMesh.textureID = (*texturesMap)[region->page->name]; \
+            } else { \
+                currMesh.textureID = attachmentVertices->_textureUUID; \
+            } \
+        } while(0)
+
+    #define INIT_ATTACHMENT_VERTICES(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap) \
+        do { \
+            if (!(attachmentVertices) && !(attachment)->getRegion()) { \
+                (attachment)->getSequence()->apply((slot), (attachment)); \
+                if ((attachment)->getRegion()) { \
+                    (attachmentVertices) = generateAttachmentVertices((attachment)); \
+                    if ((texturesMap)->containsKey((attachmentVertices)->_textureName)) { \
+                        (attachmentVertices)->_textureUUID = (*(texturesMap))[(attachmentVertices)->_textureName]; \
+                    } \
+                    (attachmentVerticesMap)->put((attachment), (attachmentVertices)); \
+                } \
+            } \
+        } while(0)
+#else
+    #define SET_SPINE_TEXTURE_ID(currMesh, attachment, attachmentVertices, texturesMap) \
+        do { \
+            currMesh.textureID = attachmentVertices->_textureUUID; \
+        } while(0)
+
+    #define INIT_ATTACHMENT_VERTICES(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap) \
+        do { /* Empty for non-4.2 versions */ } while(0)
+#endif
+
 
 static void animationCallback(AnimationState *state, EventType type, TrackEntry *entry, Event *event) {
     SpineSkeletonInstance *instance = (static_cast<SpineSkeletonInstance *>(state->getRendererObject()));
@@ -177,6 +222,12 @@ void SpineSkeletonInstance::collectMeshData() {
 #else
     void* _effect = nullptr;
 #endif
+#ifdef CC_SPINE_VERSION_4_2
+    if (!spineTexturesMap.containsKey(_skeletonData)) return;
+    auto* texturesMap = spineTexturesMap[_skeletonData];
+#endif
+    if (!spineAttachmentVerticesMap.containsKey(_skeletonData)) return;
+    auto* attachmentVerticesMap = spineAttachmentVerticesMap[_skeletonData];
     const Color& skeletonColor = _skeleton->getColor();
     for (uint32_t drawIdx = 0; drawIdx < slotCount; ++drawIdx) {
         auto* slot = slotArray[drawIdx];
@@ -195,25 +246,24 @@ void SpineSkeletonInstance::collectMeshData() {
         color.a = _userData.color.a;
         spine::Attachment* attachmentSlot = slot->getAttachment();
         AttachmentVertices *cacheSlotAttachmentVertices = nullptr;
+        AttachmentVertices *attachmentVertices = nullptr;
+        if (attachmentVerticesMap->containsKey(attachmentSlot)) {
+            attachmentVertices = (*attachmentVerticesMap)[attachmentSlot];
+        }
         if (_userData.useSlotTexture && _slotTextureSet.containsKey(slot)) {
             auto info = _slotTextureSet[slot];
             attachmentSlot = info.attachment;
             cacheSlotAttachmentVertices = info.attachmentVertices;
         }
+        if (cacheSlotAttachmentVertices) {
+            attachmentVertices = cacheSlotAttachmentVertices;
+        }
         const spine::RTTI& attachmentRTTI = attachmentSlot->getRTTI();
         if (attachmentRTTI.isExactly(spine::RegionAttachment::rtti)) {
             debugShapeType = DEBUG_SHAPE_TYPE::DEBUG_REGION;
             auto *attachment = static_cast<spine::RegionAttachment *>(attachmentSlot);
-            auto *attachmentVertices = cacheSlotAttachmentVertices;
-            if (!attachmentVertices) {
-#ifdef CC_SPINE_VERSION_3_8
-                attachmentVertices = reinterpret_cast<AttachmentVertices *>(attachment->getRendererObject());
-#else
-                auto *tmpMap = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(attachment->getRegion()->rendererObject);
-                attachmentVertices = (*tmpMap)[slot->getAttachment()];
-#endif
-            }
-
+            INIT_ATTACHMENT_VERTICES(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap);
+            SET_SPINE_TEXTURE_ID(currMesh, attachment, attachmentVertices, texturesMap);
             auto *triangles = attachmentVertices->_triangles;
             auto vertCount = triangles->vertCount;
             auto indexCount = triangles->indexCount;
@@ -222,14 +272,23 @@ void SpineSkeletonInstance::collectMeshData() {
             auto vbSize = vertCount * byteStrideColor;
             auto *vertices = SpineMeshData::queryVBuffer();
             auto *indices = SpineMeshData::queryIBuffer();
-            
             if (!_userData.useTint) {
                 memcpy(static_cast<void *>(vertices), static_cast<void *>(triangles->verts), vbSize);
+#ifdef CC_SPINE_VERSION_4_2
+                const auto& uvs = attachment->getUVs();
+                V3F_T2F_C4B* tmp = (V3F_T2F_C4B *)(vertices);
+                LOOP_UV_COORDS(tmp, uvs, 4);
+ #endif
             } else {
                 V3F_T2F_C4B_C4B *verts = (V3F_T2F_C4B_C4B *)vertices;
-                for (int ii = 0; ii < vertCount; ii++) {
-                    verts[ii].texCoord = triangles->verts[ii].texCoord;
-                }
+#ifdef CC_SPINE_VERSION_4_2
+                    const auto& uvs = attachment->getUVs();
+                    LOOP_UV_COORDS(verts, uvs, vertCount);
+#else
+                    for (int ii = 0; ii < vertCount; ii++) {
+                        verts[ii].texCoord = triangles->verts[ii].texCoord;
+                    }
+#endif
             }
             memcpy(indices, triangles->indices, ibSize);
 #ifdef CC_SPINE_VERSION_3_8
@@ -243,20 +302,11 @@ void SpineSkeletonInstance::collectMeshData() {
             color.g *= attachmentColor.g;
             color.b *= attachmentColor.b;
             color.a *= attachmentColor.a;
-            currMesh.textureID = attachmentVertices->_textureUUID;
         } else if (attachmentRTTI.isExactly(spine::MeshAttachment::rtti)) {
             debugShapeType = DEBUG_SHAPE_TYPE::DEBUG_MESH;
             auto *attachment = static_cast<spine::MeshAttachment *>(attachmentSlot);
-            auto *attachmentVertices = cacheSlotAttachmentVertices;
-            if (!attachmentVertices) {
-#ifdef CC_SPINE_VERSION_3_8
-                attachmentVertices = static_cast<AttachmentVertices *>(attachment->getRendererObject());
-#else
-                auto *tmpMap = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(attachment->getRegion()->rendererObject);
-                attachmentVertices = (*tmpMap)[slot->getAttachment()];
-#endif
-            }
-
+            INIT_ATTACHMENT_VERTICES(attachmentVertices, attachment, slot, texturesMap, attachmentVerticesMap);
+            SET_SPINE_TEXTURE_ID(currMesh, attachment, attachmentVertices, texturesMap);
             auto *triangles = attachmentVertices->_triangles;
             auto vertCount = triangles->vertCount;
             auto indexCount = triangles->indexCount;
@@ -265,13 +315,25 @@ void SpineSkeletonInstance::collectMeshData() {
             auto vbSize = vertCount * byteStrideColor;
             auto *vertices = SpineMeshData::queryVBuffer();
             auto *indices = SpineMeshData::queryIBuffer();
+            bool isRegionChanged = currMesh.textureID != attachmentVertices->_textureUUID;
             if (!_userData.useTint) {
                 memcpy(static_cast<void *>(vertices), static_cast<void *>(triangles->verts), vbSize);
+#ifdef CC_SPINE_VERSION_4_2
+                // Calling 'attachment->computeWorldVertices()' can alter the UV coordinates.
+                const auto& uvs = attachment->getUVs();
+                V3F_T2F_C4B* tmp = (V3F_T2F_C4B *)(vertices);
+                LOOP_UV_COORDS(tmp, uvs, 4);
+#endif
             } else {
                 V3F_T2F_C4B_C4B *verts = (V3F_T2F_C4B_C4B *)vertices;
+#ifdef CC_SPINE_VERSION_4_2
+                const auto& uvs = attachment->getUVs();
+                LOOP_UV_COORDS(verts, uvs, vertCount);
+#else
                 for (int ii = 0; ii < vertCount; ii++) {
                     verts[ii].texCoord = triangles->verts[ii].texCoord;
                 }
+#endif
             }
             memcpy(indices, triangles->indices, ibSize);
             attachment->computeWorldVertices(*slot, 0, attachment->getWorldVerticesLength(), (float *)vertices, 0, strideColor);
@@ -281,7 +343,6 @@ void SpineSkeletonInstance::collectMeshData() {
             color.g *= attachmentColor.g;
             color.b *= attachmentColor.b;
             color.a *= attachmentColor.a;
-            currMesh.textureID = attachmentVertices->_textureUUID;
         } else if (attachmentRTTI.isExactly(spine::ClippingAttachment::rtti)) {
             auto *clip = static_cast<spine::ClippingAttachment *>(attachmentSlot);
             _clipper->clipStart(*slot, clip);
@@ -530,6 +591,11 @@ void SpineSkeletonInstance::onAnimationStateEvent(TrackEntry *entry, EventType t
 
 void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint32_t width, uint32_t height, bool createNew) {
     if (!_skeleton) return;
+    HashMap<Attachment *, AttachmentVertices *> *attachmentVerticesMap = nullptr;
+    if (spineAttachmentVerticesMap.containsKey(_skeletonData)) {
+        attachmentVerticesMap = spineAttachmentVerticesMap[_skeletonData];
+    }
+    if (!attachmentVerticesMap) return;
     auto* slot = _skeleton->findSlot(slotName);
     if (!slot) return;
     auto *attachment = slot->getAttachment();
@@ -551,11 +617,6 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
         region->setHeight(height);
         region->setUVs(0, 0, 1.0f, 1.0f, false);
         region->updateOffset();
-        auto *attachmentVertices = static_cast<AttachmentVertices *>(region->getRendererObject());
-        if (createNew) {
-            attachmentVertices = attachmentVertices->copy();
-            info.attachmentVertices = attachmentVertices;
-        }
 #else
         auto *textureRegion = region->getRegion();
         if (textureRegion) {
@@ -581,13 +642,17 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
         uvs[0] = 1;
         uvs[1] = 1;
         region->updateRegion();
-        auto *tmpMap = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(textureRegion->rendererObject);
-        auto *attachmentVertices = (*tmpMap)[slot->getAttachment()];
+#endif
+
+        AttachmentVertices *attachmentVertices = nullptr;
+        if (attachmentVerticesMap->containsKey(attachment)) {
+            attachmentVertices = (*attachmentVerticesMap)[attachment];
+        }
+        if (!attachmentVertices) return;
         if (createNew) {
             attachmentVertices = attachmentVertices->copy();
             info.attachmentVertices = attachmentVertices;
         }
-#endif
         V3F_T2F_C4B *vertices = attachmentVertices->_triangles->verts;
         auto &UVs = region->getUVs();
         for (int i = 0, ii = 0; i < 4; ++i, ii += 2) {
@@ -610,11 +675,6 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
         mesh->setRegionRotate(true);
         mesh->setRegionDegrees(0);
         mesh->updateUVs();
-        auto *attachmentVertices = static_cast<AttachmentVertices *>(mesh->getRendererObject());
-        if (createNew) {
-            attachmentVertices = attachmentVertices->copy();
-            info.attachmentVertices = attachmentVertices;
-        }
 #else
         auto *region = mesh->getRegion();
         if (region) {
@@ -631,13 +691,17 @@ void SpineSkeletonInstance::resizeSlotRegion(const spine::String &slotName, uint
         mesh->setWidth(width);
         mesh->setHeight(height);
         mesh->updateRegion();
-        auto *tmpMap = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(mesh->getRegion()->rendererObject);
-        auto *attachmentVertices = (*tmpMap)[slot->getAttachment()];
+#endif
+
+         AttachmentVertices *attachmentVertices = nullptr;
+        if (attachmentVerticesMap->containsKey(attachment)) {
+            attachmentVertices = (*attachmentVerticesMap)[attachment];
+        }
+        if (!attachmentVertices) return;
         if (createNew) {
             attachmentVertices = attachmentVertices->copy();
             info.attachmentVertices = attachmentVertices;
         }
-#endif
         V3F_T2F_C4B *vertices = attachmentVertices->_triangles->verts;
         const auto &UVs = mesh->getUVs();
         for (size_t i = 0, ii = 0, nn = mesh->getWorldVerticesLength(); ii < nn; ++i, ii += 2) {

--- a/native/cocos/editor-support/spine-wasm/spine-wasm.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-wasm.cpp
@@ -80,9 +80,9 @@ HashMap<String, SkeletonData*> skeletonDataMap{};
 
 void saveAttachmentVertices(SkeletonData* skeletonData, const spine::Vector<spine::String>& textureNames, const spine::Vector<spine::String>& textureUUIDs) {
     spine::HashMap<spine::String, spine::String> textureMap{};
-    spine::HashMap<spine::String, spine::String> *texturesMap = nullptr;
+    spine::HashMap<spine::String, spine::String>* texturesMap = nullptr;
 #ifdef CC_SPINE_VERSION_3_8
-    // Attachment can not switch pages in 3.8 
+    // Attachment can not switch pages in 3.8
     texturesMap = &textureMap;
 #else
     if (!spineTexturesMap.containsKey(skeletonData)) {
@@ -97,9 +97,9 @@ void saveAttachmentVertices(SkeletonData* skeletonData, const spine::Vector<spin
     for (int i = 0; i < textureSize; ++i) {
         texturesMap->put(textureNames[i], textureUUIDs[i]);
     }
-    HashMap<Attachment *, AttachmentVertices *> *attachmentVerticesMap = nullptr;
+    HashMap<Attachment*, AttachmentVertices*>* attachmentVerticesMap = nullptr;
     if (!spineAttachmentVerticesMap.containsKey(skeletonData)) {
-        attachmentVerticesMap = new HashMap<Attachment *, AttachmentVertices *>();
+        attachmentVerticesMap = new HashMap<Attachment*, AttachmentVertices*>();
         spineAttachmentVerticesMap.put(skeletonData, attachmentVerticesMap);
     } else {
         attachmentVerticesMap = spineAttachmentVerticesMap[skeletonData];

--- a/native/cocos/editor-support/spine-wasm/spine-wasm.cpp
+++ b/native/cocos/editor-support/spine-wasm/spine-wasm.cpp
@@ -11,6 +11,50 @@
 
 using namespace spine;
 
+HashMap<SkeletonData *, HashMap<Attachment *, AttachmentVertices *>*> spineAttachmentVerticesMap{};
+HashMap<SkeletonData *, HashMap<spine::String, spine::String>*> spineTexturesMap{};
+
+
+static const uint16_t quadTriangles[6] = {0, 1, 2, 2, 3, 0};
+
+extern "C" AttachmentVertices* generateAttachmentVertices(Attachment* attachment) {
+    AttachmentVertices* attachmentVertices = nullptr;
+    if (attachment->getRTTI().isExactly(RegionAttachment::rtti)) {
+        auto* regionAttachment = static_cast<RegionAttachment*>(attachment);
+#ifdef CC_SPINE_VERSION_3_8
+        auto* region = static_cast<AtlasRegion*>(regionAttachment->getRendererObject());
+#else
+        auto* region = static_cast<AtlasRegion*>(regionAttachment->getRegion());
+#endif
+        if (!region) return nullptr;
+        attachmentVertices = new AttachmentVertices(4, const_cast<uint16_t*>(quadTriangles), 6, region->page->name);
+        V3F_T2F_C4B* vertices = attachmentVertices->_triangles->verts;
+        const auto& uvs = regionAttachment->getUVs();
+        for (int i = 0, ii = 0; i < 4; ++i, ii += 2) {
+            vertices[i].texCoord.u = uvs[ii];
+            vertices[i].texCoord.v = uvs[ii + 1];
+        }
+
+    } else if (attachment->getRTTI().isExactly(MeshAttachment::rtti)) {
+        auto* meshAttachment = static_cast<MeshAttachment*>(attachment);
+#ifdef CC_SPINE_VERSION_3_8
+        auto* region = static_cast<AtlasRegion*>(meshAttachment->getRendererObject());
+#else
+        auto* region = static_cast<AtlasRegion*>(meshAttachment->getRegion());
+#endif
+        if (!region) return nullptr;
+        attachmentVertices = new AttachmentVertices(
+            static_cast<int32_t>(meshAttachment->getWorldVerticesLength() >> 1), meshAttachment->getTriangles().buffer(), static_cast<int32_t>(meshAttachment->getTriangles().size()), region->page->name);
+        V3F_T2F_C4B* vertices = attachmentVertices->_triangles->verts;
+        const auto& uvs = meshAttachment->getUVs();
+        for (size_t i = 0, ii = 0, nn = meshAttachment->getWorldVerticesLength(); ii < nn; ++i, ii += 2) {
+            vertices[i].texCoord.u = uvs[ii];
+            vertices[i].texCoord.v = uvs[ii + 1];
+        }
+    }
+    return attachmentVertices;
+}
+
 namespace {
 const int LOG_LEVEL_ERROR = 3;
 const int LOG_LEVEL_WARN = 2;
@@ -34,11 +78,31 @@ void logToConsole(const char* message, int logLevel = LOG_LEVEL_INFO) {
 
 HashMap<String, SkeletonData*> skeletonDataMap{};
 
-void updateAttachmentVerticesTextureId(SkeletonData* skeletonData, const spine::Vector<spine::String>& textureNames, const spine::Vector<spine::String>& textureUUIDs) {
+void saveAttachmentVertices(SkeletonData* skeletonData, const spine::Vector<spine::String>& textureNames, const spine::Vector<spine::String>& textureUUIDs) {
     spine::HashMap<spine::String, spine::String> textureMap{};
+    spine::HashMap<spine::String, spine::String> *texturesMap = nullptr;
+#ifdef CC_SPINE_VERSION_3_8
+    // Attachment can not switch pages in 3.8 
+    texturesMap = &textureMap;
+#else
+    if (!spineTexturesMap.containsKey(skeletonData)) {
+        texturesMap = new HashMap<spine::String, spine::String>();
+        spineTexturesMap.put(skeletonData, texturesMap);
+    } else {
+        texturesMap = spineTexturesMap[skeletonData];
+    }
+#endif
+
     int textureSize = textureNames.size();
     for (int i = 0; i < textureSize; ++i) {
-        textureMap.put(textureNames[i], textureUUIDs[i]);
+        texturesMap->put(textureNames[i], textureUUIDs[i]);
+    }
+    HashMap<Attachment *, AttachmentVertices *> *attachmentVerticesMap = nullptr;
+    if (!spineAttachmentVerticesMap.containsKey(skeletonData)) {
+        attachmentVerticesMap = new HashMap<Attachment *, AttachmentVertices *>();
+        spineAttachmentVerticesMap.put(skeletonData, attachmentVerticesMap);
+    } else {
+        attachmentVerticesMap = spineAttachmentVerticesMap[skeletonData];
     }
 
     auto& skins = skeletonData->getSkins();
@@ -50,28 +114,19 @@ void updateAttachmentVerticesTextureId(SkeletonData* skeletonData, const spine::
             Skin::AttachmentMap::Entry& entry = entries.next();
             AttachmentVertices* attachmentVertices = nullptr;
             auto* attachment = entry._attachment;
-            spine::HashMap<Attachment *, AttachmentVertices *> *map = nullptr;
-            if (attachment->getRTTI().isExactly(MeshAttachment::rtti)) {
-                auto* meshAttachment = static_cast<MeshAttachment*>(attachment);
-#ifdef CC_SPINE_VERSION_3_8
-                attachmentVertices = static_cast<AttachmentVertices*>(meshAttachment->getRendererObject());
-#else
-                map = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(meshAttachment->getRegion()->rendererObject);
-                attachmentVertices = (*map)[attachment];
-#endif
-            } else if (attachment->getRTTI().isExactly(RegionAttachment::rtti)) {
-                auto* regionAttachment = static_cast<RegionAttachment*>(attachment);
-#ifdef CC_SPINE_VERSION_3_8
-                attachmentVertices = static_cast<AttachmentVertices*>(regionAttachment->getRendererObject());
-#else
-                map = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(regionAttachment->getRegion()->rendererObject);
-                attachmentVertices = (*map)[attachment];
-#endif
+            if (attachmentVerticesMap->containsKey(attachment)) {
+                attachmentVertices = (*attachmentVerticesMap)[attachment];
+            } else {
+                attachmentVertices = generateAttachmentVertices(attachment);
+                if (attachmentVertices) {
+                    attachmentVerticesMap->put(attachment, attachmentVertices);
+                }
             }
+
             if (attachmentVertices) {
                 auto& textureName = attachmentVertices->_textureName;
-                if (textureMap.containsKey(textureName)) {
-                    attachmentVertices->_textureUUID = textureMap[textureName];
+                if (texturesMap->containsKey(textureName)) {
+                    attachmentVertices->_textureUUID = (*texturesMap)[textureName];
                 } else {
                     spine::String logInfo(textureName);
                     logInfo.append(" attachment's texture doesn`t exist ");
@@ -134,7 +189,7 @@ SkeletonData* SpineWasmUtil::createSpineSkeletonDataWithJson(const String& jsonS
         logToConsole(errorMsg.buffer(), LOG_LEVEL_WARN);
     }
 
-    updateAttachmentVerticesTextureId(skeletonData, textureNames, textureUUIDs);
+    saveAttachmentVertices(skeletonData, textureNames, textureUUIDs);
 
     return skeletonData;
 #else
@@ -161,7 +216,7 @@ SkeletonData* SpineWasmUtil::createSpineSkeletonDataWithBinary(uint32_t byteSize
         logToConsole(errorMsg.buffer(), LOG_LEVEL_WARN);
     }
 
-    updateAttachmentVerticesTextureId(skeletonData, textureNames, textureUUIDs);
+    saveAttachmentVertices(skeletonData, textureNames, textureUUIDs);
 
     return skeletonData;
 #else
@@ -178,38 +233,19 @@ void SpineWasmUtil::registerSpineSkeletonDataWithUUID(SkeletonData* data, const 
 void SpineWasmUtil::destroySpineSkeletonDataWithUUID(const String& uuid) {
     if (skeletonDataMap.containsKey(uuid)) {
         auto* data = skeletonDataMap[uuid];
-#if CC_USE_SPINE_4_2
-        auto& skins = data->getSkins();
-        auto skinSize = skins.size();
-        // release AttachmentVertices
-        for (int i = 0; i < skinSize; ++i) {
-            auto* skin = skins[i];
-            auto entries = skin->getAttachments();
+        HashMap<Attachment *, AttachmentVertices *> *attachmentVerticesMap = nullptr;
+        if (spineAttachmentVerticesMap.containsKey(data)) {
+            attachmentVerticesMap = spineAttachmentVerticesMap[data];
+            auto entries = attachmentVerticesMap->getEntries();
             while (entries.hasNext()) {
-                Skin::AttachmentMap::Entry& entry = entries.next();
-                auto* attachment = entry._attachment;
-                spine::HashMap<Attachment *, AttachmentVertices *> *map = nullptr;
-                if (attachment->getRTTI().isExactly(MeshAttachment::rtti)) {
-                    auto* meshAttachment = static_cast<MeshAttachment*>(attachment);
-                    map = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(meshAttachment->getRegion()->rendererObject);
-                    meshAttachment->getRegion()->rendererObject = nullptr;
-                } else if (attachment->getRTTI().isExactly(RegionAttachment::rtti)) {
-                    auto* regionAttachment = static_cast<RegionAttachment*>(attachment);
-                    map = static_cast<spine::HashMap<Attachment *, AttachmentVertices *> *>(regionAttachment->getRegion()->rendererObject);
-                    regionAttachment->getRegion()->rendererObject = nullptr;
-                }
-                if (map) {
-                    auto attachmentVerticesEntries = map->getEntries();
-                    while (attachmentVerticesEntries.hasNext()) {
-                        auto entryTmp = attachmentVerticesEntries.next();
-                        auto *attachmentVertices = entryTmp.value;
-                        delete attachmentVertices;
-                    }
-                    delete map;
-                }
+                auto entry = entries.next();
+                auto* attachmentVertices = entry.value;
+                delete attachmentVertices;
             }
+            delete attachmentVerticesMap;
+
+            spineAttachmentVerticesMap.remove(data);
         }
-#endif
         delete data;
         skeletonDataMap.remove(uuid);
     }

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos",
         "name": "cocos-engine-external",
-        "checkout": "v3.8.7-14"
+        "checkout": "v3.8.7-15"
     }
 }

--- a/native/tools/swig-config/spine_3_8.i
+++ b/native/tools/swig-config/spine_3_8.i
@@ -115,6 +115,7 @@ using namespace spine;
 %ignore cc::SkeletonDataMgr::setSkeletonData;
 %ignore cc::SkeletonDataMgr::retainByUUID;
 %ignore cc::SkeletonDataMgr::releaseByUUID;
+%ignore cc::SkeletonDataMgr::getSkeletonDataInfo;
 %ignore cc::SkeletonCacheAnimation::render;
 %ignore cc::SkeletonCacheAnimation::requestDrawInfo;
 %ignore cc::SkeletonCacheAnimation::requestMaterial;

--- a/native/tools/swig-config/spine_4_2.i
+++ b/native/tools/swig-config/spine_4_2.i
@@ -113,6 +113,7 @@ using namespace spine;
 %ignore cc::SkeletonDataMgr::setSkeletonData;
 %ignore cc::SkeletonDataMgr::retainByUUID;
 %ignore cc::SkeletonDataMgr::releaseByUUID;
+%ignore cc::SkeletonDataMgr::getSkeletonDataInfo;
 %ignore cc::SkeletonCacheAnimation::render;
 %ignore cc::SkeletonCacheAnimation::requestDrawInfo;
 %ignore cc::SkeletonCacheAnimation::requestMaterial;


### PR DESCRIPTION
Re: #
https://github.com/cocos/cocos-engine/issues/18696
https://github.com/cocos/cocos-engine-external/pull/495

One attachment maybe have multiple regions, and different regions have different uvs.

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
