### PR TITLE
Align AnimationEventType with EventType updates in Spine C++.

### DIFF
--- a/cocos/spine/index.jsb.ts
+++ b/cocos/spine/index.jsb.ts
@@ -93,16 +93,16 @@ export enum AnimationEventType {
      */
     END = 2,
     /**
-     * @en The entry will be disposed.
-     * @zh entry 将被销毁。
-     */
-    DISPOSE = 3,
-    /**
      * @en The play spine skeleton animation complete type.
      * @zh 播放骨骼动画完成。
      * @property {Number} COMPLETE
      */
-    COMPLETE = 4,
+    COMPLETE = 3,
+    /**
+     * @en The entry will be disposed.
+     * @zh entry 将被销毁。
+     */
+    DISPOSE = 4,
     /**
      * @en The spine skeleton animation event type.
      * @zh 骨骼动画事件。

--- a/cocos/spine/index.ts
+++ b/cocos/spine/index.ts
@@ -103,16 +103,16 @@ export enum AnimationEventType {
      */
     END = 2,
     /**
-     * @en The entry will be disposed.
-     * @zh entry 将被销毁。
-     */
-    DISPOSE = 3,
-    /**
      * @en The play spine skeleton animation complete type.
      * @zh 播放骨骼动画完成。
      * @property {Number} COMPLETE
      */
-    COMPLETE = 4,
+    COMPLETE = 3,
+    /**
+     * @en The entry will be disposed.
+     * @zh entry 将被销毁。
+     */
+    DISPOSE = 4,
     /**
      * @en The spine skeleton animation event type.
      * @zh 骨骼动画事件。


### PR DESCRIPTION
Re: #
https://github.com/cocos/cocos-engine/issues/18671

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
