### PR TITLE
Fix getting previous Graphics content on Metal/Vulkan platforms.

### DIFF
--- a/cocos/2d/components/graphics.ts
+++ b/cocos/2d/components/graphics.ts
@@ -552,7 +552,9 @@ export class Graphics extends UIRenderer {
         } else if (this.model) {
             for (let i = 0; i < this.model.subModels.length; i++) {
                 const subModel = this.model.subModels[i];
-                subModel.inputAssembler.indexCount = 0;
+                const ia = subModel.inputAssembler;
+                ia.indexCount = 0;
+                ia.vertexCount = 0;
             }
         }
 

--- a/native/cocos/2d/renderer/UIModelProxy.cpp
+++ b/native/cocos/2d/renderer/UIModelProxy.cpp
@@ -129,6 +129,9 @@ void UIModelProxy::destroy() {
 }
 
 void UIModelProxy::clear() {
+    if (_model == nullptr) {
+        return;
+    }
     const auto& subModels = _model->getSubModels();
     for (const auto &subModel : subModels) {
         auto *ia = subModel->getInputAssembler();

--- a/native/cocos/2d/renderer/UIModelProxy.cpp
+++ b/native/cocos/2d/renderer/UIModelProxy.cpp
@@ -129,6 +129,12 @@ void UIModelProxy::destroy() {
 }
 
 void UIModelProxy::clear() {
+    const auto& subModels = _model->getSubModels();
+    for (const auto &subModel : subModels) {
+        auto *ia = subModel->getInputAssembler();
+        ia->setVertexCount(0);
+        ia->setIndexCount(0);
+    }
 }
 
 // for ui model

--- a/native/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
+++ b/native/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
@@ -615,20 +615,22 @@ void CCMTLCommandBuffer::draw(const DrawInfo &info) {
                 const auto &drawInfo = drawInfos[i];
                 offset += drawInfo.firstIndex * stride;
                 if (indirectBuffer->isDrawIndirectByIndex()) {
-                    if (drawInfo.instanceCount == 0) {
-                        // indexbuffer offset: [backbuffer(triplebuffer maybe) offset] + [offset in this drawcall]
-                        [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
-                                               indexCount:drawInfo.indexCount
-                                                indexType:indexBuffer->getIndexType()
-                                              indexBuffer:indexBuffer->mtlBuffer()
-                                        indexBufferOffset:offset + indexBuffer->currentOffset()];
-                    } else {
-                        [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
-                                               indexCount:drawInfo.indexCount
-                                                indexType:indexBuffer->getIndexType()
-                                              indexBuffer:indexBuffer->mtlBuffer()
-                                        indexBufferOffset:offset + indexBuffer->currentOffset()
-                                            instanceCount:drawInfo.instanceCount];
+                    if (drawInfo.indexCount > 0) {
+                        if (drawInfo.instanceCount == 0) {
+                            // indexbuffer offset: [backbuffer(triplebuffer maybe) offset] + [offset in this drawcall]
+                            [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
+                                                   indexCount:drawInfo.indexCount
+                                                    indexType:indexBuffer->getIndexType()
+                                                  indexBuffer:indexBuffer->mtlBuffer()
+                                            indexBufferOffset:offset + indexBuffer->currentOffset()];
+                        } else {
+                            [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
+                                                   indexCount:drawInfo.indexCount
+                                                    indexType:indexBuffer->getIndexType()
+                                                  indexBuffer:indexBuffer->mtlBuffer()
+                                            indexBufferOffset:offset + indexBuffer->currentOffset()
+                                                instanceCount:drawInfo.instanceCount];
+                        }
                     }
                 } else {
                     if (drawInfo.instanceCount == 0) {
@@ -645,22 +647,24 @@ void CCMTLCommandBuffer::draw(const DrawInfo &info) {
             }
         }
     } else {
-        if (info.indexCount > 0) {
-            uint32_t offset = 0;
-            offset += info.firstIndex * indexBuffer->getStride();
-            if (info.instanceCount == 0) {
-                [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
-                                       indexCount:info.indexCount
-                                        indexType:indexBuffer->getIndexType()
-                                      indexBuffer:indexBuffer->mtlBuffer()
-                                indexBufferOffset:offset + indexBuffer->currentOffset()];
-            } else {
-                [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
-                                       indexCount:info.indexCount
-                                        indexType:indexBuffer->getIndexType()
-                                      indexBuffer:indexBuffer->mtlBuffer()
-                                indexBufferOffset:offset + indexBuffer->currentOffset()
-                                    instanceCount:info.instanceCount];
+        if (indexBuffer) {
+            if (info.indexCount > 0) {
+                uint32_t offset = 0;
+                offset += info.firstIndex * indexBuffer->getStride();
+                if (info.instanceCount == 0) {
+                    [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
+                                           indexCount:info.indexCount
+                                            indexType:indexBuffer->getIndexType()
+                                          indexBuffer:indexBuffer->mtlBuffer()
+                                    indexBufferOffset:offset + indexBuffer->currentOffset()];
+                } else {
+                    [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
+                                           indexCount:info.indexCount
+                                            indexType:indexBuffer->getIndexType()
+                                          indexBuffer:indexBuffer->mtlBuffer()
+                                    indexBufferOffset:offset + indexBuffer->currentOffset()
+                                        instanceCount:info.instanceCount];
+                }
             }
         } else if (info.vertexCount) {
             if (info.instanceCount == 0) {

--- a/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
@@ -502,11 +502,13 @@ void CCVKCommandBuffer::draw(const DrawInfo &info) {
         }
     } else {
         uint32_t instanceCount = std::max(info.instanceCount, 1U);
-        bool hasIndexBuffer = _curGPUInputAssembler->gpuIndexBuffer && info.indexCount > 0;
+        bool hasIndexBuffer = _curGPUInputAssembler->gpuIndexBuffer;
 
         if (hasIndexBuffer) {
-            vkCmdDrawIndexed(_gpuCommandBuffer->vkCommandBuffer, info.indexCount, instanceCount,
+            if (info.indexCount > 0) {
+                vkCmdDrawIndexed(_gpuCommandBuffer->vkCommandBuffer, info.indexCount, instanceCount,
                              info.firstIndex, info.vertexOffset, info.firstInstance);
+            }
         } else {
             vkCmdDraw(_gpuCommandBuffer->vkCommandBuffer, info.vertexCount, instanceCount,
                       info.firstVertex, info.firstInstance);


### PR DESCRIPTION
### Video represents the bug:


https://github.com/user-attachments/assets/75c13a47-b649-4f37-a545-cf77b2777121


### Video which is correct behavior:


https://github.com/user-attachments/assets/5850fb9e-0c30-46b2-b6ee-b9dcd376851c

### Reason 1 causes the bug

The gfx backends have different behaviors, webgl1/2, opengles2/3 are correct, metal + vulkan are wrong while handling indexed drawing.

Reference code: 

#### gfx-webgl2 ( Correct ):

https://github.com/cocos/cocos-engine/blob/3.8.6/cocos/gfx/webgl2/webgl2-commands.ts#L2617

Check the indexBuffer firstly, drawElements only if the indexCount is higher than 0.

![WeChat7140caca60467023db39acfccbfd1ad2](https://github.com/user-attachments/assets/00715bd0-3ba5-445a-b16b-cd5e495fc7ad)

#### gfx-metal (Wrong)

https://github.com/cocos/cocos-engine/blob/3.8.6/native/cocos/renderer/gfx-metal/MTLCommandBuffer.mm#L648

![WeChat62b0a047eb01be341a2f6560cc14af1b](https://github.com/user-attachments/assets/7cde6319-6d85-470a-b8b5-7de5d569844e)

#### gfx-vulkan is also wrong behavior like which in gfx-metal.

### Reason 2 causes the bug

`UIModelProxy::clear` on native platforms is doing nothing, while in the non-native implementation, it will set the `indexCount` to zero.

Refer to https://github.com/cocos/cocos-engine/blob/3.8.6/cocos/2d/components/graphics.ts#L555

![WeChat3dd4885690ad6cb4be1bc9438c606196](https://github.com/user-attachments/assets/72dc3f7b-bec3-45aa-8162-606736b621a9)


### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
