### PR TITLE
Fix the problem of calling ark function without parameter to report error

### DIFF
--- a/native/cocos/bindings/manual/JavaScriptArkTsBridge.cpp
+++ b/native/cocos/bindings/manual/JavaScriptArkTsBridge.cpp
@@ -144,7 +144,7 @@ static bool JavaScriptArkTsBridge_callStaticMethod(se::State& s) {
     const auto& args = s.args();
     int argc = (int)args.size();
 
-    if (argc == 3 || argc == 4) {
+    if (argc > 1) {
         bool ok = false;
         bool isSync = true;
         std::string clsPath, methodName, paramStr;
@@ -154,9 +154,11 @@ static bool JavaScriptArkTsBridge_callStaticMethod(se::State& s) {
 
         methodName = seval_to_type<std::string>(args[1], ok);
         SE_PRECONDITION2(ok, false, "Converting methodName failed!");
-
-        paramStr = seval_to_type<std::string>(args[2], ok);
-        SE_PRECONDITION2(ok, false, "Converting paramStr failed!");
+        
+        if(argc == 3) {
+            paramStr = seval_to_type<std::string>(args[2], ok);
+            SE_PRECONDITION2(ok, false, "Converting paramStr failed!");
+        }
 
         if (argc == 4) {
             ok = args[3].isBoolean();

--- a/native/cocos/bindings/manual/JavaScriptArkTsBridge.cpp
+++ b/native/cocos/bindings/manual/JavaScriptArkTsBridge.cpp
@@ -155,12 +155,12 @@ static bool JavaScriptArkTsBridge_callStaticMethod(se::State& s) {
         methodName = seval_to_type<std::string>(args[1], ok);
         SE_PRECONDITION2(ok, false, "Converting methodName failed!");
         
-        if(argc == 3) {
+        if(argc > 2) {
             paramStr = seval_to_type<std::string>(args[2], ok);
             SE_PRECONDITION2(ok, false, "Converting paramStr failed!");
         }
 
-        if (argc == 4) {
+        if (argc > 3) {
             ok = args[3].isBoolean();
             SE_PRECONDITION2(ok, false, "isSync must be boolean type");
             isSync = args[3].toBoolean();


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
