### PR TITLE
fix animation track err and optimize function createRuntimeBinding

### DIFF
--- a/cocos/animation/tracks/track.ts
+++ b/cocos/animation/tracks/track.ts
@@ -26,7 +26,7 @@
 import { ccclass, serializable, uniquelyReferenced } from 'cc.decorator';
 import { SUPPORT_JIT } from 'internal:constants';
 import type { Component } from '../../scene-graph/component';
-import { error, ObjectCurve, QuatCurve, RealCurve, errorID, warnID, js } from '../../core';
+import { ObjectCurve, QuatCurve, RealCurve, errorID, warnID, js } from '../../core';
 import { assertIsTrue } from '../../core/data/utils/asserts';
 
 import { Node } from '../../scene-graph';
@@ -345,7 +345,7 @@ export class TrackBinding {
         const { path, proxy } = this;
         const nPaths = path.length;
         const iLastPath = nPaths - 1;
-        // 提前返回，减少嵌套
+        // return error in adanvance
         if (nPaths === 0 || !(path.isPropertyAt(iLastPath) || path.isElementAt(iLastPath)) || proxy) {
             if (!proxy) {
                 errorID(3921);
@@ -370,7 +370,6 @@ export class TrackBinding {
             return binding;
         }
 
-        // 处理标准属性路径
         const lastPropertyKey = path.isPropertyAt(iLastPath)
             ? path.parsePropertyAt(iLastPath)
             : path.parseElementAt(iLastPath);
@@ -379,11 +378,11 @@ export class TrackBinding {
         if (resultTarget === null) {
             return null;
         }
-        // 特殊处理 Node 的变换属性
+        // tackle Node properties
         if (poseOutput && resultTarget instanceof Node && isTrsPropertyName(lastPropertyKey)) {
             return poseOutput.createPoseWriter(resultTarget, lastPropertyKey, isConstant);
         }
-        // 获取或创建访问器函数
+        // get handle constructor
         let animationFunction = TrackBinding._animationFunctions.get(resultTarget.constructor);
         if (!animationFunction) {
             animationFunction = new Map();
@@ -399,8 +398,8 @@ export class TrackBinding {
                     getValue: Function(`return this.target[${lastPropertyKey}];`) as () => any,
                 };
             } else {
-                // 非 JIT 模式下使用闭包
-                const key = lastPropertyKey; // 捕获变量，避免闭包引用外部变量
+                // Non JIT Mode
+                const key = lastPropertyKey;
                 accessor = {
                     setValue: (value: unknown): void => { resultTarget[key] = value; },
                     getValue: (): unknown => resultTarget[key] as unknown,

--- a/cocos/animation/tracks/track.ts
+++ b/cocos/animation/tracks/track.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /*
  Copyright (c) 2022-2023 Xiamen Yaji Software Co., Ltd.
 
@@ -238,7 +239,7 @@ class TrackPath {
     /**
      * @internal
      */
-    public [parseTrsPathTag] (): { node: string; property: "position" | "scale" | "rotation" | "eulerAngles"; } | null {
+    public [parseTrsPathTag] (): { node: string; property: 'position' | 'scale' | 'rotation' | 'eulerAngles'; } | null {
         const { _paths: paths } = this;
         const nPaths = paths.length;
 
@@ -331,7 +332,7 @@ export class TrackBinding {
 
     private static _animationFunctions = new WeakMap<Constructor, Map<string | number, AnimationFunction>>();
 
-    public parseTrsPath (): { node: string; property: "position" | "scale" | "rotation" | "eulerAngles"; } | null {
+    public parseTrsPath (): { node: string; property: 'position' | 'scale' | 'rotation' | 'eulerAngles'; } | null {
         if (this.proxy) {
             return null;
         } else {
@@ -339,57 +340,17 @@ export class TrackBinding {
         }
     }
 
+    // eslint-disable-next-line max-len
     public createRuntimeBinding (target: unknown, poseOutput: PoseOutput | undefined, isConstant: boolean): RuntimeBinding<unknown> | { target: any; setValue: any; getValue: any; } | null {
         const { path, proxy } = this;
         const nPaths = path.length;
         const iLastPath = nPaths - 1;
-        if (nPaths !== 0 && (path.isPropertyAt(iLastPath) || path.isElementAt(iLastPath)) && !proxy) {
-            const lastPropertyKey = path.isPropertyAt(iLastPath)
-                ? path.parsePropertyAt(iLastPath)
-                : path.parseElementAt(iLastPath);
-            const resultTarget = path[normalizedFollowTag](target, 0, nPaths - 1) as any;
-            if (resultTarget === null) {
+        // 提前返回，减少嵌套
+        if (nPaths === 0 || !(path.isPropertyAt(iLastPath) || path.isElementAt(iLastPath)) || proxy) {
+            if (!proxy) {
+                errorID(3921);
                 return null;
             }
-            if (poseOutput && resultTarget instanceof Node && isTrsPropertyName(lastPropertyKey)) {
-                const blendStateWriter = poseOutput.createPoseWriter(resultTarget, lastPropertyKey, isConstant);
-                return blendStateWriter;
-            }
-            let setValue; let getValue;
-            if (SUPPORT_JIT) {
-                let animationFunction = TrackBinding._animationFunctions.get(resultTarget.constructor);
-                if (!animationFunction) {
-                    animationFunction = new Map();
-                    TrackBinding._animationFunctions.set(resultTarget.constructor, animationFunction);
-                }
-
-                let accessor = animationFunction.get(lastPropertyKey);
-                if (!accessor) {
-                    accessor = {
-                        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-                        setValue: Function('value', `this.target.${lastPropertyKey} = value;`) as (val: any) => void,
-                        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-                        getValue: Function(`return this.target.${lastPropertyKey};`) as () => any,
-                    };
-                    animationFunction.set(lastPropertyKey, accessor);
-                }
-                setValue = accessor.setValue;
-                getValue = accessor.getValue;
-            } else {
-                setValue = (value: unknown): void => {
-                    resultTarget[lastPropertyKey] = value;
-                };
-                getValue = (): unknown => resultTarget[lastPropertyKey] as unknown;
-            }
-            return {
-                target: resultTarget,
-                setValue,
-                getValue,
-            };
-        } else if (!proxy) {
-            errorID(3921);
-            return null;
-        } else {
             const resultTarget = path[normalizedFollowTag](target, 0, nPaths);
             if (resultTarget === null) {
                 return null;
@@ -399,9 +360,7 @@ export class TrackBinding {
                 return null;
             }
             const binding: RuntimeBinding = {
-                setValue: (value): void => {
-                    runtimeProxy.set(value);
-                },
+                setValue: (value): void => runtimeProxy.set(value),
             };
             const proxyGet = runtimeProxy.get;
             if (proxyGet) {
@@ -410,6 +369,51 @@ export class TrackBinding {
             }
             return binding;
         }
+
+        // 处理标准属性路径
+        const lastPropertyKey = path.isPropertyAt(iLastPath)
+            ? path.parsePropertyAt(iLastPath)
+            : path.parseElementAt(iLastPath);
+
+        const resultTarget = path[normalizedFollowTag](target, 0, iLastPath) as any;
+        if (resultTarget === null) {
+            return null;
+        }
+        // 特殊处理 Node 的变换属性
+        if (poseOutput && resultTarget instanceof Node && isTrsPropertyName(lastPropertyKey)) {
+            return poseOutput.createPoseWriter(resultTarget, lastPropertyKey, isConstant);
+        }
+        // 获取或创建访问器函数
+        let animationFunction = TrackBinding._animationFunctions.get(resultTarget.constructor);
+        if (!animationFunction) {
+            animationFunction = new Map();
+            TrackBinding._animationFunctions.set(resultTarget.constructor, animationFunction);
+        }
+        let accessor = animationFunction.get(lastPropertyKey);
+        if (!accessor) {
+            if (SUPPORT_JIT) {
+                accessor = {
+                    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+                    setValue: Function('value', `this.target[${lastPropertyKey}] = value;`) as (val: any) => void,
+                    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+                    getValue: Function(`return this.target[${lastPropertyKey}];`) as () => any,
+                };
+            } else {
+                // 非 JIT 模式下使用闭包
+                const key = lastPropertyKey; // 捕获变量，避免闭包引用外部变量
+                accessor = {
+                    setValue: (value: unknown): void => { resultTarget[key] = value; },
+                    getValue: (): unknown => resultTarget[key] as unknown,
+                };
+            }
+            animationFunction.set(lastPropertyKey, accessor);
+        }
+
+        return {
+            target: resultTarget,
+            setValue: accessor.setValue,
+            getValue: accessor.getValue,
+        };
     }
 
     public isMaskedOff (mask: AnimationMask): boolean {

--- a/cocos/animation/tracks/track.ts
+++ b/cocos/animation/tracks/track.ts
@@ -345,12 +345,53 @@ export class TrackBinding {
         const { path, proxy } = this;
         const nPaths = path.length;
         const iLastPath = nPaths - 1;
-        // return error in adanvance
-        if (nPaths === 0 || !(path.isPropertyAt(iLastPath) || path.isElementAt(iLastPath)) || proxy) {
-            if (!proxy) {
-                errorID(3921);
+        if (nPaths !== 0 && (path.isPropertyAt(iLastPath) || path.isElementAt(iLastPath)) && !proxy) {
+            const lastPropertyKey = path.isPropertyAt(iLastPath)
+                ? path.parsePropertyAt(iLastPath)
+                : path.parseElementAt(iLastPath);
+            const resultTarget = path[normalizedFollowTag](target, 0, nPaths - 1) as any;
+            if (resultTarget === null) {
                 return null;
             }
+            if (poseOutput && resultTarget instanceof Node && isTrsPropertyName(lastPropertyKey)) {
+                const blendStateWriter = poseOutput.createPoseWriter(resultTarget, lastPropertyKey, isConstant);
+                return blendStateWriter;
+            }
+            let setValue; let getValue;
+            if (SUPPORT_JIT) {
+                let animationFunction = TrackBinding._animationFunctions.get(resultTarget.constructor);
+                if (!animationFunction) {
+                    animationFunction = new Map();
+                    TrackBinding._animationFunctions.set(resultTarget.constructor, animationFunction);
+                }
+
+                let accessor = animationFunction.get(lastPropertyKey);
+                if (!accessor) {
+                    accessor = {
+                        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+                        setValue: Function('value', `this.target[${lastPropertyKey}] = value;`) as (val: any) => void,
+                        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+                        getValue: Function(`return this.target[${lastPropertyKey}];`) as () => any,
+                    };
+                    animationFunction.set(lastPropertyKey, accessor);
+                }
+                setValue = accessor.setValue;
+                getValue = accessor.getValue;
+            } else {
+                setValue = (value: unknown): void => {
+                    resultTarget[lastPropertyKey] = value;
+                };
+                getValue = (): unknown => resultTarget[lastPropertyKey] as unknown;
+            }
+            return {
+                target: resultTarget,
+                setValue,
+                getValue,
+            };
+        } else if (!proxy) {
+            errorID(3921);
+            return null;
+        } else {
             const resultTarget = path[normalizedFollowTag](target, 0, nPaths);
             if (resultTarget === null) {
                 return null;
@@ -360,7 +401,9 @@ export class TrackBinding {
                 return null;
             }
             const binding: RuntimeBinding = {
-                setValue: (value): void => runtimeProxy.set(value),
+                setValue: (value): void => {
+                    runtimeProxy.set(value);
+                },
             };
             const proxyGet = runtimeProxy.get;
             if (proxyGet) {
@@ -369,50 +412,6 @@ export class TrackBinding {
             }
             return binding;
         }
-
-        const lastPropertyKey = path.isPropertyAt(iLastPath)
-            ? path.parsePropertyAt(iLastPath)
-            : path.parseElementAt(iLastPath);
-
-        const resultTarget = path[normalizedFollowTag](target, 0, iLastPath) as any;
-        if (resultTarget === null) {
-            return null;
-        }
-        // tackle Node properties
-        if (poseOutput && resultTarget instanceof Node && isTrsPropertyName(lastPropertyKey)) {
-            return poseOutput.createPoseWriter(resultTarget, lastPropertyKey, isConstant);
-        }
-        // get handle constructor
-        let animationFunction = TrackBinding._animationFunctions.get(resultTarget.constructor);
-        if (!animationFunction) {
-            animationFunction = new Map();
-            TrackBinding._animationFunctions.set(resultTarget.constructor, animationFunction);
-        }
-        let accessor = animationFunction.get(lastPropertyKey);
-        if (!accessor) {
-            if (SUPPORT_JIT) {
-                accessor = {
-                    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-                    setValue: Function('value', `this.target[${lastPropertyKey}] = value;`) as (val: any) => void,
-                    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-                    getValue: Function(`return this.target[${lastPropertyKey}];`) as () => any,
-                };
-            } else {
-                // Non JIT Mode
-                const key = lastPropertyKey;
-                accessor = {
-                    setValue: (value: unknown): void => { resultTarget[key] = value; },
-                    getValue: (): unknown => resultTarget[key] as unknown,
-                };
-            }
-            animationFunction.set(lastPropertyKey, accessor);
-        }
-
-        return {
-            target: resultTarget,
-            setValue: accessor.setValue,
-            getValue: accessor.getValue,
-        };
     }
 
     public isMaskedOff (mask: AnimationMask): boolean {

--- a/cocos/animation/tracks/track.ts
+++ b/cocos/animation/tracks/track.ts
@@ -369,9 +369,9 @@ export class TrackBinding {
                 if (!accessor) {
                     accessor = {
                         // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-                        setValue: Function('value', `this.target[${lastPropertyKey}] = value;`) as (val: any) => void,
+                        setValue: Function('value', `this.target["${lastPropertyKey}"] = value;`) as (val: any) => void,
                         // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-                        getValue: Function(`return this.target[${lastPropertyKey}];`) as () => any,
+                        getValue: Function(`return this.target["${lastPropertyKey}"];`) as () => any,
                     };
                     animationFunction.set(lastPropertyKey, accessor);
                 }


### PR DESCRIPTION
Re: #https://github.com/cocos/3d-tasks/issues/18982

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
