### PR TITLE
Fix the new version of WeChat minigame IDE reporting the error: readFile:fail Parameter check error

### DIFF
--- a/platforms/minigame/platforms/wechat/wrapper/fs-utils.js
+++ b/platforms/minigame/platforms/wechat/wrapper/fs-utils.js
@@ -169,7 +169,9 @@ const fsUtils = {
     },
 
     readArrayBuffer (filePath, onComplete) {
-        // Should pass undefined to encoding parameter, otherwise, the new version of WeChat mini-game IDE will report an error:
+        // Should pass undefined to 'encoding' parameter instead of passing an empty string,
+        // otherwise, the new version of WeChat mini-game IDE will report an error:
+        //
         // Error: readFile:fail Parameter check error:
         //     parameter.encoding 字段需为 'ascii' | 'base64' | 'binary' | 'hex' | 'latin1' | 'ucs-2' | 'ucs2' | 'utf-16le' | 'utf-8' | 'utf16le' | 'utf8'
         //         at Object.fail (web-adapter.js? [sm]:1)
@@ -182,7 +184,7 @@ const fsUtils = {
         //         at VM20 WAGame.js:1
         //         at r (VM20 WAGame.js:1)
         //         at s (VM20 WAGame.js:1)
-        // So the workaround is to pass an 'undefined' value.
+        //
         // API Reference: https://developers.weixin.qq.com/miniprogram/dev/api/file/FileSystemManager.readFile.html
         fsUtils.readFile(filePath, undefined, onComplete);
     },

--- a/platforms/minigame/platforms/wechat/wrapper/fs-utils.js
+++ b/platforms/minigame/platforms/wechat/wrapper/fs-utils.js
@@ -169,7 +169,22 @@ const fsUtils = {
     },
 
     readArrayBuffer (filePath, onComplete) {
-        fsUtils.readFile(filePath, '', onComplete);
+        // Should pass undefined to encoding parameter, otherwise, the new version of WeChat mini-game IDE will report an error:
+        // Error: readFile:fail Parameter check error:
+        //     parameter.encoding 字段需为 'ascii' | 'base64' | 'binary' | 'hex' | 'latin1' | 'ucs-2' | 'ucs2' | 'utf-16le' | 'utf-8' | 'utf16le' | 'utf8'
+        //         at Object.fail (web-adapter.js? [sm]:1)
+        //         at Object.t (VM31 WAGameSubContext.js:1)
+        //         at Function.C.forEach.v.<computed> (VM20 WAGame.js:1)
+        //         at p (VM20 WAGame.js:1)
+        //         at Object.fail (VM20 WAGame.js:1)
+        //         at VM20 WAGame.js:1
+        //         at oe (VM20 WAGame.js:1)
+        //         at VM20 WAGame.js:1
+        //         at r (VM20 WAGame.js:1)
+        //         at s (VM20 WAGame.js:1)
+        // So the workaround is to pass an 'undefined' value.
+        // API Reference: https://developers.weixin.qq.com/miniprogram/dev/api/file/FileSystemManager.readFile.html
+        fsUtils.readFile(filePath, undefined, onComplete);
     },
 
     readJson (filePath, onComplete) {


### PR DESCRIPTION
Re: https://forum.cocos.org/t/topic/168287

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
