### PR TITLE
download cconb refactor

### DIFF
--- a/cocos/asset/asset-manager/downloader.ts
+++ b/cocos/asset/asset-manager/downloader.ts
@@ -31,7 +31,7 @@ import downloadScript from './download-script';
 import { files } from './shared';
 import { retry, RetryFunction, urlAppendTimestamp } from './utilities';
 import { IConfigOption } from './config';
-import { CCON, decodeCCONBinary } from '../../serialization/ccon';
+import { CCON, decodeCCONBinary, isCconb } from '../../serialization/ccon';
 import type { AssetManager } from './asset-manager';
 
 export type DownloadHandler = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)) => void;
@@ -65,7 +65,16 @@ const downloadJson = (url: string, options: Record<string, any>, onComplete: ((e
 
 const downloadArrayBuffer = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)): void => {
     options.xhrResponseType = 'arraybuffer';
-    downloadFile(url, options, options.onFileProgress as FileProgressCallback, onComplete);
+    downloadFile(url, options, options.onFileProgress as FileProgressCallback, (err: Error | null, data?: any) => {
+        if (!err && data && (data instanceof ArrayBuffer || data instanceof Uint8Array)) {
+            const uint8Array = data instanceof Uint8Array ? data : new Uint8Array(data as ArrayBuffer);
+            if (isCconb(uint8Array)) {
+                onComplete(null, decodeCCONBinary(uint8Array));
+                return;
+            }
+        }
+        onComplete(err, data);
+    });
 };
 
 const downloadCCONB = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: CCON | null) => void)): void => {

--- a/cocos/asset/asset-manager/downloader.ts
+++ b/cocos/asset/asset-manager/downloader.ts
@@ -79,18 +79,7 @@ const downloadArrayBuffer = (url: string, options: Record<string, any>, onComple
 
 const downloadCCONB = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: CCON | null) => void)): void => {
     url = url.replace('.cconb', '.bin');
-    downloader._downloadArrayBuffer(url, options, (err, arrayBuffer: ArrayBuffer): void => {
-        if (err) {
-            onComplete(err);
-            return;
-        }
-        try {
-            const ccon = decodeCCONBinary(new Uint8Array(arrayBuffer));
-            onComplete(null, ccon);
-        } catch (err) {
-            onComplete(err as Error);
-        }
-    });
+    downloader._downloadArrayBuffer(url, options, onComplete);
 };
 
 const downloadText = (url: string, options: Record<string, any>, onComplete: ((err: Error | null, data?: any) => void)): void => {

--- a/cocos/serialization/ccon.ts
+++ b/cocos/serialization/ccon.ts
@@ -141,6 +141,30 @@ export function decodeCCONBinary (bytes: Uint8Array): CCON {
     return new CCON(json, chunks);
 }
 
+export function isCconb (bytes: Uint8Array | null): boolean {
+    if (!bytes || bytes.length < 16) {
+        return false;
+    }
+
+    const dataView = new DataView(
+        bytes.buffer,
+        bytes.byteOffset,
+        bytes.byteLength,
+    );
+
+    const magic = dataView.getUint32(0, true);
+    if (magic !== MAGIC) {
+        return false;
+    }
+
+    const version = dataView.getUint32(4, true);
+    if (version !== VERSION) {
+        return false;
+    }
+
+    return true;
+}
+
 /**
  * Partial signature of Node.js `Buffer`: https://nodejs.org/api/buffer.html
  */


### PR DESCRIPTION
…r to see if it is in the cconb binary format. If it is, proceed with the download cconb processing; otherwise, follow the original processing.

Re: https://github.com/cocos/3d-tasks/issues/19026

### Changelog

*When downloading a file with the .bin extension, check the file header to see if it is in the cconb binary format. If it is, proceed with the download cconb processing; otherwise, follow the original processing.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
