### PR TITLE
fixed box2d module export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",
-        "@cocos/box2d": "1.0.1",
+        "@cocos/box2d": "1.0.2",
         "@cocos/cannon": "1.2.8",
         "@cocos/ccbuild": "^2.3.16",
         "@cocos/dragonbones-js": "^1.0.1",
@@ -2048,9 +2048,9 @@
       }
     },
     "node_modules/@cocos/box2d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/@cocos/box2d/-/box2d-1.0.1.tgz",
-      "integrity": "sha512-qNPK0KZEnEwMMtrj1f/p71FuuutmzXD0n1z6jLU3ntULk7EyNfnlsKUkAZEDVtr9nPmUvQozt/XquZ+biGxTCg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cocos/box2d/-/box2d-1.0.2.tgz",
+      "integrity": "sha512-5XTWfbSCuv9SoWaT0Xa3/jrKMWVd+txI8A/KfgCEyzQzLG0QckzfEC+7nb8cwOnzGWUI/cA0O0FnNr8V2Z/AZw==",
       "dependencies": {
         "@types/systemjs": "^0.20.6"
       }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@cocos/box2d": "1.0.1",
+    "@cocos/box2d": "1.0.2",
     "@cocos/cannon": "1.2.8",
     "@cocos/ccbuild": "^2.3.16",
     "@cocos/dragonbones-js": "^1.0.1",


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/18901

### Changelog

* fixed box2d module export. update box2d version to v1.0.2

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
