### PR TITLE
Fix missing i18n display for properties

### DIFF
--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -1361,6 +1361,7 @@ module.exports = link(mixin({
 require('./modules/physics'),
 require('./modules/rendering'),
 require('./modules/ui.js'),
+require('./modules/terrain.js'),
 require('./animation'),
 
 ));

--- a/editor/i18n/en/modules/terrain.js
+++ b/editor/i18n/en/modules/terrain.js
@@ -1,0 +1,34 @@
+module.exports = {
+    classes: {
+        cc: {
+            Terrain: {
+                properties: {
+                    _asset: {
+                        tooltip: 'The terrain asset.',
+                    },
+                    effectAsset: {
+                        tooltip: 'The terrain effect asset.',
+                    },
+                    lightmapInfos: {
+                        tooltip: 'The terrain info.',
+                    },
+                    receiveShadow: {
+                        tooltip: 'Receive shadow.',
+                    },
+                    useNormalMap: {
+                        tooltip: 'Use normal map.',
+                    },
+                    usePBR: {
+                        tooltip: 'Use pbr material.',
+                    },
+                    lodEnable: {
+                        tooltip: 'Enable lod.',
+                    },
+                    LodBias: {
+                        tooltip: 'Lod bias.',
+                    },
+                },
+            },
+        },
+    },
+};

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -1339,6 +1339,7 @@ module.exports = link(mixin({
 require('./modules/physics'),
 require('./modules/rendering'),
 require('./modules/ui.js'),
+require('./modules/terrain.js'),
 require('./animation'),
 
 ));

--- a/editor/i18n/zh/modules/terrain.js
+++ b/editor/i18n/zh/modules/terrain.js
@@ -1,0 +1,34 @@
+module.exports = {
+    classes: {
+        cc: {
+            Terrain: {
+                properties: {
+                    _asset: {
+                        tooltip: '地形所使用的资源。',
+                    },
+                    effectAsset: {
+                        tooltip: '地形特效资源。',
+                    },
+                    lightmapInfos: {
+                        tooltip: '地形信息。',
+                    },
+                    receiveShadow: {
+                        tooltip: '是否接受阴影。',
+                    },
+                    useNormalMap: {
+                        tooltip: '是否使用法线贴图。',
+                    },
+                    usePBR: {
+                        tooltip: '是否使用物理材质。',
+                    },
+                    lodEnable: {
+                        tooltip: '是否允许 lod。',
+                    },
+                    LodBias: {
+                        tooltip: 'Lod 偏移距离。',
+                    },
+                },
+            },
+        },
+    },
+};


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/19055

### Changelog

* Fix missing i18n display for properties

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
