### PR TITLE
Update scheduler.ts , 解决 element 不存在时的报错

### DIFF
--- a/cocos/core/scheduler.ts
+++ b/cocos/core/scheduler.ts
@@ -764,7 +764,7 @@ export class Scheduler extends System {
     public unscheduleForTimer (timerToUnschedule: CallbackTimer, target: ISchedulable): void {
         const targetId = (target.uuid || target.id) as string;
         const element = this._hashForTimers[targetId];
-        const timers = element.timers;
+        const timers = element?.timers;
         if (!timers || timers.length === 0) {
             return;
         }


### PR DESCRIPTION
该文件中 其他用到 element.timers 的地方 之前都有判断element是否存在. 但是此处没有. 补充下.


否则偶尔会遇到图中的错误: 

<img width="1436" height="572" alt="4329c8dc3cd2046fc332447fbbba8a30" src="https://github.com/user-attachments/assets/2995715c-fe1c-4a5e-887e-846f1a0dc621" />


Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
