### PR TITLE
Synchronize the native setSlotTexture with the web logic

### DIFF
--- a/native/cocos/editor-support/spine-creator-support/SkeletonCache.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonCache.cpp
@@ -317,9 +317,9 @@ void SkeletonCache::renderAnimationFrame(AnimationData *animationData) {
     }
 
 
-    auto *verticesMap = SkeletonDataMgr::getInstance()->getSkeletonDataInfo(_uuid);
-    if (!verticesMap) return;
-    auto &attachmentVerticesMap = *verticesMap;
+    auto *skeletonDataInfo = SkeletonDataMgr::getInstance()->getSkeletonDataInfo(_uuid);
+    if (!skeletonDataInfo) return;
+    auto &attachmentVerticesMap = skeletonDataInfo->attachmentVerticesMap;
     auto &drawOrder = _skeleton->getDrawOrder();
     for (size_t i = 0, n = drawOrder.size(); i < n; ++i) {
         slot = drawOrder[i];

--- a/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
@@ -77,38 +77,26 @@ extern "C" AttachmentVertices *generateAttachmentVertices(Attachment *attachment
 }
 
 namespace cc {
-class SkeletonDataInfo {
-public:
-    SkeletonDataInfo() = default;
-
-    ~SkeletonDataInfo() {
-        if (data) {
-            delete data;
-            data = nullptr;
-        }
-
-        if (atlas) {
-            delete atlas;
-            atlas = nullptr;
-        }
-
-        if (attachmentLoader) {
-            delete attachmentLoader;
-            attachmentLoader = nullptr;
-        }
-
-        for (const auto& pair : attachmentVerticesMap) {
-            delete pair.second;
-        }
+SkeletonDataInfo::~SkeletonDataInfo() {
+    if (data) {
+        delete data;
+        data = nullptr;
     }
 
-    SkeletonData *data = nullptr;
-    Atlas *atlas = nullptr;
-    AttachmentLoader *attachmentLoader = nullptr;
-    std::vector<int> texturesIndex;
-    std::unordered_map<Attachment *, AttachmentVertices *> attachmentVerticesMap;
-};
+    if (atlas) {
+        delete atlas;
+        atlas = nullptr;
+    }
 
+    if (attachmentLoader) {
+        delete attachmentLoader;
+        attachmentLoader = nullptr;
+    }
+
+    for (const auto &pair : attachmentVerticesMap) {
+        delete pair.second;
+    }
+}
 
 void saveAttachmentVertices(SkeletonDataInfo *info) {
     auto &attachmentVerticesMap = info->attachmentVerticesMap;
@@ -162,13 +150,21 @@ void SkeletonDataMgr::setSkeletonData(const std::string &uuid, SkeletonData *dat
     saveAttachmentVertices(info);
 }
 
-std::unordered_map<Attachment *, AttachmentVertices *>
-    *SkeletonDataMgr::getSkeletonDataInfo(const std::string &uuid) {
+SkeletonDataInfo *SkeletonDataMgr::getSkeletonDataInfo(const std::string &uuid) {
     auto dataIt = _dataMap.find(uuid);
     if (dataIt == _dataMap.end()) {
         return nullptr;
     }
-    return &dataIt->second->attachmentVerticesMap;
+    return dataIt->second;
+}
+
+std::vector<SkeletonDataInfo *> SkeletonDataMgr::getSkeletonDataInfos() const {
+    std::vector<SkeletonDataInfo *> infos;
+    infos.reserve(_dataMap.size());
+    for (const auto &pair : _dataMap) {
+        infos.push_back(pair.second);
+    }
+    return infos;
 }
 
 SkeletonData *SkeletonDataMgr::retainByUUID(const std::string &uuid) {

--- a/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include "AttachmentVertices.h"
 #include "base/RefCounted.h"
 #include "spine/SkeletonData.h"
 #include "spine/spine.h"
@@ -41,8 +42,21 @@
 using namespace spine;
 namespace cc {
 
-class SkeletonDataInfo;
 class AttachmentVertices;
+
+
+class SkeletonDataInfo {
+public:
+    SkeletonDataInfo() = default;
+
+    ~SkeletonDataInfo();
+
+    SkeletonData *data = nullptr;
+    Atlas *atlas = nullptr;
+    AttachmentLoader *attachmentLoader = nullptr;
+    std::vector<int> texturesIndex;
+    std::unordered_map<Attachment *, AttachmentVertices *> attachmentVerticesMap;
+};
 
 /**
  * Cache skeleton data.
@@ -73,13 +87,14 @@ public:
     // equal to 'deleteByUUID'
     void releaseByUUID(const std::string &uuid);
 
-    std::unordered_map<Attachment *, AttachmentVertices *>
-        *getSkeletonDataInfo(const std::string &uuid);
+    SkeletonDataInfo *getSkeletonDataInfo(const std::string &uuid);
 
     using destroyCallback = std::function<void(int)>;
     void setDestroyCallback(destroyCallback callback) {
         _destroyCallback = std::move(callback);
     }
+
+    std::vector<SkeletonDataInfo*> getSkeletonDataInfos() const;
 
 private:
     static SkeletonDataMgr *instance;

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -67,6 +67,21 @@ enum DebugType {
 
 extern "C" AttachmentVertices *generateAttachmentVertices(Attachment *attachment);
 namespace cc {
+
+/**
+ * The slot-associated attachment may exist on different skeletonData, so setSlotTexture needs to traverse all skeletonData.
+ */
+AttachmentVertices *getAttachmentVertices(Attachment *attachment) {
+    const auto &vecInfos = SkeletonDataMgr::getInstance()->getSkeletonDataInfos();
+    for (const auto &info : vecInfos) {
+        auto &attachmentVerticesMap = info->attachmentVerticesMap;
+        if (attachmentVerticesMap.count(attachment) > 0) {
+            return attachmentVerticesMap[attachment];
+        }
+    }
+    return nullptr;
+}
+
 SkeletonRenderer *SkeletonRenderer::create() {
     return new SkeletonRenderer();
 }
@@ -412,9 +427,9 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
    void *effect = nullptr;
 #endif
 
-    auto *verticesMap = SkeletonDataMgr::getInstance()->getSkeletonDataInfo(_uuid);
-    if (!verticesMap) return;
-    auto &attachmentVerticesMap = *verticesMap;
+    auto *skeletonDataInfo = SkeletonDataMgr::getInstance()->getSkeletonDataInfo(_uuid);
+    if (!skeletonDataInfo) return;
+    auto &attachmentVerticesMap = skeletonDataInfo->attachmentVerticesMap;
     auto &drawOrder = _skeleton->getDrawOrder();
     for (size_t i = 0, n = drawOrder.size(); i < n; ++i) {
         isFull = 0;
@@ -1160,10 +1175,7 @@ void SkeletonRenderer::setSlotTexture(const std::string &slotName, cc::Texture2D
     if (!attachment) return;
     auto width = tex2d->getWidth();
     auto height = tex2d->getHeight();
-    auto *verticesMap = SkeletonDataMgr::getInstance()->getSkeletonDataInfo(_uuid);
-    if (!verticesMap) return;
-    auto &attachmentVerticesMap = *verticesMap;
-    auto *attachmentVertices = attachmentVerticesMap.at(attachment);
+    auto *attachmentVertices = getAttachmentVertices(slot->getAttachment());
 
     if (createAttachment) {
         attachment = attachment->copy();

--- a/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/native/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -464,7 +464,8 @@ void SkeletonRenderer::render(float /*deltaTime*/) {
         if (iterAttachment != attachmentVerticesMap.end()) {
             attachmentVertices = iterAttachment->second;
         } else {
-            attachmentVertices = nullptr;
+            //attachment maybe set from other skeletonData
+            attachmentVertices = getAttachmentVertices(tmpAttachment);
         }
 
         auto iter = _slotTextureSet.find(slot);

--- a/native/tools/swig-config/spine_3_8.i
+++ b/native/tools/swig-config/spine_3_8.i
@@ -52,6 +52,7 @@ using namespace spine;
 %ignore spine::Polygon::Polygon;
 %ignore spine::Polygon::_vertices;
 
+%ignore cc::SkeletonDataInfo;
 %ignore cc::SlotCacheInfo;
 %ignore cc::SkeletonRenderer::create;
 %ignore cc::SkeletonRenderer::initWithJsonFile;
@@ -116,6 +117,7 @@ using namespace spine;
 %ignore cc::SkeletonDataMgr::retainByUUID;
 %ignore cc::SkeletonDataMgr::releaseByUUID;
 %ignore cc::SkeletonDataMgr::getSkeletonDataInfo;
+%ignore cc::SkeletonDataMgr::getSkeletonDataInfos();
 %ignore cc::SkeletonCacheAnimation::render;
 %ignore cc::SkeletonCacheAnimation::requestDrawInfo;
 %ignore cc::SkeletonCacheAnimation::requestMaterial;

--- a/native/tools/swig-config/spine_4_2.i
+++ b/native/tools/swig-config/spine_4_2.i
@@ -51,6 +51,7 @@ using namespace spine;
 %ignore spine::Polygon::Polygon;
 %ignore spine::Polygon::_vertices;
 
+%ignore cc::SkeletonDataInfo;
 %ignore cc::SlotCacheInfo;
 %ignore cc::SkeletonRenderer::create;
 %ignore cc::SkeletonRenderer::initWithJsonFile;
@@ -114,6 +115,7 @@ using namespace spine;
 %ignore cc::SkeletonDataMgr::retainByUUID;
 %ignore cc::SkeletonDataMgr::releaseByUUID;
 %ignore cc::SkeletonDataMgr::getSkeletonDataInfo;
+%ignore cc::SkeletonDataMgr::getSkeletonDataInfos();
 %ignore cc::SkeletonCacheAnimation::render;
 %ignore cc::SkeletonCacheAnimation::requestDrawInfo;
 %ignore cc::SkeletonCacheAnimation::requestMaterial;


### PR DESCRIPTION
Re: #
https://github.com/cocos/cocos-engine/pull/18810
https://forum.cocos.org/t/topic/169762
https://forum.cocos.org/t/topic/167558/1136

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
