### PR TITLE
将 UIRenderer 的 _fillColorType 属性 改为  protected 

### DIFF
--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -355,6 +355,7 @@ export class UIRenderer extends Renderer {
 
     public onLoad (): void {
         this._renderEntity.setNode(this.node);
+        this._renderEntity.setFillColorType(this._fillColorType);
     }
 
     public __preload (): void {

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -311,7 +311,7 @@ export class UIRenderer extends Renderer {
      * @en UI rendering component fill color type, COLOR means using color property value to fill, VERTEX means using vertex color value to fill.
      * @zh UI 渲染组件填充颜色类型，COLOR 表示使用 color 属性值填充，VERTEX 表示使用顶点颜色值填充。
      */
-    private _fillColorType = RenderEntityFillColorType.COLOR;
+    protected _fillColorType: RenderEntityFillColorType = RenderEntityFillColorType.COLOR;
 
     /**
      * @engineInternal

--- a/cocos/particle-2d/motion-streak-2d.ts
+++ b/cocos/particle-2d/motion-streak-2d.ts
@@ -73,10 +73,7 @@ export class Point {
 export class MotionStreak extends UIRenderer {
     public static Point = Point;
 
-    constructor () {
-        super();
-        this.setFillColorType(RenderEntityFillColorType.VERTEX);
-    }
+    protected _fillColorType = RenderEntityFillColorType.VERTEX;
 
     /**
      * @en Preview the trailing effect in editor mode.


### PR DESCRIPTION
修改理由: 
1. 子类可以更方便的操作该属性
2. 子类中 如果 _fillColorType 的默认值不同, 可以直接设置, 不用再麻烦的弄个构造函数.   (可以参考 MotionStreak 的更改)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Changed `UIRenderer._fillColorType` from private to protected with explicit type annotation, allowing subclasses to override the default value directly through property initialization instead of requiring a constructor.

- Simplified `MotionStreak` by removing its constructor and directly setting `_fillColorType = RenderEntityFillColorType.VERTEX`
- Added `_renderEntity.setFillColorType(this._fillColorType)` call in `UIRenderer.onLoad()` to ensure the render entity is properly configured with the (potentially overridden) fill color type
- Added explicit type annotation `: RenderEntityFillColorType` to `_fillColorType` property for better type safety

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-designed and improve code quality. The visibility change from private to protected follows proper OOP encapsulation principles, the explicit type annotation improves type safety, and the addition of `setFillColorType()` in `onLoad()` ensures proper initialization. The refactoring of `MotionStreak` demonstrates the benefit of this change by eliminating boilerplate constructor code. This is a clean refactoring with no functional changes to existing behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cocos/2d/framework/ui-renderer.ts | Changed `_fillColorType` from private to protected with explicit type annotation, added initialization call in `onLoad()` |
| cocos/particle-2d/motion-streak-2d.ts | Removed constructor, now directly initializes `_fillColorType` as a protected property with VERTEX value |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Subclass as MotionStreak (Subclass)
    participant Base as UIRenderer (Base)
    participant Entity as RenderEntity
    
    Note over Subclass,Entity: Before PR: Constructor approach
    Subclass->>Base: constructor()
    Base->>Base: _fillColorType = COLOR (default)
    Base->>Entity: createRenderEntity()
    Subclass->>Base: setFillColorType(VERTEX)
    Base->>Base: _fillColorType = VERTEX
    Base->>Entity: setFillColorType(VERTEX)
    
    Note over Subclass,Entity: After PR: Property override approach
    Subclass->>Subclass: _fillColorType = VERTEX (property initialization)
    Subclass->>Base: constructor()
    Base->>Base: (skips _fillColorType init, already set)
    Base->>Entity: createRenderEntity()
    Note over Base: onLoad() lifecycle
    Base->>Entity: setFillColorType(_fillColorType)
    Entity->>Entity: Applies VERTEX value
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->