### PR TITLE
label.ts 中统一使用 _renderData .

### DIFF
--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -963,7 +963,7 @@ export class Label extends UIRenderer {
             this._flushAssembler();
             // Hack: Fixed the bug that richText wants to get the label length by _measureText,
             // _assembler.updateRenderData will update the content size immediately.
-            if (this.renderData) this.renderData.vertDirty = true;
+            if (this._renderData) this._renderData.vertDirty = true;
             this._applyFontTexture();
         }
         if (this._assembler) {
@@ -972,7 +972,7 @@ export class Label extends UIRenderer {
     }
 
     protected _render (render: IBatcher): void {
-        render.commitComp(this, this.renderData, this._texture, this._assembler!, null);
+        render.commitComp(this, this._renderData, this._texture, this._assembler!, null);
     }
 
     // Cannot use the base class methods directly because BMFont and CHAR cannot be updated in assambler with just color.
@@ -1024,10 +1024,10 @@ export class Label extends UIRenderer {
             this.textRenderData.reset();
         }
 
-        if (!this.renderData) {
+        if (!this._renderData) {
             if (this._assembler && this._assembler.createData) {
                 this._renderData = this._assembler.createData(this) as RenderData;
-                this.renderData!.material = this.material;
+                this._renderData.material = this.material;
                 this._updateColor();
             }
         }
@@ -1040,8 +1040,8 @@ export class Label extends UIRenderer {
             const spriteFrame = font.spriteFrame;
             if (spriteFrame && spriteFrame.texture) {
                 this._texture = spriteFrame;
-                if (this.renderData) {
-                    this.renderData.textureDirty = true;
+                if (this._renderData) {
+                    this._renderData.textureDirty = true;
                 }
                 this.changeMaterialForDefine();
                 if (this._assembler) {


### PR DESCRIPTION
label 内部有 _renderData，同时提供了 get renderData。

目前版本中， label.ts 内部时而用  this.renderData , 时而用 this._renderData . 很不统一。

同时，本着尽量减少非必要的function-call 的原则, 统一改为 this._renderData，有助于性能提升。

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
