### PR TITLE
Update base.ts, 导出一些渲染相关的接口

### DIFF
--- a/cocos/2d/renderer/base.ts
+++ b/cocos/2d/renderer/base.ts
@@ -31,6 +31,11 @@ import type { UIRenderer } from '../framework/ui-renderer';
 import type { IBatcher } from './i-batcher';
 import type { BaseRenderData } from './render-data';
 
+export type { IBatcher } from './i-batcher';
+export { StaticVBAccessor, StaticVBChunk } from './static-vb-accessor';
+export { RenderDrawInfo, RenderDrawInfoType } from './render-draw-info';
+export { RenderEntity, RenderEntityType, RenderEntityFillColorType } from './render-entity';
+
 /**
  * @internal
  */

--- a/cocos/2d/renderer/base.ts
+++ b/cocos/2d/renderer/base.ts
@@ -36,6 +36,8 @@ export type { Batcher2D } from './batcher-2d';
 export { StaticVBAccessor, StaticVBChunk } from './static-vb-accessor';
 export { RenderDrawInfo, RenderDrawInfoType } from './render-draw-info';
 export { RenderEntity, RenderEntityType, RenderEntityFillColorType } from './render-entity';
+export { Stage, StencilManager } from './stencil-manager';
+
 
 /**
  * @internal

--- a/cocos/2d/renderer/base.ts
+++ b/cocos/2d/renderer/base.ts
@@ -32,6 +32,7 @@ import type { IBatcher } from './i-batcher';
 import type { BaseRenderData } from './render-data';
 
 export type { IBatcher } from './i-batcher';
+export type { Batcher2D } from './batcher-2d';
 export { StaticVBAccessor, StaticVBChunk } from './static-vb-accessor';
 export { RenderDrawInfo, RenderDrawInfoType } from './render-draw-info';
 export { RenderEntity, RenderEntityType, RenderEntityFillColorType } from './render-entity';


### PR DESCRIPTION
这些接口不需要写入文档. 给那些愿意阅读 cocos 代码以及对 cocos 进行扩展的高级 cocos 开发者使用.
主要是用来在项目中实现自己的 UIRenderer子类 和 Assembler .

经过一段时间的尝试, 总结了一下 这个PR 里的类和接口是一定要导出的, 否则很难扩展.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds exports for `Stage` enum and `StencilManager` class from the stencil-manager module to `base.ts`, completing a series of export additions for advanced Cocos developers.

- Part of an incremental effort to expose rendering internals for custom UIRenderer subclasses and Assembler implementations
- Previous commits already exported `IBatcher`, `Batcher2D`, `StaticVBAccessor`, `StaticVBChunk`, `RenderDrawInfo`, `RenderDrawInfoType`, `RenderEntity`, `RenderEntityType`, and `RenderEntityFillColorType`
- The exported `Stage` enum is marked as `@deprecated since v3.7.0` in the source file with a note that it's an "engine private interface that will be removed in the future"
- The exported `StencilManager` class has the same deprecation warning
- Exporting deprecated/internal interfaces increases maintenance burden and creates implicit API contracts

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor concern about exporting deprecated interfaces
- The change is syntactically correct and consistent with previous commits in this series. All exported items exist and are already exported from their source modules. However, exporting `Stage` and `StencilManager` which are explicitly marked as `@deprecated since v3.7.0` with warnings about future removal creates a tension between supporting advanced use cases and maintaining a stable API surface. The PR description acknowledges these are for advanced developers willing to read engine code, but doesn't address the deprecation status.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cocos/2d/renderer/base.ts | Adds exports for `Stage` and `StencilManager` from stencil-manager module to support custom UIRenderer and Assembler implementations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Advanced Developer
    participant Base as base.ts (Module Entry)
    participant SM as stencil-manager.ts
    participant Index as 2d/index.ts
    participant App as User Application
    
    Note over Base: PR adds Stage & StencilManager exports
    
    Dev->>Base: Import rendering interfaces
    Base->>SM: Re-export Stage enum
    Base->>SM: Re-export StencilManager class
    
    Base->>Index: Exported via export * from './renderer/base'
    Index->>App: Available for custom UIRenderer implementations
    
    Note over App: Enables extending UIRenderer<br/>and creating custom Assemblers
    
    App->>SM: Use Stage for stencil states
    App->>SM: Use StencilManager for stencil operations
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->