### PR TITLE
Optimize LabelComponent

### DIFF
--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -278,10 +278,10 @@ export class Label extends UIRenderer {
 
     /**
      * @en
-     * The actual rendering font size in shrink mode.
+     * The actual rendering font size.
      *
      * @zh
-     * SHRINK 模式下面文本实际渲染的字体大小。
+     * 文本实际渲染的字体大小。
      */
     get actualFontSize (): number {
         return this._actualFontSize;
@@ -460,14 +460,12 @@ export class Label extends UIRenderer {
     @displayOrder(13)
     @visible(function (this: Label) { return !this._isSystemFontUsed; })
     get font (): Font | null {
-        // return this._N$file;
         return this._font;
     }
     set font (value) {
         if (this._font === value) {
             return;
         }
-
         // if delete the font, we should change isSystemFontUsed to true
         this._isSystemFontUsed = !value;
 
@@ -475,10 +473,7 @@ export class Label extends UIRenderer {
             this._userDefinedFont = value;
         }
 
-        // this._N$file = value;
         this._font = value;
-        // if (value && this._isSystemFontUsed)
-        //     this._isSystemFontUsed = false;
 
         this.destroyRenderData();
 
@@ -797,8 +792,6 @@ export class Label extends UIRenderer {
     @serializable
     protected _verticalAlign = VerticalTextAlignment.CENTER;
     @serializable
-    protected _actualFontSize = 0;
-    @serializable
     protected _fontSize = 40;
     @serializable
     protected _fontFamily = 'Arial';
@@ -840,8 +833,7 @@ export class Label extends UIRenderer {
     protected _shadowBlur = 2;
 
     // don't need serialize
-    // 这个保存了旧项目的 file 数据
-    protected _N$file: Font | null = null;
+    protected _actualFontSize = 0;
     protected _texture: SpriteFrame | LetterRenderTexture | null = null;
     protected _ttfSpriteFrame: SpriteFrame | null = null;
     protected _userDefinedFont: Font | null = null;


### PR DESCRIPTION
Re: #

### Changelog

* en: cc.Label._actualFontSize does not need to be serialized, as it will be calculated in real-time during actual rendering.
* zh: cc.Label._actualFontSize 没有必要序列化，实际渲染时会实时计算

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
