### PR TITLE
fixed minigame failed to read files after executing clearLRU

### DIFF
--- a/cocos/asset/asset-manager/release-manager.ts
+++ b/cocos/asset/asset-manager/release-manager.ts
@@ -259,6 +259,7 @@ export class ReleaseManager {
         }
         dependUtil.remove(uuid);
         files.remove(asset.uuid + "@import");
+        files.remove(asset.uuid + "@native");
         if (EDITOR) {
             const dependant = references!.get(uuid);
             if (dependant && dependant.length === 0) {

--- a/cocos/asset/asset-manager/release-manager.ts
+++ b/cocos/asset/asset-manager/release-manager.ts
@@ -28,7 +28,7 @@ import { isValid, js, misc } from '../../core';
 import { Node, Scene } from '../../scene-graph';
 import Cache from './cache';
 import dependUtil from './depend-util';
-import { assets, references } from './shared';
+import { assets, files, references } from './shared';
 
 function visitAsset (asset: Asset, deps: string[]): void {
     // Skip assets generated programmatically or by user (e.g. label texture)
@@ -258,6 +258,7 @@ export class ReleaseManager {
             asset.destroy();
         }
         dependUtil.remove(uuid);
+        files.remove(asset.uuid + "@import");
         if (EDITOR) {
             const dependant = references!.get(uuid);
             if (dependant && dependant.length === 0) {

--- a/platforms/minigame/common/engine/cache-manager.js
+++ b/platforms/minigame/common/engine/cache-manager.js
@@ -190,8 +190,7 @@ const cacheManager = {
             caches.length = Math.floor(caches.length / 3);
         }
         for (let i = 0, l = caches.length; i < l; i++) {
-            const cacheKey = `${cc.assetManager.utils.getUuidFromURL(caches[i].originUrl)}@native`;
-            cc.assetManager.files.remove(cacheKey);
+            this.removeAssetManagerFileCahce(caches[i].originUrl);
             this.cachedFiles.remove(caches[i].originUrl);
         }
 
@@ -231,7 +230,17 @@ const cacheManager = {
         }
     },
 
-    _deleteFileCB (err) {
+    removeAssetManagerFileCahce(url) {
+        if (url.indexOf(".json") > -1) {
+            const cacheImportKey = cc.assetManager.utils.getUuidFromURL(url) + "@import";
+            cc.assetManager._files.remove(cacheImportKey);
+        } else {
+            const cacheNativeKey = cc.assetManager.utils.getUuidFromURL(url) + "@native";
+            cc.assetManager._files.remove(cacheNativeKey);
+        }
+    },
+
+    _deleteFileCB(err) {
         if (!err) this.outOfStorage = false;
     },
 


### PR DESCRIPTION
在 https://github.com/cocos/cocos-engine/pull/16707 的基础上，进一步修复了可能因为依赖资源被删除后，资源缓存对象没有同步删除，从而导致的资源加载失败问题。
On the basis of https://github.com/cocos/cocos-engine/pull/16707, the problem of resource loading failure may be caused by the fact that the resource cache object is not deleted synchronously after the dependent resource is deleted.