### PR TITLE
Update batcher-2d.ts , 删除无用代码

### DIFF
--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -486,51 +486,6 @@ export class Batcher2D implements IBatcher {
 
     /**
      * @en
-     * Render component data submission process for individual [[gfx.InputAssembler]]
-     * @zh
-     * 渲染组件中针对独立 [[gfx.InputAssembler]] 的提交流程
-     * 例如：Spine 和 DragonBones 等包含动态数据和材质的组件在内部管理 IA 并提交批次
-     * @param comp - The committed renderable component
-     * @param ia - The committed [[gfx.InputAssembler]]
-     * @param tex - The texture used
-     * @param mat - The material used
-     * @param [transform] - The related node transform if the render data is based on node's local coordinates
-     * @deprecated since v3.6.2, please use [[commitMiddleware]] instead
-     */
-    public commitIA (renderComp: UIRenderer, ia: InputAssembler, tex?: TextureBase, mat?: Material, transform?: Node): void {
-        // if the last comp is spriteComp, previous comps should be batched.
-        if (this._currMaterial !== this._emptyMaterial) {
-            this.autoMergeBatches(this._currComponent!);
-            this.resetRenderStates();
-        }
-        let depthStencil: DepthStencilState | null = null;
-        let dssHash = 0;
-        if (renderComp) {
-            renderComp.stencilStage = StencilManager.sharedManager!.stage;
-            if (renderComp.customMaterial !== null) {
-                depthStencil = StencilManager.sharedManager!.getStencilStage(renderComp.stencilStage, mat);
-            } else {
-                depthStencil = StencilManager.sharedManager!.getStencilStage(renderComp.stencilStage);
-            }
-            dssHash = StencilManager.sharedManager!.getStencilHash(renderComp.stencilStage);
-        }
-
-        const curDrawBatch = this._currStaticRoot ? this._currStaticRoot._requireDrawBatch() : this._drawBatchPool.alloc();
-        curDrawBatch.visFlags = renderComp.node.layer;
-        curDrawBatch.inputAssembler = ia;
-        curDrawBatch.useLocalData = transform || null;
-        if (tex) {
-            curDrawBatch.texture = tex.getGFXTexture();
-            curDrawBatch.sampler = tex.getGFXSampler();
-            curDrawBatch.textureHash = tex.getHash();
-            curDrawBatch.samplerHash = curDrawBatch.sampler.hash;
-        }
-        curDrawBatch.fillPasses(mat || null, depthStencil, dssHash, null);
-        this._batches.push(curDrawBatch);
-    }
-
-    /**
-     * @en
      * Render component data submission process for middleware2d components
      * @zh
      * 渲染组件中针对2D中间件组件渲染数据的提交流程


### PR DESCRIPTION
删除不再使用的 `commitIA()` 方法.
 这个 Batcher2D 类你们从来没有暴路出来过 ,  cocos 的用户们几乎不可能用到 commitIA() 方法.
而你们代码内部 也没有用.
因为 `@deprecated since v3.6.2, please use [[commitMiddleware]] instead` .

现在你们内部都在用 commitMiddleware 了.

所以这个 方法删了吧.
你们不是总想着缩小代码体积吗, 这种没用过的方法能删尽量删吧.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
