### PR TITLE
Use a better approach to address the issue in PR #18052, while fixing the problem where material cannot be read in the onEnable callback.

### DIFF
--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -1027,7 +1027,7 @@ export class Label extends UIRenderer {
         if (!this.renderData) {
             if (this._assembler && this._assembler.createData) {
                 this._renderData = this._assembler.createData(this) as RenderData;
-                this.renderData!.material = this.getSharedMaterial(0);
+                this.renderData!.material = this.getRenderMaterial(0);
                 this._updateColor();
             }
         }

--- a/cocos/2d/components/label.ts
+++ b/cocos/2d/components/label.ts
@@ -1027,7 +1027,7 @@ export class Label extends UIRenderer {
         if (!this.renderData) {
             if (this._assembler && this._assembler.createData) {
                 this._renderData = this._assembler.createData(this) as RenderData;
-                this.renderData!.material = this.material;
+                this.renderData!.material = this.getSharedMaterial(0);
                 this._updateColor();
             }
         }

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -398,9 +398,7 @@ export class UIRenderer extends Renderer {
         this.node.off(NodeEventType.ANCHOR_CHANGED, this._nodeStateChange, this);
         this.node.off(NodeEventType.SIZE_CHANGED, this._nodeStateChange, this);
         this.node.off(NodeEventType.PARENT_CHANGED, this._colorDirty, this);
-        // When disabling, it is necessary to free up idle space to fully utilize chunks
-        // and avoid breaking batch processing.
-        this._destroyData();
+        this.destroyRenderData();
         uiRendererManager.removeRenderer(this);
         this._renderFlag = false;
         this._renderEntity.enabled = false;


### PR DESCRIPTION
Fixed https://github.com/cocos/cocos-engine/pull/18052 causing the output getSharedMaterial(0) in the onEnable callback to become null when nodes were repeatedly displayed hidden
修复因 https://github.com/cocos/cocos-engine/pull/18052 导致的节点重复显示隐藏时 onEnable 回调中输出的 getSharedMaterial(0) 变为 null