### PR TITLE
Fix the issue where the input field position is incorrect after the keyboard pops up on an Android pad.

### DIFF
--- a/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
+++ b/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
@@ -70,6 +70,7 @@ public class CocosEditBoxActivity extends Activity {
     private boolean mConfirmHold = true;
     private int mEditTextID = 1;
     private int mButtonLayoutID = 2;
+    private int mInitialSystemWindowInsetBottom = -1;
 
     /***************************************************************************************
      Inner class.
@@ -208,13 +209,13 @@ public class CocosEditBoxActivity extends Activity {
             this.removeTextChangedListener(mTextWatcher);
         }
 
-        private boolean isSystemAdjustUIWhenPopKeyboard(int bottom) {
+        private boolean isSystemAdjustUIWhenPopKeyboard() {
             int bottomOffset = 0;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 bottomOffset = getWindow().getDecorView().getRootWindowInsets().getSystemWindowInsetBottom();
             }
             // view will be scrolled to the target position by system,
-            if (Math.abs(bottom - bottomOffset) < 10) {
+            if (Math.abs(mInitialSystemWindowInsetBottom - bottomOffset) > 100) {
                 return true;
             }
             return false;
@@ -232,7 +233,7 @@ public class CocosEditBoxActivity extends Activity {
                         if (!keyboardVisible) {
                             keyboardVisible = true;
                         }
-                        if (!isSystemAdjustUIWhenPopKeyboard(heightDiff)) {
+                        if (!isSystemAdjustUIWhenPopKeyboard()) {
                             getRootView().scrollTo(0, heightDiff);
                         }
                     } else {
@@ -293,6 +294,14 @@ public class CocosEditBoxActivity extends Activity {
                 extras.getBoolean("confirmHold"),
                 extras.getString("confirmType"),
                 extras.getString("inputType"));
+        }
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        View decorView = getWindow().getDecorView();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            mInitialSystemWindowInsetBottom = decorView.getRootWindowInsets().getSystemWindowInsetBottom();
         }
     }
 

--- a/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
+++ b/native/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
@@ -62,6 +62,7 @@ public class CocosEditBoxActivity extends Activity {
     // a color of dark green, was used for confirm button background
     private static final int DARK_GREEN = Color.parseColor("#1fa014");
     private static final int DARK_GREEN_PRESS = Color.parseColor("#008e26");
+    private static final String ORIENTATION = "orientation";
 
     private static CocosEditBoxActivity sThis = null;
     private Cocos2dxEditText mEditText = null;
@@ -288,6 +289,8 @@ public class CocosEditBoxActivity extends Activity {
                 "text"
                 );
         } else {
+            int orientation = extras.getInt(ORIENTATION);
+            setRequestedOrientation(orientation);
             show(extras.getString("defaultValue"),
                 extras.getInt("maxLength"),
                 extras.getBoolean("isMultiline"),
@@ -443,6 +446,7 @@ public class CocosEditBoxActivity extends Activity {
                 i.putExtra("confirmHold", confirmHold);
                 i.putExtra("confirmType", confirmType);
                 i.putExtra("inputType", inputType);
+                i.putExtra(ORIENTATION, GlobalObject.getActivity().getRequestedOrientation());
                 GlobalObject.getActivity().startActivity(i);
             }
         });


### PR DESCRIPTION
Re: #
https://github.com/cocos/3d-tasks/issues/19124

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
