### PR TITLE
Fix the OpenGL error caused by a mismatch between the vertexCount stored in renderData and the actual value.

### DIFF
--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -360,6 +360,11 @@ export class RenderData extends BaseRenderData {
         }
     }
 
+    public updateSize (vertexCount: number, indexCount: number): void {
+        this._vc = vertexCount;
+        this._ic = indexCount;
+    }
+
     /** @mangle */
     protected override setRenderDrawInfoAttributes (): void {
         if (JSB) {

--- a/cocos/spine/assembler/simple.ts
+++ b/cocos/spine/assembler/simple.ts
@@ -158,10 +158,12 @@ function realTimeTraverse (comp: Skeleton): void {
     if (!rd || vc < 1 || ic < 1) return;
 
     if (rd.vertexCount !== vc || rd.indexCount !== ic) {
-        if (rd.vertexCount < vc || rd.indexCount < ic) {
-            rd.resize(Math.ceil(vc * ADJUST_SIZE_RATE), Math.ceil(ic * ADJUST_SIZE_RATE));
-        }
         comp._vLength = vc * Float32Array.BYTES_PER_ELEMENT * floatStride;
+        if (!rd.chunk || rd.chunk.vb.byteLength < comp._vLength || rd.chunk.indexCount < ic)  {
+            rd.resize(Math.ceil(vc * ADJUST_SIZE_RATE), Math.ceil(ic * ADJUST_SIZE_RATE));
+        } else if (rd.chunk) {
+            rd.updateSize(vc, ic);
+        }
         comp._vBuffer = new Uint8Array(rd.chunk.vb.buffer, rd.chunk.vb.byteOffset, comp._vLength);
         comp._iLength = Uint16Array.BYTES_PER_ELEMENT * ic;
     }
@@ -284,8 +286,10 @@ function cacheTraverse (comp: Skeleton): void {
     const rd = comp.renderData;
     if (!rd || vc < 1 || ic < 1) return;
     if (rd.vertexCount !== vc || rd.indexCount !== ic) {
-        if (rd.vertexCount < vc || rd.indexCount < ic) {
+        if (!rd.chunk || rd.chunk.vb.byteLength < vc * Float32Array.BYTES_PER_ELEMENT * _byteStrideTwoColor || rd.chunk.indexCount < ic) {
             rd.resize(Math.ceil(vc * ADJUST_SIZE_RATE), Math.ceil(ic * ADJUST_SIZE_RATE));
+        } else if (rd.chunk) {
+            rd.updateSize(vc, ic);
         }
     }
     if (!rd.indices || rd.indices.length < ic) {


### PR DESCRIPTION
Re: #
https://forum.cocos.org/t/topic/167558/1411

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
