### PR TITLE
Use PROP_ENABLE_COMPRESS_SO to control whether dynamic libraries are compressed in Android build outputs

### DIFF
--- a/.github/workflows/native-compile-platforms.yml
+++ b/.github/workflows/native-compile-platforms.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r21e
+          ndk-version: r28b
           add-to-path: false
           local-cache: true
       - uses: actions/setup-java@v4
@@ -93,6 +93,7 @@ jobs:
         run: |
           NATIVE_ROOT=$GITHUB_WORKSPACE/native
           ANDROID_NDK=${{ steps.setup-ndk.outputs.ndk-path }}
+          NDK_VERSION=${{ steps.setup-ndk.outputs.ndk-full-version }}
           NATIVE_DIR=$GITHUB_WORKSPACE/templates/android-template
           echo "Compiling Android ... "
           cd $GITHUB_WORKSPACE/templates/
@@ -119,7 +120,7 @@ jobs:
 
           ASSET_DIR=$GITHUB_WORKSPACE/templates/android/build/build-android/
 
-          sed -i "s@^PROP_NDK_PATH.*@PROP_NDK_PATH=$ANDROID_NDK@g" gradle.properties
+          sed -i "s@^PROP_NDK_VERSION.*@PROP_NDK_VERSION=$NDK_VERSION@g" gradle.properties
           sed -i "s@^APPLICATION_ID.*@APPLICATION_ID=com.cocos.android@g" gradle.properties
           sed -i "s@^RES_PATH.*@RES_PATH=$ASSET_DIR@g" gradle.properties
           sed -i "s@^COCOS_ENGINE_PATH.*@COCOS_ENGINE_PATH=$NATIVE_ROOT@g" gradle.properties
@@ -178,7 +179,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r21e
+          ndk-version: r28b
           add-to-path: false
           local-cache: true
       - uses: actions/setup-java@v4
@@ -192,6 +193,7 @@ jobs:
         run: |
           NATIVE_ROOT=$GITHUB_WORKSPACE/native
           ANDROID_NDK=${{ steps.setup-ndk.outputs.ndk-path }}
+          NDK_VERSION=${{ steps.setup-ndk.outputs.ndk-full-version }}
           NATIVE_DIR=$GITHUB_WORKSPACE/templates/android-template
           echo "Compiling Android ... "
           cd $GITHUB_WORKSPACE/templates/
@@ -228,7 +230,7 @@ jobs:
 
           ASSET_DIR=$GITHUB_WORKSPACE/templates/android/build/build-android/
 
-          sed -i "s@^PROP_NDK_PATH.*@PROP_NDK_PATH=$ANDROID_NDK@g" gradle.properties
+          sed -i "s@^PROP_NDK_VERSION.*@PROP_NDK_VERSION=$NDK_VERSION@g" gradle.properties
           sed -i "s@^APPLICATION_ID.*@APPLICATION_ID=com.cocos.android@g" gradle.properties
           sed -i "s@^RES_PATH.*@RES_PATH=$ASSET_DIR@g" gradle.properties
           sed -i "s@^COCOS_ENGINE_PATH.*@COCOS_ENGINE_PATH=$NATIVE_ROOT@g" gradle.properties

--- a/native/cocos/core/scene-graph/Node.cpp
+++ b/native/cocos/core/scene-graph/Node.cpp
@@ -57,7 +57,14 @@ Node::Node(const ccstd::string &name) {
     _colorDirty = 1;
     
 #define NODE_SHARED_MEMORY_BYTE_LENGTH (36)
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+#endif
     static_assert(offsetof(Node, _finalOpacity) + sizeof(_finalOpacity) - offsetof(Node, _eventMask) == NODE_SHARED_MEMORY_BYTE_LENGTH, "Wrong shared memory size");
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     _sharedMemoryActor.initialize(&_eventMask, NODE_SHARED_MEMORY_BYTE_LENGTH);
 #undef NODE_SHARED_MEMORY_BYTE_LENGTH
 

--- a/native/cocos/platform/android/jni/JniCocosSurfaceView.cpp
+++ b/native/cocos/platform/android/jni/JniCocosSurfaceView.cpp
@@ -219,14 +219,14 @@ JNIEXPORT void JNICALL Java_com_cocos_lib_CocosTouchHandler_handleActionMove(JNI
 
     touchEvent.windowId = windowId;
     touchEvent.type = cc::TouchEvent::Type::MOVED;
-    int size = env->GetArrayLength(ids);
-    jint id[size];
-    jfloat x[size];
-    jfloat y[size];
+    const int size = env->GetArrayLength(ids);
+    std::vector<jint> id(size);
+    std::vector<jfloat> x(size);
+    std::vector<jfloat> y(size);
 
-    env->GetIntArrayRegion(ids, 0, size, id);
-    env->GetFloatArrayRegion(xs, 0, size, x);
-    env->GetFloatArrayRegion(ys, 0, size, y);
+    env->GetIntArrayRegion(ids, 0, size, id.data());
+    env->GetFloatArrayRegion(xs, 0, size, x.data());
+    env->GetFloatArrayRegion(ys, 0, size, y.data());
     for (int i = 0; i < size; i++) {
         touchEvent.touches.emplace_back(x[i], y[i], id[i]);
     }
@@ -246,14 +246,14 @@ JNIEXPORT void JNICALL Java_com_cocos_lib_CocosTouchHandler_handleActionCancel(J
 
     touchEvent.windowId = windowId;
     touchEvent.type = cc::TouchEvent::Type::CANCELLED;
-    int size = env->GetArrayLength(ids);
-    jint id[size];
-    jfloat x[size];
-    jfloat y[size];
+    const int size = env->GetArrayLength(ids);
+    std::vector<jint> id(size);
+    std::vector<jfloat> x(size);
+    std::vector<jfloat> y(size);
 
-    env->GetIntArrayRegion(ids, 0, size, id);
-    env->GetFloatArrayRegion(xs, 0, size, x);
-    env->GetFloatArrayRegion(ys, 0, size, y);
+    env->GetIntArrayRegion(ids, 0, size, id.data());
+    env->GetFloatArrayRegion(xs, 0, size, x.data());
+    env->GetFloatArrayRegion(ys, 0, size, y.data());
     for (int i = 0; i < size; i++) {
         touchEvent.touches.emplace_back(x[i], y[i], id[i]);
     }

--- a/scripts/native-pack-tool/source/platforms/android.ts
+++ b/scripts/native-pack-tool/source/platforms/android.ts
@@ -21,6 +21,7 @@ export interface IAndroidParams {
     javaHome: string;
     javaPath: string;
     androidInstant: boolean,
+    isSoFileCompressed: boolean;
     maxAspectRatio: string;
     remoteUrl?: string;
     apiLevel: number;
@@ -363,13 +364,22 @@ export class AndroidPackTool extends NativePackTool {
             content = content.replace(/COCOS_ENGINE_PATH=.*/, `COCOS_ENGINE_PATH=${cchelper.fixPath(Paths.nativeRoot)}`);
             content = content.replace(/APPLICATION_ID=.*/, `APPLICATION_ID=${options.packageName}`);
             content = content.replace(/NATIVE_DIR=.*/, `NATIVE_DIR=${cchelper.fixPath(this.paths.platformTemplateDirInPrj)}`);
+            content = content.replace(/PROP_ENABLE_COMPRESS_SO=.*/, `PROP_ENABLE_COMPRESS_SO=${options.isSoFileCompressed ? "true" : "false"}`);
 
+
+            const ndkPropertiesPath = cchelper.join(options.ndkPath, 'source.properties');
+            if (fs.existsSync(ndkPropertiesPath)) {
+                const ndkContent = fs.readFileSync(ndkPropertiesPath, 'utf-8');
+                const regexp = new RegExp(`Pkg.Revision = (.*)`);
+                const r = ndkContent.match(regexp);
+                if (r) {
+                    content = content.replace(/PROP_NDK_VERSION=.*/, `PROP_NDK_VERSION=${r[1]}`);
+                }
+            }
 
             if (process.platform === 'win32') {
                 options.ndkPath = options.ndkPath.replace(/\\/g, '\\\\');
             }
-
-            content = content.replace(/PROP_NDK_PATH=.*/, `PROP_NDK_PATH=${options.ndkPath}`);
 
             const abis = (options.appABIs && options.appABIs.length > 0) ? options.appABIs.join(':') : 'armeabi-v7a';
             // todo:新的template里面有个注释也是这个字段，所以要加个g

--- a/scripts/native-pack-tool/source/platforms/google-play.ts
+++ b/scripts/native-pack-tool/source/platforms/google-play.ts
@@ -51,7 +51,8 @@ export interface IAndroidParams {
     resizeableActivity: boolean;
     googleBilling: boolean;
     playGames: boolean;
-    customIconInfo: ICustomIconInfo,
+    customIconInfo: ICustomIconInfo;
+    isSoFileCompressed: boolean;
 }
 
 const DefaultAPILevel = 27;
@@ -406,13 +407,21 @@ export class GooglePlayPackTool extends NativePackTool {
 
             content = content.replace(/PROP_ENABLE_GOOGLE_BILLING=.*/, `PROP_ENABLE_GOOGLE_BILLING=${options.googleBilling ? "true" : "false"}`);
             content = content.replace(/PROP_ENABLE_GOOGLE_PLAY_GAMES=.*/, `PROP_ENABLE_GOOGLE_PLAY_GAMES=${options.playGames ? "true" : "false"}`);
+            content = content.replace(/PROP_ENABLE_COMPRESS_SO=.*/, `PROP_ENABLE_COMPRESS_SO=${options.isSoFileCompressed ? "true" : "false"}`);
 
+            const ndkPropertiesPath = cchelper.join(options.ndkPath, 'source.properties');
+            if (fs.existsSync(ndkPropertiesPath)) {
+                const ndkContent = fs.readFileSync(ndkPropertiesPath, 'utf-8');
+                const regexp = new RegExp(`Pkg.Revision = (.*)`);
+                const r = ndkContent.match(regexp);
+                if (r) {
+                    content = content.replace(/PROP_NDK_VERSION=.*/, `PROP_NDK_VERSION=${r[1]}`);
+                }
+            }
 
             if (process.platform === 'win32') {
                 options.ndkPath = options.ndkPath.replace(/\\/g, '\\\\');
             }
-
-            content = content.replace(/PROP_NDK_PATH=.*/, `PROP_NDK_PATH=${options.ndkPath}`);
 
             const abis = (options.appABIs && options.appABIs.length > 0) ? options.appABIs.join(':') : 'armeabi-v7a';
             // todo:新的template里面有个注释也是这个字段，所以要加个g

--- a/templates/android/build/build.gradle
+++ b/templates/android/build/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/android/build/gradle.properties
+++ b/templates/android/build/gradle.properties
@@ -24,16 +24,16 @@ android.injected.testOnly=false
 android.native.buildOutput=verbose
 
 # Android SDK version that will be used as the compile project
-PROP_COMPILE_SDK_VERSION=34
+PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=34
+PROP_TARGET_SDK_VERSION=36
 
 # Android Build Tools version that will be used as the compile project
-PROP_BUILD_TOOLS_VERSION=34.0.0
+PROP_BUILD_TOOLS_VERSION=36.0.0
 
 # Android Application Name
 PROP_APP_NAME=Cocos Game
@@ -44,7 +44,9 @@ PROP_ENABLE_INSTANT_APP=true
 # InputSDK
 PROP_ENABLE_INPUTSDK=false
 
-PROP_NDK_PATH=
+PROP_NDK_VERSION=
+
+PROP_ENABLE_COMPRESS_SO=false
 
 # Build variant
 PROP_IS_DEBUG=true

--- a/templates/android/build/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/android/build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 25 14:17:09 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/android/template/app/AndroidManifest.xml
+++ b/templates/android/template/app/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-        android:extractNativeLibs="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"

--- a/templates/android/template/app/build.gradle
+++ b/templates/android/template/app/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/${project.name ==~ /^[_a-zA-Z0-9-]+$/ ? proje
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -42,6 +42,12 @@ android {
         jniLibs {
             // Vulkan validation layer
             // srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
         }
     }
 

--- a/templates/android/template/build.gradle
+++ b/templates/android/template/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/android/template/instantapp/AndroidManifest.xml
+++ b/templates/android/template/instantapp/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-            android:extractNativeLibs="true"
             android:allowBackup="true"
             android:label="@string/app_name"
             android:usesCleartextTraffic="true"

--- a/templates/android/template/instantapp/build.gradle
+++ b/templates/android/template/instantapp/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/instantapp"
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -39,6 +39,12 @@ android {
         jniLibs.srcDirs "../libs", 'libs'
         manifest.srcFile "AndroidManifest.xml"
         assets.srcDir "${RES_PATH}/data"
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
+        }
     }
 
     externalNativeBuild {

--- a/templates/google-play/build/build.gradle
+++ b/templates/google-play/build/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/google-play/build/gradle.properties
+++ b/templates/google-play/build/gradle.properties
@@ -24,16 +24,16 @@ android.injected.testOnly=false
 android.native.buildOutput=verbose
 
 # Android SDK version that will be used as the compile project
-PROP_COMPILE_SDK_VERSION=34
+PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=34
+PROP_TARGET_SDK_VERSION=36
 
 # Android Build Tools version that will be used as the compile project
-PROP_BUILD_TOOLS_VERSION=34.0.0
+PROP_BUILD_TOOLS_VERSION=36.0.0
 
 # Android Application Name
 PROP_APP_NAME=Cocos Game
@@ -44,7 +44,9 @@ PROP_ENABLE_INSTANT_APP=true
 # InputSDK
 PROP_ENABLE_INPUTSDK=false
 
-PROP_NDK_PATH=
+PROP_NDK_VERSION=
+
+PROP_ENABLE_COMPRESS_SO=false
 
 # Build variant
 PROP_IS_DEBUG=true

--- a/templates/google-play/build/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/google-play/build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 25 14:17:09 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/google-play/template/app/AndroidManifest.xml
+++ b/templates/google-play/template/app/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-        android:extractNativeLibs="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"

--- a/templates/google-play/template/app/build.gradle
+++ b/templates/google-play/template/app/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/${project.name ==~ /^[_a-zA-Z0-9-]+$/ ? proje
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -42,6 +42,12 @@ android {
         jniLibs {
             // Vulkan validation layer
             // srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
         }
     }
 

--- a/templates/google-play/template/build.gradle
+++ b/templates/google-play/template/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/google-play/template/instantapp/AndroidManifest.xml
+++ b/templates/google-play/template/instantapp/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-            android:extractNativeLibs="true"
             android:allowBackup="true"
             android:label="@string/app_name"
             android:usesCleartextTraffic="true"

--- a/templates/google-play/template/instantapp/build.gradle
+++ b/templates/google-play/template/instantapp/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/instantapp"
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -39,6 +39,12 @@ android {
         jniLibs.srcDirs "../libs", 'libs'
         manifest.srcFile "AndroidManifest.xml"
         assets.srcDir "${RES_PATH}/data"
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
+        }
     }
 
     externalNativeBuild {

--- a/templates/xr-huaweivr/build/build.gradle
+++ b/templates/xr-huaweivr/build/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-huaweivr/build/gradle.properties
+++ b/templates/xr-huaweivr/build/gradle.properties
@@ -24,16 +24,16 @@ android.injected.testOnly=false
 android.native.buildOutput=verbose
 
 # Android SDK version that will be used as the compile project
-PROP_COMPILE_SDK_VERSION=28
+PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=27
+PROP_TARGET_SDK_VERSION=36
 
 # Android Build Tools version that will be used as the compile project
-PROP_BUILD_TOOLS_VERSION=30.0.3
+PROP_BUILD_TOOLS_VERSION=36.0.0
 
 # Android Application Name
 PROP_APP_NAME=Cocos Game
@@ -44,7 +44,9 @@ PROP_ENABLE_INSTANT_APP=true
 # InputSDK
 PROP_ENABLE_INPUTSDK=false
 
-PROP_NDK_PATH=
+PROP_NDK_VERSION=
+
+PROP_ENABLE_COMPRESS_SO=false
 
 # Build variant
 PROP_IS_DEBUG=true

--- a/templates/xr-huaweivr/build/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/xr-huaweivr/build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 25 14:17:09 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/xr-huaweivr/template/app/AndroidManifest.xml
+++ b/templates/xr-huaweivr/template/app/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-        android:extractNativeLibs="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"

--- a/templates/xr-huaweivr/template/app/build.gradle
+++ b/templates/xr-huaweivr/template/app/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/${project.name ==~ /^[_a-zA-Z0-9-]+$/ ? proje
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -42,6 +42,12 @@ android {
         jniLibs {
             // Vulkan validation layer
             // srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
         }
     }
 

--- a/templates/xr-huaweivr/template/build.gradle
+++ b/templates/xr-huaweivr/template/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-huaweivr/template/instantapp/AndroidManifest.xml
+++ b/templates/xr-huaweivr/template/instantapp/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-            android:extractNativeLibs="true"
             android:allowBackup="true"
             android:label="@string/app_name"
             android:usesCleartextTraffic="true"

--- a/templates/xr-huaweivr/template/instantapp/build.gradle
+++ b/templates/xr-huaweivr/template/instantapp/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/instantapp"
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -39,6 +39,12 @@ android {
         jniLibs.srcDirs "../libs", 'libs'
         manifest.srcFile "AndroidManifest.xml"
         assets.srcDir "${RES_PATH}/data"
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
+        }
     }
 
     externalNativeBuild {

--- a/templates/xr-meta/build/build.gradle
+++ b/templates/xr-meta/build/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-meta/build/gradle.properties
+++ b/templates/xr-meta/build/gradle.properties
@@ -24,16 +24,16 @@ android.injected.testOnly=false
 android.native.buildOutput=verbose
 
 # Android SDK version that will be used as the compile project
-PROP_COMPILE_SDK_VERSION=28
+PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=27
+PROP_TARGET_SDK_VERSION=36
 
 # Android Build Tools version that will be used as the compile project
-PROP_BUILD_TOOLS_VERSION=30.0.3
+PROP_BUILD_TOOLS_VERSION=36.0.0
 
 # Android Application Name
 PROP_APP_NAME=Cocos Game
@@ -44,7 +44,9 @@ PROP_ENABLE_INSTANT_APP=true
 # InputSDK
 PROP_ENABLE_INPUTSDK=false
 
-PROP_NDK_PATH=
+PROP_NDK_VERSION=
+
+PROP_ENABLE_COMPRESS_SO=false
 
 # Build variant
 PROP_IS_DEBUG=true

--- a/templates/xr-meta/build/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/xr-meta/build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 25 14:17:09 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/xr-meta/template/app/AndroidManifest.xml
+++ b/templates/xr-meta/template/app/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-        android:extractNativeLibs="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"

--- a/templates/xr-meta/template/app/build.gradle
+++ b/templates/xr-meta/template/app/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/${project.name ==~ /^[_a-zA-Z0-9-]+$/ ? proje
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -42,6 +42,12 @@ android {
         jniLibs {
             // Vulkan validation layer
             // srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
         }
     }
 

--- a/templates/xr-meta/template/build.gradle
+++ b/templates/xr-meta/template/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-meta/template/instantapp/AndroidManifest.xml
+++ b/templates/xr-meta/template/instantapp/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-            android:extractNativeLibs="true"
             android:allowBackup="true"
             android:label="@string/app_name"
             android:usesCleartextTraffic="true"

--- a/templates/xr-meta/template/instantapp/build.gradle
+++ b/templates/xr-meta/template/instantapp/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/instantapp"
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -39,6 +39,12 @@ android {
         jniLibs.srcDirs "../libs", 'libs'
         manifest.srcFile "AndroidManifest.xml"
         assets.srcDir "${RES_PATH}/data"
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
+        }
     }
 
     externalNativeBuild {

--- a/templates/xr-monado/build/build.gradle
+++ b/templates/xr-monado/build/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-monado/build/gradle.properties
+++ b/templates/xr-monado/build/gradle.properties
@@ -24,16 +24,16 @@ android.injected.testOnly=false
 android.native.buildOutput=verbose
 
 # Android SDK version that will be used as the compile project
-PROP_COMPILE_SDK_VERSION=28
+PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=27
+PROP_TARGET_SDK_VERSION=36
 
 # Android Build Tools version that will be used as the compile project
-PROP_BUILD_TOOLS_VERSION=30.0.3
+PROP_BUILD_TOOLS_VERSION=36.0.0
 
 # Android Application Name
 PROP_APP_NAME=Cocos Game
@@ -44,7 +44,9 @@ PROP_ENABLE_INSTANT_APP=true
 # InputSDK
 PROP_ENABLE_INPUTSDK=false
 
-PROP_NDK_PATH=
+PROP_NDK_VERSION=
+
+PROP_ENABLE_COMPRESS_SO=false
 
 # Build variant
 PROP_IS_DEBUG=true

--- a/templates/xr-monado/build/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/xr-monado/build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 25 14:17:09 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/xr-monado/template/app/AndroidManifest.xml
+++ b/templates/xr-monado/template/app/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-        android:extractNativeLibs="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"

--- a/templates/xr-monado/template/app/build.gradle
+++ b/templates/xr-monado/template/app/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/${project.name ==~ /^[_a-zA-Z0-9-]+$/ ? proje
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -42,6 +42,12 @@ android {
         jniLibs {
             // Vulkan validation layer
             // srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
         }
     }
 

--- a/templates/xr-monado/template/build.gradle
+++ b/templates/xr-monado/template/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-monado/template/instantapp/AndroidManifest.xml
+++ b/templates/xr-monado/template/instantapp/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-            android:extractNativeLibs="true"
             android:allowBackup="true"
             android:label="@string/app_name"
             android:usesCleartextTraffic="true"

--- a/templates/xr-monado/template/instantapp/build.gradle
+++ b/templates/xr-monado/template/instantapp/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/instantapp"
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -39,6 +39,12 @@ android {
         jniLibs.srcDirs "../libs", 'libs'
         manifest.srcFile "AndroidManifest.xml"
         assets.srcDir "${RES_PATH}/data"
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
+        }
     }
 
     externalNativeBuild {

--- a/templates/xr-pico/build/build.gradle
+++ b/templates/xr-pico/build/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-pico/build/gradle.properties
+++ b/templates/xr-pico/build/gradle.properties
@@ -24,16 +24,16 @@ android.injected.testOnly=false
 android.native.buildOutput=verbose
 
 # Android SDK version that will be used as the compile project
-PROP_COMPILE_SDK_VERSION=28
+PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=27
+PROP_TARGET_SDK_VERSION=36
 
 # Android Build Tools version that will be used as the compile project
-PROP_BUILD_TOOLS_VERSION=30.0.3
+PROP_BUILD_TOOLS_VERSION=36.0.0
 
 # Android Application Name
 PROP_APP_NAME=Cocos Game
@@ -44,7 +44,9 @@ PROP_ENABLE_INSTANT_APP=true
 # InputSDK
 PROP_ENABLE_INPUTSDK=false
 
-PROP_NDK_PATH=
+PROP_NDK_VERSION=
+
+PROP_ENABLE_COMPRESS_SO=false
 
 # Build variant
 PROP_IS_DEBUG=true

--- a/templates/xr-pico/build/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/xr-pico/build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 25 14:17:09 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/xr-pico/template/app/AndroidManifest.xml
+++ b/templates/xr-pico/template/app/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-        android:extractNativeLibs="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"

--- a/templates/xr-pico/template/app/build.gradle
+++ b/templates/xr-pico/template/app/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/${project.name ==~ /^[_a-zA-Z0-9-]+$/ ? proje
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -42,6 +42,12 @@ android {
         jniLibs {
             // Vulkan validation layer
             // srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
         }
     }
 

--- a/templates/xr-pico/template/build.gradle
+++ b/templates/xr-pico/template/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-pico/template/instantapp/AndroidManifest.xml
+++ b/templates/xr-pico/template/instantapp/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-            android:extractNativeLibs="true"
             android:allowBackup="true"
             android:label="@string/app_name"
             android:usesCleartextTraffic="true"

--- a/templates/xr-pico/template/instantapp/build.gradle
+++ b/templates/xr-pico/template/instantapp/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/instantapp"
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -39,6 +39,12 @@ android {
         jniLibs.srcDirs "../libs", 'libs'
         manifest.srcFile "AndroidManifest.xml"
         assets.srcDir "${RES_PATH}/data"
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
+        }
     }
 
     externalNativeBuild {

--- a/templates/xr-rokid/build/build.gradle
+++ b/templates/xr-rokid/build/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-rokid/build/gradle.properties
+++ b/templates/xr-rokid/build/gradle.properties
@@ -24,16 +24,16 @@ android.injected.testOnly=false
 android.native.buildOutput=verbose
 
 # Android SDK version that will be used as the compile project
-PROP_COMPILE_SDK_VERSION=28
+PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=27
+PROP_TARGET_SDK_VERSION=36
 
 # Android Build Tools version that will be used as the compile project
-PROP_BUILD_TOOLS_VERSION=30.0.3
+PROP_BUILD_TOOLS_VERSION=36.0.0
 
 # Android Application Name
 PROP_APP_NAME=Cocos Game
@@ -44,7 +44,9 @@ PROP_ENABLE_INSTANT_APP=true
 # InputSDK
 PROP_ENABLE_INPUTSDK=false
 
-PROP_NDK_PATH=
+PROP_NDK_VERSION=
+
+PROP_ENABLE_COMPRESS_SO=false
 
 # Build variant
 PROP_IS_DEBUG=true

--- a/templates/xr-rokid/build/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/xr-rokid/build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 25 14:17:09 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/xr-rokid/template/app/AndroidManifest.xml
+++ b/templates/xr-rokid/template/app/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-        android:extractNativeLibs="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"

--- a/templates/xr-rokid/template/app/build.gradle
+++ b/templates/xr-rokid/template/app/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/${project.name ==~ /^[_a-zA-Z0-9-]+$/ ? proje
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -42,6 +42,12 @@ android {
         jniLibs {
             // Vulkan validation layer
             // srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
         }
     }
 

--- a/templates/xr-rokid/template/build.gradle
+++ b/templates/xr-rokid/template/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-rokid/template/instantapp/AndroidManifest.xml
+++ b/templates/xr-rokid/template/instantapp/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-            android:extractNativeLibs="true"
             android:allowBackup="true"
             android:label="@string/app_name"
             android:usesCleartextTraffic="true"

--- a/templates/xr-rokid/template/instantapp/build.gradle
+++ b/templates/xr-rokid/template/instantapp/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/instantapp"
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -41,6 +41,12 @@ android {
         assets.srcDir "${RES_PATH}/data"
     }
 
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
+        }
+    }
+    
     externalNativeBuild {
         cmake {
             version "3.22.1"

--- a/templates/xr-spaces/build/build.gradle
+++ b/templates/xr-spaces/build/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-spaces/build/gradle.properties
+++ b/templates/xr-spaces/build/gradle.properties
@@ -24,16 +24,16 @@ android.injected.testOnly=false
 android.native.buildOutput=verbose
 
 # Android SDK version that will be used as the compile project
-PROP_COMPILE_SDK_VERSION=31
+PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=31
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=29
+PROP_TARGET_SDK_VERSION=36
 
 # Android Build Tools version that will be used as the compile project
-PROP_BUILD_TOOLS_VERSION=30.0.3
+PROP_BUILD_TOOLS_VERSION=36.0.0
 
 # Android Application Name
 PROP_APP_NAME=Cocos Game
@@ -44,7 +44,9 @@ PROP_ENABLE_INSTANT_APP=true
 # InputSDK
 PROP_ENABLE_INPUTSDK=false
 
-PROP_NDK_PATH=
+PROP_NDK_VERSION=
+
+PROP_ENABLE_COMPRESS_SO=false
 
 # Build variant
 PROP_IS_DEBUG=true

--- a/templates/xr-spaces/build/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/xr-spaces/build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 25 14:17:09 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/xr-spaces/template/app/AndroidManifest.xml
+++ b/templates/xr-spaces/template/app/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-        android:extractNativeLibs="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"

--- a/templates/xr-spaces/template/app/build.gradle
+++ b/templates/xr-spaces/template/app/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/${project.name ==~ /^[_a-zA-Z0-9-]+$/ ? proje
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -42,6 +42,12 @@ android {
         jniLibs {
             // Vulkan validation layer
             // srcDir "${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
         }
     }
 

--- a/templates/xr-spaces/template/build.gradle
+++ b/templates/xr-spaces/template/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // jcenter() // keeped as anchor, will be removed soon
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/xr-spaces/template/instantapp/AndroidManifest.xml
+++ b/templates/xr-spaces/template/instantapp/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
-            android:extractNativeLibs="true"
             android:allowBackup="true"
             android:label="@string/app_name"
             android:usesCleartextTraffic="true"

--- a/templates/xr-spaces/template/instantapp/build.gradle
+++ b/templates/xr-spaces/template/instantapp/build.gradle
@@ -9,7 +9,7 @@ buildDir = "${RES_PATH}/proj/build/instantapp"
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
     buildToolsVersion PROP_BUILD_TOOLS_VERSION
-    ndkPath PROP_NDK_PATH
+    ndkVersion PROP_NDK_VERSION
     namespace APPLICATION_ID
 
     compileOptions {
@@ -39,6 +39,12 @@ android {
         jniLibs.srcDirs "../libs", 'libs'
         manifest.srcFile "AndroidManifest.xml"
         assets.srcDir "${RES_PATH}/data"
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging Boolean.parseBoolean(PROP_ENABLE_COMPRESS_SO)
+        }
     }
 
     externalNativeBuild {


### PR DESCRIPTION
### Changelog
Releated: 
https://github.com/cocos/cocos-engine-external/pull/501
https://github.com/cocos/creator-runtime-extensions/pull/716
https://github.com/cocos/cocos-engine/pull/19000
*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
