### PR TITLE
fixed when low fps cannot play particle

### DIFF
--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -1443,7 +1443,7 @@ export class ParticleSystem extends ModelRenderer {
         // emit particles.
         const startDelay = self.startDelay.evaluate(0, 1)!;
         if (self._time > startDelay) {
-            if (self._time > (self.duration + startDelay)) {
+            if (self._time - (self.duration + startDelay) > dt) {
                 // self._time = startDelay; // delay will not be applied from the second loop.(Unity)
                 // self._emitRateTimeCounter = 0.0;
                 // self._emitRateDistanceCounter = 0.0;

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -1479,7 +1479,7 @@ export class ParticleSystem extends ModelRenderer {
             }
 
             // bursts
-            if (timeLeft <= 0) {
+            if (timeLeft <= 0 || self.loop) {
                 for (const burst of self.bursts) {
                     burst.update(self, dt);
                 }

--- a/cocos/particle/particle-system.ts
+++ b/cocos/particle/particle-system.ts
@@ -1443,7 +1443,8 @@ export class ParticleSystem extends ModelRenderer {
         // emit particles.
         const startDelay = self.startDelay.evaluate(0, 1)!;
         if (self._time > startDelay) {
-            if (self._time - (self.duration + startDelay) > dt) {
+            const timeLeft = self._time - (self.duration + startDelay);
+            if (timeLeft > dt) {
                 // self._time = startDelay; // delay will not be applied from the second loop.(Unity)
                 // self._emitRateTimeCounter = 0.0;
                 // self._emitRateDistanceCounter = 0.0;
@@ -1478,8 +1479,10 @@ export class ParticleSystem extends ModelRenderer {
             }
 
             // bursts
-            for (const burst of self.bursts) {
-                burst.update(self, dt);
+            if (timeLeft <= 0) {
+                for (const burst of self.bursts) {
+                    burst.update(self, dt);
+                }
             }
         }
     }


### PR DESCRIPTION
Re: https://github.com/cocos/3d-tasks/issues/19127

当粒子系统的播放时间与粒子可存活的总时间相差小于一帧时，允许在当前帧尝试播放粒子，避免游戏低帧率时粒子系统因为卡顿错过了可用于播放粒子的帧。
When the playback time of the particle system differs from the total survival time of the particles by less than one frame, it is allowed to attempt to play the particles in the current frame to prevent the particle system from missing the frames available for playing the particles due to lag when the game has a low frame rate.

此修改同时解决了以下类似情况的粒子播放问题:
* 设定可播放粒子时间为 2 s ，每秒播放粒子数量为 3，粒子存活时间为 1 s。在此设定下粒子只发射了 5 次。（当需要发射最后一个粒子时因为粒子剩余可播放时间不足一帧的间隔时间，所以无法发射）

This modification also resolves the particle playback issues in the following similar scenarios: 
* Set the playable particle time to 2 s, the number of particles played per second to 3, and the particle survival time to 1 s. Under this setting, particles were only emitted 5 times. (When the last particle needed to be emitted, it could not be emitted because the remaining playable time of the particle was less than the interval time of one frame.)