### PR TITLE
fixed sprite alpha can not change

### DIFF
--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -703,6 +703,7 @@ export class Sprite extends UIRenderer {
             }
             if (textureChanged) {
                 if (self.renderData) self.renderData.textureDirty = true;
+                this._colorDirty();
                 // texture type changed, set this._instanceMaterialType to default value
                 const oldIsRT = oldFrame ? oldFrame.texture instanceof RenderTexture : false;
                 const newIsRT = spriteFrame.texture instanceof RenderTexture;

--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -24,7 +24,7 @@
 */
 
 import { ccclass, help, executionOrder, menu, tooltip, displayOrder, type, range, editable, serializable, visible } from 'cc.decorator';
-import { BUILD, EDITOR } from 'internal:constants';
+import { BUILD, JSB, EDITOR } from 'internal:constants';
 import { SpriteAtlas } from '../assets/sprite-atlas';
 import { SpriteFrame, SpriteFrameEvent } from '../assets/sprite-frame';
 import { builtinResMgr } from '../../asset/asset-manager/builtin-res-mgr';
@@ -703,7 +703,7 @@ export class Sprite extends UIRenderer {
             }
             if (textureChanged) {
                 if (self.renderData) self.renderData.textureDirty = true;
-                this._colorDirty();
+                if (JSB) this._colorDirty();
                 // texture type changed, set this._instanceMaterialType to default value
                 const oldIsRT = oldFrame ? oldFrame.texture instanceof RenderTexture : false;
                 const newIsRT = spriteFrame.texture instanceof RenderTexture;

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -542,10 +542,8 @@ export class UIRenderer extends Renderer {
     }
 
     protected _updateColor (): void {
-        this.node._uiProps.colorDirty = true;
-        this.setEntityColorDirty(true);
+        this._colorDirty();
         this.setEntityColor(this._color);
-
         const assembler = this._assembler;
         if (assembler) {
             if (assembler.updateColor) {


### PR DESCRIPTION
Re: #
native 平台中，sprite 组件在没有 spriteFrame 时无法设置透明度值，需要在 sprite 组件更新 spriteFrame 时让其更新一次透明度值并作用到 ui 渲染上。
In native platform, sprite component can't set transparency value without spriteFrame. You need to let sprite component update transparency value once when spriteFrame is updated and apply it to ui rendering.

test bug code:

```typescript
import { _decorator, Component, Node, Sprite, SpriteFrame } from 'cc';
const { ccclass, property } = _decorator;

@ccclass('NewComponent')
export class NewComponent extends Component {

    @property(Sprite)
    testSp: Sprite = null;

    @property(SpriteFrame)
    testSpf: SpriteFrame = null;

    start() {
        this.node.on(Node.EventType.TOUCH_END, this.test, this);
    }

    test () {
        if(this.testSp){
            var targetColor = this.testSp.color.clone();
            targetColor.a = 30;
            this.testSp.color = targetColor;
            setTimeout(()=>{
                this.testSp.spriteFrame = this.testSpf;
                console.log(`target Color alpha is ${this.testSp.color.a}`);
            })
        }
    }
}
```