### PR TITLE
38x layout uiTransform cannot vary width and height based on sub objects

### DIFF
--- a/cocos/ui/layout.ts
+++ b/cocos/ui/layout.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /*
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2023 Xiamen Yaji Software Co., Ltd.
@@ -825,6 +826,7 @@ export class Layout extends Component {
             newChildWidth = (baseWidth - paddingH - (activeChildCount - 1) * this._spacingX) / activeChildCount;
         }
 
+        let maxRowWidth = baseWidth;
         const children = this._usefulLayoutObj;
         for (let i = 0; i < children.length; ++i) {
             const childTrans = children[i];
@@ -886,10 +888,21 @@ export class Layout extends Component {
             }
 
             nextX += rightBoundaryOfChild;
+            // If the position of the child node is greater than the width of the container,
+            // then the baseWidth plus the difference greater than is the layout width.
+            if (Math.abs(nextX) > baseWidth / 2 && applyChildren) {
+                maxRowWidth = baseWidth / 2 + nextX;
+            }
         }
 
         rowMaxHeight = Math.max(rowMaxHeight, tempMaxHeight);
         const containerResizeBoundary = Math.max(maxHeight, totalHeight + rowMaxHeight) + this._getPaddingV();
+        // if width changes, adjust the container again
+        if (this._resizeMode === LayoutResizeMode.CONTAINER && maxRowWidth != baseWidth && this._layoutType === LayoutType.GRID) {
+            this.node._uiProps.uiTransformComp!.setContentSize(maxRowWidth, containerResizeBoundary);
+            // Because the container width changes, the position of the child will also change, and it needs to be adjusted.
+            return this._doLayoutHorizontally(maxRowWidth, true, fnPositionY, true);
+        }
         return containerResizeBoundary;
     }
 
@@ -1016,10 +1029,6 @@ export class Layout extends Component {
         }
 
         this._doLayoutHorizontally(baseWidth, true, fnPositionY, true);
-
-        if (this._resizeMode === LayoutResizeMode.CONTAINER) {
-            this.node._getUITransformComp()!.setContentSize(baseWidth, newHeight);
-        }
     }
 
     protected _doLayoutGridAxisVertical (layoutAnchor: Vec2 | Readonly<Vec2>, layoutSize: Size): void {

--- a/cocos/ui/layout.ts
+++ b/cocos/ui/layout.ts
@@ -682,6 +682,7 @@ export class Layout extends Component {
     protected _childrenDirty = false;
     protected _usefulLayoutObj: UITransform[] = [];
     protected _init = false;
+    protected bottomBoundaryOfLayout = 0;
 
     /**
      * @en
@@ -891,14 +892,22 @@ export class Layout extends Component {
             // If the position of the child node is greater than the width of the container,
             // then the baseWidth plus the difference greater than is the layout width.
             if (Math.abs(nextX) > baseWidth / 2 && applyChildren) {
-                maxRowWidth = baseWidth / 2 + nextX;
+                maxRowWidth = Math.abs(sign * baseWidth / 2 + nextX);
             }
         }
 
         rowMaxHeight = Math.max(rowMaxHeight, tempMaxHeight);
         const containerResizeBoundary = Math.max(maxHeight, totalHeight + rowMaxHeight) + this._getPaddingV();
         // if width changes, adjust the container again
-        if (this._resizeMode === LayoutResizeMode.CONTAINER && maxRowWidth != baseWidth && this._layoutType === LayoutType.GRID) {
+        if (this._resizeMode === LayoutResizeMode.CONTAINER && this._layoutType === LayoutType.GRID
+            // eslint-disable-next-line eqeqeq
+            && (maxRowWidth != baseWidth || (containerResizeBoundary != trans.height && applyChildren))
+        ) {
+            let ySign = 1;
+            if (this._verticalDirection === LayoutVerticalDirection.TOP_TO_BOTTOM) {
+                ySign = -1;
+            }
+            this.bottomBoundaryOfLayout = (Math.abs(ySign - 1) / 2 - layoutAnchor.y) * containerResizeBoundary;
             this.node._uiProps.uiTransformComp!.setContentSize(maxRowWidth, containerResizeBoundary);
             // Because the container width changes, the position of the child will also change, and it needs to be adjusted.
             return this._doLayoutHorizontally(maxRowWidth, true, fnPositionY, true);
@@ -1006,26 +1015,21 @@ export class Layout extends Component {
         const baseWidth = layoutSize.width;
 
         let sign = 1;
-        let bottomBoundaryOfLayout = -layoutAnchor.y * layoutSize.height;
+        this.bottomBoundaryOfLayout = -layoutAnchor.y * layoutSize.height;
         let paddingY = this._paddingBottom;
         if (this._verticalDirection === LayoutVerticalDirection.TOP_TO_BOTTOM) {
             sign = -1;
-            bottomBoundaryOfLayout = (1 - layoutAnchor.y) * layoutSize.height;
+            this.bottomBoundaryOfLayout = (1 - layoutAnchor.y) * layoutSize.height;
             paddingY = this._paddingTop;
         }
 
-        const fnPositionY = (child: Node, childTrans: UITransform, topOffset: number): number => bottomBoundaryOfLayout + sign * (topOffset + (1 - childTrans.anchorY) * childTrans.height * this._getUsedScaleValue(child.scale.y) + paddingY);
+        const fnPositionY = (child: Node, childTrans: UITransform, topOffset: number): number => this.bottomBoundaryOfLayout + sign * (topOffset + (1 - childTrans.anchorY) * childTrans.height * this._getUsedScaleValue(child.scale.y) + paddingY);
 
         let newHeight = 0;
         if (this._resizeMode === LayoutResizeMode.CONTAINER) {
             // calculate the new height of container, it won't change the position of it's children
             newHeight = this._doLayoutHorizontally(baseWidth, true, fnPositionY, false);
-            bottomBoundaryOfLayout = -layoutAnchor.y * newHeight;
-
-            if (this._verticalDirection === LayoutVerticalDirection.TOP_TO_BOTTOM) {
-                sign = -1;
-                bottomBoundaryOfLayout = (1 - layoutAnchor.y) * newHeight;
-            }
+            this.bottomBoundaryOfLayout = (Math.abs(sign - 1) / 2 - layoutAnchor.y) * newHeight;
         }
 
         this._doLayoutHorizontally(baseWidth, true, fnPositionY, true);


### PR DESCRIPTION
Re: # https://github.com/cocos/3d-tasks/issues/19128

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
