### PR TITLE
Fixed rich text sorting order issue when used together with Sorting2D component

### DIFF
--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -44,6 +44,7 @@ import {
     getEnglishWordPartAtLast,
     getSymbolAt,
 } from '../utils/text-utils';
+import { Sorting2D } from '../../sorting/sorting-2d';
 
 const _htmlTextParser = new HtmlTextParser();
 const RichTextChildName = 'RICHTEXT_CHILD';
@@ -504,10 +505,21 @@ export class RichText extends Component {
     protected _lineOffsetX = 0;
     protected declare _updateRichTextStatus: () => void;
     protected _labelChildrenNum = 0; // only ISegment
+    protected _currentSortingLayer = 0;
+    protected _currentSortingOrder = 0;
+    protected _sorting2d: Sorting2D | null = null;
 
     constructor () {
         super();
         this._updateRichTextStatus = this._updateRichText;
+    }
+
+    protected override __preload (): void {
+        this._sorting2d = this.getComponent(Sorting2D);
+        if (this._sorting2d != null) {
+            this._currentSortingOrder = this._sorting2d.sortingOrder;
+            this._currentSortingLayer = this._sorting2d.sortingLayer;
+        }
     }
 
     public onLoad (): void {
@@ -864,7 +876,11 @@ export class RichText extends Component {
         this.node.insertChild(labelSegment.node, this._labelChildrenNum++);
         this._applyTextAttribute(labelSegment);
         this._segments.push(labelSegment);
-
+        if (this._sorting2d != null) {
+            const childSorting = labelSegment.node.addComponent(Sorting2D);
+            childSorting.sortingOrder = this._sorting2d.sortingOrder;
+            childSorting.sortingLayer = this._sorting2d.sortingLayer;
+        }
         return labelSegment;
     }
 
@@ -1046,6 +1062,11 @@ this._measureText(styleIndex) as unknown as (s: string) => number,
             if (event) {
                 segment.clickHandler = event.click;
                 segment.clickParam = event.param;
+            }
+            if (this._sorting2d != null) {
+                const childSorting = segment.node.addComponent(Sorting2D);
+                childSorting.sortingOrder = this._sorting2d.sortingOrder;
+                childSorting.sortingLayer = this._sorting2d.sortingLayer;
             }
         }
     }
@@ -1343,6 +1364,26 @@ this._measureText(styleIndex) as unknown as (s: string) => number,
         label.isBold = false;
         label.isItalic = false;
         label.isUnderline = false;
+    }
+
+    protected update (dt: number): void {
+        if (this._sorting2d == null) {
+            return;
+        }
+
+        if (this._sorting2d.sortingOrder !== this._currentSortingOrder
+            || this._sorting2d.sortingLayer !== this._currentSortingLayer
+        ) {
+            this._currentSortingOrder = this._sorting2d.sortingOrder;
+            this._currentSortingLayer = this._sorting2d.sortingLayer;
+            this._segments.forEach((seg) => {
+                const sortingChild = seg.node.getComponent(Sorting2D);
+                if (sortingChild) {
+                    sortingChild.sortingOrder = this._currentSortingOrder;
+                    sortingChild.sortingLayer = this._currentSortingLayer;
+                }
+            });
+        }
     }
 }
 

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -445,6 +445,11 @@ export function WebGLCmdFuncCreateBuffer (device: WebGLDevice, gpuBuffer: IWebGL
     const { gl, stateCache } = device;
     const glUsage: GLenum = gpuBuffer.memUsage & MemoryUsageBit.HOST ? WebGLConstants.DYNAMIC_DRAW : WebGLConstants.STATIC_DRAW;
 
+    // iOS fix: Initialize version tracking for VAO invalidation
+    if (systemInfo.os === OS.IOS) {
+        gpuBuffer.updateVersion = 0;
+    }
+
     if (gpuBuffer.usage & BufferUsageBit.VERTEX) {
         gpuBuffer.glTarget = WebGLConstants.ARRAY_BUFFER;
         const glBuffer = gl.createBuffer();
@@ -643,6 +648,11 @@ export function WebGLCmdFuncUpdateBuffer (
             }
             gfxStateCache.gpuInputAssembler = null;
 
+            // iOS fix: Increment version when buffer is updated
+            if (systemInfo.os === OS.IOS && gpuBuffer.updateVersion !== undefined) {
+                gpuBuffer.updateVersion++;
+            }
+
             if (stateCache.glArrayBuffer !== gpuBuffer.glBuffer) {
                 gl.bindBuffer(WebGLConstants.ARRAY_BUFFER, gpuBuffer.glBuffer);
                 stateCache.glArrayBuffer = gpuBuffer.glBuffer;
@@ -657,6 +667,11 @@ export function WebGLCmdFuncUpdateBuffer (
                 }
             }
             gfxStateCache.gpuInputAssembler = null;
+
+            // iOS fix: Increment version when buffer is updated
+            if (systemInfo.os === OS.IOS && gpuBuffer.updateVersion !== undefined) {
+                gpuBuffer.updateVersion++;
+            }
 
             if (stateCache.glElementArrayBuffer !== gpuBuffer.glBuffer) {
                 gl.bindBuffer(WebGLConstants.ELEMENT_ARRAY_BUFFER, gpuBuffer.glBuffer);
@@ -2258,11 +2273,60 @@ export function WebGLCmdFuncBindStates (
         if (device.extensions.useVAO) {
             const vao = device.extensions.OES_vertex_array_object!;
 
+            // iOS Safari WebGL-to-Metal: Check if buffers were updated since VAO creation
+            const isIOS = systemInfo.os === OS.IOS;
+            let needRecreateVAO = false;
+
+            if (isIOS) {
+                // Compute current buffer version hash
+                let currentVersion = 0;
+                for (let i = 0; i < gpuInputAssembler.gpuVertexBuffers.length; i++) {
+                    const buf = gpuInputAssembler.gpuVertexBuffers[i];
+                    if (buf.updateVersion !== undefined) {
+                        currentVersion += buf.updateVersion * (i + 1);
+                    }
+                }
+                if (gpuInputAssembler.gpuIndexBuffer && gpuInputAssembler.gpuIndexBuffer.updateVersion !== undefined) {
+                    currentVersion += gpuInputAssembler.gpuIndexBuffer.updateVersion * 1000;
+                }
+
+                // Check if VAO was created with different buffer versions
+                const cachedVersion = gpuInputAssembler.vaoVersions?.get(gpuShader.glProgram!);
+                if (cachedVersion !== undefined && cachedVersion !== currentVersion) {
+                    needRecreateVAO = true;
+                }
+            }
+
             // check vao
             let glVAO = gpuInputAssembler.glVAOs.get(gpuShader.glProgram!);
-            if (!glVAO) {
+            if (!glVAO || needRecreateVAO) {
+                // Delete old VAO if recreating
+                if (needRecreateVAO && glVAO) {
+                    vao.deleteVertexArrayOES(glVAO);
+                    if (cache.glVAO === glVAO) {
+                        cache.glVAO = null;
+                    }
+                }
                 glVAO = vao.createVertexArrayOES()!;
                 gpuInputAssembler.glVAOs.set(gpuShader.glProgram!, glVAO);
+
+                // iOS fix: Store buffer versions when VAO is created
+                if (isIOS) {
+                    let vaoVersion = 0;
+                    for (let i = 0; i < gpuInputAssembler.gpuVertexBuffers.length; i++) {
+                        const buf = gpuInputAssembler.gpuVertexBuffers[i];
+                        if (buf.updateVersion !== undefined) {
+                            vaoVersion += buf.updateVersion * (i + 1);
+                        }
+                    }
+                    if (gpuInputAssembler.gpuIndexBuffer && gpuInputAssembler.gpuIndexBuffer.updateVersion !== undefined) {
+                        vaoVersion += gpuInputAssembler.gpuIndexBuffer.updateVersion * 1000;
+                    }
+                    if (!gpuInputAssembler.vaoVersions) {
+                        gpuInputAssembler.vaoVersions = new Map<WebGLProgram, number>();
+                    }
+                    gpuInputAssembler.vaoVersions.set(gpuShader.glProgram!, vaoVersion);
+                }
 
                 vao.bindVertexArrayOES(glVAO);
                 gl.bindBuffer(WebGLConstants.ARRAY_BUFFER, null);
@@ -2316,7 +2380,8 @@ export function WebGLCmdFuncBindStates (
                 cache.glElementArrayBuffer = null;
             }
 
-            if (cache.glVAO !== glVAO) {
+            // iOS Safari: Force VAO rebinding on iOS, or when cache doesn't match
+            if (isIOS || cache.glVAO !== glVAO) {
                 vao.bindVertexArrayOES(glVAO);
                 cache.glVAO = glVAO;
             }

--- a/cocos/gfx/webgl/webgl-gpu-objects.ts
+++ b/cocos/gfx/webgl/webgl-gpu-objects.ts
@@ -150,6 +150,9 @@ export interface IWebGLGPUBuffer {
     vf32: Float32Array | null;
     /** @mangle */
     indirects: WebGLIndirectDrawInfos;
+    /** @mangle */
+    // iOS fix: Track buffer updates to invalidate VAOs
+    updateVersion?: number;
 }
 
 /** @mangle */
@@ -348,6 +351,9 @@ export interface IWebGLGPUInputAssembler {
     glAttribs: IWebGLAttrib[];
     glIndexType: GLenum;
     glVAOs: Map<WebGLProgram, WebGLVertexArrayObjectOES>;
+    /** @mangle */
+    // iOS fix: Track buffer versions when VAOs were created
+    vaoVersions?: Map<WebGLProgram, number>;
 }
 
 /** @mangle */

--- a/cocos/gfx/webgl/webgl-input-assembler.ts
+++ b/cocos/gfx/webgl/webgl-input-assembler.ts
@@ -105,6 +105,7 @@ export class WebGLInputAssembler extends InputAssembler {
             glAttribs: [],
             glIndexType,
             glVAOs: new Map<WebGLProgram, WebGLVertexArrayObjectOES>(),
+            vaoVersions: new Map<WebGLProgram, number>(), // iOS fix
         };
 
         WebGLCmdFuncCreateInputAssember(WebGLDeviceManager.instance, this._gpuInputAssembler);

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -624,6 +624,11 @@ export function WebGL2CmdFuncCreateBuffer (device: WebGL2Device, gpuBuffer: IWeb
     const cache = device.getStateCache();
     const glUsage: GLenum = gpuBuffer.memUsage & MemoryUsageBit.HOST ? WebGLConstants.DYNAMIC_DRAW : WebGLConstants.STATIC_DRAW;
 
+    // iOS fix: Initialize buffer version tracking
+    if (systemInfo.os === OS.IOS) {
+        gpuBuffer.updateVersion = 0;
+    }
+
     if (gpuBuffer.usage & BufferUsageBit.VERTEX) {
         gpuBuffer.glTarget = WebGLConstants.ARRAY_BUFFER;
         const glBuffer = gl.createBuffer();
@@ -830,12 +835,20 @@ export function WebGL2CmdFuncUpdateBuffer (
 
         switch (gpuBuffer.glTarget) {
         case WebGLConstants.ARRAY_BUFFER: {
+            // iOS fix: Increment buffer version to invalidate VAOs that reference this buffer
+            if (systemInfo.os === OS.IOS && gpuBuffer.updateVersion !== undefined) {
+                gpuBuffer.updateVersion++;
+            }
+
             if (device.extensions.useVAO) {
+                // When updating vertex buffer data, unbind VAO to force rebind on next draw
+                // This is critical because VAO caches vertex attribute pointers to buffers
                 if (cache.glVAO) {
                     gl.bindVertexArray(null);
                     cache.glVAO = null;
                 }
             }
+            // Invalidate input assembler cache to force VAO rebind/recreation
             gfxStateCache.gpuInputAssembler = null;
 
             if (cache.glArrayBuffer !== gpuBuffer.glBuffer) {
@@ -857,6 +870,11 @@ export function WebGL2CmdFuncUpdateBuffer (
             break;
         }
         case WebGLConstants.ELEMENT_ARRAY_BUFFER: {
+            // iOS fix: Increment buffer version to invalidate VAOs that reference this buffer
+            if (systemInfo.os === OS.IOS && gpuBuffer.updateVersion !== undefined) {
+                gpuBuffer.updateVersion++;
+            }
+
             if (device.extensions.useVAO) {
                 if (cache.glVAO) {
                     gl.bindVertexArray(null);
@@ -2345,11 +2363,60 @@ export function WebGL2CmdFuncBindStates (
         gfxStateCache.gpuInputAssembler = gpuInputAssembler;
 
         if (device.extensions.useVAO) {
+            // iOS Safari WebGL-to-Metal: Check if buffers were updated since VAO creation
+            const isIOS = systemInfo.os === OS.IOS;
+            let needRecreateVAO = false;
+
+            if (isIOS) {
+                // Compute current buffer version hash
+                let currentVersion = 0;
+                for (let i = 0; i < gpuInputAssembler.gpuVertexBuffers.length; i++) {
+                    const buf = gpuInputAssembler.gpuVertexBuffers[i];
+                    if (buf.updateVersion !== undefined) {
+                        currentVersion += buf.updateVersion * (i + 1);
+                    }
+                }
+                if (gpuInputAssembler.gpuIndexBuffer && gpuInputAssembler.gpuIndexBuffer.updateVersion !== undefined) {
+                    currentVersion += gpuInputAssembler.gpuIndexBuffer.updateVersion * 1000;
+                }
+
+                // Check if VAO was created with different buffer versions
+                const cachedVersion = gpuInputAssembler.vaoVersions?.get(gpuShader.glProgram!);
+                if (cachedVersion !== undefined && cachedVersion !== currentVersion) {
+                    needRecreateVAO = true;
+                }
+            }
+
             // check vao
             let glVAO = gpuInputAssembler.glVAOs.get(gpuShader.glProgram!);
-            if (!glVAO) {
+            if (!glVAO || needRecreateVAO) {
+                // Delete old VAO if recreating
+                if (needRecreateVAO && glVAO) {
+                    gl.deleteVertexArray(glVAO);
+                    if (cache.glVAO === glVAO) {
+                        cache.glVAO = null;
+                    }
+                }
                 glVAO = gl.createVertexArray()!;
                 gpuInputAssembler.glVAOs.set(gpuShader.glProgram!, glVAO);
+
+                // iOS fix: Store buffer versions when VAO is created
+                if (isIOS) {
+                    let vaoVersion = 0;
+                    for (let i = 0; i < gpuInputAssembler.gpuVertexBuffers.length; i++) {
+                        const buf = gpuInputAssembler.gpuVertexBuffers[i];
+                        if (buf.updateVersion !== undefined) {
+                            vaoVersion += buf.updateVersion * (i + 1);
+                        }
+                    }
+                    if (gpuInputAssembler.gpuIndexBuffer && gpuInputAssembler.gpuIndexBuffer.updateVersion !== undefined) {
+                        vaoVersion += gpuInputAssembler.gpuIndexBuffer.updateVersion * 1000;
+                    }
+                    if (!gpuInputAssembler.vaoVersions) {
+                        gpuInputAssembler.vaoVersions = new Map();
+                    }
+                    gpuInputAssembler.vaoVersions.set(gpuShader.glProgram!, vaoVersion);
+                }
 
                 gl.bindVertexArray(glVAO);
                 gl.bindBuffer(WebGLConstants.ARRAY_BUFFER, null);
@@ -2401,7 +2468,8 @@ export function WebGL2CmdFuncBindStates (
                 cache.glElementArrayBuffer = null;
             }
 
-            if (cache.glVAO !== glVAO) {
+            // iOS Safari: Force VAO rebinding on iOS, or when cache doesn't match
+            if (isIOS || cache.glVAO !== glVAO) {
                 gl.bindVertexArray(glVAO);
                 cache.glVAO = glVAO;
             }

--- a/cocos/gfx/webgl2/webgl2-gpu-objects.ts
+++ b/cocos/gfx/webgl2/webgl2-gpu-objects.ts
@@ -130,6 +130,9 @@ export interface IWebGL2GPUBuffer {
 
     buffer: ArrayBufferView | null;
     indirects: WebGL2IndirectDrawInfos;
+
+    /** @mangle */
+    updateVersion: number; // iOS fix: track buffer updates to invalidate VAOs
 }
 
 /** @mangle */
@@ -349,6 +352,9 @@ export interface IWebGL2GPUInputAssembler {
     glAttribs: IWebGL2Attrib[];
     glIndexType: GLenum;
     glVAOs: Map<WebGLProgram, WebGLVertexArrayObject>;
+
+    /** @mangle */
+    vaoVersions: Map<WebGLProgram, number>; // iOS fix: track buffer versions when VAO was created
 }
 
 /** @mangle */

--- a/cocos/gfx/webgl2/webgl2-input-assembler.ts
+++ b/cocos/gfx/webgl2/webgl2-input-assembler.ts
@@ -106,6 +106,7 @@ export class WebGL2InputAssembler extends InputAssembler {
             glAttribs: [],
             glIndexType,
             glVAOs: new Map<WebGLProgram, WebGLVertexArrayObject>(),
+            vaoVersions: new Map<WebGLProgram, number>(), // iOS fix: track buffer versions
         };
 
         WebGL2CmdFuncCreateInputAssember(WebGL2DeviceManager.instance, this._gpuInputAssembler);


### PR DESCRIPTION
The RichText component was creating label and Sprite nodes that did not propagate the Sorting2D component that the RichText had. This resulted in incorrect render orders for rich text because all it's child nodes would render on the default layer with 0 sorting order.

This pull request fixes this issue: https://github.com/cocos/cocos-engine/issues/19015

Example project archive: 
[richtextbadlayer_example.zip](https://github.com/user-attachments/files/23729338/richtextbadlayer_example.zip)

Example of issue:
layer setup:
<img width="1252" height="452" alt="image" src="https://github.com/user-attachments/assets/1e4e8e5d-70de-476a-8fea-516c448effa9" />

Before fix:
<img width="2075" height="732" alt="image" src="https://github.com/user-attachments/assets/9277c250-59ae-4a10-9597-352fda12caea" />

After fix:
<img width="2541" height="1005" alt="image" src="https://github.com/user-attachments/assets/13c2a8c7-406b-4bd7-bf90-a9bd4674a1f2" />

Re: #

### Changelog

* Added Sorting2D components on label and image nodes of the richText node if the richText has a Sorting2d component on it. Updated their values with the ones from the richText node

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes RichText rendering order issue where child Label and Sprite nodes did not inherit Sorting2D properties from parent RichText components, causing incorrect layer ordering
- Implements iOS-specific WebGL VAO invalidation fixes to handle buffer update synchronization issues in Safari's WebGL-to-Metal translation layer
- Adds version tracking system for buffers and VAOs with hash-based staleness detection to prevent rendering corruption on iOS devices

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `cocos/2d/components/rich-text.ts` | Fixed RichText to propagate Sorting2D properties to child nodes and sync values during runtime |
| `cocos/gfx/webgl2/webgl2-commands.ts` | Added comprehensive iOS VAO invalidation logic with buffer version tracking and forced rebinding |
| `cocos/gfx/webgl/webgl-commands.ts` | Implemented iOS-specific buffer versioning and VAO recreation to fix WebGL-to-Metal rendering issues |
| `cocos/gfx/webgl2/webgl2-gpu-objects.ts` | Added interface definitions for buffer updateVersion and VAO version tracking fields |
| `cocos/gfx/webgl/webgl-gpu-objects.ts` | Added optional updateVersion and vaoVersions fields to GPU buffer and input assembler interfaces |

<h3>Confidence score: 4/5</h3>


- This PR addresses well-documented issues with solid implementation patterns but involves complex graphics pipeline changes that require careful testing
- Score reflects the iOS VAO fixes being platform-specific workarounds for WebGL-to-Metal translation issues, plus the RichText change affecting UI component hierarchies
- Pay close attention to WebGL command files which implement intricate buffer versioning logic and VAO recreation mechanisms that could impact rendering performance

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant WebGL2CmdFuncUpdateBuffer
    participant Device
    participant GL as "WebGL Context"
    participant VAO as "VAO Cache"
    participant IA as "Input Assembler"

    User->>WebGL2CmdFuncUpdateBuffer: "Update buffer data"
    WebGL2CmdFuncUpdateBuffer->>Device: "Check if iOS"
    alt iOS Platform
        WebGL2CmdFuncUpdateBuffer->>WebGL2CmdFuncUpdateBuffer: "Increment updateVersion++"
        WebGL2CmdFuncUpdateBuffer->>VAO: "Unbind current VAO"
        WebGL2CmdFuncUpdateBuffer->>GL: "gl.bindVertexArray(null)"
        WebGL2CmdFuncUpdateBuffer->>IA: "Invalidate input assembler cache"
    end
    WebGL2CmdFuncUpdateBuffer->>GL: "Bind target buffer"
    WebGL2CmdFuncUpdateBuffer->>GL: "gl.bufferSubData() or gl.bufferData()"
    
    Note over User,IA: Later during rendering...
    
    User->>WebGL2CmdFuncBindStates: "Bind rendering states"
    WebGL2CmdFuncBindStates->>Device: "Check if iOS and VAO needed"
    alt iOS Platform and VAO Required
        WebGL2CmdFuncBindStates->>WebGL2CmdFuncBindStates: "Compute current buffer versions"
        WebGL2CmdFuncBindStates->>VAO: "Check cached VAO version"
        alt Version Mismatch
            WebGL2CmdFuncBindStates->>GL: "Delete old VAO"
            WebGL2CmdFuncBindStates->>GL: "Create new VAO"
            WebGL2CmdFuncBindStates->>VAO: "Store new version hash"
        end
    end
    WebGL2CmdFuncBindStates->>GL: "Bind VAO for rendering"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->