### PR TITLE
Fix the issue of unresponsive buttons on the HarmonyOS Next platform.

### DIFF
--- a/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
+++ b/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
@@ -209,10 +209,9 @@ int ohKeyCodeToCocosKeyCode(OH_NativeXComponent_KeyCode ohKeyCode) {
         {KEY_NUMPAD_ADD, cc::KeyCode::NUMPAD_PLUS},
         {KEY_NUMPAD_ENTER, cc::KeyCode::NUMPAD_ENTER},
         {KEY_NUMPAD_DOT, cc::KeyCode::NUMPAD_DECIMAL},
-    
         {KEY_NUMPAD_COMMA, cc::KeyCode::COMMA},
         {KEY_NUMPAD_EQUALS, cc::KeyCode::EQUAL},
-
+    
         {KEY_NUMPAD_0, cc::KeyCode::NUMPAD_0},
         {KEY_NUMPAD_1, cc::KeyCode::NUMPAD_1},
         {KEY_NUMPAD_2, cc::KeyCode::NUMPAD_2},
@@ -223,8 +222,6 @@ int ohKeyCodeToCocosKeyCode(OH_NativeXComponent_KeyCode ohKeyCode) {
         {KEY_NUMPAD_7, cc::KeyCode::NUMPAD_7},
         {KEY_NUMPAD_8, cc::KeyCode::NUMPAD_8},
         {KEY_NUMPAD_9, cc::KeyCode::NUMPAD_9},
-        
-        
     };
     if (keyCodeMap.find(ohKeyCode) != keyCodeMap.end()) {
         return int(keyCodeMap[ohKeyCode]);

--- a/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
+++ b/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
@@ -200,8 +200,8 @@ int ohKeyCodeToCocosKeyCode(OH_NativeXComponent_KeyCode ohKeyCode) {
         {KEY_PAGE_UP, cc::KeyCode::PAGE_UP},
         {KEY_PAGE_DOWN, cc::KeyCode::PAGE_DOWN},
         {KEY_SCROLL_LOCK, cc::KeyCode::SCROLLLOCK},
-        // numpad
         {KEY_BREAK, cc::KeyCode::PAUSE},
+        // numpad
         {KEY_NUM_LOCK, cc::KeyCode::NUM_LOCK},
         {KEY_NUMPAD_DIVIDE, cc::KeyCode::NUMPAD_DIVIDE},
         {KEY_NUMPAD_MULTIPLY, cc::KeyCode::NUMPAD_MULTIPLY},

--- a/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
+++ b/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
@@ -186,11 +186,45 @@ int ohKeyCodeToCocosKeyCode(OH_NativeXComponent_KeyCode ohKeyCode) {
         {KEY_SPACE, cc::KeyCode::SPACE},
         {KEY_ALT_RIGHT, cc::KeyCode::ALT_RIGHT},
         {KEY_CTRL_RIGHT, cc::KeyCode::CONTROL_RIGHT},
+    
         {KEY_DPAD_LEFT, cc::KeyCode::ARROW_LEFT},
         {KEY_DPAD_RIGHT, cc::KeyCode::ARROW_RIGHT},
         {KEY_DPAD_DOWN, cc::KeyCode::ARROW_DOWN},
         {KEY_DPAD_UP, cc::KeyCode::ARROW_UP},
+        {KEY_DPAD_CENTER, cc::KeyCode::DPAD_CENTER},
+    
+        {KEY_MOVE_HOME, cc::KeyCode::HOME},
+        {KEY_MOVE_END, cc::KeyCode::END},
+        {KEY_FORWARD_DEL, cc::KeyCode::DELETE_KEY},
         {KEY_INSERT, cc::KeyCode::INSERT},
+        {KEY_PAGE_UP, cc::KeyCode::PAGE_UP},
+        {KEY_PAGE_DOWN, cc::KeyCode::PAGE_DOWN},
+        {KEY_SCROLL_LOCK, cc::KeyCode::SCROLLLOCK},
+        // numpad
+        {KEY_BREAK, cc::KeyCode::PAUSE},
+        {KEY_NUM_LOCK, cc::KeyCode::NUM_LOCK},
+        {KEY_NUMPAD_DIVIDE, cc::KeyCode::NUMPAD_DIVIDE},
+        {KEY_NUMPAD_MULTIPLY, cc::KeyCode::NUMPAD_MULTIPLY},
+        {KEY_NUMPAD_SUBTRACT, cc::KeyCode::NUMPAD_MINUS},
+        {KEY_NUMPAD_ADD, cc::KeyCode::NUMPAD_PLUS},
+        {KEY_NUMPAD_ENTER, cc::KeyCode::NUMPAD_ENTER},
+        {KEY_NUMPAD_DOT, cc::KeyCode::NUMPAD_DECIMAL},
+    
+        {KEY_NUMPAD_COMMA, cc::KeyCode::COMMA},
+        {KEY_NUMPAD_EQUALS, cc::KeyCode::EQUAL},
+
+        {KEY_NUMPAD_0, cc::KeyCode::NUMPAD_0},
+        {KEY_NUMPAD_1, cc::KeyCode::NUMPAD_1},
+        {KEY_NUMPAD_2, cc::KeyCode::NUMPAD_2},
+        {KEY_NUMPAD_3, cc::KeyCode::NUMPAD_3},
+        {KEY_NUMPAD_4, cc::KeyCode::NUMPAD_4},
+        {KEY_NUMPAD_5, cc::KeyCode::NUMPAD_5},
+        {KEY_NUMPAD_6, cc::KeyCode::NUMPAD_6},
+        {KEY_NUMPAD_7, cc::KeyCode::NUMPAD_7},
+        {KEY_NUMPAD_8, cc::KeyCode::NUMPAD_8},
+        {KEY_NUMPAD_9, cc::KeyCode::NUMPAD_9},
+        
+        
     };
     if (keyCodeMap.find(ohKeyCode) != keyCodeMap.end()) {
         return int(keyCodeMap[ohKeyCode]);


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR expands the OpenHarmony key code mapping table in `ohKeyCodeToCocosKeyCode()` to support additional keyboard inputs:

- **D-pad center button**: Maps `KEY_DPAD_CENTER` to `DPAD_CENTER` for gamepad/remote controls
- **Navigation keys**: Adds support for Home, End, Delete, Insert, Page Up/Down, Scroll Lock, and Pause keys
- **Full numpad support**: Maps all numpad keys (0-9) and operators (divide, multiply, subtract, add, enter, decimal, comma, equals)

The mappings follow the existing pattern used by other platforms (Android, Mac) and correctly map OpenHarmony key codes to Cocos engine key codes. This fix allows buttons that were previously unresponsive to be properly recognized on HarmonyOS Next devices.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it only adds static key code mappings with no runtime behavior changes.
- The changes are straightforward additions to a static lookup table. All mappings follow existing patterns and use defined key code constants. No risk of runtime errors or regressions.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp | 5/5 | Added key code mappings for D-pad center, navigation keys (Home, End, Delete, Page Up/Down, Scroll Lock, Pause), and numpad keys (0-9 and operators) to fix unresponsive buttons on HarmonyOS Next. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OH as OpenHarmony System
    participant XC as XComponent Callback
    participant KM as ohKeyCodeToCocosKeyCode()
    participant EV as KeyboardEvent
    participant WK as Worker Thread

    OH->>XC: dispatchKeyEventCB(keyEvent)
    XC->>KM: ohKeyCodeToCocosKeyCode(ohKeyCode)
    Note over KM: Lookup in keyCodeMap
    KM-->>XC: cocosKeyCode
    XC->>EV: Create KeyboardEvent
    XC->>WK: sendMsgToWorker(KEY_EVENT)
    WK->>WK: Broadcast event
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->