### PR TITLE
Add response for the keyboard "Menu" button.

### DIFF
--- a/native/cocos/engine/EngineEvents.h
+++ b/native/cocos/engine/EngineEvents.h
@@ -265,7 +265,10 @@ enum class KeyCode {
     DPAD_LEFT = 1000,
     DPAD_DOWN = 1004,
     DPAD_RIGHT = 1001,
-    DPAD_CENTER = 1005
+    DPAD_CENTER = 1005,
+    // WIN/Command按钮
+    LGUI = 20300,
+    RGUI = 20301,
 };
 
 class KeyboardEvent {

--- a/native/cocos/engine/EngineEvents.h
+++ b/native/cocos/engine/EngineEvents.h
@@ -266,9 +266,6 @@ enum class KeyCode {
     DPAD_DOWN = 1004,
     DPAD_RIGHT = 1001,
     DPAD_CENTER = 1005,
-    // WIN/Command按钮
-    LGUI = 20300,
-    RGUI = 20301,
 };
 
 class KeyboardEvent {

--- a/native/cocos/platform/SDLHelper.cpp
+++ b/native/cocos/platform/SDLHelper.cpp
@@ -35,8 +35,8 @@
 
 namespace {
 std::unordered_map<int, cc::KeyCode> gKeyMap = {
-    {SDLK_LGUI, cc::KeyCode::LGUI},
-    {SDLK_RGUI, cc::KeyCode::RGUI},
+    {SDLK_LGUI, cc::KeyCode::META_LEFT},
+    {SDLK_RGUI, cc::KeyCode::META_RIGHT},
     {SDLK_APPLICATION, cc::KeyCode::CONTEXT_MENU},
     {SDLK_SCROLLLOCK, cc::KeyCode::SCROLLLOCK},
     {SDLK_PAUSE, cc::KeyCode::PAUSE},

--- a/native/cocos/platform/SDLHelper.cpp
+++ b/native/cocos/platform/SDLHelper.cpp
@@ -35,6 +35,8 @@
 
 namespace {
 std::unordered_map<int, cc::KeyCode> gKeyMap = {
+    {SDLK_LGUI, cc::KeyCode::LGUI},
+    {SDLK_RGUI, cc::KeyCode::RGUI},
     {SDLK_APPLICATION, cc::KeyCode::CONTEXT_MENU},
     {SDLK_SCROLLLOCK, cc::KeyCode::SCROLLLOCK},
     {SDLK_PAUSE, cc::KeyCode::PAUSE},

--- a/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
+++ b/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
@@ -222,6 +222,8 @@ int ohKeyCodeToCocosKeyCode(OH_NativeXComponent_KeyCode ohKeyCode) {
         {KEY_NUMPAD_7, cc::KeyCode::NUMPAD_7},
         {KEY_NUMPAD_8, cc::KeyCode::NUMPAD_8},
         {KEY_NUMPAD_9, cc::KeyCode::NUMPAD_9},
+
+        {KEY_MENU, cc::KeyCode::CONTEXT_MENU},
     };
     if (keyCodeMap.find(ohKeyCode) != keyCodeMap.end()) {
         return int(keyCodeMap[ohKeyCode]);

--- a/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
+++ b/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
@@ -224,6 +224,9 @@ int ohKeyCodeToCocosKeyCode(OH_NativeXComponent_KeyCode ohKeyCode) {
         {KEY_NUMPAD_9, cc::KeyCode::NUMPAD_9},
 
         {KEY_MENU, cc::KeyCode::CONTEXT_MENU},
+        {KEY_SYSRQ, cc::KeyCode::PRINT_SCREEN},
+        {KEY_META_LEFT, cc::KeyCode::LGUI},
+        {KEY_META_RIGHT, cc::KeyCode::RGUI},
     };
     if (keyCodeMap.find(ohKeyCode) != keyCodeMap.end()) {
         return int(keyCodeMap[ohKeyCode]);

--- a/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
+++ b/native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
@@ -225,8 +225,8 @@ int ohKeyCodeToCocosKeyCode(OH_NativeXComponent_KeyCode ohKeyCode) {
 
         {KEY_MENU, cc::KeyCode::CONTEXT_MENU},
         {KEY_SYSRQ, cc::KeyCode::PRINT_SCREEN},
-        {KEY_META_LEFT, cc::KeyCode::LGUI},
-        {KEY_META_RIGHT, cc::KeyCode::RGUI},
+        {KEY_META_LEFT, cc::KeyCode::META_LEFT},
+        {KEY_META_RIGHT, cc::KeyCode::META_RIGHT},
     };
     if (keyCodeMap.find(ohKeyCode) != keyCodeMap.end()) {
         return int(keyCodeMap[ohKeyCode]);


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds keyboard support for additional special keys across SDL and OpenHarmony platforms. The changes include mappings for the Menu button (`CONTEXT_MENU`), Win/Command keys (`META_LEFT`, `META_RIGHT`), and Print Screen (`PRINT_SCREEN`).

Key changes:
- Fixed missing comma after `DPAD_CENTER` enum in `EngineEvents.h` (required for proper C++ syntax)
- Added SDL mappings for `SDLK_LGUI` and `SDLK_RGUI` to support Win/Command keys on desktop platforms
- Added OpenHarmony mappings for `KEY_MENU`, `KEY_SYSRQ`, `KEY_META_LEFT`, and `KEY_META_RIGHT`

All key codes already exist in the `KeyCode` enum, and the implementation correctly maps platform-specific key codes to the engine's unified key codes.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are straightforward key mappings that follow established patterns in the codebase. The comma fix in EngineEvents.h is essential and correct. All mapped key codes already exist in the KeyCode enum, preventing undefined behavior. The implementation is consistent across both platforms.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| native/cocos/engine/EngineEvents.h | 5/5 | Fixed missing comma after `DPAD_CENTER` enum value - essential syntax fix |
| native/cocos/platform/SDLHelper.cpp | 5/5 | Added SDL key mappings for left/right Win/Command keys (`SDLK_LGUI`, `SDLK_RGUI`) |
| native/cocos/platform/openharmony/OpenHarmonyPlatform.cpp | 5/5 | Added OpenHarmony key mappings for Menu, Print Screen, and Meta keys |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant OS as Operating System
    participant SDL as SDL Platform (SDLHelper)
    participant OH as OpenHarmony Platform
    participant Engine as Cocos Engine
    participant App as Application

    Note over User,App: Keyboard Input Flow

    alt SDL Platform (Desktop)
        User->>OS: Press Menu/Win key
        OS->>SDL: SDLK_APPLICATION/SDLK_LGUI/SDLK_RGUI
        SDL->>SDL: sdlKeycodeToCocosCode()
        SDL->>Engine: KeyCode::CONTEXT_MENU/META_LEFT/META_RIGHT
        Engine->>App: Keyboard event dispatched
    end

    alt OpenHarmony Platform
        User->>OS: Press Menu/Win/SysRq key
        OS->>OH: KEY_MENU/KEY_META_LEFT/KEY_META_RIGHT/KEY_SYSRQ
        OH->>OH: ohKeyCodeToCocosKeyCode()
        OH->>Engine: KeyCode::CONTEXT_MENU/META_LEFT/META_RIGHT/PRINT_SCREEN
        Engine->>App: Keyboard event dispatched
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->