### PR TITLE
Fixed the issue where the file size could not be correctly obtained within the HarmonyOS Next sandbox.

### DIFF
--- a/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
+++ b/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
@@ -178,6 +178,11 @@ long FileUtilsOpenHarmony::getFileSize(const std::string &filepath) {
     if (fullPath.empty()) {
         return 0;
     }
+
+    if(fullPath[0] == '/') {
+        return FileUtils::getFileSize(fullPath);
+    }
+
     if (nullptr == _nativeResourceManager) {
         CC_LOG_ERROR("nativeResourceManager is nullptr");
         return 0;
@@ -201,11 +206,11 @@ bool FileUtilsOpenHarmony::isFileExistInternal(const std::string &strFilePath) c
         return false;
     }
 
-    if (strFilePath[0] != '/') { 
+    if (strFilePath[0] != '/') {
         const char *s = strFilePath.c_str();
         // Found "@assets/" at the beginning of the path and we don't want it
         if (strFilePath.find(ASSETS_FOLDER_NAME) == 0) s += strlen(ASSETS_FOLDER_NAME);
-        
+
         if (nullptr == _nativeResourceManager) {
             CC_LOG_ERROR("nativeResourceManager is nullptr");
             return false;
@@ -217,7 +222,7 @@ bool FileUtilsOpenHarmony::isFileExistInternal(const std::string &strFilePath) c
             return true;
         }
         return false;
-    } 
+    }
     FILE *fp = fopen(strFilePath.c_str(), "r");
     if (fp) {
         fclose(fp);

--- a/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
+++ b/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
@@ -183,6 +183,15 @@ long FileUtilsOpenHarmony::getFileSize(const std::string &filepath) {
         return 0;
     }
 
+    if (fullPath[0] == '/') {
+        struct stat info;
+        int result = stat(fullPath.c_str(), &info);
+        if (result != 0) {
+            return -1;
+        }
+        return static_cast<long>(info.st_size);
+    }
+
     long filesize = 0;
     RawFile64 *rawFile = OH_ResourceManager_OpenRawFile64(_nativeResourceManager, fullPath.c_str());
     if (rawFile) {
@@ -201,11 +210,11 @@ bool FileUtilsOpenHarmony::isFileExistInternal(const std::string &strFilePath) c
         return false;
     }
 
-    if (strFilePath[0] != '/') { 
+    if (strFilePath[0] != '/') {
         const char *s = strFilePath.c_str();
         // Found "@assets/" at the beginning of the path and we don't want it
         if (strFilePath.find(ASSETS_FOLDER_NAME) == 0) s += strlen(ASSETS_FOLDER_NAME);
-        
+
         if (nullptr == _nativeResourceManager) {
             CC_LOG_ERROR("nativeResourceManager is nullptr");
             return false;
@@ -217,7 +226,7 @@ bool FileUtilsOpenHarmony::isFileExistInternal(const std::string &strFilePath) c
             return true;
         }
         return false;
-    } 
+    }
     FILE *fp = fopen(strFilePath.c_str(), "r");
     if (fp) {
         fclose(fp);


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR attempts to fix a file size retrieval issue in HarmonyOS Next sandbox environments for absolute file paths. However, the implementation contains a critical logic error in the `getFileSize()` method of `FileUtils-OpenHarmony.cpp`. The code checks for absolute paths (starting with '/') twice in succession - first delegating to `FileUtils::getFileSize()` and then immediately using direct `stat()` calls. This creates unreachable code where the second implementation (lines 191-198) will never execute because the same condition was already handled above (lines 182-184). The change also includes minor formatting corrections in the `isFileExistInternal()` method that don't affect functionality.

PR Description Notes:
- The changelog section is empty and should be filled out
- Several compatibility checkboxes are unchecked, which may need attention

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp | 1/5 | Contains unreachable code due to duplicate condition checking for absolute paths, creating a logic error |

<h3>Confidence score: 1/5</h3>


- This PR is not ready to merge due to a critical logic error that makes part of the code unreachable
- Score reflects the presence of unreachable code caused by duplicate conditional checks, which indicates incomplete refactoring or merge conflict resolution
- Pay close attention to the FileUtils-OpenHarmony.cpp file as it contains duplicate logic that needs to be resolved before merging

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->