### PR TITLE
Fixed the issue where the file size could not be correctly obtained within the HarmonyOS Next sandbox.

### DIFF
--- a/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
+++ b/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
@@ -178,6 +178,11 @@ long FileUtilsOpenHarmony::getFileSize(const std::string &filepath) {
     if (fullPath.empty()) {
         return 0;
     }
+
+    if(fullPath[0] == '/') {
+        return FileUtils::getFileSize(fullPath);
+    }
+
     if (nullptr == _nativeResourceManager) {
         CC_LOG_ERROR("nativeResourceManager is nullptr");
         return 0;
@@ -201,11 +206,11 @@ bool FileUtilsOpenHarmony::isFileExistInternal(const std::string &strFilePath) c
         return false;
     }
 
-    if (strFilePath[0] != '/') { 
+    if (strFilePath[0] != '/') {
         const char *s = strFilePath.c_str();
         // Found "@assets/" at the beginning of the path and we don't want it
         if (strFilePath.find(ASSETS_FOLDER_NAME) == 0) s += strlen(ASSETS_FOLDER_NAME);
-        
+
         if (nullptr == _nativeResourceManager) {
             CC_LOG_ERROR("nativeResourceManager is nullptr");
             return false;
@@ -217,7 +222,7 @@ bool FileUtilsOpenHarmony::isFileExistInternal(const std::string &strFilePath) c
             return true;
         }
         return false;
-    } 
+    }
     FILE *fp = fopen(strFilePath.c_str(), "r");
     if (fp) {
         fclose(fp);

--- a/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
+++ b/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
@@ -188,15 +188,6 @@ long FileUtilsOpenHarmony::getFileSize(const std::string &filepath) {
         return 0;
     }
 
-    if (fullPath[0] == '/') {
-        struct stat info;
-        int result = stat(fullPath.c_str(), &info);
-        if (result != 0) {
-            return -1;
-        }
-        return static_cast<long>(info.st_size);
-    }
-
     long filesize = 0;
     RawFile64 *rawFile = OH_ResourceManager_OpenRawFile64(_nativeResourceManager, fullPath.c_str());
     if (rawFile) {

--- a/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
+++ b/native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp
@@ -183,6 +183,15 @@ long FileUtilsOpenHarmony::getFileSize(const std::string &filepath) {
         return 0;
     }
 
+    if (fullPath[0] == '/') {
+        struct stat info;
+        int result = stat(fullPath.c_str(), &info);
+        if (result != 0) {
+            return -1;
+        }
+        return static_cast<long>(info.st_size);
+    }
+
     long filesize = 0;
     RawFile64 *rawFile = OH_ResourceManager_OpenRawFile64(_nativeResourceManager, fullPath.c_str());
     if (rawFile) {
@@ -201,11 +210,11 @@ bool FileUtilsOpenHarmony::isFileExistInternal(const std::string &strFilePath) c
         return false;
     }
 
-    if (strFilePath[0] != '/') { 
+    if (strFilePath[0] != '/') {
         const char *s = strFilePath.c_str();
         // Found "@assets/" at the beginning of the path and we don't want it
         if (strFilePath.find(ASSETS_FOLDER_NAME) == 0) s += strlen(ASSETS_FOLDER_NAME);
-        
+
         if (nullptr == _nativeResourceManager) {
             CC_LOG_ERROR("nativeResourceManager is nullptr");
             return false;
@@ -217,7 +226,7 @@ bool FileUtilsOpenHarmony::isFileExistInternal(const std::string &strFilePath) c
             return true;
         }
         return false;
-    } 
+    }
     FILE *fp = fopen(strFilePath.c_str(), "r");
     if (fp) {
         fclose(fp);


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a file size retrieval bug specific to HarmonyOS Next sandbox environment. The issue was that the `getFileSize()` method in the HarmonyOS platform adapter was incorrectly attempting to handle absolute file paths (starting with '/') using the HarmonyOS ResourceManager API, which is intended only for bundled assets. The fix adds a simple check to delegate absolute paths to the base `FileUtils::getFileSize()` method, ensuring they are handled by standard filesystem operations instead.

This change aligns with the existing pattern already implemented in other methods like `getContents()` and `isFileExistInternal()`, creating consistency across the HarmonyOS file handling implementation. The change is platform-specific and contained within the HarmonyOS adapter, maintaining the engine's cross-platform file access abstraction while properly supporting both asset bundle files and absolute filesystem paths on HarmonyOS.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| native/cocos/platform/openharmony/FileUtils-OpenHarmony.cpp | 5/5 | Added absolute path check in getFileSize() method to delegate to base FileUtils for paths starting with '/' |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it fixes a specific platform bug without affecting other systems
- Score reflects a simple, well-targeted fix that follows existing patterns in the codebase and addresses a clear functional issue
- No files require special attention as the change is straightforward and follows established conventions

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->