### PR TITLE
fix ios compile

### DIFF
--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -77,7 +77,8 @@ struct ResourceAccessNode {
 
     ResourceAccessNode(ResourceAccessNode&& rhs) noexcept = default;
     ResourceAccessNode(ResourceAccessNode const& rhs) = delete;
-    ResourceAccessNode& operator=(ResourceAccessNode&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ResourceAccessNode& operator=(ResourceAccessNode&& rhs) = default;
     ResourceAccessNode& operator=(ResourceAccessNode const& rhs) = default;
 
     PmrFlatMap<ccstd::pmr::string, AccessStatus> resourceStatus;
@@ -100,7 +101,8 @@ struct AttachmentInfo {
 
     AttachmentInfo(AttachmentInfo&& rhs) noexcept = default;
     AttachmentInfo(AttachmentInfo const& rhs) = delete;
-    AttachmentInfo& operator=(AttachmentInfo&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    AttachmentInfo& operator=(AttachmentInfo&& rhs) = default;
     AttachmentInfo& operator=(AttachmentInfo const& rhs) = default;
 
     ccstd::pmr::string parentName;
@@ -120,7 +122,8 @@ struct FGRenderPassInfo {
 
     FGRenderPassInfo(FGRenderPassInfo&& rhs) noexcept = default;
     FGRenderPassInfo(FGRenderPassInfo const& rhs) = delete;
-    FGRenderPassInfo& operator=(FGRenderPassInfo&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    FGRenderPassInfo& operator=(FGRenderPassInfo&& rhs) = default;
     FGRenderPassInfo& operator=(FGRenderPassInfo const& rhs) = default;
 
     ccstd::vector<LayoutAccess> colorAccesses;
@@ -266,7 +269,8 @@ struct ResourceAccessGraph {
 
         Vertex(Vertex&& rhs) noexcept = default;
         Vertex(Vertex const& rhs) = delete;
-        Vertex& operator=(Vertex&& rhs) noexcept = default;
+        // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+        Vertex& operator=(Vertex&& rhs) = default;
         Vertex& operator=(Vertex const& rhs) = default;
 
         ccstd::pmr::vector<OutEdge> outEdges;
@@ -401,7 +405,8 @@ struct RelationGraph {
 
         Vertex(Vertex&& rhs) noexcept = default;
         Vertex(Vertex const& rhs) = delete;
-        Vertex& operator=(Vertex&& rhs) noexcept = default;
+        // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+        Vertex& operator=(Vertex&& rhs) = default;
         Vertex& operator=(Vertex const& rhs) = default;
 
         ccstd::pmr::vector<OutEdge> outEdges;
@@ -430,7 +435,8 @@ struct RenderingInfo {
 
     RenderingInfo(RenderingInfo&& rhs) noexcept = default;
     RenderingInfo(RenderingInfo const& rhs) = delete;
-    RenderingInfo& operator=(RenderingInfo&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RenderingInfo& operator=(RenderingInfo&& rhs) = default;
     RenderingInfo& operator=(RenderingInfo const& rhs) = default;
 
     gfx::RenderPassInfo renderpassInfo;

--- a/native/cocos/renderer/pipeline/custom/LayoutGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/LayoutGraphTypes.h
@@ -156,7 +156,8 @@ struct DescriptorDB {
 
     DescriptorDB(DescriptorDB&& rhs) noexcept = default;
     DescriptorDB(DescriptorDB const& rhs) = delete;
-    DescriptorDB& operator=(DescriptorDB&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    DescriptorDB& operator=(DescriptorDB&& rhs) = default;
     DescriptorDB& operator=(DescriptorDB const& rhs) = default;
 
     ccstd::pmr::map<DescriptorBlockIndex, DescriptorBlock> blocks;
@@ -178,7 +179,8 @@ struct RenderPhase {
 
     RenderPhase(RenderPhase&& rhs) noexcept = default;
     RenderPhase(RenderPhase const& rhs) = delete;
-    RenderPhase& operator=(RenderPhase&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RenderPhase& operator=(RenderPhase&& rhs) = default;
     RenderPhase& operator=(RenderPhase const& rhs) = default;
 
     PmrTransparentSet<ccstd::pmr::string> shaders;
@@ -206,7 +208,8 @@ struct LayoutGraph {
 
     LayoutGraph(LayoutGraph&& rhs) noexcept = default;
     LayoutGraph(LayoutGraph const& rhs) = delete;
-    LayoutGraph& operator=(LayoutGraph&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    LayoutGraph& operator=(LayoutGraph&& rhs) = default;
     LayoutGraph& operator=(LayoutGraph const& rhs) = default;
 
     // Graph
@@ -333,7 +336,8 @@ struct LayoutGraph {
 
         Vertex(Vertex&& rhs) noexcept = default;
         Vertex(Vertex const& rhs) = delete;
-        Vertex& operator=(Vertex&& rhs) noexcept = default;
+        // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+        Vertex& operator=(Vertex&& rhs) = default;
         Vertex& operator=(Vertex const& rhs) = default;
 
         ccstd::pmr::vector<OutEdge> outEdges;
@@ -381,7 +385,8 @@ struct UniformBlockData {
 
     UniformBlockData(UniformBlockData&& rhs) noexcept = default;
     UniformBlockData(UniformBlockData const& rhs) = delete;
-    UniformBlockData& operator=(UniformBlockData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    UniformBlockData& operator=(UniformBlockData&& rhs) = default;
     UniformBlockData& operator=(UniformBlockData const& rhs) = default;
 
     uint32_t bufferSize{0};
@@ -437,7 +442,8 @@ struct DescriptorBlockData {
 
     DescriptorBlockData(DescriptorBlockData&& rhs) noexcept = default;
     DescriptorBlockData(DescriptorBlockData const& rhs) = delete;
-    DescriptorBlockData& operator=(DescriptorBlockData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    DescriptorBlockData& operator=(DescriptorBlockData&& rhs) = default;
     DescriptorBlockData& operator=(DescriptorBlockData const& rhs) = default;
 
     DescriptorTypeOrder type{DescriptorTypeOrder::UNIFORM_BUFFER};
@@ -463,7 +469,8 @@ struct DescriptorSetLayoutData {
 
     DescriptorSetLayoutData(DescriptorSetLayoutData&& rhs) noexcept = default;
     DescriptorSetLayoutData(DescriptorSetLayoutData const& rhs) = delete;
-    DescriptorSetLayoutData& operator=(DescriptorSetLayoutData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    DescriptorSetLayoutData& operator=(DescriptorSetLayoutData&& rhs) = default;
     DescriptorSetLayoutData& operator=(DescriptorSetLayoutData const& rhs) = delete;
 
     uint32_t slot{0xFFFFFFFF};
@@ -487,7 +494,8 @@ struct DescriptorSetData {
 
     DescriptorSetData(DescriptorSetData&& rhs) noexcept = default;
     DescriptorSetData(DescriptorSetData const& rhs) = delete;
-    DescriptorSetData& operator=(DescriptorSetData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    DescriptorSetData& operator=(DescriptorSetData&& rhs) = default;
     DescriptorSetData& operator=(DescriptorSetData const& rhs) = delete;
 
     DescriptorSetLayoutData descriptorSetLayoutData;
@@ -507,7 +515,8 @@ struct PipelineLayoutData {
 
     PipelineLayoutData(PipelineLayoutData&& rhs) noexcept = default;
     PipelineLayoutData(PipelineLayoutData const& rhs) = delete;
-    PipelineLayoutData& operator=(PipelineLayoutData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    PipelineLayoutData& operator=(PipelineLayoutData&& rhs) = default;
     PipelineLayoutData& operator=(PipelineLayoutData const& rhs) = delete;
 
     ccstd::pmr::map<UpdateFrequency, DescriptorSetData> descriptorSets;
@@ -525,7 +534,8 @@ struct ShaderBindingData {
 
     ShaderBindingData(ShaderBindingData&& rhs) noexcept = default;
     ShaderBindingData(ShaderBindingData const& rhs) = delete;
-    ShaderBindingData& operator=(ShaderBindingData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ShaderBindingData& operator=(ShaderBindingData&& rhs) = default;
     ShaderBindingData& operator=(ShaderBindingData const& rhs) = delete;
 
     PmrFlatMap<NameLocalID, uint32_t> descriptorBindings;
@@ -542,7 +552,8 @@ struct ShaderLayoutData {
 
     ShaderLayoutData(ShaderLayoutData&& rhs) noexcept = default;
     ShaderLayoutData(ShaderLayoutData const& rhs) = delete;
-    ShaderLayoutData& operator=(ShaderLayoutData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ShaderLayoutData& operator=(ShaderLayoutData&& rhs) = default;
     ShaderLayoutData& operator=(ShaderLayoutData const& rhs) = delete;
 
     ccstd::pmr::map<UpdateFrequency, DescriptorSetLayoutData> layoutData;
@@ -560,7 +571,8 @@ struct TechniqueData {
 
     TechniqueData(TechniqueData&& rhs) noexcept = default;
     TechniqueData(TechniqueData const& rhs) = delete;
-    TechniqueData& operator=(TechniqueData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    TechniqueData& operator=(TechniqueData&& rhs) = default;
     TechniqueData& operator=(TechniqueData const& rhs) = delete;
 
     ccstd::pmr::vector<ShaderLayoutData> passes;
@@ -577,7 +589,8 @@ struct EffectData {
 
     EffectData(EffectData&& rhs) noexcept = default;
     EffectData(EffectData const& rhs) = delete;
-    EffectData& operator=(EffectData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    EffectData& operator=(EffectData&& rhs) = default;
     EffectData& operator=(EffectData const& rhs) = delete;
 
     ccstd::pmr::map<ccstd::pmr::string, TechniqueData> techniques;
@@ -594,7 +607,8 @@ struct ShaderProgramData {
 
     ShaderProgramData(ShaderProgramData&& rhs) noexcept = default;
     ShaderProgramData(ShaderProgramData const& rhs) = delete;
-    ShaderProgramData& operator=(ShaderProgramData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ShaderProgramData& operator=(ShaderProgramData&& rhs) = default;
     ShaderProgramData& operator=(ShaderProgramData const& rhs) = delete;
 
     PipelineLayoutData layout;
@@ -612,7 +626,8 @@ struct RenderStageData {
 
     RenderStageData(RenderStageData&& rhs) noexcept = default;
     RenderStageData(RenderStageData const& rhs) = delete;
-    RenderStageData& operator=(RenderStageData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RenderStageData& operator=(RenderStageData&& rhs) = default;
     RenderStageData& operator=(RenderStageData const& rhs) = delete;
 
     PmrUnorderedMap<NameLocalID, gfx::ShaderStageFlagBit> descriptorVisibility;
@@ -629,7 +644,8 @@ struct RenderPhaseData {
 
     RenderPhaseData(RenderPhaseData&& rhs) noexcept = default;
     RenderPhaseData(RenderPhaseData const& rhs) = delete;
-    RenderPhaseData& operator=(RenderPhaseData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RenderPhaseData& operator=(RenderPhaseData&& rhs) = default;
     RenderPhaseData& operator=(RenderPhaseData const& rhs) = delete;
 
     ccstd::pmr::string rootSignature;
@@ -653,7 +669,8 @@ struct LayoutGraphData {
 
     LayoutGraphData(LayoutGraphData&& rhs) noexcept = default;
     LayoutGraphData(LayoutGraphData const& rhs) = delete;
-    LayoutGraphData& operator=(LayoutGraphData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    LayoutGraphData& operator=(LayoutGraphData&& rhs) = default;
     LayoutGraphData& operator=(LayoutGraphData const& rhs) = delete;
 
     // Graph
@@ -780,7 +797,8 @@ struct LayoutGraphData {
 
         Vertex(Vertex&& rhs) noexcept = default;
         Vertex(Vertex const& rhs) = delete;
-        Vertex& operator=(Vertex&& rhs) noexcept = default;
+        // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+        Vertex& operator=(Vertex&& rhs) = default;
         Vertex& operator=(Vertex const& rhs) = default;
 
         ccstd::pmr::vector<OutEdge> outEdges;

--- a/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
+++ b/native/cocos/renderer/pipeline/custom/NativePipelineTypes.h
@@ -914,7 +914,8 @@ struct RenderInstancingQueue {
 
     RenderInstancingQueue(RenderInstancingQueue&& rhs) noexcept = default;
     RenderInstancingQueue(RenderInstancingQueue const& rhs) = delete;
-    RenderInstancingQueue& operator=(RenderInstancingQueue&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RenderInstancingQueue& operator=(RenderInstancingQueue&& rhs) = default;
     RenderInstancingQueue& operator=(RenderInstancingQueue const& rhs) = default;
 
     bool empty() const noexcept;
@@ -953,7 +954,8 @@ struct ProbeHelperQueue {
 
     ProbeHelperQueue(ProbeHelperQueue&& rhs) noexcept = default;
     ProbeHelperQueue(ProbeHelperQueue const& rhs) = delete;
-    ProbeHelperQueue& operator=(ProbeHelperQueue&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ProbeHelperQueue& operator=(ProbeHelperQueue&& rhs) = default;
     ProbeHelperQueue& operator=(ProbeHelperQueue const& rhs) = default;
 
     static LayoutGraphData::vertex_descriptor getDefaultId(const LayoutGraphData &lg);
@@ -983,7 +985,8 @@ struct RenderDrawQueue {
 
     RenderDrawQueue(RenderDrawQueue&& rhs) noexcept = default;
     RenderDrawQueue(RenderDrawQueue const& rhs) = delete;
-    RenderDrawQueue& operator=(RenderDrawQueue&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RenderDrawQueue& operator=(RenderDrawQueue&& rhs) = default;
     RenderDrawQueue& operator=(RenderDrawQueue const& rhs) = default;
 
     void add(const scene::Model& model, float depth, uint32_t subModelIdx, uint32_t passIdx);
@@ -1008,7 +1011,8 @@ struct NativeRenderQueue {
 
     NativeRenderQueue(NativeRenderQueue&& rhs) noexcept = default;
     NativeRenderQueue(NativeRenderQueue const& rhs) = delete;
-    NativeRenderQueue& operator=(NativeRenderQueue&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    NativeRenderQueue& operator=(NativeRenderQueue&& rhs) = default;
     NativeRenderQueue& operator=(NativeRenderQueue const& rhs) = delete;
 
     void sort();
@@ -1055,7 +1059,8 @@ struct BufferPool {
 
     BufferPool(BufferPool&& rhs) noexcept = default;
     BufferPool(BufferPool const& rhs) = delete;
-    BufferPool& operator=(BufferPool&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    BufferPool& operator=(BufferPool&& rhs) = default;
     BufferPool& operator=(BufferPool const& rhs) = delete;
     void init(gfx::Device* deviceIn, uint32_t sz, bool bDynamic);
     void syncResources();
@@ -1082,7 +1087,8 @@ struct DescriptorSetPool {
 
     DescriptorSetPool(DescriptorSetPool&& rhs) noexcept = default;
     DescriptorSetPool(DescriptorSetPool const& rhs) = delete;
-    DescriptorSetPool& operator=(DescriptorSetPool&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    DescriptorSetPool& operator=(DescriptorSetPool&& rhs) = default;
     DescriptorSetPool& operator=(DescriptorSetPool const& rhs) = delete;
     void init(gfx::Device* deviceIn, IntrusivePtr<gfx::DescriptorSetLayout> layout);
     void syncDescriptorSets();
@@ -1107,7 +1113,8 @@ struct UniformBlockResource {
 
     UniformBlockResource(UniformBlockResource&& rhs) noexcept = default;
     UniformBlockResource(UniformBlockResource const& rhs) = delete;
-    UniformBlockResource& operator=(UniformBlockResource&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    UniformBlockResource& operator=(UniformBlockResource&& rhs) = default;
     UniformBlockResource& operator=(UniformBlockResource const& rhs) = delete;
     void init(gfx::Device* deviceIn, uint32_t sz, bool bDynamic);
     gfx::Buffer* createFromCpuBuffer();
@@ -1127,7 +1134,8 @@ struct ProgramResource {
 
     ProgramResource(ProgramResource&& rhs) noexcept = default;
     ProgramResource(ProgramResource const& rhs) = delete;
-    ProgramResource& operator=(ProgramResource&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ProgramResource& operator=(ProgramResource&& rhs) = default;
     ProgramResource& operator=(ProgramResource const& rhs) = delete;
     void syncResources() noexcept;
 
@@ -1146,7 +1154,8 @@ struct LayoutGraphNodeResource {
 
     LayoutGraphNodeResource(LayoutGraphNodeResource&& rhs) noexcept = default;
     LayoutGraphNodeResource(LayoutGraphNodeResource const& rhs) = delete;
-    LayoutGraphNodeResource& operator=(LayoutGraphNodeResource&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    LayoutGraphNodeResource& operator=(LayoutGraphNodeResource&& rhs) = default;
     LayoutGraphNodeResource& operator=(LayoutGraphNodeResource const& rhs) = delete;
     void syncResources() noexcept;
 
@@ -1214,7 +1223,8 @@ struct FrustumCulling {
 
     FrustumCulling(FrustumCulling&& rhs) noexcept = default;
     FrustumCulling(FrustumCulling const& rhs) = delete;
-    FrustumCulling& operator=(FrustumCulling&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    FrustumCulling& operator=(FrustumCulling&& rhs) = default;
     FrustumCulling& operator=(FrustumCulling const& rhs) = default;
 
     ccstd::pmr::unordered_map<FrustumCullingKey, FrustumCullingID> resultIndex;
@@ -1265,7 +1275,8 @@ struct LightBoundsCulling {
 
     LightBoundsCulling(LightBoundsCulling&& rhs) noexcept = default;
     LightBoundsCulling(LightBoundsCulling const& rhs) = delete;
-    LightBoundsCulling& operator=(LightBoundsCulling&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    LightBoundsCulling& operator=(LightBoundsCulling&& rhs) = default;
     LightBoundsCulling& operator=(LightBoundsCulling const& rhs) = default;
 
     ccstd::pmr::unordered_map<LightBoundsCullingKey, LightBoundsCullingID> resultIndex;
@@ -1316,7 +1327,8 @@ struct SceneCulling {
 
     SceneCulling(SceneCulling&& rhs) noexcept = default;
     SceneCulling(SceneCulling const& rhs) = delete;
-    SceneCulling& operator=(SceneCulling&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    SceneCulling& operator=(SceneCulling&& rhs) = default;
     SceneCulling& operator=(SceneCulling const& rhs) = delete;
 
     void clear() noexcept;
@@ -1432,7 +1444,8 @@ struct DeviceRenderData {
 
     DeviceRenderData(DeviceRenderData&& rhs) noexcept = default;
     DeviceRenderData(DeviceRenderData const& rhs) = delete;
-    DeviceRenderData& operator=(DeviceRenderData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    DeviceRenderData& operator=(DeviceRenderData&& rhs) = default;
     DeviceRenderData& operator=(DeviceRenderData const& rhs) = delete;
 
     void clear() noexcept {
@@ -1533,7 +1546,8 @@ struct PipelineCustomization {
 
     PipelineCustomization(PipelineCustomization&& rhs) noexcept = default;
     PipelineCustomization(PipelineCustomization const& rhs) = delete;
-    PipelineCustomization& operator=(PipelineCustomization&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    PipelineCustomization& operator=(PipelineCustomization&& rhs) = default;
     PipelineCustomization& operator=(PipelineCustomization const& rhs) = default;
 
     std::shared_ptr<CustomPipelineContext> currentContext;

--- a/native/cocos/renderer/pipeline/custom/NativeTypes.h
+++ b/native/cocos/renderer/pipeline/custom/NativeTypes.h
@@ -56,7 +56,8 @@ struct ProgramInfo {
 
     ProgramInfo(ProgramInfo&& rhs) noexcept = default;
     ProgramInfo(ProgramInfo const& rhs) = delete;
-    ProgramInfo& operator=(ProgramInfo&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ProgramInfo& operator=(ProgramInfo&& rhs) = default;
     ProgramInfo& operator=(ProgramInfo const& rhs) = default;
 
     IProgramInfo programInfo;
@@ -78,7 +79,8 @@ struct ProgramGroup {
 
     ProgramGroup(ProgramGroup&& rhs) noexcept = default;
     ProgramGroup(ProgramGroup const& rhs) = delete;
-    ProgramGroup& operator=(ProgramGroup&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ProgramGroup& operator=(ProgramGroup&& rhs) = default;
     ProgramGroup& operator=(ProgramGroup const& rhs) = default;
 
     PmrTransparentMap<ccstd::pmr::string, ProgramInfo> programInfos;

--- a/native/cocos/renderer/pipeline/custom/RenderCommonTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderCommonTypes.h
@@ -308,7 +308,8 @@ struct ResolvePair {
 
     ResolvePair(ResolvePair&& rhs) noexcept = default;
     ResolvePair(ResolvePair const& rhs) = delete;
-    ResolvePair& operator=(ResolvePair&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ResolvePair& operator=(ResolvePair&& rhs) = default;
     ResolvePair& operator=(ResolvePair const& rhs) = default;
 
     ccstd::pmr::string source;
@@ -340,7 +341,8 @@ struct CopyPair {
 
     CopyPair(CopyPair&& rhs) noexcept = default;
     CopyPair(CopyPair const& rhs) = delete;
-    CopyPair& operator=(CopyPair&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    CopyPair& operator=(CopyPair&& rhs) = default;
     CopyPair& operator=(CopyPair const& rhs) = default;
 
     ccstd::pmr::string source;
@@ -367,7 +369,8 @@ struct UploadPair {
 
     UploadPair(UploadPair&& rhs) noexcept = default;
     UploadPair(UploadPair const& rhs) = delete;
-    UploadPair& operator=(UploadPair&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    UploadPair& operator=(UploadPair&& rhs) = default;
     UploadPair& operator=(UploadPair const& rhs) = delete;
 
     ccstd::vector<uint8_t> source;
@@ -392,7 +395,8 @@ struct MovePair {
 
     MovePair(MovePair&& rhs) noexcept = default;
     MovePair(MovePair const& rhs) = delete;
-    MovePair& operator=(MovePair&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    MovePair& operator=(MovePair&& rhs) = default;
     MovePair& operator=(MovePair const& rhs) = default;
 
     ccstd::pmr::string source;

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
@@ -93,7 +93,8 @@ struct RasterView {
 
     RasterView(RasterView&& rhs) noexcept = default;
     RasterView(RasterView const& rhs) = delete;
-    RasterView& operator=(RasterView&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RasterView& operator=(RasterView&& rhs) = default;
     RasterView& operator=(RasterView const& rhs) = default;
 
     ccstd::pmr::string slotName;
@@ -131,7 +132,8 @@ struct ComputeView {
 
     ComputeView(ComputeView&& rhs) noexcept = default;
     ComputeView(ComputeView const& rhs) = delete;
-    ComputeView& operator=(ComputeView&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ComputeView& operator=(ComputeView&& rhs) = default;
     ComputeView& operator=(ComputeView const& rhs) = default;
 
     bool isRead() const {
@@ -266,7 +268,8 @@ struct Subpass {
 
     Subpass(Subpass&& rhs) noexcept = default;
     Subpass(Subpass const& rhs) = delete;
-    Subpass& operator=(Subpass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    Subpass& operator=(Subpass&& rhs) = default;
     Subpass& operator=(Subpass const& rhs) = default;
 
     PmrTransparentMap<ccstd::pmr::string, RasterView> rasterViews;
@@ -299,7 +302,8 @@ struct SubpassGraph {
 
     SubpassGraph(SubpassGraph&& rhs) noexcept = default;
     SubpassGraph(SubpassGraph const& rhs) = delete;
-    SubpassGraph& operator=(SubpassGraph&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    SubpassGraph& operator=(SubpassGraph&& rhs) = default;
     SubpassGraph& operator=(SubpassGraph const& rhs) = default;
 
     // Graph
@@ -386,7 +390,8 @@ struct SubpassGraph {
 
         Vertex(Vertex&& rhs) noexcept = default;
         Vertex(Vertex const& rhs) = delete;
-        Vertex& operator=(Vertex&& rhs) noexcept = default;
+        // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+        Vertex& operator=(Vertex&& rhs) = default;
         Vertex& operator=(Vertex const& rhs) = default;
 
         ccstd::pmr::vector<OutEdge> outEdges;
@@ -425,7 +430,8 @@ struct RasterSubpass {
 
     RasterSubpass(RasterSubpass&& rhs) noexcept = default;
     RasterSubpass(RasterSubpass const& rhs) = delete;
-    RasterSubpass& operator=(RasterSubpass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RasterSubpass& operator=(RasterSubpass&& rhs) = default;
     RasterSubpass& operator=(RasterSubpass const& rhs) = default;
 
     PmrTransparentMap<ccstd::pmr::string, RasterView> rasterViews;
@@ -451,7 +457,8 @@ struct ComputeSubpass {
 
     ComputeSubpass(ComputeSubpass&& rhs) noexcept = default;
     ComputeSubpass(ComputeSubpass const& rhs) = delete;
-    ComputeSubpass& operator=(ComputeSubpass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ComputeSubpass& operator=(ComputeSubpass&& rhs) = default;
     ComputeSubpass& operator=(ComputeSubpass const& rhs) = default;
 
     PmrTransparentMap<ccstd::pmr::string, RasterView> rasterViews;
@@ -471,7 +478,8 @@ struct RasterPass {
 
     RasterPass(RasterPass&& rhs) noexcept = default;
     RasterPass(RasterPass const& rhs) = delete;
-    RasterPass& operator=(RasterPass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RasterPass& operator=(RasterPass&& rhs) = default;
     RasterPass& operator=(RasterPass const& rhs) = default;
 
     PmrTransparentMap<ccstd::pmr::string, RasterView> rasterViews;
@@ -512,7 +520,8 @@ struct PersistentRenderPassAndFramebuffer {
 
     PersistentRenderPassAndFramebuffer(PersistentRenderPassAndFramebuffer&& rhs) noexcept = default;
     PersistentRenderPassAndFramebuffer(PersistentRenderPassAndFramebuffer const& rhs) = delete;
-    PersistentRenderPassAndFramebuffer& operator=(PersistentRenderPassAndFramebuffer&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    PersistentRenderPassAndFramebuffer& operator=(PersistentRenderPassAndFramebuffer&& rhs) = default;
     PersistentRenderPassAndFramebuffer& operator=(PersistentRenderPassAndFramebuffer const& rhs) = default;
 
     IntrusivePtr<gfx::RenderPass> renderPass;
@@ -704,7 +713,8 @@ struct ResourceGraph {
 
         Vertex(Vertex&& rhs) noexcept = default;
         Vertex(Vertex const& rhs) = delete;
-        Vertex& operator=(Vertex&& rhs) noexcept = default;
+        // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+        Vertex& operator=(Vertex&& rhs) = default;
         Vertex& operator=(Vertex const& rhs) = default;
 
         ccstd::pmr::vector<OutEdge> outEdges;
@@ -756,7 +766,8 @@ struct ComputePass {
 
     ComputePass(ComputePass&& rhs) noexcept = default;
     ComputePass(ComputePass const& rhs) = delete;
-    ComputePass& operator=(ComputePass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ComputePass& operator=(ComputePass&& rhs) = default;
     ComputePass& operator=(ComputePass const& rhs) = default;
 
     PmrTransparentMap<ccstd::pmr::string, ccstd::pmr::vector<ComputeView>> computeViews;
@@ -775,7 +786,8 @@ struct ResolvePass {
 
     ResolvePass(ResolvePass&& rhs) noexcept = default;
     ResolvePass(ResolvePass const& rhs) = delete;
-    ResolvePass& operator=(ResolvePass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ResolvePass& operator=(ResolvePass&& rhs) = default;
     ResolvePass& operator=(ResolvePass const& rhs) = default;
 
     ccstd::pmr::vector<ResolvePair> resolvePairs;
@@ -792,7 +804,8 @@ struct CopyPass {
 
     CopyPass(CopyPass&& rhs) noexcept = default;
     CopyPass(CopyPass const& rhs) = delete;
-    CopyPass& operator=(CopyPass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    CopyPass& operator=(CopyPass&& rhs) = default;
     CopyPass& operator=(CopyPass const& rhs) = delete;
 
     ccstd::pmr::vector<CopyPair> copyPairs;
@@ -811,7 +824,8 @@ struct MovePass {
 
     MovePass(MovePass&& rhs) noexcept = default;
     MovePass(MovePass const& rhs) = delete;
-    MovePass& operator=(MovePass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    MovePass& operator=(MovePass&& rhs) = default;
     MovePass& operator=(MovePass const& rhs) = default;
 
     ccstd::pmr::vector<MovePair> movePairs;
@@ -829,7 +843,8 @@ struct RaytracePass {
 
     RaytracePass(RaytracePass&& rhs) noexcept = default;
     RaytracePass(RaytracePass const& rhs) = delete;
-    RaytracePass& operator=(RaytracePass&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RaytracePass& operator=(RaytracePass&& rhs) = default;
     RaytracePass& operator=(RaytracePass const& rhs) = default;
 
     PmrTransparentMap<ccstd::pmr::string, ccstd::pmr::vector<ComputeView>> computeViews;
@@ -855,7 +870,8 @@ struct ClearView {
 
     ClearView(ClearView&& rhs) noexcept = default;
     ClearView(ClearView const& rhs) = delete;
-    ClearView& operator=(ClearView&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ClearView& operator=(ClearView&& rhs) = default;
     ClearView& operator=(ClearView const& rhs) = default;
 
     ccstd::pmr::string slotName;
@@ -969,7 +985,8 @@ struct Blit {
 
     Blit(Blit&& rhs) noexcept = default;
     Blit(Blit const& rhs) = delete;
-    Blit& operator=(Blit&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    Blit& operator=(Blit&& rhs) = default;
     Blit& operator=(Blit const& rhs) = default;
 
     IntrusivePtr<Material> material;
@@ -991,7 +1008,8 @@ struct RenderData {
 
     RenderData(RenderData&& rhs) noexcept = default;
     RenderData(RenderData const& rhs) = delete;
-    RenderData& operator=(RenderData&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RenderData& operator=(RenderData&& rhs) = default;
     RenderData& operator=(RenderData const& rhs) = delete;
 
     PmrFlatMap<uint32_t, ccstd::pmr::vector<char>> constants;
@@ -1016,7 +1034,8 @@ struct RenderGraph {
 
     RenderGraph(RenderGraph&& rhs) noexcept = default;
     RenderGraph(RenderGraph const& rhs) = delete;
-    RenderGraph& operator=(RenderGraph&& rhs) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    RenderGraph& operator=(RenderGraph&& rhs) = default;
     RenderGraph& operator=(RenderGraph const& rhs) = delete;
 
     // Graph
@@ -1158,7 +1177,8 @@ struct RenderGraph {
 
         Object(Object&& rhs) noexcept = default;
         Object(Object const& rhs) = delete;
-        Object& operator=(Object&& rhs) noexcept = default;
+        // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+        Object& operator=(Object&& rhs) = default;
         Object& operator=(Object const& rhs) = default;
 
         ccstd::pmr::vector<ChildEdge> children;
@@ -1177,7 +1197,8 @@ struct RenderGraph {
 
         Vertex(Vertex&& rhs) noexcept = default;
         Vertex(Vertex const& rhs) = delete;
-        Vertex& operator=(Vertex&& rhs) noexcept = default;
+        // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+        Vertex& operator=(Vertex&& rhs) = default;
         Vertex& operator=(Vertex const& rhs) = default;
 
         ccstd::pmr::vector<OutEdge> outEdges;


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Removed `noexcept` specifier from 59 move assignment operators across 6 header files in the custom rendering pipeline to fix iOS compilation errors.

- **Root cause**: PMR (polymorphic memory resource) containers like `PmrFlatMap`, `ccstd::pmr::vector`, and `ccstd::pmr::map` can throw exceptions during move operations when allocators differ, violating the `noexcept` guarantee
- **Solution**: Removed `noexcept` from move assignment operators while keeping move constructors as `noexcept = default`
- **Added linter suppressions**: Used `// NOLINTNEXTLINE(performance-noexcept-move-constructor)` comments to acknowledge the intentional deviation from best practices
- **Scope**: Affects structs in FGDispatcherTypes, LayoutGraphTypes, NativePipelineTypes, NativeTypes, RenderCommonTypes, and RenderGraphTypes
- **Impact**: Minor performance consideration - move assignments are no longer guaranteed non-throwing, but this reflects the actual behavior of PMR containers

<h3>Confidence Score: 5/5</h3>


- Safe to merge - correctly fixes iOS compiler error by aligning noexcept specifications with actual PMR container behavior
- The change is mechanically correct and necessary. PMR containers can throw during move assignment when allocators differ, so marking these operators as `noexcept` was technically incorrect. The iOS compiler caught this inconsistency. The fix is consistent across all 59 occurrences, properly documented with linter comments, and doesn't change runtime behavior.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h | 5/5 | Removed `noexcept` from 6 move assignment operators to match PMR container behavior |
| native/cocos/renderer/pipeline/custom/LayoutGraphTypes.h | 5/5 | Removed `noexcept` from 18 move assignment operators to match PMR container behavior |
| native/cocos/renderer/pipeline/custom/NativePipelineTypes.h | 5/5 | Removed `noexcept` from 15 move assignment operators to match PMR container behavior |
| native/cocos/renderer/pipeline/custom/NativeTypes.h | 5/5 | Removed `noexcept` from 2 move assignment operators to match PMR container behavior |
| native/cocos/renderer/pipeline/custom/RenderCommonTypes.h | 5/5 | Removed `noexcept` from 4 move assignment operators to match PMR container behavior |
| native/cocos/renderer/pipeline/custom/RenderGraphTypes.h | 5/5 | Removed `noexcept` from 14 move assignment operators to match PMR container behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant iOS as iOS Compiler
    participant Struct as Struct with PMR Members
    participant PMR as PMR Container (PmrFlatMap)
    participant Allocator as Custom Allocator

    Note over iOS,Allocator: Before Fix: Move Assignment with noexcept
    iOS->>Struct: Call move assignment operator=(T&&) noexcept
    Struct->>PMR: Move PMR containers
    PMR->>Allocator: Allocator propagation check
    Note over Allocator: May throw if allocators differ
    Allocator-->>PMR: Exception possible
    PMR-->>Struct: Can throw during move
    Note over iOS: Compile Error: noexcept violation!

    Note over iOS,Allocator: After Fix: Move Assignment without noexcept
    iOS->>Struct: Call move assignment operator=(T&&)
    Struct->>PMR: Move PMR containers
    PMR->>Allocator: Allocator propagation check
    Allocator-->>PMR: Exception allowed
    PMR-->>Struct: Move completes successfully
    Struct-->>iOS: Compilation succeeds
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->