### PR TITLE
更新计算 vDataCountLimit 的逻辑.

### DIFF
--- a/cocos/2d/renderer/mesh-buffer.ts
+++ b/cocos/2d/renderer/mesh-buffer.ts
@@ -251,9 +251,8 @@ export class MeshBuffer {
 
         this.floatsPerVertex = getAttributeStride(attrs) >> 2;
 
-        let vDataCountLimit = macro.BATCHER2D_MEM_INCREMENT * 256; // 1024 / 4 = 256
-        const glApi = device.gfxAPI;
-        if (glApi !== API.WEBGPU && glApi !== API.WEBGL2 && !(glApi === API.WEBGL && device.hasFeature(Feature.ELEMENT_INDEX_UINT))) {
+        let vDataCountLimit = macro.BATCHER2D_MEM_INCREMENT * 256; // 256 = 1024 / 4
+        if (!device.hasFeature(Feature.ELEMENT_INDEX_UINT)) {
             vDataCountLimit = Math.min(vDataCountLimit, 65536); // 2^16
         }
         assertIsTrue(this._initVDataCount / this._floatsPerVertex < vDataCountLimit, getError(9005));

--- a/cocos/2d/renderer/mesh-buffer.ts
+++ b/cocos/2d/renderer/mesh-buffer.ts
@@ -23,9 +23,9 @@
 */
 
 import { JSB } from 'internal:constants';
-import { Device, BufferUsageBit, MemoryUsageBit, Attribute, Buffer, BufferInfo, InputAssembler, InputAssemblerInfo, Feature, API } from '../../gfx';
+import { Device, BufferUsageBit, MemoryUsageBit, Attribute, Buffer, BufferInfo, InputAssembler, InputAssemblerInfo, Feature } from '../../gfx';
 import { getAttributeStride } from './vertex-format';
-import { sys, getError, warnID, assertIsTrue } from '../../core';
+import { sys, getError, warnID, assertIsTrue, macro } from '../../core';
 import { NativeUIMeshBuffer } from './native-2d';
 
 interface IIARef {

--- a/cocos/2d/renderer/mesh-buffer.ts
+++ b/cocos/2d/renderer/mesh-buffer.ts
@@ -251,10 +251,10 @@ export class MeshBuffer {
 
         this.floatsPerVertex = getAttributeStride(attrs) >> 2;
 
-        var vDataCountLimit = 65536; // 2^16 - 1
+        let vDataCountLimit = macro.BATCHER2D_MEM_INCREMENT * 256;  // 1024 / 4 = 256
         const glApi = device.gfxAPI;
-        if (glApi === API.WEBGPU || glApi === API.WEBGL2 || glApi === API.WEBGL && device.hasFeature(Feature.ELEMENT_INDEX_UINT)) {
-            vDataCountLimit = 4294967295; // 2^32 - 1
+        if (glApi !== API.WEBGPU && glApi !== API.WEBGL2 && !(glApi === API.WEBGL && device.hasFeature(Feature.ELEMENT_INDEX_UINT))) {
+            vDataCountLimit = Math.min(vDataCountLimit, 65536);
         }
         assertIsTrue(this._initVDataCount / this._floatsPerVertex < vDataCountLimit, getError(9005));
 

--- a/cocos/2d/renderer/mesh-buffer.ts
+++ b/cocos/2d/renderer/mesh-buffer.ts
@@ -251,10 +251,10 @@ export class MeshBuffer {
 
         this.floatsPerVertex = getAttributeStride(attrs) >> 2;
 
-        let vDataCountLimit = macro.BATCHER2D_MEM_INCREMENT * 256;  // 1024 / 4 = 256
+        let vDataCountLimit = macro.BATCHER2D_MEM_INCREMENT * 256; // 1024 / 4 = 256
         const glApi = device.gfxAPI;
         if (glApi !== API.WEBGPU && glApi !== API.WEBGL2 && !(glApi === API.WEBGL && device.hasFeature(Feature.ELEMENT_INDEX_UINT))) {
-            vDataCountLimit = Math.min(vDataCountLimit, 65536);
+            vDataCountLimit = Math.min(vDataCountLimit, 65536); // 2^16
         }
         assertIsTrue(this._initVDataCount / this._floatsPerVertex < vDataCountLimit, getError(9005));
 


### PR DESCRIPTION
详见 #19104 中的讨论

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refactors the `vDataCountLimit` calculation in `MeshBuffer.initialize()` to address issues identified in #19104:

**Key Changes:**
- **Fixed comment accuracy**: The old comment said "2^16 - 1" but the value was correctly 65536. Since the check uses `<` (not `<=`), 65536 is correct to allow vertices 0-65535. The new comment correctly states "2^16"
- **Dynamic limit calculation**: Changed from hardcoded values (65536 and 4294967295) to a formula based on `macro.BATCHER2D_MEM_INCREMENT * 256`, which represents the maximum float count that fits in the allocated memory
- **Simplified GPU feature detection**: Replaced complex API type checks with a direct `hasFeature(ELEMENT_INDEX_UINT)` check, which is cleaner and more maintainable
- **Removed unused import**: Dropped the `API` enum import since it's no longer needed

**How it works:**
The new formula `vDataCountLimit = macro.BATCHER2D_MEM_INCREMENT * 256` calculates the total number of floats that fit in memory (since `BATCHER2D_MEM_INCREMENT` is in KB, and each float is 4 bytes: `KB * 1024 / 4 = KB * 256`). For devices without `ELEMENT_INDEX_UINT` support, this is capped at 65536 vertices (the Uint16 index limit). The assertion `initVDataCount / floatsPerVertex < vDataCountLimit` ensures the requested vertex count doesn't exceed either the memory-based limit or the GPU indexing limit.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are well-reasoned improvements that fix documented issues from #19104. The refactoring makes the code more maintainable by deriving limits from `BATCHER2D_MEM_INCREMENT` instead of hardcoding magic numbers, fixes comment accuracy (2^16 vs 2^16-1), and simplifies GPU feature detection. The logic is mathematically sound and the check correctly prevents buffer overflow by ensuring vertex counts don't exceed either memory allocation or GPU indexing limits
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cocos/2d/renderer/mesh-buffer.ts | Improved vDataCountLimit calculation to derive from BATCHER2D_MEM_INCREMENT, fixed comment accuracy, removed unused API import, simplified GPU feature detection logic |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as BufferAccessor
    participant MB as MeshBuffer
    participant Device as GPU Device
    participant Macro as macro.BATCHER2D_MEM_INCREMENT
    
    Caller->>Macro: Read BATCHER2D_MEM_INCREMENT (144 KB default)
    Caller->>Caller: Calculate vCount = floor(144 * 1024 / vertexFormatBytes)
    Caller->>Caller: Calculate initVDataCount = vCount * floatsPerVertex
    Caller->>MB: initialize(device, attrs, initVDataCount, iCount)
    
    MB->>MB: Calculate floatsPerVertex from attrs
    MB->>Macro: Read BATCHER2D_MEM_INCREMENT
    MB->>MB: vDataCountLimit = BATCHER2D_MEM_INCREMENT * 256
    MB->>Device: Check hasFeature(ELEMENT_INDEX_UINT)
    
    alt Device lacks ELEMENT_INDEX_UINT
        Device-->>MB: false (WebGL1 without extension)
        MB->>MB: vDataCountLimit = min(vDataCountLimit, 65536)
        Note over MB: Cap at 2^16 vertices (Uint16 indices 0-65535)
    else Device has ELEMENT_INDEX_UINT
        Device-->>MB: true (WebGL2/WebGPU/WebGL1+ext)
        Note over MB: Use full memory-based limit
    end
    
    MB->>MB: Assert: initVDataCount / floatsPerVertex < vDataCountLimit
    
    alt Assertion passes
        MB->>MB: Allocate vData and iData buffers
        MB-->>Caller: Initialization complete
    else Assertion fails
        MB->>MB: Throw error 9005
        Note over MB: BATCHER2D_MEM_INCREMENT too large<br/>for GPU capabilities
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->