### PR TITLE
修复 boneIdx 为 0 时的bug

### DIFF
--- a/cocos/spine/skeleton.ts
+++ b/cocos/spine/skeleton.ts
@@ -1589,7 +1589,7 @@ export class Skeleton extends UIRenderer {
             const socket = this._sockets[i];
             if (socket.path && socket.target) {
                 const boneIdx = this._cachedSockets.get(socket.path);
-                if (!boneIdx) {
+                if (boneIdx == null) {
                     error(`Skeleton data does not contain path ${socket.path}`);
                     continue;
                 }


### PR DESCRIPTION
用 boneIdx == null 代替 !boneIdx

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a critical bug in the Spine skeleton socket binding logic where bone index `0` was incorrectly treated as missing due to JavaScript's falsy evaluation.

## Key Changes
- Changed condition from `!boneIdx` to `boneIdx == null` in `_updateSocketBindings()` method
- Fixes bug where the first bone (index 0) would trigger an error and be skipped
- The `_cachedSockets` Map stores bone indices (numbers starting from 0), so `!boneIdx` would falsely evaluate to true when `boneIdx` is `0`

## Impact
This is a correct and important fix that ensures bones at index 0 can be properly used as socket attachment points in Spine animations.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix correctly addresses a classic JavaScript falsy value bug. The change from `!boneIdx` to `boneIdx == null` is the proper way to check for undefined/null values when 0 is a valid value. This is a single-line change with clear intent and no side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cocos/spine/skeleton.ts | Fixed falsy check bug where boneIdx 0 was incorrectly treated as missing |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Skeleton
    participant _cachedSockets as _cachedSockets Map
    participant _socketNodes as _socketNodes Map

    Client->>Skeleton: _updateSocketBindings()
    Skeleton->>Skeleton: Check if _skeleton exists
    
    loop For each socket
        Skeleton->>Skeleton: Get socket.path and socket.target
        Skeleton->>_cachedSockets: get(socket.path)
        _cachedSockets-->>Skeleton: boneIdx (could be 0, undefined, or other number)
        
        alt boneIdx == null (NEW FIX)
            Skeleton->>Skeleton: error("path not found")
            Skeleton->>Skeleton: continue to next socket
        else boneIdx is valid (including 0)
            Skeleton->>_socketNodes: set(boneIdx, socket.target)
        end
    end
    
    Note over Skeleton,_socketNodes: Before fix: boneIdx=0 incorrectly triggered error<br/>After fix: boneIdx=0 properly sets socket binding
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->