### PR TITLE
Fix webgl1 and webgl2 vao implementation on ios

### DIFF
--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -44,6 +44,7 @@ import {
     getEnglishWordPartAtLast,
     getSymbolAt,
 } from '../utils/text-utils';
+import { Sorting2D } from '../../sorting/sorting-2d';
 
 const _htmlTextParser = new HtmlTextParser();
 const RichTextChildName = 'RICHTEXT_CHILD';
@@ -504,10 +505,21 @@ export class RichText extends Component {
     protected _lineOffsetX = 0;
     protected declare _updateRichTextStatus: () => void;
     protected _labelChildrenNum = 0; // only ISegment
+    protected _currentSortingLayer = 0;
+    protected _currentSortingOrder = 0;
+    protected _sorting2d: Sorting2D | null = null;
 
     constructor () {
         super();
         this._updateRichTextStatus = this._updateRichText;
+    }
+
+    protected override __preload (): void {
+        this._sorting2d = this.getComponent(Sorting2D);
+        if (this._sorting2d != null) {
+            this._currentSortingOrder = this._sorting2d.sortingOrder;
+            this._currentSortingLayer = this._sorting2d.sortingLayer;
+        }
     }
 
     public onLoad (): void {
@@ -864,7 +876,11 @@ export class RichText extends Component {
         this.node.insertChild(labelSegment.node, this._labelChildrenNum++);
         this._applyTextAttribute(labelSegment);
         this._segments.push(labelSegment);
-
+        if (this._sorting2d != null) {
+            const childSorting = labelSegment.node.addComponent(Sorting2D);
+            childSorting.sortingOrder = this._sorting2d.sortingOrder;
+            childSorting.sortingLayer = this._sorting2d.sortingLayer;
+        }
         return labelSegment;
     }
 
@@ -1046,6 +1062,11 @@ this._measureText(styleIndex) as unknown as (s: string) => number,
             if (event) {
                 segment.clickHandler = event.click;
                 segment.clickParam = event.param;
+            }
+            if (this._sorting2d != null) {
+                const childSorting = segment.node.addComponent(Sorting2D);
+                childSorting.sortingOrder = this._sorting2d.sortingOrder;
+                childSorting.sortingLayer = this._sorting2d.sortingLayer;
             }
         }
     }
@@ -1343,6 +1364,26 @@ this._measureText(styleIndex) as unknown as (s: string) => number,
         label.isBold = false;
         label.isItalic = false;
         label.isUnderline = false;
+    }
+
+    protected update (dt: number): void {
+        if (this._sorting2d == null) {
+            return;
+        }
+
+        if (this._sorting2d.sortingOrder !== this._currentSortingOrder
+            || this._sorting2d.sortingLayer !== this._currentSortingLayer
+        ) {
+            this._currentSortingOrder = this._sorting2d.sortingOrder;
+            this._currentSortingLayer = this._sorting2d.sortingLayer;
+            this._segments.forEach((seg) => {
+                const sortingChild = seg.node.getComponent(Sorting2D);
+                if (sortingChild) {
+                    sortingChild.sortingOrder = this._currentSortingOrder;
+                    sortingChild.sortingLayer = this._currentSortingLayer;
+                }
+            });
+        }
     }
 }
 

--- a/cocos/2d/components/rich-text.ts
+++ b/cocos/2d/components/rich-text.ts
@@ -44,7 +44,6 @@ import {
     getEnglishWordPartAtLast,
     getSymbolAt,
 } from '../utils/text-utils';
-import { Sorting2D } from '../../sorting/sorting-2d';
 
 const _htmlTextParser = new HtmlTextParser();
 const RichTextChildName = 'RICHTEXT_CHILD';
@@ -505,21 +504,10 @@ export class RichText extends Component {
     protected _lineOffsetX = 0;
     protected declare _updateRichTextStatus: () => void;
     protected _labelChildrenNum = 0; // only ISegment
-    protected _currentSortingLayer = 0;
-    protected _currentSortingOrder = 0;
-    protected _sorting2d: Sorting2D | null = null;
 
     constructor () {
         super();
         this._updateRichTextStatus = this._updateRichText;
-    }
-
-    protected override __preload (): void {
-        this._sorting2d = this.getComponent(Sorting2D);
-        if (this._sorting2d != null) {
-            this._currentSortingOrder = this._sorting2d.sortingOrder;
-            this._currentSortingLayer = this._sorting2d.sortingLayer;
-        }
     }
 
     public onLoad (): void {
@@ -876,11 +864,7 @@ export class RichText extends Component {
         this.node.insertChild(labelSegment.node, this._labelChildrenNum++);
         this._applyTextAttribute(labelSegment);
         this._segments.push(labelSegment);
-        if (this._sorting2d != null) {
-            const childSorting = labelSegment.node.addComponent(Sorting2D);
-            childSorting.sortingOrder = this._sorting2d.sortingOrder;
-            childSorting.sortingLayer = this._sorting2d.sortingLayer;
-        }
+
         return labelSegment;
     }
 
@@ -1062,11 +1046,6 @@ this._measureText(styleIndex) as unknown as (s: string) => number,
             if (event) {
                 segment.clickHandler = event.click;
                 segment.clickParam = event.param;
-            }
-            if (this._sorting2d != null) {
-                const childSorting = segment.node.addComponent(Sorting2D);
-                childSorting.sortingOrder = this._sorting2d.sortingOrder;
-                childSorting.sortingLayer = this._sorting2d.sortingLayer;
             }
         }
     }
@@ -1364,26 +1343,6 @@ this._measureText(styleIndex) as unknown as (s: string) => number,
         label.isBold = false;
         label.isItalic = false;
         label.isUnderline = false;
-    }
-
-    protected update (dt: number): void {
-        if (this._sorting2d == null) {
-            return;
-        }
-
-        if (this._sorting2d.sortingOrder !== this._currentSortingOrder
-            || this._sorting2d.sortingLayer !== this._currentSortingLayer
-        ) {
-            this._currentSortingOrder = this._sorting2d.sortingOrder;
-            this._currentSortingLayer = this._sorting2d.sortingLayer;
-            this._segments.forEach((seg) => {
-                const sortingChild = seg.node.getComponent(Sorting2D);
-                if (sortingChild) {
-                    sortingChild.sortingOrder = this._currentSortingOrder;
-                    sortingChild.sortingLayer = this._currentSortingLayer;
-                }
-            });
-        }
     }
 }
 

--- a/cocos/gfx/webgl/webgl-commands.ts
+++ b/cocos/gfx/webgl/webgl-commands.ts
@@ -445,6 +445,11 @@ export function WebGLCmdFuncCreateBuffer (device: WebGLDevice, gpuBuffer: IWebGL
     const { gl, stateCache } = device;
     const glUsage: GLenum = gpuBuffer.memUsage & MemoryUsageBit.HOST ? WebGLConstants.DYNAMIC_DRAW : WebGLConstants.STATIC_DRAW;
 
+    // iOS fix: Initialize version tracking for VAO invalidation
+    if (systemInfo.os === OS.IOS) {
+        gpuBuffer.updateVersion = 0;
+    }
+
     if (gpuBuffer.usage & BufferUsageBit.VERTEX) {
         gpuBuffer.glTarget = WebGLConstants.ARRAY_BUFFER;
         const glBuffer = gl.createBuffer();
@@ -643,6 +648,11 @@ export function WebGLCmdFuncUpdateBuffer (
             }
             gfxStateCache.gpuInputAssembler = null;
 
+            // iOS fix: Increment version when buffer is updated
+            if (systemInfo.os === OS.IOS && gpuBuffer.updateVersion !== undefined) {
+                gpuBuffer.updateVersion++;
+            }
+
             if (stateCache.glArrayBuffer !== gpuBuffer.glBuffer) {
                 gl.bindBuffer(WebGLConstants.ARRAY_BUFFER, gpuBuffer.glBuffer);
                 stateCache.glArrayBuffer = gpuBuffer.glBuffer;
@@ -657,6 +667,11 @@ export function WebGLCmdFuncUpdateBuffer (
                 }
             }
             gfxStateCache.gpuInputAssembler = null;
+
+            // iOS fix: Increment version when buffer is updated
+            if (systemInfo.os === OS.IOS && gpuBuffer.updateVersion !== undefined) {
+                gpuBuffer.updateVersion++;
+            }
 
             if (stateCache.glElementArrayBuffer !== gpuBuffer.glBuffer) {
                 gl.bindBuffer(WebGLConstants.ELEMENT_ARRAY_BUFFER, gpuBuffer.glBuffer);
@@ -2258,11 +2273,60 @@ export function WebGLCmdFuncBindStates (
         if (device.extensions.useVAO) {
             const vao = device.extensions.OES_vertex_array_object!;
 
+            // iOS Safari WebGL-to-Metal: Check if buffers were updated since VAO creation
+            const isIOS = systemInfo.os === OS.IOS;
+            let needRecreateVAO = false;
+
+            if (isIOS) {
+                // Compute current buffer version hash
+                let currentVersion = 0;
+                for (let i = 0; i < gpuInputAssembler.gpuVertexBuffers.length; i++) {
+                    const buf = gpuInputAssembler.gpuVertexBuffers[i];
+                    if (buf.updateVersion !== undefined) {
+                        currentVersion += buf.updateVersion * (i + 1);
+                    }
+                }
+                if (gpuInputAssembler.gpuIndexBuffer && gpuInputAssembler.gpuIndexBuffer.updateVersion !== undefined) {
+                    currentVersion += gpuInputAssembler.gpuIndexBuffer.updateVersion * 1000;
+                }
+
+                // Check if VAO was created with different buffer versions
+                const cachedVersion = gpuInputAssembler.vaoVersions?.get(gpuShader.glProgram!);
+                if (cachedVersion !== undefined && cachedVersion !== currentVersion) {
+                    needRecreateVAO = true;
+                }
+            }
+
             // check vao
             let glVAO = gpuInputAssembler.glVAOs.get(gpuShader.glProgram!);
-            if (!glVAO) {
+            if (!glVAO || needRecreateVAO) {
+                // Delete old VAO if recreating
+                if (needRecreateVAO && glVAO) {
+                    vao.deleteVertexArrayOES(glVAO);
+                    if (cache.glVAO === glVAO) {
+                        cache.glVAO = null;
+                    }
+                }
                 glVAO = vao.createVertexArrayOES()!;
                 gpuInputAssembler.glVAOs.set(gpuShader.glProgram!, glVAO);
+
+                // iOS fix: Store buffer versions when VAO is created
+                if (isIOS) {
+                    let vaoVersion = 0;
+                    for (let i = 0; i < gpuInputAssembler.gpuVertexBuffers.length; i++) {
+                        const buf = gpuInputAssembler.gpuVertexBuffers[i];
+                        if (buf.updateVersion !== undefined) {
+                            vaoVersion += buf.updateVersion * (i + 1);
+                        }
+                    }
+                    if (gpuInputAssembler.gpuIndexBuffer && gpuInputAssembler.gpuIndexBuffer.updateVersion !== undefined) {
+                        vaoVersion += gpuInputAssembler.gpuIndexBuffer.updateVersion * 1000;
+                    }
+                    if (!gpuInputAssembler.vaoVersions) {
+                        gpuInputAssembler.vaoVersions = new Map<WebGLProgram, number>();
+                    }
+                    gpuInputAssembler.vaoVersions.set(gpuShader.glProgram!, vaoVersion);
+                }
 
                 vao.bindVertexArrayOES(glVAO);
                 gl.bindBuffer(WebGLConstants.ARRAY_BUFFER, null);
@@ -2316,7 +2380,8 @@ export function WebGLCmdFuncBindStates (
                 cache.glElementArrayBuffer = null;
             }
 
-            if (cache.glVAO !== glVAO) {
+            // iOS Safari: Force VAO rebinding on iOS, or when cache doesn't match
+            if (isIOS || cache.glVAO !== glVAO) {
                 vao.bindVertexArrayOES(glVAO);
                 cache.glVAO = glVAO;
             }

--- a/cocos/gfx/webgl/webgl-gpu-objects.ts
+++ b/cocos/gfx/webgl/webgl-gpu-objects.ts
@@ -150,6 +150,9 @@ export interface IWebGLGPUBuffer {
     vf32: Float32Array | null;
     /** @mangle */
     indirects: WebGLIndirectDrawInfos;
+    /** @mangle */
+    // iOS fix: Track buffer updates to invalidate VAOs
+    updateVersion?: number;
 }
 
 /** @mangle */
@@ -348,6 +351,9 @@ export interface IWebGLGPUInputAssembler {
     glAttribs: IWebGLAttrib[];
     glIndexType: GLenum;
     glVAOs: Map<WebGLProgram, WebGLVertexArrayObjectOES>;
+    /** @mangle */
+    // iOS fix: Track buffer versions when VAOs were created
+    vaoVersions?: Map<WebGLProgram, number>;
 }
 
 /** @mangle */

--- a/cocos/gfx/webgl/webgl-input-assembler.ts
+++ b/cocos/gfx/webgl/webgl-input-assembler.ts
@@ -105,6 +105,7 @@ export class WebGLInputAssembler extends InputAssembler {
             glAttribs: [],
             glIndexType,
             glVAOs: new Map<WebGLProgram, WebGLVertexArrayObjectOES>(),
+            vaoVersions: new Map<WebGLProgram, number>(), // iOS fix
         };
 
         WebGLCmdFuncCreateInputAssember(WebGLDeviceManager.instance, this._gpuInputAssembler);

--- a/cocos/gfx/webgl2/webgl2-commands.ts
+++ b/cocos/gfx/webgl2/webgl2-commands.ts
@@ -624,6 +624,11 @@ export function WebGL2CmdFuncCreateBuffer (device: WebGL2Device, gpuBuffer: IWeb
     const cache = device.getStateCache();
     const glUsage: GLenum = gpuBuffer.memUsage & MemoryUsageBit.HOST ? WebGLConstants.DYNAMIC_DRAW : WebGLConstants.STATIC_DRAW;
 
+    // iOS fix: Initialize buffer version tracking
+    if (systemInfo.os === OS.IOS) {
+        gpuBuffer.updateVersion = 0;
+    }
+
     if (gpuBuffer.usage & BufferUsageBit.VERTEX) {
         gpuBuffer.glTarget = WebGLConstants.ARRAY_BUFFER;
         const glBuffer = gl.createBuffer();
@@ -830,12 +835,20 @@ export function WebGL2CmdFuncUpdateBuffer (
 
         switch (gpuBuffer.glTarget) {
         case WebGLConstants.ARRAY_BUFFER: {
+            // iOS fix: Increment buffer version to invalidate VAOs that reference this buffer
+            if (systemInfo.os === OS.IOS && gpuBuffer.updateVersion !== undefined) {
+                gpuBuffer.updateVersion++;
+            }
+
             if (device.extensions.useVAO) {
+                // When updating vertex buffer data, unbind VAO to force rebind on next draw
+                // This is critical because VAO caches vertex attribute pointers to buffers
                 if (cache.glVAO) {
                     gl.bindVertexArray(null);
                     cache.glVAO = null;
                 }
             }
+            // Invalidate input assembler cache to force VAO rebind/recreation
             gfxStateCache.gpuInputAssembler = null;
 
             if (cache.glArrayBuffer !== gpuBuffer.glBuffer) {
@@ -857,6 +870,11 @@ export function WebGL2CmdFuncUpdateBuffer (
             break;
         }
         case WebGLConstants.ELEMENT_ARRAY_BUFFER: {
+            // iOS fix: Increment buffer version to invalidate VAOs that reference this buffer
+            if (systemInfo.os === OS.IOS && gpuBuffer.updateVersion !== undefined) {
+                gpuBuffer.updateVersion++;
+            }
+
             if (device.extensions.useVAO) {
                 if (cache.glVAO) {
                     gl.bindVertexArray(null);
@@ -2345,11 +2363,60 @@ export function WebGL2CmdFuncBindStates (
         gfxStateCache.gpuInputAssembler = gpuInputAssembler;
 
         if (device.extensions.useVAO) {
+            // iOS Safari WebGL-to-Metal: Check if buffers were updated since VAO creation
+            const isIOS = systemInfo.os === OS.IOS;
+            let needRecreateVAO = false;
+
+            if (isIOS) {
+                // Compute current buffer version hash
+                let currentVersion = 0;
+                for (let i = 0; i < gpuInputAssembler.gpuVertexBuffers.length; i++) {
+                    const buf = gpuInputAssembler.gpuVertexBuffers[i];
+                    if (buf.updateVersion !== undefined) {
+                        currentVersion += buf.updateVersion * (i + 1);
+                    }
+                }
+                if (gpuInputAssembler.gpuIndexBuffer && gpuInputAssembler.gpuIndexBuffer.updateVersion !== undefined) {
+                    currentVersion += gpuInputAssembler.gpuIndexBuffer.updateVersion * 1000;
+                }
+
+                // Check if VAO was created with different buffer versions
+                const cachedVersion = gpuInputAssembler.vaoVersions?.get(gpuShader.glProgram!);
+                if (cachedVersion !== undefined && cachedVersion !== currentVersion) {
+                    needRecreateVAO = true;
+                }
+            }
+
             // check vao
             let glVAO = gpuInputAssembler.glVAOs.get(gpuShader.glProgram!);
-            if (!glVAO) {
+            if (!glVAO || needRecreateVAO) {
+                // Delete old VAO if recreating
+                if (needRecreateVAO && glVAO) {
+                    gl.deleteVertexArray(glVAO);
+                    if (cache.glVAO === glVAO) {
+                        cache.glVAO = null;
+                    }
+                }
                 glVAO = gl.createVertexArray()!;
                 gpuInputAssembler.glVAOs.set(gpuShader.glProgram!, glVAO);
+
+                // iOS fix: Store buffer versions when VAO is created
+                if (isIOS) {
+                    let vaoVersion = 0;
+                    for (let i = 0; i < gpuInputAssembler.gpuVertexBuffers.length; i++) {
+                        const buf = gpuInputAssembler.gpuVertexBuffers[i];
+                        if (buf.updateVersion !== undefined) {
+                            vaoVersion += buf.updateVersion * (i + 1);
+                        }
+                    }
+                    if (gpuInputAssembler.gpuIndexBuffer && gpuInputAssembler.gpuIndexBuffer.updateVersion !== undefined) {
+                        vaoVersion += gpuInputAssembler.gpuIndexBuffer.updateVersion * 1000;
+                    }
+                    if (!gpuInputAssembler.vaoVersions) {
+                        gpuInputAssembler.vaoVersions = new Map();
+                    }
+                    gpuInputAssembler.vaoVersions.set(gpuShader.glProgram!, vaoVersion);
+                }
 
                 gl.bindVertexArray(glVAO);
                 gl.bindBuffer(WebGLConstants.ARRAY_BUFFER, null);
@@ -2401,7 +2468,8 @@ export function WebGL2CmdFuncBindStates (
                 cache.glElementArrayBuffer = null;
             }
 
-            if (cache.glVAO !== glVAO) {
+            // iOS Safari: Force VAO rebinding on iOS, or when cache doesn't match
+            if (isIOS || cache.glVAO !== glVAO) {
                 gl.bindVertexArray(glVAO);
                 cache.glVAO = glVAO;
             }

--- a/cocos/gfx/webgl2/webgl2-gpu-objects.ts
+++ b/cocos/gfx/webgl2/webgl2-gpu-objects.ts
@@ -132,7 +132,7 @@ export interface IWebGL2GPUBuffer {
     indirects: WebGL2IndirectDrawInfos;
 
     /** @mangle */
-    updateVersion: number; // iOS fix: track buffer updates to invalidate VAOs
+    updateVersion?: number; // iOS fix: track buffer updates to invalidate VAOs
 }
 
 /** @mangle */

--- a/cocos/gfx/webgl2/webgl2-gpu-objects.ts
+++ b/cocos/gfx/webgl2/webgl2-gpu-objects.ts
@@ -130,6 +130,9 @@ export interface IWebGL2GPUBuffer {
 
     buffer: ArrayBufferView | null;
     indirects: WebGL2IndirectDrawInfos;
+
+    /** @mangle */
+    updateVersion: number; // iOS fix: track buffer updates to invalidate VAOs
 }
 
 /** @mangle */
@@ -349,6 +352,9 @@ export interface IWebGL2GPUInputAssembler {
     glAttribs: IWebGL2Attrib[];
     glIndexType: GLenum;
     glVAOs: Map<WebGLProgram, WebGLVertexArrayObject>;
+
+    /** @mangle */
+    vaoVersions: Map<WebGLProgram, number>; // iOS fix: track buffer versions when VAO was created
 }
 
 /** @mangle */

--- a/cocos/gfx/webgl2/webgl2-input-assembler.ts
+++ b/cocos/gfx/webgl2/webgl2-input-assembler.ts
@@ -106,6 +106,7 @@ export class WebGL2InputAssembler extends InputAssembler {
             glAttribs: [],
             glIndexType,
             glVAOs: new Map<WebGLProgram, WebGLVertexArrayObject>(),
+            vaoVersions: new Map<WebGLProgram, number>(), // iOS fix: track buffer versions
         };
 
         WebGL2CmdFuncCreateInputAssember(WebGL2DeviceManager.instance, this._gpuInputAssembler);


### PR DESCRIPTION
Sometimes the VAO on IOS would not bind correctly because of the async nature of IOS metal. To solve this I implemented vertex buffer versioning.

This should fix https://github.com/cocos/cocos-engine/issues/19088 . (tested it on the issue I was able to reproduce and it was fixed). 
### Changelog

*  This is a similar solution that Three.js would do but at a higher level. We do a hash of the vertex buffer and rebind VAO when the hash is different.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Implemented iOS-specific VAO versioning to fix rendering issues caused by async Metal backend behavior. When buffers are updated, their version counters increment, and VAOs are recreated if buffer versions changed since VAO creation. Additionally forces VAO rebinding on every draw call on iOS.

**Key changes:**
- Added `updateVersion` counter to buffer objects, incremented on each buffer update
- Added `vaoVersions` map to track buffer version hashes when VAOs are created
- On iOS, computes version hash from all vertex/index buffers and compares with cached version
- Recreates VAO if hash mismatch detected
- Forces VAO rebinding on every draw call on iOS (bypasses cache check)

**Issues found:**
- Hash collision vulnerability: weighted sum approach can produce identical hashes for different buffer update patterns
- Performance concern: forced rebinding on every draw may have overhead

<h3>Confidence Score: 3/5</h3>


- PR addresses real iOS rendering bug but hash collision risk could cause correctness issues
- The implementation successfully tracks buffer updates and recreates VAOs, which should fix the iOS Metal async issue. However, the weighted sum hashing approach has mathematical collision vulnerabilities that could prevent VAO recreation when needed, potentially leaving the original bug unfixed in edge cases. The forced rebinding provides a safety net but may impact performance.
- `cocos/gfx/webgl/webgl-commands.ts` and `cocos/gfx/webgl2/webgl2-commands.ts` need attention for hash collision fix

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cocos/gfx/webgl/webgl-commands.ts | Added iOS-specific VAO versioning with buffer update tracking and forced rebinding; potential hash collision in version calculation |
| cocos/gfx/webgl2/webgl2-commands.ts | Added iOS-specific VAO versioning identical to WebGL1 implementation; same hash collision risk exists |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant Buf as Buffer Update
    participant Ver as Version Tracking
    participant Bind as Bind States
    participant VAO as VAO Management
    participant GPU as GPU/Metal

    App->>Buf: Update vertex/index buffer
    Buf->>Ver: Increment updateVersion++ (iOS only)
    Buf->>Buf: Unbind current VAO
    Buf->>GPU: Upload buffer data

    App->>Bind: Draw call - bind states
    Bind->>Ver: Compute current version hash
    Note over Ver: hash = Σ(bufferVersion[i] × (i+1))<br/>+ indexVersion × 1000
    
    Bind->>VAO: Get cached VAO for shader
    
    alt VAO exists and iOS
        Bind->>Ver: Get cached vaoVersion
        Ver->>Bind: Return cached version
        
        alt Versions match
            Bind->>VAO: Reuse existing VAO
        else Versions differ
            Bind->>VAO: Delete old VAO
            Bind->>VAO: Create new VAO
            Bind->>Ver: Store new vaoVersion
            VAO->>GPU: Configure vertex attributes
        end
    else No VAO exists
        Bind->>VAO: Create new VAO
        Bind->>Ver: Store vaoVersion (iOS only)
        VAO->>GPU: Configure vertex attributes
    end
    
    alt iOS platform
        Bind->>VAO: Force rebind VAO (every draw)
    else Other platforms
        Bind->>VAO: Bind if cache miss
    end
    
    Bind->>GPU: Draw call with VAO
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->