### PR TITLE
test build

### DIFF
--- a/.github/workflows/build-wasm-libs.yml
+++ b/.github/workflows/build-wasm-libs.yml
@@ -38,6 +38,7 @@ jobs:
               echo "Ninja is already installed."
           fi
           which ninja
+          ninja --version
 
       - name: Apply emscripten patches
         run: |

--- a/.github/workflows/build-wasm-libs.yml
+++ b/.github/workflows/build-wasm-libs.yml
@@ -37,7 +37,7 @@ jobs:
           else
               echo "Ninja is already installed."
           fi
-          ninja --version
+          /usr/local/bin/ninja --version
           which ninja
 
       - name: Apply emscripten patches

--- a/.github/workflows/build-wasm-libs.yml
+++ b/.github/workflows/build-wasm-libs.yml
@@ -37,8 +37,8 @@ jobs:
           else
               echo "Ninja is already installed."
           fi
-          which ninja
           ninja --version
+          which ninja
 
       - name: Apply emscripten patches
         run: |


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added ninja version check with hardcoded path in the build workflow. 

- The change adds `/usr/local/bin/ninja --version` to verify ninja installation
- The hardcoded path `/usr/local/bin/ninja` may cause failures since `apt install ninja-build` typically installs to `/usr/bin/ninja`
- This creates a potential mismatch between the installation location and the version check

<h3>Confidence Score: 3/5</h3>


- This PR has a logic issue that may cause the workflow to fail in certain environments
- Score reflects a single-line change with a hardcoded path issue. The hardcoded `/usr/local/bin/ninja` path conflicts with the `apt install ninja-build` command which installs to `/usr/bin/ninja`, potentially causing the version check to fail even when ninja is properly installed
- `.github/workflows/build-wasm-libs.yml` requires attention for the hardcoded path issue

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-wasm-libs.yml | Added hardcoded path to ninja version check, potential portability concern |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Step as Install ninja step
    participant System as Ubuntu System
    
    GHA->>Step: Execute install ninja step
    Step->>System: Check if ninja command exists
    alt Ninja not found
        Step->>System: apt install ninja-build
        System-->>Step: Install at /usr/bin/ninja
    else Ninja already installed
        Step->>Step: Log "already installed"
    end
    Step->>System: /usr/local/bin/ninja --version
    Note over Step,System: Hardcoded path may fail if<br/>ninja installed at /usr/bin/ninja
    Step->>System: which ninja
    Step-->>GHA: Step complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->