### PR TITLE
Fixes high DPI compatibility on Windows platform

### DIFF
--- a/native/cocos/application/BaseGame.cpp
+++ b/native/cocos/application/BaseGame.cpp
@@ -58,7 +58,8 @@ int BaseGame::init() {
     _windowInfo.height = _windowInfo.height == -1 ? 600 : _windowInfo.height;
     _windowInfo.flags = _windowInfo.flags == -1 ? cc::ISystemWindow::CC_WINDOW_SHOWN |
                                                       cc::ISystemWindow::CC_WINDOW_RESIZABLE |
-                                                      cc::ISystemWindow::CC_WINDOW_INPUT_FOCUS
+                                                      cc::ISystemWindow::CC_WINDOW_INPUT_FOCUS |
+                                                      cc::ISystemWindow::CC_WINDOW_ALLOW_HIGHDPI
                                                 : _windowInfo.flags;
     std::call_once(_windowCreateFlag, [&]() {
         ISystemWindowInfo info;

--- a/native/cocos/platform/SDLHelper.cpp
+++ b/native/cocos/platform/SDLHelper.cpp
@@ -315,6 +315,7 @@ void SDLHelper::dispatchSDLEvent(uint32_t windowId, const SDL_Event &sdlEvent) {
             const SDL_TouchFingerEvent &event = sdlEvent.tfinger;
             touch.type = TouchEvent::Type::ENDED;
             touch.touches = {TouchInfo(event.x, event.y, (int)event.fingerId)};
+            touch.windowId = event.windowID;
             events::Touch::broadcast(touch);
             break;
         }
@@ -322,6 +323,7 @@ void SDLHelper::dispatchSDLEvent(uint32_t windowId, const SDL_Event &sdlEvent) {
             const SDL_TouchFingerEvent &event = sdlEvent.tfinger;
             touch.type = TouchEvent::Type::BEGAN;
             touch.touches = {TouchInfo(event.x, event.y, (int)event.fingerId)};
+            touch.windowId = event.windowID;
             events::Touch::broadcast(touch);
             break;
         }
@@ -329,6 +331,7 @@ void SDLHelper::dispatchSDLEvent(uint32_t windowId, const SDL_Event &sdlEvent) {
             const SDL_TouchFingerEvent &event = sdlEvent.tfinger;
             touch.type = TouchEvent::Type::MOVED;
             touch.touches = {TouchInfo(event.x, event.y, (int)event.fingerId)};
+            touch.windowId = event.windowID;
             events::Touch::broadcast(touch);
             break;
         }

--- a/native/cocos/platform/SDLHelper.cpp
+++ b/native/cocos/platform/SDLHelper.cpp
@@ -155,6 +155,9 @@ SDLHelper::~SDLHelper() {
 }
 
 int SDLHelper::init() {
+#if CC_PLATFORM == CC_PLATFORM_WINDOWS
+    SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, "0");
+#endif
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         // Display error message
         CC_LOG_ERROR("SDL could not initialize! SDL_Error: %s\n", SDL_GetError());
@@ -195,20 +198,30 @@ void SDLHelper::dispatchWindowEvent(uint32_t windowId, const SDL_WindowEvent &we
             break;
         }
         case SDL_WINDOWEVENT_SIZE_CHANGED: {
-            auto *screen = BasePlatform::getPlatform()->getInterface<IScreen>();
-            CC_ASSERT(screen != nullptr);
             ev.type = WindowEvent::Type::SIZE_CHANGED;
+#if CC_PLATFORM == CC_PLATFORM_WINDOWS
+            ev.width = wevent.data1;
+            ev.height = wevent.data2;
+#else
+            auto *screen = BasePlatform::getPlatform()->getInterface<IScreen>();
+            CC_ASSERT(screen != nullptr);            
             ev.width = wevent.data1 * screen->getDevicePixelRatio();
             ev.height = wevent.data2 * screen->getDevicePixelRatio();
+#endif
             events::WindowEvent::broadcast(ev);
             break;
         }
         case SDL_WINDOWEVENT_RESIZED: {
+            ev.type = WindowEvent::Type::RESIZED;
+#if CC_PLATFORM == CC_PLATFORM_WINDOWS
+            ev.width = wevent.data1;
+            ev.height = wevent.data2;
+#else
             auto *screen = BasePlatform::getPlatform()->getInterface<IScreen>();
             CC_ASSERT(screen != nullptr);
-            ev.type = WindowEvent::Type::RESIZED;
             ev.width = wevent.data1 * screen->getDevicePixelRatio();
             ev.height = wevent.data2 * screen->getDevicePixelRatio();
+#endif
             events::WindowEvent::broadcast(ev);
             break;
         }

--- a/native/cocos/platform/win32/modules/Screen.cpp
+++ b/native/cocos/platform/win32/modules/Screen.cpp
@@ -31,19 +31,27 @@
 namespace cc {
 
 int Screen::getDPI() const {
+    // 参考：https://learn.microsoft.com/zh-cn/windows/win32/api/wingdi/nf-wingdi-getdevicecaps
     static int dpi = -1;
     if (dpi == -1) {
+
+        dpi = 96;
         HDC hScreenDC = GetDC(nullptr);
-        int PixelsX = GetDeviceCaps(hScreenDC, HORZRES);
-        int MMX = GetDeviceCaps(hScreenDC, HORZSIZE);
-        ReleaseDC(nullptr, hScreenDC);
-        dpi = static_cast<int>(254.0f * PixelsX / MMX / 10);
+        if (hScreenDC) {
+            // LOGPIXELSX 对应水平方向每逻辑英寸的像素点数
+            dpi = GetDeviceCaps(hScreenDC, LOGPIXELSX);
+            ReleaseDC(nullptr, hScreenDC);
+        }
+        // win10 1607 以上
+        // HWND hDesktop = GetDesktopWindow();
+        // dpi = GetDpiForWindow(hDesktop);
     }
     return dpi;
 }
 
 float Screen::getDevicePixelRatio() const {
-    return 1;
+    // return 1;
+    return Screen::getDPI() / 96.0f;
 }
 
 void Screen::setKeepScreenOn(bool value) {

--- a/native/cocos/platform/win32/modules/Screen.cpp
+++ b/native/cocos/platform/win32/modules/Screen.cpp
@@ -50,8 +50,7 @@ int Screen::getDPI() const {
 }
 
 float Screen::getDevicePixelRatio() const {
-    // return 1;
-    return Screen::getDPI() / 96.0f;
+    return getDPI() / 96.0f;
 }
 
 void Screen::setKeepScreenOn(bool value) {

--- a/native/cocos/platform/win32/modules/SystemWindow.cpp
+++ b/native/cocos/platform/win32/modules/SystemWindow.cpp
@@ -29,6 +29,7 @@
 #include "engine/EngineEvents.h"
 #include "platform/SDLHelper.h"
 #include "platform/win32/WindowsPlatform.h"
+#include "platform/interfaces/modules/IScreen.h"
 
 namespace cc {
 SystemWindow::SystemWindow(uint32_t windowId, void *externalHandle)
@@ -45,13 +46,14 @@ SystemWindow::~SystemWindow() {
 
 bool SystemWindow::createWindow(const char *title,
                                 int w, int h, int flags) {
-    _window = SDLHelper::createWindow(title, w, h, flags);
+    float dpr = cc::BasePlatform::getPlatform()->getInterface<cc::IScreen>()->getDevicePixelRatio();
+    _width = w * dpr;
+    _height = h * dpr;
+    _window = SDLHelper::createWindow(title, _width, _height, flags);
     if (!_window) {
         return false;
     }
 
-    _width = w;
-    _height = h;
     _windowHandle = SDLHelper::getWindowHandle(_window);
     return true;
 }
@@ -59,13 +61,15 @@ bool SystemWindow::createWindow(const char *title,
 bool SystemWindow::createWindow(const char *title,
                                 int x, int y, int w,
                                 int h, int flags) {
-    _window = SDLHelper::createWindow(title, x, y, w, h, flags);
+    float dpr = cc::BasePlatform::getPlatform()->getInterface<cc::IScreen>()->getDevicePixelRatio();
+    _width = w * dpr;
+    _height = h * dpr;
+
+    _window = SDLHelper::createWindow(title, x, y, _width, _height, flags);
     if (!_window) {
         return false;
     }
 
-    _width = w;
-    _height = h;
     _windowHandle = SDLHelper::getWindowHandle(_window);
 
     return true;

--- a/native/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/native/cocos/ui/edit-box/EditBox-win32.cpp
@@ -28,6 +28,7 @@
 #include "cocos/bindings/manual/jsb_global.h"
 #include "cocos/platform/interfaces/modules/ISystemWindow.h"
 #include "cocos/platform/interfaces/modules/ISystemWindowManager.h"
+#include "platform/interfaces/modules/IScreen.h"
 
 #include <stdlib.h>
 #include <windows.h>
@@ -214,16 +215,17 @@ void EditBox::show(const EditBox::ShowInfo &showInfo) {
         g_prevMainWindowProc = (WNDPROC)SetWindowLongPtr(parent, GWLP_WNDPROC, (LONG_PTR)mainWindowProc);
         g_prevEditWindowProc = (WNDPROC)SetWindowLongPtr(g_hwndEditBox, GWLP_WNDPROC, (LONG_PTR)editWindowProc);
     }
-
+    auto *screen = BasePlatform::getPlatform()->getInterface<IScreen>();
+    float dpr = screen->getDevicePixelRatio();
     ::SendMessageW(g_hwndEditBox, EM_LIMITTEXT, showInfo.maxLength, 0);
 
     // SendMessage(g_hwndEditBox, EM_SETCHARFORMAT, SCF_ALL, (LPARAM)&cf);
     SetWindowPos(g_hwndEditBox,
                  HWND_NOTOPMOST,
-                 showInfo.x,
-                 windowHeight - showInfo.y - showInfo.height,
-                 showInfo.width,
-                 showInfo.height,
+                 showInfo.x * dpr,
+                 windowHeight - showInfo.y * dpr - showInfo.height * dpr,
+                 showInfo.width * dpr,
+                 showInfo.height * dpr,
                  SWP_NOZORDER);
 
     ::SetWindowTextW(g_hwndEditBox, str2ws(showInfo.defaultValue).c_str());
@@ -243,7 +245,7 @@ void EditBox::show(const EditBox::ShowInfo &showInfo) {
     RECT rect;
 
     GetWindowRect(getCurrentWindowHwnd(), &rect);
-    float WindowRatio = (float)(rect.bottom - rect.top) / (float)CC_GET_MAIN_SYSTEM_WINDOW()->getViewSize().height;
+    float WindowRatio = (float)(rect.bottom - rect.top) / (float)CC_GET_MAIN_SYSTEM_WINDOW()->getViewSize().height * dpr;
     float JsFontRatio = float(showInfo.fontSize) / 5;
     /** A probale way to calculate the increase of font size
      * OriginalSize + Increase = OriginalSize * Ratio_of_js_fontSize * Ratio_of_window

--- a/native/tools/simulator/frameworks/runtime-src/CMakeLists.txt
+++ b/native/tools/simulator/frameworks/runtime-src/CMakeLists.txt
@@ -152,6 +152,10 @@ else()
     add_executable(${LIB_NAME} ${PROJ_SOURCES} ${PROJ_EXTRA_SOURCE})
 endif()
 
+if(WINDOWS AND MSVC)
+    set_property(TARGET ${LIB_NAME} PROPERTY VS_DPI_AWARE "PerMonitor")
+endif()
+
 target_link_libraries(${LIB_NAME} ${ENGINE_NAME} simulator)
 target_include_directories(${LIB_NAME} PRIVATE
     Classes

--- a/pal/input/native/mouse-input.ts
+++ b/pal/input/native/mouse-input.ts
@@ -116,7 +116,10 @@ export class MouseInputSource {
     private _getLocation (event: jsb.MouseEvent): Vec2 {
         const window = this._windowManager.getWindow(event.windowId);
         const windowSize = window.getViewSize();
-        const dpr = screenAdapter.devicePixelRatio;
+        let dpr = screenAdapter.devicePixelRatio;
+        if (systemInfo.os === OS.WINDOWS) { // 在windows下DPI变化时下发的是实际坐标
+            dpr = 1;
+        }        
         const x = event.x * dpr;
         const y = windowSize.height - event.y * dpr;
         return new Vec2(x, y);
@@ -187,7 +190,10 @@ export class MouseInputSource {
         const eventMouse = new EventMouse(eventType, false, this._preMousePos, mouseEvent.windowId);
         eventMouse.setLocation(location.x, location.y);
         eventMouse.setButton(button);
-        const dpr = screenAdapter.devicePixelRatio;
+        let dpr = screenAdapter.devicePixelRatio;
+        if (systemInfo.os === OS.WINDOWS) { // 在windows下DPI变化时下发的是实际坐标
+            dpr = 1;
+        }
         eventMouse.movementX = typeof mouseEvent.xDelta === 'undefined' ? 0 : mouseEvent.xDelta * dpr;
         eventMouse.movementY = typeof mouseEvent.yDelta === 'undefined' ? 0 : mouseEvent.yDelta * dpr;
         // update previous mouse position.

--- a/pal/input/native/mouse-input.ts
+++ b/pal/input/native/mouse-input.ts
@@ -119,7 +119,7 @@ export class MouseInputSource {
         let dpr = screenAdapter.devicePixelRatio;
         if (systemInfo.os === OS.WINDOWS) { // 在windows下DPI变化时下发的是实际坐标
             dpr = 1;
-        }        
+        }
         const x = event.x * dpr;
         const y = windowSize.height - event.y * dpr;
         return new Vec2(x, y);

--- a/pal/input/native/touch-input.ts
+++ b/pal/input/native/touch-input.ts
@@ -154,7 +154,7 @@ export class TouchInputSource {
         let dpr = screenAdapter.devicePixelRatio;
         if (systemInfo.os === OS.WINDOWS) { // 在windows下DPI变化时下发的是实际坐标
             dpr = 1;
-        }        
+        }
         const x = touch.clientX * dpr;
         const y = windowSize.height - touch.clientY * dpr;
         return new Vec2(x, y);

--- a/pal/input/native/touch-input.ts
+++ b/pal/input/native/touch-input.ts
@@ -28,6 +28,8 @@ import { EventTarget } from '../../../cocos/core/event';
 import { EventTouch, Touch as CCTouch } from '../../../cocos/input/types';
 import { touchManager } from '../touch-manager';
 import { InputEventType } from '../../../cocos/input/types/event-enum';
+import { systemInfo } from 'pal/system-info';
+import { OS } from '../../system-info/enum-type';
 
 export type TouchCallback = (res: EventTouch) => void;
 
@@ -114,7 +116,12 @@ export class TouchInputSource {
     private _dispatchEvent (eventType: InputEventType, changedTouches: Touch[], windowId: number): void {
         const handleTouches: CCTouch[] = [];
         const length = changedTouches.length;
-        const windowSize = this._windowManager.getWindow(windowId).getViewSize() as Size;
+        const window = this._windowManager.getWindow(windowId);
+        if (window === null) {
+            return;
+        }
+        const windowSize = window.getViewSize();        
+        // const windowSize = this._windowManager.getWindow(windowId).getViewSize() as Size;
         for (let i = 0; i < length; ++i) {
             const changedTouch = changedTouches[i];
             const touchID = changedTouch.identifier;
@@ -144,7 +151,10 @@ export class TouchInputSource {
     }
 
     private _getLocation (touch: globalThis.Touch, windowSize: Size): Vec2 {
-        const dpr = screenAdapter.devicePixelRatio;
+        let dpr = screenAdapter.devicePixelRatio;
+        if (systemInfo.os === OS.WINDOWS) { // 在windows下DPI变化时下发的是实际坐标
+            dpr = 1;
+        }        
         const x = touch.clientX * dpr;
         const y = windowSize.height - touch.clientY * dpr;
         return new Vec2(x, y);

--- a/pal/input/native/touch-input.ts
+++ b/pal/input/native/touch-input.ts
@@ -23,12 +23,12 @@
 */
 
 import { screenAdapter } from 'pal/screen-adapter';
+import { systemInfo } from 'pal/system-info';
 import { Size, Vec2 } from '../../../cocos/core/math';
 import { EventTarget } from '../../../cocos/core/event';
 import { EventTouch, Touch as CCTouch } from '../../../cocos/input/types';
 import { touchManager } from '../touch-manager';
 import { InputEventType } from '../../../cocos/input/types/event-enum';
-import { systemInfo } from 'pal/system-info';
 import { OS } from '../../system-info/enum-type';
 
 export type TouchCallback = (res: EventTouch) => void;
@@ -120,8 +120,7 @@ export class TouchInputSource {
         if (window === null) {
             return;
         }
-        const windowSize = window.getViewSize();        
-        // const windowSize = this._windowManager.getWindow(windowId).getViewSize() as Size;
+        const windowSize = window.getViewSize() as Size;
         for (let i = 0; i < length; ++i) {
             const changedTouch = changedTouches[i];
             const touchID = changedTouch.identifier;

--- a/templates/compatibility-info.json
+++ b/templates/compatibility-info.json
@@ -1,5 +1,5 @@
 {
     "native": {
-        "default": ">=3.6.0"
+        "default": ">=3.8.0"
     }
 }

--- a/templates/windows/CMakeLists.txt
+++ b/templates/windows/CMakeLists.txt
@@ -14,4 +14,5 @@ cc_windows_before_target(${EXECUTABLE_NAME})
 add_executable(${EXECUTABLE_NAME}
     ${CC_ALL_SOURCES}
 )
+set_property(TARGET ${EXECUTABLE_NAME} PROPERTY VS_DPI_AWARE "PerMonitor")
 cc_windows_after_target(${EXECUTABLE_NAME})


### PR DESCRIPTION
参考：https://learn.microsoft.com/zh-cn/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows

Re: #

### Changelog

* 修复Windows下高DPI没有响应适配问题

当设置系统->屏幕->缩放 设置不为100%时
<img width="1204" height="534" alt="image" src="https://github.com/user-attachments/assets/9f67fd33-bfb0-4293-90d7-5df3be5f9762" />

重新生成 win32 工程设置
（旧的工程确认更新了engine\templates\windows\CMakeLists.txt 拷贝到you_project\native\engine\win64\CMakeLists.txt）
或者按下图手动修改
<img width="1655" height="921" alt="image" src="https://github.com/user-attachments/assets/68f2c3d8-1735-4241-af5c-df5d08f9071a" />


|  | 测试工程截图 | 
| :--- | :----: | 
| 修复前 | <img width="1706" height="1008" alt="image" src="https://github.com/user-attachments/assets/3fc68e21-4366-4a9e-aa1f-2e8dcc2974c6" /> |  
| 修复后 | <img width="1708" height="1007" alt="image" src="https://github.com/user-attachments/assets/e94667f8-7ad4-49df-a2bd-2fc857756b51" /> | 

上述截图点击看大图

<img width="1343" height="1008" alt="image" src="https://github.com/user-attachments/assets/ea0595da-d017-4cfa-bb1b-cbd9f1dfcb02" />

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements comprehensive high DPI support for the Windows platform by enabling SDL's high DPI mode, updating DPI calculation methods, and adjusting coordinate transformations throughout the codebase.

**Key Changes:**
- Enabled Windows high DPI awareness via CMake (`VS_DPI_AWARE "PerMonitor"`) and SDL hints
- Changed Windows DPI detection from `HORZRES/HORZSIZE` calculation to `LOGPIXELSX`, which is the correct API for DPI-aware applications
- Modified `Screen::getDevicePixelRatio()` on Windows to return `DPI/96.0f` instead of hardcoded `1`
- Updated window creation to pre-scale dimensions by DPR in `SystemWindow.cpp`
- Changed input coordinate handling: On Windows, SDL now provides actual pixel coordinates, so the TypeScript input layer sets `dpr=1` to avoid double-scaling
- Applied DPR scaling to EditBox positioning and dimensions
- Updated minimum compatibility version to `>=3.8.0`

**Architecture:**
The implementation follows a "scale at boundaries" approach where Windows creates physically-sized windows and events carry physical pixel values, while other platforms continue to use logical coordinates scaled by DPR at the event layer.

<h3>Confidence Score: 3/5</h3>

- This PR has one critical logic error in EditBox font size calculation that will cause incorrect rendering at non-100% DPI scales
- While the overall high DPI implementation approach is sound and well-structured, the `WindowRatio` calculation in `EditBox-win32.cpp:248` incorrectly multiplies by dpr when both the numerator and denominator are already in physical pixels, causing double-scaling of the font size ratio. This will result in EditBox text appearing at the wrong size when DPI scaling is active.
- Pay close attention to `native/cocos/ui/edit-box/EditBox-win32.cpp` - the font size calculation has a critical bug that must be fixed before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| native/cocos/platform/win32/modules/Screen.cpp | Changed DPI calculation from HORZRES/HORZSIZE to LOGPIXELSX and updated getDevicePixelRatio to return DPI/96.0f instead of hardcoded 1 |
| native/cocos/platform/SDLHelper.cpp | Enabled SDL high DPI support for Windows, modified window size events to use raw values instead of DPR-scaled values, added windowId to touch events |
| native/cocos/platform/win32/modules/SystemWindow.cpp | Applied DPR scaling to window dimensions at creation time, storing scaled dimensions in _width and _height |
| pal/input/native/mouse-input.ts | Set DPR to 1 for Windows platform in coordinate calculations since native layer now provides actual pixel coordinates |
| pal/input/native/touch-input.ts | Set DPR to 1 for Windows in coordinate calculations and added null check for window object |
| native/cocos/ui/edit-box/EditBox-win32.cpp | Applied DPR scaling to EditBox position and size calculations to match high DPI window coordinates |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant SDL as SDLHelper
    participant SysWin as SystemWindow
    participant Screen as Screen(Win32)
    participant Input as Input Layer (TS)
    participant EditBox as EditBox(Win32)

    Note over App,EditBox: Initialization Phase
    App->>SDL: init() with SDL_HINT_VIDEO_HIGHDPI_DISABLED="0"
    SDL-->>App: High DPI enabled for Windows
    App->>SysWin: createWindow(w, h, flags with CC_WINDOW_ALLOW_HIGHDPI)
    SysWin->>Screen: getDevicePixelRatio()
    Screen-->>SysWin: DPI/96.0f (e.g., 1.5 for 144 DPI)
    SysWin->>SysWin: _width = w * dpr, _height = h * dpr
    SysWin->>SDL: createWindow(_width, _height)
    SDL-->>SysWin: Window created with scaled dimensions

    Note over App,EditBox: Runtime Event Handling
    SDL->>SDL: Window resize/size changed event
    alt Windows Platform
        SDL->>App: SIZE_CHANGED/RESIZED with raw pixel values (no DPR scaling)
    else Other Platforms
        SDL->>Screen: getDevicePixelRatio()
        Screen-->>SDL: dpr value
        SDL->>App: SIZE_CHANGED/RESIZED with scaled values (data * dpr)
    end

    Note over App,EditBox: Input Coordinate Processing
    SDL->>Input: Mouse/Touch event with coordinates
    Input->>Screen: getDevicePixelRatio() via screenAdapter
    Screen-->>Input: dpr value
    alt Windows Platform
        Input->>Input: Set dpr=1 (coordinates already in actual pixels)
    else Other Platforms
        Input->>Input: Use dpr from Screen (apply scaling)
    end
    Input->>App: EventMouse/EventTouch with correct coordinates

    Note over App,EditBox: EditBox Positioning
    App->>EditBox: show(x, y, width, height)
    EditBox->>Screen: getDevicePixelRatio()
    Screen-->>EditBox: dpr value
    EditBox->>EditBox: SetWindowPos(x*dpr, y*dpr, width*dpr, height*dpr)
    EditBox-->>App: EditBox positioned correctly in high DPI
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->