### PR TITLE
fixed color interpolation for 2d particle systems

### DIFF
--- a/cocos/particle-2d/particle-simulator-2d.ts
+++ b/cocos/particle-2d/particle-simulator-2d.ts
@@ -47,12 +47,32 @@ function getWorldRotation (node): number {
     }
     return rotation;
 }
+class ColorNumber {
+    public r = 0;
+    public g = 0;
+    public b = 0;
+    public a = 0;
+
+    constructor (r: number, g: number, b: number, a: number) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.a = a;
+    }
+
+    set (r: number, g: number, b: number, a: number): void {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.a = a;
+    }
+}
 
 class Particle {
     public pos = new Vec2(0, 0);
     public startPos = new Vec2(0, 0);
-    public color = new Color(0, 0, 0, 255);
-    public deltaColor = { r: 0, g: 0, b: 0, a: 255 };
+    public color = new ColorNumber(0, 0, 0, 255);
+    public deltaColor = new ColorNumber(0, 0, 0, 255);
     public size = 0;
     public deltaSize = 0;
     public rotation = 0;
@@ -81,8 +101,7 @@ const pool = new ParticlePool((par: Particle): void => {
     par.pos.set(Vec2.ZERO);
     par.startPos.set(Vec2.ZERO);
     par.color.set(0, 0, 0, 255);
-    par.deltaColor.r = par.deltaColor.g = par.deltaColor.b = 0;
-    par.deltaColor.a = 255;
+    par.deltaColor.set(0, 0, 0, 255);
     par.size = 0;
     par.deltaSize = 0;
     par.rotation = 0;


### PR DESCRIPTION
Re: #
The PR fixes bug reported here: https://github.com/cocos/cocos-engine/issues/19144
### Changelog

* Replaced color structure for particle interpolation with a colorNumber structure. The issue was that the initial Color structure has r g b and a quantitized on 8 bits which is not enough for small deltas. Issue was that a small enough delta would never increment the particle color over time.  (easy way to test is do a particle system with a different starting color and ending color then set lifetime to a big value (over 8 seconds if you are running at 60 fps))

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes color interpolation precision loss in 2D particle systems by replacing `Color` class (which uses `Uint8ClampedArray` for 8-bit storage) with a new `ColorNumber` class that stores color components as floating-point numbers.

**Key Changes:**
- Added `ColorNumber` class with float-precision `r`, `g`, `b`, `a` properties
- Updated `Particle.color` and `Particle.deltaColor` to use `ColorNumber` instead of `Color`
- Updated particle pool reset logic to use `ColorNumber.set()` method

**Problem Solved:**
Previously, when particles had long lifetimes (>8 seconds at 60fps) and small color deltas, the 8-bit quantization would truncate fractional color increments (e.g., `0.01`) to `0`, preventing any visible color change over time. The new implementation allows these small deltas to accumulate correctly.

**Issue Found:**
- Color values can now exceed the [0, 255] range during interpolation without clamping, potentially causing rendering artifacts when normalized for display

<h3>Confidence Score: 3/5</h3>

- PR fixes the reported bug but introduces a potential bounds issue with color interpolation
- The fix correctly addresses the precision loss issue by using float storage instead of 8-bit integers, but lacks clamping for interpolated colors which could exceed valid [0, 255] range and cause rendering artifacts
- Pay attention to `cocos/particle-2d/particle-simulator-2d.ts:453-456` where color clamping should be added

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cocos/particle-2d/particle-simulator-2d.ts | Replaced Color with ColorNumber class for particle color interpolation to fix precision loss with small delta values; missing bounds checking for interpolated colors |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PS as ParticleSystem2D
    participant Sim as Simulator
    participant P as Particle
    participant CN as ColorNumber
    participant Pool as ParticlePool
    
    Note over PS,Sim: Particle Emission
    PS->>Sim: emitParticle(pos)
    Sim->>Pool: get()
    Pool-->>Sim: particle
    Sim->>P: Initialize properties
    
    Note over P,CN: Color Initialization (Fixed)
    P->>CN: color = new ColorNumber(sr, sg, sb, sa)
    P->>CN: deltaColor = new ColorNumber(dr, dg, db, da)
    Note right of CN: Uses float precision<br/>instead of Uint8ClampedArray
    
    Note over PS,Sim: Animation Loop
    PS->>Sim: step(dt)
    loop For each particle
        Sim->>P: Update timeToLive
        
        alt timeToLive > 0
            Note over P,CN: Color Interpolation (Fixed)
            P->>CN: color.r += deltaColor.r * dt
            P->>CN: color.g += deltaColor.g * dt
            P->>CN: color.b += deltaColor.b * dt
            P->>CN: color.a += deltaColor.a * dt
            Note right of CN: Small deltas now accumulate<br/>correctly over time
            
            Sim->>Sim: updateParticleBuffer()
            Note over Sim: Normalize color: r/255, g/255, b/255, a/255
        else timeToLive <= 0
            Sim->>Pool: put(particle)
            Note over Pool: Particle reset:<br/>color.set(0, 0, 0, 255)
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->