### PR TITLE
add error log

### DIFF
--- a/native/cocos/editor-support/spine/3.8/spine/SkeletonBinary.cpp
+++ b/native/cocos/editor-support/spine/3.8/spine/SkeletonBinary.cpp
@@ -511,6 +511,7 @@ Attachment *SkeletonBinary::readAttachment(DataInput *input, Skin *skin, int slo
 
             RegionAttachment *region = _attachmentLoader->newRegionAttachment(*skin, String(name), String(path));
             if (region == NULL) {
+                setError("Error reading attachment: ", name.buffer());
                 return NULL;
             }
             region->_path = path;

--- a/native/cocos/editor-support/spine/3.8/spine/SkeletonBinary.cpp
+++ b/native/cocos/editor-support/spine/3.8/spine/SkeletonBinary.cpp
@@ -279,6 +279,12 @@ SkeletonData *SkeletonBinary::readSkeletonData(const unsigned char *binary, cons
         skeletonData->_defaultSkin = defaultSkin;
         skeletonData->_skins.add(defaultSkin);
     }
+    
+    if (!this->getError().isEmpty()) {
+		delete input;
+		delete skeletonData;
+		return NULL;
+	}
 
     /* Skins. */
     for (size_t i = 0, n = (size_t)readVarint(input, true); i < n; ++i) {


### PR DESCRIPTION
Re: #

### Changelog

* Reference: Spine4.2, Spine 3.8 – Return immediately if the default skin fails to load, to prevent subsequent reading from causing a Memory access out of bounds error
-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves error handling in Spine 3.8's `SkeletonBinary` by adding two related safety checks: (1) calling `setError()` when `newRegionAttachment` returns `NULL` in `readAttachment` (line 520), and (2) adding an early-return guard after the default skin is read (lines 283–287) so that a failed region attachment causes `readSkeletonData` to cleanly release resources and return `NULL` instead of silently continuing with a broken skeleton.

The `setError` call follows the existing pattern already applied to `MeshAttachment` failure (line 556), ensuring callers can retrieve meaningful error information via `getError()`. The early-return guard is correctly positioned between default-skin and non-default-skin reading, preventing continued binary parsing after a fatal attachment-load failure.

The only remaining issue is mixed indentation in the new guard block (lines 283–287): the body uses hard tabs while the rest of the file uses spaces, causing visual misalignment.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the indentation issue in the new guard block.
- The behavioral changes are correct and well-placed—adding error handling for failed region attachment reads and preventing continued parsing after a fatal load failure. Both patterns match existing code in the file. The score is 4/5 rather than 5 solely due to the mixed indentation (tabs vs. spaces) in lines 283–287, which should be corrected to match the file's space-based style before merging.
- Fix indentation in native/cocos/editor-support/spine/3.8/spine/SkeletonBinary.cpp (lines 283–287) to use spaces instead of tabs.

<sub>Last reviewed commit: 8c71e73</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->