### PR TITLE
fix: 缓存的 BlitDesc._blit 更新

### DIFF
--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -619,6 +619,7 @@ class DeviceRenderQueue implements RecordingInterface {
         if (!this._blitDesc) {
             this._blitDesc = new BlitDesc(blit);
         }
+        this._blitDesc.blit = blit;
         this._blitDesc.createScreenQuad();
         this._blitDesc.createStageDescriptor();
     }


### PR DESCRIPTION
Re: #

### Changelog

缓存的 [BlitDesc._blit]与对象池复用机制不兼容，导致在 shadingScale 改变 blit 分配顺序后读取到失效/被复写的 blit 对象。

复现思路 ：多 pass 混合
场景里同时存在：
fullscreen 后处理 blit
UI 渲染
shadingScale 引入的缩放 pass
多帧运行后，用多个不同后处理配置的相机，从A开启切换到B开启，某帧中对象池 slot 被复用
旧 [BlitDesc._blit]指向了被重置后的 UI blit，触发空材质访问


-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
