### PR TITLE
fix bug: AnimationController does not override clips in PoseGraph

### DIFF
--- a/cocos/animation/marionette/pose-graph/instantiation.ts
+++ b/cocos/animation/marionette/pose-graph/instantiation.ts
@@ -25,12 +25,21 @@ class InstantiatedPoseGraph {
     constructor (
         private _rootPoseNode: PoseNode | undefined,
         private _countingPlayMotionNodes: readonly PoseNodePlayMotion[] | undefined,
+        private _allPoseNodes: readonly PoseNode[],
     ) {
 
     }
 
     public bind (context: AnimationGraphBindingContext): void {
         this._rootPoseNode?.bind(context);
+    }
+
+    public overrideClips (context: AnimationGraphBindingContext): void {
+        const { _allPoseNodes: allPoseNodes } = this;
+        const nNodes = allPoseNodes.length;
+        for (let iNode = 0; iNode < nNodes; ++iNode) {
+            allPoseNodes[iNode].overrideClips(context);
+        }
     }
 
     public settle (context: AnimationGraphSettleContext): void {
@@ -97,6 +106,7 @@ export function instantiatePoseGraph (
         return new InstantiatedPoseGraph(
             undefined,
             mayCountMotionTime ? [] : undefined,
+            [],
         );
     }
     // If the output node has a binding, it must be pose node.
@@ -113,11 +123,13 @@ export function instantiatePoseGraph (
     );
     assertIsTrue(mainRecord instanceof PoseNode);
 
+    const allPoseNodes = Array.from(instantiationMap.values()).filter((node): node is PoseNode => node instanceof PoseNode);
     return new InstantiatedPoseGraph(
         mainRecord,
         mayCountMotionTime
             ? Array.from(instantiationMap.values()).filter((node): node is PoseNodePlayMotion => node instanceof PoseNodePlayMotion)
             : undefined,
+        allPoseNodes,
     );
 }
 
@@ -287,6 +299,7 @@ function linkPoseNode (
 
     if (producerOutputIndex !== 0) {
         // Rule: pose nodes have and only have one output.
+        // eslint-disable-next-line no-implicit-coercion
         warn(`Node ${producerNode.toString()} does not have specified output ${producerOutputIndex}.`);
         return;
     }

--- a/cocos/animation/marionette/pose-graph/instantiation.ts
+++ b/cocos/animation/marionette/pose-graph/instantiation.ts
@@ -299,7 +299,7 @@ function linkPoseNode (
 
     if (producerOutputIndex !== 0) {
         // Rule: pose nodes have and only have one output.
-        // eslint-disable-next-line no-implicit-coercion
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         warn(`Node ${producerNode.toString()} does not have specified output ${producerOutputIndex}.`);
         return;
     }

--- a/cocos/animation/marionette/pose-graph/pose-node.ts
+++ b/cocos/animation/marionette/pose-graph/pose-node.ts
@@ -52,6 +52,12 @@ export abstract class PoseNode extends PoseGraphNode {
     public abstract settle (context: AnimationGraphSettleContext): void;
 
     /**
+     * Rebinds motions when clip overrides on the binding context change.
+     * Pose nodes that own motion evaluations or nested graphs override this.
+     */
+    public overrideClips (_context: AnimationGraphBindingContext): void {}
+
+    /**
      * Reenter this pose nodes.
      *
      * @note Subclasses shall implement this method to perform some state resetting works.
@@ -94,12 +100,16 @@ export abstract class PoseNode extends PoseGraphNode {
 
         if (POSE_NODE_EVALUATION_STACK_ORDER_DEBUG_ENABLED) {
             // The stack should certainly increase 1.
-            assertIsTrue(context._stackSize_debugging === stackSizeBefore + 1,
-                `PoseNode.doEvaluate() should certainly push a pose node onto the stack and return it.`);
+            assertIsTrue(
+                context._stackSize_debugging === stackSizeBefore + 1,
+                `PoseNode.doEvaluate() should certainly push a pose node onto the stack and return it.`
+            );
             // The returned pose should be the increased pose, that's,
             // can not return a already-popped pose.
-            assertIsTrue(context._isStackTopPose_debugging(pose),
-                `PoseNode.doEvaluate() should certainly push a pose node onto the stack and return it.`);
+            assertIsTrue(
+                context._isStackTopPose_debugging(pose),
+                `PoseNode.doEvaluate() should certainly push a pose node onto the stack and return it.`
+            );
         }
 
         const currentSpace = pose._poseTransformSpace;

--- a/cocos/animation/marionette/pose-graph/pose-node.ts
+++ b/cocos/animation/marionette/pose-graph/pose-node.ts
@@ -102,13 +102,13 @@ export abstract class PoseNode extends PoseGraphNode {
             // The stack should certainly increase 1.
             assertIsTrue(
                 context._stackSize_debugging === stackSizeBefore + 1,
-                `PoseNode.doEvaluate() should certainly push a pose node onto the stack and return it.`
+                `PoseNode.doEvaluate() should certainly push a pose node onto the stack and return it.`,
             );
             // The returned pose should be the increased pose, that's,
             // can not return a already-popped pose.
             assertIsTrue(
                 context._isStackTopPose_debugging(pose),
-                `PoseNode.doEvaluate() should certainly push a pose node onto the stack and return it.`
+                `PoseNode.doEvaluate() should certainly push a pose node onto the stack and return it.`,
             );
         }
 

--- a/cocos/animation/marionette/pose-graph/pose-nodes/play-motion.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/play-motion.ts
@@ -1,5 +1,5 @@
 import { EDITOR } from 'internal:constants';
-import { ccclass, displayName, editable, serializable, unit } from '../../../../core/data/decorators';
+import { ccclass, editable, serializable, unit } from '../../../../core/data/decorators';
 import { CLASS_NAME_PREFIX_ANIM } from '../../../define';
 import { ClipMotion } from '../../motion/clip-motion';
 import { createEval } from '../../create-eval';
@@ -77,6 +77,10 @@ export class PoseNodePlayMotion extends PoseNode {
         if (this.syncInfo.group) {
             this._runtimeSyncRecord = context.motionSyncManager.register(this.syncInfo);
         }
+    }
+
+    public overrideClips (context: AnimationGraphBindingContext): void {
+        this._workspace?.motionEval.overrideClips(context);
     }
 
     public settle (context: AnimationGraphSettleContext): void {

--- a/cocos/animation/marionette/pose-graph/pose-nodes/sample-motion.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/sample-motion.ts
@@ -51,6 +51,10 @@ export class PoseNodeSampleMotion extends PoseNode {
         this._workspace = workspace;
     }
 
+    public overrideClips (context: AnimationGraphBindingContext): void {
+        this._workspace?.motionEval.overrideClips(context);
+    }
+
     public settle (context: AnimationGraphSettleContext): void {
         // Do nothing.
     }

--- a/cocos/animation/marionette/pose-graph/pose-nodes/state-machine.ts
+++ b/cocos/animation/marionette/pose-graph/pose-nodes/state-machine.ts
@@ -45,6 +45,10 @@ export class PoseNodeStateMachine extends PoseNode {
         );
     }
 
+    public overrideClips (context: AnimationGraphBindingContext): void {
+        this._stateMachineEval?.overrideClips(context);
+    }
+
     public settle (context: AnimationGraphSettleContext): void {
         this._stateMachineEval?.settle(context);
     }

--- a/cocos/animation/marionette/state-machine/state-machine-eval.ts
+++ b/cocos/animation/marionette/state-machine/state-machine-eval.ts
@@ -6,7 +6,7 @@ import {
 } from '../animation-graph';
 import { MotionEval, MotionPort } from '../motion';
 import { createEval } from '../create-eval';
-import { BindContext, validateVariableExistence, validateVariableType, VariableType } from '../parametric';
+import { validateVariableExistence, validateVariableType, VariableType } from '../parametric';
 import { ConditionEval, TriggerCondition } from './condition';
 import { MotionState } from './motion-state';
 import { warnID, assertIsTrue, assertIsNonNullable, Pool, approx, clamp01 } from '../../../core';
@@ -21,10 +21,8 @@ import {
     TriggerResetter,
 } from '../animation-graph-context';
 import { blendPoseInto, Pose } from '../../core/pose';
-import { PoseNode } from '../pose-graph/pose-node';
 import { instantiatePoseGraph, InstantiatedPoseGraph } from '../pose-graph/instantiation';
 import { ConditionEvaluationContext } from './condition/condition-base';
-import { ReadonlyClipOverrideMap } from '../clip-overriding';
 import { AnimationGraphEventBinding } from '../event/event-binding';
 
 /**
@@ -256,6 +254,11 @@ class TopLevelStateMachineEvaluation {
         for (let iMotionState = 0; iMotionState < nMotionStates; ++iMotionState) {
             const node = motionStates[iMotionState];
             node.overrideClips(context);
+        }
+        const { _proceduralPoseStates: proceduralPoseStates } = this;
+        const nProcedural = proceduralPoseStates.length;
+        for (let iProcedural = 0; iProcedural < nProcedural; ++iProcedural) {
+            proceduralPoseStates[iProcedural].overrideClips(context);
         }
     }
 
@@ -1449,6 +1452,10 @@ class ProceduralPoseStateEval extends EventifiedStateEval {
 
     public countMotionTime (): number {
         return this._instantiatedPoseGraph.countMotionTime();
+    }
+
+    public overrideClips (context: AnimationGraphBindingContext): void {
+        this._instantiatedPoseGraph.overrideClips(context);
     }
 
     private _instantiatedPoseGraph: InstantiatedPoseGraph;


### PR DESCRIPTION
bug desc: https://github.com/cocos/cocos-engine/issues/19162

While fixing this BUG, I initially thought it was simply a missing loop for  `_proceduralPoseStates`  in  `state-machine-eval.ts`:
```typescript
    public overrideClips (context: AnimationGraphBindingContext): void {
        ...............
        const { _proceduralPoseStates: proceduralPoseStates } = this;
        const nProcedural = proceduralPoseStates.length;
        for (let iProcedural = 0; iProcedural < nProcedural; ++iProcedural) {
            proceduralPoseStates[iProcedural].overrideClips(context);
        }
    }
```
However, during the fix, I discovered that the entire  `ProceduralPoseState`  was not designed with an `overrideClip` mechanism at all. So I'm unclear why the official team did it this way... was this functionality accidentally omitted? Or was it never intended for  `ProceduralPoseState` to have clip override capabilities? If this was intentional, please let me know the reason, as this global replacement is crucial for our current animation feature implementation. Thank you!