### PR TITLE
fix(rendering): use lightIdx instead of loop index l in GPU instancing forward-add light path

### DIFF
--- a/cocos/rendering/render-additive-light-queue.ts
+++ b/cocos/rendering/render-additive-light-queue.ts
@@ -243,6 +243,7 @@ export class RenderAdditiveLightQueue {
     public recordCommandBuffer (device: Device, renderPass: RenderPass, cmdBuff: CommandBuffer): void {
         const globalDSManager: GlobalDSManager = this._pipeline.globalDSManager;
         for (let j = 0; j < this._instancedQueues.length; ++j) {
+            if (!this._instancedQueues[j]) { continue; }
             const light = this._instancedLightPassPool.lights[j];
             _dynamicOffsets[0] = this._instancedLightPassPool.dynamicOffsets[j];
             const descriptorSet = globalDSManager.getOrCreateDescriptorSet(light);
@@ -318,11 +319,11 @@ export class RenderAdditiveLightQueue {
             if (((visibility & model.node.layer) === model.node.layer)) {
                 switch (batchingScheme) {
                 case BatchingSchemes.INSTANCING: {
-                    const buffer = pass.getInstancedBuffer(l);
+                    const buffer = pass.getInstancedBuffer(lightIdx);
                     buffer.merge(subModel, lightPassIdx);
-                    buffer.dynamicOffsets[0] = this._lightBufferStride;
-                    if (!this._instancedQueues[l]) { this._instancedQueues[l] = new RenderInstancedQueue(); }
-                    this._instancedQueues[l].queue.add(buffer);
+                    buffer.dynamicOffsets[0] = this._lightBufferStride * lightIdx;
+                    if (!this._instancedQueues[lightIdx]) { this._instancedQueues[lightIdx] = new RenderInstancedQueue(); }
+                    this._instancedQueues[lightIdx].queue.add(buffer);
                 } break;
                 default:
                     lp!.lights.push(light);


### PR DESCRIPTION
## Problem

In `_addRenderQueue` of `render-additive-light-queue.ts`, the `BatchingSchemes.INSTANCING` branch was using the local loop index `l` for `getInstancedBuffer(l)` and `_instancedQueues[l]` instead of `lightIdx` (the global light index from `validPunctualLights`).

This caused mismatched indexing between:
- The **instancing path** (used local per-model light indices `l`)
- **`recordCommandBuffer` / `gatherLightPasses`** (use global light indices `lightIdx`)

Result: wrong UBO/descriptor bindings for additional lights when different models have different light culling results under GPU instancing. The non-instancing `default` branch already correctly uses `lightIdx`.

## Fix

Changed 3 occurrences of `l` to `lightIdx` in the `BatchingSchemes.INSTANCING` case:
- `pass.getInstancedBuffer(l)` → `pass.getInstancedBuffer(lightIdx)`
- `this._instancedQueues[l]` → `this._instancedQueues[lightIdx]` (2 occurrences)

## Reproduce Conditions

- Scene has multiple valid additional lights (>= 2 `validPunctualLights`)
- Material uses GPU Instancing (`BatchingSchemes.INSTANCING`)
- Different models have different `_lightCulling` results (non-uniform `_lightIndices` per model)

Fixes: #19170

### Changelog

- Fixed incorrect light indexing in GPU instancing forward-add render queue