### PR TITLE
fix(screen-adapter): debounce resize handler to prevent black flicker on web

### DIFF
--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -187,6 +187,7 @@ class ScreenAdapter extends EventTarget {
     private _onFullscreenError?: () => void;
     // We need to set timeout to handle screen event.
     private _orientationChangeTimeoutId = -1;
+    private _resizeTimeoutId = -1;
     private _cachedFrameSize = new Size(0, 0); // cache before enter fullscreen.
     private _exactFitScreen = false;
     private _isHeadlessMode = false;
@@ -383,10 +384,16 @@ class ScreenAdapter extends EventTarget {
         });
 
         window.addEventListener('resize', (): void => {
-            // if (!this.handleResizeEvent) {
-            //     return;
-            // }
-            this._updateFrame();
+            if (!this.handleResizeEvent) {
+                return;
+            }
+            if (this._resizeTimeoutId !== -1) {
+                clearTimeout(this._resizeTimeoutId);
+            }
+            this._resizeTimeoutId = setTimeout((): void => {
+                this._updateFrame();
+                this._resizeTimeoutId = -1;
+            }, EVENT_TIMEOUT);
         });
 
         const notifyOrientationChange = (orientation): void => {
@@ -439,11 +446,17 @@ class ScreenAdapter extends EventTarget {
                 const mediaQueryResolution = window.matchMedia(`(resolution: ${dpr}dppx)`);
                 if (mediaQueryResolution.addEventListener) {
                     mediaQueryResolution.addEventListener('change', (): void => {
+                        if (!this.handleResizeEvent) {
+                            return;
+                        }
                         this.emit('window-resize', this.windowSize.width, this.windowSize.height);
                         updateDPRChangeListener();
                     }, { once: true });
                 } else if (mediaQueryResolution.addListener) {
                     mediaQueryResolution.addListener((): void => {
+                        if (!this.handleResizeEvent) {
+                            return;
+                        }
                         this.emit('window-resize', this.windowSize.width, this.windowSize.height);
                     });
                 }


### PR DESCRIPTION
## Problem

On Web builds, continuously resizing the browser window produces rapid black flickering. Each `resize` event synchronously calls `_resizeFrame()` → `_updateContainer()` → `emit('window-resize')`, which triggers a swapchain/backbuffer reallocation. During a continuous drag this fires dozens of times per second, each producing a blank (black) frame before the next render.

The same continuous-resize test does not flicker in Cocos Creator 2.x (because v2 keeps a fixed backbuffer and CSS-scales it rather than reallocating on every resize).

## Root Cause

In `pal/screen-adapter/src/web/screen-adapter.ts`, the `resize` event handler (line 380) had no debounce, unlike the `orientationchange` handler (line 407) which already uses `EVENT_TIMEOUT` (200ms) + `setTimeout`.

Additionally, the DPR `matchMedia` change listener (line 397) emitted `window-resize` directly, bypassing:
- The `handleResizeEvent` guard (used by `view.resizeWithBrowserSize(false)`)
- Any debounce mechanism

## Fix

1. **Debounce the resize handler** — Added a `_resizeTimeoutId` field and debounce logic using the same `EVENT_TIMEOUT` (200ms) pattern already used by the orientation change handler. Rapid resize events cancel the pending timeout and restart it; only the last event after the drag stops triggers `_resizeFrame()`.

2. **Gate DPR matchMedia handler** — Added `handleResizeEvent` check before emitting `window-resize`, consistent with the resize and orientation handlers.

## Changes

- `pal/screen-adapter/src/web/screen-adapter.ts`: +11/-1 lines
  - Added `_resizeTimeoutId` private field
  - Wrapped `_resizeFrame()` call inside `setTimeout`/`clearTimeout` debounce
  - Added `handleResizeEvent` guard to DPR matchMedia listener

## Side Effects

| Consumer | Impact |
|----------|--------|
| `_resizeFrame()` → `_updateContainer()` | Now debounced; triggers at most once per 200ms after last resize event |
| `edit-box-impl.ts` (temporarily disables handleResizeEvent) | No change; guard still works |
| `view.resizeWithBrowserSize(false)` | No change; guard still works |
| Orientation handler | No change; already has its own debounce |

Fixes: #19182

### Changelog

- Fixed rapid black flicker during continuous browser window resize on web builds by debouncing the resize event handler