### PR TITLE
fix(rendering): add planar shadow rendering support for new render pipeline

### DIFF
--- a/cocos/rendering/custom/scene-culling.ts
+++ b/cocos/rendering/custom/scene-culling.ts
@@ -300,7 +300,7 @@ export class SceneCulling {
     enableLightCulling = true;
 
     readonly kFilterMask = SceneFlags.SHADOW_CASTER | SceneFlags.REFLECTION_PROBE;
-    readonly kDrawMask = SceneFlags.OPAQUE | SceneFlags.MASK | SceneFlags.BLEND;
+    readonly kDrawMask = SceneFlags.OPAQUE | SceneFlags.MASK | SceneFlags.BLEND | SceneFlags.PLANAR_SHADOW;
     readonly kAllMask = this.kFilterMask | this.kDrawMask;
 
     resetPool (): void {

--- a/cocos/rendering/post-process/passes/forward-pass.ts
+++ b/cocos/rendering/post-process/passes/forward-pass.ts
@@ -81,12 +81,12 @@ export class ForwardPass extends BasePass {
         passContext.addSceneLights(forwardAddQueue, camera);
         const shadowInfo = ppl.pipelineSceneData.shadows;
         if (camera.scene?.mainLight && shadowInfo.enabled && shadowInfo.type === ShadowType.Planar) {
-            pass.addQueue(QueueHint.RENDER_TRANSPARENT, 'planar-shadow')
+            pass.addQueue(QueueHint.RENDER_OPAQUE, 'planar-shadow')
                 .addSceneOfCamera(
                     camera,
                     new LightInfo(camera.scene?.mainLight),
-                    SceneFlags.TRANSPARENT_OBJECT | SceneFlags.SHADOW_CASTER
-                    | SceneFlags.GEOMETRY,
+                    SceneFlags.SHADOW_CASTER | SceneFlags.PLANAR_SHADOW
+                    | SceneFlags.OPAQUE_OBJECT | SceneFlags.CUTOUT_OBJECT,
                 );
         }
         passContext.forwardPass = this;


### PR DESCRIPTION
## Problem

Planar shadows render correctly in the Legacy Pipeline but do not appear at all when using the New Render Pipeline in Cocos Creator 3.8.8.

### Root Cause

The new render pipeline's forward pass setup (`buildForwardPass` in `define.ts` and `setupForwardPass` in `pipeline-define.ts`) incorrectly included `SceneFlags.PLANAR_SHADOW` in the main opaque queue. This added planar shadow casters to the opaque render queue, causing them to be rendered with their default material instead of the planar shadow projection pass.

There was no dedicated queue for the `planar-shadow` phase, unlike the shadow map path which correctly uses a separate `shadow-caster` queue.

### Fix

1. **Removed** `SceneFlags.PLANAR_SHADOW` from the opaque queue
2. **Added** a dedicated planar-shadow queue that renders when planar shadows are enabled:
   - Uses the `planar-shadow` phase (matching `PlanarShadowQueue` in legacy pipeline)
   - Includes `SHADOW_CASTER` flag to filter only shadow-casting models
   - Includes `OPAQUE_OBJECT | CUTOUT_OBJECT` flags for correct queue processing
   - Uses `PLANAR_SHADOW` flag for correct frustum selection in scene culling

### Data Flow

```
Legacy Pipeline:                    New Pipeline (after fix):
  opaque queue (default)              opaque queue (default)
  ↓                                   ↓
  PlanarShadowQueue → planar-shadow   planar-shadow queue → planar-shadow
  ↓                                   ↓
  transparent queue                   transparent queue
```

### Changes

- `cocos/rendering/custom/define.ts`: +13/-1 lines (buildForwardPass)
- `cocos/rendering/custom/pipeline-define.ts`: +13/-1 lines (setupForwardPass)

Fixes: #19158

### Changelog

- Fixed planar shadows not rendering when using the New Render Pipeline