### PR TITLE
Prevent AssetsManagerEx destructor from clearing active static instance

### DIFF
--- a/native/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/native/extensions/assets-manager/AssetsManagerEx.cpp
@@ -115,7 +115,7 @@ AssetsManagerEx::~AssetsManagerEx() {
     }
     CC_SAFE_RELEASE(_remoteManifest);
 	if(assetsManager == this){
-		//avoid race conditon to current static variable
+		//avoid race conditon to current static variable.
 		assetsManager = nullptr;
 	}
     

--- a/native/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/native/extensions/assets-manager/AssetsManagerEx.cpp
@@ -114,7 +114,11 @@ AssetsManagerEx::~AssetsManagerEx() {
         CC_SAFE_RELEASE(_tempManifest);
     }
     CC_SAFE_RELEASE(_remoteManifest);
-    assetsManager = nullptr;
+	if(assetsManager == this){
+		//avoid race conditon to current static variable
+		assetsManager = nullptr;
+	}
+    
 }
 
 AssetsManagerEx *AssetsManagerEx::create(const std::string &manifestUrl, const std::string &storagePath) {


### PR DESCRIPTION
Re: #

### Changelog

- Prevent a potential race condition when multiple `AssetsManagerEx` instances are created sequentially.
- Avoid clearing the active static `assetsManager` pointer when an older instance is destroyed.
- Ensure native events continue to be dispatched to the current `AssetsManagerEx` instance during sequential hot updates.

-------

## Patch

```diff
AssetsManagerEx::~AssetsManagerEx()
{
-    assetsManager = nullptr;
+    if (assetsManager == this) {
+        assetsManager = nullptr;
+    }
}
```
-------
### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
