### PR TITLE
fix(pipeline): keep MANAGED render targets alive across frames in release builds

### DIFF
--- a/cocos/rendering/custom/executor.ts
+++ b/cocos/rendering/custom/executor.ts
@@ -1686,6 +1686,22 @@ export class Executor {
     private _removeDeviceResource (): void {
         const pipeline: any = context.pipeline;
         const resourceUses = pipeline.resourceUses;
+        // Names this frame's graph references. Compiler is the only other writer of this list and
+        // it does not contribute in release builds, so without this every MANAGED resource reads as
+        // unused and is released and reallocated once per frame.
+        const rg = context.renderGraph;
+        const use = (resName: string): void => {
+            if (!resourceUses.includes(resName)) resourceUses.push(resName);
+        };
+        for (let v = 0; v !== rg.nv(); ++v) {
+            if (rg.h(RenderGraphValue.RasterPass, v)) {
+                const rasterPass = rg.j<RasterPass>(v);
+                for (const [resName] of rasterPass.rasterViews) use(resName);
+                for (const [resName] of rasterPass.computeViews) use(resName);
+            } else if (rg.h(RenderGraphValue.Compute, v)) {
+                for (const [resName] of rg.j<ComputePass>(v).computeViews) use(resName);
+            }
+        }
         const deletes: string[] = [];
         const deviceTexs = context.deviceTextures;
         for (const [name, dTex] of deviceTexs) {


### PR DESCRIPTION
Re: #19197

### Changelog

* Custom pipeline: collect the frame's resource names from the render graph at the start of `Executor._removeDeviceResource()`. `pipeline.resourceUses` is filled only by `Compiler`, which does not contribute in a release build, so every `MANAGED` device texture and buffer — the cascaded shadow map among them — was released at the start of each frame and reallocated during it.

### Where I put it, and why there

I looked for an existing per-frame traversal of the frame's resource names to fill the list from, and
did not find one — but I may well be missing something, and a better home for this is entirely
possible. What I checked:

* `Compiler` fills the list at `compiler.ts:170`, but that line sits after `if (validPass) return;`, and `web-pipeline.ts:1648` wraps the whole compiler in `if (DEBUG)`.
* The `resourceUses.push()` at `executor.ts:156` is in the `ResourceVisitor` constructor, and the visitor looks like a module-level singleton created once at `executor.ts:754` with the default `resName = ''`, while the `resName` setter does not push. If that is right, the registration may have been intended to sit in the setter.
* `DeviceRenderPass` does iterate `rasterPass.rasterViews`, but instances appear to be cached by pass hash in `context.devicePasses` and dropped only in `release()`, so that loop would not run per frame.

If there is a more natural place for this, happy to move it.

### Alternative worth considering

`pipeline.resourceUses` has exactly one consumer — this method — and it is queried with `Array.includes()` in two loops below. A local `Set` built here and queried with `has()` would drop the linear scans and make the deduplication free, and would remove the need for the array to carry state between the compile and execute phases at all. That would make both existing writers dead code, so it is a call for the maintainers rather than something to slip into a bug fix; this PR keeps the public field and its semantics untouched and only deduplicates on insert.

### Verification

Web Mobile release build, Redmi 9C (Helio G35, PowerVR GE8320, 3 GB): 8 fps before, 24 after, output unchanged. Texture allocations over 150 frames drop from 300 (two 2048×2048 per frame) to 0. Tested on a scene with cascaded shadows and no post-processing; `Compute` and `Copy` passes were not exercised.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.
