### PR TITLE
fix(particle): handle floating-point precision in burst triggers

### DIFF
--- a/cocos/particle/burst.ts
+++ b/cocos/particle/burst.ts
@@ -23,7 +23,7 @@
 */
 
 import { ccclass, type, serializable, editable, range } from 'cc.decorator';
-import { repeat } from '../core/math';
+import { EPSILON, repeat } from '../core/math';
 import CurveRange from './animator/curve-range';
 import type { ParticleSystem } from './particle-system';
 
@@ -108,7 +108,7 @@ export default class Burst {
             let preFrameTime = repeat(psys.time - psys.startDelay.evaluate(0, 1), psys.duration) - dt;
             preFrameTime = (preFrameTime > 0.0) ? preFrameTime : 0.0;
             const curFrameTime = repeat(psys.time - psys.startDelay.evaluate(0, 1), psys.duration);
-            if (this._curTime >= preFrameTime && this._curTime < curFrameTime) {
+            if (this._curTime >= preFrameTime - EPSILON && this._curTime < curFrameTime) {
                 psys.emit(this.count.evaluate(this._curTime / psys.duration, 1), dt - (curFrameTime - this._curTime));
                 this._curTime += this.repeatInterval;
                 --this._remainingCount;


### PR DESCRIPTION
Particle Burst determines whether the current frame crosses a trigger point using floating-point time. Account for precision errors during the comparison.

Reference: https://forum.cocos.org/t/topic/176928

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
