### PR TITLE
fix(ui)：keep destroy widgets out of the widget's active list

### DIFF
--- a/cocos/ui/widget-manager.ts
+++ b/cocos/ui/widget-manager.ts
@@ -204,7 +204,7 @@ function align (node: Node, widget: Widget): void {
 // TODO: type is hack, Change to the type actually used (Node or BaseNode) when BaseNode complete
 function visitNode (node: any): void {
     const widget = node.getComponent(Widget);
-    if (widget && widget.enabled) {
+    if (widget && widget.enabled && cclegacy.isValid(widget, true)) {
         if (DEV) {
             widget._validateTargetInDEV();
         }

--- a/cocos/ui/widget.ts
+++ b/cocos/ui/widget.ts
@@ -852,6 +852,9 @@ export class Widget extends Component {
     }
 
     public onDestroy (): void {
+        // `onDisable` is skipped when the component was never enabled by the scheduler
+        // (`IsOnEnableCalled` unset), so unregister here as well.
+        cclegacy._widgetManager?.remove(this);
         this._removeParentEvent();
     }
 


### PR DESCRIPTION
Re: https://github.com/cocos/cocos-engine/issues/18893
Cherry-pick‌ From: https://github.com/cocos/cocos4/pull/302

### Changelog

* `activeWidgets` could keep widgets that have already been destroyed, so
  `refreshScene` called `align()` with `widget.node === null` (reset by
  `CCObject._destruct`) and threw every frame.
  Entries got in through `visitNode`, which collected widgets by `widget.enabled`
  alone - a flag that stays true after `destroy()`. Entries only got out through
  `Widget.onDisable`, which `disableComp` skips unless the component was enabled
  by the scheduler (`IsOnEnableCalled`).
  * `visitNode` now rejects widgets that are already marked for destruction.
  * `Widget.onDestroy` unregisters as well, covering widgets that were collected
    while still valid but never got `onDisable`.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
